### PR TITLE
Update loader square to circle

### DIFF
--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -16,7 +16,7 @@
 
 $loader-width: 54px;
 $loader-width-inline: 16px;
-$loader-stroke-width: 6px;
+$loader-stroke-width: 8px;
 $loader-stroke-width-inline: 4px;
 
 :host {
@@ -58,38 +58,39 @@ $loader-stroke-width-inline: 4px;
   line-height: 0.25;
 }
 
-.loader__square {
+.loader__circle {
   width: $loader-width;
   height: $loader-width;
+  border-radius: 50%;
   position: absolute;
   top: var(--calcite-loader-padding);
   left: 0;
   left: 50%;
   margin-left: -$loader-width / 2;
-  stroke-dasharray: 50% 350%; // must add up to 400% to loop seamlessly
+  stroke-dasharray: 30% 330%; // must add up to 360% to loop seamlessly
   animation: loader-clockwise 2s infinite linear;
 }
 
-.loader__square--2 {
-  stroke-dasharray: 100% 225% 50% 25%;
+.loader__circle--2 {
+  stroke-dasharray: 90% 215% 40% 15%;
   animation: loader-clockwise 1s infinite linear;
 }
 
-.loader__square--3 {
-  stroke-dasharray: 50% 50% 75% 225%;
+.loader__circle--3 {
+  stroke-dasharray: 40% 40% 75% 205%;
   animation: loader-clockwise 1.85s infinite linear;
 }
 
 // Edge can't animate stroke dash offset, so offset will be animated via JavaScript
 @supports (-ms-ime-align: auto) {
-  .loader__square {
+  .loader__circle {
     stroke-dashoffset: var(--calcite-loader-offset);
     animation: none;
   }
-  .loader__square--2 {
+  .loader__circle--2 {
     stroke-dashoffset: var(--calcite-loader-offset2);
   }
-  .loader__square--3 {
+  .loader__circle--3 {
     stroke-dashoffset: var(--calcite-loader-offset3);
   }
 }
@@ -97,9 +98,9 @@ $loader-stroke-width-inline: 4px;
 :host([type="determinate"]) {
   stroke: var(--calcite-loader-neutral);
   animation: none;
-  .loader__square--3 {
+  .loader__circle--3 {
     stroke: var(--calcite-loader-spot);
-    stroke-dasharray: 400%;
+    stroke-dasharray: 360%;
     stroke-dashoffset: var(--calcite-loader-progress);
     transition: 50ms linear all;
     transform: rotate(90deg);
@@ -131,7 +132,7 @@ $loader-stroke-width-inline: 4px;
   display: inline-block;
 }
 
-:host([inline]) .loader__square {
+:host([inline]) .loader__circle {
   margin: 0;
   position: absolute;
   top: 0;
@@ -154,6 +155,6 @@ $loader-stroke-width-inline: 4px;
     stroke-dashoffset: 0;
   }
   100% {
-    stroke-dashoffset: -400%;
+    stroke-dashoffset: -360%;
   }
 }

--- a/src/components/calcite-loader/calcite-loader.tsx
+++ b/src/components/calcite-loader/calcite-loader.tsx
@@ -81,7 +81,7 @@ export class CalciteLoader {
       "aria-valuemin": 0,
       "aria-valuemax": 100
     };
-    const size = this.inline ? 16 : 56;
+    const size = this.inline ? 8 : 28;
     const viewbox = this.inline ? "0 0 16 16" : "0 0 56 56";
     const isDeterminate = this.type === "determinate";
     const styleProperties = {};
@@ -97,7 +97,7 @@ export class CalciteLoader {
       ] = `${this.loaderBarOffsets[2]}%`;
     }
     const progress = {
-      "--calcite-loader-progress": `${-400 - this.value * 4}%`
+      "--calcite-loader-progress": `${-360 - this.value * 3.141}%`
     };
     return (
       <Host
@@ -107,18 +107,18 @@ export class CalciteLoader {
         {...(this.type === "determinate" ? ariaAttributes : {})}
         style={styleProperties}
       >
-        <svg viewBox={viewbox} class="loader__square">
-          <rect width={size} height={size} />
+        <svg viewBox={viewbox} class="loader__circle">
+          <circle r={size} cx={size} cy={size} />
         </svg>
-        <svg viewBox={viewbox} class="loader__square loader__square--2">
-          <rect width={size} height={size} />
+        <svg viewBox={viewbox} class="loader__circle loader__circle--2">
+          <circle r={size} cx={size} cy={size} />
         </svg>
         <svg
           viewBox={viewbox}
-          class="loader__square loader__square--3"
+          class="loader__circle loader__circle--3"
           style={isDeterminate ? progress : {}}
         >
-          <rect width={size} height={size} />
+          <circle r={size} cx={size} cy={size} />
         </svg>
         {this.text ? <div class="loader__text">{this.text}</div> : ""}
         {this.value ? (
@@ -178,7 +178,7 @@ export class CalciteLoader {
    */
   private rotateLoaderBars(barOffsets: number[]): number[] {
     return barOffsets.map((offset, i) => {
-      if (offset > -400) {
+      if (offset > -360) {
         return offset - this.loaderBarRates[i];
       } else {
         return 0;

--- a/src/demos/calcite-loader.html
+++ b/src/demos/calcite-loader.html
@@ -36,6 +36,14 @@
   <p style="text-align: center;">
     <calcite-loader is-active inline></calcite-loader>Inline Loader
   </p>
+      <calcite-loader is-active type="determinate" value="50" text="Determinate loader">
+  </calcite-loader>
+    <calcite-loader is-active type="determinate" value="85" text="Determinate loader">
+  </calcite-loader>
+  <calcite-loader is-active type="determinate" value="99" text="Determinate loader">
+  </calcite-loader>
+  <calcite-loader is-active type="determinate" value="100" text="Determinate loader">
+  </calcite-loader>
   <calcite-loader is-active type="determinate" value="0" id="loader-determinate" text="Determinate loader">
   </calcite-loader>
   <script>


### PR DESCRIPTION
This makes the loading square a circle, in order to not have a branded design possibly be consumed by non-Esri users. I believe @paulcpederson mentioned that now that it's not a square, the component can be reconfigured to be a little simpler, but wanted to get this PR up since it's time sensitive to remove the "square". We can open another issue for further changes, if needed.