### PR TITLE
Clean up dropdown css, tsx

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -1,16 +1,3 @@
-// scale: s
-:host([scale="s"]) {
-  --calcite-dropdown-group-padding: #{$baseline/3 0};
-}
-
-:host([scale="m"]) {
-  --calcite-dropdown-group-padding: #{$baseline/2 0};
-}
-
-:host([scale="l"]) {
-  --calcite-dropdown-group-padding: #{$baseline/1.5 0};
-}
-
 :host .dropdown-title {
   display: block;
   margin: 0 $baseline/1.5 -1px $baseline/1.5;

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -8,7 +8,6 @@ import {
   Listen,
   Prop
 } from "@stencil/core";
-import { getElementTheme} from "../../utils/dom";
 import { guid } from "../../utils/guid";
 
 @Component({
@@ -73,13 +72,12 @@ export class CalciteDropdownGroup {
   }
 
   render() {
-    const theme = getElementTheme(this.el);
     const groupTitle = this.groupTitle ? (
       <span class="dropdown-title">{this.groupTitle}</span>
     ) : null;
 
     return (
-      <Host theme={theme}>
+      <Host>
         {groupTitle}
         <slot />
       </Host>

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -8,7 +8,7 @@ import {
   Listen,
   Prop
 } from "@stencil/core";
-import { getElementTheme, getElementProp } from "../../utils/dom";
+import { getElementTheme} from "../../utils/dom";
 import { guid } from "../../utils/guid";
 
 @Component({
@@ -74,13 +74,12 @@ export class CalciteDropdownGroup {
 
   render() {
     const theme = getElementTheme(this.el);
-    const scale = getElementProp(this.el, "scale", "m");
     const groupTitle = this.groupTitle ? (
       <span class="dropdown-title">{this.groupTitle}</span>
     ) : null;
 
     return (
-      <Host theme={theme} scale={scale}>
+      <Host theme={theme}>
         {groupTitle}
         <slot />
       </Host>

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -1,34 +1,3 @@
-// scale: s
-:host([scale="s"]) {
-  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5
-    $baseline * 1.5};
-}
-
-:host([scale="m"]) {
-  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3
-    $baseline * 1.5};
-}
-
-:host([scale="l"]) {
-  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2
-    $baseline * 1.5};
-}
-
-:host([dir="rtl"][scale="s"]) {
-  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5
-    $baseline/1.5};
-}
-
-:host([dir="rtl"][scale="m"]) {
-  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3
-    $baseline / 1.5};
-}
-
-:host([dir="rtl"][scale="l"]) {
-  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2
-    $baseline / 1.5};
-}
-
 @mixin itemStyling {
   display: flex;
   flex-grow: 1;

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../utils/keys";
 import {
   getElementDir,
-  getElementTheme,
   getElementProp
 } from "../../utils/dom";
 import { guid } from "../../utils/guid";
@@ -86,7 +85,6 @@ export class CalciteDropdownItem {
 
   render() {
     const dir = getElementDir(this.el);
-    const theme = getElementTheme(this.el);
     const scale = getElementProp(this.el, "scale", "m");
     const iconScale = scale === "s" || scale === "m" ? "s" : "m";
     const iconStartEl = (
@@ -125,7 +123,6 @@ export class CalciteDropdownItem {
 
     return (
       <Host
-        theme={theme}
         dir={dir}
         tabindex="0"
         role="menuitem"

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -127,7 +127,6 @@ export class CalciteDropdownItem {
       <Host
         theme={theme}
         dir={dir}
-        scale={scale}
         tabindex="0"
         role="menuitem"
         aria-selected={this.active.toString()}

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,4 +1,4 @@
-// scale: s
+// width
 :host([width="s"]) {
   --calcite-dropdown-width: 12.5em;
 }
@@ -10,6 +10,41 @@
 :host([width="l"]) {
   --calcite-dropdown-width: 20em;
 }
+
+// scale
+:host([scale="s"]) {
+  --calcite-dropdown-group-padding: #{$baseline/3 0};
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5
+    $baseline * 1.5};
+}
+
+:host([scale="m"]) {
+  --calcite-dropdown-group-padding: #{$baseline/2 0};
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3
+    $baseline * 1.5};
+}
+
+:host([scale="l"]) {
+  --calcite-dropdown-group-padding: #{$baseline/1.5 0};
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2
+    $baseline * 1.5};
+}
+
+:host([dir="rtl"][scale="s"]) {
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5
+    $baseline/1.5};
+}
+
+:host([dir="rtl"][scale="m"]) {
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3
+    $baseline / 1.5};
+}
+
+:host([dir="rtl"][scale="l"]) {
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2
+    $baseline / 1.5};
+}
+
 :host {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Moves css vars from children items to parent. 
Removes unused theme declarations.

No change for users.