### PR TITLE
fix(switch): honor user-set tab index

### DIFF
--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -126,6 +126,19 @@ describe("calcite-switch", () => {
     expect(input).toHaveAttribute("checked");
   });
 
+  it("honors tabindex", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-switch></calcite-switch>`);
+    await page.waitForChanges();
+    const calciteSwitch = await page.find("calcite-switch");
+
+    expect(await calciteSwitch.getProperty("tabIndex")).toBe(0);
+
+    calciteSwitch.setAttribute("tabindex", "-1");
+    await page.waitForChanges();
+    expect(await calciteSwitch.getProperty("tabIndex")).toBe(-1);
+  });
+
   it("renders requested props", async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -96,13 +96,23 @@ export class CalciteSwitch {
   render() {
     const dir = getElementDir(this.el);
     return (
-      <Host role="checkbox" dir={dir} aria-checked={this.switched.toString()} tabindex="0">
+      <Host role="checkbox" dir={dir} aria-checked={this.switched.toString()} tabIndex={this.tabIndex}>
         <div class="track">
           <div class="handle" />
         </div>
         <slot />
       </Host>
     );
+  }
+
+  private get tabIndex(): number {
+    const hasTabIndex = this.el.hasAttribute("tabindex");
+
+    if (hasTabIndex) {
+      return Number(this.el.getAttribute("tabindex"));
+    }
+
+    return 0;
   }
 
   private setupProxyInput() {


### PR DESCRIPTION
Currently, it's not possible to set `tabindex` on the switch because it's hardcoded. This PR allows overriding it by using a [pattern from Ionic's `tab-button` component](https://github.com/ionic-team/ionic/blob/94159291b27ddf1a859c8f3f87a0d6e54a8b5f13/core/src/components/tab-button/tab-button.tsx#L110-L120
).

Side note, I can remove the test if deemed redundant. Just wanted to have an automated way to test the behavior.