### PR TITLE
scroll modal content rather than full modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### [Unreleased][HEAD]
 
+### Fixed
+- Fixed scroll behavior in tall modals (only scroll modal content)
+
 ## [v1.0.0-beta.8] - Sep 3rd 2019
 
 ### Added
@@ -73,10 +76,13 @@ Fix issue with previous release.
 
 First initial beta release.
 
-[v1.0.0-beta.6]: https://github.com/ArcGIS/calcite-components/compare/v1.0.0-beta.5...v1.0.0-beta.6 "v1.0.0-beta.6"
-[v1.0.0-beta.5]: https://github.com/ArcGIS/calcite-components/compare/v1.0.0-beta.4...v1.0.0-beta.5 "v1.0.0-beta.5"
-[v1.0.0-beta.4]: https://github.com/ArcGIS/calcite-components/compare/v1.0.0-beta.3...v1.0.0-beta.4 "v1.0.0-beta.4"
-[v1.0.0-beta.3]: https://github.com/ArcGIS/calcite-components/compare/v1.0.0-beta.2...v1.0.0-beta.3 "v1.0.0-beta.3"
-[v1.0.0-beta.2]: https://github.com/ArcGIS/calcite-components/compare/v1.0.0-beta.1...v1.0.0-beta.2 "v1.0.0-beta.2"
-[v1.0.0-beta.1]: https://github.com/ArcGIS/calcite-components/compare/dafb2312835ec6fef134d0d2b20aabd1dfe907cf...v1.0.0-beta.1 "v1.0.0-beta.1"
-[HEAD]: https://github.com/ArcGIS/calcite-components/compare/v1.0.0-beta.3...HEAD "Unreleased Changes"
+
+[v1.0.0-beta.8]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.7...v1.0.0-beta.8 "v1.0.0-beta.8"
+[v1.0.0-beta.7]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.6...v1.0.0-beta.7 "v1.0.0-beta.7"
+[v1.0.0-beta.6]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.5...v1.0.0-beta.6 "v1.0.0-beta.6"
+[v1.0.0-beta.5]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.4...v1.0.0-beta.5 "v1.0.0-beta.5"
+[v1.0.0-beta.4]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.3...v1.0.0-beta.4 "v1.0.0-beta.4"
+[v1.0.0-beta.3]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.2...v1.0.0-beta.3 "v1.0.0-beta.3"
+[v1.0.0-beta.2]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.1...v1.0.0-beta.2 "v1.0.0-beta.2"
+[v1.0.0-beta.1]: https://github.com/Esri/calcite-components/compare/dafb2312835ec6fef134d0d2b20aabd1dfe907cf...v1.0.0-beta.1 "v1.0.0-beta.1"
+[HEAD]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...HEAD "Unreleased Changes"

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -38,11 +38,9 @@
 
 .modal {
   box-sizing: border-box;
-  max-height: 80vh;
   z-index: 102;
   float: none;
   text-align: left;
-  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   display: flex;
   flex-direction: column;
@@ -148,6 +146,8 @@ slot[name="header"]::slotted(*) {
   padding: $baseline;
   height: 100%;
   overflow: auto;
+  max-height: calc(100vh - 14rem);
+  overflow-y: auto;
   display: block;
   background-color: var(--calcite-modal-background);
   z-index: 1;
@@ -213,7 +213,8 @@ slot[name="primary"] {
         margin: 0;
       }
       .modal__content {
-        flex: 1 1 auto;
+        flex: 1 1 0;
+        max-height: unset;
       }
     }
     :host([size="#{$size}"][docked]) {

--- a/src/index.html
+++ b/src/index.html
@@ -366,7 +366,8 @@
         <calcite-modal class="js-modal-1" size="small">
           <h3 slot="header">Small Modal</h3>
           <div slot="content">
-            <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
+            <p>
+              The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
             </p>
           </div>
           <calcite-button slot="back" color="light" appearance="outline"


### PR DESCRIPTION
Small update to modal scrolling behavior. Only the content will scroll now, rather than the entire modal.

Also updated the links in the `CHANGELOG` so that they pointed to `Esri/calcite-components`  and made sure we had them all accounted for.

@macandcheese you already reviewed this, but adding you again anyways.