### PR TITLE
Allow calcite-tab to take up full height of calcite-tabs component

### DIFF
--- a/src/components/calcite-tab/calcite-tab.scss
+++ b/src/components/calcite-tab/calcite-tab.scss
@@ -11,5 +11,7 @@
 }
 
 section {
+  height: 100%;
+  width: 100%;
   display: none;
 }

--- a/src/components/calcite-tab/calcite-tab.scss
+++ b/src/components/calcite-tab/calcite-tab.scss
@@ -11,5 +11,6 @@
 }
 
 section {
+  height: 100%;
   display: none;
 }

--- a/src/components/calcite-tab/calcite-tab.scss
+++ b/src/components/calcite-tab/calcite-tab.scss
@@ -11,6 +11,5 @@
 }
 
 section {
-  height: 100%;
   display: none;
 }

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -1,5 +1,6 @@
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
 
   --calcite-tabs-layout: flex-start;
   --calcite-tabs-tab-basis: auto;
@@ -19,12 +20,6 @@
   --calcite-tabs-tab-text-align: center;
   --calcite-tabs-tab-margin-start: 1.25rem;
   --calcite-tabs-tab-margin-end: 1.25rem;
-}
-
-:host > div {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
 }
 
 section {

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -21,6 +21,13 @@
   --calcite-tabs-tab-margin-end: 1.25rem;
 }
 
+:host > div {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 section {
+  height: 100%;
   border-top: 1px solid var(--calcite-ui-border-1);
 }

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -28,6 +28,8 @@
 }
 
 section {
-  height: 100%;
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
   border-top: 1px solid var(--calcite-ui-border-1);
 }

--- a/src/components/calcite-tabs/calcite-tabs.tsx
+++ b/src/components/calcite-tabs/calcite-tabs.tsx
@@ -54,12 +54,10 @@ export class CalciteTabs {
 
     return (
       <Host>
-        <div>
-          <slot name="tab-nav" />
-          <section>
-            <slot />
-          </section>
-        </div>
+        <slot name="tab-nav" />
+        <section>
+          <slot />
+        </section>
       </Host>
     );
   }


### PR DESCRIPTION
We're making use of the `calcite-tabs` component and ran into a bit of an issue with styling.  Basically, we're giving the `calcite-tabs` component a defined height.  And we want each `calcite-tab` component within it to take up the full height (minus the height of the tab nav) even if the tab's content doesn't fill that space completely (this is useful for something like a vertically-centered empty state).  This seems like a fairly common use case.  Unfortunately, it seems like we're only able get each tab to take up as much vertical space as its content does.  

Example of behavior:
- `calcite-tabs` component given a height of `500px`, represented in blue.
- `calcite-tab` component given height of `100%`, represented in green.
There doesn't seem to be a good way to get the tab content to fill the space of the `calcite-tabs` component, since the inner elements of `calcite-tabs` don't take up its full height.
![before](https://user-images.githubusercontent.com/17748358/76236896-bf2c5900-6203-11ea-8e1b-a00b3f425fc6.png)

So I added some additional styling that will allow for this.
Behavior with this PR's changes:
- `calcite-tabs` component given a height of `500px`, represented in blue.
- `calcite-tab` component given height of `100%`, represented in green.
Tab content now fills excess space.
![Screen Shot 2020-03-09 at 12 35 19 PM](https://user-images.githubusercontent.com/17748358/76237150-2813d100-6204-11ea-917f-23bac8ccd98c.png)
