### PR TITLE
Popover: Accept id string for reference element as a convenience.

### DIFF
--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -36,7 +36,9 @@ describe("calcite-popover", () => {
   it("popover positions when referenceElement is set", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-popover open placement="horizontal"></calcite-popover><div>referenceElement</div>`);
+    await page.setContent(
+      `<calcite-popover open placement="horizontal"></calcite-popover><div>referenceElement</div>`
+    );
 
     const element = await page.find("calcite-popover");
 
@@ -56,7 +58,9 @@ describe("calcite-popover", () => {
   it("open popover should be visible", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-popover placement="horizontal"></calcite-popover><div>referenceElement</div>`);
+    await page.setContent(
+      `<calcite-popover placement="horizontal"></calcite-popover><div>referenceElement</div>`
+    );
 
     const element = await page.find("calcite-popover");
 
@@ -77,5 +81,27 @@ describe("calcite-popover", () => {
     await page.waitForChanges();
 
     expect(await container.isVisible()).toBe(true);
+  });
+
+  it("should accept referenceElement as string id", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<calcite-popover placement="horizontal" reference-element="ref" open>content</calcite-popover><div id="ref">referenceElement</div>`
+    );
+
+    await page.waitForChanges();
+
+    const container = await page.find(`calcite-popover >>> .${CSS.container}`);
+
+    await page.waitForChanges();
+
+    expect(await container.isVisible()).toBe(true);
+
+    const element = await page.find("calcite-popover");
+
+    const computedStyle = await element.getComputedStyle();
+
+    expect(computedStyle.transform).not.toBe("none");
   });
 });

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -54,10 +54,11 @@ export class CalcitePopover {
   /**
    * Reference HTMLElement used to position this component according to the placement property.
    */
-  @Prop() referenceElement: HTMLElement;
+  @Prop() referenceElement: HTMLElement | string;
 
   @Watch("referenceElement")
   referenceElementHandler() {
+    this._referenceElement = this.getReferenceElement();
     this.destroyPopper();
     this.reposition();
   }
@@ -91,6 +92,8 @@ export class CalcitePopover {
   @Element() el: HTMLCalcitePopoverElement;
 
   @State() popper: Popper;
+
+  @State() _referenceElement: HTMLElement = this.getReferenceElement();
 
   // --------------------------------------------------------------------------
   //
@@ -128,6 +131,16 @@ export class CalcitePopover {
   //
   // --------------------------------------------------------------------------
 
+  getReferenceElement(): HTMLElement {
+    const { referenceElement } = this;
+
+    return (
+      (typeof referenceElement === "string"
+        ? document.getElementById(referenceElement)
+        : referenceElement) || null
+    );
+  }
+
   getPlacement(): Popper.Placement {
     return this.placement === "vertical" ? "bottom-start" : "auto-start";
   }
@@ -152,13 +165,13 @@ export class CalcitePopover {
   }
 
   createPopper(): void {
-    const { el, open, referenceElement } = this;
+    const { el, open, _referenceElement } = this;
 
-    if (!referenceElement || !open) {
+    if (!_referenceElement || !open) {
       return;
     }
 
-    const newPopper = new Popper(referenceElement, el, {
+    const newPopper = new Popper(_referenceElement, el, {
       eventsEnabled: false,
       placement: this.getPlacement(),
       modifiers: this.getModifiers(),
@@ -210,12 +223,14 @@ export class CalcitePopover {
   // --------------------------------------------------------------------------
 
   render() {
+    const { _referenceElement, open } = this;
+
     return (
       <Host>
         <div
           class={{
             [CSS.container]: true,
-            [CSS.containerOpen]: this.open
+            [CSS.containerOpen]: _referenceElement && open
           }}
         >
           <slot />

--- a/src/components/calcite-popover/readme.md
+++ b/src/components/calcite-popover/readme.md
@@ -5,13 +5,13 @@
 
 ## Properties
 
-| Property           | Attribute   | Description                                                                                                                                                                     | Type                         | Default        |
-| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------- |
-| `open`             | `open`      | Display and position the component.                                                                                                                                             | `boolean`                    | `false`        |
-| `placement`        | `placement` | Determines where the element will be positioned. horizontal: Positioned to the left or right of the referenceElement. vertical: Positioned above or below the referenceElement. | `"horizontal" \| "vertical"` | `"horizontal"` |
-| `referenceElement` | --          | Reference HTMLElement used to position this component according to the placement property.                                                                                      | `HTMLElement`                | `undefined`    |
-| `xOffset`          | `x-offset`  | Offset the position of the popover in the horizontal direction.                                                                                                                 | `number`                     | `0`            |
-| `yOffset`          | `y-offset`  | Offset the position of the popover in the vertical direction.                                                                                                                   | `number`                     | `0`            |
+| Property           | Attribute           | Description                                                                                                                                                                     | Type                         | Default        |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------- |
+| `open`             | `open`              | Display and position the component.                                                                                                                                             | `boolean`                    | `false`        |
+| `placement`        | `placement`         | Determines where the element will be positioned. horizontal: Positioned to the left or right of the referenceElement. vertical: Positioned above or below the referenceElement. | `"horizontal" \| "vertical"` | `"horizontal"` |
+| `referenceElement` | `reference-element` | Reference HTMLElement used to position this component according to the placement property.                                                                                      | `HTMLElement \| string`      | `undefined`    |
+| `xOffset`          | `x-offset`          | Offset the position of the popover in the horizontal direction.                                                                                                                 | `number`                     | `0`            |
+| `yOffset`          | `y-offset`          | Offset the position of the popover in the vertical direction.                                                                                                                   | `number`                     | `0`            |
 
 
 ## Methods

--- a/src/components/calcite-radio-group/readme.md
+++ b/src/components/calcite-radio-group/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                     | Type                | Default     |
-| -------------- | --------------- | ----------------------------------------------- | ------------------- | ----------- |
-| `name`         | `name`          | The group's name. Gets submitted with the form. | `string`            | `undefined` |
-| `scale`        | `scale`         | The scale of the button                         | `"l" \| "m" \| "s"` | `"m"`       |
-| `selectedItem` | `selected-item` | The group's selected item.                      | `any`               | `undefined` |
-| `theme`        | `theme`         | The component's theme.                          | `"dark" \| "light"` | `"light"`   |
+| Property       | Attribute | Description                                     | Type                               | Default     |
+| -------------- | --------- | ----------------------------------------------- | ---------------------------------- | ----------- |
+| `name`         | `name`    | The group's name. Gets submitted with the form. | `string`                           | `undefined` |
+| `scale`        | `scale`   | The scale of the button                         | `"l" \| "m" \| "s"`                | `"m"`       |
+| `selectedItem` | --        | The group's selected item.                      | `HTMLCalciteRadioGroupItemElement` | `undefined` |
+| `theme`        | `theme`   | The component's theme.                          | `"dark" \| "light"`                | `"light"`   |
 
 
 ## Events

--- a/src/index.html
+++ b/src/index.html
@@ -520,8 +520,27 @@
             <div style="background-color: cornflowerblue; color:white; padding:20px">Hello! I am some popover content!</div>
           </calcite-popover>
 
-          <calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-            Click Me!</calcite-button>
+          <calcite-popover reference-element="popover-button-two" placement="vertical" id="popover-two">
+            <div style="background-color: cornflowerblue; color:white; padding:20px">Hello! I am some popover content!</div>
+          </calcite-popover>
+
+          <style>
+          .popover-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+          }
+          .popover-list li{
+            margin: 8px 0;
+          }
+          </style>
+
+          <ul class="popover-list">
+            <li><calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+              Click Me!</calcite-button></li>
+              <li><calcite-button id="popover-button-two" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+                Click Me!</calcite-button></li>
+          </ul>
 
           <script>
             var popover = document.getElementById("popover");
@@ -529,6 +548,12 @@
             popover.referenceElement = popoverButton;
             popoverButton.addEventListener("click", function() {
               popover.toggle();
+            });
+
+            var popoverTwo = document.getElementById("popover-two");
+            var popoverButtonTwo = document.getElementById("popover-button-two");
+            popoverButtonTwo.addEventListener("click", function() {
+              popoverTwo.toggle();
             });
           </script>
       </calcite-tab>
@@ -1599,7 +1624,7 @@
             </calcite-tree>
           </calcite-tree-item>
         </calcite-tree>
-         
+
 
         <h3>Big Tree</h3>
         <p>Parent Items in this tree also have links. Click the chevron icon to toggle expand/collapse or anywhere else


### PR DESCRIPTION
Popover: Accept id string for reference element as a convenience.

---

This will allow a user to set the id string of the reference element instead of having to go through the DOM.