### PR TITLE
add scrollContent method to calcite-modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix clicks of radio group item in Edge (#139)
 - Fix clicks of calcite-switch in Edge (#138)
 
+### Added
+- new `ScrollContent` method on modals, which allows manipulating scroll position of modal content
+
 ## [v1.0.0-beta.12] - Nov 1st 2019
 
 ### Updated

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -96,7 +96,7 @@ export class CalciteModal {
               <slot name="header" />
             </header>
           </div>
-          <div class="modal__content">
+          <div class="modal__content" ref={(el) => this.modalContent = el}>
             <slot name="content" />
           </div>
           <div class="modal__footer">
@@ -182,6 +182,18 @@ export class CalciteModal {
     });
   }
 
+  /** Set the scroll top of the modal content */
+  @Method() async scrollContent(top: number = 0, left: number = 0): Promise<void> {
+    if (this.modalContent) {
+      if (this.modalContent.scrollTo) {
+        this.modalContent.scrollTo({top, left, behavior: 'smooth'});
+      } else {
+        this.modalContent.scrollTop = top;
+        this.modalContent.scrollLeft = left;
+      }
+    }
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Private State/Props
@@ -190,6 +202,7 @@ export class CalciteModal {
   @State() isActive: boolean;
   private previousActiveElement: HTMLElement;
   private closeButton: HTMLButtonElement;
+  private modalContent: HTMLDivElement;
 
   private focusFirstElement() {
     this.closeButton && this.closeButton.focus();

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -95,6 +95,16 @@ Type: `Promise<HTMLElement>`
 
 
 
+### `scrollContent(top?: number, left?: number) => Promise<void>`
+
+Set the scroll top of the modal content
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ----------------------------------------------
 

--- a/src/components/calcite-radio-group/readme.md
+++ b/src/components/calcite-radio-group/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                     | Type                | Default     |
-| -------------- | --------------- | ----------------------------------------------- | ------------------- | ----------- |
-| `name`         | `name`          | The group's name. Gets submitted with the form. | `string`            | `undefined` |
-| `scale`        | `scale`         | The scale of the button                         | `"l" \| "m" \| "s"` | `"m"`       |
-| `selectedItem` | `selected-item` | The group's selected item.                      | `any`               | `undefined` |
-| `theme`        | `theme`         | The component's theme.                          | `"dark" \| "light"` | `"light"`   |
+| Property       | Attribute | Description                                     | Type                               | Default     |
+| -------------- | --------- | ----------------------------------------------- | ---------------------------------- | ----------- |
+| `name`         | `name`    | The group's name. Gets submitted with the form. | `string`                           | `undefined` |
+| `scale`        | `scale`   | The scale of the button                         | `"l" \| "m" \| "s"`                | `"m"`       |
+| `selectedItem` | --        | The group's selected item.                      | `HTMLCalciteRadioGroupItemElement` | `undefined` |
+| `theme`        | `theme`   | The component's theme.                          | `"dark" \| "light"`                | `"light"`   |
 
 
 ## Events


### PR DESCRIPTION
Needed a way to make the content of a modal scroll back to the top. As the scrollable element is in the shadow dom, you don't have access as a consuming dev to set `scrollTop` values.