### PR TITLE
Popper: Allow pointer events for poppers that have escaped their container

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -7,7 +7,6 @@
     left: -999999px;
   }
 
-  :host([data-popper-escaped]),
   :host([aria-hidden="true"]) {
     pointer-events: none;
   }


### PR DESCRIPTION
Popper: Allow pointer events for poppers that have escaped their container