### PR TITLE
Modal fix

### DIFF
--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -100,6 +100,7 @@ focus-trap {
 
 .modal__close {
   padding: $baseline * 0.75;
+  margin: 0;
   order: 2;
   flex: 0 0 auto;
   transition-delay: 300ms;

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -145,7 +145,6 @@ slot[name="header"]::slotted(*) {
   position: relative;
   padding: $baseline;
   height: 100%;
-  flex: 0;
   overflow: auto;
   display: block;
   background-color: var(--calcite-modal-background);
@@ -257,7 +256,6 @@ slot[name="primary"] {
     height: auto !important;
   }
   .modal__content {
-    flex: 0;
     height: auto;
   }
 }


### PR DESCRIPTION
- use of `flex: 0` on firefox was causing the content area of modals to be much too short
- on safari, the close button was inheriting a 3px margin and causing misalignment