### PR TITLE
Updates button style

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -78,6 +78,7 @@
   padding: $baseline/4 1rem;
   text-decoration: none;
   width: 100%;
+  height: 100%;
   border-radius: 0;
   border: none;
   user-select: none;
@@ -124,6 +125,8 @@
   position: relative;
   height: 16px;
   width: 16px;
+  min-width: 16px;
+  min-height: 16px;
   margin: 0;
   line-height: inherit;
   transition: $transition;

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -30,6 +30,14 @@
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Button</h1>
+  <h3>Side by Side test</h3>
+  <div style="width:300px;position:relative;display:flex;">
+    <calcite-button icon="M22 13h-9v9h-1v-9H3v-1h9V3h1v9h9z" appearance="transparent" width="half">Field
+    </calcite-button>
+    <calcite-button icon="M22 13h-9v9h-1v-9H3v-1h9V3h1v9h9z" appearance="transparent" width="half">Long Expression
+    </calcite-button>
+  </div>
+  <h3>FAB with custom positioned container</h3>
 
   <div style="height:300px;width:200px;overflow:scroll;position:relative;display:inline-flex;flex-direction:column">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut varius, sem id ullamcorper volutpat, nibh risus


### PR DESCRIPTION
Maintains full height when flexed
Preserves icon width when adjacent to long text strings
Adds example to doc

addresses https://github.com/Esri/calcite-components/issues/299, further improvements can be made here: https://github.com/Esri/calcite-components/issues/297

cc @AdelheidF 👀 

<img width="349" alt="Screen Shot 2020-01-21 at 2 48 54 PM" src="https://user-images.githubusercontent.com/4733155/72850745-a6b9ac80-3c5e-11ea-9aa4-8b8aa56328e9.png">

It will still overflow if there's a very long string so perhaps a `scale="s/xs"` could be justified if it's still running over.