### PR TITLE
Style updates - focus fix for hidden items

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -3,47 +3,70 @@
   color: var(--calcite-tree-text);
   cursor: pointer;
   outline: none;
+  @include font-size(-2);
+  max-width: 100%;
 }
 
-::slotted(a) {
-  @include font-size(-2);
+::slotted(*) {
   color: var(--calcite-tree-text);
+  @include font-size(-2);
   text-decoration: none;
 }
 
 .calcite-tree-children {
-  transition: 0.15s $easing-function, opacity 0.15s $easing-function,
-    all 0.15s ease-in-out;
-  height: 0;
-  transform: scaleY(0);
-  opacity: 0;
-  transform-origin: top;
+  z-index: 1;
+  display: none;
   margin-left: var(--calcite-tree-children-indent-start);
   margin-right: var(--calcite-tree-children-indent-end);
   padding-left: var(--calcite-tree-children-padding-start);
   padding-right: var(--calcite-tree-children-padding-end);
-  border-left: 2px solid var(--calcite-tree-line);
-
-  :host([expanded]) & {
-    transform: scaleY(1);
-    opacity: 1;
-    height: auto;
-  }
-}
-
-.calcite-tree-node {
-  @include font-size(-2);
-  display: flex;
-  padding: var(--calcite-tree-vertical-padding) 0;
   position: relative;
-
-  &:before {
+  &:after {
+    transition: all $transition;
     content: "";
     height: 100%;
-    width: 2px;
+    width: var(--calcite-tree-line-width);
     background: var(--calcite-tree-line);
     left: var(--calcite-tree-line-position-start);
     right: var(--calcite-tree-line-position-end);
+    top: 0;
+    position: absolute;
+  }
+  :host([expanded]) & {
+    display: block;
+  }
+}
+:host([has-children]) .calcite-tree-children:hover,
+:host([has-children]) .calcite-tree-children:focus {
+  &:after {
+    background: var(--calcite-tree-line-hover);
+  }
+}
+.calcite-tree-node {
+  display: flex;
+  padding: var(--calcite-tree-vertical-padding) 0;
+  padding-left: var(--calcite-tree-indent-start);
+  padding-right: var(--calcite-tree-indent-end);
+  position: relative;
+
+  &:before {
+    content: "\2022";
+    position: absolute;
+    left: var(--calcite-tree-indicator-distance-start);
+    right: var(--calcite-tree-indicator-distance-end);
+    opacity: 0;
+    color: var(--calcite-tree-indicator);
+    transition: all $transition;
+  }
+
+  &:after {
+    transition: all $transition;
+    content: "";
+    height: 100%;
+    width: var(--calcite-tree-line-width);
+    background: var(--calcite-tree-line);
+    left: var(--calcite-tree-parent-line-position-start);
+    right: var(--calcite-tree-parent-line-position-end);
     top: 0;
     position: absolute;
 
@@ -53,46 +76,33 @@
   }
 }
 
-:host([selected]) .calcite-tree-node {
-  color: var(--calcite-tree-text-active);
-  font-weight: 500;
-
+:host([has-children]) .calcite-tree-node {
+  padding-left: 0;
+  padding-right: 0;
   &:before {
-    background: var(--calcite-tree-line-active);
-  }
-
-  ::slotted(a) {
-    color: var(--calcite-tree-text-active);
-  }
-
-  .calcite-tree-indicator {
-    opacity: 1;
-  }
-
-  .calcite-tree-chevron {
-    fill: var(--calcite-tree-chevron-active);
-  }
-  .calcite-tree-indicator {
-    fill: var(--calcite-tree-indicator-active);
+    display: none;
   }
 }
-
+:host([depth="1"]) .calcite-tree-node,
+:host([depth="1"]) .calcite-tree-children {
+  &:before {
+    left: var(--calcite-tree-indicator-first-start);
+    right: var(--calcite-tree-indicator-first-end);
+  }
+}
 .calcite-tree-node:hover,
 :host([selected]) .calcite-tree-node:hover,
 :host(:focus) .calcite-tree-node {
-  font-weight: 500;
-  color: var(--calcite-tree-text-hover);
-
   &:before {
-    background: var(--calcite-tree-line-hover);
-  }
-
-  ::slotted(a) {
-    color: var(--calcite-tree-text-hover);
-  }
-
-  .calcite-tree-indicator {
     opacity: 1;
+  }
+  &:after {
+    width: var(--calcite-tree-hover-line-width);
+    background: var(--calcite-tree-line-hover);
+    z-index: 2;
+  }
+  ::slotted(*) {
+    color: var(--calcite-tree-text-hover);
   }
 
   .calcite-tree-chevron {
@@ -102,19 +112,56 @@
     fill: var(--calcite-tree-indicator-hover);
   }
 }
+:host([selected]) .calcite-tree-node,
+:host([selected]) .calcite-tree-node:hover {
+  color: var(--calcite-tree-text-active);
+  font-weight: 500;
 
-.calcite-tree-chevron,
-.calcite-tree-indicator {
-  flex: 0 0 1rem;
-  width: 1rem;
-  height: 1rem;
-  margin-right: var(--calcite-tree-icon-padding-start);
-  margin-left: var(--calcite-tree-icon-padding-end);
-  margin-top: 0.125rem;
+  &:before {
+    opacity: 1;
+    color: var(--calcite-tree-indicator-active);
+  }
+  &:after {
+    background: var(--calcite-tree-line-active);
+    width: var(--calcite-tree-hover-line-width);
+    z-index: 2;
+  }
+  ::slotted(*) {
+    color: var(--calcite-tree-text-active);
+  }
+}
+
+// dropdown expanded and not selected
+:host([has-children][expanded]) .calcite-tree-node {
+  color: var(--calcite-tree-text-active);
+  font-weight: 500;
+  &:after {
+    background: var(--calcite-tree-line-active);
+  }
+  &:before {
+    opacity: 1;
+    color: var(--calcite-tree-indicator-active);
+  }
+  ::slotted(*) {
+    color: var(--calcite-tree-text-active);
+  }
+}
+// dropdown expanded and selected
+:host([has-children][expanded][selected]) .calcite-tree-node:after {
+  background: var(--calcite-tree-line-active);
+  width: var(--calcite-tree-hover-line-width);
+  z-index: 2;
 }
 
 .calcite-tree-chevron {
-  transition: transform 0.15s $easing-function;
+  transition: all $transition;
+  flex: 0 0 1;
+  position: relative;
+  align-self: center;
+  left: var(--calcite-tree-icon-edge-distance-start);
+  right: var(--calcite-tree-icon-edge-distance-end);
+  margin-right: var(--calcite-tree-icon-content-distance-start);
+  margin-left: var(--calcite-tree-icon-content-distance-end);
   transform: rotate(0deg);
   fill: var(--calcite-tree-chevron);
 
@@ -122,17 +169,17 @@
     transform: rotate(180deg);
   }
 
+  :host(:hover) &,
+  :host(:focus) & {
+    fill: var(--calcite-tree-chevron-hover);
+    stroke: var(--calcite-tree-chevron-hover);
+    stroke-width: 0.75;
+  }
+
   :host([expanded]) & {
     transform: rotate(90deg);
-  }
-}
-
-.calcite-tree-indicator {
-  transition: opacity 0.15s $easing-function;
-  opacity: 0;
-  fill: transparent;
-
-  :host([children]) & {
-    opacity: 0;
+    fill: var(--calcite-tree-chevron-active);
+    stroke-width: 0.75;
+    stroke: var(--calcite-tree-chevron-active);
   }
 }

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -9,7 +9,7 @@ import {
   Listen,
   h
 } from "@stencil/core";
-import { chevronRight16F } from "@esri/calcite-ui-icons";
+import { chevronRight16 } from "@esri/calcite-ui-icons";
 import { TreeItemSelectDetail } from "../../interfaces/TreeItemSelect";
 import { TreeSelectionMode } from "../../interfaces/TreeSelectionMode";
 import { getElementDir } from "../../utils/dom";
@@ -90,19 +90,9 @@ export class CalciteTreeItem {
         width="16"
         viewBox="0 0 16 16"
       >
-        <path d={chevronRight16F} />
+        <path d={chevronRight16} />
       </svg>
-    ) : (
-      <svg
-        class="calcite-tree-indicator"
-        height="16"
-        width="16"
-        viewBox="0 0 16 16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <circle cx="8" cy="8" r="3" />
-      </svg>
-    );
+    ) : null;
 
     return (
       <Host

--- a/src/components/calcite-tree/calcite-tree.scss
+++ b/src/components/calcite-tree/calcite-tree.scss
@@ -2,85 +2,92 @@
   display: block;
   outline: none;
   --calcite-tree-text: #{$blk-180};
-  --calcite-tree-text-hover: #{$blk-200};
-  --calcite-tree-line: transparent;
-  --calcite-tree-line-hover: transparent;
-  --calcite-tree-line-active: transparent;
+  --calcite-tree-text-hover: #{$blk-220};
+  --calcite-tree-text-active: #{$blk-230};
   --calcite-tree-chevron: #{$blk-060};
-  --calcite-tree-chevron-hover: #{$h-bb-040};
+  --calcite-tree-chevron-hover: #{$blk-140};
   --calcite-tree-chevron-active: #{$ui-blue};
-  --calcite-tree-indicator: #{$blk-060};
-  --calcite-tree-indicator-hover: #{$h-bb-040};
-  --calcite-tree-indicator-active: #{$ui-blue};
   --calcite-tree-vertical-padding: #{$baseline/4};
-  --calcite-tree-icon-padding-start: #{$baseline/4};
-  --calcite-tree-icon-padding-end: 0;
-  --calcite-tree-children-indent-start: 0.5rem;
+  --calcite-tree-indicator: #{$blk-060};
+  --calcite-tree-indicator-active: #{$ui-blue};
+  --calcite-tree-indicator-first-start: 0.1rem;
+  --calcite-tree-indicator-first-end: 0;
+  --calcite-tree-indicator-distance-start: 0.15rem;
+  --calcite-tree-indicator-distance-end: 0;
+  --calcite-tree-icon-edge-distance-start: -0.2rem;
+  --calcite-tree-icon-edge-distance-end: 0;
+  --calcite-tree-icon-content-distance-start: #{$baseline/4};
+  --calcite-tree-icon-content-distance-end: 0;
+  --calcite-tree-indent-start: 1.4rem;
+  --calcite-tree-indent-end: 0;
+  --calcite-tree-children-indent-start: 0.25rem;
   --calcite-tree-children-indent-end: 0;
-  --calcite-tree-children-padding-start: #{$baseline/2};
+  --calcite-tree-children-padding-start: 1rem;
   --calcite-tree-children-padding-end: 0;
-  --calcite-tree-line-position-start: -0.875rem;
+  --calcite-tree-line-position-start: 0.05rem;
   --calcite-tree-line-position-end: 0;
-}
-
-:host([size="s"]) {
-  --calcite-tree-vertical-padding: #{$baseline/6};
-  --calcite-tree-icon-padding-start: #{$baseline/6};
-  --calcite-tree-icon-padding-end: 0;
-  --calcite-tree-children-padding-start: #{$baseline/4};
-  --calcite-tree-children-padding-end: 0;
-  --calcite-tree-line-position-start: -0.5rem;
-  --calcite-tree-line-position-end: 0;
+  --calcite-tree-parent-line-position-start: -0.95rem;
+  --calcite-tree-parent-line-position-end: 0;
 }
 
 :host([theme="dark"]) {
   --calcite-tree-text: #{$blk-040};
   --calcite-tree-text-hover: #{$blk-020};
-  --calcite-tree-line: transparent;
-  --calcite-tree-line-hover: transparent;
-  --calcite-tree-line-active: transparent;
+  --calcite-tree-text-active: #{$blk-010};
   --calcite-tree-chevron: #{$blk-160};
-  --calcite-tree-chevron-hover: #{$h-bb-060};
+  --calcite-tree-chevron-hover: #{$blk-100};
   --calcite-tree-chevron-active: #{$ui-blue-dark};
   --calcite-tree-indicator: #{$blk-160};
-  --calcite-tree-indicator-hover: #{$h-bb-060};
   --calcite-tree-indicator-active: #{$ui-blue-dark};
 }
 
 :host([lines]) {
-  --calcite-tree-line: #{$blk-040};
+  --calcite-tree-line-width: #{1px};
+  --calcite-tree-hover-line-width: #{3px};
+  --calcite-tree-line: #{$blk-020};
+  --calcite-tree-line-hover: #{$blk-050};
   --calcite-tree-line-active: #{$ui-blue};
-  --calcite-tree-line-hover: #{$h-bb-040};
 }
 
 :host([lines][theme="dark"]) {
-  --calcite-tree-line: #{$blk-180};
+  --calcite-tree-line: #{$blk-160};
+  --calcite-tree-line-hover: #{$blk-120};
   --calcite-tree-line-active: #{$ui-blue-dark};
-  --calcite-tree-line-hover: #{$h-bb-060};
+}
+
+:host([size="s"]) {
+  --calcite-tree-hover-line-width: #{2px};
+  --calcite-tree-vertical-padding: #{$baseline/6};
+  --calcite-tree-children-indent-start: 0rem;
+  --calcite-tree-children-padding-start: 0.8rem;
+  --calcite-tree-line-position-start: 0.3rem;
+  --calcite-tree-parent-line-position-start: -0.5rem;
 }
 
 :host([dir="rtl"]) {
-  --calcite-tree-icon-padding-start: 0;
-  --calcite-tree-icon-padding-end: #{$baseline/4};
+  --calcite-tree-indicator-first-start: 0;
+  --calcite-tree-indicator-first-end: 0.1rem;
+  --calcite-tree-indicator-distance-start: 0;
+  --calcite-tree-indicator-distance-end: 0.15rem;
+  --calcite-tree-icon-edge-distance-start: 0;
+  --calcite-tree-icon-edge-distance-end: -0.2rem;
+  --calcite-tree-icon-content-distance-start: 0;
+  --calcite-tree-icon-content-distance-end: #{$baseline/4};
+  --calcite-tree-indent-start: 0;
+  --calcite-tree-indent-end: 1.4rem;
   --calcite-tree-children-indent-start: 0;
-  --calcite-tree-children-indent-end: 0.5rem;
+  --calcite-tree-children-indent-end: 0.25rem;
   --calcite-tree-children-padding-start: 0;
-  --calcite-tree-children-padding-end: #{$baseline/2};
+  --calcite-tree-children-padding-end: 1rem;
   --calcite-tree-line-position-start: 0;
-  --calcite-tree-line-position-end: -0.875rem;
+  --calcite-tree-line-position-end: 0.05rem;
+  --calcite-tree-parent-line-position-start: 0;
+  --calcite-tree-parent-line-position-end: -0.95rem;
 }
 
 :host([dir="rtl"][size="s"]) {
-  --calcite-tree-icon-padding-start: 0;
-  --calcite-tree-icon-padding-end: #{$baseline/6};
-  --calcite-tree-children-padding-start: 0;
-  --calcite-tree-children-padding-end: #{$baseline/4};
-  --calcite-tree-line-position-start: 0;
-  --calcite-tree-line-position-end: -0.5rem;
-}
-
-:host([root]) ::slotted(calcite-tree-item) {
-  border-left: none;
-  margin-left: 0;
-  padding-left: 0;
+  --calcite-tree-children-indent-end: 0rem;
+  --calcite-tree-children-padding-end: 0.8rem;
+  --calcite-tree-line-position-end: 0.3rem;
+  --calcite-tree-parent-line-position-end: -0.5rem;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -613,7 +613,7 @@
         <div class="demo-background-dark">
           <h3>Dark Theme</h3>
           <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" theme="dark" label-ticks ticks="10"></calcite-slider>
+            max-label="Temperature range (upper)" theme="dark" label-ticks ticks="10"></calcite-slider>
         </div>
         <h3>Event Listener</h3>
         <calcite-slider id="sliderEvents" min="0" max="100" value="50" step="1" label="Temperature"></calcite-slider>
@@ -874,11 +874,12 @@
           icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>in the middle
         </calcite-button> of some text.<br /><br />
         <div class="demo-background-dark">
-          An anchor link <calcite-button theme="dark" href="http://google.com" appearance="inline" rel="noopener noreferrer"
-            target="_blank" title="in the middle">in
+          An anchor link <calcite-button theme="dark" href="http://google.com" appearance="inline"
+            rel="noopener noreferrer" target="_blank" title="in the middle">in
             the middle</calcite-button> of some text.<br />
-          An anchor link <calcite-button theme="dark" href="http://google.com" appearance="inline" rel="noopener noreferrer"
-            target="_blank" title="in the middle" color='red'>to Google.</calcite-button><br />
+          An anchor link <calcite-button theme="dark" href="http://google.com" appearance="inline"
+            rel="noopener noreferrer" target="_blank" title="in the middle" color='red'>to Google.</calcite-button>
+          <br />
           An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
             rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
             icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>to Google with an
@@ -1107,11 +1108,10 @@
             <calcite-dropdown-item>Table</calcite-dropdown-item>
           </calcite-dropdown-group>
         </calcite-dropdown>
-
+      </calcite-tab>
       <calcite-tab>
         <h3>Nav Tree</h3>
-        <button>Focus Test</button>
-        <calcite-tree>
+        <calcite-tree lines>
           <calcite-tree-item>
             <a href="#">Child 1</a>
           </calcite-tree-item>
@@ -1131,13 +1131,38 @@
                   </calcite-tree-item>
                   <calcite-tree-item>
                     <a href="#">Great-Grandchild 2</a>
+                    <calcite-tree slot="children">
+                      <calcite-tree-item>
+                        <a href="#">Great-Great-Grandchild 1</a>
+                      </calcite-tree-item>
+                      <calcite-tree-item>
+                        <a href="#">Great-Great-Grandchild 2</a>
+                        <calcite-tree slot="children">
+                          <calcite-tree-item>
+                            <a href="#">Great-Great-Great-Grandchild 1</a>
+                          </calcite-tree-item>
+                          <calcite-tree-item>
+                            <a href="#">Great-Great-Great-Grandchild 2</a>
+                          </calcite-tree-item>
+                      </calcite-tree-item>
+                    </calcite-tree>
                   </calcite-tree-item>
-                </calcite-tree>
               </calcite-tree-item>
             </calcite-tree>
-
           </calcite-tree-item>
+          <calcite-tree-item>
+            <a href="#">Child 3</a>
+            <calcite-tree slot="children">
+              <calcite-tree-item>
+                <a href="#">Grandchild 1</a>
+              </calcite-tree-item>
+              <calcite-tree-item>
+                <a href="#">Grandchild 2</a>
+              </calcite-tree-item>
+          </calcite-tree-item>
+
         </calcite-tree>
+
 
         <h3>Compact</h3>
 
@@ -1161,13 +1186,38 @@
                   </calcite-tree-item>
                   <calcite-tree-item>
                     <a href="#">Great-Grandchild 2</a>
+                    <calcite-tree slot="children">
+                      <calcite-tree-item>
+                        <a href="#">Great-Great-Grandchild 1</a>
+                      </calcite-tree-item>
+                      <calcite-tree-item>
+                        <a href="#">Great-Great-Grandchild 2</a>
+                        <calcite-tree slot="children">
+                          <calcite-tree-item>
+                            <a href="#">Great-Great-Great-Grandchild 1</a>
+                          </calcite-tree-item>
+                          <calcite-tree-item>
+                            <a href="#">Great-Great-Great-Grandchild 2</a>
+                          </calcite-tree-item>
+                      </calcite-tree-item>
+                    </calcite-tree>
                   </calcite-tree-item>
-                </calcite-tree>
               </calcite-tree-item>
             </calcite-tree>
-
           </calcite-tree-item>
+          <calcite-tree-item>
+            <a href="#">Child 3</a>
+            <calcite-tree slot="children">
+              <calcite-tree-item>
+                <a href="#">Grandchild 1</a>
+              </calcite-tree-item>
+              <calcite-tree-item>
+                <a href="#">Grandchild 2</a>
+              </calcite-tree-item>
+          </calcite-tree-item>
+
         </calcite-tree>
+
 
         <h3>Dark Theme</h3>
         <div class="demo-background-dark">
@@ -1279,7 +1329,7 @@
               <calcite-tree-item selected expanded>
                 <a href="#">Grandchild 2</a>
                 <calcite-tree slot="children">
-                  <calcite-tree-item  selected>
+                  <calcite-tree-item selected>
                     <a href="#">Great-Grandchild 1</a>
                   </calcite-tree-item>
                   <calcite-tree-item selected>
@@ -1510,7 +1560,7 @@
         </calcite-tree>
 
         <script>
-          (function (){
+          (function () {
             var tree = document.getElementById("tree-events-demo-tree");
             var result = document.getElementById("tree-events-demo-result");
             tree.addEventListener("calciteTreeSelect", function (e) {


### PR DESCRIPTION
Mostly some subtle style changes to bring this inline with some of our other designs. Also, it seemed like you could "tab" through collapsed items in scale(0) so just made display:none/block.

- Changes styling of “hidden” items to just display:none - previously you were able to tab through closed items that had scale(0)

- Adjusts spacing and alignment
- Updates caret icon and sizing
- Adds transition to all hover effects
- Hovering over a child item will now add a hover state to all parent lines
- Adds distinct styles for “open” vs” open and selected” for parent level items
- Uses char symbol for active dot, vs. icon, to match dropdown 
- Updates hover style to gray dot to match dropdown 
- Adds “hover / active width” to lines to better match that of tabs component
- Updates small scale active border width
- Normalizes font size for slotted items
- Updates dark mode colors

I think we could make "s" even tighter if we did in fact get rid of the active dot in "s" - @patrickarlt not sure if your use case requires a tighter view than this.