### PR TITLE
✨ Loader improvements

### DIFF
--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -51,7 +51,7 @@ $segment-3-duration: 1.16s;
 
 .loader__text {
   display: block;
-  margin-top: $loader-padding;
+  margin-top: $loader-padding + 1rem;
   text-align: center;
   @include font-size(-2);
 }

--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -1,37 +1,46 @@
-:host {
-  --calcite-loader-spot: var(--calcite-ui-blue);
-  --calcite-loader-spot-light: var(--calcite-ui-blue);
-  --calcite-loader-spot-dark: var(--calcite-ui-blue);
-  --calcite-loader-neutral: #{$blk-020};
-  --calcite-loader-padding: 4rem;
-}
+$loader-size: 56;
+$loader-size-inline: 20;
+$loader-width: $loader-size * 1px;
+$loader-width-inline: $loader-size-inline * 1px;
+$loader-stroke: 3;
+$loader-stroke-inline: 2;
+$loader-padding: 4rem;
+$loader-circumference: ($loader-size - (2 * $loader-stroke)) * 3.14159;
 
-:host-context([theme="dark"]) {
-  --calcite-loader-neutral: #{$blk-220};
-}
-
-:host([no-padding]) {
-  --calcite-loader-padding: 0;
-}
-
-$loader-width: 54px;
-$loader-width-inline: 16px;
-$loader-stroke-width: 6px;
-$loader-stroke-width-inline: 4px;
+/**
+  Segment variables
+  - size      length of the segment (0 - 100)
+  - growth    how much the segment grows during the animation
+              (size + growth should not exceed 100)
+  - duration  how long the segment takes to rotate 360° (seconds)
+*/
+$segment-1-size: 10;
+$segment-1-growth: 40;
+$segment-1-duration: .9s;
+$segment-2-size: 20;
+$segment-2-growth: 30;
+$segment-2-duration: 1.21s;
+$segment-3-size: 5;
+$segment-3-growth: 45;
+$segment-3-duration: 1.45s;
 
 :host {
   position: relative;
   display: none;
-  padding-bottom: var(--calcite-loader-padding);
-  padding-top: var(--calcite-loader-padding);
+  padding-bottom: $loader-padding;
+  padding-top: $loader-padding;
   margin-left: auto;
   margin-right: auto;
   min-height: $loader-width;
-  stroke: var(--calcite-loader-light);
-  stroke-width: $loader-stroke-width;
-  stroke-dashoffset: 0;
+  stroke: var(--calcite-ui-blue);
+  stroke-width: $loader-stroke;
   fill: none;
-  animation: loader-color-shift 2s alternate-reverse infinite linear;
+  animation: loader-color-shift 6s alternate-reverse infinite linear;
+}
+
+:host([no-padding]) {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 :host([is-active]) {
@@ -40,7 +49,7 @@ $loader-stroke-width-inline: 4px;
 
 .loader__text {
   display: block;
-  margin-top: var(--calcite-loader-padding);
+  margin-top: $loader-padding;
   text-align: center;
   @include font-size(-2);
 }
@@ -49,7 +58,7 @@ $loader-stroke-width-inline: 4px;
   display: block;
   width: $loader-width;
   position: absolute;
-  top: var(--calcite-loader-padding);
+  top: $loader-padding;
   left: 50%;
   margin-left: -$loader-width / 2;
   margin-top: ($loader-width / 2);
@@ -58,58 +67,43 @@ $loader-stroke-width-inline: 4px;
   line-height: 0.25;
 }
 
-.loader__square {
+.loader__svg {
   width: $loader-width;
   height: $loader-width;
   position: absolute;
-  top: var(--calcite-loader-padding);
-  left: 0;
+  top: $loader-padding;
   left: 50%;
   margin-left: -$loader-width / 2;
-  stroke-dasharray: 50% 350%; // must add up to 400% to loop seamlessly
-  animation: loader-clockwise 2s infinite linear;
+  overflow: visible;
+  transform-origin: 50% 50%;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  // by default the animation is rotation for ie. and edge
+  animation-name: loader-clockwise;
 }
 
-.loader__square--2 {
-  stroke-dasharray: 100% 225% 50% 25%;
-  animation: loader-clockwise 1s infinite linear;
-}
-
-.loader__square--3 {
-  stroke-dasharray: 50% 50% 75% 225%;
-  animation: loader-clockwise 1.85s infinite linear;
-}
-
-// Edge can't animate stroke dash offset, so offset will be animated via JavaScript
-@supports (-ms-ime-align: auto) {
-  .loader__square {
-    stroke-dashoffset: var(--calcite-loader-offset);
-    animation: none;
-  }
-  .loader__square--2 {
-    stroke-dashoffset: var(--calcite-loader-offset2);
-  }
-  .loader__square--3 {
-    stroke-dashoffset: var(--calcite-loader-offset3);
-  }
+// in newer browsers use the stroke-dash-offset animation as it looks better
+@supports (display: grid) {
+  .loader__svg--1 { animation-name: loader-offset-1; }
+  .loader__svg--2 { animation-name: loader-offset-2; }
+  .loader__svg--3 { animation-name: loader-offset-3; }
 }
 
 :host([type="determinate"]) {
-  stroke: var(--calcite-loader-neutral);
+  stroke: var(--calcite-ui-border-3);
   animation: none;
-  .loader__square--3 {
-    stroke: var(--calcite-loader-spot);
-    stroke-dasharray: 400%;
-    stroke-dashoffset: var(--calcite-loader-progress);
-    transition: 50ms linear all;
+  .loader__svg--3 {
+    stroke: var(--calcite-ui-blue);
+    stroke-dasharray: $loader-circumference;
     transform: rotate(90deg);
     animation: none;
+    transition: all 100ms linear;
   }
 }
 
 :host([inline]) {
   stroke: currentColor;
-  stroke-width: $loader-stroke-width-inline;
+  stroke-width: $loader-stroke-inline;
   animation: none;
   margin: 0;
   padding-bottom: 0;
@@ -119,7 +113,7 @@ $loader-stroke-width-inline: 4px;
   min-height: $loader-width-inline;
   width: $loader-width-inline;
   margin-right: $loader-width-inline / 2;
-  vertical-align: -$loader-width-inline / 8;
+  vertical-align: -$loader-width-inline / 5;
 }
 
 :host([inline][dir="rtl"]) {
@@ -131,7 +125,7 @@ $loader-stroke-width-inline: 4px;
   display: inline-block;
 }
 
-:host([inline]) .loader__square {
+:host([inline]) .loader__svg {
   margin: 0;
   position: absolute;
   top: 0;
@@ -140,20 +134,54 @@ $loader-stroke-width-inline: 4px;
   height: $loader-width-inline;
 }
 
+@mixin generateSegment($i, $size, $growth, $duration) {
+  $circumference: $loader-circumference / $loader-size * 100%;
+  $length: ($size / 100) * $circumference;
+  $end: $length + ($growth / 100) * $circumference;
+  .loader__svg--#{$i} {
+    stroke-dasharray: $length $circumference - $end;
+    animation-duration: $duration;
+  }
+  @keyframes loader-offset-#{$i} {
+    0% {
+      stroke-dasharray: $length $circumference - $length;
+      stroke-dashoffset: 0;
+    }
+    50% {
+      stroke-dasharray: $end $circumference - $end;
+      stroke-dashoffset: -$circumference / 2 - ($length - $end) / 2;
+    }
+    100% {
+      stroke-dasharray: $length $circumference - $length;
+      stroke-dashoffset: -$circumference;
+    }
+  }
+}
+
+@include generateSegment(1, $segment-1-size, $segment-1-growth, $segment-1-duration);
+@include generateSegment(2, $segment-2-size, $segment-2-growth, $segment-2-duration);
+@include generateSegment(3, $segment-3-size, $segment-3-growth, $segment-3-duration);
+
 @keyframes loader-color-shift {
   0% {
-    stroke: var(--calcite-loader-spot-light);
+    stroke: var(--calcite-ui-blue);
+  }
+  33% {
+    stroke: var(--calcite-ui-blue-press);
+  }
+  66% {
+    stroke: var(--calcite-ui-blue-hover);
   }
   100% {
-    stroke: var(--calcite-loader-spot-dark);
+    stroke: var(--calcite-ui-blue);
   }
 }
 
 @keyframes loader-clockwise {
   0% {
-    stroke-dashoffset: 0;
+    transform: rotate(0deg);
   }
   100% {
-    stroke-dashoffset: -400%;
+    transform: rotate(360deg);
   }
 }

--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -16,13 +16,13 @@ $loader-circumference: ($loader-size - (2 * $loader-stroke)) * 3.14159;
 */
 $segment-1-size: 10;
 $segment-1-growth: 40;
-$segment-1-duration: .9s;
+$segment-1-duration: .72s;
 $segment-2-size: 20;
 $segment-2-growth: 30;
-$segment-2-duration: 1.21s;
+$segment-2-duration: .96s;
 $segment-3-size: 5;
 $segment-3-growth: 45;
-$segment-3-duration: 1.45s;
+$segment-3-duration: 1.16s;
 
 :host {
   position: relative;

--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -35,6 +35,8 @@ $segment-3-duration: 1.45s;
   stroke: var(--calcite-ui-blue);
   stroke-width: $loader-stroke;
   fill: none;
+  opacity: 1;
+  transform: scale(1, 1);
   animation: loader-color-shift 6s alternate-reverse infinite linear;
 }
 
@@ -64,10 +66,12 @@ $segment-3-duration: 1.45s;
   margin-top: ($loader-width / 2);
   text-align: center;
   font-size: 0.875rem;
+  color: var(--calcite-ui-text-1);
   line-height: 0.25;
+  transform: scale(1, 1);
 }
 
-.loader__svg {
+.loader__svgs {
   width: $loader-width;
   height: $loader-width;
   position: absolute;
@@ -75,7 +79,18 @@ $segment-3-duration: 1.45s;
   left: 50%;
   margin-left: -$loader-width / 2;
   overflow: visible;
-  transform-origin: 50% 50%;
+  opacity: 1;
+  transform: scale(1, 1);
+}
+
+.loader__svg {
+  width: $loader-width;
+  height: $loader-width;
+  position: absolute;
+  top: 0;
+  left: 0;
+  overflow: visible;
+  transform-origin: center;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
   // by default the animation is rotation for ie. and edge
@@ -125,13 +140,38 @@ $segment-3-duration: 1.45s;
   display: inline-block;
 }
 
-:host([inline]) .loader__svg {
-  margin: 0;
-  position: absolute;
+:host([inline]) .loader__svgs {
   top: 0;
   left: 0;
+  margin: 0;
   width: $loader-width-inline;
   height: $loader-width-inline;
+}
+
+:host([inline]) .loader__svg {
+  width: $loader-width-inline;
+  height: $loader-width-inline;
+}
+
+:host([complete]) {
+  opacity: 0;
+  transform: scale(.75, .75);
+  transform-origin: center;
+  transition: opacity 200ms linear 1000ms, transform 200ms linear 1000ms;
+}
+
+:host([complete]) .loader__svgs {
+  opacity: 0;
+  transform: scale(.75, .75);
+  transform-origin: center;
+  transition: opacity 180ms linear 800ms, transform 180ms linear 800ms;
+}
+
+:host([complete]) .loader__percentage {
+  color: var(--calcite-ui-blue);
+  transform: scale(1.075, 1.075);
+  transform-origin: center;
+  transition: color 200ms linear, transform 200ms linear;
 }
 
 @mixin generateSegment($i, $size, $growth, $duration) {

--- a/src/components/calcite-loader/calcite-loader.tsx
+++ b/src/components/calcite-loader/calcite-loader.tsx
@@ -47,28 +47,35 @@ export class CalciteLoader {
     const progress = (this.value / 100) * circumference;
     const remaining = circumference - progress;
     const value = Math.floor(this.value);
-    const ariaAttributes = {
+    const hostAttributes = {
       "aria-valuenow": value,
       "aria-valuemin": 0,
-      "aria-valuemax": 100
+      "aria-valuemax": 100,
+      complete: value === 100
     };
-    const determinateStyle = { "stroke-dasharray": `${progress} ${remaining}` };
     const svgAttributes = { r: radius, cx: size / 2, cy: size / 2 };
+    const determinateStyle = { "stroke-dasharray": `${progress} ${remaining}` };
     return (
       <Host
         id={id}
         role="progressbar"
-        {...(isDeterminate ? ariaAttributes : {})}
+        {...(isDeterminate ? hostAttributes : {})}
       >
-        <svg viewBox={viewbox} class="loader__svg loader__svg--1">
-          <circle {...svgAttributes} />
-        </svg>
-        <svg viewBox={viewbox} class="loader__svg loader__svg--2">
-          <circle {...svgAttributes} />
-        </svg>
-        <svg viewBox={viewbox} class="loader__svg loader__svg--3" {...(isDeterminate ? { style: determinateStyle } : {})}>
-          <circle {...svgAttributes} />
-        </svg>
+        <div class="loader__svgs">
+          <svg viewBox={viewbox} class="loader__svg loader__svg--1">
+            <circle {...svgAttributes} />
+          </svg>
+          <svg viewBox={viewbox} class="loader__svg loader__svg--2">
+            <circle {...svgAttributes} />
+          </svg>
+          <svg
+            viewBox={viewbox}
+            class="loader__svg loader__svg--3"
+            {...(isDeterminate ? { style: determinateStyle } : {})}
+          >
+            <circle {...svgAttributes} />
+          </svg>
+        </div>
         {this.text && <div class="loader__text">{this.text}</div>}
         {isDeterminate && <div class="loader__percentage">{value}</div>}
       </Host>

--- a/src/components/calcite-loader/calcite-loader.tsx
+++ b/src/components/calcite-loader/calcite-loader.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, Prop, State } from "@stencil/core";
+import { Component, Element, h, Host, Prop } from "@stencil/core";
 import { guid } from "../../utils/guid";
 
 @Component({
@@ -19,111 +19,58 @@ export class CalciteLoader {
   //  Properties
   //
   //--------------------------------------------------------------------------
-  /**
-   * Show the loader
-   */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  isActive: boolean = false;
-  /**
-   * Inline loaders are smaller and will appear to the left of the text
-   */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  inline: boolean = false;
-  /**
-   * Use indeterminate if finding actual progress value is impossible
-   */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  type: "indeterminate" | "determinate" = "indeterminate";
-  /**
-   * Percent complete of 100, only valid for determinate indicators
-   */
+  /** Show the loader */
+  @Prop({ reflect: true }) isActive: boolean = false;
+  /** Inline loaders are smaller and will appear to the left of the text */
+  @Prop({ reflect: true }) inline: boolean = false;
+  /** Use indeterminate if finding actual progress value is impossible */
+  @Prop({ reflect: true }) type: "indeterminate" | "determinate";
+  /** Percent complete of 100, only valid for determinate indicators */
   @Prop() value = 0;
-  /**
-   * Text which should appear under the loading indicator (optional)
-   */
+  /** Text which should appear under the loading indicator (optional) */
   @Prop() text: string = "";
-
   /** Turn off spacing around the loader */
   @Prop() noPadding?: boolean;
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
-  componentWillLoad() {
-    this.isEdge = /Edge/.test(navigator.userAgent);
-    if (this.isEdge) {
-      this.updateOffset();
-    }
-  }
-
-  componentDidUnload() {
-    if (this.animationID) {
-      window.cancelAnimationFrame(this.animationID);
-    }
-  }
-
   render() {
     const id = this.el.id || this.guid;
+    const size = this.inline ? 20 : 56;
+    const radius = this.inline ? 9 : 25;
+    const viewbox = `0 0 ${size} ${size}`;
+    const isDeterminate = this.type === "determinate";
+    const circumference = 2 * radius * Math.PI;
+    const progress = (this.value / 100) * circumference;
+    const remaining = circumference - progress;
+    const value = Math.floor(this.value);
     const ariaAttributes = {
-      "aria-valuenow": this.value,
+      "aria-valuenow": value,
       "aria-valuemin": 0,
       "aria-valuemax": 100
     };
-    const size = this.inline ? 16 : 56;
-    const viewbox = this.inline ? "0 0 16 16" : "0 0 56 56";
-    const isDeterminate = this.type === "determinate";
-    const styleProperties = {};
-    if (this.isEdge) {
-      styleProperties[
-        "--calcite-loader-offset"
-      ] = `${this.loaderBarOffsets[0]}%`;
-      styleProperties[
-        "--calcite-loader-offset2"
-      ] = `${this.loaderBarOffsets[1]}%`;
-      styleProperties[
-        "--calcite-loader-offset3"
-      ] = `${this.loaderBarOffsets[2]}%`;
-    }
-    const progress = {
-      "--calcite-loader-progress": `${-400 - this.value * 4}%`
-    };
+    const determinateStyle = { "stroke-dasharray": `${progress} ${remaining}` };
+    const svgAttributes = { r: radius, cx: size / 2, cy: size / 2 };
     return (
       <Host
         id={id}
-
         role="progressbar"
-        {...(this.type === "determinate" ? ariaAttributes : {})}
-        style={styleProperties}
+        {...(isDeterminate ? ariaAttributes : {})}
       >
-        <svg viewBox={viewbox} class="loader__square">
-          <rect width={size} height={size} />
+        <svg viewBox={viewbox} class="loader__svg loader__svg--1">
+          <circle {...svgAttributes} />
         </svg>
-        <svg viewBox={viewbox} class="loader__square loader__square--2">
-          <rect width={size} height={size} />
+        <svg viewBox={viewbox} class="loader__svg loader__svg--2">
+          <circle {...svgAttributes} />
         </svg>
-        <svg
-          viewBox={viewbox}
-          class="loader__square loader__square--3"
-          style={isDeterminate ? progress : {}}
-        >
-          <rect width={size} height={size} />
+        <svg viewBox={viewbox} class="loader__svg loader__svg--3" {...(isDeterminate ? { style: determinateStyle } : {})}>
+          <circle {...svgAttributes} />
         </svg>
-        {this.text ? <div class="loader__text">{this.text}</div> : ""}
-        {this.value ? (
-          <div class="loader__percentage">{Math.floor(this.value)}</div>
-        ) : (
-          ""
-        )}
+        {this.text && <div class="loader__text">{this.text}</div>}
+        {isDeterminate && <div class="loader__percentage">{value}</div>}
       </Host>
     );
   }
@@ -133,54 +80,6 @@ export class CalciteLoader {
   //  Private State/Props
   //
   //--------------------------------------------------------------------------
-  /**
-   * @internal
-   */
-  @State() private loaderBarOffsets: number[] = [0, 0, 0];
-
-  /**
-   * @internal
-   */
-  private loaderBarRates: number[] = [1, 2.25, 3.5];
-
-  /**
-   * @internal
-   */
-  @State() private isEdge: boolean = false;
-
-  /**
-   * @internal
-   */
-  private animationID: any = null;
-
-  /**
-   * @internal
-   */
+  /** @internal */
   private guid = `calcite-loader-${guid()}`;
-
-  //--------------------------------------------------------------------------
-  //
-  //  Private Methods
-  //
-  //--------------------------------------------------------------------------
-  /**
-   * @internal
-   */
-  private updateOffset(): void {
-    this.loaderBarOffsets = this.rotateLoaderBars(this.loaderBarOffsets);
-    this.animationID = window.requestAnimationFrame(() => this.updateOffset());
-  }
-
-  /**
-   * @internal
-   */
-  private rotateLoaderBars(barOffsets: number[]): number[] {
-    return barOffsets.map((offset, i) => {
-      if (offset > -400) {
-        return offset - this.loaderBarRates[i];
-      } else {
-        return 0;
-      }
-    });
-  }
 }

--- a/src/components/calcite-loader/readme.md
+++ b/src/components/calcite-loader/readme.md
@@ -27,14 +27,14 @@ For instances when you don't have room for the full loader, you can use the smal
 
 ## Properties
 
-| Property    | Attribute    | Description                                                        | Type                               | Default           |
-| ----------- | ------------ | ------------------------------------------------------------------ | ---------------------------------- | ----------------- |
-| `inline`    | `inline`     | Inline loaders are smaller and will appear to the left of the text | `boolean`                          | `false`           |
-| `isActive`  | `is-active`  | Show the loader                                                    | `boolean`                          | `false`           |
-| `noPadding` | `no-padding` | Turn off spacing around the loader                                 | `boolean`                          | `undefined`       |
-| `text`      | `text`       | Text which should appear under the loading indicator (optional)    | `string`                           | `""`              |
-| `type`      | `type`       | Use indeterminate if finding actual progress value is impossible   | `"determinate" \| "indeterminate"` | `"indeterminate"` |
-| `value`     | `value`      | Percent complete of 100, only valid for determinate indicators     | `number`                           | `0`               |
+| Property    | Attribute    | Description                                                        | Type                               | Default     |
+| ----------- | ------------ | ------------------------------------------------------------------ | ---------------------------------- | ----------- |
+| `inline`    | `inline`     | Inline loaders are smaller and will appear to the left of the text | `boolean`                          | `false`     |
+| `isActive`  | `is-active`  | Show the loader                                                    | `boolean`                          | `false`     |
+| `noPadding` | `no-padding` | Turn off spacing around the loader                                 | `boolean`                          | `undefined` |
+| `text`      | `text`       | Text which should appear under the loading indicator (optional)    | `string`                           | `""`        |
+| `type`      | `type`       | Use indeterminate if finding actual progress value is impossible   | `"determinate" \| "indeterminate"` | `undefined` |
+| `value`     | `value`      | Percent complete of 100, only valid for determinate indicators     | `number`                           | `0`         |
 
 
 ## Dependencies

--- a/src/demos/calcite-loader.html
+++ b/src/demos/calcite-loader.html
@@ -12,6 +12,13 @@
       color: white;
       padding: 1rem;
     }
+    h2 {
+      text-align: center;
+      padding-top: 6rem;
+    }
+    h2:first-of-type {
+      padding-top: 2rem;
+    }
   </style>
   <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="../build/calcite.css" />
@@ -22,44 +29,50 @@
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Loader</h1>
+  <h2>Standard</h2>
   <calcite-loader is-active></calcite-loader>
-  <calcite-loader is-active no-padding></calcite-loader>
-  <calcite-loader is-active title="optional loading text&hellip;" type="indeterminate"></calcite-loader>
-  <calcite-loader is-active class="green" title="Custom theme..."></calcite-loader>
-  <style>
-    calcite-loader.green {
-      --calcite-loader-spot-light: #50ba5f;
-      --calcite-loader-spot-dark: #1a6324;
-      --calcite-loader-spot: #338033;
-    }
-  </style>
-  <p style="text-align: center;">
-    <calcite-loader is-active inline></calcite-loader>Inline Loader
-  </p>
+  <h2>Determinate</h2>
   <calcite-loader is-active type="determinate" value="0" id="loader-determinate" text="Determinate loader">
   </calcite-loader>
+  <div style="text-align: center">
+    <calcite-button id="replay" appearance="transparent" icon="refresh">Replay</calcite-button>
+  </div>
   <script>
-    // Preview the loading progress
     (function () {
       var loader = document.querySelector("#loader-determinate");
       var randoms = [0, 0, 0, 0, 0, 0, 1, 3];
       function updateLoader() {
         var random = randoms[Math.floor(Math.random() * randoms.length)];
-        if (loader.value + random > 100) {
-          loader.value = 0;
-          setTimeout(function () {
-            requestAnimationFrame(updateLoader);
-          }, 50);
-        } else {
-          loader.value = loader.value + random;
+        loader.value = Math.min(loader.value + random, 100);
+        if (loader.value !== 100) {
           requestAnimationFrame(updateLoader);
         }
       }
+
       updateLoader();
+
+      document.querySelector("#replay").addEventListener("click", function () {
+        cancelAnimationFrame(updateLoader);
+        loader.value = 0;
+        updateLoader();
+      });
     })();
   </script>
-
-
+  <h2>Inline</h2>
+  <p style="text-align: center;">
+    <calcite-loader is-active inline></calcite-loader>Inline Loader
+  </p>
+  <h2>Custom theme</h2>
+  <calcite-loader is-active class="green"></calcite-loader>
+  <style>
+    calcite-loader.green {
+      --calcite-ui-blue-press: #50ba5f;
+      --calcite-ui-blue-hover: #1a6324;
+      --calcite-ui-blue: #338033;
+    }
+  </style>
+  <h2>Loading Text</h2>
+  <calcite-loader is-active text="optional loading text&hellip;" type="indeterminate"></calcite-loader>
 </body>
 
 </html>


### PR DESCRIPTION
1. Converted to circle
2. Works in edge
3. Works in ie11
4. Determinate loader has new fade-out on completion
5. No more `requestAnimationFrame` js stuff for edge 

In IE and Old Edge the segments are rotated, but in more modern browsers the dash-array is animated. The dash-array animation is slightly sharper, so for machines that can handle it I've left it.

@julio8a @bstifle I've also added a [series of variables](https://github.com/Esri/calcite-components/pull/384/files#diff-a3b65abeb0b9258c91de75281e64c75bR17-R25) that act as knobs letting you easily tweak the animation if you want to run this locally and change numbers until it looks right.

@macandcheese I think we can close the other loader pr that is currently open after this? IDK let me know