### PR TITLE
Update to progress - remove slotted children, don't display text container if not requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Breaking Changes
+- `calcite-progress` no longer accepts slotted content
+
 ### Added
 - `setFocus()` added to `calcite-alert` - focuses a slotted link or a close button, if present
 

--- a/src/components/calcite-progress/calcite-progress.tsx
+++ b/src/components/calcite-progress/calcite-progress.tsx
@@ -42,14 +42,16 @@ export class CalciteProgress {
         theme={theme}
       >
         <div class="calcite-progress--track" />
-        <div class={{
+        <div
+          class={{
             "calcite-progress--bar": true,
             "--indeterminate": this.type === "indeterminate",
             "--determinate": this.type === "determinate"
           }}
         />
-        <div class="calcite-progress--text">{this.text}</div>
-        <slot />
+        {this.text ? (
+          <div class="calcite-progress--text">{this.text}</div>
+        ) : null}
       </Host>
     );
   }

--- a/src/components/calcite-progress/readme.md
+++ b/src/components/calcite-progress/readme.md
@@ -1,17 +1,12 @@
 # calcite-progress
 
-The `calcite-progress` component is used to show progress on some async task to the user. Wrap your content in the progress element to add an animated progress indicator above it:
+The `calcite-progress` component is used to show progress on some async task to the user. 
 
 ```html
-<calcite-progress type="indeterminate">
-  <h1>Hello World!</h1>
-</calcite-progress>
+<calcite-progress type="indeterminate"></calcite-progress>
 ```
 
 ## TODO
-
-- tests
-- verify designs and api
 
 <!-- Auto Generated Below -->
 

--- a/src/index.html
+++ b/src/index.html
@@ -842,24 +842,17 @@
 
       <calcite-tab>
         <h1>Indeterminate</h1>
-        <calcite-progress type="indeterminate">
-          <br>
-        </calcite-progress>
-        <br>
-        <br>
+        <calcite-progress type="indeterminate"></calcite-progress>
         <h1>Determinate</h1>
         <calcite-progress type="determinate" value="0.5" text="50% Complete (optional text)"></calcite-progress>
-        <br>
-        <br>
-        <br>
-
+        <br />
+        <br />
+        <br />
         <div class="demo-background-dark">
           <h1>Indeterminate</h1>
-          <calcite-progress theme="dark" type="indeterminate">
-            <br>
-          </calcite-progress>
-          <br>
-          <br>
+          <calcite-progress theme="dark" type="indeterminate"></calcite-progress>
+          <br />
+          <br />
           <h1>Determinate</h1>
           <calcite-progress theme="dark" type="determinate" value="0.5" text="50% Complete (optional text)">
           </calcite-progress>


### PR DESCRIPTION
Addresses https://github.com/Esri/calcite-components/issues/246

- Conditionally display calcite-progress--text only if text attribute is present (removes unwanted padding)
- Removes slot from component - previously it was used as a wrapping component around content, now it can be used as a standalone item that can be positioned by the consumer
- Update readme and docs

@driskull I think you originally wrote this - thoughts on changing from a "wrapping" component to one that can be positioned by the consumer?