### PR TITLE
BREAKING - Dropdown updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+
+### Breaking Changes
+- `calcite-dropdown` - `alignment` attribute now uses `start` and `end` values instead of `left` and `right`
+
+### Updated
+- `calcite-dropdown` - updates styling for `selection-mode=none`
+- `calcite-dropdown` - active state indicators for `selection-mode=multi` have been updated to use checkmarks
+
+### Fixed
+- `calcite-dropdown` - `alignment=center` now correctly positions the dropdown if the slotted `dropdown-trigger` is wider than the dropdown container
+
 ## [v1.0.0-beta.20] - Feb 25th 2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking Changes
 - `calcite-dropdown` - `alignment` attribute now uses `start` and `end` values instead of `left` and `right`
+- `calcite-dropdown-item` - removes `href` and `link-title` attributes
 
 ### Updated
 - `calcite-dropdown` - updates styling for `selection-mode=none`

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -1,4 +1,4 @@
-@mixin itemStyling {
+:host {
   display: flex;
   flex-grow: 1;
   align-items: center;
@@ -18,10 +18,6 @@
     color: $blk-120;
     transition: $transition;
   }
-}
-
-:host {
-  @include itemStyling;
 }
 
 :host(:hover),
@@ -63,80 +59,29 @@
 
 // no dot for none and multi modes
 :host([selection-mode="multi"]):before,
-:host([selection-mode="none"]):before,
-:host([selection-mode="multi"][isLink]) a:before,
-:host([selection-mode="none"][isLink]) a:before {
+:host([selection-mode="none"]):before {
   display: none;
 }
 
-:host([selection-mode="none"]),
-:host([selection-mode="none"][isLink]) a {
+:host([selection-mode="none"]) {
   padding-left: $baseline/1.5;
 }
 
-:host([dir="rtl"][selection-mode="none"]),
-:host([dir="rtl"][selection-mode="none"][isLink]) a {
+:host([dir="rtl"][selection-mode="none"]) {
   padding-right: $baseline/1.5;
 }
 
-// when used as link move styling anchor
-:host([islink]) {
-  padding: 0;
-  &:before {
-    display: none;
-  }
-  & a {
-    @include itemStyling;
-  }
-}
-
-
-:host([islink]) a:hover,
-:host([islink]) a:focus,
-:host([islink]) a:active {
-  background-color: var(--calcite-ui-foreground-hover);
-  text-decoration: none;
-  &:before {
-    opacity: 1;
-  }
-}
-
-:host([islink]) a:active {
-  background-color: var(--calcite-ui-foreground-press);
-}
-
-:host([islink][active]:not([selection-mode="none"])) a {
-  color: var(--calcite-ui-text-1);
-  font-weight: 500;
-  &:before {
-    opacity: 1;
-    color: var(--calcite-ui-blue);
-  }
-}
-
-:host([islink][dir="rtl"]) a {
-  padding: var(--calcite-dropdown-item-padding);
-  &:before {
-    left: unset;
-    right: 1rem;
-  }
-}
-
-:host([islink][selection-mode="none"]) a:before {
-  display: none;
-}
 // multi select check icon
 :host .dropdown-item-check-icon {
   position: absolute;
   left: $baseline / 1.75;
   opacity: 0;
-  transform: scaleY(0.5);
+  transform: scale(0.9);
 }
 
 :host([dir="rtl"]) .dropdown-item-check-icon {
   left: unset;
   right: $baseline / 1.75;
-
 }
 
 :host(:hover) .dropdown-item-check-icon {
@@ -153,6 +98,7 @@
 :host .dropdown-item-icon-start {
   margin-right: $baseline / 1.5;
 }
+
 :host .dropdown-item-icon-end {
   margin-left: auto;
   padding-left: $baseline / 1.5;

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -49,7 +49,7 @@
   }
 }
 
-:host([active]) {
+:host([active]:not([selection-mode="none"])) {
   color: var(--calcite-ui-text-1);
   font-weight: 500;
   &:before {
@@ -59,6 +59,24 @@
   & calcite-icon {
     color: var(--calcite-ui-blue);
   }
+}
+
+// no dot for none and multi modes
+:host([selection-mode="multi"]):before,
+:host([selection-mode="none"]):before,
+:host([selection-mode="multi"][isLink]) a:before,
+:host([selection-mode="none"][isLink]) a:before {
+  display: none;
+}
+
+:host([selection-mode="none"]),
+:host([selection-mode="none"][isLink]) a {
+  padding-left: $baseline/1.5;
+}
+
+:host([dir="rtl"][selection-mode="none"]),
+:host([dir="rtl"][selection-mode="none"][isLink]) a {
+  padding-right: $baseline/1.5;
 }
 
 // when used as link move styling anchor
@@ -71,6 +89,7 @@
     @include itemStyling;
   }
 }
+
 
 :host([islink]) a:hover,
 :host([islink]) a:focus,
@@ -86,7 +105,7 @@
   background-color: var(--calcite-ui-foreground-press);
 }
 
-:host([islink][active]) a {
+:host([islink][active]:not([selection-mode="none"])) a {
   color: var(--calcite-ui-text-1);
   font-weight: 500;
   &:before {
@@ -103,8 +122,34 @@
   }
 }
 
-//icons
+:host([islink][selection-mode="none"]) a:before {
+  display: none;
+}
+// multi select check icon
+:host .dropdown-item-check-icon {
+  position: absolute;
+  left: $baseline / 1.75;
+  opacity: 0;
+  transform: scaleY(0.5);
+}
 
+:host([dir="rtl"]) .dropdown-item-check-icon {
+  left: unset;
+  right: $baseline / 1.75;
+
+}
+
+:host(:hover) .dropdown-item-check-icon {
+  color: var(--calcite-ui-text-1);
+  opacity: 1;
+}
+
+:host([active]) .dropdown-item-check-icon {
+  color: var(--calcite-ui-blue);
+  opacity: 1;
+}
+
+// icons
 :host .dropdown-item-icon-start {
   margin-right: $baseline / 1.5;
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -18,10 +18,7 @@ import {
   END,
   SPACE
 } from "../../utils/keys";
-import {
-  getElementDir,
-  getElementProp
-} from "../../utils/dom";
+import { getElementDir, getElementProp } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 
 @Component({
@@ -126,9 +123,17 @@ export class CalciteDropdownItem {
         dir={dir}
         tabindex="0"
         role="menuitem"
+        selection-mode={this.selectionMode}
         aria-selected={this.active.toString()}
         isLink={this.href}
       >
+        {this.selectionMode === "multi" ? (
+          <calcite-icon
+            class="dropdown-item-check-icon"
+            scale="s"
+            icon="check"
+          />
+        ) : null}
         {contentEl}
       </Host>
     );

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -43,12 +43,6 @@ export class CalciteDropdownItem {
 
   @Prop({ reflect: true, mutable: true }) active: boolean = false;
 
-  /** pass an optional href to render an anchor around the link items */
-  @Prop() href?: string;
-
-  /** pass an optional title for rendered href */
-  @Prop() linkTitle?: string;
-
   /** optionally pass an icon to display at the start of an item - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconStart?: string;
 
@@ -99,7 +93,7 @@ export class CalciteDropdownItem {
       ></calcite-icon>
     );
 
-    const slottedContent =
+    const content =
       this.iconStart && this.iconEnd ? (
         [iconStartEl, <slot />, iconEndEl]
       ) : this.iconStart ? (
@@ -110,14 +104,6 @@ export class CalciteDropdownItem {
         <slot />
       );
 
-    const contentEl = !this.href ? (
-      slottedContent
-    ) : (
-      <a href={this.href} title={this.linkTitle}>
-        {slottedContent}
-      </a>
-    );
-
     return (
       <Host
         dir={dir}
@@ -125,7 +111,6 @@ export class CalciteDropdownItem {
         role="menuitem"
         selection-mode={this.selectionMode}
         aria-selected={this.active.toString()}
-        isLink={this.href}
       >
         {this.selectionMode === "multi" ? (
           <calcite-icon
@@ -134,7 +119,7 @@ export class CalciteDropdownItem {
             icon="check"
           />
         ) : null}
-        {contentEl}
+        {content}
       </Host>
     );
   }

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -10,10 +10,8 @@
 | Property    | Attribute    | Description                                                                                | Type      | Default     |
 | ----------- | ------------ | ------------------------------------------------------------------------------------------ | --------- | ----------- |
 | `active`    | `active`     |                                                                                            | `boolean` | `false`     |
-| `href`      | `href`       | pass an optional href to render an anchor around the link items                            | `string`  | `undefined` |
 | `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of an item - accepts calcite ui icon names   | `string`  | `undefined` |
 | `iconStart` | `icon-start` | optionally pass an icon to display at the start of an item - accepts calcite ui icon names | `string`  | `undefined` |
-| `linkTitle` | `link-title` | pass an optional title for rendered href                                                   | `string`  | `undefined` |
 
 
 ## Events

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -46,7 +46,7 @@ describe("calcite-dropdown", () => {
     expect(element).toEqualAttribute("scale", "m");
     expect(element).toEqualAttribute("width", "m");
     expect(element).toEqualAttribute("theme", "light");
-    expect(element).toEqualAttribute("alignment", "left");
+    expect(element).toEqualAttribute("alignment", "start");
     expect(group1).toEqualAttribute("selection-mode", "single");
   });
 
@@ -73,14 +73,14 @@ describe("calcite-dropdown", () => {
     expect(element).toEqualAttribute("scale", "m");
     expect(element).toEqualAttribute("width", "m");
     expect(element).toEqualAttribute("theme", "light");
-    expect(element).toEqualAttribute("alignment", "left");
+    expect(element).toEqualAttribute("alignment", "start");
     expect(group1).toEqualAttribute("selection-mode", "single");
   });
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-dropdown alignment="right" scale="l" width="l" theme="dark">
+    <calcite-dropdown alignment="end" scale="l" width="l" theme="dark">
     <calcite-button slot="dropdown-trigger">Open dropdown</calcite-button>
     <calcite-dropdown-group id="group-1" selection-mode="multi">
     <calcite-dropdown-item id="item-1">
@@ -100,7 +100,7 @@ describe("calcite-dropdown", () => {
     expect(element).toEqualAttribute("scale", "l");
     expect(element).toEqualAttribute("width", "l");
     expect(element).toEqualAttribute("theme", "dark");
-    expect(element).toEqualAttribute("alignment", "right");
+    expect(element).toEqualAttribute("alignment", "end");
     expect(group1).toEqualAttribute("selection-mode", "multi");
   });
 

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -82,19 +82,24 @@
   left: unset;
 }
 
-:host([alignment="right"]) .calcite-dropdown-wrapper {
+:host([alignment="end"]) .calcite-dropdown-wrapper {
   right: 0;
   left: unset;
 }
 
-:host([dir="rtl"][alignment="right"]) .calcite-dropdown-wrapper {
+:host([dir="rtl"][alignment="end"]) .calcite-dropdown-wrapper {
   right: unset;
   left: 0;
 }
 
 :host([alignment="center"]) .calcite-dropdown-wrapper {
   right: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+:host([alignment="center"][dir="rtl"]) .calcite-dropdown-wrapper {
+  right: 50%;
   left: 0;
-  margin-right: auto;
-  margin-left: auto;
+  transform: translateX(50%);
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.js
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.js
@@ -10,7 +10,7 @@ storiesOf("Dropdown", module)
     "Simple",
     () => `
     <calcite-dropdown
-      alignment="${select("alignment", ["left", "right"], "left")}"
+      alignment="${select("alignment", ["start", "center", "end"], "start")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
@@ -33,7 +33,7 @@ storiesOf("Dropdown", module)
     "With Icons",
     () => `
     <calcite-dropdown
-      alignment="${select("alignment", ["left", "right"], "left")}"
+      alignment="${select("alignment", ["start","center", "end"], "start")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
@@ -74,7 +74,7 @@ storiesOf("Dropdown", module)
     "Groups and selection modes",
     () => `
   <calcite-dropdown
-    alignment="${select("alignment", ["left", "right"], "left")}"
+    alignment="${select("alignment", ["start","center", "end"], "start")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
@@ -103,7 +103,7 @@ storiesOf("Dropdown", module)
     () => `
     <calcite-dropdown
       theme="dark"
-      alignment="${select("alignment", ["left", "right"], "left")}"
+      alignment="${select("alignment", ["start","center", "end"], "start")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
        width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
@@ -127,7 +127,7 @@ storiesOf("Dropdown", module)
     () => `
     <calcite-dropdown
       theme="dark"
-      alignment="${select("alignment", ["left", "right"], "left")}"
+      alignment="${select("alignment", ["start","center", "end"], "start")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
@@ -169,7 +169,7 @@ storiesOf("Dropdown", module)
     () => `
   <calcite-dropdown
     theme="dark"
-    alignment="${select("alignment", ["left", "right"], "left")}"
+    alignment="${select("alignment", ["start","center", "end"], "start")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
   >
@@ -191,4 +191,28 @@ storiesOf("Dropdown", module)
   </calcite-dropdown>
 `,
 { notes, backgrounds: darkBackground }
+  )
+  .add(
+    "Simple - RTL",
+    () => `
+    <calcite-dropdown
+      dir="rtl"
+      alignment="${select("alignment", ["start","center", "end"], "start")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      width="${select("width", ["s", "m", "l"], "m")}"
+      type="${select("type", ["click", "hover"], "click")}"
+    >
+      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+      <calcite-dropdown-group selection-mode="${select(
+        "group selection mode",
+        ["single", "multi", "none"],
+        "single"
+      )}" group-title="Sort by">
+        <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+        <calcite-dropdown-item>Title</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+  `,
+    { notes }
   );

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -36,9 +36,9 @@ export class CalciteDropdown {
 
   /** specify the alignment of dropdrown, defaults to left */
   @Prop({ mutable: true, reflect: true }) alignment:
-    | "left"
-    | "right"
-    | "center" = "left";
+    | "start"
+    | "center"
+    | "end" = "start";
 
   /** specify the theme of the dropdown, defaults to light */
   @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
@@ -60,8 +60,8 @@ export class CalciteDropdown {
 
   connectedCallback() {
     // validate props
-    let alignment = ["left", "right", "center"];
-    if (!alignment.includes(this.alignment)) this.alignment = "left";
+    let alignment = ["start", "center", "end"];
+    if (!alignment.includes(this.alignment)) this.alignment = "start";
 
     let theme = ["light", "dark"];
     if (!theme.includes(this.theme)) this.theme = "light";

--- a/src/components/calcite-dropdown/readme.md
+++ b/src/components/calcite-dropdown/readme.md
@@ -41,14 +41,14 @@ You can combine groups in a single dropdown, with varying selection modes:
 
 ## Properties
 
-| Property    | Attribute   | Description                                                                     | Type                            | Default   |
-| ----------- | ----------- | ------------------------------------------------------------------------------- | ------------------------------- | --------- |
-| `active`    | `active`    |                                                                                 | `boolean`                       | `false`   |
-| `alignment` | `alignment` | specify the alignment of dropdrown, defaults to left                            | `"center" \| "left" \| "right"` | `"left"`  |
-| `scale`     | `scale`     | specify the scale of dropdrown, defaults to m                                   | `"l" \| "m" \| "s"`             | `"m"`     |
-| `theme`     | `theme`     | specify the theme of the dropdown, defaults to light                            | `"dark" \| "light"`             | `"light"` |
-| `type`      | `type`      | specify whether the dropdown is opened by hover or click of the trigger element | `"click" \| "hover"`            | `"click"` |
-| `width`     | `width`     | specify the width of dropdrown, defaults to m                                   | `"l" \| "m" \| "s"`             | `"m"`     |
+| Property    | Attribute   | Description                                                                     | Type                           | Default   |
+| ----------- | ----------- | ------------------------------------------------------------------------------- | ------------------------------ | --------- |
+| `active`    | `active`    |                                                                                 | `boolean`                      | `false`   |
+| `alignment` | `alignment` | specify the alignment of dropdrown, defaults to left                            | `"center" \| "end" \| "start"` | `"start"` |
+| `scale`     | `scale`     | specify the scale of dropdrown, defaults to m                                   | `"l" \| "m" \| "s"`            | `"m"`     |
+| `theme`     | `theme`     | specify the theme of the dropdown, defaults to light                            | `"dark" \| "light"`            | `"light"` |
+| `type`      | `type`      | specify whether the dropdown is opened by hover or click of the trigger element | `"click" \| "hover"`           | `"click"` |
+| `width`     | `width`     | specify the width of dropdrown, defaults to m                                   | `"l" \| "m" \| "s"`            | `"m"`     |
 
 
 ----------------------------------------------

--- a/src/components/calcite-radio-group/readme.md
+++ b/src/components/calcite-radio-group/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                     | Type                | Default     |
-| -------------- | --------------- | ----------------------------------------------- | ------------------- | ----------- |
-| `name`         | `name`          | The group's name. Gets submitted with the form. | `string`            | `undefined` |
-| `scale`        | `scale`         | The scale of the button                         | `"l" \| "m" \| "s"` | `"m"`       |
-| `selectedItem` | `selected-item` | The group's selected item.                      | `any`               | `undefined` |
-| `theme`        | `theme`         | The component's theme.                          | `"dark" \| "light"` | `"light"`   |
+| Property       | Attribute | Description                                     | Type                               | Default     |
+| -------------- | --------- | ----------------------------------------------- | ---------------------------------- | ----------- |
+| `name`         | `name`    | The group's name. Gets submitted with the form. | `string`                           | `undefined` |
+| `scale`        | `scale`   | The scale of the button                         | `"l" \| "m" \| "s"`                | `"m"`       |
+| `selectedItem` | --        | The group's selected item.                      | `HTMLCalciteRadioGroupItemElement` | `undefined` |
+| `theme`        | `theme`   | The component's theme.                          | `"dark" \| "light"`                | `"light"`   |
 
 
 ## Events

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -74,7 +74,7 @@
     <br />
     <br />
 
-    <h3> Dropdown widths</h3>
+    <h3>Dropdown widths</h3>
     <calcite-dropdown width="s">
       <calcite-button slot="dropdown-trigger">Icon - Width S</calcite-button>
       <calcite-dropdown-group selection-mode="single" group-title="Selection Mode: Single - default">
@@ -163,7 +163,7 @@
       </calcite-dropdown-group>
     </calcite-dropdown>
 
-    <calcite-dropdown alignment="right" type="hover">
+    <calcite-dropdown alignment="end" type="hover">
       <calcite-button slot="dropdown-trigger">Open Dropdown type hover right aligned</calcite-button>
 
       <calcite-dropdown-group group-title="View">
@@ -195,6 +195,22 @@
         <calcite-dropdown-item href="/mypage" link-title="My Page" icon-start="grid">Relevance</calcite-dropdown-item>
         <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
         <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+    <calcite-dropdown>
+      <calcite-button slot="dropdown-trigger">Links - selection mode none</calcite-button>
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item href="/mypage" link-title="My Page" icon-start="grid">Relevance</calcite-dropdown-item>
+        <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
+        <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+    <calcite-dropdown>
+      <calcite-button slot="dropdown-trigger">Links - selection mode none</calcite-button>
+      <calcite-dropdown-group selection-mode="multi">
+        <calcite-dropdown-item href="/mypage" link-title="My Page" icon-start="grid">Relevance</calcite-dropdown-item>
+        <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
+        <calcite-dropdown-item href="/mypage3" link-title="My Page 3" active>Title</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
     <br />

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -91,6 +91,10 @@
         <calcite-dropdown-item icon-end="grid">Less</calcite-dropdown-item>
         <calcite-dropdown-item icon-end="list">Also this that might wrap</calcite-dropdown-item>
       </calcite-dropdown-group>
+      <calcite-dropdown-group selection-mode="none" group-title="Selection Mode: None">
+        <calcite-dropdown-item icon-start="grid">Less</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="list">Also this that might wrap</calcite-dropdown-item>
+      </calcite-dropdown-group>
     </calcite-dropdown>
     <calcite-dropdown>
       <calcite-button slot="dropdown-trigger">Icon - Width M</calcite-button>
@@ -104,9 +108,18 @@
         <calcite-dropdown-item icon-start="list">That</calcite-dropdown-item>
         <calcite-dropdown-item icon-start="table" active>Also this that might wrap</calcite-dropdown-item>
       </calcite-dropdown-group>
+      <calcite-dropdown-group selection-mode="multi" group-title="Selection Mode: Multi">
+        <calcite-dropdown-item icon-end="grid" active>This</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="list">That</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="table" active>Also this that might wrap</calcite-dropdown-item>
+      </calcite-dropdown-group>
       <calcite-dropdown-group selection-mode="none" group-title="Selection Mode: None">
         <calcite-dropdown-item icon-end="grid">Less</calcite-dropdown-item>
         <calcite-dropdown-item icon-end="list">Also this that might wrap</calcite-dropdown-item>
+      </calcite-dropdown-group>
+      <calcite-dropdown-group selection-mode="none" group-title="Selection Mode: None">
+        <calcite-dropdown-item icon-start="grid">Less</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="list">Also this that might wrap</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
 
@@ -125,6 +138,10 @@
       <calcite-dropdown-group selection-mode="none" group-title="Selection Mode: None">
         <calcite-dropdown-item icon-end="grid">Less</calcite-dropdown-item>
         <calcite-dropdown-item icon-end="list">Also this that might wrap</calcite-dropdown-item>
+      </calcite-dropdown-group>
+      <calcite-dropdown-group selection-mode="none" group-title="Selection Mode: None">
+        <calcite-dropdown-item icon-start="grid">Less</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="list">Also this that might wrap</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
     <br />
@@ -183,50 +200,6 @@
         <calcite-dropdown-item>Banana</calcite-dropdown-item>
         <calcite-dropdown-item>Vanilla</calcite-dropdown-item>
         <calcite-dropdown-item>Strawberry</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-    <br />
-    <br />
-
-    <h3> Dropdowns with items as links</h3>
-    <calcite-dropdown>
-      <calcite-button slot="dropdown-trigger">Dropdowns with items as links</calcite-button>
-      <calcite-dropdown-group>
-        <calcite-dropdown-item href="/mypage" link-title="My Page" icon-start="grid">Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-    <calcite-dropdown>
-      <calcite-button slot="dropdown-trigger">Links - selection mode none</calcite-button>
-      <calcite-dropdown-group selection-mode="none">
-        <calcite-dropdown-item href="/mypage" link-title="My Page" icon-start="grid">Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-    <calcite-dropdown>
-      <calcite-button slot="dropdown-trigger">Links - selection mode none</calcite-button>
-      <calcite-dropdown-group selection-mode="multi">
-        <calcite-dropdown-item href="/mypage" link-title="My Page" icon-start="grid">Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage2" link-title="My Page 2" active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage3" link-title="My Page 3" active>Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-    <br />
-    <br />
-    <h3> Dropdowns with items as links mixed with not links</h3>
-    <calcite-dropdown>
-      <calcite-button slot="dropdown-trigger">Dropdowns with items as links</calcite-button>
-      <calcite-dropdown-group group-title="Not Links">
-        <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item>Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-      <calcite-dropdown-group group-title="Link">
-        <calcite-dropdown-item href="/mypage" link-title="My Page">Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage2" link-title="My Page 3" active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item href="/mypage3" link-title="My Page 3">Title</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
     <br />


### PR DESCRIPTION
Follow up PR from conversations, also includes a couple other cleanup items: @TheBlueDog @driskull @kstinson14

<img width="324" alt="Screen Shot 2020-03-03 at 2 59 12 PM" src="https://user-images.githubusercontent.com/4733155/75827939-9289c480-5d5f-11ea-97e4-a8cffddfd0e9.png">


- **BREAKING:** renames "left/right" alignment to logical property "start/end" nomenclature

- **BREAKING:** removes href and link-title attributes from calcite-dropdown-item

- **FIXES:** "center" alignment when the dropdown-trigger is narrower than the width of the dropdown should now be correctly positioned

- **DESIGN:** Removes dot and horizontal padding in "none" selection-mode

- **DESIGN:** Now uses check icons instead of dots in "multi" selection-mode

- **MISC:** Updates tests, storybook, dev demo page
