### PR TITLE
Updates button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+### Added
+- adds transparent appearance style for `calcite-button`
+- adds `iconposition` prop to `calcite-button`
+- updates dark theme style for `calcite-button`
+  
+### Fixed
+
+
 ## [v1.0.0-beta.4] - Aug 19th 2019
 
 ### Added
@@ -26,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - date picker page-up and page-down buttons
 - pre-render support for existing components
 
-### Fixes
+### Fixed
 - style updates/dark theme for buttons
 - fixed styling of modals in firefox
 - fixed radio-group styling in Edge

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -7,10 +7,13 @@
   --calcite-button-red: #{$ui-red};
   --calcite-button-red-hover: #{$ui-red-hover};
   --calcite-button-red-pressed: #{$ui-red-pressed};
-  --calcite-button-blue-inline-underline: #{rgba($ui-blue, 0.4)};
-  --calcite-button-red-inline-underline: #{rgba($ui-red, 0.4)};
+  --calcite-button-blue-inline-underline: #{rgba($ui-blue, 0.2)};
+  --calcite-button-red-inline-underline: #{rgba($ui-red, 0.2)};
   --calcite-button-blue-solid-color: #{$blk-000};
   --calcite-button-red-solid-color: #{$blk-000};
+  --calcite-button-outline-background: #{$blk-000};
+  --calcite-button-outline-color: #{$blk-230};
+  --calcite-button-outline-color-pressed: #{$blk-230};
 }
 
 // dark theme
@@ -21,10 +24,13 @@
   --calcite-button-red: #{$ui-red-dark};
   --calcite-button-red-hover: #{$ui-red-hover-dark};
   --calcite-button-red-pressed: #{$ui-red-pressed-dark};
-  --calcite-button-blue-inline-underline: #{rgba($ui-blue-dark, 0.4)};
-  --calcite-button-red-inline-underline: #{rgba($ui-red-dark, 0.4)};
+  --calcite-button-blue-inline-underline: #{rgba($ui-blue-dark, 0.2)};
+  --calcite-button-red-inline-underline: #{rgba($ui-red-dark, 0.2)};
   --calcite-button-blue-solid-color: #{$blk-230};
   --calcite-button-red-solid-color: #{$blk-230};
+  --calcite-button-outline-background: #{$blk-220};
+  --calcite-button-outline-color: #{$blk-000};
+  --calcite-button-outline-color-pressed: #{$blk-000};
 }
 
 // button base
@@ -77,25 +83,48 @@
   transition: all 0.15s ease-in-out;
 }
 
-:host([hastext]) .calcite-button--icon {
+// icon positioning and styles
+:host([hastext][iconposition="start"]) .calcite-button--icon {
   margin-right: $baseline/3;
 }
 
-:host([hastext][dir="rtl"]) .calcite-button--icon {
+:host([hastext][iconposition="start"][dir="rtl"]) .calcite-button--icon {
   margin-right: 0;
   margin-left: $baseline/3;
 }
 
+:host([hastext][iconposition="end"]) .calcite-button--icon {
+  margin-left: $baseline/3;
+}
+
+:host([hastext][iconposition="end"][dir="rtl"]) .calcite-button--icon {
+  margin-left: 0;
+  margin-right: $baseline/3;
+}
+
+// icon positioning and styles for inline
 :host([appearance="inline"]) .calcite-button--icon {
-  margin-left: $baseline/8;
-  margin-right: 0;
   max-height: $baseline/2;
   top: 0;
 }
 
-:host([appearance="inline"][dir="rtl"]) .calcite-button--icon {
+:host([appearance="inline"][iconposition="start"]) .calcite-button--icon {
+  margin-right: $baseline/4;
+}
+
+:host([appearance="inline"][iconposition="start"][dir="rtl"])
+  .calcite-button--icon {
+  margin-left: $baseline/4;
+  margin-right: 0;
+}
+
+:host([appearance="inline"][iconposition="end"]) .calcite-button--icon {
+  margin-left: $baseline/4;
+}
+:host([appearance="inline"][iconposition="end"][dir="rtl"])
+  .calcite-button--icon {
   margin-left: 0;
-  margin-right: $baseline/8;
+  margin-right: $baseline/4;
 }
 
 .calcite-button--loader {
@@ -205,6 +234,9 @@
     color: $color-press;
     border-color: $border-color-press;
     box-shadow: inset 0 0 0 2px $border-color-press;
+    & .calcite-button--icon {
+      fill: $color-press;
+    }
   }
   & .calcite-button--icon {
     fill: $color;
@@ -218,7 +250,7 @@
   button,
   a {
     @include btn-outline-clear(
-      $blk-000,
+      var(--calcite-button-outline-background),
       var(--calcite-button-blue),
       var(--calcite-button-blue-hover),
       var(--calcite-button-blue-pressed),
@@ -231,7 +263,7 @@
   button,
   a {
     @include btn-outline-clear(
-      $blk-000,
+      var(--calcite-button-outline-background),
       var(--calcite-button-red),
       var(--calcite-button-red-hover),
       var(--calcite-button-red-pressed),
@@ -244,12 +276,12 @@
   button,
   a {
     @include btn-outline-clear(
-      $blk-000,
+      var(--calcite-button-outline-background),
       $blk-010,
       $blk-000,
       $blk-020,
-      $blk-220,
-      $blk-240
+      var(--calcite-button-outline-color),
+      var(--calcite-button-outline-pressed)
     );
   }
 }
@@ -257,12 +289,12 @@
   button,
   a {
     @include btn-outline-clear(
-      $blk-000,
+      var(--calcite-button-outline-background),
       $blk-200,
       $blk-180,
       $blk-240,
-      $blk-220,
-      $blk-240
+      var(--calcite-button-outline-color),
+      var(--calcite-button-outline-pressed)
     );
   }
 }
@@ -318,6 +350,67 @@
     );
   }
 }
+
+// transparent
+@mixin btn-transparent($color, $color-hover, $color-pressed) {
+  color: $color;
+  background-color: transparent;
+  border: 1px solid transparent;
+  &:hover {
+    color: $color-hover;
+    & .calcite-button--icon {
+      fill: $color-hover;
+    }
+  }
+  &:active,
+  &:focus {
+    color: $color-pressed;
+    & .calcite-button--icon {
+      fill: $color-pressed;
+    }
+  }
+  & .calcite-button--icon {
+    fill: $color;
+  }
+  & calcite-loader {
+    color: $color;
+  }
+}
+
+:host([appearance="transparent"][color="blue"]) {
+  button,
+  a {
+    @include btn-transparent(
+      var(--calcite-button-blue),
+      var(--calcite-button-blue-hover),
+      var(--calcite-button-blue-pressed)
+    );
+  }
+}
+
+:host([appearance="transparent"][color="red"]) {
+  button,
+  a {
+    @include btn-transparent(
+      var(--calcite-button-red),
+      var(--calcite-button-red-hover),
+      var(--calcite-button-red-pressed)
+    );
+  }
+}
+:host([appearance="transparent"][color="light"]) {
+  button,
+  a {
+    @include btn-transparent($blk-010, $blk-000, $blk-020);
+  }
+}
+:host([appearance="transparent"][color="dark"]) {
+  button,
+  a {
+    @include btn-transparent($blk-200, $blk-180, $blk-220);
+  }
+}
+
 // inline
 @mixin btn-inline($color, $color-hover, $border-color) {
   display: inline;
@@ -334,17 +427,20 @@
     linear-gradient($border-color, $border-color);
   background-position: 0% 100%, 100% 100%;
   background-repeat: no-repeat, no-repeat;
-  background-size: 0% 2px, 100% 1px;
+  background-size: 0% 1px, 100% 1px;
   transition: all 0.15s ease-in-out, background-size 0.3s ease-in-out;
 
   &:hover,
   &:focus {
     color: $color-hover;
-    background-size: 100% 2px, 100% 1px;
+    background-size: 100% 1px, 100% 1px;
+    & .calcite-button--icon {
+      fill: $color-hover;
+    }
   }
   &:active {
     color: $color;
-    background-size: 100% 2px, 100% 1px;
+    background-size: 100% 1px, 100% 1px;
   }
   & .calcite-button--icon {
     fill: $color;
@@ -378,13 +474,13 @@
 :host([appearance="inline"][color="light"]) {
   button,
   a {
-    @include btn-inline($blk-010, $blk-000, rgba($blk-000, 0.4));
+    @include btn-inline($blk-010, $blk-000, rgba($blk-000, 0.2));
   }
 }
 :host([appearance="inline"][color="dark"]) {
   button,
   a {
-    @include btn-inline($blk-200, $blk-180, rgba($blk-180, 0.4));
+    @include btn-inline($blk-200, $blk-180, rgba($blk-180, 0.2));
   }
 }
 :host([appearance="inline"][dir="rtl"]) {

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -48,7 +48,10 @@ export class CalciteButton {
   @Prop({ reflect: true }) href?: string;
 
   /** optionally pass icon path data to be positioned within the button - pass only raw path data from calcite ui helper  */
-  @Prop({ reflect: true }) icon?: string = null;
+  @Prop({ reflect: true }) icon?: string;
+
+  /** optionally used with icon, select where to position the icon */
+  @Prop({ reflect: true }) iconposition?: "start" | "end" = "start";
 
   /**
    * @internal
@@ -58,7 +61,7 @@ export class CalciteButton {
 
   connectedCallback() {
     // prop validations
-    let appearance = ["solid", "outline", "clear", "inline"];
+    let appearance = ["solid", "outline", "clear", "inline", "transparent"];
     if (!appearance.includes(this.appearance)) this.appearance = "solid";
 
     let color = ["blue", "red", "dark", "light"];
@@ -72,6 +75,10 @@ export class CalciteButton {
 
     let theme = ["dark", "light"];
     if (!theme.includes(this.theme)) this.theme = "light";
+
+    let iconposition = ["start", "end"];
+    if (this.icon !== null && !iconposition.includes(this.iconposition))
+      this.iconposition = "start";
   }
 
   componentDidLoad() {
@@ -84,15 +91,18 @@ export class CalciteButton {
   }
 
   getAttributes() {
-    // spreadable attributes to pass to component child, if they aren't props
+    // spread attributes specified on the compoennt to component child, if they aren't props
     let props = [
       "appearance",
       "color",
+      "dir",
+      "hastext",
+      "icon",
+      "iconposition",
       "loading",
       "scale",
       "width",
-      "icon",
-      "dir"
+      "theme"
     ];
     return Array.from(this.el.attributes)
       .filter(a => a && !props.includes(a.name))
@@ -119,7 +129,17 @@ export class CalciteButton {
         <path d={this.icon} />
       </svg>
     ) : null;
-    if (this.appearance === "inline") {
+    if (this.iconposition === "start") {
+      return (
+        <Host dir={dir} hastext={this.hastext}>
+          <Type {...attributes} role={role}>
+            {loader}
+            {icon}
+            <slot />
+          </Type>
+        </Host>
+      );
+    } else if (this.iconposition === "end") {
       return (
         <Host dir={dir} hastext={this.hastext}>
           <Type {...attributes} role={role}>
@@ -130,15 +150,12 @@ export class CalciteButton {
         </Host>
       );
     } else {
-      return (
-        <Host dir={dir} hastext={this.hastext}>
-          <Type {...attributes} role={role}>
-            {loader}
-            {icon}
-            <slot />
-          </Type>
-        </Host>
-      );
+      <Host dir={dir} hastext={this.hastext}>
+        <Type {...attributes} role={role}>
+          {loader}
+          <slot />
+        </Type>
+      </Host>;
     }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -826,15 +826,16 @@
         </calcite-button>
         <br />
         <br />
-        <h5>Theme="dark" on blue /red (no effect on light / dark)</h5>
+        <h5>Theme="dark" on blue /red (no effect on light / dark except outline)</h5>
         <div class="demo-background-dark">
           <calcite-button theme="dark" title="blue outline button" appearance='outline'>blue outline button
           </calcite-button>
           <calcite-button theme="dark" title="red outline button" appearance='outline' color='red'>red outline button
           </calcite-button>
-          <calcite-button title="light outline button" appearance='outline' color='light'>light outline button
+          <calcite-button theme="dark" title="light outline button" appearance='outline' color='light'>light outline
+            button
           </calcite-button>
-          <calcite-button title="dark outline button" appearance='outline' color='dark'>dark outline button
+          <calcite-button theme="dark" title="dark outline button" appearance='outline' color='dark'>dark outline button
           </calcite-button>
         </div>
 
@@ -856,19 +857,73 @@
           <calcite-button title="dark clear button" appearance='clear' color='dark'>dark clear button</calcite-button>
         </div>
 
+        <h3>Type: Outline</h3>
+        <calcite-button title="blue outline button" appearance='outline'>blue outline button</calcite-button>
+        <calcite-button title="red outline button" appearance='outline' color='red'>red outline button</calcite-button>
+        <calcite-button title="light outline button" appearance='outline' color='light'>light outline button
+        </calcite-button>
+        <calcite-button title="dark outline button" appearance='outline' color='dark'>dark outline button
+        </calcite-button>
+        <br />
+        <br />
+        <h5>Theme="dark" on blue /red (no effect on light / dark except outline)</h5>
+        <div class="demo-background-dark">
+          <calcite-button theme="dark" title="blue outline button" appearance='outline'>blue outline button
+          </calcite-button>
+          <calcite-button theme="dark" title="red outline button" appearance='outline' color='red'>red outline button
+          </calcite-button>
+          <calcite-button theme="dark" title="light outline button" appearance='outline' color='light'>light outline
+            button
+          </calcite-button>
+          <calcite-button theme="dark" title="dark outline button" appearance='outline' color='dark'>dark outline button
+          </calcite-button>
+        </div>
+
+        <h3>Type: Transparent</h3>
+        <calcite-button title="blue transparent button" appearance='transparent'
+          icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
+          transparent and icon</calcite-button>
+        <calcite-button title="blue transparent button" iconposition="end" appearance='transparent'
+          icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
+          transparent and end icon</calcite-button>
+        <calcite-button title="blue transparent button" appearance='transparent'>blue transparent button
+        </calcite-button>
+        <calcite-button title="red transparent button" appearance='transparent' color='red'>red transparent button
+        </calcite-button>
+
+        <calcite-button title="light transparent button" appearance='transparent' color='light'>light transparent button
+        </calcite-button>
+        <calcite-button title="dark transparent button" appearance='transparent' color='dark'>dark transparent button
+        </calcite-button>
+        <br />
+        <br />
+        <h5>Theme="dark" on blue /red (no effect on light / dark)</h5>
+        <div class="demo-background-dark">
+          <calcite-button theme="dark" title="blue transparent button" appearance='transparent'>blue transparent button
+          </calcite-button>
+          <calcite-button theme="dark" title="red transparent button" appearance='transparent' color='red'>red
+            transparent button
+          </calcite-button>
+          <calcite-button title="light transparent button" appearance='transparent' color='light'>light transparent
+            button
+          </calcite-button>
+          <calcite-button title="dark transparent button" appearance='transparent' color='dark'>dark transparent button
+          </calcite-button>
+        </div>
+
         <h3>Type: Inline (render as anchor)</h3>
         An anchor <calcite-button title="in the middle" href="/" appearance="inline">in the middle</calcite-button> of
         some
         text.<br />
         An anchor <calcite-button href="/"
           title="in the middle that might be long enough to wrap to illustrate animation" appearance="inline"
-          color='red'>in the middle that might be long enough to wrap to illustrate animation
-        </calcite-button> of some text.<br />
+          color='red'>in the middle that might be long enough to wrap to illustrate animation</calcite-button> of some
+        text.<br />
         An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
           rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
           icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>to Google with an
-          icon
-        </calcite-button> in some text.<br />
+          icon</calcite-button> in some text.<br />
+
         An anchor link <calcite-button href="http://google.com" appearance="inline" rel="noopener noreferrer"
           target="_blank" title="in the middle with an icon" color='dark'
           icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>in the middle
@@ -882,14 +937,21 @@
           <br />
           An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
             rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
+            icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'
+            iconposition="end"> to Google with an
+            icon</calcite-button> in some text.<br />
+          An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
+            rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
             icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>to Google with an
-            icon
-          </calcite-button> in some text.<br />
+            icon</calcite-button> in some text.<br />
+          An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
+            rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
+            icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>to Google with an
+            icon</calcite-button> in some text.<br />
           An anchor link <calcite-button href="http://google.com" appearance="inline" color='dark'
             rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
             icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'>to Google with an
-            icon
-          </calcite-button> in some text.<br />
+            icon</calcite-button> in some text.<br />
 
         </div>
 
@@ -937,9 +999,9 @@
         <calcite-button onclick="loadingButton(this, 3000)"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
         </calcite-button>
-        <calcite-button appearance="outline" color="dark"
+        <calcite-button appearance="outline" color="dark" iconposition="end"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
-          Download</calcite-button>
+          Download icon end</calcite-button>
         <calcite-button scale="l" appearance="outline"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
           Download</calcite-button>
@@ -952,7 +1014,8 @@
         <calcite-button color='red' appearance="outline" onclick="loadingButton(this, 3000)"
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           Delete this (loader)</calcite-button>
-        <calcite-button color='red' scale="l" appearance="outline" onclick="loadingButton(this, 3000)"
+        <calcite-button color='red' scale="l" appearance="outline" iconposition="end"
+          onclick="loadingButton(this, 3000)"
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           Delete this (loader)</calcite-button>
         <calcite-button color='red' scale="xs" appearance="outline" onclick="loadingButton(this, 3000)"


### PR DESCRIPTION
- Adds "transparent" button style
- Makes "outline" buttons have a dark bg in dark theme
- adds "iconposition" prop to position icon, you can now define iconposition=start/end (defaults to start)
- cleans up some styles

I'd still like to refactor how we allow icons - once we have an "icon component", we can refactor a bit to better scale icons based on button size, and think about letting consumers pass a "calcite ui icon name" as a prop instead of path data, which is pretty messy.