### PR TITLE
✨ Icon update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,9 +1172,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-2.7.1.tgz",
-      "integrity": "sha512-XG3t3WbfJeA0/KadImznxMPNORhQk0E+p33upEdo4eU5iTBdPL7At6bkOR/kWzFu/5cCM090FrCW4EyrhNhM9A==",
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.0.0-beta.5.tgz",
+      "integrity": "sha512-+Z43/N7N0zILpeeuWw2FBJhmSicyAAPnjx1n1aaexR4K2bHXYghd2BnWCD8eXVbx4l8j3nXOZffodMOQCg7/Ww==",
       "dev": true
     },
     "@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "npm run copy-icons && stencil build",
-    "copy-icons": "cpy ./node_modules/@esri/calcite-ui-icons/js/*.js ./src/components/calcite-icon/assets",
+    "copy-icons": "cpy ./node_modules/@esri/calcite-ui-icons/js/*.json ./src/components/calcite-icon/assets",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
     "start": "npm run copy-icons && stencil build --dev --watch --serve",
     "test": "npm run copy-icons && stencil test --spec --e2e",
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "^1.7.1",
-    "@esri/calcite-ui-icons": "^2.7.1",
+    "@esri/calcite-ui-icons": "^3.0.0-beta.5",
     "@stencil/core": "^1.8.9",
     "@stencil/sass": "^1.1.1",
     "@stencil/state-tunnel": "^1.0.1",

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -59,6 +59,7 @@
   display: flex;
   position: fixed;
   justify-content: center;
+  align-items: center;
   pointer-events: none;
   margin: 0 auto;
   width: var(--calcite-alert-width);
@@ -182,6 +183,7 @@
 
 .alert-close {
   @include alert-element-base;
+  align-self: stretch;
   background-color: transparent;
   -webkit-appearance: none;
   border: none;
@@ -213,6 +215,7 @@
   display: flex;
   align-items: center;
   justify-content: space-around;
+  align-self: stretch;
   overflow: hidden;
   width: 0;
   visibility: hidden;

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -140,7 +140,7 @@ export class CalciteAlert {
         onClick={() => this.close()}
         ref={el => (this.closeButton = el)}
       >
-        <calcite-icon icon="x" scale="s"></calcite-icon>
+        <calcite-icon icon="x" scale="m"></calcite-icon>
       </button>
     );
 
@@ -278,7 +278,7 @@ export class CalciteAlert {
     var path = this.iconDefaults[this.color];
     return (
       <div class="alert-icon">
-        <calcite-icon icon={path} filled scale="s"></calcite-icon>
+        <calcite-icon icon={path} scale="m"></calcite-icon>
       </div>
     );
   }

--- a/src/components/calcite-date-month-header/calcite-date-month-header.scss
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.scss
@@ -8,7 +8,7 @@ input {
 
 .right-icon,
 .left-icon {
-  fill: var(--calcite-ui-text-3);
+  color: var(--calcite-ui-text-3);
   flex-grow: 1;
   outline: none;
   padding: 0;

--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -102,14 +102,7 @@ export class CalciteDateMonthHeader {
             aria-label={this.prevMonthLabel}
             onClick={ () => this.selectPrevMonth()}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 16 16"
-              height="16"
-              width="16"
-            >
-              <path d="M11.783 14H9.017l-6-6 6-6h2.766l-6 6z" />
-            </svg>
+            <calcite-icon icon="chevron-left" scale="s"></calcite-icon>
           </button>
           <div class="month-year-text">
             <span class="month" role="heading">
@@ -129,14 +122,7 @@ export class CalciteDateMonthHeader {
             aria-label={this.nextMonthLabel}
             onClick={() => this.selectNextMonth()}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 16 16"
-              height="16"
-              width="16"
-            >
-              <path d="M10.217 8l-6-6h2.766l6 6-6 6H4.217z" />
-            </svg>
+            <calcite-icon icon="chevron-right" scale="s"></calcite-icon>
           </button>
         </div>
       </Host>

--- a/src/components/calcite-date-month-header/readme.md
+++ b/src/components/calcite-date-month-header/readme.md
@@ -33,9 +33,14 @@
 
  - [calcite-date-picker](../calcite-date)
 
+### Depends on
+
+- [calcite-icon](../calcite-icon)
+
 ### Graph
 ```mermaid
 graph TD;
+  calcite-date-month-header --> calcite-icon
   calcite-date-picker --> calcite-date-month-header
   style calcite-date-month-header fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/calcite-date/calcite-date-picker.scss
+++ b/src/components/calcite-date/calcite-date-picker.scss
@@ -23,7 +23,7 @@
     }
 
     .calendar-icon {
-      fill: var(--calcite-ui-text-3);
+      color: var(--calcite-ui-text-3);
       position: absolute;
       top: $baseline/1.8;
       left: $baseline/1.15;

--- a/src/components/calcite-date/calcite-date-picker.tsx
+++ b/src/components/calcite-date/calcite-date-picker.tsx
@@ -116,15 +116,7 @@ export class CalciteDatePicker {
           class={`date-input-wrapper ${this.showCalendar ? "expanded" : ""}`}
           role="application"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="calendar-icon"
-            viewBox="0 0 16 16"
-            width="16"
-            height="16"
-          >
-            <path d="M16 16H0V6h16zM3 7H1v2h2zm3 0H4v2h2zm3 0H7v2h2zm3 0h-2v2h2zm3 0h-2v2h2zM3 10H1v2h2zm3 0H4v2h2zm3 0H7v2h2zm3 0h-2v2h2zm3 0h-2v2h2zM3 13H1v2h2zm3 0H4v2h2zm3 0H7v2h2zm3 0h-2v2h2zm3 0h-2v2h2zM5 2V1h6v1zm9-1v1h1v2H1V2h1V1H0v4h16V1zM4 0H3v2h1zm9 0h-1v2h1z" />
-          </svg>
+          <calcite-icon icon="calendar" class="calendar-icon" scale="s"></calcite-icon>
           <input
             type="text"
             placeholder={this.placeholder}

--- a/src/components/calcite-date/readme.md
+++ b/src/components/calcite-date/readme.md
@@ -33,14 +33,17 @@
 
 ### Depends on
 
+- [calcite-icon](../calcite-icon)
 - [calcite-date-month-header](../calcite-date-month-header)
 - [calcite-date-month](../calcite-date-month)
 
 ### Graph
 ```mermaid
 graph TD;
+  calcite-date-picker --> calcite-icon
   calcite-date-picker --> calcite-date-month-header
   calcite-date-picker --> calcite-date-month
+  calcite-date-month-header --> calcite-icon
   calcite-date-month --> calcite-date-day
   style calcite-date-picker fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/calcite-dropdown/readme.md
+++ b/src/components/calcite-dropdown/readme.md
@@ -45,10 +45,10 @@ You can combine groups in a single dropdown, with varying selection modes:
 | ----------- | ----------- | ------------------------------------------------------------------------------- | ------------------------------ | ----------- |
 | `active`    | `active`    |                                                                                 | `boolean`                      | `false`     |
 | `alignment` | `alignment` | specify the alignment of dropdown, defaults to start                            | `"center" \| "end" \| "start"` | `"start"`   |
-| `scale`     | `scale`     | specify the scale of dropdown, defaults to m                                   | `"l" \| "m" \| "s"`            | `"m"`       |
+| `scale`     | `scale`     | specify the scale of dropdown, defaults to m                                    | `"l" \| "m" \| "s"`            | `"m"`       |
 | `theme`     | `theme`     | specify the theme of the dropdown, defaults to light                            | `"dark" \| "light"`            | `undefined` |
 | `type`      | `type`      | specify whether the dropdown is opened by hover or click of the trigger element | `"click" \| "hover"`           | `"click"`   |
-| `width`     | `width`     | specify the width of dropdown, defaults to m                                   | `"l" \| "m" \| "s"`            | `"m"`       |
+| `width`     | `width`     | specify the width of dropdown, defaults to m                                    | `"l" \| "m" \| "s"`            | `"m"`       |
 
 
 ----------------------------------------------

--- a/src/components/calcite-icon/calcite-icon.scss
+++ b/src/components/calcite-icon/calcite-icon.scss
@@ -5,3 +5,7 @@
 :host([mirror]) {
   transform: scaleX(-1);
 }
+
+.svg {
+  display: block;
+}

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -121,7 +121,8 @@ export class CalciteIcon {
       >
         <svg
           class={{
-            [CSS.mirrored]: dir === "rtl" && mirrored
+            [CSS.mirrored]: dir === "rtl" && mirrored,
+            "svg": true
           }}
           xmlns="http://www.w3.org/2000/svg"
           fill="currentColor"

--- a/src/components/calcite-icon/readme.md
+++ b/src/components/calcite-icon/readme.md
@@ -35,6 +35,8 @@ To use a custom color for the icon fill, you can add a class to the `calcite-ico
  - [calcite-accordion-item](../calcite-accordion-item)
  - [calcite-alert](../calcite-alert)
  - [calcite-button](../calcite-button)
+ - [calcite-date-month-header](../calcite-date-month-header)
+ - [calcite-date-picker](../calcite-date)
  - [calcite-dropdown-item](../calcite-dropdown-item)
  - [calcite-modal](../calcite-modal)
  - [calcite-notice](../calcite-notice)
@@ -48,6 +50,8 @@ graph TD;
   calcite-accordion-item --> calcite-icon
   calcite-alert --> calcite-icon
   calcite-button --> calcite-icon
+  calcite-date-month-header --> calcite-icon
+  calcite-date-picker --> calcite-icon
   calcite-dropdown-item --> calcite-icon
   calcite-modal --> calcite-icon
   calcite-notice --> calcite-icon

--- a/src/components/calcite-icon/utils.ts
+++ b/src/components/calcite-icon/utils.ts
@@ -35,19 +35,22 @@ export async function fetchIcon({
   const size = scaleToPx[scale];
   const id = `${normalizeIconName(icon)}${size}${filled ? "F" : ""}`;
 
-  if (iconCache[id]) {
-    return iconCache[id];
-  }
-
-  const request =
-    requestCache[id] ||
-    (requestCache[id] = import(getAssetPath(`./assets/${id}.js`)));
-
-  const module = await request;
-  const pathData = module[id];
-
-  iconCache[id] = pathData;
-  return pathData;
+  return new Promise(resolve => {
+    if (requestCache[id]) {
+      return resolve(requestCache[id]);
+    }
+    fetch(getAssetPath(`./assets/${id}.json`))
+      .then(resp => resp.json())
+      .then(path => {
+        iconCache[id] = path;
+        resolve(path);
+      })
+      .catch(_ => {
+        iconCache[id] = "";
+        console.error(`"${id}" is not a valid calcite-ui-icon name`);
+        resolve("");
+      });
+  });
 }
 
 /**

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -72,7 +72,7 @@
 }
 
 .modal__close {
-  padding: $baseline * 0.75;
+  padding: .75rem;
   margin: 0;
   order: 2;
   flex: 0 0 auto;
@@ -318,7 +318,7 @@ slot[name="primary"] {
     padding: $baseline * 0.25 $baseline * 0.675;
   }
   .modal__close {
-    padding: $baseline * 0.675;
+    padding: .75rem;
   }
   .modal__content--spaced {
     padding: $baseline * 0.675;

--- a/src/components/calcite-modal/calcite-modal.stories.js
+++ b/src/components/calcite-modal/calcite-modal.stories.js
@@ -25,8 +25,7 @@ storiesOf('Modal', module)
             The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
           </p>
         </div>
-        <calcite-button slot="back" color="light" appearance="outline"
-          icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z" width="full">Back</calcite-button>
+        <calcite-button slot="back" color="light" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
         <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
         <calcite-button slot="primary" width="full">Save</calcite-button>
       </calcite-modal>
@@ -52,8 +51,7 @@ storiesOf('Modal', module)
             The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
           </p>
         </div>
-        <calcite-button theme="dark" slot="back" color="light" appearance="outline"
-          icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z" width="full">Back</calcite-button>
+        <calcite-button theme="dark" slot="back" color="light" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
         <calcite-button theme="dark" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
         <calcite-button theme="dark" slot="primary" width="full">Save</calcite-button>
       </calcite-modal>

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -81,7 +81,7 @@ export class CalciteModal {
               ref={el => (this.closeButton = el)}
               onClick={() => this.close()}
             >
-              <calcite-icon icon="x" scale="m"></calcite-icon>
+              <calcite-icon icon="x" scale="l"></calcite-icon>
             </button>
             <header class="modal__title">
               <slot name="header" />

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -8,7 +8,7 @@ calcite modal allows you to show a modal/dialog to your users. The modal handles
   <div slot="content">
     The actual content of the modal
   </div>
-  <calcite-button slot="back" color="light" appearance="outline" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z" width="full">
+  <calcite-button slot="back" color="light" appearance="outline" icon="chevron-left" width="full">
     Back
   </calcite-button>
   <calcite-button slot="secondary" width="full" appearance="outline">

--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -76,6 +76,7 @@
 
 :host([active]) {
   display: inline-flex;
+  align-items: center;
   opacity: 1;
   max-height: 100%;
   pointer-events: initial;
@@ -145,6 +146,7 @@
 
 .notice-close {
   @include notice-element-base;
+  align-self: stretch;
   background-color: transparent;
   -webkit-appearance: none;
   border: none;

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -101,7 +101,7 @@ export class CalciteNotice {
         onClick={() => this.close()}
         ref={el => (this.closeButton = el)}
       >
-        <calcite-icon icon="x" scale="s"></calcite-icon>
+        <calcite-icon icon="x" scale="m"></calcite-icon>
       </button>
     );
 
@@ -186,7 +186,7 @@ export class CalciteNotice {
     var path = this.iconDefaults[this.color];
     return (
       <div class="notice-icon">
-        <calcite-icon icon={path} filled scale="s"></calcite-icon>
+        <calcite-icon icon={path} scale="m"></calcite-icon>
       </div>
     );
   }

--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -18,22 +18,20 @@ $image_max_height: 200px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: flex-start;
   line-height: 24px;
 }
 
 .close-button {
-  display: flex;
-  justify-content: flex-end;
-  width: 40px;
-  height: 50px;
-  z-index: 1;
-  color: var(--calcite-ui-text-1);
-  padding: 16px 12px;
+  display: block;
+  flex: 0 0 auto;
+  padding: 12px;
   border: none;
   border-radius: 0 var(--calcite-border-radius) 0 0;
-  display: block;
+  color: var(--calcite-ui-text-1);
   cursor: pointer;
   background: var(--calcite-ui-foreground);
+  z-index: 1;
   &:hover {
     background: var(--calcite-ui-foreground-hover);
   }

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -364,7 +364,7 @@ export class CalcitePopover {
         class={{ [CSS.closeButton]: true }}
         onClick={this.hide}
       >
-        <calcite-icon icon="x" scale="s"></calcite-icon>
+        <calcite-icon icon="x" scale="m"></calcite-icon>
       </button>
     ) : null;
   }

--- a/src/components/calcite-popover/readme.md
+++ b/src/components/calcite-popover/readme.md
@@ -12,10 +12,7 @@
   >Hello! I am some popover content!</calcite-popover
 >
 
-<calcite-button
-  id="popover-button"
-  icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z"
-  >Clickable popover</calcite-button
+<calcite-button id="popover-button">Clickable popover</calcite-button
 >
 ```
 

--- a/src/components/calcite-popover/usage/addClickHandle.md
+++ b/src/components/calcite-popover/usage/addClickHandle.md
@@ -3,9 +3,6 @@
   >Hello! I am some popover content!</calcite-popover
 >
 
-<calcite-button
-  id="popover-button"
-  icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z"
-  >Clickable popover</calcite-button
+<calcite-button id="popover-button">Clickable popover</calcite-button
 >
 ```

--- a/src/components/calcite-radio-group/readme.md
+++ b/src/components/calcite-radio-group/readme.md
@@ -22,6 +22,19 @@
 | `calciteRadioGroupChange` |             | `CustomEvent<any>` |
 
 
+## Methods
+
+### `setFocus() => Promise<void>`
+
+Focuses the selected item. If there is no selection, it focuses the first item.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/demos/calcite-alert.html
+++ b/src/demos/calcite-alert.html
@@ -11,11 +11,6 @@
   <script type="module" src="../build/calcite.esm.js"></script>
   <script nomodule src="../build/calcite.js"></script>
   <script src="../assets/demo/createAlert.js"></script>
-  <style>
-    .my-cool-theme * {
-      --calcite-ui-blue: purple;
-    }
-  </style>
 </head>
 
 <body class="my-cool-theme">

--- a/src/demos/calcite-modal.html
+++ b/src/demos/calcite-modal.html
@@ -31,7 +31,7 @@
       </p>
     </div>
     <calcite-button slot="back" width="full" color="light" appearance="outline"
-      icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z" width="full">Back</calcite-button>
+      icon="chevron-left" width="full">Back</calcite-button>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
@@ -54,7 +54,7 @@
       </table>
     </div>
     <calcite-button slot="back" width="full" color="light" appearance="outline"
-      icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">Back</calcite-button>
+      icon="chevron-left">Back</calcite-button>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
@@ -73,10 +73,10 @@
     <div slot="content">
       <p>This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your
         modal
-        need the full screen realestate (maps, etc)</p>
+        need the full screen real estate (maps, etc)</p>
     </div>
     <calcite-button slot="back" width="full" color="light" appearance="outline"
-      icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">Back</calcite-button>
+      icon="chevron-left">Back</calcite-button>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>

--- a/src/demos/calcite-popover.html
+++ b/src/demos/calcite-popover.html
@@ -104,15 +104,15 @@
 
   <ul class="popover-list">
     <li>
-      <calcite-button id="popover-button-two" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+      <calcite-button id="popover-button-two" icon="plus">
         Clickable popover</calcite-button>
 
     <li>
-      <calcite-button id="popover-button-four" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+      <calcite-button id="popover-button-four" icon="plus">
         With close button</calcite-button>
     </li>
     <li>
-      <calcite-button id="popover-button-three" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+      <calcite-button id="popover-button-three" icon="plus">
         Title, content & CTA</calcite-button>
     </li>
   </ul>


### PR DESCRIPTION
- bump calcite-ui-icons to `v3.0.0-beta.5`
- convert all existing icons to `calcite-icon` component
- update incorrect `icon=` uses on buttons in demos and docs
- update some references to icons that no longer exist in a post-3.0.0 world (lightbulb-filled, etc)
- change sizes of most of the `x` icons. They really changed the size of the x inside the bounding box so the 16x16 x was now reaaaally tiny
- fix `calcite-icon` in ie11 (now fetching the icon as JSON rather than with JS module syntax)