### PR TITLE
Fix release origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
 ## [v1.0.0-beta.9] - Sep 9th 2019
 
 ### Fixed
+
 - Fixed scroll behavior in tall modals (only scroll modal content)
+- Bug with nesing tree items with and without links
+- Fixes for buttons, alerts and dropdowns in Edge
+- Allow buttons to fill the height of their host
 
 ## [v1.0.0-beta.8] - Sep 3rd 2019
 
 ### Added
 
-* Adds a boolean "disableEscape" prop to calcite-modal to make closing on escape optional.
+- Adds a boolean "disableEscape" prop to calcite-modal to make closing on escape optional.
 
 ## [v1.0.0-beta.7] - Aug 30th 2019
 
 ### Added
 
-* Adds support for dropdown items as links
-*	Updates toggle styling and adds props for scale
+- Adds support for dropdown items as links
+- Updates toggle styling and adds props for scale
 
 ## [v1.0.0-beta.6] - Aug 26th 2019
 
@@ -33,8 +36,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [v1.0.0-beta.5] - Aug 21th 2019
 
 ### Added
+
 - adds scale prop to `calcite-radio-group`
-- updates style of  `calcite-radio-group`
+- updates style of `calcite-radio-group`
 - adds transparent appearance style for `calcite-button`
 - adds `iconposition` prop to `calcite-button`
 - updates dark theme style for `calcite-button`
@@ -42,28 +46,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - adds support for disabled `calcite-button`
 
 ### Fixed
+
 - fix width of medium/large modals with narrow contents
 
 ## [v1.0.0-beta.4] - Aug 19th 2019
 
 ### Added
+
 - dark theme for `calcite-slider`
 - added `<calcite-dropdown>`
 - added `<calcite-tree>`
 
-
 ### Fixed
+
 - solved issue with incorrect positioning of handle in `calcite-slider`
 - fix various issue in Edge
 
 ## [v1.0.0-beta.3] - Aug 16th 2019
 
 ### Added
+
 - date picker keyboard support
 - date picker page-up and page-down buttons
 - pre-render support for existing components
 
 ### Fixed
+
 - style updates/dark theme for buttons
 - fixed styling of modals in firefox
 - fixed radio-group styling in Edge
@@ -77,7 +85,6 @@ Fix issue with previous release.
 
 First initial beta release.
 
-
 [v1.0.0-beta.9]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...v1.0.0-beta.9 "v1.0.0-beta.9"
 [v1.0.0-beta.8]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.7...v1.0.0-beta.8 "v1.0.0-beta.8"
 [v1.0.0-beta.7]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.6...v1.0.0-beta.7 "v1.0.0-beta.7"
@@ -87,4 +94,4 @@ First initial beta release.
 [v1.0.0-beta.3]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.2...v1.0.0-beta.3 "v1.0.0-beta.3"
 [v1.0.0-beta.2]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.1...v1.0.0-beta.2 "v1.0.0-beta.2"
 [v1.0.0-beta.1]: https://github.com/Esri/calcite-components/compare/dafb2312835ec6fef134d0d2b20aabd1dfe907cf...v1.0.0-beta.1 "v1.0.0-beta.1"
-[HEAD]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...HEAD "Unreleased Changes"
+[head]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...HEAD "Unreleased Changes"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "Web Components for Esri's Calcite Design System.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/support/release.sh
+++ b/support/release.sh
@@ -22,10 +22,10 @@ git commit -am "v$VERSION - add built files" --no-verify
 git tag v$VERSION
 
 # push everything up to this point to master
-git push https://github.com/ArcGIS/calcite-components.git master
+git push origin master
 
 # push the new tag, not the old tags
-git push https://github.com/ArcGIS/calcite-components.git v$VERSION
+git push origin v$VERSION
 
 # publish to NPM
 npm publish --access=public


### PR DESCRIPTION
This should fix the release process for people who have 2 factor auth on their GitHub accounts (i.e. everyone) by using `origin` (which should be SSH) bypassing 2FA.