### PR TITLE
Breaking - update property / attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+- calcite-button "iconposition" attribute updated to "icon-position"
+- calcite-dropdown-group "grouptitle" attribute updated to "group-title"
+- calcite-dropdown-item "linktitle" attribute updated to "link-title"
+  
 ## [v1.0.0-beta.13] - Nov 11th 2019
 
 ### Added

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -110,20 +110,20 @@
   }
 }
 // icon positioning and styles
-:host([hastext][iconposition="start"]) .calcite-button--icon {
+:host([hastext][icon-position="start"]) .calcite-button--icon {
   margin-right: $baseline/3;
 }
 
-:host([hastext][iconposition="start"][dir="rtl"]) .calcite-button--icon {
+:host([hastext][icon-position="start"][dir="rtl"]) .calcite-button--icon {
   margin-right: 0;
   margin-left: $baseline/3;
 }
 
-:host([hastext][iconposition="end"]) .calcite-button--icon {
+:host([hastext][icon-position="end"]) .calcite-button--icon {
   margin-left: $baseline/3;
 }
 
-:host([hastext][iconposition="end"][dir="rtl"]) .calcite-button--icon {
+:host([hastext][icon-position="end"][dir="rtl"]) .calcite-button--icon {
   margin-left: 0;
   margin-right: $baseline/3;
 }
@@ -134,20 +134,20 @@
   top: 0;
 }
 
-:host([appearance="inline"][iconposition="start"]) .calcite-button--icon {
+:host([appearance="inline"][icon-position="start"]) .calcite-button--icon {
   margin-right: $baseline/4;
 }
 
-:host([appearance="inline"][iconposition="start"][dir="rtl"])
+:host([appearance="inline"][icon-position="start"][dir="rtl"])
   .calcite-button--icon {
   margin-left: $baseline/4;
   margin-right: 0;
 }
 
-:host([appearance="inline"][iconposition="end"]) .calcite-button--icon {
+:host([appearance="inline"][icon-position="end"]) .calcite-button--icon {
   margin-left: $baseline/4;
 }
-:host([appearance="inline"][iconposition="end"][dir="rtl"])
+:host([appearance="inline"][icon-position="end"][dir="rtl"])
   .calcite-button--icon {
   margin-left: 0;
   margin-right: $baseline/4;

--- a/src/components/calcite-button/calcite-button.stories.js
+++ b/src/components/calcite-button/calcite-button.stories.js
@@ -22,7 +22,7 @@ storiesOf('Button', module)
   .add('With icon', () => `
     <calcite-button
       icon="${text("icon", images24)}"
-      iconposition="${select("iconposition", {start: "start", end: "end"}, "start")}"
+      icon-position="${select("icon-position", {start: "start", end: "end"}, "start")}"
     >
       Button text
     </calcite-button>

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -63,7 +63,7 @@ export class CalciteButton {
   @Prop({ reflect: true }) icon?: string;
 
   /** optionally used with icon, select where to position the icon */
-  @Prop({ reflect: true, mutable: true }) iconposition?: "start" | "end" =
+  @Prop({ reflect: true, mutable: true }) iconPosition?: "start" | "end" =
     "start";
 
   /** is the button disabled  */
@@ -100,9 +100,9 @@ export class CalciteButton {
     let theme = ["dark", "light"];
     if (!theme.includes(this.theme)) this.theme = "light";
 
-    let iconposition = ["start", "end"];
-    if (this.icon !== null && !iconposition.includes(this.iconposition))
-      this.iconposition = "start";
+    let iconPosition = ["start", "end"];
+    if (this.icon !== null && !iconPosition.includes(this.iconPosition))
+      this.iconPosition = "start";
 
     this.childEl = this.href
       ? "a"
@@ -152,10 +152,10 @@ export class CalciteButton {
           onClick={e => this.handleClick(e)}
           disabled={this.disabled}
         >
-          {this.icon && this.iconposition === "start" ? icon : null}
+          {this.icon && this.iconPosition === "start" ? icon : null}
           {this.loading ? loader : null}
           <slot />
-          {this.icon && this.iconposition === "end" ? icon : null}
+          {this.icon && this.iconPosition === "end" ? icon : null}
         </Tag>
       </Host>
     );
@@ -185,7 +185,7 @@ export class CalciteButton {
       "dir",
       "hasText",
       "icon",
-      "iconposition",
+      "iconPosition",
       "id",
       "loading",
       "scale",

--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -7,20 +7,20 @@
 
 ## Properties
 
-| Property       | Attribute      | Description                                                                                                               | Type                                          | Default     |
-| -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
-| `appearance`   | `appearance`   | specify the appearance style of the button, defaults to solid. Specifying "inline" will render the component as an anchor | `"clear" \| "inline" \| "outline" \| "solid"` | `"solid"`   |
-| `childEl`      | `child-el`     | keep track of the rendered child type -                                                                                   | `"a" \| "button" \| "span"`                   | `"button"`  |
-| `color`        | `color`        | specify the color of the button, defaults to blue                                                                         | `"blue" \| "dark" \| "light" \| "red"`        | `"blue"`    |
-| `disabled`     | `disabled`     | is the button disabled                                                                                                    | `boolean`                                     | `undefined` |
-| `hasText`      | `has-text`     | hastext prop for spacing icon when text is present in slot                                                                | `boolean`                                     | `false`     |
-| `href`         | `href`         | optionally pass a href - used to determine if the component should render as a button or an anchor                        | `string`                                      | `undefined` |
-| `icon`         | `icon`         | optionally pass icon path data - pass only raw path data from calcite ui helper                                           | `string`                                      | `undefined` |
-| `iconposition` | `iconposition` | optionally used with icon, select where to position the icon                                                              | `"end" \| "start"`                            | `"start"`   |
-| `loading`      | `loading`      | optionally add a calcite-loader component to the button, disabling interaction.                                           | `boolean`                                     | `false`     |
-| `scale`        | `scale`        | specify the scale of the button, defaults to m                                                                            | `"l" \| "m" \| "s" \| "xl" \| "xs"`           | `"m"`       |
-| `theme`        | `theme`        | Select theme (light or dark)                                                                                              | `"dark" \| "light"`                           | `"light"`   |
-| `width`        | `width`        | specify the width of the button, defaults to auto                                                                         | `"auto" \| "full" \| "half"`                  | `"auto"`    |
+| Property       | Attribute       | Description                                                                                                               | Type                                          | Default     |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `appearance`   | `appearance`    | specify the appearance style of the button, defaults to solid. Specifying "inline" will render the component as an anchor | `"clear" \| "inline" \| "outline" \| "solid"` | `"solid"`   |
+| `childEl`      | `child-el`      | keep track of the rendered child type -                                                                                   | `"a" \| "button" \| "span"`                   | `"button"`  |
+| `color`        | `color`         | specify the color of the button, defaults to blue                                                                         | `"blue" \| "dark" \| "light" \| "red"`        | `"blue"`    |
+| `disabled`     | `disabled`      | is the button disabled                                                                                                    | `boolean`                                     | `undefined` |
+| `hasText`      | `has-text`      | hastext prop for spacing icon when text is present in slot                                                                | `boolean`                                     | `false`     |
+| `href`         | `href`          | optionally pass a href - used to determine if the component should render as a button or an anchor                        | `string`                                      | `undefined` |
+| `icon`         | `icon`          | optionally pass icon path data - pass only raw path data from calcite ui helper                                           | `string`                                      | `undefined` |
+| `iconPosition` | `icon-position` | optionally used with icon, select where to position the icon                                                              | `"end" \| "start"`                            | `"start"`   |
+| `loading`      | `loading`       | optionally add a calcite-loader component to the button, disabling interaction.                                           | `boolean`                                     | `false`     |
+| `scale`        | `scale`         | specify the scale of the button, defaults to m                                                                            | `"l" \| "m" \| "s" \| "xl" \| "xs"`           | `"m"`       |
+| `theme`        | `theme`         | Select theme (light or dark)                                                                                              | `"dark" \| "light"`                           | `"light"`   |
+| `width`        | `width`         | specify the width of the button, defaults to auto                                                                         | `"auto" \| "full" \| "half"`                  | `"auto"`    |
 
 
 ## Dependencies

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -36,7 +36,7 @@ export class CalciteDropdownGroup {
   @State() requestedDropdownItem: string = "";
 
   /** optionally set a group title for display */
-  @Prop({ reflect: true }) grouptitle?: string = null;
+  @Prop({ reflect: true }) groupTitle?: string = null;
 
   //--------------------------------------------------------------------------
   //
@@ -70,13 +70,13 @@ export class CalciteDropdownGroup {
       requestedDropdownItem: this.requestedDropdownItem
     };
 
-    const grouptitle = this.grouptitle ? (
-      <span class="dropdown-title">{this.grouptitle}</span>
+    const groupTitle = this.groupTitle ? (
+      <span class="dropdown-title">{this.groupTitle}</span>
     ) : null;
 
     return (
       <Host theme={theme} scale={scale} id={this.dropdownGroupId}>
-        {grouptitle}
+        {groupTitle}
         <DropdownInterface.Provider state={dropdownState}>
           <slot />
         </DropdownInterface.Provider>

--- a/src/components/calcite-dropdown-group/readme.md
+++ b/src/components/calcite-dropdown-group/readme.md
@@ -7,9 +7,9 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                              | Type     | Default |
-| ------------ | ------------ | ---------------------------------------- | -------- | ------- |
-| `grouptitle` | `grouptitle` | optionally set a group title for display | `string` | `null`  |
+| Property     | Attribute     | Description                              | Type     | Default |
+| ------------ | ------------- | ---------------------------------------- | -------- | ------- |
+| `groupTitle` | `group-title` | optionally set a group title for display | `string` | `null`  |
 
 
 ## Events

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -58,7 +58,7 @@ export class CalciteDropdownItem {
   @Prop() href?: string;
 
   /** pass an optional title for rendered href */
-  @Prop() linktitle?: string;
+  @Prop() linkTitle?: string;
 
   //--------------------------------------------------------------------------
   //
@@ -121,7 +121,7 @@ export class CalciteDropdownItem {
           aria-selected={this.active ? "true" : "false"}
           isLink
         >
-          <a href={this.href} title={this.linktitle}>
+          <a href={this.href} title={this.linkTitle}>
             <slot />
           </a>
         </Host>

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                                     | Type      | Default     |
-| ----------- | ----------- | --------------------------------------------------------------- | --------- | ----------- |
-| `active`    | `active`    |                                                                 | `boolean` | `false`     |
-| `href`      | `href`      | pass an optional href to render an anchor around the link items | `string`  | `undefined` |
-| `linktitle` | `linktitle` | pass an optional title for rendered href                        | `string`  | `undefined` |
+| Property    | Attribute    | Description                                                     | Type      | Default     |
+| ----------- | ------------ | --------------------------------------------------------------- | --------- | ----------- |
+| `active`    | `active`     |                                                                 | `boolean` | `false`     |
+| `href`      | `href`       | pass an optional href to render an anchor around the link items | `string`  | `undefined` |
+| `linkTitle` | `link-title` | pass an optional title for rendered href                        | `string`  | `undefined` |
 
 
 ## Events

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.js
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.js
@@ -12,7 +12,7 @@ storiesOf('Dropdown', module)
       scale="${select("scale", {s: "s", m: "m", l: "l"}, "m")}"
     >
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-      <calcite-dropdown-group grouptitle="Sort by">
+      <calcite-dropdown-group group-title="Sort by">
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
         <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
         <calcite-dropdown-item>Title</calcite-dropdown-item>
@@ -26,7 +26,7 @@ storiesOf('Dropdown', module)
       scale="${select("scale", {s: "s", m: "m", l: "l"}, "m")}"
     >
       <calcite-button slot="dropdown-trigger" theme="dark">Open Dropdown</calcite-button>
-      <calcite-dropdown-group grouptitle="Sort by">
+      <calcite-dropdown-group group-title="Sort by">
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
         <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
         <calcite-dropdown-item>Title</calcite-dropdown-item>

--- a/src/index.html
+++ b/src/index.html
@@ -1253,7 +1253,7 @@
         <calcite-button title="blue transparent button" appearance='transparent'
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           transparent and icon</calcite-button>
-        <calcite-button title="blue transparent button" iconposition="end" appearance='transparent'
+        <calcite-button title="blue transparent button" icon-position="end" appearance='transparent'
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           transparent and end icon</calcite-button>
         <calcite-button title="blue transparent button" appearance='transparent'>blue transparent button
@@ -1312,7 +1312,7 @@
           An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
             rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
             icon='M20 11h2v11H2V2h11v2H4v16h16zm-5-9v1.5h4.44l-7.93 7.93 1.062 1.06L20.5 4.56V9H22V2z'
-            iconposition="end"> to Google with an
+            icon-position="end"> to Google with an
             icon</calcite-button> in some text.<br />
           An anchor link <calcite-button href="http://google.com" appearance="inline" color='light'
             rel="noopener noreferrer" target="_blank" title="in the middle with an icon"
@@ -1398,7 +1398,7 @@
         <calcite-button onclick="loadingButton(this, 3000)"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
         </calcite-button>
-        <calcite-button appearance="outline" color="dark" iconposition="end"
+        <calcite-button appearance="outline" color="dark" icon-position="end"
           icon='M24 11.226A4.695 4.695 0 0 1 19.596 16H14v-2h5.595a2.708 2.708 0 0 0 2.406-2.774A3.175 3.175 0 0 0 19.797 8.2l-1.19-.387-.173-1.24A5.16 5.16 0 0 0 13.482 2a4.992 4.992 0 0 0-4.37 2.732L8.365 6.14l-1.538-.41a1.986 1.986 0 0 0-.504-.082 1.474 1.474 0 0 0-1.533 1.39l-.083 1.127-1.008.51a3.03 3.03 0 0 0-1.698 2.695A2.623 2.623 0 0 0 4.406 14H10v2H4.406a4.606 4.606 0 0 1-4.405-4.63 5.04 5.04 0 0 1 2.794-4.479 3.47 3.47 0 0 1 3.529-3.244 3.952 3.952 0 0 1 1.02.15A6.971 6.971 0 0 1 13.482 0a7.131 7.131 0 0 1 6.933 6.297 5.186 5.186 0 0 1 3.586 4.929zm-8 6.315l-3 2.93V12h-2v8.47l-3-2.93v2.153l4 4 4-4z'>
           Download icon end</calcite-button>
         <calcite-button scale="l" appearance="outline"
@@ -1413,7 +1413,7 @@
         <calcite-button color='red' appearance="outline" onclick="loadingButton(this, 3000)"
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           Delete this (loader)</calcite-button>
-        <calcite-button color='red' scale="l" appearance="outline" iconposition="end"
+        <calcite-button color='red' scale="l" appearance="outline" icon-position="end"
           onclick="loadingButton(this, 3000)"
           icon='M4 5l1.067 16.86A1.29 1.29 0 0 0 6.348 23h10.304a1.29 1.29 0 0 0 1.281-1.14L19 5zm4 15.5a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zm4 0a.5.5 0 0 1-1 0v-13a.5.5 0 0 1 1 0zM19 2l1 2H3l1-2h4l1-1h5l1 1z'>
           Delete this (loader)</calcite-button>
@@ -1444,28 +1444,28 @@
 
         <calcite-dropdown>
           <calcite-button slot="dropdown-trigger">Dropdown with Two Groups</calcite-button>
-          <calcite-dropdown-group grouptitle="Sort by">
+          <calcite-dropdown-group group-title="Sort by">
             <calcite-dropdown-item>Relevance</calcite-dropdown-item>
             <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
             <calcite-dropdown-item>Title</calcite-dropdown-item>
           </calcite-dropdown-group>
-          <calcite-dropdown-group grouptitle="Sort Direction">
+          <calcite-dropdown-group group-title="Sort Direction">
             <calcite-dropdown-item>Least recent</calcite-dropdown-item>
             <calcite-dropdown-item active>Most recent</calcite-dropdown-item>
           </calcite-dropdown-group>
         </calcite-dropdown>
         <calcite-dropdown>
           <calcite-button slot="dropdown-trigger">Dropdown with Three Groups</calcite-button>
-          <calcite-dropdown-group grouptitle="Sort by">
+          <calcite-dropdown-group group-title="Sort by">
             <calcite-dropdown-item>Relevance</calcite-dropdown-item>
             <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
             <calcite-dropdown-item>Title</calcite-dropdown-item>
           </calcite-dropdown-group>
-          <calcite-dropdown-group grouptitle="Sort Direction">
+          <calcite-dropdown-group group-title="Sort Direction">
             <calcite-dropdown-item active>Least recent</calcite-dropdown-item>
             <calcite-dropdown-item>Most recent</calcite-dropdown-item>
           </calcite-dropdown-group>
-          <calcite-dropdown-group grouptitle="Price">
+          <calcite-dropdown-group group-title="Price">
             <calcite-dropdown-item>Less</calcite-dropdown-item>
             <calcite-dropdown-item active>More</calcite-dropdown-item>
           </calcite-dropdown-group>
@@ -1474,7 +1474,7 @@
         <calcite-dropdown alignment="right">
           <calcite-button slot="dropdown-trigger">Open Dropdown right aligned</calcite-button>
 
-          <calcite-dropdown-group grouptitle="View">
+          <calcite-dropdown-group group-title="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>
             <calcite-dropdown-item>Table</calcite-dropdown-item>
@@ -1499,9 +1499,9 @@
         <calcite-dropdown>
           <calcite-button slot="dropdown-trigger">Dropdowns with items as links</calcite-button>
           <calcite-dropdown-group>
-            <calcite-dropdown-item href="/mypage" linktitle="My Page">Relevance</calcite-dropdown-item>
-            <calcite-dropdown-item href="/mypage2" linktitle="My Page 2" active>Date modified</calcite-dropdown-item>
-            <calcite-dropdown-item href="/mypage3" linktitle="My Page 3">Title</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage" link-title="My Page">Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
           </calcite-dropdown-group>
         </calcite-dropdown>
         <br />
@@ -1509,15 +1509,15 @@
         <h3> Dropdowns with items as links mixed with not links</h3>
         <calcite-dropdown>
           <calcite-button slot="dropdown-trigger">Dropdowns with items as links</calcite-button>
-          <calcite-dropdown-group grouptitle="Not Links">
+          <calcite-dropdown-group group-title="Not Links">
             <calcite-dropdown-item>Relevance</calcite-dropdown-item>
             <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
             <calcite-dropdown-item>Title</calcite-dropdown-item>
           </calcite-dropdown-group>
-          <calcite-dropdown-group grouptitle="Link">
-            <calcite-dropdown-item href="/mypage" linktitle="My Page">Relevance</calcite-dropdown-item>
-            <calcite-dropdown-item href="/mypage2" linktitle="My Page 3" active>Date modified</calcite-dropdown-item>
-            <calcite-dropdown-item href="/mypage3" linktitle="My Page 3">Title</calcite-dropdown-item>
+          <calcite-dropdown-group group-title="Link">
+            <calcite-dropdown-item href="/mypage" link-title="My Page">Relevance</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage2" link-title="My Page 3" active>Date modified</calcite-dropdown-item>
+            <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
           </calcite-dropdown-group>
         </calcite-dropdown>
         <br />
@@ -1535,14 +1535,14 @@
 
         <calcite-dropdown theme="dark">
           <calcite-button color="dark" slot="dropdown-trigger">Open Dropdown dark mode with groups</calcite-button>
-          <calcite-dropdown-group grouptitle="Flavors">
+          <calcite-dropdown-group group-title="Flavors">
             <calcite-dropdown-item>Mint</calcite-dropdown-item>
             <calcite-dropdown-item active>Chocolate</calcite-dropdown-item>
             <calcite-dropdown-item>Banana</calcite-dropdown-item>
             <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
             <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
           </calcite-dropdown-group>
-          <calcite-dropdown-group grouptitle="Genres">
+          <calcite-dropdown-group group-title="Genres">
             <calcite-dropdown-item>Rock</calcite-dropdown-item>
             <calcite-dropdown-item active>Country</calcite-dropdown-item>
             <calcite-dropdown-item>Western</calcite-dropdown-item>
@@ -1553,7 +1553,7 @@
         <br />
         <calcite-dropdown scale="s">
           <calcite-button scale="s" slot="dropdown-trigger">Scale S small</calcite-button>
-          <calcite-dropdown-group grouptitle="View">
+          <calcite-dropdown-group group-title="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>
             <calcite-dropdown-item>Table</calcite-dropdown-item>
@@ -1562,7 +1562,7 @@
 
         <calcite-dropdown scale="m">
           <calcite-button scale="m" slot="dropdown-trigger">Scale M medium</calcite-button>
-          <calcite-dropdown-group grouptitle="View">
+          <calcite-dropdown-group group-title="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>
             <calcite-dropdown-item>Table</calcite-dropdown-item>
@@ -1571,7 +1571,7 @@
 
         <calcite-dropdown scale="l">
           <calcite-button color="dark" scale="l" slot="dropdown-trigger">Scale L large</calcite-button>
-          <calcite-dropdown-group grouptitle="View">
+          <calcite-dropdown-group group-title="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>
             <calcite-dropdown-item>Table</calcite-dropdown-item>
@@ -1581,7 +1581,7 @@
         <calcite-dropdown>
           <button slot="dropdown-trigger" tabIndex="0">I'm not a "not calcite-button" button trigger</button>
 
-          <calcite-dropdown-group grouptitle="View">
+          <calcite-dropdown-group group-title="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>
             <calcite-dropdown-item>Table</calcite-dropdown-item>
@@ -1591,7 +1591,7 @@
 
         <calcite-dropdown>
           <a slot="dropdown-trigger" tabIndex="0">I'm not an anchor trigger</a>
-          <calcite-dropdown-group grouptitle="View">
+          <calcite-dropdown-group group-title="View">
             <calcite-dropdown-item active>List</calcite-dropdown-item>
             <calcite-dropdown-item>Grid</calcite-dropdown-item>
             <calcite-dropdown-item>Table</calcite-dropdown-item>


### PR DESCRIPTION
Fix for https://github.com/Esri/calcite-components/issues/179 cc @adelheidF

- breaking: calcite-button "iconposition" attribute updated to "icon-position"

- breaking: calcite-dropdown-group "grouptitle" attribute updated to "group-title"

- breaking: calcite-dropdown-item "linktitle" attribute updated to "link-title"

- updates docs and storybook examples