### PR TITLE
Bug fixes

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.3.2/fonts.css" />
+<link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
 <link rel="stylesheet" href="./calcite/calcite.css" />
 <script type="module" src="./calcite/calcite.esm.js"></script>
 <script nomodule="" src="./calcite/calcite.js"></script>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fix clicks of radio group item in Edge (#139)
+- Fix clicks of calcite-switch in Edge (#138)
 
 ## [v1.0.0-beta.12] - Nov 1st 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix clicks of radio group item in Edge (#139)
+
 ## [v1.0.0-beta.12] - Nov 1st 2019
 
 ### Updated
@@ -124,9 +129,10 @@ Fix issue with previous release.
 ## [v1.0.0-beta.1] - Aug 2nd 2019
 
 First initial beta release.
-[v1.0.0-beta.12]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...v1.0.0-beta.12 "v1.0.0-beta.12"
-[v1.0.0-beta.11]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...v1.0.0-beta.11 "v1.0.0-beta.11"
-[v1.0.0-beta.10]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...v1.0.0-beta.10 "v1.0.0-beta.10"
+[Unrelease]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.12...master "master"
+[v1.0.0-beta.12]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.11...v1.0.0-beta.12 "v1.0.0-beta.12"
+[v1.0.0-beta.11]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.10...v1.0.0-beta.11 "v1.0.0-beta.11"
+[v1.0.0-beta.10]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.9...v1.0.0-beta.10 "v1.0.0-beta.10"
 [v1.0.0-beta.9]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.8...v1.0.0-beta.9 "v1.0.0-beta.9"
 [v1.0.0-beta.8]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.7...v1.0.0-beta.8 "v1.0.0-beta.8"
 [v1.0.0-beta.7]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.6...v1.0.0-beta.7 "v1.0.0-beta.7"

--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -6,7 +6,7 @@
   display: inline-block;
   cursor: pointer;
   user-select: none;
-  tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .check-svg {
@@ -19,7 +19,7 @@
   border-radius: 2px;
   vertical-align: -0.25em;
   margin-right: 0.25em;
-  cursor: pointer;
+  pointer-events: none;
   transition: all 150ms linear;
   box-sizing: border-box;
 }

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -68,8 +68,9 @@ export class CalciteCheckbox {
     }
   }
 
-  @Listen("keydown") keyDownHandler({ keyCode }: KeyboardEvent) {
-    if (keyCode === SPACE || keyCode === ENTER) {
+  @Listen("keydown") keyDownHandler(e: KeyboardEvent) {
+    if (e.keyCode === SPACE || e.keyCode === ENTER) {
+      e.preventDefault();
       this.toggle();
     }
   }

--- a/src/components/calcite-loader/calcite-loader.tsx
+++ b/src/components/calcite-loader/calcite-loader.tsx
@@ -58,7 +58,7 @@ export class CalciteLoader {
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
-  componentDidLoad() {
+  componentWillLoad() {
     this.isEdge = /Edge/.test(navigator.userAgent);
     if (this.isEdge) {
       this.updateOffset();

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -36,7 +36,7 @@
 }
 
 label {
-  cursor: pointer;
+  pointer-events: none;
 }
 
 ::slotted(input) {

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -100,6 +100,7 @@
   background-color: var(--calcite-switch-track-background);
   border-radius: 30px;
   border: 1px solid var(--calcite-switch-track-border);
+  pointer-events: none;
   transition: all $transition;
 }
 
@@ -114,6 +115,7 @@
   background-color: var(--calcite-switch-handle-background);
   border-radius: 30px;
   border: 2px solid var(--calcite-switch-handle-border);
+  pointer-events: none;
   transition: all $transition;
 }
 

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -57,6 +57,7 @@ export class CalciteSwitch {
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent) {
     if (e.keyCode === SPACE || e.keyCode === ENTER) {
+      e.preventDefault();
       this.switched = !this.switched;
     }
   }

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
       padding: 1rem;
     }
   </style>
-  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.3.2/fonts.css" />
+  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="/build/calcite.css" />
   <script type="module" src="build/calcite.esm.js"></script>
   <script nomodule src="build/calcite.js"></script>


### PR DESCRIPTION
- bump to calcite-fonts 1.4.1 (fixes wrong baseline on medium weight)
- fix radio groups in edge
- fix switches/checkboxes in edge
- stop browsers from scrolling the page when space bar on switch or checkbox
- optimize calcite-loader initialization by moving to willLoad
- fix all the links in the `CHANGELOG` as the comparisons were wrong