### PR TITLE
Explicitly emit change event on keypress

### DIFF
--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -39,30 +39,28 @@ export class CalciteSwitch {
   @Prop({ reflect: true, mutable: true }) theme: "light" | "dark";
 
   @Event() calciteSwitchChange: EventEmitter;
+  @Event() change: EventEmitter;
 
   private observer: MutationObserver;
 
   @Listen("click") onClick(e) {
     // prevent duplicate click events that occur
     // when the component is wrapped in a label and checkbox is clicked
-
     if (
       (this.el.closest("label") && e.target === this.inputProxy) ||
       (!this.el.closest("label") && e.target === this.el)
     ) {
-      this.switched = !this.switched;
+      this.updateSwitch(e);
     }
   }
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent) {
     if (e.keyCode === SPACE || e.keyCode === ENTER) {
-      e.preventDefault();
-      this.switched = !this.switched;
+      this.updateSwitch(e);
     }
   }
 
   @Watch("switched") switchWatcher() {
-    this.calciteSwitchChange.emit();
     this.switched
       ? this.inputProxy.setAttribute("checked", "")
       : this.inputProxy.removeAttribute("checked");
@@ -90,7 +88,11 @@ export class CalciteSwitch {
 
   render() {
     return (
-      <Host role="checkbox" aria-checked={this.switched.toString()} tabIndex={this.tabIndex}>
+      <Host
+        role="checkbox"
+        aria-checked={this.switched.toString()}
+        tabIndex={this.tabIndex}
+      >
         <div class="track">
           <div class="handle" />
         </div>
@@ -141,4 +143,10 @@ export class CalciteSwitch {
     this.inputProxy.setAttribute("name", this.name);
     this.inputProxy.setAttribute("value", this.value);
   };
+  private updateSwitch(e) {
+    e.preventDefault();
+    this.switched = !this.switched;
+    this.change.emit();
+    this.calciteSwitchChange.emit();
+  }
 }

--- a/src/demos/calcite-switch.html
+++ b/src/demos/calcite-switch.html
@@ -25,11 +25,11 @@
   <div>
     <label>
       <calcite-switch id="basicSwitch" switched="true"></calcite-switch>
-      Without a proxy <code>input</code> element.
+      Without a proxy <code>input</code> element and listening for "change"
       <script>
         var basicSwitch = document.getElementById("basicSwitch");
 
-        basicSwitch.addEventListener("calciteSwitchChange", function (
+        basicSwitch.addEventListener("change", function (
           e
         ) {
           console.log(
@@ -91,10 +91,10 @@
   <div class="demo-background-dark">
     <div>
       <label>
-        <calcite-switch theme="dark" id="basicSwitch" switched="true"></calcite-switch>
-        Without a proxy <code>input</code> element.
+        <calcite-switch theme="dark" id="basicSwitch2" switched="true"></calcite-switch>
+        Without a proxy <code>input</code> element and listening for "calciteSwitchChange".
         <script>
-          var basicSwitch = document.getElementById("basicSwitch");
+          var basicSwitch = document.getElementById("basicSwitch2");
 
           basicSwitch.addEventListener("calciteSwitchChange", function (
             e


### PR DESCRIPTION
Fix for https://github.com/Esri/calcite-components/issues/385 - had to explicitly emit the change event. cc @rslibed

@vcolavin can you give this a sanity check - should we "re-emit" native events like this (sorry, can't add as a reviewer)? 

There have been a few issues opened now around `calcite-switch`(https://github.com/Esri/calcite-components/issues/283) and I wonder how much has to do with the proxy / wrapped input stuff we are doing. 

@patrickarlt I know initially we were doing this to handle some specific Angular requirements - is this still a good methodology? Would we be able to simplify these components to disallow the wrapping of custom inputs, while we work towards a more holistic solution like seeing if https://github.com/ionic-team/stencil-ds-plugins works, or taking a stance that while in beta these are unsupported?

