### PR TITLE
Initial Dropdown Commit

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.e2e.ts
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("calcite-dropdown", () => {
+  it("renders", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent("<calcite-dropdown></calcite-dropdown>");
+    const element = await page.find("calcite-dropdown");
+    expect(element).toHaveClass("hydrated");
+  });
+});

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -1,9 +1,21 @@
+// light theme
+:host {
+  --calcite-dropdown-group-color: #{$blk-180};
+  --calcite-dropdown-group-border-color: #{$blk-020};
+}
+
+// dark theme
+:host([theme="dark"]) {
+  --calcite-dropdown-group-color: #{$blk-000};
+  --calcite-dropdown-group-border-color: #{$blk-180};
+}
+
 :host .dropdown-title {
   display: block;
   margin: 0 $baseline/1.5 -1px $baseline/1.5;
   padding: $baseline/2 0;
-  border-bottom: 1px solid $lightest-gray;
-  color: $darkest-gray;
+  border-bottom: 1px solid var(--calcite-dropdown-group-border-color);
+  color: var(--calcite-dropdown-group-color);
   font-weight: 600;
   word-wrap: break-word;
   cursor: default;

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -10,10 +10,23 @@
   --calcite-dropdown-group-border-color: #{$blk-180};
 }
 
+// scale: s
+:host([scale="s"]) {
+  --calcite-dropdown-group-padding: #{$baseline/3 0};
+}
+
+:host([scale="m"]) {
+  --calcite-dropdown-group-padding: #{$baseline/2 0};
+}
+
+:host([scale="l"]) {
+  --calcite-dropdown-group-padding: #{$baseline/1.5 0};
+}
+
 :host .dropdown-title {
   display: block;
   margin: 0 $baseline/1.5 -1px $baseline/1.5;
-  padding: $baseline/2 0;
+  padding: var(--calcite-dropdown-group-padding);
   border-bottom: 1px solid var(--calcite-dropdown-group-border-color);
   color: var(--calcite-dropdown-group-color);
   font-weight: 600;

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -1,0 +1,11 @@
+:host .dropdown-title {
+  display: block;
+  margin: 0 $baseline/1.5 -1px $baseline/1.5;
+  padding: $baseline/2 0;
+  border-bottom: 1px solid $lightest-gray;
+  color: $darkest-gray;
+  font-weight: 600;
+  word-wrap: break-word;
+  cursor: default;
+  @include font-size(-2);
+}

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -10,7 +10,7 @@ import {
   State
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
-
+import { getElementTheme } from "../../utils/dom";
 import DropdownInterface from "../../interfaces/DropdownInterface";
 
 @Component({
@@ -55,7 +55,7 @@ export class CalciteDropdownGroup {
 
   componentDidLoad() {
     this.groupPosition = this.getGroupPosition();
-    this.sortItems();
+    this.items = this.sortItems(this.items);
     this.registerCalciteDropdownGroup.emit({
       items: this.items,
       position: this.groupPosition
@@ -63,6 +63,7 @@ export class CalciteDropdownGroup {
   }
 
   render() {
+    const theme = getElementTheme(this.el);
     const dropdownState = {
       requestedDropdownGroup: this.requestedDropdownGroup,
       requestedDropdownItem: this.requestedDropdownItem
@@ -73,7 +74,7 @@ export class CalciteDropdownGroup {
     ) : null;
 
     return (
-      <Host id={this.dropdownGroupId}>
+      <Host theme={theme} id={this.dropdownGroupId}>
         {grouptitle}
         <DropdownInterface.Provider state={dropdownState}>
           <slot />
@@ -140,13 +141,12 @@ export class CalciteDropdownGroup {
     return groupPosition;
   }
 
-  private sortItems() {
-    this.items = this.items
+  private sortItems = (items: any[]): any[] =>
+    items
       .sort(function(a, b) {
         return a.position - b.position;
       })
       .map(function(a) {
         return a.item;
       });
-  }
 }

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -1,0 +1,152 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+  State
+} from "@stencil/core";
+import { guid } from "../../utils/guid";
+
+import DropdownInterface from "../../interfaces/DropdownInterface";
+
+@Component({
+  tag: "calcite-dropdown-group",
+  styleUrl: "calcite-dropdown-group.scss",
+  shadow: true
+})
+export class CalciteDropdownGroup {
+  //--------------------------------------------------------------------------
+  //
+  //  Element
+  //
+  //--------------------------------------------------------------------------
+  @Element() el: HTMLElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Public Properties
+  //
+  //--------------------------------------------------------------------------
+
+  @State() requestedDropdownGroup: string = "";
+  @State() requestedDropdownItem: string = "";
+
+  /** optionally set a group title for display */
+  @Prop({ reflect: true }) grouptitle?: string = null;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  //--------------------------------------------------------------------------
+
+  @Event() calciteDropdownItemHasChanged: EventEmitter;
+  @Event() registerCalciteDropdownGroup: EventEmitter;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  componentDidLoad() {
+    this.groupPosition = this.getGroupPosition();
+    this.sortItems();
+    this.registerCalciteDropdownGroup.emit({
+      items: this.items,
+      position: this.groupPosition
+    });
+  }
+
+  render() {
+    const dropdownState = {
+      requestedDropdownGroup: this.requestedDropdownGroup,
+      requestedDropdownItem: this.requestedDropdownItem
+    };
+
+    const grouptitle = this.grouptitle ? (
+      <span class="dropdown-title">{this.grouptitle}</span>
+    ) : null;
+
+    return (
+      <Host id={this.dropdownGroupId}>
+        {grouptitle}
+        <DropdownInterface.Provider state={dropdownState}>
+          <slot />
+        </DropdownInterface.Provider>
+      </Host>
+    );
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Event Listeners
+  //
+  //--------------------------------------------------------------------------
+
+  @Listen("calciteDropdownItemSelected") updateActiveItemOnChange(
+    event: CustomEvent
+  ) {
+    this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
+    this.requestedDropdownItem = event.detail.requestedDropdownItem;
+
+    this.calciteDropdownItemHasChanged.emit({
+      requestedDropdownGroup: this.requestedDropdownGroup,
+      requestedDropdownItem: this.requestedDropdownItem
+    });
+  }
+
+  @Listen("registerCalciteDropdownItem") registerCalciteDropdownItem(
+    e: CustomEvent
+  ) {
+    const item = {
+      item: e.detail.item as HTMLCalciteDropdownItemElement,
+      position: e.detail.position
+    };
+    this.items.push(item);
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private State/Props
+  //
+  //--------------------------------------------------------------------------
+
+  /** created list of dropdown items */
+  @State() private items = [];
+
+  /** @internal */
+  @State() private groupPosition: number;
+
+  /** unique id for dropdown group */
+  /** @internal */
+  private dropdownGroupId = `calcite-dropdown-group-${guid()}`;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  private getGroupPosition() {
+    const groupPosition = Array.prototype.indexOf.call(
+      this.el.parentElement.querySelectorAll("calcite-dropdown-group"),
+      this.el
+    );
+    return groupPosition;
+  }
+
+  private sortItems() {
+    this.items = this.items
+      .sort(function(a, b) {
+        return a.position - b.position;
+      })
+      .map(function(a) {
+        return a.item;
+      });
+  }
+}

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -10,7 +10,7 @@ import {
   State
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
-import { getElementTheme } from "../../utils/dom";
+import { getElementTheme, getElementProp } from "../../utils/dom";
 import DropdownInterface from "../../interfaces/DropdownInterface";
 
 @Component({
@@ -64,6 +64,7 @@ export class CalciteDropdownGroup {
 
   render() {
     const theme = getElementTheme(this.el);
+    const scale = getElementProp(this.el, "scale", "m");
     const dropdownState = {
       requestedDropdownGroup: this.requestedDropdownGroup,
       requestedDropdownItem: this.requestedDropdownItem
@@ -74,7 +75,7 @@ export class CalciteDropdownGroup {
     ) : null;
 
     return (
-      <Host theme={theme} id={this.dropdownGroupId}>
+      <Host theme={theme} scale={scale} id={this.dropdownGroupId}>
         {grouptitle}
         <DropdownInterface.Provider state={dropdownState}>
           <slot />
@@ -134,19 +135,12 @@ export class CalciteDropdownGroup {
   //--------------------------------------------------------------------------
 
   private getGroupPosition() {
-    const groupPosition = Array.prototype.indexOf.call(
+    return Array.prototype.indexOf.call(
       this.el.parentElement.querySelectorAll("calcite-dropdown-group"),
       this.el
     );
-    return groupPosition;
   }
 
   private sortItems = (items: any[]): any[] =>
-    items
-      .sort(function(a, b) {
-        return a.position - b.position;
-      })
-      .map(function(a) {
-        return a.item;
-      });
+    items.sort((a, b) => a.position - b.position).map(a => a.item);
 }

--- a/src/components/calcite-dropdown-group/readme.md
+++ b/src/components/calcite-dropdown-group/readme.md
@@ -1,0 +1,38 @@
+# calcite-dropdown-group
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute    | Description                              | Type     | Default |
+| ------------ | ------------ | ---------------------------------------- | -------- | ------- |
+| `grouptitle` | `grouptitle` | optionally set a group title for display | `string` | `null`  |
+
+
+## Events
+
+| Event                           | Description | Type               |
+| ------------------------------- | ----------- | ------------------ |
+| `calciteDropdownItemHasChanged` |             | `CustomEvent<any>` |
+| `registerCalciteDropdownGroup`  |             | `CustomEvent<any>` |
+
+
+## Dependencies
+
+### Depends on
+
+- context-consumer
+
+### Graph
+```mermaid
+graph TD;
+  calcite-dropdown-group --> context-consumer
+  style calcite-dropdown-group fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.e2e.ts
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("calcite-dropdown", () => {
+  it("renders", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent("<calcite-dropdown></calcite-dropdown>");
+    const element = await page.find("calcite-dropdown");
+    expect(element).toHaveClass("hydrated");
+  });
+});

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -6,7 +6,7 @@
   --calcite-dropdown-item-color-active: #{$blk-180};
   --calcite-dropdown-item-background-color-hover: #{$blk-010};
   --calcite-dropdown-item-background-color-pressed: #{$blk-020};
-  --calcite-dropdown-item-dot-active: #{$ui-blue};
+  --calcite-dropdown-item-dot-active-color: #{$ui-blue};
 }
 
 // dark theme
@@ -16,7 +16,23 @@
   --calcite-dropdown-item-color-active: #{$blk-000};
   --calcite-dropdown-item-background-color-hover: #{$blk-210};
   --calcite-dropdown-item-background-color-pressed: #{$blk-220};
-  --calcite-dropdown-item-dot-active: #{$ui-blue-dark};
+  --calcite-dropdown-item-dot-active-color: #{$ui-blue-dark};
+}
+
+// scale: s
+:host([scale="s"]) {
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5
+    $baseline * 1.5};
+}
+
+:host([scale="m"]) {
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3
+    $baseline * 1.5};
+}
+
+:host([scale="l"]) {
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2
+    $baseline * 1.5};
 }
 
 :host slot {
@@ -24,7 +40,7 @@
   @include font-size(-2);
   color: var(--calcite-dropdown-item-color);
   transition: 0.15s all ease-in-out;
-  padding: $baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5;
+  padding: var(--calcite-dropdown-item-padding);
   cursor: pointer;
   text-decoration: none;
 
@@ -43,7 +59,7 @@
     position: absolute;
     left: 1rem;
     opacity: 0;
-    color: $gray;
+    color: $blk-120;
     transition: 0.15s ease-in-out;
   }
   &:hover:before,
@@ -66,6 +82,6 @@
   font-weight: 500;
   &:before {
     opacity: 1;
-    color: var(--calcite-dropdown-item-dot-active);
+    color: var(--calcite-dropdown-item-dot-active-color);
   }
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -35,7 +35,7 @@
     $baseline * 1.5};
 }
 
-:host slot {
+:host {
   display: block;
   @include font-size(-2);
   color: var(--calcite-dropdown-item-color);
@@ -43,33 +43,34 @@
   padding: var(--calcite-dropdown-item-padding);
   cursor: pointer;
   text-decoration: none;
-
-  &:hover,
-  &:focus,
-  &:active {
-    background-color: var(--calcite-dropdown-item-background-color-hover);
-    color: var(--calcite-dropdown-item-color-hover);
-    text-decoration: none;
-  }
-  &:active {
-    background-color: var(--calcite-dropdown-item-background-color-pressed);
-  }
-  &:before {
-    content: "\2022";
-    position: absolute;
-    left: 1rem;
-    opacity: 0;
-    color: $blk-120;
-    transition: 0.15s ease-in-out;
-  }
-  &:hover:before,
-  &:active:before,
-  &:focus:before {
-    opacity: 1;
-  }
+  position: relative;
 }
 
-:host([dir="rtl"]) slot {
+:host(:hover),
+:host(:focus),
+:host(:active) {
+  background-color: var(--calcite-dropdown-item-background-color-hover);
+  color: var(--calcite-dropdown-item-color-hover);
+  text-decoration: none;
+}
+:host(:active) {
+  background-color: var(--calcite-dropdown-item-background-color-pressed);
+}
+:host:before {
+  content: "\2022";
+  position: absolute;
+  left: 1rem;
+  opacity: 0;
+  color: $blk-120;
+  transition: 0.15s ease-in-out;
+}
+:host(:hover):before,
+:host(:active):before,
+:host(:focus):before {
+  opacity: 1;
+}
+
+:host([dir="rtl"]) {
   padding: $baseline/3 $baseline * 1.5 $baseline/3 $baseline/1.5;
   &:before {
     left: unset;
@@ -77,7 +78,7 @@
   }
 }
 
-:host([active]) slot {
+:host([active]) {
   color: var(--calcite-dropdown-item-color-active);
   font-weight: 500;
   &:before {

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -1,0 +1,51 @@
+:host slot {
+  display: block;
+  @include font-size(-2);
+  color: $dark-gray;
+  transition: 0.15s all ease-in-out;
+  padding: $baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5;
+  cursor: pointer;
+  text-decoration: none;
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: $off-white;
+    color: $darkest-gray;
+    text-decoration: none;
+  }
+  &:active {
+    background-color: $lightest-gray;
+  }
+  &:before {
+    content: "\2022";
+    position: absolute;
+    left: 1rem;
+    opacity: 0;
+    color: $gray;
+    transition: 0.15s ease-in-out;
+  }
+  &:hover:before {
+    opacity: 1;
+  }
+  &:focus:before {
+    opacity: 1;
+    color: $blue;
+  }
+}
+
+:host([dir="rtl"]) slot {
+  padding: $baseline/3 $baseline * 1.5 $baseline/3 $baseline/1.5;
+  &:before {
+    left: unset;
+    right: 1rem;
+  }
+}
+
+:host([active]) slot {
+  color: $black;
+  font-weight: 500;
+  &:before {
+    opacity: 1;
+    color: $blue;
+  }
+}

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -1,20 +1,42 @@
+// theme variables
+// light theme
+:host {
+  --calcite-dropdown-item-color: #{$blk-140};
+  --calcite-dropdown-item-color-hover: #{$blk-160};
+  --calcite-dropdown-item-color-active: #{$blk-180};
+  --calcite-dropdown-item-background-color-hover: #{$blk-010};
+  --calcite-dropdown-item-background-color-pressed: #{$blk-020};
+  --calcite-dropdown-item-dot-active: #{$ui-blue};
+}
+
+// dark theme
+:host([theme="dark"]) {
+  --calcite-dropdown-item-color: #{$blk-040};
+  --calcite-dropdown-item-color-hover: #{$blk-020};
+  --calcite-dropdown-item-color-active: #{$blk-000};
+  --calcite-dropdown-item-background-color-hover: #{$blk-210};
+  --calcite-dropdown-item-background-color-pressed: #{$blk-220};
+  --calcite-dropdown-item-dot-active: #{$ui-blue-dark};
+}
+
 :host slot {
   display: block;
   @include font-size(-2);
-  color: $dark-gray;
+  color: var(--calcite-dropdown-item-color);
   transition: 0.15s all ease-in-out;
   padding: $baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5;
   cursor: pointer;
   text-decoration: none;
+
   &:hover,
   &:focus,
   &:active {
-    background-color: $off-white;
-    color: $darkest-gray;
+    background-color: var(--calcite-dropdown-item-background-color-hover);
+    color: var(--calcite-dropdown-item-color-hover);
     text-decoration: none;
   }
   &:active {
-    background-color: $lightest-gray;
+    background-color: var(--calcite-dropdown-item-background-color-pressed);
   }
   &:before {
     content: "\2022";
@@ -24,12 +46,10 @@
     color: $gray;
     transition: 0.15s ease-in-out;
   }
-  &:hover:before {
-    opacity: 1;
-  }
+  &:hover:before,
+  &:active:before,
   &:focus:before {
     opacity: 1;
-    color: $blue;
   }
 }
 
@@ -42,10 +62,10 @@
 }
 
 :host([active]) slot {
-  color: $black;
+  color: var(--calcite-dropdown-item-color-active);
   font-weight: 500;
   &:before {
     opacity: 1;
-    color: $blue;
+    color: var(--calcite-dropdown-item-dot-active);
   }
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -9,7 +9,17 @@ import {
   Prop,
   State
 } from "@stencil/core";
-import { getElementDir } from "../../utils/dom";
+import {
+  UP,
+  DOWN,
+  TAB,
+  ENTER,
+  ESCAPE,
+  HOME,
+  END,
+  SPACE
+} from "../../utils/keys";
+import { getElementDir, getElementTheme } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import DropdownInterface from "../../interfaces/DropdownInterface";
 
@@ -34,9 +44,6 @@ export class CalciteDropdownItem {
   //--------------------------------------------------------------------------
 
   @Prop({ reflect: true, mutable: true }) active: boolean = false;
-
-  /** @internal */
-  @Prop() currentDropdownGroup: string = this.el.parentElement.id;
 
   /** @internal */
   @Prop() requestedDropdownGroup: string = "";
@@ -77,9 +84,11 @@ export class CalciteDropdownItem {
 
   render() {
     const dir = getElementDir(this.el);
+    const theme = getElementTheme(this.el);
     const selected = this.active ? "true" : null;
     return (
       <Host
+        theme={theme}
         dir={dir}
         id={this.dropdownItemId}
         tabindex="0"
@@ -102,19 +111,19 @@ export class CalciteDropdownItem {
   }
 
   @Listen("keydown") keyDownHandler(e) {
-    switch (e.key) {
-      case " ":
-      case "Enter":
+    switch (e.keyCode) {
+      case SPACE:
+      case ENTER:
         this.emitRequestedItem(e);
         break;
-      case "Escape":
+      case ESCAPE:
         this.closeCalciteDropdown.emit();
         break;
-      case "Tab":
-      case "ArrowUp":
-      case "ArrowDown":
-      case "Home":
-      case "End":
+      case TAB:
+      case UP:
+      case DOWN:
+      case HOME:
+      case END:
         this.calciteDropdownItemKeyEvent.emit({ item: e });
         break;
     }
@@ -130,8 +139,13 @@ export class CalciteDropdownItem {
   /** @internal */
   private dropdownItemId = `calcite-dropdown-item-${guid()}`;
 
+  /** position withing group */
   /** @internal */
   @State() private itemPosition: number;
+
+  /** id of containing group */
+  /** @internal */
+  @State() private currentDropdownGroup: string = this.el.parentElement.id;
 
   //--------------------------------------------------------------------------
   //
@@ -156,11 +170,10 @@ export class CalciteDropdownItem {
   }
 
   private getItemPosition() {
-    const itemPosition = Array.prototype.indexOf.call(
+    return Array.prototype.indexOf.call(
       this.el.parentElement.querySelectorAll("calcite-dropdown-item"),
       this.el
     );
-    return itemPosition;
   }
 }
 

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -19,7 +19,7 @@ import {
   END,
   SPACE
 } from "../../utils/keys";
-import { getElementDir, getElementTheme } from "../../utils/dom";
+import { getElementDir, getElementTheme, getElementProp } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import DropdownInterface from "../../interfaces/DropdownInterface";
 
@@ -85,11 +85,13 @@ export class CalciteDropdownItem {
   render() {
     const dir = getElementDir(this.el);
     const theme = getElementTheme(this.el);
+    const scale = getElementProp(this.el, "scale", "m");
     const selected = this.active ? "true" : null;
     return (
       <Host
         theme={theme}
         dir={dir}
+        scale={scale}
         id={this.dropdownItemId}
         tabindex="0"
         role="menuitem"

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -1,0 +1,176 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+  State
+} from "@stencil/core";
+import { getElementDir } from "../../utils/dom";
+import { guid } from "../../utils/guid";
+import DropdownInterface from "../../interfaces/DropdownInterface";
+
+@Component({
+  tag: "calcite-dropdown-item",
+  styleUrl: "calcite-dropdown-item.scss",
+  shadow: true
+})
+export class CalciteDropdownItem {
+  //--------------------------------------------------------------------------
+  //
+  //  Element
+  //
+  //--------------------------------------------------------------------------
+
+  @Element() el: HTMLElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Public Properties
+  //
+  //--------------------------------------------------------------------------
+
+  @Prop({ reflect: true, mutable: true }) active: boolean = false;
+
+  /** @internal */
+  @Prop() currentDropdownGroup: string = this.el.parentElement.id;
+
+  /** @internal */
+  @Prop() requestedDropdownGroup: string = "";
+
+  /** @internal */
+  @Prop() requestedDropdownItem: string = "";
+
+  //--------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  //--------------------------------------------------------------------------
+
+  @Event() calciteDropdownItemSelected: EventEmitter;
+  @Event() calciteDropdownItemKeyEvent: EventEmitter;
+  @Event() closeCalciteDropdown: EventEmitter;
+  @Event() registerCalciteDropdownItem: EventEmitter;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  componentDidLoad() {
+    this.currentDropdownGroup = this.el.parentElement.id;
+    this.itemPosition = this.getItemPosition();
+
+    this.registerCalciteDropdownItem.emit({
+      item: this.el,
+      position: this.itemPosition
+    });
+  }
+
+  componentDidUpdate() {
+    this.determineActiveItem();
+  }
+
+  render() {
+    const dir = getElementDir(this.el);
+    const selected = this.active ? "true" : null;
+    return (
+      <Host
+        dir={dir}
+        id={this.dropdownItemId}
+        tabindex="0"
+        role="menuitem"
+        aria-selected={selected}
+      >
+        <slot />
+      </Host>
+    );
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Event Listeners
+  //
+  //--------------------------------------------------------------------------
+
+  @Listen("click") onClick(e) {
+    this.emitRequestedItem(e);
+  }
+
+  @Listen("keydown") keyDownHandler(e) {
+    switch (e.key) {
+      case " ":
+      case "Enter":
+        this.emitRequestedItem(e);
+        break;
+      case "Escape":
+        this.closeCalciteDropdown.emit();
+        break;
+      case "Tab":
+      case "ArrowUp":
+      case "ArrowDown":
+      case "Home":
+      case "End":
+        this.calciteDropdownItemKeyEvent.emit({ item: e });
+        break;
+    }
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private State/Props
+  //
+  //--------------------------------------------------------------------------
+
+  /** unique id for dropdown item */
+  /** @internal */
+  private dropdownItemId = `calcite-dropdown-item-${guid()}`;
+
+  /** @internal */
+  @State() private itemPosition: number;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  private determineActiveItem() {
+    if (this.requestedDropdownItem === this.dropdownItemId) {
+      this.active = true;
+    } else if (this.requestedDropdownGroup === this.currentDropdownGroup) {
+      this.active = false;
+    }
+  }
+
+  private emitRequestedItem(e) {
+    this.calciteDropdownItemSelected.emit({
+      requestedDropdownItem: e.target.id,
+      requestedDropdownGroup: e.target.parentElement.id
+    });
+    this.closeCalciteDropdown.emit();
+  }
+
+  private getItemPosition() {
+    const itemPosition = Array.prototype.indexOf.call(
+      this.el.parentElement.querySelectorAll("calcite-dropdown-item"),
+      this.el
+    );
+    return itemPosition;
+  }
+}
+
+//--------------------------------------------------------------------------
+//
+//  Inject Props
+//
+//--------------------------------------------------------------------------
+
+DropdownInterface.injectProps(CalciteDropdownItem, [
+  "requestedDropdownItem",
+  "requestedDropdownGroup"
+]);

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -19,7 +19,11 @@ import {
   END,
   SPACE
 } from "../../utils/keys";
-import { getElementDir, getElementTheme, getElementProp } from "../../utils/dom";
+import {
+  getElementDir,
+  getElementTheme,
+  getElementProp
+} from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import DropdownInterface from "../../interfaces/DropdownInterface";
 

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -1,0 +1,40 @@
+# calcite-dropdown-item
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description | Type      | Default |
+| -------- | --------- | ----------- | --------- | ------- |
+| `active` | `active`  |             | `boolean` | `false` |
+
+
+## Events
+
+| Event                         | Description | Type               |
+| ----------------------------- | ----------- | ------------------ |
+| `calciteDropdownItemKeyEvent` |             | `CustomEvent<any>` |
+| `calciteDropdownItemSelected` |             | `CustomEvent<any>` |
+| `closeCalciteDropdown`        |             | `CustomEvent<any>` |
+| `registerCalciteDropdownItem` |             | `CustomEvent<any>` |
+
+
+## Dependencies
+
+### Depends on
+
+- context-consumer
+
+### Graph
+```mermaid
+graph TD;
+  calcite-dropdown-item --> context-consumer
+  style calcite-dropdown-item fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("calcite-dropdown", () => {
+  it("renders", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent("<calcite-dropdown></calcite-dropdown>");
+    const element = await page.find("calcite-dropdown");
+    expect(element).toHaveClass("hydrated");
+  });
+});

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,0 +1,56 @@
+:host {
+  position: relative;
+  display: inline-block;
+}
+:host([active]) .calcite-dropdown-wrapper {
+  transform: translate3d(0, 0, 0);
+  opacity: 1;
+  visibility: visible;
+}
+
+:host .calcite-dropdown-wrapper {
+  transform: translate3d(0, $baseline, 0);
+  transition: 300ms $easing-function, opacity 300ms $easing-function,
+    all 0.15s ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  display: block;
+  position: absolute;
+  left: 0;
+  z-index: 200;
+  overflow: auto;
+  width: auto;
+  width: 12.5rem;
+  background: $white;
+  border: 1px solid $lighter-gray;
+  box-shadow: 0 0 12px 0 rgba($black, 0.15);
+}
+
+:host([dir="rtl"]) .calcite-dropdown-wrapper {
+  right: 0;
+  left: unset;
+}
+
+:host([alignment="right"]) .calcite-dropdown-wrapper {
+  right: 0;
+  left: unset;
+}
+
+:host([dir="rtl"][alignment="right"]) .calcite-dropdown-wrapper {
+  right: unset;
+  left: 0;
+}
+
+:host([alignment="center"]) .calcite-dropdown-wrapper {
+  right: 0;
+  left: 0;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@mixin dropdown-element-base() {
+  @include font-size(-2);
+  display: block;
+  color: $dark-gray;
+  background-color: transparent;
+}

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,3 +1,16 @@
+// theme variables
+// light theme
+:host {
+  --calcite-dropdown-background-color: #{$blk-000};
+  --calcite-dropdown-border-color: #{$blk-020};
+}
+
+// dark theme
+:host([theme="dark"]) {
+  --calcite-dropdown-background-color: #{$blk-200};
+  --calcite-dropdown-border-color: #{$blk-220};
+}
+
 :host {
   position: relative;
   display: inline-block;
@@ -21,9 +34,9 @@
   overflow: auto;
   width: auto;
   width: 12.5rem;
-  background: $white;
-  border: 1px solid $lighter-gray;
-  box-shadow: 0 0 12px 0 rgba($black, 0.15);
+  background: var(--calcite-dropdown-background-color);
+  border: 1px solid var(--calcite-dropdown-border-color);
+  box-shadow: 0 0 12px 0 rgba($blk-240, 0.15);
 }
 
 :host([dir="rtl"]) .calcite-dropdown-wrapper {
@@ -46,11 +59,4 @@
   left: 0;
   margin-right: auto;
   margin-left: auto;
-}
-
-@mixin dropdown-element-base() {
-  @include font-size(-2);
-  display: block;
-  color: $dark-gray;
-  background-color: transparent;
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -51,6 +51,9 @@ export class CalciteDropdown {
   /** specify the alignment of dropdrown, defaults to left */
   @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
 
+  /** specify the scale of dropdrown, defaults to m */
+  @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" = "m";
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -64,6 +67,9 @@ export class CalciteDropdown {
 
     let theme = ["light", "dark"];
     if (!theme.includes(this.theme)) this.theme = "light";
+
+    let scale = ["s", "m", "l"];
+    if (!scale.includes(this.scale)) this.scale = "m";
   }
 
   componentWillUpdate() {

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -1,0 +1,216 @@
+import {
+  Component,
+  Element,
+  h,
+  Host,
+  Listen,
+  Prop,
+  State
+} from "@stencil/core";
+import { getElementDir } from "../../utils/dom";
+import { guid } from "../../utils/guid";
+
+@Component({
+  tag: "calcite-dropdown",
+  styleUrl: "calcite-dropdown.scss",
+  shadow: true
+})
+export class CalciteDropdown {
+  //--------------------------------------------------------------------------
+  //
+  //  Element
+  //
+  //--------------------------------------------------------------------------
+
+  @Element() el: HTMLElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Public Properties
+  //
+  //--------------------------------------------------------------------------
+
+  @State() active: boolean = false;
+
+  /** specify the alignment of dropdrown, defaults to left */
+  @Prop({ mutable: true, reflect: true }) alignment:
+    | "left"
+    | "right"
+    | "center" = "left";
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  connectedCallback() {
+    // validate props
+    let alignment = ["left", "right", "center"];
+    if (!alignment.includes(this.alignment)) this.alignment = "left";
+  }
+
+  componentWillUpdate() {
+    if (!this.sorted) this.sortItems();
+  }
+
+  render() {
+    const dir = getElementDir(this.el);
+    const expanded = this.active ? "true" : "false";
+    return (
+      <Host dir={dir} active={!!this.active} id={this.dropdownId}>
+        <slot
+          name="dropdown-trigger"
+          aria-haspopup="true"
+          aria-expanded={expanded}
+        ></slot>
+        <div class="calcite-dropdown-wrapper" role="menu">
+          <slot />
+        </div>
+      </Host>
+    );
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Event Listeners
+  //
+  //--------------------------------------------------------------------------
+
+  @Listen("click") openDropdown(e) {
+    if (e.target.slot === "dropdown-trigger") {
+      this.openCalciteDropdown();
+    }
+  }
+
+  @Listen("click", { target: "window" }) closeCalciteDropdownOnClick(e) {
+    if (this.active && e.target.offsetParent.id !== this.dropdownId)
+      this.closeCalciteDropdown();
+  }
+
+  @Listen("closeCalciteDropdown") closeCalciteDropdownOnEvent() {
+    this.closeCalciteDropdown();
+  }
+
+  @Listen("keydown") keyDownHandler(e) {
+    if (e.target.slot === "dropdown-trigger") {
+      if (
+        e.target.nodeName !== "BUTTON" &&
+        e.target.nodeName !== "CALCITE-BUTTON"
+      ) {
+        switch (e.key) {
+          case " ":
+          case "Enter":
+            this.openCalciteDropdown();
+            break;
+          case "Escape":
+            this.closeCalciteDropdown();
+            break;
+        }
+      } else if (e.key === "Escape" || (e.shiftKey && e.key === "Tab")) {
+        this.closeCalciteDropdown();
+      }
+    }
+  }
+
+  @Listen("calciteDropdownItemKeyEvent") calciteDropdownItemKeyEvent(
+    item: CustomEvent
+  ) {
+    let e = item.detail.item;
+    let isFirstItem = this.itemIndex(e.target) === 0;
+    let isLastItem = this.itemIndex(e.target) === this.items.length - 1;
+    switch (e.key) {
+      case "Tab":
+        if (isLastItem && !e.shiftKey) this.closeCalciteDropdown();
+        if (isFirstItem && e.shiftKey) this.closeCalciteDropdown();
+        break;
+      case "ArrowDown":
+        this.focusNextItem(e.target);
+        break;
+      case "ArrowUp":
+        this.focusPrevItem(e.target);
+        break;
+      case "Home":
+        this.focusFirstItem();
+        break;
+      case "End":
+        this.focusLastItem();
+        break;
+    }
+  }
+
+  @Listen("registerCalciteDropdownGroup") registerCalciteDropdownGroup(
+    e: CustomEvent
+  ) {
+    const items = {
+      items: e.detail.items as HTMLCalciteDropdownItemElement,
+      position: e.detail.position
+    };
+    this.items.push(items);
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private State/Props
+  //
+  //--------------------------------------------------------------------------
+
+  /** created list of dropdown items */
+  @State() private items = [];
+
+  @State() private sorted = false;
+
+  /** unique id for dropdown */
+  /** @internal */
+  private dropdownId = `calcite-dropdown-${guid()}`;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  private closeCalciteDropdown() {
+    this.active = false;
+  }
+
+  private focusFirstItem() {
+    const firstItem = this.items[0];
+    firstItem.focus();
+  }
+
+  private focusLastItem() {
+    const lastItem = this.items[this.items.length - 1];
+    lastItem.focus();
+  }
+
+  private focusNextItem(e) {
+    const index = this.itemIndex(e);
+    const nextItem = this.items[index + 1] || this.items[0];
+    nextItem.focus();
+  }
+
+  private focusPrevItem(e) {
+    const index = this.itemIndex(e);
+    const prevItem = this.items[index - 1] || this.items[this.items.length - 1];
+    prevItem.focus();
+  }
+
+  private itemIndex(e) {
+    return this.items.indexOf(e);
+  }
+
+  private openCalciteDropdown() {
+    this.active = !this.active;
+    this.focusFirstItem();
+  }
+
+  private sortItems() {
+    this.items = this.items
+      .sort(function(a, b) {
+        return a.position - b.position;
+      })
+      .concat.apply([], this.items.map(item => item.items));
+    this.sorted = true;
+  }
+}

--- a/src/components/calcite-dropdown/readme.md
+++ b/src/components/calcite-dropdown/readme.md
@@ -1,0 +1,19 @@
+# calcite-dropdown
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute   | Description                                          | Type                            | Default   |
+| ----------- | ----------- | ---------------------------------------------------- | ------------------------------- | --------- |
+| `alignment` | `alignment` | specify the alignment of dropdrown, defaults to left | `"center" \| "left" \| "right"` | `"left"`  |
+| `scale`     | `scale`     | specify the scale of dropdrown, defaults to m        | `"l" \| "m" \| "s"`             | `"m"`     |
+| `theme`     | `theme`     | specify the alignment of dropdrown, defaults to left | `"dark" \| "light"`             | `"light"` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/index.html
+++ b/src/index.html
@@ -876,21 +876,21 @@
           </calcite-dropdown-group>
         </calcite-dropdown>
         <calcite-dropdown>
-            <calcite-button slot="dropdown-trigger">Dropdown with Three Groups</calcite-button>
-            <calcite-dropdown-group grouptitle="Sort by">
-              <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-              <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
-              <calcite-dropdown-item>Title</calcite-dropdown-item>
-            </calcite-dropdown-group>
-            <calcite-dropdown-group grouptitle="Sort Direction">
-              <calcite-dropdown-item active>Least recent</calcite-dropdown-item>
-              <calcite-dropdown-item>Most recent</calcite-dropdown-item>
-            </calcite-dropdown-group>
-            <calcite-dropdown-group grouptitle="Price">
-                <calcite-dropdown-item>Less</calcite-dropdown-item>
-                <calcite-dropdown-item active>More</calcite-dropdown-item>
-              </calcite-dropdown-group>
-          </calcite-dropdown>
+          <calcite-button slot="dropdown-trigger">Dropdown with Three Groups</calcite-button>
+          <calcite-dropdown-group grouptitle="Sort by">
+            <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item>Title</calcite-dropdown-item>
+          </calcite-dropdown-group>
+          <calcite-dropdown-group grouptitle="Sort Direction">
+            <calcite-dropdown-item active>Least recent</calcite-dropdown-item>
+            <calcite-dropdown-item>Most recent</calcite-dropdown-item>
+          </calcite-dropdown-group>
+          <calcite-dropdown-group grouptitle="Price">
+            <calcite-dropdown-item>Less</calcite-dropdown-item>
+            <calcite-dropdown-item active>More</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
 
         <calcite-dropdown alignment="right">
           <calcite-button slot="dropdown-trigger">Open Dropdown right aligned</calcite-button>
@@ -917,15 +917,15 @@
         <br />
         <br />
         <calcite-dropdown theme="dark">
-        <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode</calcite-button>
-        <calcite-dropdown-group>
-          <calcite-dropdown-item>Mint</calcite-dropdown-item>
-          <calcite-dropdown-item active>Chocolate</calcite-dropdown-item>
-          <calcite-dropdown-item>Banana</calcite-dropdown-item>
-          <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
-          <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>
+          <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode</calcite-button>
+          <calcite-dropdown-group>
+            <calcite-dropdown-item>Mint</calcite-dropdown-item>
+            <calcite-dropdown-item active>Chocolate</calcite-dropdown-item>
+            <calcite-dropdown-item>Banana</calcite-dropdown-item>
+            <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
+            <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
 
         <calcite-dropdown theme="dark">
           <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode with groups</calcite-button>
@@ -942,11 +942,29 @@
             <calcite-dropdown-item>Western</calcite-dropdown-item>
             <calcite-dropdown-item>R&B</calcite-dropdown-item>
           </calcite-dropdown-group>
-      </calcite-dropdown>
-      <br />
-      <br />
-        <calcite-dropdown>
-          <span slot="dropdown-trigger" tabIndex="0">I'm a span trigger</span>
+        </calcite-dropdown>
+        <br />
+        <br />
+        <calcite-dropdown scale="s">
+          <calcite-button scale="s" slot="dropdown-trigger">Scale S small</calcite-button>
+          <calcite-dropdown-group grouptitle="View">
+            <calcite-dropdown-item active>List</calcite-dropdown-item>
+            <calcite-dropdown-item>Grid</calcite-dropdown-item>
+            <calcite-dropdown-item>Table</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+
+        <calcite-dropdown scale="m">
+          <calcite-button scale="m" slot="dropdown-trigger">Scale M medium</calcite-button>
+          <calcite-dropdown-group grouptitle="View">
+            <calcite-dropdown-item active>List</calcite-dropdown-item>
+            <calcite-dropdown-item>Grid</calcite-dropdown-item>
+            <calcite-dropdown-item>Table</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+
+        <calcite-dropdown scale="l">
+          <calcite-button color="dark" scale="l" slot="dropdown-trigger">Scale L large</calcite-button>
           <calcite-dropdown-group grouptitle="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>

--- a/src/index.html
+++ b/src/index.html
@@ -915,10 +915,38 @@
           </calcite-dropdown-group>
         </calcite-dropdown>
         <br />
+        <br />
+        <calcite-dropdown theme="dark">
+        <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode</calcite-button>
+        <calcite-dropdown-group>
+          <calcite-dropdown-item>Mint</calcite-dropdown-item>
+          <calcite-dropdown-item active>Chocolate</calcite-dropdown-item>
+          <calcite-dropdown-item>Banana</calcite-dropdown-item>
+          <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
+          <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
 
+        <calcite-dropdown theme="dark">
+          <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode with groups</calcite-button>
+          <calcite-dropdown-group grouptitle="Flavors">
+            <calcite-dropdown-item>Mint</calcite-dropdown-item>
+            <calcite-dropdown-item active>Chocolate</calcite-dropdown-item>
+            <calcite-dropdown-item>Banana</calcite-dropdown-item>
+            <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
+            <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
+          </calcite-dropdown-group>
+          <calcite-dropdown-group grouptitle="Genres">
+            <calcite-dropdown-item>Rock</calcite-dropdown-item>
+            <calcite-dropdown-item active>Country</calcite-dropdown-item>
+            <calcite-dropdown-item>Western</calcite-dropdown-item>
+            <calcite-dropdown-item>R&B</calcite-dropdown-item>
+          </calcite-dropdown-group>
+      </calcite-dropdown>
+      <br />
+      <br />
         <calcite-dropdown>
           <span slot="dropdown-trigger" tabIndex="0">I'm a span trigger</span>
-
           <calcite-dropdown-group grouptitle="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,6 @@
       padding: 1rem;
     }
   </style>
-  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.2.0/fonts.css" />
   <link rel="stylesheet" href="/build/calcite.css" />
   <script type="module" src="build/calcite.esm.js"></script>
   <script nomodule src="build/calcite.js"></script>
@@ -35,6 +34,8 @@
         <calcite-tab-title>Slider</calcite-tab-title>
         <calcite-tab-title>Switch and Checkbox</calcite-tab-title>
         <calcite-tab-title>Buttons</calcite-tab-title>
+        <calcite-tab-title>Dropdowns</calcite-tab-title>
+
       </calcite-tab-nav>
 
       <calcite-tab is-active>
@@ -362,7 +363,8 @@
         <calcite-modal class="js-modal-1" size="small">
           <h3 slot="header">Small Modal</h3>
           <div slot="content">
-            <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.</p>
+            <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
+            </p>
           </div>
           <calcite-button slot="back" color="light" appearance="outline"
             icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z" width="full">Back</calcite-button>
@@ -376,7 +378,8 @@
               <tbody>
                 <tr>
                   <td>
-                    <p>The medium modal is large enough to fit a two column layout where both columns will have a readable line-length on
+                    <p>The medium modal is large enough to fit a two column layout where both columns will have a
+                      readable line-length on
                       most desktop devices.</p>
                   </td>
                   <td>
@@ -394,8 +397,9 @@
         <calcite-modal class="js-modal-3" size="large">
           <h3 slot="header">Large modal</h3>
           <div slot="content">
-            <p>This modal will be fullscreen until it is as wide as the calcite-web grid's max-width. This enables you to use gridded
-            layouts within the modal and keeps your modal from growing beyond a readable line length.</p>
+            <p>This modal will be fullscreen until it is as wide as the calcite-web grid's max-width. This enables you
+              to use gridded
+              layouts within the modal and keeps your modal from growing beyond a readable line length.</p>
           </div>
           <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
           <calcite-button slot="primary" width="full">Save</calcite-button>
@@ -403,7 +407,8 @@
         <calcite-modal class="js-modal-4" size="fullscreen">
           <h3 slot="header">Fullscreen modal</h3>
           <div slot="content">
-            <p>This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your modal
+            <p>This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your
+              modal
               need the full screen realestate (maps, etc)</p>
           </div>
           <calcite-button slot="back" width="full" color="light" appearance="outline"
@@ -430,7 +435,8 @@
         <calcite-modal class="js-modal-7" status="info" docked>
           <h3 slot="header">Docked</h3>
           <div slot="content">
-            <p>For devices smaller than a tablet this modal will "dock" to the bottom. This makes action selection more thumb-friendly.</p>
+            <p>For devices smaller than a tablet this modal will "dock" to the bottom. This makes action selection more
+              thumb-friendly.</p>
           </div>
           <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
           <calcite-button slot="primary" width="full">Save</calcite-button>
@@ -438,8 +444,10 @@
         <calcite-modal class="js-modal-8" status="info" docked>
           <h3 slot="header">Tab Fencing</h3>
           <div slot="content">
-            <p>When you open a modal, the focus should be set to the first focusable element. <calcite-button>LIKE THIS</calcite-button>.</p>
-            <div><a href="#">Anchors</a>, <input type="text" value="inputs">, <calcite-slider></calcite-slider></div>
+            <p>When you open a modal, the focus should be set to the first focusable element. <calcite-button>LIKE THIS
+              </calcite-button>.</p>
+            <div><a href="#">Anchors</a>, <input type="text" value="inputs">, <calcite-slider></calcite-slider>
+            </div>
           </div>
           <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
           <calcite-button slot="primary" width="full">Save</calcite-button>
@@ -447,20 +455,39 @@
         <calcite-modal theme="dark" class="js-modal-9">
           <h3 slot="header">Dark Theme</h3>
           <div slot="content">
-            <p>Example of a modal rendered in dark theme. The text will become light on dark, but notice box shadows are still dark.
+            <p>Example of a modal rendered in dark theme. The text will become light on dark, but notice box shadows are
+              still dark.
           </div>
           <calcite-button slot="primary">OK</calcite-button>
         </calcite-modal>
         <ul>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-1')">Small Modal</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-2')">Medium Modal</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-3')">Large Modal</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-4')">Fullscreen Modal</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-5')">Destructive Modal</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-6')">Info Modal</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-7')">Docked</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-8')">Tab Fencing</calcite-button></li>
-          <li><calcite-button appearance="inline" onClick="openModal('.js-modal-9')">Dark Theme</calcite-button></li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-1')">Small Modal</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-2')">Medium Modal</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-3')">Large Modal</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-4')">Fullscreen Modal</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-5')">Destructive Modal</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-6')">Info Modal</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-7')">Docked</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-8')">Tab Fencing</calcite-button>
+          </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-9')">Dark Theme</calcite-button>
+          </li>
         </ul>
         <script>
           function openModal(selector) {
@@ -678,9 +705,12 @@
 
       <calcite-tab>
         <h3>Normal Lockup</h3>
-        <calcite-button title="Back" appearance='outline'>Back</calcite-button>
+        <calcite-button color="light" appearance='outline' icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+          Back</calcite-button>
+        <calcite-button appearance='outline'>Cancel</calcite-button>
         <calcite-button>Continue</calcite-button>
-        <calcite-button href="/">Continue with href</calcite-button>
+
+
         <h3>Type: Solid (default)</h3>
         <calcite-button title="blue solid button">blue solid button</calcite-button>
         <calcite-button title="red solid button" color='red'>red solid button</calcite-button>
@@ -700,7 +730,6 @@
         <h3>Type: Outline</h3>
         <calcite-button title="blue outline button" appearance='outline'>blue outline button</calcite-button>
         <calcite-button title="red outline button" appearance='outline' color='red'>red outline button</calcite-button>
-
         <calcite-button title="light outline button" appearance='outline' color='light'>light outline button
         </calcite-button>
         <calcite-button title="dark outline button" appearance='outline' color='dark'>dark outline button
@@ -757,7 +786,7 @@
             rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
             icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>to Google with an
             icon
-          </calcite-button> in some text.<br />
+          </calcite-button>in some text.<br />
           An anchor link <calcite-button href="http://google.com" appearance="inline" rel="noopener noreferrer"
             target="_blank" title="in the middle" color='red'>to Google.</calcite-button><br />
         </div>
@@ -790,7 +819,8 @@
         </calcite-button>
 
         <h3>Loader</h3>
-        <h5>These examples show a loader when the attribute is present, and remove it when the attribute is removed</h5>
+        <h5>These examples remove on the consumer end, the loader attribute when done... We could also present a "done"
+          loader state somehow...</h5>
         <calcite-button onclick="loadingButton(this, 5000)">Do something</calcite-button>
         <calcite-button appearance="outline" onclick="loadingButton(this, 5000)">Do something</calcite-button>
         <calcite-button color="red" onclick="loadingButton(this, 500000000)">Do something</calcite-button>
@@ -801,14 +831,14 @@
         <h5>pass path data - recommend using Calcite UI Icon Filled variants @ 24.</h5>
         <calcite-button appearance="outline" color="light"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
-          </calcite-button>
-          <calcite-button  onclick="loadingButton(this, 3000)"
+        </calcite-button>
+        <calcite-button onclick="loadingButton(this, 3000)"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
-          </calcite-button>
+        </calcite-button>
         <calcite-button appearance="outline" color="dark"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
           Download</calcite-button>
-          <calcite-button scale="l" appearance="outline"
+        <calcite-button scale="l" appearance="outline"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
           Download</calcite-button>
         <calcite-button
@@ -827,6 +857,95 @@
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           Delete this (loader)</calcite-button>
       </calcite-tab>
+
+
+
+      <calcite-tab>
+        <h3>Dropdowns</h3>
+
+        <calcite-dropdown>
+          <calcite-button slot="dropdown-trigger">Dropdown with Two Groups</calcite-button>
+          <calcite-dropdown-group grouptitle="Sort by">
+            <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item>Title</calcite-dropdown-item>
+          </calcite-dropdown-group>
+          <calcite-dropdown-group grouptitle="Sort Direction">
+            <calcite-dropdown-item>Least recent</calcite-dropdown-item>
+            <calcite-dropdown-item active>Most recent</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <calcite-dropdown>
+            <calcite-button slot="dropdown-trigger">Dropdown with Three Groups</calcite-button>
+            <calcite-dropdown-group grouptitle="Sort by">
+              <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+              <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+              <calcite-dropdown-item>Title</calcite-dropdown-item>
+            </calcite-dropdown-group>
+            <calcite-dropdown-group grouptitle="Sort Direction">
+              <calcite-dropdown-item active>Least recent</calcite-dropdown-item>
+              <calcite-dropdown-item>Most recent</calcite-dropdown-item>
+            </calcite-dropdown-group>
+            <calcite-dropdown-group grouptitle="Price">
+                <calcite-dropdown-item>Less</calcite-dropdown-item>
+                <calcite-dropdown-item active>More</calcite-dropdown-item>
+              </calcite-dropdown-group>
+          </calcite-dropdown>
+
+        <calcite-dropdown alignment="right">
+          <calcite-button slot="dropdown-trigger">Open Dropdown right aligned</calcite-button>
+
+          <calcite-dropdown-group grouptitle="View">
+            <calcite-dropdown-item active>List</calcite-dropdown-item>
+            <calcite-dropdown-item>Grid</calcite-dropdown-item>
+            <calcite-dropdown-item>Table</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+
+        <calcite-dropdown alignment="center">
+
+          <calcite-button slot="dropdown-trigger">Open Dropdown center aligned</calcite-button>
+
+          <calcite-dropdown-group>
+            <calcite-dropdown-item>Mint</calcite-dropdown-item>
+            <calcite-dropdown-item active>Chocolate</calcite-dropdown-item>
+            <calcite-dropdown-item>Banana</calcite-dropdown-item>
+            <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
+            <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <br />
+
+        <calcite-dropdown>
+          <span slot="dropdown-trigger" tabIndex="0">I'm a span trigger</span>
+
+          <calcite-dropdown-group grouptitle="View">
+            <calcite-dropdown-item active>List</calcite-dropdown-item>
+            <calcite-dropdown-item>Grid</calcite-dropdown-item>
+            <calcite-dropdown-item>Table</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <br />
+        <calcite-dropdown>
+          <button slot="dropdown-trigger" tabIndex="0">I'm not a "not calcite-button" button trigger</button>
+
+          <calcite-dropdown-group grouptitle="View">
+            <calcite-dropdown-item active>List</calcite-dropdown-item>
+            <calcite-dropdown-item>Grid</calcite-dropdown-item>
+            <calcite-dropdown-item>Table</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <br />
+
+        <calcite-dropdown>
+          <a slot="dropdown-trigger" tabIndex="0">I'm not an anchor trigger</a>
+          <calcite-dropdown-group grouptitle="View">
+            <calcite-dropdown-item active>List</calcite-dropdown-item>
+            <calcite-dropdown-item>Grid</calcite-dropdown-item>
+            <calcite-dropdown-item>Table</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+
     </calcite-tabs>
 
     <calcite-alerts id="my-alert-container">
@@ -905,6 +1024,7 @@
         <div slot="alert-message">11 A general piece of information</div>
         <calcite-button slot="alert-link" title="my action" appearance="inline">Take action</calcite-button>
       </calcite-alert>
+
     </calcite-alerts>
   </div>
 </body>

--- a/src/interfaces/DropdownInterface.tsx
+++ b/src/interfaces/DropdownInterface.tsx
@@ -2,9 +2,8 @@ import { h } from "@stencil/core";
 import { createProviderConsumer } from "@stencil/state-tunnel";
 
 export interface DropdownInterface {
-  requestedDropdownGroup: string,
-  requestedDropdownItem: string
-
+  requestedDropdownGroup: string;
+  requestedDropdownItem: string;
 }
 
 export default createProviderConsumer<DropdownInterface>(

--- a/src/interfaces/DropdownInterface.tsx
+++ b/src/interfaces/DropdownInterface.tsx
@@ -1,0 +1,18 @@
+import { h } from "@stencil/core";
+import { createProviderConsumer } from "@stencil/state-tunnel";
+
+export interface DropdownInterface {
+  requestedDropdownGroup: string,
+  requestedDropdownItem: string
+
+}
+
+export default createProviderConsumer<DropdownInterface>(
+  {
+    requestedDropdownGroup: "",
+    requestedDropdownItem: ""
+  },
+  (subscribe, child) => (
+    <context-consumer subscribe={subscribe} renderer={child} />
+  )
+);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -8,11 +8,16 @@ export function nodeListToArray(domNodeList): Element[] {
 }
 
 export function getElementDir(el: HTMLElement) {
-  return (el.closest("[dir='rtl']") && "rtl") || "ltr";
+  return getElementProp(el, "dir", "ltr");
 }
 
 export function getElementTheme(el: HTMLElement) {
-  return (el.closest("[theme='dark']") && "dark") || "light";
+  return getElementProp(el, "theme", "light");
+}
+
+export function getElementProp(el: HTMLElement, prop, value) {
+  const closestWithProp = el.closest(`[${prop}]`);
+  return closestWithProp ? closestWithProp.getAttribute(prop) : value;
 }
 
 export function hasSlottedContent(el: HTMLSlotElement) {

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -15,6 +15,7 @@ export const config: Config = {
         "calcite-tabs"
       ]
     },
+    { components: ["calcite-dropdown", "calcite-dropdown-group", "calcite-dropdown-item"] },
     { components: ["calcite-progress"] },
     { components: ["calcite-alert", "calcite-alerts"] },
     { components: ["calcite-loader"] },


### PR DESCRIPTION
This for the most part follows the API discussed in https://github.com/Esri/calcite-components/issues/6

At its simplest:
```
<calcite-dropdown alignment="right">
    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
        <calcite-dropdown-group grouptitle="View">
        <calcite-dropdown-item active>List</calcite-dropdown-item>
        <calcite-dropdown-item>Grid</calcite-dropdown-item>
        <calcite-dropdown-item>Table</calcite-dropdown-item>
    </calcite-dropdown-group>
</calcite-dropdown>

```

Each `calcite-dropdown-item` registers itself in a `calcite-dropdown-group`, which handles sorting of items within itself. Similarly, `calcite-dropdown-group` registers itself in the containing `calcite-dropdown`, which handles sorting of groups - needed for dropdowns that contain multiple `calcite-dropdown-group` children.

**Note** that while groups are required to wrap items, as it handles sorting, you can leave off the `grouptitle` prop from `calcite-dropdown-group` to give the appearance of ungrouped items.

State tunnel is used to determine when to set the active item, and preserve each group's active item.

Keyboard events are handled on the containing `calcite-dropdown`, and support tab, home, end, up, down keys. Tabbing through the end of a dropdown will close it, and shift tabbing from the first item will also close it. 

'dropdown-trigger' slot handles keypress events for when the element is not a button.

The only props on `calcite-dropdown` are `alignment`, which accepts `left`, `center`, or `right` values and defaults to `left`, and  `scale`- `s/m/l` (defaults to m)


The only prop on `calcite-dropdown-group` is `grouptitle`, which you can use to display a title and a separator between groups in a single dropdown (of which you can have.... unlimited)

To do: 
- I still need to write tests for this 😬 
- Focus first item on open, re-focus trigger element on close 
- Perhaps support passing an icon, or failing that, better support icons.
- Should we emit the value of the item when requested on click / key ?
- Should value of item be a passed prop vs. "freeform" `<slot/>` 

So, still some cleanup to do but wanted to get some eyes on this as I'll be tied up for the rest of the week, and the styles and keyboard functionality is mostly there.
