### PR TITLE
Alert accessibility updates

### DIFF
--- a/src/components/calcite-alert/calcite-alert.e2e.ts
+++ b/src/components/calcite-alert/calcite-alert.e2e.ts
@@ -21,10 +21,28 @@ describe("calcite-alert", () => {
     expect(close).not.toBeNull();
     expect(icon).toBeNull();
   });
-});
 
-describe("calcite-alert", () => {
-  it("renders requested props", async () => {
+  it("renders requested props with dismiss and no alert-link present", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-alert theme="dark" color="yellow" duration="fast" dismiss>
+    <div slot="alert-title">Title Text</div>
+    <div slot="alert-message">Message Text</div>
+    </calcite-alert>`);
+
+    const element = await page.find("calcite-alert");
+    const close = await page.find("calcite-alert >>> .alert-close");
+    const icon = await page.find("calcite-alert >>> .alert-icon");
+
+    expect(element).toHaveClass("hydrated");
+    expect(element).toEqualAttribute("color", "yellow");
+    expect(element).toEqualAttribute("duration", "fast");
+    expect(element).toEqualAttribute("theme", "dark");
+    expect(close).toBeNull();
+    expect(icon).toBeNull();
+  });
+
+  it("forces close button when dismiss and link are present", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-alert theme="dark" color="yellow" duration="fast" dismiss>
@@ -41,12 +59,10 @@ describe("calcite-alert", () => {
     expect(element).toEqualAttribute("color", "yellow");
     expect(element).toEqualAttribute("duration", "fast");
     expect(element).toEqualAttribute("theme", "dark");
-    expect(close).toBeNull();
+    expect(close).not.toBeNull();
     expect(icon).toBeNull();
   });
-});
 
-describe("calcite-alert", () => {
   it("renders with an icon", async () => {
     const page = await newE2EPage();
     await page.setContent(`
@@ -63,10 +79,8 @@ describe("calcite-alert", () => {
     expect(close).not.toBeNull();
     expect(icon).not.toBeNull();
   });
-});
 
-describe("calcite-alert", () => {
-  it("validates incorrect props with dismiss", async () => {
+  it("validates incorrect props and forces close button with dismiss and alert-link present", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-alert color="zip" duration="zot" theme="zat" dismiss>
@@ -82,12 +96,29 @@ describe("calcite-alert", () => {
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("duration", "medium");
     expect(element).toEqualAttribute("theme", "light");
+    expect(close).not.toBeNull();
+    expect(icon).toBeNull();
+  });
+
+  it("validates incorrect props with dismiss and no alert-link", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-alert color="zip" duration="zot" theme="zat" dismiss>
+    <div slot="alert-title">Title Text</div>
+    <div slot="alert-message">Message Text</div>
+    </calcite-alert>`);
+
+    const element = await page.find("calcite-alert");
+    const close = await page.find("calcite-alert >>> .alert-close");
+    const icon = await page.find("calcite-alert >>> .alert-icon");
+    expect(element).toHaveClass("hydrated");
+    expect(element).toEqualAttribute("color", "blue");
+    expect(element).toEqualAttribute("duration", "medium");
+    expect(element).toEqualAttribute("theme", "light");
     expect(close).toBeNull();
     expect(icon).toBeNull();
   });
-});
 
-describe("calcite-alert", () => {
   it("validates incorrect props with close and icon", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -44,7 +44,7 @@ export class CalciteAlert {
   @State() active: boolean = false;
 
   /** Determine if the alert contains an alert-link slot */
-  @State() hasLink = false;
+  @State() hasLink: boolean = false;
 
   /** Close the alert automatically (recommended for passive, non-blocking alerts) */
   @Prop() dismiss: boolean = false;

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -24,6 +24,8 @@ import AlertInterface from "../../interfaces/AlertInterface";
  * will lead to unexpected and potentially undesireable results
  */
 
+/** Due to accessibility concerns, alerts containing the "alert-link" slot will not autodismiss, even if the dismiss attribute is present */
+
 /**
  * @slot alert-title - Title of the alert (optional)
  * @slot alert-message - Main text of the alert
@@ -40,6 +42,9 @@ export class CalciteAlert {
 
   /** Is the alert currently active or not */
   @State() active: boolean = false;
+
+  /** Determine if the alert contains an alert-link slot */
+  @State() hasLink = false;
 
   /** Close the alert automatically (recommended for passive, non-blocking alerts) */
   @Prop() dismiss: boolean = false;
@@ -122,6 +127,10 @@ export class CalciteAlert {
 
     let themes = ["dark", "light"];
     if (!themes.includes(this.theme)) this.theme = "light";
+
+    // prevent auto dismissing of alerts with action links
+    this.hasLink = !!this.el.querySelector("[slot=alert-link]");
+    if (this.hasLink) this.dismiss = false;
   }
 
   setIcon() {
@@ -158,7 +167,6 @@ export class CalciteAlert {
         </svg>
       </button>
     );
-
     const close = !this.dismiss ? closeButton : "";
     const icon = this.icon ? this.setIcon() : "";
     const count = (
@@ -168,8 +176,14 @@ export class CalciteAlert {
     );
     const progress =
       this.active && this.dismiss ? <div class="alert-dismiss"></div> : "";
+    const role =
+      this.active && this.dismiss
+        ? "alert"
+        : this.active
+        ? "alertdialog"
+        : null;
     return (
-      <Host active={this.active} dir={dir}>
+      <Host active={this.active} dir={dir} role={role}>
         {icon}
         <div class="alert-content">
           <slot name="alert-title"></slot>

--- a/src/index.html
+++ b/src/index.html
@@ -279,6 +279,7 @@
 
       <calcite-tab>
         <h5>Multiple alerts will be added to a queue.</h5>
+        <h6>Alerts that contain alert-link will NOT honor dismiss attribute</h6>
         <calcite-button title="1 Autodismiss, title, link, red" color="red" scale="s"
           onclick="document.querySelector('#alert-one').openCalciteAlert()">1 Autodismiss, title, link, red
         </calcite-button>
@@ -521,42 +522,48 @@
           </div>
         </calcite-popover>
 
-          <calcite-popover reference-element="popover-button-two" placement="vertical" id="popover-two">
-            <div style="background-color: cornflowerblue; color:white; padding:20px">Hello! I am some popover content!</div>
-          </calcite-popover>
+        <calcite-popover reference-element="popover-button-two" placement="vertical" id="popover-two">
+          <div style="background-color: cornflowerblue; color:white; padding:20px">Hello! I am some popover content!
+          </div>
+        </calcite-popover>
 
-          <style>
+        <style>
           .popover-list {
             list-style: none;
             margin: 0;
             padding: 0;
           }
-          .popover-list li{
+
+          .popover-list li {
             margin: 8px 0;
           }
-          </style>
+        </style>
 
-          <ul class="popover-list">
-            <li><calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-              Click Me!</calcite-button></li>
-              <li><calcite-button id="popover-button-two" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-                Click Me!</calcite-button></li>
-          </ul>
+        <ul class="popover-list">
+          <li>
+            <calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+              Click Me!</calcite-button>
+          </li>
+          <li>
+            <calcite-button id="popover-button-two" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+              Click Me!</calcite-button>
+          </li>
+        </ul>
 
-          <script>
-            var popover = document.getElementById("popover");
-            var popoverButton = document.getElementById("popover-button");
-            popover.referenceElement = popoverButton;
-            popoverButton.addEventListener("click", function() {
-              popover.toggle();
-            });
+        <script>
+          var popover = document.getElementById("popover");
+          var popoverButton = document.getElementById("popover-button");
+          popover.referenceElement = popoverButton;
+          popoverButton.addEventListener("click", function () {
+            popover.toggle();
+          });
 
-            var popoverTwo = document.getElementById("popover-two");
-            var popoverButtonTwo = document.getElementById("popover-button-two");
-            popoverButtonTwo.addEventListener("click", function() {
-              popoverTwo.toggle();
-            });
-          </script>
+          var popoverTwo = document.getElementById("popover-two");
+          var popoverButtonTwo = document.getElementById("popover-button-two");
+          popoverButtonTwo.addEventListener("click", function () {
+            popoverTwo.toggle();
+          });
+        </script>
       </calcite-tab>
 
       <calcite-tab>


### PR DESCRIPTION
Arjav (not taggable) pointed out some accessibility concerns with alerts, so this is a best attempt to solve them. The docs around usage of role="alert" are vague at best so if anyone has more to add here please contribute.

This pr does a few things
- adds `role="alert"` to active alerts that autodismiss
- adds `role="alertdialog"` to active alerts that have a close button
- Forces `this.dismiss` to be `false` when alert-link slot is present, in practice adding a close button and forcing `role="alertdialog"`.
- Updates tests to account for changes
- Adds a bit of doc around forcing close button with alert-link

I did a bit of testing with Voiceover and it does complete reading alerts that *do* autodismiss, even if the alert is dismissed before text is read, before returning to previously focused element. Again open to additions here, this was just my interpretation.

cc @asangma 