### PR TITLE
add `closeOnEscape` option to calcite-modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+## [v1.0.0-beta.8] - Sep 3rd 2019
+
+### Added
+
+* Adds a boolean "disableEscape" prop to calcite-modal to make closing on escape optional.
+
 ## [v1.0.0-beta.7] - Aug 30th 2019
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Web Components for Esri's Calcite Design System.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -154,4 +154,16 @@ describe("calcite-modal accessibility checks", () => {
     await page.waitForChanges();
     expect(modal).not.toHaveClass("is-active");
   });
+
+  it("does not close when Escape is pressed and disable-escape is set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal disable-escape></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    await modal.callMethod("open");
+    await page.waitForChanges();
+    expect(modal).toHaveClass("is-active");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(modal).toHaveClass("is-active");
+  });
 });

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -47,6 +47,8 @@ export class CalciteModal {
   @Prop({ reflect: true }) docked: boolean;
   /** Specify an element to focus when the modal is first opened */
   @Prop() firstFocus?: HTMLElement;
+  /** Flag to disable the default close on escape behavior */
+  @Prop() disableEscape?: boolean;
   /** Set the overall size of the modal */
   @Prop({ reflect: true }) size: "small" | "medium" | "large" | "fullscreen" =
     "small";
@@ -91,7 +93,7 @@ export class CalciteModal {
         theme={theme}
       >
         <div class="modal">
-          <focus-trap ref={el => (this.trap = el as FocusTrap)}>
+          <focus-trap ref={(el: FocusTrap) => (this.trap = el)}>
             <div class="modal__header">
               <button
                 class="modal__close"
@@ -138,7 +140,7 @@ export class CalciteModal {
   //
   //--------------------------------------------------------------------------
   @Listen("keyup") handleEscape(e: KeyboardEvent) {
-    if (e.key === "Escape") {
+    if (e.key === "Escape" && !this.disableEscape) {
       this.close();
     }
   }

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -53,15 +53,16 @@ modal.open();
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                  | Type                                             | Default                       |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------- |
-| `beforeClose` | --            | Optionally pass a function to run before close                                                               | `(el: HTMLElement) => Promise<void>`             | `() =>     Promise.resolve()` |
-| `closeLabel`  | `close-label` | Aria label for the close button                                                                              | `string`                                         | `"Close"`                     |
-| `color`       | `color`       | Adds a color bar at the top for visual impact, Use color to add importance to desctructive/workflow dialogs. | `"blue" \| "red"`                                | `undefined`                   |
-| `docked`      | `docked`      | Prevent the modal from taking up the entire screen on mobile                                                 | `boolean`                                        | `undefined`                   |
-| `firstFocus`  | --            | Specify an element to focus when the modal is first opened                                                   | `HTMLElement`                                    | `undefined`                   |
-| `size`        | `size`        | Set the overall size of the modal                                                                            | `"fullscreen" \| "large" \| "medium" \| "small"` | `"small"`                     |
-| `theme`       | `theme`       | Select theme (light or dark)                                                                                 | `"dark" \| "light"`                              | `"light"`                     |
+| Property        | Attribute         | Description                                                                                                  | Type                                             | Default                       |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------- |
+| `beforeClose`   | --                | Optionally pass a function to run before close                                                               | `(el: HTMLElement) => Promise<void>`             | `() =>     Promise.resolve()` |
+| `closeLabel`    | `close-label`     | Aria label for the close button                                                                              | `string`                                         | `"Close"`                     |
+| `closeOnEscape` | `close-on-escape` | Specify whether the modal should close when escape is pressed                                                | `boolean`                                        | `true`                        |
+| `color`         | `color`           | Adds a color bar at the top for visual impact, Use color to add importance to desctructive/workflow dialogs. | `"blue" \| "red"`                                | `undefined`                   |
+| `docked`        | `docked`          | Prevent the modal from taking up the entire screen on mobile                                                 | `boolean`                                        | `undefined`                   |
+| `firstFocus`    | --                | Specify an element to focus when the modal is first opened                                                   | `HTMLElement`                                    | `undefined`                   |
+| `size`          | `size`            | Set the overall size of the modal                                                                            | `"fullscreen" \| "large" \| "medium" \| "small"` | `"small"`                     |
+| `theme`         | `theme`           | Select theme (light or dark)                                                                                 | `"dark" \| "light"`                              | `"light"`                     |
 
 
 ## Events

--- a/src/index.html
+++ b/src/index.html
@@ -463,6 +463,13 @@
           </div>
           <calcite-button slot="primary">OK</calcite-button>
         </calcite-modal>
+        <calcite-modal class="js-modal-10" disable-escape>
+          <div slot="content">
+            <p>This modal has <code>disable-escape</code> set, so pressing the escape key will not dismiss it.</p>
+          </div>
+          <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+        </calcite-modal>
+
         <ul>
           <li>
             <calcite-button appearance="inline" onClick="openModal('.js-modal-1')">Small Modal</calcite-button>
@@ -491,6 +498,10 @@
           <li>
             <calcite-button appearance="inline" onClick="openModal('.js-modal-9')">Dark Theme</calcite-button>
           </li>
+          <li>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-10')">Close on escape press disabled</calcite-button>
+          </li>
+
         </ul>
         <script>
           function openModal(selector) {


### PR DESCRIPTION
The code here is hopefully self-explanatory.

I have a use-case where the user can do a bunch of work inside of the modal, and accidentally hitting "escape" would dismiss all of that work without a prompt, which I've already found is very frustrating.

Even with this option, the modal ought to remain accessible because the user can still tab to the "X" button and hit enter.