### PR TITLE
Updates to dropdown focus, general clean up

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -95,7 +95,6 @@ export class CalciteDropdownGroup {
   ) {
     this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
     this.requestedDropdownItem = event.detail.requestedDropdownItem;
-
     this.calciteDropdownItemHasChanged.emit({
       requestedDropdownGroup: this.requestedDropdownGroup,
       requestedDropdownItem: this.requestedDropdownItem
@@ -119,10 +118,10 @@ export class CalciteDropdownGroup {
   //--------------------------------------------------------------------------
 
   /** created list of dropdown items */
-  @State() private items = [];
+  private items = [];
 
   /** @internal */
-  @State() private groupPosition: number;
+  private groupPosition: number;
 
   /** unique id for dropdown group */
   /** @internal */

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -104,7 +104,7 @@ export class CalciteDropdownItem {
           id={this.dropdownItemId}
           tabindex="0"
           role="menuitem"
-          aria-selected={this.active ? "true" : null}
+          aria-selected={this.active ? "true" : "false"}
         >
           <slot />
         </Host>
@@ -118,7 +118,7 @@ export class CalciteDropdownItem {
           id={this.dropdownItemId}
           tabindex="0"
           role="menuitem"
-          aria-selected={this.active ? "true" : null}
+          aria-selected={this.active ? "true" : "false"}
           isLink
         >
           <a href={this.href} title={this.linktitle}>

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -16,12 +16,13 @@
 
 ## Events
 
-| Event                         | Description | Type               |
-| ----------------------------- | ----------- | ------------------ |
-| `calciteDropdownItemKeyEvent` |             | `CustomEvent<any>` |
-| `calciteDropdownItemSelected` |             | `CustomEvent<any>` |
-| `closeCalciteDropdown`        |             | `CustomEvent<any>` |
-| `registerCalciteDropdownItem` |             | `CustomEvent<any>` |
+| Event                          | Description | Type               |
+| ------------------------------ | ----------- | ------------------ |
+| `calciteDropdownItemKeyEvent`  |             | `CustomEvent<any>` |
+| `calciteDropdownItemMouseover` |             | `CustomEvent<any>` |
+| `calciteDropdownItemSelected`  |             | `CustomEvent<any>` |
+| `closeCalciteDropdown`         |             | `CustomEvent<any>` |
+| `registerCalciteDropdownItem`  |             | `CustomEvent<any>` |
 
 
 ## Dependencies

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -2,7 +2,7 @@
 // light theme
 :host {
   --calcite-dropdown-background-color: #{$ui-foreground};
-  --calcite-dropdown-border-color: #{$blk-030};
+  --calcite-dropdown-border-color: #{$blk-020};
 }
 
 // dark theme


### PR DESCRIPTION
Provides an update for https://github.com/Esri/calcite-components/issues/181

Only opening a dropdown via key on the `dropdown-trigger` slot will cause the first item to be focused now, and will not occur when opening with mouse.

If keyboard and mouse are used in combination, clear keyboard focus and assign focus to the hovered item. 

This also does some general component cleanup.

This should prevent most of the styling oddities in the original issue - our general focus styles need a pass which should help further down the line.