### PR TITLE
Issue #100: Fix <calcite-radio-group> Edge issues.

### DIFF
--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -70,6 +70,9 @@ export class CalciteRadioGroupItem {
     }
 
     this.inputProxy = inputProxy;
+
+    const futureSlotted = Array.from(this.el.childNodes);
+    this.hasLabel = futureSlotted.some((child) => child.nodeType === Node.TEXT_NODE);
   }
 
   disconnectedCallback() {
@@ -81,10 +84,10 @@ export class CalciteRadioGroupItem {
 
     return (
       <Host role="radio" aria-checked={checked ? "true" : "false"}>
-        <label>
-          <slot>{value}</slot>
-          <slot name="input" />
-        </label>
+          <label>
+            {this.hasLabel ? <slot /> : value}
+            <slot name="input" />
+          </label>
       </Host>
     );
   }
@@ -103,6 +106,8 @@ export class CalciteRadioGroupItem {
   //  Private State/Props
   //
   //--------------------------------------------------------------------------
+
+  private hasLabel = false;
 
   private inputProxy: HTMLInputElement;
 

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -84,10 +84,10 @@ export class CalciteRadioGroupItem {
 
     return (
       <Host role="radio" aria-checked={checked ? "true" : "false"}>
-          <label>
-            {this.hasLabel ? <slot /> : value}
-            <slot name="input" />
-          </label>
+        <label>
+          {this.hasLabel ? <slot /> : value}
+          <slot name="input" />
+        </label>
       </Host>
     );
   }

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -1,5 +1,6 @@
 :host {
-  display: block;
+  display: flex;
+
   --calcite-radio-group-color: #{$blk-000};
   --calcite-radio-group-border-color: #{$blk-130};
   --calcite-radio-group-color-active: #{$ui-blue};
@@ -24,7 +25,3 @@
   z-index: 0;
 }
 
-slot {
-  display: flex;
-  flex-direction: row;
-}


### PR DESCRIPTION
Fixes the following Edge issues:

1. In the `External inputs` case (from demo), the label obtained from the proxied input wasn't being rendered. ~~I think this may be a Stencil bug although I haven't been able to create an isolated test case. I'll have to dig a little deeper.~~ Created Stencil issue: https://github.com/ionic-team/stencil/issues/1811
  
2. Layout was broken in Edge (items were aligned vertically).