### PR TITLE
Tree fixes

### DIFF
--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -16,3 +16,7 @@ calcite-tab {
 calcite-tab[is-active] {
   display: block;
 }
+
+a {
+  color: $ui-blue;
+}

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -8,7 +8,7 @@
 }
 
 ::slotted(*) {
-  color: var(--calcite-tree-text);
+  color: var(--calcite-tree-text) !important;
   @include font-size(-2);
   text-decoration: none;
 }

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -15,12 +15,20 @@
 
 .calcite-tree-children {
   z-index: 1;
-  display: none;
   margin-left: var(--calcite-tree-children-indent-start);
   margin-right: var(--calcite-tree-children-indent-end);
   padding-left: var(--calcite-tree-children-padding-start);
   padding-right: var(--calcite-tree-children-padding-end);
   position: relative;
+
+  transform: scaleY(0);
+  opacity: 0;
+  overflow: hidden;
+  transition: 0.15s $easing-function, opacity 0.15s $easing-function,
+    all 0.15s ease-in-out; // note that we're transitioning transform, not height!
+  height: 0;
+  transform-origin: top; // keep the top of the element in the same place. this is optional.
+
   &:after {
     transition: all $transition;
     content: "";
@@ -33,15 +41,19 @@
     position: absolute;
   }
   :host([expanded]) & {
-    display: block;
+    transform: scaleY(1);
+    opacity: 1;
+    height: auto;
   }
 }
+
 :host([has-children]) .calcite-tree-children:hover,
 :host([has-children]) .calcite-tree-children:focus {
   &:after {
     background: var(--calcite-tree-line-hover);
   }
 }
+
 .calcite-tree-node {
   display: flex;
   padding: var(--calcite-tree-vertical-padding) 0;
@@ -70,7 +82,7 @@
     top: 0;
     position: absolute;
 
-    :host([depth="1"]) & {
+    :host([depth="1"]) > & {
       display: none;
     }
   }
@@ -83,6 +95,7 @@
     display: none;
   }
 }
+
 :host([depth="1"]) .calcite-tree-node,
 :host([depth="1"]) .calcite-tree-children {
   &:before {
@@ -90,6 +103,7 @@
     right: var(--calcite-tree-indicator-first-end);
   }
 }
+
 .calcite-tree-node:hover,
 :host([selected]) .calcite-tree-node:hover,
 :host(:focus) .calcite-tree-node {
@@ -112,6 +126,7 @@
     fill: var(--calcite-tree-indicator-hover);
   }
 }
+
 :host([selected]) .calcite-tree-node,
 :host([selected]) .calcite-tree-node:hover {
   color: var(--calcite-tree-text-active);
@@ -146,6 +161,7 @@
     color: var(--calcite-tree-text-active);
   }
 }
+
 // dropdown expanded and selected
 :host([has-children][expanded][selected]) .calcite-tree-node:after {
   background: var(--calcite-tree-line-active);

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -40,7 +40,7 @@
     top: 0;
     position: absolute;
   }
-  :host([expanded]) & {
+  :host([expanded]) > & {
     transform: scaleY(1);
     opacity: 1;
     height: auto;
@@ -88,7 +88,7 @@
   }
 }
 
-:host([has-children]) .calcite-tree-node {
+:host([has-children]) > .calcite-tree-node {
   padding-left: 0;
   padding-right: 0;
   &:before {
@@ -96,8 +96,8 @@
   }
 }
 
-:host([depth="1"]) .calcite-tree-node,
-:host([depth="1"]) .calcite-tree-children {
+:host([depth="1"]) > .calcite-tree-node,
+:host([depth="1"]) > .calcite-tree-children {
   &:before {
     left: var(--calcite-tree-indicator-first-start);
     right: var(--calcite-tree-indicator-first-end);
@@ -127,8 +127,8 @@
   }
 }
 
-:host([selected]) .calcite-tree-node,
-:host([selected]) .calcite-tree-node:hover {
+:host([selected]) > .calcite-tree-node,
+:host([selected]) > .calcite-tree-node:hover {
   color: var(--calcite-tree-text-active);
   font-weight: 500;
 
@@ -147,7 +147,7 @@
 }
 
 // dropdown expanded and not selected
-:host([has-children][expanded]) .calcite-tree-node {
+:host([has-children][expanded]) > .calcite-tree-node {
   color: var(--calcite-tree-text-active);
   font-weight: 500;
   &:after {
@@ -163,7 +163,7 @@
 }
 
 // dropdown expanded and selected
-:host([has-children][expanded][selected]) .calcite-tree-node:after {
+:host([has-children][expanded][selected]) > .calcite-tree-node:after {
   background: var(--calcite-tree-line-active);
   width: var(--calcite-tree-hover-line-width);
   z-index: 2;
@@ -192,7 +192,7 @@
     stroke-width: 0.75;
   }
 
-  :host([expanded]) & {
+  :host([expanded]) > .calcite-tree-node > & {
     transform: rotate(90deg);
     fill: var(--calcite-tree-chevron-active);
     stroke-width: 0.75;

--- a/src/components/calcite-tree/calcite-tree.scss
+++ b/src/components/calcite-tree/calcite-tree.scss
@@ -57,7 +57,7 @@
 
 :host([size="s"]) {
   --calcite-tree-hover-line-width: #{2px};
-  --calcite-tree-vertical-padding: #{$baseline/6};
+  --calcite-tree-vertical-padding: #{$baseline/8};
   --calcite-tree-children-indent-start: 0rem;
   --calcite-tree-children-padding-start: 0.8rem;
   --calcite-tree-line-position-start: 0.3rem;

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -8,11 +8,14 @@ import {
   Listen,
   h
 } from "@stencil/core";
-import { getElementDir, getElementTheme } from "../../utils/dom";
+import {
+  nodeListToArray,
+  getElementDir,
+  getElementTheme
+} from "../../utils/dom";
 import { TreeSelectionMode } from "../../interfaces/TreeSelectionMode";
 import { TreeItemSelectDetail } from "../../interfaces/TreeItemSelect";
 import { TreeSelectDetail } from "../../interfaces/TreeSelect";
-import { nodeListToArray } from "../../utils/dom";
 
 @Component({
   tag: "calcite-tree",

--- a/src/index.html
+++ b/src/index.html
@@ -1110,6 +1110,7 @@
         </calcite-dropdown>
       </calcite-tab>
       <calcite-tab>
+
         <h3>Nav Tree</h3>
         <calcite-tree lines>
           <calcite-tree-item>


### PR DESCRIPTION
This PR makes 3 fixes for `<calcite-tree>`:

1. When pre-rendering/hydrating CSS for the expanded tree items no longer extends to all children.
2. Links in tree nav are now black even if other styles are applied.
3. The tab order fixes from @macandcheese in https://github.com/Esri/calcite-components/pull/111 are maintained.

@macandcheese one thing I did notice is that selected/open parent items don't have a distinct focus state, not sure if you want to follow up on that today.