### PR TITLE
bump fonts link to fix medium weight avenir

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
       padding: 1rem;
     }
   </style>
-  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.3.0/fonts.css" />
+  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.3.1/fonts.css" />
   <link rel="stylesheet" href="/build/calcite.css" />
   <script type="module" src="build/calcite.esm.js"></script>
   <script nomodule src="build/calcite.js"></script>


### PR DESCRIPTION
There was a problem with the files in calcite-fonts 1.3.0 for medium weight.