### PR TITLE
Fix for dropdown hover animation

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -8,6 +8,7 @@
   opacity: 1;
   max-height: 100vh;
   visibility: visible;
+  pointer-events: initial;
 }
 
 :host .calcite-dropdown-wrapper {
@@ -26,6 +27,7 @@
   background: var(--calcite-ui-foreground);
   border-radius: var(--calcite-border-radius);
   box-shadow: $shadow-2;
+  pointer-events: none;
 }
 
 :host([dir="rtl"]) .calcite-dropdown-wrapper {


### PR DESCRIPTION
When hovering over the dropdown-trigger, there were a few pixels that would cause the animation to stutter as the transition occurred - this should fix that.