### PR TITLE
Tree: Force long strings to wrap

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -11,6 +11,8 @@
   color: var(--calcite-tree-text) !important;
   @include font-size(-2);
   text-decoration: none !important;
+  max-width: 100%;
+  word-wrap: break-word;
 
   &:hover {
     text-decoration: none !important;


### PR DESCRIPTION
Currently long strings inside `calcite-tree-item` will overflow from `calcite-tree`. This makes them not do that.