### PR TITLE
Adds setFocus() method to alert, use calcite-icon, update styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `setFocus()` added to `calcite-alert` - focuses a slotted link or a close button, if present
 
 ### Updated
 - `setFocus()` now focuses the first element in a `calcite-notice` - a slotted link or a close button, if present

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -1,21 +1,19 @@
 // theme variables
 // light theme
 :host {
-  --calcite-alert-icon-fill: #{$blk-220};
   --calcite-alert-dismiss-progress-background: #{rgba($blk-000, 0.8)};
 }
 
 // dark theme
 :host([theme="dark"]) {
-  --calcite-alert-icon-fill: #{$blk-040};
   --calcite-alert-dismiss-progress-background: #{rgba($blk-200, 0.8)};
 }
 
-// scale variants for child
+// scale variables
 :host([scale="s"]) {
   --calcite-alert-width: 40em;
-  --calcite-alert-spacing-token-small: #{$baseline/3};
-  --calcite-alert-spacing-token-large: #{$baseline/2};
+  --calcite-alert-spacing-token-small: #{$baseline/2};
+  --calcite-alert-spacing-token-large: #{$baseline/1.5};
   @include slotted("alert-title", "div") {
     @include font-size(-2);
   }
@@ -44,8 +42,8 @@
 
 :host([scale="l"]) {
   --calcite-alert-width: 60em;
-  --calcite-alert-spacing-token-small: #{$baseline};
-  --calcite-alert-spacing-token-large: #{$baseline * 1.5};
+  --calcite-alert-spacing-token-small: #{$baseline/1.25};
+  --calcite-alert-spacing-token-large: #{$baseline * 1.25};
   @include slotted("alert-title", "div") {
     @include font-size(0);
   }
@@ -132,12 +130,6 @@
   flex: 0 0 auto;
   transition: all 0.15s ease-in-out;
 
-  & svg {
-    height: 16px;
-    width: 16px;
-    vertical-align: top;
-  }
-
   @media only screen and (max-width: $viewport-medium) {
     padding: $baseline;
   }
@@ -189,11 +181,7 @@
   border: none;
   outline: none;
   cursor: pointer;
-  border-radius: 0 0 var(--calcite-border-radius) 0;
-
-  & svg {
-    fill: var(--calcite-alert-icon-fill);
-  }
+  color: var(--calcite-ui-text-2);
 
   &:hover,
   &:focus {
@@ -287,10 +275,7 @@ $alertColors: "blue" var(--calcite-ui-blue), "red" var(--calcite-ui-red),
 
   :host([color="#{$name}"]) {
     border-top-color: $color;
-
-    & .alert-icon svg {
-      fill: $color;
-    }
+    color: $color;
   }
 }
 

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -9,12 +9,6 @@ import {
   Listen,
   Prop
 } from "@stencil/core";
-import {
-  lightbulb24F,
-  exclamationMarkTriangle24F,
-  checkCircle24F,
-  x32
-} from "@esri/calcite-ui-icons";
 import { getElementDir } from "../../utils/dom";
 
 /** Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
@@ -134,6 +128,12 @@ export class CalciteAlert {
     }
   }
 
+  componentDidLoad() {
+    this.alertLinkEl = this.el.querySelectorAll(
+      "calcite-button"
+    )[0] as HTMLCalciteButtonElement;
+  }
+
   render() {
     const dir = getElementDir(this.el);
     const closeButton = (
@@ -141,15 +141,9 @@ export class CalciteAlert {
         class="alert-close"
         aria-label="close"
         onClick={() => this.close()}
+        ref={el => (this.closeButton = el)}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          height="32"
-          width="32"
-          viewBox="0 0 32 32"
-        >
-          <path d={x32} />
-        </svg>
+        <calcite-icon icon="x" scale="s"></calcite-icon>
       </button>
     );
 
@@ -218,6 +212,18 @@ export class CalciteAlert {
     });
   }
 
+  /** focus the close button, if present and requested */
+  @Method()
+  async setFocus() {
+    if (!this.closeButton && !this.alertLinkEl) {
+      return;
+    }
+    if (this.alertLinkEl) this.alertLinkEl.setFocus();
+    else if (this.closeButton) {
+      this.closeButton.focus();
+    }
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Private State/Props
@@ -236,19 +242,17 @@ export class CalciteAlert {
   /** Unique ID for this alert */
   private alertId: string = this.el.id;
 
+  /** the close button element */
+  private closeButton?: HTMLElement;
+
+  /** the alert link child element  */
+  private alertLinkEl?: HTMLCalciteButtonElement;
+
   /** map dismissal durations */
   private autoDismissDurations = {
     slow: 14000,
     medium: 10000,
     fast: 6000
-  };
-
-  /** map icons to colors */
-  private iconDefaults = {
-    green: checkCircle24F,
-    yellow: exclamationMarkTriangle24F,
-    red: exclamationMarkTriangle24F,
-    blue: lightbulb24F
   };
 
   /** based on the current alert determine which alert is active */
@@ -266,19 +270,17 @@ export class CalciteAlert {
     }
   }
 
-  /** set the icon */
+  private iconDefaults = {
+    green: "checkCircle",
+    yellow: "exclamationMarkTriangle",
+    red: "exclamationMarkTriangle",
+    blue: "lightbulb"
+  };
   private setIcon() {
     var path = this.iconDefaults[this.color];
     return (
       <div class="alert-icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          height="24"
-          width="24"
-          viewBox="0 0 24 24"
-        >
-          <path d={path} />
-        </svg>
+        <calcite-icon icon={path} filled scale="s"></calcite-icon>
       </div>
     );
   }

--- a/src/components/calcite-alert/readme.md
+++ b/src/components/calcite-alert/readme.md
@@ -69,6 +69,16 @@ Type: `Promise<void>`
 
 
 
+### `setFocus() => Promise<void>`
+
+focus the close button, if present and requested
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ## Slots
 
@@ -78,6 +88,19 @@ Type: `Promise<void>`
 | `"alert-message"` | Main text of the alert                                                       |
 | `"alert-title"`   | Title of the alert (optional)                                                |
 
+
+## Dependencies
+
+### Depends on
+
+- [calcite-icon](../calcite-icon)
+
+### Graph
+```mermaid
+graph TD;
+  calcite-alert --> calcite-icon
+  style calcite-alert fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/src/components/calcite-icon/readme.md
+++ b/src/components/calcite-icon/readme.md
@@ -16,6 +16,21 @@
 | `theme`    | `theme`    | Icon theme. Can be "light" or "dark".                                                                                               | `"dark" \| "light"` | `"light"` |
 
 
+## Dependencies
+
+### Used by
+
+ - [calcite-alert](../calcite-alert)
+ - [calcite-notice](../calcite-notice)
+
+### Graph
+```mermaid
+graph TD;
+  calcite-alert --> calcite-icon
+  calcite-notice --> calcite-icon
+  style calcite-icon fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/calcite-notice/readme.md
+++ b/src/components/calcite-notice/readme.md
@@ -71,6 +71,19 @@ Type: `Promise<void>`
 | `"notice-title"`   | Title of the notice (optional)                                                |
 
 
+## Dependencies
+
+### Depends on
+
+- [calcite-icon](../calcite-icon)
+
+### Graph
+```mermaid
+graph TD;
+  calcite-notice --> calcite-icon
+  style calcite-notice fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/index.html
+++ b/src/index.html
@@ -336,6 +336,11 @@
         <calcite-button title="Close or remove alert created 2" color="red" scale="xs"
           onclick="document.querySelector('#created-2').close()">Close or remove alert created 2
         </calcite-button>
+        <h5>using the setFocus() method (once opened)</h5>
+        <calcite-button onclick=document.querySelector('#alert-four').setFocus()>focus first alert 4 item
+        </calcite-button>
+        <calcite-button onclick=document.querySelector('#alert-five').setFocus()>focus first alert 5 item
+        </calcite-button>
       </calcite-tab>
       <calcite-tab>
         <h3>Notice</h3>
@@ -3251,6 +3256,7 @@
     </calcite-tabs>
 
     <calcite-alert color="red" id="alert-one" scale="s" auto-dismiss>
+
       <div slot="alert-title">Something failed - scale s</div>
       <div slot="alert-message">
         1 That thing you wanted to do didn't work as expected
@@ -3312,7 +3318,7 @@
     <!-- test prop validation duration -->
     <calcite-alert id="alert-nine" theme="dark" auto-dismiss auto-dismiss-duration="blast">
       <div slot="alert-message">9 A general piece of information</div>
-      <calcite-button slot="alert-link" title="my action" appearance="inline">Take action
+      <calcite-button slot="alert-link" theme="dark" title="my action" appearance="inline">Take action
       </calcite-button>
     </calcite-alert>
 


### PR DESCRIPTION
- Updates component to use new calcite-icon component
- Adds setFocus() method to focus either a slotted alert-link or a close button, if present (same functionality as for notice)
- Styling updates to match those to calcite-notice
- Update some generated docs, changelog