### PR TITLE
Fix for inline with no href, and button width props

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -2,6 +2,7 @@
 // light theme
 :host {
   display: inline-block;
+  width: auto;
   --calcite-button-blue: #{$ui-blue};
   --calcite-button-blue-hover: #{$ui-blue-hover};
   --calcite-button-blue-pressed: #{$ui-blue-pressed};
@@ -46,7 +47,7 @@
   display: block;
   padding: $baseline/4 1rem;
   text-decoration: none;
-  width: auto;
+  width: 100%;
   border-radius: 0;
   border: none;
   user-select: none;
@@ -69,13 +70,15 @@
 }
 
 // button width
-:host([width="half"]) button,
-:host([width="half"]) a {
+:host([width="auto"]) {
+  width: auto;
+}
+
+:host([width="half"]) {
   width: 50%;
 }
 
-:host([width="full"]) button,
-:host([width="full"]) a {
+:host([width="full"]) {
   width: 100%;
 }
 

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -42,7 +42,8 @@
 
 // button base
 :host button,
-:host a {
+:host a,
+:host span {
   position: relative;
   display: block;
   padding: $baseline/4 1rem;
@@ -470,7 +471,7 @@
 }
 
 :host([appearance="inline"][color="blue"]) {
-  button,
+  span,
   a {
     @include btn-inline(
       var(--calcite-button-blue),
@@ -481,7 +482,7 @@
 }
 
 :host([appearance="inline"][color="red"]) {
-  button,
+  span,
   a {
     @include btn-inline(
       var(--calcite-button-red),
@@ -491,19 +492,19 @@
   }
 }
 :host([appearance="inline"][color="light"]) {
-  button,
+  span,
   a {
     @include btn-inline($blk-010, $blk-000, rgba($blk-000, 0.2));
   }
 }
 :host([appearance="inline"][color="dark"]) {
-  button,
+  span,
   a {
     @include btn-inline($blk-200, $blk-180, rgba($blk-180, 0.2));
   }
 }
 :host([appearance="inline"][dir="rtl"]) {
-  button,
+  span,
   a {
     background-position: 100% 100%, 100% 100%;
   }

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -131,7 +131,12 @@ export class CalciteButton {
     if (this.iconposition === "start") {
       return (
         <Host dir={dir} hastext={this.hastext}>
-          <Tag {...attributes} role={role} disabled={this.disabled}>
+          <Tag
+            tabindex="0"
+            {...attributes}
+            role={role}
+            disabled={this.disabled}
+          >
             {loader}
             {icon}
             <slot />
@@ -141,7 +146,12 @@ export class CalciteButton {
     } else if (this.iconposition === "end") {
       return (
         <Host dir={dir} hastext={this.hastext}>
-          <Tag {...attributes} role={role} disabled={this.disabled}>
+          <Tag
+            tabindex="0"
+            {...attributes}
+            role={role}
+            disabled={this.disabled}
+          >
             {loader}
             <slot />
             {icon}
@@ -149,12 +159,19 @@ export class CalciteButton {
         </Host>
       );
     } else {
-      <Host dir={dir} hastext={this.hastext}>
-        <Tag {...attributes} role={role} disabled={this.disabled}>
-          {loader}
-          <slot />
-        </Tag>
-      </Host>;
+      return (
+        <Host dir={dir} hastext={this.hastext}>
+          <Tag
+            tabindex="0"
+            {...attributes}
+            role={role}
+            disabled={this.disabled}
+          >
+            {loader}
+            <slot />
+          </Tag>
+        </Host>
+      );
     }
   }
 }

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -90,7 +90,7 @@ export class CalciteButton {
   }
 
   getAttributes() {
-    // spread attributes specified on the compoennt to component child, if they aren't props
+    // spread attributes specified on the component to rendered child, if they aren't props
     let props = [
       "appearance",
       "color",
@@ -111,8 +111,13 @@ export class CalciteButton {
   render() {
     const dir = getElementDir(this.el);
     const attributes = this.getAttributes();
-    const Tag = this.href || this.appearance === "inline" ? "a" : "button";
-    const role = Tag === "a" ? "link" : "button";
+    const Tag = this.href
+      ? "a"
+      : this.appearance === "inline"
+      ? "span"
+      : "button";
+    const role = Tag === "span" ? "button" : null;
+    const tabIndex = Tag === "span" ? 0 : null;
     const loader = this.loading ? (
       <div class="calcite-button--loader">
         <calcite-loader is-active inline></calcite-loader>
@@ -132,9 +137,9 @@ export class CalciteButton {
       return (
         <Host dir={dir} hastext={this.hastext}>
           <Tag
-            tabindex="0"
             {...attributes}
             role={role}
+            tabindex={tabIndex}
             disabled={this.disabled}
           >
             {loader}
@@ -147,9 +152,9 @@ export class CalciteButton {
       return (
         <Host dir={dir} hastext={this.hastext}>
           <Tag
-            tabindex="0"
             {...attributes}
             role={role}
+            tabindex={tabIndex}
             disabled={this.disabled}
           >
             {loader}
@@ -162,9 +167,9 @@ export class CalciteButton {
       return (
         <Host dir={dir} hastext={this.hastext}>
           <Tag
-            tabindex="0"
             {...attributes}
             role={role}
+            tabindex={tabIndex}
             disabled={this.disabled}
           >
             {loader}

--- a/src/index.html
+++ b/src/index.html
@@ -500,7 +500,8 @@
             <calcite-button appearance="inline" onClick="openModal('.js-modal-9')">Dark Theme</calcite-button>
           </li>
           <li>
-            <calcite-button appearance="inline" onClick="openModal('.js-modal-10')">Close on escape press disabled</calcite-button>
+            <calcite-button appearance="inline" onClick="openModal('.js-modal-10')">Close on escape press disabled
+            </calcite-button>
           </li>
 
         </ul>
@@ -1044,7 +1045,8 @@
         </div>
 
         <h3>Type: Inline (render as anchor)</h3>
-        An anchor <calcite-button title="in the middle" appearance="inline"> with no href in the middle</calcite-button> of
+        An anchor <calcite-button title="in the middle" appearance="inline"> with no href in the middle</calcite-button>
+        of
         some
         text.<br />
         An anchor <calcite-button title="in the middle" href="/" appearance="inline">in the middle</calcite-button> of

--- a/src/index.html
+++ b/src/index.html
@@ -1044,6 +1044,9 @@
         </div>
 
         <h3>Type: Inline (render as anchor)</h3>
+        An anchor <calcite-button title="in the middle" appearance="inline"> with no href in the middle</calcite-button> of
+        some
+        text.<br />
         An anchor <calcite-button title="in the middle" href="/" appearance="inline">in the middle</calcite-button> of
         some
         text.<br />


### PR DESCRIPTION
Sets tabindex for all rendered child items to ensure focusability
Sets explicit width on parent for width half / full (fix for recent change to button structure)