### PR TITLE
feat(radio-group): add setFocus method

### DIFF
--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -269,4 +269,36 @@ describe("calcite-radio-group", () => {
     expect(child2).toEqualAttribute("scale", "m");
     expect(child3).toEqualAttribute("scale", "m");
   });
+
+  describe("setFocus()", () => {
+    it("focuses the first item if there is no selection", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-radio-group>
+          <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+        </calcite-radio-group>`
+      });
+
+      const element = await page.find("calcite-radio-group");
+      await element.callMethod("setFocus");
+
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-1");
+    });
+
+    it("focuses the selected item", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-radio-group>
+          <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+          <calcite-radio-group-item id="child-3" value="3" checked>three</calcite-radio-group-item>
+        </calcite-radio-group>`
+      });
+
+      const element = await page.find("calcite-radio-group");
+      await element.callMethod("setFocus");
+
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-3");
+    });
+  });
 });

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
   Watch,
   Host,
-  Build
+  Build, Method
 } from "@stencil/core";
 
 import { getElementDir } from "../../utils/dom";
@@ -221,6 +221,18 @@ export class CalciteRadioGroup {
 
   @Event()
   calciteRadioGroupChange: EventEmitter;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Methods
+  //
+  // --------------------------------------------------------------------------
+
+  /** Focuses the selected item. If there is no selection, it focuses the first item. */
+  @Method()
+  async setFocus() {
+    (this.selectedItem || this.getItems()[0])?.focus();
+  }
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
Related issue: #74 

Adds `CalciteRadioGroup#setFocus()` 👁👓:camera:  📸 