### PR TITLE
Edge fixes for alerts, dropdowns, buttons

### DIFF
--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -20,3 +20,10 @@ calcite-tab[is-active] {
 a {
   color: $ui-blue;
 }
+
+@mixin slotted($selector, $tag) {
+  slot[name="#{$selector}"]::slotted(#{$tag}),
+  #{$tag}::slotted([slot="#{$selector}"]) {
+    @content;
+  }
+}

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -9,7 +9,7 @@
   --calcite-alert-close-background-pressed: #{$blk-020};
   --calcite-alert-count-text: #{$blk-180};
   --calcite-alert-count-border: #{$blk-010};
-  --calcite-alert-dismiss-background: #{rgba($blk-000, 0.6)};
+  --calcite-alert-dismiss-background: #{rgba($blk-000, 0.8)};
   --calcite-alert-border-blue: #{$ui-blue};
   --calcite-alert-border-green: #{$ui-green};
   --calcite-alert-border-red: #{$ui-red};
@@ -26,7 +26,7 @@
   --calcite-alert-close-background-pressed: #{$blk-220};
   --calcite-alert-count-text: #{$blk-040};
   --calcite-alert-count-border: #{$blk-210};
-  --calcite-alert-dismiss-background: #{rgba($blk-200, 0.6)};
+  --calcite-alert-dismiss-background: #{rgba($blk-200, 0.8)};
   --calcite-alert-border-blue: #{$ui-blue-dark};
   --calcite-alert-border-green: #{$ui-green-dark};
   --calcite-alert-border-red: #{$ui-red-dark};
@@ -50,7 +50,7 @@
   transform: translate3d(0, $baseline, 0);
   transition: 300ms $easing-function, opacity 300ms $easing-function,
     all 0.15s ease-in-out;
-  border-block-start: 0px solid transparent;
+  border-top: 0px solid transparent;
   @media only screen and (max-width: $viewport-medium) {
     width: 100%;
     max-width: 100%;
@@ -61,35 +61,37 @@
   &:host(.hydrated) {
     visibility: hidden !important;
   }
+}
 
-  &:host([active]) {
-    opacity: 1;
-    max-height: 100%;
-    transform: translate3d(0, -$baseline, 0);
-    pointer-events: initial;
-    border-block-start-width: 3px;
+:host([active]) {
+  opacity: 1;
+  max-height: 100%;
+  transform: translate3d(0, -$baseline, 0);
+  pointer-events: initial;
+  border-top-width: 3px;
 
-    &:host(.hydrated) {
-      visibility: visible !important;
-    }
+  &:host(.hydrated) {
+    visibility: visible !important;
+  }
 
-    @media only screen and (max-width: $viewport-medium) {
-      transform: translate3d(0, 0, 0);
-    }
+  @media only screen and (max-width: $viewport-medium) {
+    transform: translate3d(0, 0, 0);
   }
 }
 
-:host slot[name="alert-title"]::slotted(div) {
+slot[name="alert-title"]::slotted(div),
+div::slotted([slot="alert-title"]) {
   @include font-size(0);
   color: var(--calcite-alert-title-text);
   font-weight: 500;
 }
-:host slot[name="alert-link"]::slotted(calcite-button),
-:host slot[name="alert-link"]::slotted(a) {
+
+::slotted(calcite-button) {
   @include font-size(-1);
 }
 
-:host slot[name="alert-message"]::slotted(div) {
+slot[name="alert-message"]::slotted(div),
+div::slotted([slot="alert-message"]) {
   display: inline;
   margin-right: $baseline/2;
   @include font-size(-1);
@@ -97,7 +99,8 @@
 }
 
 :host([dir="rtl"]) {
-  & slot[name="alert-message"]::slotted(div) {
+  & slot[name="alert-message"]::slotted(div),
+  & div::slotted([slot="alert-message"]) {
     margin-right: unset;
     margin-left: $baseline/2;
   }
@@ -124,23 +127,28 @@
   flex: 1 1 auto;
   min-width: 0;
   word-wrap: break-word;
-  padding-block-start: $baseline/2;
-  padding-block-end: $baseline/2;
-  padding-inline-end: $baseline/2;
-  padding-inline-start: 0;
+  padding: $baseline/2 $baseline/2 $baseline/2 0;
 
   &:first-of-type {
-    padding-inline-start: $baseline;
+    padding-left: $baseline;
   }
 
   @media only screen and (max-width: $viewport-medium) {
-    padding-block-start: $baseline;
-    padding-block-end: $baseline;
-    padding-inline-end: $baseline/2;
-    padding-inline-start: 0;
+    padding: $baseline $baseline/2 $baseline 0;
   }
 }
 
+:host([dir="rtl"]) {
+  .alert-content {
+    &:first-of-type {
+      padding-right: $baseline;
+      padding-left: none;
+    }
+    @media only screen and (max-width: $viewport-medium) {
+      padding: $baseline 0 $baseline $baseline/2;
+    }
+  }
+}
 .alert-icon {
   @include alert-element-base;
   display: flex;
@@ -183,7 +191,7 @@
   @include font-size(-2);
   display: flex;
   align-items: center;
-  justify-content: space-evenly;
+  justify-content: space-around;
   overflow: hidden;
   width: 0;
   visibility: hidden;
@@ -191,8 +199,8 @@
   text-align: center;
   color: var(--calcite-alert-count-text);
   opacity: 0;
-  border-inline-start: 0px solid transparent;
-  border-inline-end: 0px solid transparent;
+  border-left: 0px solid transparent;
+  border-right: 0px solid transparent;
   cursor: default;
   transition: all 0.15s ease-in-out;
 
@@ -201,11 +209,11 @@
     opacity: 1;
     padding: 0 $baseline/4;
     width: $baseline * 2;
-    border-inline-start: 1px solid var(--calcite-alert-count-border);
-    border-inline-end: 1px solid var(--calcite-alert-count-border);
+    border-left: 1px solid var(--calcite-alert-count-border);
+    border-right: 1px solid var(--calcite-alert-count-border);
 
     &:last-child {
-      border-inline-end: 0px solid transparent;
+      border-right: 0px solid transparent;
     }
   }
 
@@ -213,7 +221,12 @@
     border-radius: 0;
   }
 }
-
+:host([dir="rtl"]) {
+  &.active:last-child {
+    border-left: 1px solid var(--calcite-alert-count-border);
+    border-right: 0px solid transparent;
+  }
+}
 .alert-dismiss {
   display: block;
   position: absolute;
@@ -247,7 +260,7 @@ $alertColors: "blue" var(--calcite-alert-border-blue),
   $color: nth($alertColor, 2);
 
   :host([color="#{$name}"]) {
-    border-block-start-color: $color;
+    border-top-color: $color;
 
     & .alert-icon svg {
       fill: $color;
@@ -270,7 +283,7 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
 @keyframes dismissProgress {
   0% {
     width: 0;
-    opacity: 0;
+    opacity: 0.8;
   }
   100% {
     width: 100%;

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -79,8 +79,7 @@
   }
 }
 
-slot[name="alert-title"]::slotted(div),
-div::slotted([slot="alert-title"]) {
+@include slotted("alert-title", "div") {
   @include font-size(0);
   color: var(--calcite-alert-title-text);
   font-weight: 500;
@@ -90,8 +89,7 @@ div::slotted([slot="alert-title"]) {
   @include font-size(-1);
 }
 
-slot[name="alert-message"]::slotted(div),
-div::slotted([slot="alert-message"]) {
+@include slotted("alert-message", "div") {
   display: inline;
   margin-right: $baseline/2;
   @include font-size(-1);
@@ -99,8 +97,7 @@ div::slotted([slot="alert-message"]) {
 }
 
 :host([dir="rtl"]) {
-  & slot[name="alert-message"]::slotted(div),
-  & div::slotted([slot="alert-message"]) {
+  @include slotted("alert-message", "div") {
     margin-right: unset;
     margin-left: $baseline/2;
   }

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -59,7 +59,7 @@ export class CalciteAlert {
   @Prop() icon: boolean = false;
 
   /** Unique ID for this alert */
-   /** @internal */
+  /** @internal */
   @Prop() alertId: string = this.el.id;
 
   /** @internal */
@@ -169,7 +169,7 @@ export class CalciteAlert {
     const progress =
       this.active && this.dismiss ? <div class="alert-dismiss"></div> : "";
     return (
-      <Host active={!!this.active} dir={dir}>
+      <Host active={this.active} dir={dir}>
         {icon}
         <div class="alert-content">
           <slot name="alert-title"></slot>

--- a/src/components/calcite-alerts/calcite-alerts.scss
+++ b/src/components/calcite-alerts/calcite-alerts.scss
@@ -6,8 +6,8 @@
   bottom: 0;
   pointer-events: none;
   z-index: 101;
+}
 
-  &:host([active]) {
-    display: block;
-  }
+:host([active]) {
+  display: block;
 }

--- a/src/components/calcite-alerts/calcite-alerts.tsx
+++ b/src/components/calcite-alerts/calcite-alerts.tsx
@@ -68,7 +68,7 @@ export class CalciteAlerts {
     };
 
     return (
-      <Host active={!!this.active}>
+      <Host active={this.active}>
         <AlertInterface.Provider state={alertState}>
           <slot />
         </AlertInterface.Provider>

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -85,10 +85,7 @@ export class CalciteButton {
 
   componentDidLoad() {
     if (Build.isBrowser) {
-      let textSlot = this.el.shadowRoot.querySelector("slot");
-      let textNode = textSlot ? textSlot.assignedNodes() : null;
-      if (textNode && (textNode[0] !== undefined && textNode[0] !== null))
-        this.hastext = true;
+      this.hastext = this.el.textContent.length > 0;
     }
   }
 

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -157,6 +157,7 @@ export class CalciteDropdownItem {
         this.calciteDropdownItemKeyEvent.emit({ item: e });
         break;
     }
+    e.preventDefault();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -103,7 +103,7 @@ export class CalciteDropdown {
   //--------------------------------------------------------------------------
 
   @Listen("click") openDropdown(e) {
-    if (e.target.slot === "dropdown-trigger") {
+    if (e.target.outerHTML.includes(`slot="dropdown-trigger"`)) {
       this.openCalciteDropdown();
     }
   }
@@ -118,7 +118,7 @@ export class CalciteDropdown {
   }
 
   @Listen("keydown") keyDownHandler(e) {
-    if (e.target.slot === "dropdown-trigger") {
+    if (e.target.outerHTML.includes(`slot="dropdown-trigger"`)) {
       if (
         e.target.nodeName !== "BUTTON" &&
         e.target.nodeName !== "CALCITE-BUTTON"
@@ -142,21 +142,23 @@ export class CalciteDropdown {
     item: CustomEvent
   ) {
     let e = item.detail.item;
-    let isFirstItem = this.itemIndex(e.target) === 0;
-    let isLastItem = this.itemIndex(e.target) === this.items.length - 1;
-    e.preventDefault();
+    // handle edge
+    let itemToFocus =
+      e.target.nodeName !== "A" ? e.target : e.target.parentNode;
+    let isFirstItem = this.itemIndex(itemToFocus) === 0;
+    let isLastItem = this.itemIndex(itemToFocus) === this.items.length - 1;
     switch (e.keyCode) {
       case TAB:
         if (isLastItem && !e.shiftKey) this.closeCalciteDropdown();
         else if (isFirstItem && e.shiftKey) this.closeCalciteDropdown();
-        else if (e.shiftKey) this.focusPrevItem(e.target);
-        else this.focusNextItem(e.target);
+        else if (e.shiftKey) this.focusPrevItem(itemToFocus);
+        else this.focusNextItem(itemToFocus);
         break;
       case DOWN:
-        this.focusNextItem(e.target);
+        this.focusNextItem(itemToFocus);
         break;
       case UP:
-        this.focusPrevItem(e.target);
+        this.focusPrevItem(itemToFocus);
         break;
       case HOME:
         this.focusFirstItem();
@@ -165,6 +167,7 @@ export class CalciteDropdown {
         this.focusLastItem();
         break;
     }
+    e.preventDefault();
   }
 
   @Listen("registerCalciteDropdownGroup") registerCalciteDropdownGroup(

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -103,8 +103,9 @@ export class CalciteDropdown {
   //--------------------------------------------------------------------------
 
   @Listen("click") openDropdown(e) {
-    if (e.target.outerHTML.includes(`slot="dropdown-trigger"`)) {
+    if (e.target.getAttribute("slot") === "dropdown-trigger") {
       this.openCalciteDropdown();
+      e.preventDefault();
     }
   }
 
@@ -118,7 +119,7 @@ export class CalciteDropdown {
   }
 
   @Listen("keydown") keyDownHandler(e) {
-    if (e.target.outerHTML.includes(`slot="dropdown-trigger"`)) {
+    if (e.target.getAttribute("slot") === "dropdown-trigger") {
       if (
         e.target.nodeName !== "BUTTON" &&
         e.target.nodeName !== "CALCITE-BUTTON"

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -18,7 +18,7 @@
   --calcite-tabs-border: #{$blk-180};
   --calcite-tabs-border-hover: #{$blk-130};
   --calcite-tabs-color-active: #{$blk-005};
-  --calcite-tabs-border-active: #{$blk-000};
+  --calcite-tabs-border-active: #{$ui-blue-dark};
 }
 
 :host([dir="rtl"]) {


### PR DESCRIPTION
Restores function for alerts and dropdowns
Fixes styling for alerts, dropdowns, and buttons
Syntax changes due to Edge's incompatibility with shadowRoot / ::slotted styling
Adjusts active color for tabs

Having to use  
`if (e.target.outerHTML.includes('slot="dropdown-trigger"')) { ... }`

instead of 
` if (e.target.slot === "dropdown-trigger") { ... } `

_feels wrong_, so if there is a better pattern that lets you target slots in Edge, I'm all ears and happy to update.