### PR TITLE
Popover: Reverse x-offset/y-offset when top/bottom placement

### DIFF
--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -216,17 +216,23 @@ export class CalcitePopover {
   }
 
   getModifiers(): Popper.Modifiers {
-    const { xOffset, yOffset } = this;
-    const offsetEnabled = !!(yOffset || xOffset);
-    const offset = `${yOffset}, ${xOffset}`;
+    const verticalRE = /top|bottom/gi;
+    const autoRE = /auto/gi;
+    const { placement, xOffset, yOffset } = this;
+    const offsetEnabled = !!(yOffset || xOffset) && !autoRE.test(placement);
+    const offsets = [yOffset, xOffset];
+
+    if (verticalRE.test(placement)) {
+      offsets.reverse();
+    }
 
     return {
       hide: {
         enabled: false
       },
       offset: {
-        enabled: offsetEnabled,
-        offset
+        enabled: !!offsetEnabled,
+        offset: offsets.join(",")
       },
       preventOverflow: {
         enabled: false


### PR DESCRIPTION
#182

- Fixes the offsets for x/y when the placement is top or bottom.
- If the placement is "auto" then x-offset/y-offset will not be respected.