### PR TITLE
Use calcite-base from npm, finish updating variables to new color format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,9 @@
       }
     },
     "@esri/calcite-base": {
-      "version": "github:ArcGIS/calcite-base#3d18d243f5d2d9fb80a450b7a4950381a6048f1d",
-      "from": "github:ArcGIS/calcite-base"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-base/-/calcite-base-1.0.0.tgz",
+      "integrity": "sha512-5//DBl/Utjv61zREGJkISi/+df57Kn1sDtsWgGpNr4izjXYJYuZg9ArEVpEqPTYiJXSZT6b3ULn5g0jAUwj2YQ=="
     },
     "@esri/calcite-colors": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@a11y/focus-trap": "^1.0.2",
-    "@esri/calcite-base": "github:ArcGIS/calcite-base",
+    "@esri/calcite-base": "^1.0.0",
     "@esri/calcite-colors": "^1.3.1",
     "@esri/calcite-ui-icons": "^2.0.1"
   },

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -87,25 +87,25 @@
 :host([appearance="solid"][color="blue"]) {
   button,
   a {
-    @include btn-solid($ui-blue, $ui-blue-hover, $ui-blue-pressed, $white);
+    @include btn-solid($ui-blue, $ui-blue-hover, $ui-blue-pressed, $blk-000);
   }
 }
 :host([appearance="solid"][color="red"]) {
   button,
   a {
-    @include btn-solid($ui-red, $ui-red-hover, $ui-red-pressed, $white);
+    @include btn-solid($ui-red, $ui-red-hover, $ui-red-pressed, $blk-000);
   }
 }
 :host([appearance="solid"][color="light"]) {
   button,
   a {
-    @include btn-solid($lightest-gray, $white, $lighter-gray, $black);
+    @include btn-solid($blk-010, $blk-000, $blk-020, $blk-240);
   }
 }
 :host([appearance="solid"][color="dark"]) {
   button,
   a {
-    @include btn-solid($darkest-gray, $darker-gray, $black, $white);
+    @include btn-solid($blk-200, $blk-180, $blk-240, $blk-000);
   }
 }
 // outline and clear
@@ -140,7 +140,7 @@
   button,
   a {
     @include btn-outline-clear(
-      $white,
+      $blk-000,
       $ui-blue,
       $ui-blue-hover,
       $ui-blue-pressed,
@@ -153,7 +153,7 @@
   button,
   a {
     @include btn-outline-clear(
-      $white,
+      $blk-000,
       $ui-red,
       $ui-red-hover,
       $ui-red-pressed,
@@ -166,12 +166,12 @@
   button,
   a {
     @include btn-outline-clear(
-      $white,
-      $lightest-gray,
-      $white,
-      $lighter-gray,
-      $off-black,
-      $black
+      $blk-000,
+      $blk-010,
+      $blk-000,
+      $blk-020,
+      $blk-220,
+      $blk-240
     );
   }
 }
@@ -179,12 +179,12 @@
   button,
   a {
     @include btn-outline-clear(
-      $white,
-      $darkest-gray,
-      $darker-gray,
-      $black,
-      $off-black,
-      $black
+      $blk-000,
+      $blk-200,
+      $blk-180,
+      $blk-240,
+      $blk-220,
+      $blk-240
     );
   }
 }
@@ -219,11 +219,11 @@
   a {
     @include btn-outline-clear(
       transparent,
-      $lightest-gray,
-      $white,
-      $lighter-gray,
-      $off-white,
-      $white
+      $blk-010,
+      $blk-000,
+      $blk-020,
+      $blk-005,
+      $blk-000
     );
   }
 }
@@ -232,11 +232,11 @@
   a {
     @include btn-outline-clear(
       transparent,
-      $darkest-gray,
-      $darker-gray,
-      $black,
-      $off-black,
-      $black
+      $blk-200,
+      $blk-180,
+      $blk-240,
+      $blk-220,
+      $blk-240
     );
   }
 }
@@ -290,13 +290,13 @@
 :host([appearance="inline"][color="light"]) {
   button,
   a {
-    @include btn-inline($lightest-gray, $white);
+    @include btn-inline($blk-010, $blk-000);
   }
 }
 :host([appearance="inline"][color="dark"]) {
   button,
   a {
-    @include btn-inline($darkest-gray, $darker-gray);
+    @include btn-inline($blk-200, $blk-180);
   }
 }
 :host([appearance="inline"][dir="rtl"]) {

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -1,13 +1,13 @@
 :host {
-  --calcite-modal-background: #{$white};
+  --calcite-modal-background: #{$blk-000};
   --calcite-modal-hover: #{$blk-010};
   --calcite-modal-pressed: #{$blk-020};
   --calcite-modal-header-text: #{$blk-220};
   --calcite-modal-body-text: #{$blk-220};
-  --calcite-modal-scrim: #{$transparent-black};
-  --calcite-modal-border: #{$lightest-gray};
-  --calcite-modal-red: #{$h-rr-060};
-  --calcite-modal-blue: #{$h-bb-060};
+  --calcite-modal-scrim: rgba(0, 0, 0, 0.75);
+  --calcite-modal-border: #{$blk-010};
+  --calcite-modal-red: #{$ui-red};
+  --calcite-modal-blue: #{$ui-blue};
   position: fixed;
   top: 0;
   right: 0;
@@ -31,11 +31,9 @@
   --calcite-modal-pressed: #{$blk-210};
   --calcite-modal-header-text: #{$blk-000};
   --calcite-modal-body-text: #{$blk-010};
-  --calcite-modal-scrim: #{$transparent-black};
   --calcite-modal-border: #{$blk-200};
-  --calcite-modal-hover: #{$darkest-gray};
-  --calcite-modal-red: #{$v-rr-160};
-  --calcite-modal-blue: #{$v-bb-160};
+  --calcite-modal-red: #{$ui-red-dark};
+  --calcite-modal-blue: #{$ui-blue-dark};
 }
 
 .modal {

--- a/src/components/calcite-progress/calcite-progress.scss
+++ b/src/components/calcite-progress/calcite-progress.scss
@@ -21,7 +21,7 @@ $looping-progress-bar-params: 1500ms linear infinite !default;
   width: 100%;
 }
 .calcite-progress:after {
-  background-color: rgba($white, 0.6);
+  background-color: rgba($ui-background, 0.6);
   z-index: 0;
 }
 

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -1,11 +1,11 @@
 :host {
   display: block;
-  --calcite-radio-group-color: #{$white};
+  --calcite-radio-group-color: #{$blk-000};
   --calcite-radio-group-border-color: #{$blk-130};
   --calcite-radio-group-color-active: #{$ui-blue};
-  --calcite-radio-group-text-color: #{$black};
-  --calcite-radio-group-text-color-active: #{$white};
-  --calcite-radio-group-color-hover: #{$off-white};
+  --calcite-radio-group-text-color: #{$blk-240};
+  --calcite-radio-group-text-color-active: #{$blk-000};
+  --calcite-radio-group-color-hover: #{$blk-005};
 
   @include font-size(-1);
 }
@@ -14,8 +14,8 @@
   --calcite-radio-group-color: #{$blk-200};
   --calcite-radio-group-border-color: #{$blk-210};
   --calcite-radio-group-color-active: #{$v-bb-160};
-  --calcite-radio-group-text-color: #{$white};
-  --calcite-radio-group-text-color-active: #{$white};
+  --calcite-radio-group-text-color: #{$blk-000};
+  --calcite-radio-group-text-color-active: #{$blk-000};
   --calcite-radio-group-color-hover: #{$blk-190};
 }
 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -15,7 +15,7 @@
   vertical-align: top;
   width: 36px;
   height: 20px;
-  background-color: $off-white;
+  background-color: $blk-005;
   border-radius: 30px;
   border: 1px solid $blk-020;
   transition: all 0.25s ease;
@@ -29,7 +29,7 @@
   top: -1px;
   left: -1px;
   right: auto;
-  background-color: $white;
+  background-color: $blk-000;
   border-radius: 30px;
   border: 2px solid $blk-130;
   box-shadow: 0 1px 1px 0px rgba($blk-200, 0.2);

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -4,7 +4,7 @@
   --calcite-tabs-color: #{$blk-200};
   --calcite-tabs-border: #{$blk-020};
   --calcite-tabs-border-hover: #{$blk-030};
-  --calcite-tabs-color-active: #{$off-black};
+  --calcite-tabs-color-active: #{$blk-220};
   --calcite-tabs-border-active: #{$ui-blue};
   --calcite-tabs-layout: flex-start;
   --calcite-tabs-tab-basis: auto;
@@ -17,8 +17,8 @@
   --calcite-tabs-color: #{$blk-010};
   --calcite-tabs-border: #{$blk-180};
   --calcite-tabs-border-hover: #{$blk-130};
-  --calcite-tabs-color-active: #{$off-white};
-  --calcite-tabs-border-active: #{$white};
+  --calcite-tabs-color-active: #{$blk-005};
+  --calcite-tabs-border-active: #{$blk-000};
 }
 
 :host([dir="rtl"]) {

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
       padding: 1rem;
     }
   </style>
+  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.2.0/fonts.css" />
   <link rel="stylesheet" href="/build/calcite.css" />
   <script type="module" src="build/calcite.esm.js"></script>
   <script nomodule src="build/calcite.js"></script>


### PR DESCRIPTION
- use calcite-base from newly published npm module
- update all remaining pre 1.0.0 colors
- add fonts via new CDN css reference