### PR TITLE
Popover modifier enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13664,9 +13664,9 @@
       }
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",
-    "popper.js": "1.15.0"
+    "popper.js": "1.16.0"
   },
   "devDependencies": {
     "@esri/calcite-base": "^1.1.0",

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -54,6 +54,11 @@ export class CalcitePopover {
   @Prop({ reflect: true }) disablePointer = false;
 
   /**
+   * Makes the popover flow toward the inner of the reference element.
+   */
+  @Prop({ reflect: true }) flowInner = false;
+
+  /**
    * Display and position the component.
    */
   @Prop({ reflect: true }) open = false;
@@ -224,7 +229,7 @@ export class CalcitePopover {
   getModifiers(): Popper.Modifiers {
     const verticalRE = /top|bottom/gi;
     const autoRE = /auto/gi;
-    const { placement, xOffset, yOffset } = this;
+    const { flowInner, placement, xOffset, yOffset } = this;
     const offsetEnabled = !!(yOffset || xOffset) && !autoRE.test(placement);
     const offsets = [yOffset, xOffset];
 
@@ -233,6 +238,9 @@ export class CalcitePopover {
     }
 
     return {
+      inner: {
+        enabled: flowInner
+      },
       offset: {
         enabled: !!offsetEnabled,
         offset: offsets.join(",")

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -233,9 +233,6 @@ export class CalcitePopover {
     }
 
     return {
-      hide: {
-        enabled: false
-      },
       offset: {
         enabled: !!offsetEnabled,
         offset: offsets.join(",")

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -49,6 +49,11 @@ export class CalcitePopover {
   @Prop({ reflect: true }) closeButton = false;
 
   /**
+   * Prevents flipping the popover's placement when it starts to overlap its reference element.
+   */
+  @Prop({ reflect: true }) disableFlip = false;
+
+  /**
    * Removes the caret pointer.
    */
   @Prop({ reflect: true }) disablePointer = false;
@@ -229,7 +234,7 @@ export class CalcitePopover {
   getModifiers(): Popper.Modifiers {
     const verticalRE = /top|bottom/gi;
     const autoRE = /auto/gi;
-    const { flowInner, placement, xOffset, yOffset } = this;
+    const { disableFlip, flowInner, placement, xOffset, yOffset } = this;
     const offsetEnabled = !!(yOffset || xOffset) && !autoRE.test(placement);
     const offsets = [yOffset, xOffset];
 
@@ -238,15 +243,21 @@ export class CalcitePopover {
     }
 
     return {
+      preventOverflow: {
+        enabled: false
+      },
+      flip: {
+        enabled: !disableFlip
+      },
+      hide: {
+        enabled: false
+      },
       inner: {
         enabled: flowInner
       },
       offset: {
         enabled: !!offsetEnabled,
         offset: offsets.join(",")
-      },
-      preventOverflow: {
-        enabled: false
       }
     };
   }

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -175,9 +175,6 @@ export class CalciteTooltip {
 
   getModifiers(): Popper.Modifiers {
     return {
-      hide: {
-        enabled: false
-      },
       preventOverflow: {
         enabled: false
       }

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -177,6 +177,9 @@ export class CalciteTooltip {
     return {
       preventOverflow: {
         enabled: false
+      },
+      hide: {
+        enabled: false
       }
     };
   }


### PR DESCRIPTION

- Updates popper.js to 1.16.
- Adds a property to disable flipping. Popover will maintain placement as defined. Would be useful when you want a popover to always position in a specific direction.
- Adds a property to flow inside of the referenceElement instead of outside. Would be useful for a popover that should cover the element.
- Define `preventOverflow` first according to docs.

calcite-popover placement issues when popover is too high #190
calcite-popover going offscreen #195