### PR TITLE
Use global CSS vars

### DIFF
--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -1,7 +1,7 @@
 :host {
-  --calcite-loader-spot: #{$ui-blue};
-  --calcite-loader-spot-light: #{$v-bb-160};
-  --calcite-loader-spot-dark: #{$h-bb-070};
+  --calcite-loader-spot: var(--calcite-ui-blue);
+  --calcite-loader-spot-light: var(--calcite-ui-blue);
+  --calcite-loader-spot-dark: var(--calcite-ui-blue-dark);
   --calcite-loader-neutral: #{$blk-020};
   --calcite-loader-padding: 4rem;
 }

--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -1,7 +1,7 @@
 :host {
   --calcite-loader-spot: var(--calcite-ui-blue);
   --calcite-loader-spot-light: var(--calcite-ui-blue);
-  --calcite-loader-spot-dark: var(--calcite-ui-blue-dark);
+  --calcite-loader-spot-dark: var(--calcite-ui-blue);
   --calcite-loader-neutral: #{$blk-020};
   --calcite-loader-padding: 4rem;
 }

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -5,15 +5,15 @@
   --calcite-switch-track-border: #{$blk-040};
   --calcite-switch-handle-background: #{$blk-000};
   --calcite-switch-handle-border: #{$blk-100};
-  --calcite-switch-hover-handle-border: #{$ui-blue-hover};
+  --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover);
   --calcite-switch-hover-track-background: #{$blk-020};
   --calcite-switch-hover-track-border: #{$blk-060};
-  --calcite-switch-switched-track-background: #{$ui-blue-hover};
-  --calcite-switch-switched-track-border: #{$ui-blue-press};
-  --calcite-switch-switched-handle-border: #{$ui-blue};
-  --calcite-switch-switched-hover-track-background: #{$ui-blue};
-  --calcite-switch-switched-hover-track-border: #{$ui-blue-hover};
-  --calcite-switch-switched-hover-handle-border: #{$ui-blue-press};
+  --calcite-switch-switched-track-background: var(--calcite-ui-blue);
+  --calcite-switch-switched-track-border: var(--calcite-ui-blue-press);
+  --calcite-switch-switched-handle-border: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue-hover);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-press);
   --calcite-switch-box-shadow-color: #{rgba($blk-130, 0.5)};
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-blue, 0.5)};
 }
@@ -24,36 +24,36 @@
   --calcite-switch-track-border: #{$blk-160};
   --calcite-switch-handle-background: #{$blk-200};
   --calcite-switch-handle-border: #{$blk-100};
-  --calcite-switch-hover-handle-border: #{$ui-blue-hover-dark};
+  --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover);
   --calcite-switch-hover-track-background: #{$blk-180};
   --calcite-switch-hover-track-border: #{$blk-120};
-  --calcite-switch-switched-track-background: #{$ui-blue-hover-dark};
-  --calcite-switch-switched-track-border: #{$ui-blue-dark};
-  --calcite-switch-switched-handle-border: #{$ui-blue-dark};
-  --calcite-switch-switched-hover-track-background: #{$ui-blue-dark};
-  --calcite-switch-switched-hover-track-border: #{$ui-blue-dark};
-  --calcite-switch-switched-hover-handle-border: #{$ui-blue-hover-dark};
+  --calcite-switch-switched-track-background: var(--calcite-ui-blue);
+  --calcite-switch-switched-track-border: var(--calcite-ui-blue-press);
+  --calcite-switch-switched-handle-border: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue-hover);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-press);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-blue-dark, 0.5)};
 }
 
 :host([color="red"]) {
-  --calcite-switch-switched-track-background: #{$ui-red-hover};
-  --calcite-switch-switched-track-border: #{$ui-red};
-  --calcite-switch-hover-handle-border: #{$ui-red-hover};
-  --calcite-switch-switched-handle-border: #{$ui-red};
-  --calcite-switch-switched-hover-track-background: #{$ui-red};
-  --calcite-switch-switched-hover-track-border: #{$ui-red-hover};
-  --calcite-switch-switched-hover-handle-border: #{$ui-red-press};
+  --calcite-switch-switched-track-background: var(--calcite-ui-red);
+  --calcite-switch-switched-track-border: var(--calcite-ui-red);
+  --calcite-switch-hover-handle-border: var(--calcite-ui-red-hover);
+  --calcite-switch-switched-handle-border: var(--calcite-ui-red);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-red);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-hover);
+  --calcite-switch-switched-hover-handle-border: var(--caclite-ui-red-press);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red, 0.5)};
 }
 :host([theme="dark"][color="red"]) {
-  --calcite-switch-switched-track-background: #{$ui-red-hover-dark};
-  --calcite-switch-switched-track-border: #{$ui-red-dark};
-  --calcite-switch-hover-handle-border: #{$ui-red-hover-dark};
-  --calcite-switch-switched-handle-border: #{$ui-red-dark};
-  --calcite-switch-switched-hover-track-background: #{$ui-red-dark};
-  --calcite-switch-switched-hover-track-border: #{$ui-red-press-dark};
-  --calcite-switch-switched-hover-handle-border: #{$ui-red-press-dark};
+  --calcite-switch-switched-track-background: var(--calcite-ui-hover-dark);
+  --calcite-switch-switched-track-border: var(--calcite-ui-red-dark);
+  --calcite-switch-hover-handle-border: var(--calcite-ui-hover-dark);
+  --calcite-switch-switched-handle-border: var(--calcite-ui-red-dark);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-red-dark);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-press);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-press);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red-dark, 0.5)};
 }
 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -43,7 +43,7 @@
   --calcite-switch-switched-handle-border: var(--calcite-ui-red);
   --calcite-switch-switched-hover-track-background: var(--calcite-ui-red);
   --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-hover);
-  --calcite-switch-switched-hover-handle-border: var(--caclite-ui-red-press);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-press);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red, 0.5)};
 }
 :host([theme="dark"][color="red"]) {

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -24,15 +24,15 @@
   --calcite-switch-track-border: #{$blk-160};
   --calcite-switch-handle-background: #{$blk-200};
   --calcite-switch-handle-border: #{$blk-100};
-  --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover);
+  --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover-dark);
   --calcite-switch-hover-track-background: #{$blk-180};
   --calcite-switch-hover-track-border: #{$blk-120};
-  --calcite-switch-switched-track-background: var(--calcite-ui-blue);
-  --calcite-switch-switched-track-border: var(--calcite-ui-blue-press);
-  --calcite-switch-switched-handle-border: var(--calcite-ui-blue);
-  --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue);
-  --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue-hover);
-  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-press);
+  --calcite-switch-switched-track-background: var(--calcite-ui-blue-dark);
+  --calcite-switch-switched-track-border: var(--calcite-ui-blue-press-dark);
+  --calcite-switch-switched-handle-border: var(--calcite-ui-blue-dark);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue-dark);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue-hover-dark);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-press-dark);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-blue-dark, 0.5)};
 }
 
@@ -47,13 +47,13 @@
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red, 0.5)};
 }
 :host([theme="dark"][color="red"]) {
-  --calcite-switch-switched-track-background: var(--calcite-ui-hover-dark);
+  --calcite-switch-switched-track-background: var(--calcite-ui-red-hover-dark);
   --calcite-switch-switched-track-border: var(--calcite-ui-red-dark);
   --calcite-switch-hover-handle-border: var(--calcite-ui-hover-dark);
   --calcite-switch-switched-handle-border: var(--calcite-ui-red-dark);
   --calcite-switch-switched-hover-track-background: var(--calcite-ui-red-dark);
-  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-press);
-  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-press);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-press-dark);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-press-dark);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red-dark, 0.5)};
 }
 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -8,7 +8,7 @@
   --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover);
   --calcite-switch-hover-track-background: #{$blk-020};
   --calcite-switch-hover-track-border: #{$blk-060};
-  --calcite-switch-switched-track-background: var(--calcite-ui-blue);
+  --calcite-switch-switched-track-background: var(--calcite-ui-blue-hover);
   --calcite-switch-switched-track-border: var(--calcite-ui-blue-press);
   --calcite-switch-switched-handle-border: var(--calcite-ui-blue);
   --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue);
@@ -24,20 +24,20 @@
   --calcite-switch-track-border: #{$blk-160};
   --calcite-switch-handle-background: #{$blk-200};
   --calcite-switch-handle-border: #{$blk-100};
-  --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover-dark);
+  --calcite-switch-hover-handle-border: var(--calcite-ui-blue-hover);
   --calcite-switch-hover-track-background: #{$blk-180};
   --calcite-switch-hover-track-border: #{$blk-120};
-  --calcite-switch-switched-track-background: var(--calcite-ui-blue-dark);
-  --calcite-switch-switched-track-border: var(--calcite-ui-blue-press-dark);
-  --calcite-switch-switched-handle-border: var(--calcite-ui-blue-dark);
-  --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue-dark);
-  --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue-hover-dark);
-  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-press-dark);
+  --calcite-switch-switched-track-background: var(--calcite-ui-blue-hover);
+  --calcite-switch-switched-track-border: var(--calcite-ui-blue);
+  --calcite-switch-switched-handle-border: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-hover);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-blue-dark, 0.5)};
 }
 
 :host([color="red"]) {
-  --calcite-switch-switched-track-background: var(--calcite-ui-red);
+  --calcite-switch-switched-track-background: var(--calcite-ui-red-hover);
   --calcite-switch-switched-track-border: var(--calcite-ui-red);
   --calcite-switch-hover-handle-border: var(--calcite-ui-red-hover);
   --calcite-switch-switched-handle-border: var(--calcite-ui-red);
@@ -47,13 +47,13 @@
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red, 0.5)};
 }
 :host([theme="dark"][color="red"]) {
-  --calcite-switch-switched-track-background: var(--calcite-ui-red-hover-dark);
-  --calcite-switch-switched-track-border: var(--calcite-ui-red-dark);
-  --calcite-switch-hover-handle-border: var(--calcite-ui-hover-dark);
-  --calcite-switch-switched-handle-border: var(--calcite-ui-red-dark);
-  --calcite-switch-switched-hover-track-background: var(--calcite-ui-red-dark);
-  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-press-dark);
-  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-press-dark);
+  --calcite-switch-switched-track-background: var(--calcite-ui-red-hover) ;
+  --calcite-switch-switched-track-border: var(--calcite-ui-red);
+  --calcite-switch-hover-handle-border: var(--calcite-ui-red-hover) ;
+  --calcite-switch-switched-handle-border: var(--calcite-ui-red);
+  --calcite-switch-switched-hover-track-background: var(--calcite-ui-red);
+  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-press);
+  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-press);
   --calcite-switch-switched-box-shadow-color: #{rgba($ui-red-dark, 0.5)};
 }
 

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -138,10 +138,10 @@
 
   &:before {
     opacity: 1;
-    color: var(--calcite-tree-indicator-active);
+    color: var(--calcite-ui-blue);
   }
   &:after {
-    background: var(--calcite-tree-line-active);
+    background: var(--calcite-ui-blue);
     width: var(--calcite-tree-hover-line-width);
     z-index: 2;
   }
@@ -155,11 +155,11 @@
   color: var(--calcite-tree-text-active);
   font-weight: 500;
   &:after {
-    background: var(--calcite-tree-line-active);
+    background: var(--calcite-ui-blue);
   }
   &:before {
     opacity: 1;
-    color: var(--calcite-tree-indicator-active);
+    color: var(--calcite-ui-blue);
   }
   ::slotted(*) {
     color: var(--calcite-tree-text-active);
@@ -168,7 +168,7 @@
 
 // dropdown expanded and selected
 :host([has-children][expanded][selected]) > .calcite-tree-node:after {
-  background: var(--calcite-tree-line-active);
+  background: var(--calcite-ui-blue);
   width: var(--calcite-tree-hover-line-width);
   z-index: 2;
 }
@@ -198,8 +198,8 @@
 
   :host([expanded]) > .calcite-tree-node > & {
     transform: rotate(90deg);
-    fill: var(--calcite-tree-chevron-active);
+    fill: var(--calcite-ui-blue);
     stroke-width: 0.75;
-    stroke: var(--calcite-tree-chevron-active);
+    stroke: var(--calcite-ui-blue);
   }
 }

--- a/src/components/calcite-tree/calcite-tree.scss
+++ b/src/components/calcite-tree/calcite-tree.scss
@@ -6,10 +6,8 @@
   --calcite-tree-text-active: #{$blk-230};
   --calcite-tree-chevron: #{$blk-060};
   --calcite-tree-chevron-hover: #{$blk-140};
-  --calcite-tree-chevron-active: #{$ui-blue};
   --calcite-tree-vertical-padding: #{$baseline/4};
   --calcite-tree-indicator: #{$blk-060};
-  --calcite-tree-indicator-active: #{$ui-blue};
   --calcite-tree-indicator-first-start: 0.1rem;
   --calcite-tree-indicator-first-end: auto;
   --calcite-tree-indicator-distance-start: 0.15rem;
@@ -38,21 +36,17 @@
   --calcite-tree-text-active: #{$blk-010};
   --calcite-tree-chevron: #{$blk-160};
   --calcite-tree-chevron-hover: #{$blk-100};
-  --calcite-tree-chevron-active: #{$ui-blue-dark};
   --calcite-tree-indicator: #{$blk-160};
-  --calcite-tree-indicator-active: #{$ui-blue-dark};
 }
 
 :host([lines]) {
   --calcite-tree-line: #{$blk-020};
   --calcite-tree-line-hover: #{$blk-050};
-  --calcite-tree-line-active: #{$ui-blue};
 }
 
 :host([lines][theme="dark"]) {
   --calcite-tree-line: #{$blk-160};
   --calcite-tree-line-hover: #{$blk-120};
-  --calcite-tree-line-active: #{$ui-blue-dark};
 }
 
 :host([size="s"]) {


### PR DESCRIPTION
- switch
- loader
- tree

### Switch
- I'm not sure about the changes to the switch, seems odd, but it works out at the end as the correct values render on the page. Open to feedback or changes if needed. 

### Loader
- @paulcpederson, I noticed `spot-light` and `spot-dark` were using `v-xx-xxx` values. I just changed them to the main blue for light and dark theme. Not sure if we still need both regular `loader-spot` and `loader-spot-light`. 