### PR TITLE
Removes z-index from calcite-notice

### DIFF
--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -63,7 +63,6 @@
   background-color: var(--calcite-ui-foreground);
   opacity: 0;
   pointer-events: none;
-  z-index: 101;
   transition: $transition;
   border-left: 0px solid;
   box-shadow: 0 0 0 0 transparent;


### PR DESCRIPTION
Z-index was erroneously set on calcite-notice. They don't float above anything so they shouldn't have a z-index set at all.