### PR TITLE
Adds support for dropdown items as links

### DIFF
--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -35,6 +35,21 @@
     $baseline * 1.5};
 }
 
+:host([dir="rtl"][scale="s"]) {
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5
+    $baseline/1.5};
+}
+
+:host([dir="rtl"][scale="m"]) {
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3
+    $baseline / 1.5};
+}
+
+:host([dir="rtl"][scale="l"]) {
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2
+    $baseline / 1.5};
+}
+
 :host {
   display: block;
   @include font-size(-2);
@@ -43,6 +58,7 @@
   padding: var(--calcite-dropdown-item-padding);
   cursor: pointer;
   text-decoration: none;
+  outline: none;
   position: relative;
 }
 
@@ -53,9 +69,11 @@
   color: var(--calcite-dropdown-item-color-hover);
   text-decoration: none;
 }
+
 :host(:active) {
   background-color: var(--calcite-dropdown-item-background-color-pressed);
 }
+
 :host:before {
   content: "\2022";
   position: absolute;
@@ -71,7 +89,6 @@
 }
 
 :host([dir="rtl"]) {
-  padding: $baseline/3 $baseline * 1.5 $baseline/3 $baseline/1.5;
   &:before {
     left: unset;
     right: 1rem;
@@ -84,5 +101,60 @@
   &:before {
     opacity: 1;
     color: var(--calcite-dropdown-item-dot-active-color);
+  }
+}
+
+// when used as link move styling anchor
+:host([islink]) {
+  padding: 0;
+  &:before {
+    display: none;
+  }
+  & a {
+    display: block;
+    position: relative;
+    padding: var(--calcite-dropdown-item-padding);
+    color: var(--calcite-dropdown-item-color);
+    text-decoration: none;
+    outline: none;
+    &:before {
+      content: "\2022";
+      position: absolute;
+      left: 1rem;
+      opacity: 0;
+      color: $blk-120;
+      transition: 0.15s ease-in-out;
+    }
+  }
+}
+
+:host([islink]) a:hover,
+:host([islink]) a:focus,
+:host([islink]) a:active {
+  background-color: var(--calcite-dropdown-item-background-color-hover);
+  text-decoration: none;
+  &:before {
+    opacity: 1;
+  }
+}
+
+:host([islink]) a:active {
+  background-color: var(--calcite-dropdown-item-background-color-pressed);
+}
+
+:host([islink][active]) a {
+  color: var(--calcite-dropdown-item-color-active);
+  font-weight: 500;
+  &:before {
+    opacity: 1;
+    color: var(--calcite-dropdown-item-dot-active-color);
+  }
+}
+
+:host([islink][dir="rtl"]) a {
+  padding: var(--calcite-dropdown-item-padding);
+  &:before {
+    left: unset;
+    right: 1rem;
   }
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -55,6 +55,12 @@ export class CalciteDropdownItem {
   /** @internal */
   @Prop() requestedDropdownItem: string = "";
 
+  /** pass an optional href to render an anchor around the link items */
+  @Prop() href?: string;
+
+  /** pass an optional title for rendered href */
+  @Prop() linktitle?: string;
+
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -75,7 +81,6 @@ export class CalciteDropdownItem {
   componentDidLoad() {
     this.currentDropdownGroup = this.el.parentElement.id;
     this.itemPosition = this.getItemPosition();
-
     this.registerCalciteDropdownItem.emit({
       item: this.el,
       position: this.itemPosition
@@ -91,19 +96,38 @@ export class CalciteDropdownItem {
     const theme = getElementTheme(this.el);
     const scale = getElementProp(this.el, "scale", "m");
     const selected = this.active ? "true" : null;
-    return (
-      <Host
-        theme={theme}
-        dir={dir}
-        scale={scale}
-        id={this.dropdownItemId}
-        tabindex="0"
-        role="menuitem"
-        aria-selected={selected}
-      >
-        <slot />
-      </Host>
-    );
+    if (!this.href) {
+      return (
+        <Host
+          theme={theme}
+          dir={dir}
+          scale={scale}
+          id={this.dropdownItemId}
+          tabindex="0"
+          role="menuitem"
+          aria-selected={selected}
+        >
+          <slot />
+        </Host>
+      );
+    } else {
+      return (
+        <Host
+          theme={theme}
+          dir={dir}
+          scale={scale}
+          id={this.dropdownItemId}
+          tabindex="0"
+          role="menuitem"
+          aria-selected={selected}
+          islink="true"
+        >
+          <a href={this.href} title={this.linktitle}>
+            <slot />
+          </a>
+        </Host>
+      );
+    }
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -22,7 +22,7 @@
 }
 
 :host .calcite-dropdown-wrapper {
-  transform: translate3d(0, $baseline, 0);
+  transform: translate3d(0, -$baseline, 0);
   transition: 300ms $easing-function, opacity 300ms $easing-function,
     all 0.15s ease-in-out;
   visibility: hidden;

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -144,10 +144,13 @@ export class CalciteDropdown {
     let e = item.detail.item;
     let isFirstItem = this.itemIndex(e.target) === 0;
     let isLastItem = this.itemIndex(e.target) === this.items.length - 1;
+    e.preventDefault();
     switch (e.keyCode) {
       case TAB:
         if (isLastItem && !e.shiftKey) this.closeCalciteDropdown();
-        if (isFirstItem && e.shiftKey) this.closeCalciteDropdown();
+        else if (isFirstItem && e.shiftKey) this.closeCalciteDropdown();
+        else if (e.shiftKey) this.focusPrevItem(e.target);
+        else this.focusNextItem(e.target);
         break;
       case DOWN:
         this.focusNextItem(e.target);
@@ -202,34 +205,44 @@ export class CalciteDropdown {
 
   private focusFirstItem() {
     const firstItem = this.items[0];
-    firstItem.focus();
+    const focusableItem = this.getFocusableElement(firstItem);
+    focusableItem.focus();
   }
 
   private focusLastItem() {
     const lastItem = this.items[this.items.length - 1];
-    lastItem.focus();
+    const focusableItem = this.getFocusableElement(lastItem);
+    focusableItem.focus();
   }
 
   private focusNextItem(e) {
     const index = this.itemIndex(e);
     const nextItem = this.items[index + 1] || this.items[0];
-    nextItem.focus();
+    const focusableItem = this.getFocusableElement(nextItem);
+    focusableItem.focus();
   }
 
   private focusPrevItem(e) {
     const index = this.itemIndex(e);
     const prevItem = this.items[index - 1] || this.items[this.items.length - 1];
-    prevItem.focus();
+    const focusableItem = this.getFocusableElement(prevItem);
+    focusableItem.focus();
   }
 
   private itemIndex(e) {
     return this.items.indexOf(e);
   }
 
+  private getFocusableElement(item) {
+    return item.attributes.islink ? item.shadowRoot.querySelector("a") : item;
+  }
+
   private openCalciteDropdown() {
     this.active = !this.active;
-    this.focusFirstItem();
+    // time for animation
+    setTimeout(() => this.focusFirstItem(), 50);
   }
+
   private sortItems = (items: any[]): any[] =>
     items
       .sort((a, b) => a.position - b.position)

--- a/src/index.html
+++ b/src/index.html
@@ -1172,6 +1172,33 @@
         </calcite-dropdown>
         <br />
         <br />
+        <h3> Dropdowns with items as links</h3>
+        <calcite-dropdown>
+          <calcite-button slot="dropdown-trigger">Dropdowns with items as links</calcite-button>
+          <calcite-dropdown-group>
+            <calcite-dropdown-item href="/mypage" linktitle="My Page">Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage2" linktitle="My Page 2" active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage3" linktitle="My Page 3">Title</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <br />
+        <br />
+        <h3> Dropdowns with items as links mixed with not links</h3>
+        <calcite-dropdown>
+          <calcite-button slot="dropdown-trigger">Dropdowns with items as links</calcite-button>
+          <calcite-dropdown-group grouptitle="Not Links">
+            <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item>Title</calcite-dropdown-item>
+          </calcite-dropdown-group>
+          <calcite-dropdown-group grouptitle="Link">
+            <calcite-dropdown-item href="/mypage" linktitle="My Page">Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage2" linktitle="My Page 3" active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage3" linktitle="My Page 3">Title</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <br />
+        <br />
         <calcite-dropdown theme="dark">
           <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode</calcite-button>
           <calcite-dropdown-group>


### PR DESCRIPTION
Auto focuses first item
Some style cleanup
Switches animation direction
RTL fixes

You can now pass href and title to dropdown links - useful for in-app navigation or context switching based on paths. Previously, you could pass an anchor in the slot, but it would render with a limited hitbox and had focus order issues. This addresses https://github.com/Esri/calcite-components/issues/124 and allows for tabbing through dropdowns with links.

```
<calcite-dropdown>
    <calcite-dropdown-group>
        <calcite-dropdown-item href="/mypage" linktitle="My Page">Relevance</calcite-dropdown-item>
        <calcite-dropdown-item href="/mypage2" linktitle="My Page 2"active>Date modified</calcite-dropdown-item>
        <calcite-dropdown-item href="/mypage3" linktitle="My Page 3">Title</calcite-dropdown-item>
    </calcite-dropdown-group>
</calcite-dropdown>
```