### PR TITLE
fix width of medium/large modals with narrow contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - adds transparent appearance style for `calcite-button`
 - adds `iconposition` prop to `calcite-button`
 - updates dark theme style for `calcite-button`
-  
-### Fixed
 
+### Fixed
+- fix width of medium/large modals with narrow contents
 
 ## [v1.0.0-beta.4] - Aug 19th 2019
 

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -54,6 +54,7 @@
   transform: translate3d(0, 20px, 0);
   box-shadow: $shadow-2;
   margin: $baseline;
+  width: 100%;
 }
 
 :host(.is-active) {
@@ -219,6 +220,10 @@ slot[name="primary"] {
       align-items: flex-end;
     }
   }
+}
+
+:host([size="small"]) .modal {
+  width: auto;
 }
 
 @include modal-size("small", 32rem);


### PR DESCRIPTION
Medium and Large modals would become very narrow when narrow content was passed in. That behavior is now only preserved in the small modal, the rest will size to the max-width immediately.