### PR TITLE
fix(icon): include all observed intersection entries to determine icon visibility

### DIFF
--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -167,12 +167,14 @@ export class CalciteIcon {
     }
 
     this.intersectionObserver = new IntersectionObserver(
-      ([iconEntry]) => {
-        if (iconEntry.isIntersecting) {
-          this.intersectionObserver.disconnect();
-          this.intersectionObserver = null;
-          callback();
-        }
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            this.intersectionObserver.disconnect();
+            this.intersectionObserver = null;
+            callback();
+          }
+        });
       },
       { rootMargin: "50px" }
     );


### PR DESCRIPTION
The current icon visibility code assumes that only one IntersectionObserverEntry would exist when the callback is invoked. This leads to an edge case where an icon would not load correctly if the second, or subsequent, entry is the one confirming its visibility. This PR addresses this by checking all possible entries to determine if the icon is visible or not.