### PR TITLE
fix(a11y): fix calcite-switch semantics

### DIFF
--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -96,7 +96,7 @@ export class CalciteSwitch {
   render() {
     const dir = getElementDir(this.el);
     return (
-      <Host role="checkbox" dir={dir} checked={this.switched.toString()} tabindex="0">
+      <Host role="checkbox" dir={dir} aria-checked={this.switched.toString()} tabindex="0">
         <div class="track">
           <div class="handle" />
         </div>


### PR DESCRIPTION
This fixes a regression caused by https://github.com/Esri/calcite-components/pull/259.