### PR TITLE
🐞  fix radio-group in ie11

### DIFF
--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -3,7 +3,6 @@
   background-color: var(--calcite-ui-foreground);
   color: var(--calcite-ui-text-3);
   cursor: pointer;
-  padding: var(--calcite-radio-group-padding);
   line-height: 1.25;
   margin: 0.25rem -1px 0 0px;
   border: 1px solid var(--calcite-ui-border-1);
@@ -14,14 +13,17 @@
 
 :host([scale="s"]) {
   @include font-size(-3);
+  padding: 0.25rem 0.75rem;
 }
 
 :host([scale="m"]) {
   @include font-size(-1);
+  padding: 0.4rem 1rem;
 }
 
 :host([scale="l"]) {
   @include font-size(0);
+  padding: 0.5rem 1.5rem;
 }
 
 :host(:hover) {
@@ -35,7 +37,7 @@
 :host([checked]) {
   background-color: var(--calcite-ui-blue);
   border-color: var(--calcite-ui-blue);
-  color: var(--calcite-radio-group-text-color-active);
+  color: var(--calcite-ui-background);
   cursor: default;
 }
 

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -7,7 +7,8 @@ import {
   Element,
   Host,
   Watch,
-  Build
+  Build,
+  State
 } from "@stencil/core";
 import { getElementProp } from "../../utils/dom";
 @Component({
@@ -78,17 +79,21 @@ export class CalciteRadioGroupItem {
     this.mutationObserver.disconnect();
   }
 
+  componentDidLoad() {
+    // only use default slot content in browsers that support shadow dom
+    // or if ie11 has no label provided (#374)
+    const label = this.el.querySelector("label");
+    this.useFallback = !label || label.textContent === "";
+  }
+
   render() {
-    const { checked, value } = this;
+    const { checked, useFallback, value } = this;
     const scale = getElementProp(this.el, "scale", "m");
+
     return (
-      <Host
-        role="radio"
-        aria-checked={checked.toString()}
-        scale={scale}
-      >
+      <Host role="radio" aria-checked={checked.toString()} scale={scale}>
         <label>
-          <slot>{value}</slot>
+          <slot>{useFallback ? value : ""}</slot>
           <slot name="input" />
         </label>
       </Host>
@@ -109,6 +114,8 @@ export class CalciteRadioGroupItem {
   //  Private State/Props
   //
   //--------------------------------------------------------------------------
+  @State() private useFallback: boolean;
+
   private inputProxy: HTMLInputElement;
 
   private mutationObserver = this.getMutationObserver();
@@ -139,6 +146,10 @@ export class CalciteRadioGroupItem {
     }
 
     this.inputProxy.value = this.value;
-    this.inputProxy.toggleAttribute("checked", this.checked);
+    if (this.checked) {
+      this.inputProxy.setAttribute("checked", "true");
+    } else {
+      this.inputProxy.removeAttribute("checked");
+    }
   }
 }

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -1,23 +1,5 @@
 :host {
   display: flex;
-  --calcite-radio-group-text-color-active: #{$blk-000};
-  --calcite-radio-group-padding: 0.5rem 1rem;
-}
-
-:host([scale="s"]) {
-  --calcite-radio-group-padding: 0.25rem 0.75rem;
-}
-
-:host([scale="m"]) {
-  --calcite-radio-group-padding: 0.4rem 1rem;
-}
-
-:host([scale="l"]) {
-  --calcite-radio-group-padding: 0.5rem 1.5rem;
-}
-
-:host-context([theme="dark"]) {
-  --calcite-radio-group-text-color-active: #{$blk-230};
 }
 
 ::slotted(calcite-radio-group-item[checked]),


### PR DESCRIPTION
Multiple problems with this one:

1. using locally declared css vars from a parent in a child component
2. Using default slot content (it always showed up in ie11)
3. Using `toggleAttribute` method 

[#374]