### PR TITLE
updates to tree css vars

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -138,10 +138,10 @@
 
   &:before {
     opacity: 1;
-    color: var(--calcite-ui-blue);
+    color: var(--calcite-tree-indicator-active);
   }
   &:after {
-    background: var(--calcite-ui-blue);
+    background: var(--calcite-tree-line-active);
     width: var(--calcite-tree-hover-line-width);
     z-index: 2;
   }
@@ -155,11 +155,11 @@
   color: var(--calcite-tree-text-active);
   font-weight: 500;
   &:after {
-    background: var(--calcite-ui-blue);
+    background: var(--calcite-tree-line-active);
   }
   &:before {
     opacity: 1;
-    color: var(--calcite-ui-blue);
+    color: var(--calcite-tree-indicator-active);
   }
   ::slotted(*) {
     color: var(--calcite-tree-text-active);
@@ -168,7 +168,7 @@
 
 // dropdown expanded and selected
 :host([has-children][expanded][selected]) > .calcite-tree-node:after {
-  background: var(--calcite-ui-blue);
+  background: var(--calcite-tree-line-active);
   width: var(--calcite-tree-hover-line-width);
   z-index: 2;
 }

--- a/src/components/calcite-tree/calcite-tree.scss
+++ b/src/components/calcite-tree/calcite-tree.scss
@@ -8,6 +8,7 @@
   --calcite-tree-chevron-hover: #{$blk-140};
   --calcite-tree-vertical-padding: #{$baseline/4};
   --calcite-tree-indicator: #{$blk-060};
+  --calcite-tree-indicator-active: var(--calcite-ui-blue);
   --calcite-tree-indicator-first-start: 0.1rem;
   --calcite-tree-indicator-first-end: auto;
   --calcite-tree-indicator-distance-start: 0.15rem;
@@ -37,16 +38,19 @@
   --calcite-tree-chevron: #{$blk-160};
   --calcite-tree-chevron-hover: #{$blk-100};
   --calcite-tree-indicator: #{$blk-160};
+  --calcite-tree-indicator-active: var(--calcite-ui-blue);
 }
 
 :host([lines]) {
   --calcite-tree-line: #{$blk-020};
   --calcite-tree-line-hover: #{$blk-050};
+  --calcite-tree-line-active: var(--calcite-ui-blue);
 }
 
 :host([lines][theme="dark"]) {
   --calcite-tree-line: #{$blk-160};
   --calcite-tree-line-hover: #{$blk-120};
+  --calcite-tree-line-active: var(--calcite-ui-blue);
 }
 
 :host([size="s"]) {


### PR DESCRIPTION
- reverted `--calcite-tree-indicator-active' and '--calcite-tree-line-active' (they reference `--calcite-ui-blue`)
- kept `--calcite-tree-chevron-active` out, since it's not being used.

#310 

@oknoway