### PR TITLE
#86 - remove calcite-fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1121,10 +1121,6 @@
         }
       }
     },
-    "calcite-fonts": {
-      "version": "github:ArcGIS/calcite-fonts#278f9aac7b4fde778d30ae2a7fa466c3d11a9977",
-      "from": "github:ArcGIS/calcite-fonts"
-    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@esri/calcite-base": "github:ArcGIS/calcite-base",
     "@esri/calcite-colors": "^1.3.1",
     "@esri/calcite-ui-icons": "^2.0.1",
-    "calcite-fonts": "github:ArcGIS/calcite-fonts",
     "npm-run-all": "4.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes calcite-fonts as a dep of calcite-components. 

Once the newest version of calcite-fonts makes it to the CDN, I'll add a link to the CDN for our local dev site, but we shouldn't have the repo listed as an actual dep.