### PR TITLE
Adds test for prop validation on radio groups

### DIFF
--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -181,4 +181,84 @@ describe("calcite-radio-group", () => {
       expect(role).toEqualText("radiogroup");
     });
   });
+
+  it("renders requested props", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      "<calcite-radio-group theme='dark' scale='l'></calcite-radio-group>"
+    );
+    const element = await page.find("calcite-radio-group");
+    expect(element).toEqualAttribute("theme", "dark");
+    expect(element).toEqualAttribute("scale", "l");
+  });
+
+  it("validates incorrect props", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      "<calcite-radio-group theme='zip' scale='zap'></calcite-radio-group>"
+    );
+
+    const element = await page.find("calcite-radio-group");
+    expect(element).toEqualAttribute("theme", "light");
+    expect(element).toEqualAttribute("scale", "m");
+  });
+
+  it("passes requested scale prop to child components", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-radio-group scale="l">
+          <calcite-radio-group-item id="child-1" value="1" checked>one</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+        </calcite-radio-group>`
+    );
+    const element = await page.find("calcite-radio-group");
+    const child1 = await page.find("#child-1");
+    const child2 = await page.find("#child-2");
+    const child3 = await page.find("#child-3");
+    expect(element).toEqualAttribute("scale", "l");
+    expect(child1).toEqualAttribute("scale", "l");
+    expect(child2).toEqualAttribute("scale", "l");
+    expect(child3).toEqualAttribute("scale", "l");
+  });
+
+  it("passes validated incorrect scale prop to child components", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-radio-group scale="zip">
+          <calcite-radio-group-item id="child-1" value="1" checked>one</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+        </calcite-radio-group>`
+    );
+
+    const element = await page.find("calcite-radio-group");
+    const child1 = await page.find("#child-1");
+    const child2 = await page.find("#child-2");
+    const child3 = await page.find("#child-3");
+    expect(element).toEqualAttribute("scale", "m");
+    expect(child1).toEqualAttribute("scale", "m");
+    expect(child2).toEqualAttribute("scale", "m");
+    expect(child3).toEqualAttribute("scale", "m");
+  });
+
+  it("passes default scale prop to child components", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-radio-group>
+          <calcite-radio-group-item id="child-1" value="1" checked>one</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+        </calcite-radio-group>`
+    );
+
+    const element = await page.find("calcite-radio-group");
+    const child1 = await page.find("#child-1");
+    const child2 = await page.find("#child-2");
+    const child3 = await page.find("#child-3");
+    expect(element).toEqualAttribute("scale", "m");
+    expect(child1).toEqualAttribute("scale", "m");
+    expect(child2).toEqualAttribute("scale", "m");
+    expect(child3).toEqualAttribute("scale", "m");
+  });
 });

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -203,6 +203,16 @@ describe("calcite-radio-group", () => {
     expect(element).toEqualAttribute("scale", "m");
   });
 
+  it("renders default props", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      "<calcite-radio-group></calcite-radio-group>"
+    );
+    const element = await page.find("calcite-radio-group");
+    expect(element).toEqualAttribute("theme", "light");
+    expect(element).toEqualAttribute("scale", "m");
+  });
+
   it("passes requested scale prop to child components", async () => {
     const page = await newE2EPage();
     await page.setContent(


### PR DESCRIPTION
Adds tests for:
- Rendering of requested scale/theme props
- Validation of incorrect scale/theme props
- Rendering of default scale/theme props
- Rendering of requested scale prop on child radio group items
- Validation of incorrect scale prop on child radio group items
- Rendering of default scale prop on child radio group items

Let me know if I should add tests for anything else.

**Note** The "when multiple items are checked, last one wins" test still fails occasionally - related to https://github.com/Esri/calcite-components/issues/104,

Sometimes it passes because it returns the correct item (item 3), sometimes it fails as it returns item 1/item2... but this was already happening pre-these-updates. I had similar "ordering" issues with calcite-dropdown-items/calcite-dropdown-groups and had to explicitly emit their position within the DOM to their parent as Stencil won't always load them in order, even if they are positioned in the DOM correctly.