### PR TITLE
Use GUID to manage alert queue if ID is not provided in DOM

### DIFF
--- a/src/components/calcite-alert/calcite-alert.stories.js
+++ b/src/components/calcite-alert/calcite-alert.stories.js
@@ -106,13 +106,13 @@ storiesOf("Alert", module)
     <h5>Open or add to queue</h5>
     <calcite-button onclick=document.querySelector("#one").open()>Open Alert 1</calcite-button>
     <calcite-button onclick=document.querySelector("#two").open()>Open Alert 2</calcite-button>
-    <calcite-button onclick=document.querySelector("#three").open()>Open Alert 3</calcite-button>
+    <calcite-button onclick=document.querySelector("[data-custom-id=my-id]").open()>Open Alert 3</calcite-button>
     <br/>
     <br/>
     <h5>Close or remove from queue</h5>
     <calcite-button color="red" onclick=document.querySelector("#one").close()>Close Alert 1</calcite-button>
     <calcite-button color="red" onclick=document.querySelector("#two").close()>Close Alert 2</calcite-button>
-    <calcite-button color="red" onclick=document.querySelector("#three").close()>Close Alert 3</calcite-button>
+    <calcite-button color="red" onclick=document.querySelector("[data-custom-id=my-id]").close()>Close Alert 3</calcite-button>
       <calcite-alert
       id="one"
       theme="light"
@@ -148,7 +148,7 @@ storiesOf("Alert", module)
     <calcite-button slot="alert-link" title="my action" appearance="inline">View layer</calcite-button>
     </calcite-alert>
     <calcite-alert
-      id="three"
+      data-custom-id="my-id"
       theme="light"
       icon="${boolean("icon-3", true)}"
       auto-dismiss="${boolean("auto-dismiss-3", true)}"
@@ -199,13 +199,13 @@ storiesOf("Alert", module)
     <h5 style="color:white">Open or add to queue</h5>
     <calcite-button theme="dark" onclick=document.querySelector("#one").open()>Open Alert 1</calcite-button>
     <calcite-button theme="dark" onclick=document.querySelector("#two").open()>Open Alert 2</calcite-button>
-    <calcite-button theme="dark" onclick=document.querySelector("#three").open()>Open Alert 3</calcite-button>
+    <calcite-button theme="dark" onclick=document.querySelector("[data-custom-id=my-id]").open()>Open Alert 3</calcite-button>
     <br/>
     <br/>
     <h5 style="color:white">Close or remove from queue</h5>
     <calcite-button theme="dark" color="red" onclick=document.querySelector("#one").close()>Close Alert 1</calcite-button>
     <calcite-button theme="dark" color="red" onclick=document.querySelector("#two").close()>Close Alert 2</calcite-button>
-    <calcite-button theme="dark" color="red" onclick=document.querySelector("#three").close()>Close Alert 3</calcite-button>
+    <calcite-button theme="dark" color="red" onclick=document.querySelector("[data-custom-id=my-id]").close()>Close Alert 3</calcite-button>
       <calcite-alert
       id="one"
       theme="dark"
@@ -241,7 +241,7 @@ storiesOf("Alert", module)
     <calcite-button theme="dark" slot="alert-link" title="my action" appearance="inline">View layer</calcite-button>
     </calcite-alert>
     <calcite-alert
-      id="three"
+      data-custom-id="my-id"
       theme="dark"
       icon="${boolean("icon-3", true)}"
       auto-dismiss="${boolean("auto-dismiss-3", true)}"

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -10,6 +10,7 @@ import {
   Prop
 } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
+import { guid } from "../../utils/guid";
 
 /** Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
  * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided. You can keep alerts in your DOM or create/open, close/destroy
@@ -240,7 +241,7 @@ export class CalciteAlert {
   @Prop() currentAlert: string;
 
   /** Unique ID for this alert */
-  private alertId: string = this.el.id;
+  private alertId: string = this.el.id || `calcite-alert-${guid()}`;
 
   /** the close button element */
   private closeButton?: HTMLElement;
@@ -276,6 +277,7 @@ export class CalciteAlert {
     red: "exclamationMarkTriangle",
     blue: "lightbulb"
   };
+
   private setIcon() {
     var path = this.iconDefaults[this.color];
     return (

--- a/src/demos/calcite-alert.html
+++ b/src/demos/calcite-alert.html
@@ -47,6 +47,16 @@
     11 Autodismiss (slow),link
   </calcite-button>
 
+  <calcite-button title="12 Without ID - generate GUID" scale="s"
+    onclick="document.querySelector('[data-custom-id=myalert1]').open()">
+    12 Without ID - generate GUID</calcite-button>
+
+  <calcite-button title="13 Without ID - generate GUID" scale="s"
+    onclick="document.querySelector('[data-custom-id=myalert2]').open()">
+    13 Without ID - generate GUID
+  </calcite-button>
+
+
 
   <h5>You can use in combination with alerts inserted into the DOM programmatically</h5>
   <calcite-button title="created alert" scale="xs" onclick="createExampleAlert('created-1')">created alert
@@ -141,6 +151,15 @@
 
   <calcite-alert id="alert-eleven" auto-dismiss auto-dismiss-duration="slow">
     <div slot="alert-message">11 A general piece of information</div>
+    <calcite-button slot="alert-link" title="my action" appearance="inline">Take action</calcite-button>
+  </calcite-alert>
+
+  <calcite-alert data-custom-id="myalert1" auto-dismiss auto-dismiss-duration="slow">
+    <div slot="alert-message">12 Generated GUID</div>
+    <calcite-button slot="alert-link" title="my action" appearance="inline">Take action</calcite-button>
+  </calcite-alert>
+  <calcite-alert data-custom-id="myalert2" auto-dismiss auto-dismiss-duration="slow">
+    <div slot="alert-message">13 Generated GUID</div>
     <calcite-button slot="alert-link" title="my action" appearance="inline">Take action</calcite-button>
   </calcite-alert>
 </body>

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -7,6 +7,7 @@ export const config: Config = {
     { components: ["calcite-accordion", "calcite-accordion-item"] },
     { components: ["calcite-alert"] },
     { components: ["calcite-button"] },
+    { components: ["calcite-card"] },
     {
       components: [
         "calcite-date-picker",
@@ -42,8 +43,6 @@ export const config: Config = {
     },
     { components: ["calcite-tooltip"] },
     { components: ["calcite-tree", "calcite-tree-item"] },
-    { components: ["calcite-card"] },
-    { components: ["calcite-icon"] }
   ],
   outputTargets: [
     { type: "dist-hydrate-script" },


### PR DESCRIPTION
Addresses https://github.com/Esri/calcite-components/issues/354

No change for users, it was unexpected to have to use an `id` in the first place so this is just an enhancement.

- If a user doesn't provide an id, fallback to a generated private GUID used for queuing.
- Also fixes a duplicate entry for `calcite-icon` in stencil config.

CC @cosbyr