### PR TITLE
Components source global CSS variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7258,8 +7258,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7280,14 +7279,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7302,20 +7299,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7432,8 +7426,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7445,7 +7438,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7460,7 +7452,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7468,14 +7459,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7494,7 +7483,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7575,8 +7563,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7588,7 +7575,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7674,8 +7660,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7711,7 +7696,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7731,7 +7715,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7775,14 +7758,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/assets/styles/_colors.scss
+++ b/src/assets/styles/_colors.scss
@@ -22,23 +22,23 @@
   }
   
   :host([theme="dark"]) {
-    --calcite-global-ui-blue-dark: $d-bb-420;
-    --calcite-global-ui-blue-hover-dark: $d-bb-430;
-    --calcite-global-ui-blue-pressed-dark: $d-bb-410;
-    --calcite-global-ui-green-dark: $d-gg-420;
-    --calcite-global-ui-green-hover-dark: $d-gg-430;
-    --calcite-global-ui-green-pressed-dark: $d-gg-410;
-    --calcite-global-ui-yellow-dark: $d-yy-420;
-    --calcite-global-ui-yellow-hover-dark: $d-yy-430;
-    --calcite-global-ui-yellow-pressed-dark: $d-yy-410;
-    --calcite-global-ui-red-dark: $d-rr-420;
-    --calcite-global-ui-red-hover-dark: $d-rr-430;
-    --calcite-global-ui-red-pressed-dark: $d-rr-410;
-    --calcite-global-ui-background-dark: $blk-210;
-    --calcite-global-ui-foreground-dark: $blk-200;
-    --calcite-global-ui-foreground-hover-dark: $blk-190;
-    --calcite-global-ui-foreground-pressed-dark: $blk-180;
-    --calcite-global-ui-text-1-dark: $blk-000;
-    --calcite-global-ui-text-2-dark:$blk-060;
-    --calcite-global-ui-text-3-dark: $blk-090;;
+    --calcite-global-ui-blue: #{$d-bb-420};
+    --calcite-global-ui-blue-hover: #{$d-bb-430};
+    --calcite-global-ui-blue-pressed: #{$d-bb-410};
+    --calcite-global-ui-green: #{$d-gg-420};
+    --calcite-global-ui-green-hover: #{$d-gg-430};
+    --calcite-global-ui-green-pressed: #{$d-gg-410};
+    --calcite-global-ui-yellow: #{$d-yy-420};
+    --calcite-global-ui-yellow-hover: #{$d-yy-430};
+    --calcite-global-ui-yellow-pressed: #{$d-yy-410};
+    --calcite-global-ui-red: #{$d-rr-420};
+    --calcite-global-ui-red-hover: #{$d-rr-430};
+    --calcite-global-ui-red-pressed: #{$d-rr-410};
+    --calcite-global-ui-background: #{$blk-210};
+    --calcite-global-ui-foreground: #{$blk-200};
+    --calcite-global-ui-foreground-hover: #{$blk-190};
+    --calcite-global-ui-foreground-pressed: #{$blk-180};
+    --calcite-global-ui-text-1: #{$blk-000};
+    --calcite-global-ui-text-2: #{$blk-060};
+    --calcite-global-ui-text-3: #{$blk-090};
   }

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -1,36 +1,16 @@
 // theme variables
 // light theme
 :host {
-  --calcite-alert-background: #{$blk-000};
-  --calcite-alert-title-text: #{$blk-180};
-  --calcite-alert-message-text: #{$blk-160};
   --calcite-alert-icon-fill: #{$blk-220};
-  --calcite-alert-close-background-hover: #{$blk-010};
-  --calcite-alert-close-background-pressed: #{$blk-020};
-  --calcite-alert-count-text: #{$blk-180};
   --calcite-alert-count-border: #{$blk-010};
   --calcite-alert-dismiss-background: #{rgba($blk-000, 0.8)};
-  --calcite-alert-border-blue: #{$ui-blue};
-  --calcite-alert-border-green: #{$ui-green};
-  --calcite-alert-border-red: #{$ui-red};
-  --calcite-alert-border-yellow: #{$ui-yellow};
 }
 
 // dark theme
 :host([theme="dark"]) {
-  --calcite-alert-background: #{$blk-200};
-  --calcite-alert-title-text: #{$blk-005};
-  --calcite-alert-message-text: #{$blk-010};
   --calcite-alert-icon-fill: #{$blk-040};
-  --calcite-alert-close-background-hover: #{$blk-210};
-  --calcite-alert-close-background-pressed: #{$blk-220};
-  --calcite-alert-count-text: #{$blk-040};
   --calcite-alert-count-border: #{$blk-210};
   --calcite-alert-dismiss-background: #{rgba($blk-200, 0.8)};
-  --calcite-alert-border-blue: #{$ui-blue-dark};
-  --calcite-alert-border-green: #{$ui-green-dark};
-  --calcite-alert-border-red: #{$ui-red-dark};
-  --calcite-alert-border-yellow: #{$ui-yellow-dark};
 }
 
 :host {
@@ -43,7 +23,7 @@
   width: 50em;
   max-width: 90%;
   max-height: 0;
-  background-color: var(--calcite-alert-background);
+  background-color: var(--calcite-global-ui-foreground);
   box-shadow: $shadow-2;
   border-radius: 2px;
   opacity: 0;
@@ -81,7 +61,7 @@
 
 @include slotted("alert-title", "div") {
   @include font-size(0);
-  color: var(--calcite-alert-title-text);
+  color: var(--calcite-global-ui-text-1);
   font-weight: 500;
 }
 
@@ -93,7 +73,7 @@
   display: inline;
   margin-right: $baseline/2;
   @include font-size(-1);
-  color: var(--calcite-alert-message-text);
+  color: var(--calcite-global-ui-text-2);
 }
 
 :host([dir="rtl"]) {
@@ -167,11 +147,11 @@
 
   &:hover,
   &:focus {
-    background-color: var(--calcite-alert-close-background-hover);
+    background-color: var(--calcite-global-ui-foreground-hover);
   }
 
   &:active {
-    background-color: var(--calcite-alert-close-background-pressed);
+    background-color: var(--calcite-global-ui-foreground-pressed);
   }
 }
 
@@ -194,7 +174,7 @@
   visibility: hidden;
   font-weight: 500;
   text-align: center;
-  color: var(--calcite-alert-count-text);
+  color: var(--calcite-global-ui-text-2);
   opacity: 0;
   border-left: 0px solid transparent;
   border-right: 0px solid transparent;
@@ -247,10 +227,10 @@
   }
 }
 
-$alertColors: "blue" var(--calcite-alert-border-blue),
-  "red" var(--calcite-alert-border-red),
-  "yellow" var(--calcite-alert-border-yellow),
-  "green" var(--calcite-alert-border-green);
+$alertColors: "blue" var(--calcite-global-ui-blue),
+  "red" var(--calcite-global-ui-red),
+  "yellow" var(--calcite-global-ui-yellow),
+  "green" var(--calcite-global-ui-green);
 
 @each $alertColor in $alertColors {
   $name: nth($alertColor, 1);

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -3,12 +3,9 @@
 :host {
   display: inline-block;
   width: auto;
-  --calcite-button-blue: #{$ui-blue};
-  --calcite-button-blue-hover: #{$ui-blue-hover};
-  --calcite-button-blue-pressed: #{$ui-blue-pressed};
-  --calcite-button-red: #{$ui-red};
-  --calcite-button-red-hover: #{$ui-red-hover};
-  --calcite-button-red-pressed: #{$ui-red-pressed};
+  --calcite-button-light: #{$blk-010};
+  --calcite-button-light-hover: #{$blk-000};
+  --calcite-button-light-pressed: #{$blk-020};
   --calcite-button-dark: #{$blk-190};
   --calcite-button-dark-hover: #{$blk-180};
   --calcite-button-dark-pressed: #{$blk-200};
@@ -23,12 +20,9 @@
 
 // dark theme
 :host([theme="dark"]) {
-  --calcite-button-blue: #{$ui-blue-dark};
-  --calcite-button-blue-hover: #{$ui-blue-hover-dark};
-  --calcite-button-blue-pressed: #{$ui-blue-pressed-dark};
-  --calcite-button-red: #{$ui-red-dark};
-  --calcite-button-red-hover: #{$ui-red-hover-dark};
-  --calcite-button-red-pressed: #{$ui-red-pressed-dark};
+  --calcite-button-light: #{$blk-010};
+  --calcite-button-light-hover: #{$blk-020};
+  --calcite-button-light-pressed: #{$blk-000};
   --calcite-button-dark: #{$blk-190};
   --calcite-button-dark-hover: #{$blk-200};
   --calcite-button-dark-pressed: #{$blk-180};
@@ -203,9 +197,9 @@
   button,
   a {
     @include btn-solid(
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-hover),
-      var(--calcite-button-blue-pressed),
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-hover),
+      var(--calcite-global-ui-blue-pressed),
       var(--calcite-button-blue-solid-color)
     );
   }
@@ -214,9 +208,9 @@
   button,
   a {
     @include btn-solid(
-      var(--calcite-button-red),
-      var(--calcite-button-red-hover),
-      var(--calcite-button-red-pressed),
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-hover),
+      var(--calcite-global-ui-red-pressed),
       var(--calcite-button-red-solid-color)
     );
   }
@@ -224,7 +218,12 @@
 :host([appearance="solid"][color="light"]) {
   button,
   a {
-    @include btn-solid($blk-010, $blk-000, $blk-020, $blk-240);
+    @include btn-solid(
+      var(--calcite-button-light),
+      var(--calcite-button-light-hover),
+      var(--calcite-button-light-pressed),
+      $blk-220
+      );
   }
 }
 :host([appearance="solid"][color="dark"]) {
@@ -278,11 +277,11 @@
   a {
     @include btn-outline-clear(
       var(--calcite-button-outline-background),
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-hover),
-      var(--calcite-button-blue-pressed),
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-pressed)
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-hover),
+      var(--calcite-global-ui-blue-pressed),
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-pressed)
     );
   }
 }
@@ -291,11 +290,11 @@
   a {
     @include btn-outline-clear(
       var(--calcite-button-outline-background),
-      var(--calcite-button-red),
-      var(--calcite-button-red-hover),
-      var(--calcite-button-red-pressed),
-      var(--calcite-button-red),
-      var(--calcite-button-red-pressed)
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-hover),
+      var(--calcite-global-ui-red-pressed),
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-pressed)
     );
   }
 }
@@ -319,7 +318,7 @@
       var(--calcite-button-outline-background),
       $blk-200,
       $blk-180,
-      $blk-240,
+      $blk-220,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-pressed)
     );
@@ -330,11 +329,11 @@
   a {
     @include btn-outline-clear(
       transparent,
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-hover),
-      var(--calcite-button-blue-pressed),
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-pressed)
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-hover),
+      var(--calcite-global-ui-blue-pressed),
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-pressed)
     );
   }
 }
@@ -343,11 +342,11 @@
   a {
     @include btn-outline-clear(
       transparent,
-      var(--calcite-button-red),
-      var(--calcite-button-red-hover),
-      var(--calcite-button-red-pressed),
-      var(--calcite-button-red),
-      var(--calcite-button-red-pressed)
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-hover),
+      var(--calcite-global-ui-red-pressed),
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-pressed)
     );
   }
 }
@@ -371,9 +370,9 @@
       transparent,
       $blk-200,
       $blk-180,
-      $blk-240,
       $blk-220,
-      $blk-240
+      $blk-220,
+      $blk-220
     );
   }
 }
@@ -408,9 +407,9 @@
   button,
   a {
     @include btn-transparent(
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-hover),
-      var(--calcite-button-blue-pressed)
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-hover),
+      var(--calcite-global-ui-blue-pressed)
     );
   }
 }
@@ -419,9 +418,9 @@
   button,
   a {
     @include btn-transparent(
-      var(--calcite-button-red),
-      var(--calcite-button-red-hover),
-      var(--calcite-button-red-pressed)
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-hover),
+      var(--calcite-global-ui-red-pressed)
     );
   }
 }
@@ -482,9 +481,9 @@
   span,
   a {
     @include btn-inline(
-      var(--calcite-button-blue),
-      var(--calcite-button-blue-hover),
-      var(--calcite-button-blue-inline-underline)
+      var(--calcite-global-ui-blue),
+      var(--calcite-global-ui-blue-hover),
+      var(--calcite-global-ui-blue-inline-underline)
     );
   }
 }
@@ -493,9 +492,9 @@
   span,
   a {
     @include btn-inline(
-      var(--calcite-button-red),
-      var(--calcite-button-red-hover),
-      var(--calcite-button-red-inline-underline)
+      var(--calcite-global-ui-red),
+      var(--calcite-global-ui-red-hover),
+      var(--calcite-global-ui-red-inline-underline)
     );
   }
 }

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -1,12 +1,10 @@
 // light theme
 :host {
-  --calcite-dropdown-group-color: #{$ui-text-2};
   --calcite-dropdown-group-border-color: #{$blk-020};
 }
 
 // dark theme
 :host([theme="dark"]) {
-  --calcite-dropdown-group-color: #{$ui-text-2-dark};
   --calcite-dropdown-group-border-color: #{$blk-180};
 }
 
@@ -28,7 +26,7 @@
   margin: 0 $baseline/1.5 -1px $baseline/1.5;
   padding: var(--calcite-dropdown-group-padding);
   border-bottom: 1px solid var(--calcite-dropdown-group-border-color);
-  color: var(--calcite-dropdown-group-color);
+  color: var(--calcite-global-ui-text-2);
   font-weight: 600;
   word-wrap: break-word;
   cursor: default;

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -1,24 +1,3 @@
-// theme variables
-// light theme
-:host {
-  --calcite-dropdown-item-color: #{$ui-text-2};
-  --calcite-dropdown-item-color-hover: #{$ui-text-1};
-  --calcite-dropdown-item-color-active: #{$ui-text-1};
-  --calcite-dropdown-item-background-color-hover: #{$ui-foreground-hover};
-  --calcite-dropdown-item-background-color-pressed: #{$ui-foreground-pressed};
-  --calcite-dropdown-item-dot-active-color: #{$ui-blue};
-}
-
-// dark theme
-:host([theme="dark"]) {
-  --calcite-dropdown-item-color: #{$ui-text-2};
-  --calcite-dropdown-item-color-hover: #{$ui-text-1-dark};
-  --calcite-dropdown-item-color-active: #{$ui-text-1-dark};
-  --calcite-dropdown-item-background-color-hover: #{$ui-foreground-hover-dark};
-  --calcite-dropdown-item-background-color-pressed: #{$ui-foreground-pressed-dark};
-  --calcite-dropdown-item-dot-active-color: #{$ui-blue-dark};
-}
-
 // scale: s
 :host([scale="s"]) {
   --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5
@@ -53,7 +32,7 @@
 :host {
   display: block;
   @include font-size(-2);
-  color: var(--calcite-dropdown-item-color);
+  color: var(--calcite-global-ui-text-3);
   transition: 0.15s all ease-in-out;
   padding: var(--calcite-dropdown-item-padding);
   cursor: pointer;
@@ -65,13 +44,13 @@
 :host(:hover),
 :host(:focus),
 :host(:active) {
-  background-color: var(--calcite-dropdown-item-background-color-hover);
-  color: var(--calcite-dropdown-item-color-hover);
+  background-color: var(--calcite-global-ui-foreground-hover);
+  color: var(--calcite-global-ui-text-1);
   text-decoration: none;
 }
 
 :host(:active) {
-  background-color: var(--calcite-dropdown-item-background-color-pressed);
+  background-color: var(--calcite-global-ui-foreground-pressed);
 }
 
 :host:before {
@@ -96,11 +75,11 @@
 }
 
 :host([active]) {
-  color: var(--calcite-dropdown-item-color-active);
+  color: var(--calcite-global-ui-text-1);
   font-weight: 500;
   &:before {
     opacity: 1;
-    color: var(--calcite-dropdown-item-dot-active-color);
+    color: var(--calcite-global-ui-blue);
   }
 }
 
@@ -114,7 +93,7 @@
     display: block;
     position: relative;
     padding: var(--calcite-dropdown-item-padding);
-    color: var(--calcite-dropdown-item-color);
+    color: var(--calcite-global-ui-text-3);
     text-decoration: none;
     outline: none;
     &:before {
@@ -131,7 +110,7 @@
 :host([islink]) a:hover,
 :host([islink]) a:focus,
 :host([islink]) a:active {
-  background-color: var(--calcite-dropdown-item-background-color-hover);
+  background-color: var(--calcite-global-ui-foreground-hover);
   text-decoration: none;
   &:before {
     opacity: 1;
@@ -139,15 +118,15 @@
 }
 
 :host([islink]) a:active {
-  background-color: var(--calcite-dropdown-item-background-color-pressed);
+  background-color: var(--calcite-global-ui-foreground-pressed);
 }
 
 :host([islink][active]) a {
-  color: var(--calcite-dropdown-item-color-active);
+  color: var(--calcite-global-ui-text-1);
   font-weight: 500;
   &:before {
     opacity: 1;
-    color: var(--calcite-dropdown-item-dot-active-color);
+    color: var(--calcite-global-ui-blue);
   }
 }
 

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,13 +1,11 @@
 // theme variables
 // light theme
 :host {
-  --calcite-dropdown-background-color: #{$ui-foreground};
   --calcite-dropdown-border-color: #{$blk-020};
 }
 
 // dark theme
 :host([theme="dark"]) {
-  --calcite-dropdown-background-color: #{$ui-foreground-dark};
   --calcite-dropdown-border-color: #{$blk-180};
 }
 
@@ -34,7 +32,7 @@
   overflow: auto;
   width: auto;
   width: 12.5rem;
-  background: var(--calcite-dropdown-background-color);
+  background: var(--calcite-global-ui-foreground);
   border: 1px solid var(--calcite-dropdown-border-color);
   border-radius: 2px;
   box-shadow: 0 0 12px 0 rgba($blk-240, 0.15);

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -1,13 +1,6 @@
 :host {
-  --calcite-modal-background: #{$ui-foreground};
-  --calcite-modal-hover: #{$ui-foreground-hover};
-  --calcite-modal-pressed: #{$ui-foreground-pressed};
-  --calcite-modal-header-text: #{$blk-220};
-  --calcite-modal-body-text: #{$blk-220};
   --calcite-modal-scrim: rgba(0, 0, 0, 0.75);
   --calcite-modal-border: #{$blk-010};
-  --calcite-modal-accent-red: #{$ui-red};
-  --calcite-modal-accent-blue: #{$ui-blue};
   position: fixed;
   top: 0;
   right: 0;
@@ -17,7 +10,7 @@
   justify-content: center;
   align-items: center;
   overflow-y: hidden;
-  color: var(--calcite-modal-body-text);
+  color: var(--calcite-global-ui-text-2);
   opacity: 0;
   visibility: hidden !important;
   background: var(--calcite-modal-scrim);
@@ -26,14 +19,7 @@
 }
 
 :host([theme="dark"]) {
-  --calcite-modal-background: #{$ui-foreground-dark};
-  --calcite-modal-hover: #{$ui-foreground-hover-dark};
-  --calcite-modal-pressed: #{$ui-foreground-pressed-dark};
-  --calcite-modal-header-text: #{$blk-000};
-  --calcite-modal-body-text: #{$blk-010};
   --calcite-modal-border: #{$ui-foreground-hover-dark};
-  --calcite-modal-accent-red: #{$ui-red-dark};
-  --calcite-modal-accent-blue: #{$ui-blue-dark};
 }
 
 .modal {
@@ -50,7 +36,7 @@
   transition: transform 300ms $easing-function, visibility 0ms linear 300ms,
     opacity 300ms $easing-function;
   transform: translate3d(0, 20px, 0);
-  background-color: var(--calcite-modal-background);
+  background-color: var(--calcite-global-ui-foreground);
   box-shadow: $shadow-2--press;
   border-radius: 2px;
   margin: $baseline;
@@ -80,7 +66,7 @@
  * Header
  */
 .modal__header {
-  background-color: var(--calcite-modal-background);
+  background-color: var(--calcite-global-ui-foreground);
   flex: 0;
   display: flex;
   max-width: 100%;
@@ -100,7 +86,7 @@
   background-color: transparent;
   -webkit-appearance: none;
   border: none;
-  color: var(--calcite-modal-body-text);
+  color: var(--calcite-global-ui-text-1);
   outline: none;
   cursor: pointer;
   border-radius: 0 2px 0 0;
@@ -109,10 +95,10 @@
   }
   &:hover,
   &:focus {
-    background-color: var(--calcite-modal-hover);
+    background-color: var(--calcite-global-ui-foreground-hover);
   }
   &:active {
-    background-color: var(--calcite-modal-pressed);
+    background-color: var(--calcite-global-ui-foreground-pressed);
   }
 }
 
@@ -133,7 +119,7 @@
   margin: 0;
   font-weight: 400;
   @include font-size(2);
-  color: var(--calcite-modal-header-text);
+  color: var(--calcite-global-ui-text-1);
 }
 
 /**
@@ -147,7 +133,7 @@
   max-height: calc(100vh - 12rem);
   overflow-y: auto;
   display: block;
-  background-color: var(--calcite-modal-background);
+  background-color: var(--calcite-global-ui-foreground);
   z-index: 1;
 }
 
@@ -167,7 +153,7 @@
   box-sizing: border-box;
   border-radius: 0 0 2px 2px;
   width: 100%;
-  background-color: var(--calcite-modal-background);
+  background-color: var(--calcite-global-ui-foreground);
   border-top: 1px solid var(--calcite-modal-border);
   z-index: 2;
 }
@@ -305,13 +291,13 @@ slot[name="primary"] {
  */
 :host([color="red"]) {
   .modal {
-    border-top: 4px solid var(--calcite-modal-accent-red);
+    border-top: 4px solid var(--calcite-global-ui-red);
   }
 }
 
 :host([color="blue"]) {
   .modal {
-    border-top: 4px solid var(--calcite-modal-accent-blue);
+    border-top: 4px solid var(--calcite-global-ui-blue);
   }
 }
 

--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -1,10 +1,6 @@
 $image_max_height: 200px;
 
 :host {
-  --calcite-popover-background: #{$ui-foreground};
-  --calcite-popover-primary-text: var(--calcite-global-ui-text-1);
-  --calcite-popover-close-hover: #{$ui-foreground-hover};
-  --calcite-popover-close-pressed: #{$ui-foreground-pressed};
   display: block;
   position: absolute;
   z-index: 999;
@@ -13,10 +9,6 @@ $image_max_height: 200px;
 }
 
 :host([theme="dark"]) {
-  --calcite-popover-background: #{$ui-foreground-dark};
-  --calcite-popover-primary-text: #{$ui-text-1-dark};
-  --calcite-popover-close-hover: #{$ui-foreground-hover-dark};
-  --calcite-popover-close-pressed: #{$ui-foreground-pressed-dark};
 }
 
 .container {
@@ -35,8 +27,8 @@ $image_max_height: 200px;
   display: flex;
   max-width: 350px;
   flex-direction: column;
-  background: var(--calcite-popover-background);
-  color: var(--calcite-popover-primary-text);
+  background: var(--calcite-global-ui-foreground);
+  color: var(--calcite-global-ui-text-1);
 }
 
 .content {
@@ -52,18 +44,18 @@ $image_max_height: 200px;
   width: 40px;
   height: 45px;
   z-index: 1;
-  background: var(--calcite-popover-background);
-  color: var(--calcite-popover-primary-text);
+  background: var(--calcite-global-ui-foreground);
+  color: var(--calcite-global-ui-text-1);
   padding: 16px 12px;
   border: none;
   display: block;
   cursor: pointer;
   border-top-right-radius: 2px;
   &:hover {
-    background: var(--calcite-popover-close-hover);
+    background: var(--calcite-global-ui-foreground-hover);
   }
   &:active {
-    background: var(--calcite-popover-close-pressed);
+    background: var(--calcite-global-ui-foreground-pressed);
   }
 }
 

--- a/src/components/calcite-progress/calcite-progress.scss
+++ b/src/components/calcite-progress/calcite-progress.scss
@@ -1,12 +1,10 @@
 :host {
-  --calcite-progress-color: #{$ui-blue};
   --calcite-track-color: #{$blk-020};
   position: relative;
   display: block;
 }
 
 :host([theme="dark"]) {
-  --calcite-progress-color: #{$ui-blue-dark};
   --calcite-track-color: #{$blk-190};
 }
 
@@ -30,7 +28,7 @@ $looping-progress-bar-params: 1500ms linear infinite !default;
 }
 
 .calcite-progress--bar {
-  background-color: var(--calcite-progress-color);
+  background-color: var(--calcite-global-ui-blue);
   z-index: 0;
 }
 

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -1,7 +1,7 @@
 :host {
   display: flex;
   background-color: var(--calcite-radio-group-color);
-  color: var(--calcite-radio-group-text-color);
+  color: var(--calcite-global-ui-text-3);
   cursor: pointer;
   padding: var(--calcite-radio-group-padding);
   line-height: 1.25;
@@ -25,12 +25,16 @@
 }
 
 :host(:hover) {
-  background-color: var(--calcite-radio-group-color-hover);
+  background-color: var(--calcite-global-ui-foreground-hover);
+}
+
+:host(:active) {
+  background-color: var(--calcite-global-ui-foreground-pressed);
 }
 
 :host([checked]) {
-  background-color: var(--calcite-radio-group-color-active);
-  border-color: var(--calcite-radio-group-color-active);
+  background-color: var(--calcite-global-ui-blue);
+  border-color: var(--calcite-global-ui-blue);
   color: var(--calcite-radio-group-text-color-active);
   cursor: default;
 }

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -2,10 +2,7 @@
   display: flex;
   --calcite-radio-group-color: #{$blk-000};
   --calcite-radio-group-border-color: #{$blk-040};
-  --calcite-radio-group-color-active: #{$ui-blue};
-  --calcite-radio-group-text-color: #{$blk-240};
   --calcite-radio-group-text-color-active: #{$blk-000};
-  --calcite-radio-group-color-hover: #{$blk-005};
   --calcite-radio-group-padding: 0.5rem 1rem;
 }
 
@@ -24,10 +21,7 @@
 :host([theme="dark"]) {
   --calcite-radio-group-color: #{$blk-200};
   --calcite-radio-group-border-color: #{$blk-190};
-  --calcite-radio-group-color-active: #{$v-bb-160};
-  --calcite-radio-group-text-color: #{$blk-000};
   --calcite-radio-group-text-color-active: #{$blk-000};
-  --calcite-radio-group-color-hover: #{$blk-190};
 }
 
 ::slotted(calcite-radio-group-item[checked]),

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -12,7 +12,6 @@ $calcite-slider-tick-height: 4px;
   --calcite-slider-track: #{$blk-040};
   --calcite-slider-handle: #{$blk-000};
   --calcite-slider-handle-border: #{$blk-140};
-  --calcite-slider-handle-precise: #{$blk-140};
   display: block;
   padding: $calcite-slider-handle-size / 2 0;
   margin: $calcite-slider-handle-size / 2 0;
@@ -25,7 +24,6 @@ $calcite-slider-tick-height: 4px;
   --calcite-slider-track: #{$blk-170};
   --calcite-slider-handle: #{$blk-200};
   --calcite-slider-handle-border: #{$blk-090};
-  --calcite-slider-handle-precise: #{$blk-090};
 }
 
 :host([disabled]) {
@@ -131,12 +129,13 @@ $calcite-slider-tick-height: 4px;
   left: 50%;
   width: 2px;
   height: $calcite-slider-thumb-padding;
-  background-color: var(--calcite-slider-handle-precise);
+  background-color: var(--calcite-slider-handle-border);
   margin-left: -1px;
   margin-top: $calcite-slider-thumb-padding;
   z-index: 2;
 }
 
+.slider__thumb:hover.slider__thumb--precise:after,
 .slider__thumb:focus.slider__thumb--precise:after,
 .slider__thumb--active.slider__thumb--precise:after {
   background-color: var(--calcite-global-ui-blue);

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -7,11 +7,12 @@ $calcite-slider-track-height: 2px;
 $calcite-slider-tick-height: 4px;
 
 :host {
-  --calcite-slider-spot: #{$ui-blue};
   --calcite-slider-tick: #{$blk-100};
-  --calcite-slider-label: #{$blk-160};
-  --calcite-slider-track: #{$blk-050};
+  --calcite-slider-label: #{$ui-text-3};
+  --calcite-slider-track: #{$blk-040};
   --calcite-slider-handle: #{$blk-000};
+  --calcite-slider-handle-border: #{$blk-140};
+  --calcite-slider-handle-precise: #{$blk-140};
   display: block;
   padding: $calcite-slider-handle-size / 2 0;
   margin: $calcite-slider-handle-size / 2 0;
@@ -19,11 +20,12 @@ $calcite-slider-tick-height: 4px;
 }
 
 :host([theme="dark"]) {
-  --calcite-slider-spot: #{$ui-blue-dark};
-  --calcite-slider-tick: #{$blk-180};
-  --calcite-slider-label: #{$blk-050};
+  --calcite-slider-tick: #{$blk-140};
+  --calcite-slider-label: #{$blk-090};
   --calcite-slider-track: #{$blk-170};
   --calcite-slider-handle: #{$blk-200};
+  --calcite-slider-handle-border: #{$blk-090};
+  --calcite-slider-handle-precise: #{$blk-090};
 }
 
 :host([disabled]) {
@@ -82,7 +84,7 @@ $calcite-slider-tick-height: 4px;
   box-sizing: border-box;
   border-radius: 100%;
   background-color: var(--calcite-slider-handle);
-  border: 2px solid var(--calcite-slider-tick);
+  border: 2px solid var(--calcite-slider-handle-border);
   transition: border 0.25s ease, background-color 0.25s ease,
     box-shadow 0.25s ease;
 }
@@ -94,13 +96,15 @@ $calcite-slider-tick-height: 4px;
   width: $calcite-slider-thumb-size;
   height: 0.75em;
   @include font-size(-3);
+  font-weight: 500;
   line-height: 1;
   color: var(--calcite-slider-label);
   text-align: center;
 }
 
 .slider__thumb:hover .slider__handle {
-  border-color: var(--calcite-slider-spot);
+  border-width: 3px;
+  border-color: var(--calcite-global-ui-blue);
   @include shadow(1, "hover");
 }
 
@@ -109,8 +113,8 @@ $calcite-slider-tick-height: 4px;
   outline: none;
   z-index: 4;
   .slider__handle {
-    background-color: var(--calcite-slider-spot);
-    border-color: var(--calcite-slider-spot);
+    background-color: var(--calcite-global-ui-blue);
+    border-color: var(--calcite-global-ui-blue);
     @include shadow(1, "press");
   }
 }
@@ -127,7 +131,7 @@ $calcite-slider-tick-height: 4px;
   left: 50%;
   width: 2px;
   height: $calcite-slider-thumb-padding;
-  background-color: var(--calcite-slider-tick);
+  background-color: var(--calcite-slider-handle-precise);
   margin-left: -1px;
   margin-top: $calcite-slider-thumb-padding;
   z-index: 2;
@@ -135,7 +139,7 @@ $calcite-slider-tick-height: 4px;
 
 .slider__thumb:focus.slider__thumb--precise:after,
 .slider__thumb--active.slider__thumb--precise:after {
-  background-color: var(--calcite-slider-spot);
+  background-color: var(--calcite-global-ui-blue);
 }
 
 .slider__thumb--precise.slider__thumb--min {
@@ -166,7 +170,7 @@ $calcite-slider-tick-height: 4px;
   right: var(--calcite-slider-range-max);
   left: var(--calcite-slider-range-min);
   height: $calcite-slider-track-height;
-  background-color: var(--calcite-slider-spot);
+  background-color: var(--calcite-global-ui-blue);
 }
 
 .slider__tick {
@@ -183,12 +187,13 @@ $calcite-slider-tick-height: 4px;
 }
 
 .slider__tick--active {
-  background-color: var(--calcite-slider-spot);
+  background-color: var(--calcite-global-ui-blue);
 }
 
 .slider__tick__label {
   position: absolute;
   @include font-size(-3);
+  font-weight: 500;
   color: var(--calcite-slider-label);
   width: 4em;
   margin: $calcite-slider-thumb-size / 2 -2em;

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -1,16 +1,9 @@
 :host {
-  --calcite-tooltip-primary-text: #{$ui-text-1};
-  --calcite-tooltip-background: #{$ui-foreground};
   display: block;
   position: absolute;
   z-index: 999;
   top: -999999px;
   left: -999999px;
-}
-
-:host([theme="dark"]) {
-  --calcite-tooltip-primary-text: #{$ui-text-1-dark};
-  --calcite-tooltip-background: #{$ui-foreground-dark};
 }
 
 .tooltip-container {
@@ -24,14 +17,14 @@
 }
 
 .tooltip-content-container {
-  background: var(--calcite-tooltip-background);
+  background: var(--calcite-global-ui-foreground);
   max-width: 300px;
   max-height: 300px;
   display: flex;
   justify-content: flex-start;
   flex-direction: column;
   font-weight: 500;
-  color: var(--calcite-tooltip-primary-text);
+  color: var(--calcite-global-ui-text-1);
   padding: 12px 16px;
   @include font-size(-3);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1181,7 +1181,7 @@
           <calcite-button theme="dark" title="blue solid button">blue solid button</calcite-button>
           <calcite-button theme="dark" title="red solid button" color='red'>red solid button</calcite-button>
 
-          <calcite-button title="light solid button" color='light'>light solid button</calcite-button>
+          <calcite-button theme="dark" title="light solid button" color='light'>light solid button</calcite-button>
           <calcite-button theme="dark" title="dark solid button" color='dark'>dark solid button</calcite-button>
         </div>
 


### PR DESCRIPTION
global css variables:
- fixed a bug that was breaking dark theme

Bryan and I sat down and synched up the Sketch values with the calcite-component values: colors, weights, sizes, etc.

Went through most of the components and sourced the global css variables from https://github.com/Esri/calcite-components/blob/master/src/assets/styles/_colors.scss:
- Made sure text colors were using ui text 1, 2, 3, blue, or red.
- Added foreground colors to containers or close button. 
- sourced main ui colors 

minor UI changes
- some UI updates to sliders to match Sketch lib
- updated solid light button hover and pressed state for dark theme