### PR TITLE
Use text values for boolean ARIA attributes.

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -70,7 +70,7 @@ export class CalciteAccordionItem {
       <Host
         dir={dir}
         tabindex="0"
-        aria-expanded={this.active ? "true" : "false"}
+        aria-expanded={this.active.toString()}
       >
         <div class="accordion-item-header" onClick={this.itemHeaderClickHander}>
           <span class="accordion-item-title">{this.itemTitle}</span>

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -111,7 +111,7 @@ export class CalciteCheckbox {
     return (
       <Host
         role="checkbox"
-        aria-checked={this.checked}
+        aria-checked={this.checked.toString()}
         tabindex={this.disabled ? "-1" : "0"}
       >
         <svg class="check-svg" viewBox="0 0 16 16">

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -90,7 +90,7 @@ export class CalciteDropdownItem {
           scale={scale}
           tabindex="0"
           role="menuitem"
-          aria-selected={this.active ? "true" : "false"}
+          aria-selected={this.active.toString()}
         >
           <slot />
         </Host>
@@ -103,7 +103,7 @@ export class CalciteDropdownItem {
           scale={scale}
           tabindex="0"
           role="menuitem"
-          aria-selected={this.active ? "true" : "false"}
+          aria-selected={this.active.toString()}
           isLink
         >
           <a href={this.href} title={this.linkTitle}>

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -84,7 +84,7 @@ export class CalciteRadioGroupItem {
     return (
       <Host
         role="radio"
-        aria-checked={checked ? "true" : "false"}
+        aria-checked={checked.toString()}
         scale={scale}
       >
         <label>

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -96,7 +96,7 @@ export class CalciteSwitch {
   render() {
     const dir = getElementDir(this.el);
     return (
-      <Host role="checkbox" dir={dir} aria-checked={this.switched} tabindex="0">
+      <Host role="checkbox" dir={dir} checked={this.switched.toString()} tabindex="0">
         <div class="track">
           <div class="handle" />
         </div>

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -75,7 +75,7 @@ export class CalciteTabTitle {
       <Host
         id={id}
         aria-controls={this.controls}
-        aria-expanded={this.isActive ? "true" : "false"}
+        aria-expanded={this.isActive.toString()}
         role="tab"
         tabindex="0"
       >

--- a/src/components/calcite-tab/calcite-tab.tsx
+++ b/src/components/calcite-tab/calcite-tab.tsx
@@ -66,7 +66,7 @@ export class CalciteTab {
       <Host
         id={id}
         aria-labeledby={this.labeledBy}
-        aria-expanded={this.isActive ? "true" : "false"}
+        aria-expanded={this.isActive.toString()}
         role="tabpanel"
       >
         <section>

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -132,7 +132,7 @@ export class CalciteTreeItem {
             : undefined
         }
         aria-expanded={
-          this.hasChildren ? (this.expanded ? "true" : "false") : undefined
+          this.hasChildren ? this.expanded.toString() : undefined
         }
       >
         <div class="calcite-tree-node" ref={el => (this.defaultSlotWrapper = el as HTMLElement)}>


### PR DESCRIPTION
This fixes some [issues caught by axe](https://travis-ci.com/Esri/calcite-app-components/builds/137847375) where it would complain about `aria-some-boolean-attribute=""` being invalid. 