### PR TITLE
Popover/Tooltip enhancements for shadow/caret

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -1,8 +1,19 @@
 $pointer_arrow_size: 5px;
 
+@mixin popperMargin($selector) {
+  :host([x-placement*="bottom"]) #{$selector},
+  :host([x-placement*="top"]) #{$selector} {
+    margin: $pointer_arrow_size 0;
+  }
+
+  :host([x-placement*="left"]) #{$selector},
+  :host([x-placement*="right"]) #{$selector} {
+    margin: 0 $pointer_arrow_size;
+  }
+}
+
 @mixin popperPointer($selector) {
   :host {
-    margin: $pointer_arrow_size;
     --calcite-popper-background: #{$ui-foreground};
   }
 

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -38,6 +38,10 @@ describe("calcite-popover", () => {
       {
         propertyName: "closeButton",
         defaultValue: false
+      },
+      {
+        propertyName: "disablePointer",
+        defaultValue: false
       }
     ]));
 

--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -2,7 +2,7 @@ $image_max_height: 200px;
 
 :host {
   --calcite-popover-background: #{$ui-foreground};
-  --calcite-popover-primary-text: #{$ui-text-1};
+  --calcite-popover-primary-text: var(--calcite-global-ui-text-1);
   --calcite-popover-close-hover: #{$ui-foreground-hover};
   --calcite-popover-close-pressed: #{$ui-foreground-pressed};
   display: block;
@@ -10,7 +10,6 @@ $image_max_height: 200px;
   z-index: 999;
   top: -999999px;
   left: -999999px;
-  box-shadow: $shadow-2;
 }
 
 :host([theme="dark"]) {
@@ -21,16 +20,21 @@ $image_max_height: 200px;
 }
 
 .container {
-  display: flex;
-  max-width: 350px;
-  flex-direction: column;
+  box-shadow: $shadow-2;
   visibility: hidden;
-  background: var(--calcite-popover-background);
-  color: var(--calcite-popover-primary-text);
+  position: relative;
 }
 
 .container--open {
   visibility: visible;
+}
+
+.content-container {
+  display: flex;
+  max-width: 350px;
+  flex-direction: column;
+  background: var(--calcite-popover-background);
+  color: var(--calcite-popover-primary-text);
 }
 
 .content {
@@ -75,4 +79,5 @@ slot[name="image"]::slotted(img) {
   object-fit: cover;
 }
 
-@include popperPointer(".container");
+@include popperPointer(".container--pointer .content-container");
+@include popperMargin(".container--pointer");

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -49,9 +49,9 @@ export class CalcitePopover {
   @Prop({ reflect: true }) closeButton = false;
 
   /**
-   * Hides the caret pointer.
+   * Removes the caret pointer.
    */
-  @Prop({ reflect: true }) hidePointer = false;
+  @Prop({ reflect: true }) disablePointer = false;
 
   /**
    * Display and position the component.
@@ -320,7 +320,7 @@ export class CalcitePopover {
   }
 
   render() {
-    const { _referenceElement, open, hidePointer } = this;
+    const { _referenceElement, open, disablePointer } = this;
     const displayed = _referenceElement && open;
 
     return (
@@ -333,7 +333,7 @@ export class CalcitePopover {
           class={{
             [CSS.container]: true,
             [CSS.containerOpen]: displayed,
-            [CSS.containerPointer]: !hidePointer
+            [CSS.containerPointer]: !disablePointer
           }}
         >
           <div class={CSS.contentContainer}>

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -49,6 +49,11 @@ export class CalcitePopover {
   @Prop({ reflect: true }) closeButton = false;
 
   /**
+   * Hides the caret pointer.
+   */
+  @Prop({ reflect: true }) hidePointer = false;
+
+  /**
    * Display and position the component.
    */
   @Prop({ reflect: true }) open = false;
@@ -315,7 +320,7 @@ export class CalcitePopover {
   }
 
   render() {
-    const { _referenceElement, open } = this;
+    const { _referenceElement, open, hidePointer } = this;
     const displayed = _referenceElement && open;
 
     return (
@@ -327,13 +332,16 @@ export class CalcitePopover {
         <div
           class={{
             [CSS.container]: true,
-            [CSS.containerOpen]: displayed
+            [CSS.containerOpen]: displayed,
+            [CSS.containerPointer]: !hidePointer
           }}
         >
-          {this.renderImage()}
-          <div class={CSS.content}>
-            <slot />
-            {this.renderCloseButton()}
+          <div class={CSS.contentContainer}>
+            {this.renderImage()}
+            <div class={CSS.content}>
+              <slot />
+              {this.renderCloseButton()}
+            </div>
           </div>
         </div>
       </Host>

--- a/src/components/calcite-popover/resources.ts
+++ b/src/components/calcite-popover/resources.ts
@@ -1,6 +1,8 @@
 export const CSS = {
   container: "container",
   containerOpen: "container--open",
+  containerPointer: "container--pointer",
+  contentContainer: "content-container",
   imageContainer: "image-container",
   closeButton: "close-button",
   content: "content"

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -6,7 +6,6 @@
   z-index: 999;
   top: -999999px;
   left: -999999px;
-  box-shadow: $shadow-2;
 }
 
 :host([theme="dark"]) {
@@ -16,6 +15,15 @@
 
 .tooltip-container {
   visibility: hidden;
+  position: relative;
+  box-shadow: $shadow-2;
+}
+
+.tooltip-container--open {
+  visibility: visible;
+}
+
+.tooltip-content-container {
   background: var(--calcite-tooltip-background);
   max-width: 300px;
   max-height: 300px;
@@ -28,8 +36,5 @@
   @include font-size(-3);
 }
 
-.tooltip-container--open {
-  visibility: visible;
-}
-
-@include popperPointer(".tooltip-container");
+@include popperPointer(".tooltip-content-container");
+@include popperMargin(".tooltip-container");

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -246,7 +246,9 @@ export class CalciteTooltip {
             [CSS.containerOpen]: displayed
           }}
         >
-          <slot />
+          <div class={CSS.contentContainer}>
+            <slot />
+          </div>
         </div>
       </Host>
     );

--- a/src/components/calcite-tooltip/resources.ts
+++ b/src/components/calcite-tooltip/resources.ts
@@ -1,4 +1,5 @@
 export const CSS = {
   container: "tooltip-container",
-  containerOpen: "tooltip-container--open"
+  containerOpen: "tooltip-container--open",
+  contentContainer: "tooltip-content-container"
 };


### PR DESCRIPTION
- Move shadow to its own node so it doesn't show on host always even if not displayed.
- Only apply margin if caret is used and to the appropriate side.
- Add a property to disable the caret on the Popover

Issue: https://github.com/Esri/calcite-app-components/issues/449