### PR TITLE
Adds universal selector for theming

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -8,11 +8,13 @@
   @include calcite-light-theme();
 }
 
-[theme="dark"] {
+[theme="dark"],
+[theme="dark"] * {
   @include calcite-dark-theme();
 }
 
-[theme="light"] {
+[theme="light"],
+[theme="light"] * {
   @include calcite-light-theme();
 }
 


### PR DESCRIPTION
This fixes an issue in IE11 with nested components where only the top level component would receive the correct theme's css variables (as in calcite-dropdown and calcite-accordion)

Note this is separate from the host-context issues. Open to other suggestions but this seems to work without any ramifications in other browsers...