### PR TITLE
Hrobbins/tree edge fix 136

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -8,4 +8,87 @@ describe("calcite-tree", () => {
     const element = await page.find("calcite-tree");
     expect(element).toHaveClass("hydrated");
   });
+
+  // click on icon
+  it("should expand/collapse children when the icon is clicked", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-tree lines id="parentTree">
+      <calcite-tree-item id="firstItem">
+        <a href="#">Child 2</a>
+
+        <calcite-tree slot="children">
+          <calcite-tree-item>
+            <a href="http://www.google.com">Grandchild 1</a>
+          </calcite-tree-item>
+        </calcite-tree>
+      </calcite-tree-item>
+    </calcite-tree>`);
+
+    const icon = await page.find('#firstItem >>> [data-test-id="icon"]');
+    await icon.click();
+
+    const childContainer = await page.find('#firstItem >>> [data-test-id="calcite-tree-children"]');
+    const isVisible = await childContainer.isVisible();
+    expect(isVisible).toBe(true);
+  });
+
+  // click on link
+  it("should navigate when the link inside the tree item is clicked", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-tree lines id="parentTree">
+      <calcite-tree-item id="firstItem">
+        <a href="#">Child 1</a>
+      </calcite-tree-item>
+    </calcite-tree>`);
+
+    const anchor = await page.find('#firstItem a');
+    await anchor.click();
+
+    await page.waitForChanges();
+    expect(page.url()).toContain("#");
+  });
+
+  // click on item
+  it("should navigate to the link url when the item but not the link is clicked", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-tree lines id="parentTree">
+      <calcite-tree-item id="firstItem">
+        <a href="#">Child 1</a>
+      </calcite-tree-item>
+    </calcite-tree>`);
+
+    const item = await page.find('#firstItem');
+    await item.click();
+
+    await page.waitForChanges();
+    expect(page.url()).toContain("#");
+  });
+
+  // click on childItem
+  it.only("should navigate to the inner link when a child item is clicked and not the outer link", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-tree lines id="parentTree">
+      <calcite-tree-item expanded>
+        <a href="#outer">Child 2</a>
+
+        <calcite-tree slot="children">
+          <calcite-tree-item id="secondItem">
+            <a href="#inner">Grandchild 1</a>
+          </calcite-tree-item>
+        </calcite-tree>
+      </calcite-tree-item>
+    </calcite-tree>`);
+
+    await page.waitForChanges();
+    const item = await page.find('#secondItem');
+    await item.click();
+
+    await page.waitForChanges();
+    expect(page.url()).toContain("#inner");
+    expect(page.url()).not.toContain("#outer");
+  });
 });

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -109,6 +109,7 @@ export class CalciteTreeItem {
         width="16"
         viewBox="0 0 16 16"
         onClick={this.iconClickHandler}
+        data-test-id="icon"
       >
         <path d={chevronRight16} />
       </svg>
@@ -134,12 +135,13 @@ export class CalciteTreeItem {
           this.hasChildren ? (this.expanded ? "true" : "false") : undefined
         }
       >
-        <div class="calcite-tree-node">
+        <div class="calcite-tree-node" ref={el => (this.defaultSlotWrapper = el as HTMLElement)}>
           {icon}
           <slot></slot>
         </div>
         <div
           class="calcite-tree-children"
+          data-test-id="calcite-tree-children"
           role={this.hasChildren ? "group" : undefined}
           ref={el => (this.childrenSlotWrapper = el as HTMLElement)}
           onClick={this.childrenClickHandler}
@@ -157,8 +159,13 @@ export class CalciteTreeItem {
   //--------------------------------------------------------------------------
 
   @Listen("click") onClick(e: Event) {
-    // Children was not clicked
-    // Icon was not clicked
+    // Solve for if the item is clicked somewhere outside the slotted anchor.
+    // Anchor is triggered anywhere you click
+    const [link] = getSlottedElements( this.defaultSlotWrapper, "a" );
+    if( link && ((e.composedPath()[0] as any).tagName.toLowerCase() !== "a") ) {
+      const target = link.target === "" ? "_self" : link.target;
+      window.open(link.href , target);
+    }
     this.expanded = !this.expanded;
     this.calciteTreeItemSelect.emit({
       modifyCurrentSelection: (e as any).shiftKey,
@@ -304,6 +311,7 @@ export class CalciteTreeItem {
   @State() private selectionMode: TreeSelectionMode;
 
   childrenSlotWrapper!: HTMLElement;
+  defaultSlotWrapper!: HTMLElement;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -106,6 +106,7 @@ export class CalciteTreeItem {
         height="16"
         width="16"
         viewBox="0 0 16 16"
+        onClick={this.iconClickHandler}
       >
         <path d={chevronRight16} />
       </svg>
@@ -139,6 +140,7 @@ export class CalciteTreeItem {
           class="calcite-tree-children"
           role={this.hasChildren ? "group" : undefined}
           ref={el => (this.childrenSlotWrapper = el as HTMLElement)}
+          onClick={this.childrenClickHandler}
         >
           <slot name="children"></slot>
         </div>
@@ -153,40 +155,25 @@ export class CalciteTreeItem {
   //--------------------------------------------------------------------------
 
   @Listen("click") onClick(e: Event) {
-    // the target of this event (remapped from Shadow DOM)
-    const target = e.target as Element;
-
-    // the original target of this event (inside shadow DOM)
-    const originalTarget = ((e as any).originalTarget ||
-      (e as any).path[0]) as Element;
-
-    // if the user clicked on an SVG we should al
-    const forceToggle = originalTarget && !!originalTarget.closest("svg");
-
-    const shouldSelect =
-      target.parentElement === this.el || this.el === e.target;
-
-    const link = nodeListToArray(this.el.children).find(e =>
-      e.matches("a")
-    ) as HTMLAnchorElement;
-
-    if (!forceToggle && (link || target === this.el)) {
-      this.selected = true;
-      link.click();
-      return;
-    }
-
-    if (shouldSelect && this.hasChildren) {
-      this.expanded = !this.expanded;
-    }
-
-    if (shouldSelect) {
-      this.calciteTreeItemSelect.emit({
-        modifyCurrentSelection: (e as any).shiftKey,
-        forceToggle
-      });
-    }
+    // Children was not clicked
+    // Icon was not clicked
+    this.selected = true;
+    this.expanded = !this.expanded;
+    this.calciteTreeItemSelect.emit({
+      modifyCurrentSelection: (e as any).shiftKey,
+      forceToggle: false
+    });
   }
+
+  iconClickHandler = (event: Event) => {
+    event.stopPropagation();
+    this.calciteTreeItemSelect.emit({
+      modifyCurrentSelection: (event as any).shiftKey,
+      forceToggle: true
+    });
+    this.expanded = !this.expanded;
+  }
+  childrenClickHandler = (event) => event.stopPropagation();
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent) {
     let root;

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -59,17 +59,19 @@ export class CalciteTreeItem {
 
   @Watch("expanded")
   expandedHandler(newValue: boolean) {
-    const [childTree] = getSlottedElements(
-      this.childrenSlotWrapper,
-      "calcite-tree"
-    );
-
-    const items = getSlottedElements<HTMLCalciteTreeItemElement>(
-      childTree,
-      "calcite-tree-item"
-    );
-
-    items.forEach(item => (item.parentExpanded = newValue));
+    if ( this.childrenSlotWrapper ) {
+      const [childTree] = getSlottedElements(
+        this.childrenSlotWrapper,
+        "calcite-tree"
+      );
+      if ( childTree ) {
+        const items = getSlottedElements<HTMLCalciteTreeItemElement>(
+          childTree,
+          "calcite-tree-item"
+        );
+        items.forEach(item => (item.parentExpanded = newValue));
+      }
+    }
   }
 
   //--------------------------------------------------------------------------
@@ -157,7 +159,6 @@ export class CalciteTreeItem {
   @Listen("click") onClick(e: Event) {
     // Children was not clicked
     // Icon was not clicked
-    this.selected = true;
     this.expanded = !this.expanded;
     this.calciteTreeItemSelect.emit({
       modifyCurrentSelection: (e as any).shiftKey,
@@ -167,11 +168,11 @@ export class CalciteTreeItem {
 
   iconClickHandler = (event: Event) => {
     event.stopPropagation();
+    this.expanded = !this.expanded;
     this.calciteTreeItemSelect.emit({
       modifyCurrentSelection: (event as any).shiftKey,
       forceToggle: true
     });
-    this.expanded = !this.expanded;
   }
   childrenClickHandler = (event) => event.stopPropagation();
 


### PR DESCRIPTION
**Related Issue:** #136 

## Summary

* Refactored to use additional click events to split up click logic. 
* Refactored to use `event.composedPath()` in place of `event.originalTarget` and `event.path`
* Added a few tests to validate functionality.