### PR TITLE
Outline and Clear button style updates

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -6,12 +6,12 @@
   vertical-align: middle;
   --calcite-blue-accessible: #{$h-bb-070};
   --calcite-red-accessible: #{$h-rr-070};
-  --calcite-button-light: #{$blk-010};
-  --calcite-button-light-hover: #{$blk-000};
-  --calcite-button-light-press: #{$blk-020};
-  --calcite-button-dark: #{$blk-190};
-  --calcite-button-dark-hover: #{$blk-180};
-  --calcite-button-dark-press: #{$blk-200};
+  --calcite-button-light: #{$blk-020};
+  --calcite-button-light-hover: #{$blk-010};
+  --calcite-button-light-press: #{$blk-030};
+  --calcite-button-dark: #{$blk-180};
+  --calcite-button-dark-hover: #{$blk-170};
+  --calcite-button-dark-press: #{$blk-190};
   --calcite-button-blue-inline-underline: #{rgba($ui-blue, 0.2)};
   --calcite-button-red-inline-underline: #{rgba($ui-red, 0.2)};
   --calcite-button-blue-solid-color: #{$blk-000};
@@ -24,12 +24,12 @@
 :host-context([theme="dark"]) {
   --calcite-blue-accessible: #{$d-bb-420};
   --calcite-red-accessible: #{$d-rr-420};
-  --calcite-button-light: #{$blk-010};
-  --calcite-button-light-hover: #{$blk-020};
-  --calcite-button-light-press: #{$blk-000};
-  --calcite-button-dark: #{$blk-190};
-  --calcite-button-dark-hover: #{$blk-200};
-  --calcite-button-dark-press: #{$blk-180};
+  --calcite-button-light: #{$blk-020};
+  --calcite-button-light-hover: #{$blk-030};
+  --calcite-button-light-press: #{$blk-010};
+  --calcite-button-dark: #{$blk-180};
+  --calcite-button-dark-hover: #{$blk-190};
+  --calcite-button-dark-press: #{$blk-170};
   --calcite-button-blue-inline-underline: #{rgba($ui-blue-dark, 0.2)};
   --calcite-button-red-inline-underline: #{rgba($ui-red-dark, 0.2)};
   --calcite-button-blue-solid-color: #{$blk-230};
@@ -362,9 +362,9 @@
   a {
     @include btn-outline-clear(
       var(--calcite-ui-foreground),
-      $blk-010,
-      $blk-000,
       $blk-020,
+      $blk-010,
+      $blk-030,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-press)
     );
@@ -375,9 +375,9 @@
   a {
     @include btn-outline-clear(
       var(--calcite-ui-foreground),
-      $blk-200,
-      $blk-180,
-      $blk-220,
+      $blk-190,
+      $blk-170,
+      $blk-210,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-press)
     );
@@ -414,9 +414,9 @@
   a {
     @include btn-outline-clear(
       transparent,
-      $blk-010,
-      $blk-000,
       $blk-020,
+      $blk-010,
+      $blk-030,
       $blk-005,
       $blk-000
     );
@@ -427,9 +427,9 @@
   a {
     @include btn-outline-clear(
       transparent,
-      $blk-200,
-      $blk-180,
-      $blk-220,
+      $blk-190,
+      $blk-170,
+      $blk-210,
       $blk-220,
       $blk-220
     );
@@ -467,9 +467,9 @@
   a {
     @include btn-outline-clear-floating(
       var(--calcite-ui-foreground),
-      $blk-010,
-      $blk-000,
       $blk-020,
+      $blk-010,
+      $blk-030,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-press)
     );
@@ -480,9 +480,9 @@
   a {
     @include btn-outline-clear-floating(
       var(--calcite-ui-foreground),
-      $blk-200,
-      $blk-180,
-      $blk-220,
+      $blk-190,
+      $blk-170,
+      $blk-210,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-press)
     );
@@ -519,9 +519,9 @@
   a {
     @include btn-outline-clear-floating(
       transparent,
-      $blk-010,
-      $blk-000,
       $blk-020,
+      $blk-010,
+      $blk-030,
       $blk-005,
       $blk-000
     );
@@ -532,9 +532,9 @@
   a {
     @include btn-outline-clear-floating(
       transparent,
-      $blk-200,
-      $blk-180,
-      $blk-220,
+      $blk-190,
+      $blk-170,
+      $blk-210,
       $blk-220,
       $blk-220
     );

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -375,9 +375,9 @@
   a {
     @include btn-outline-clear(
       var(--calcite-ui-foreground),
+      $blk-180,
       $blk-190,
       $blk-170,
-      $blk-210,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-press)
     );
@@ -427,9 +427,9 @@
   a {
     @include btn-outline-clear(
       transparent,
+      $blk-180,
       $blk-190,
       $blk-170,
-      $blk-210,
       $blk-220,
       $blk-220
     );
@@ -480,9 +480,9 @@
   a {
     @include btn-outline-clear-floating(
       var(--calcite-ui-foreground),
+      $blk-180,
       $blk-190,
       $blk-170,
-      $blk-210,
       var(--calcite-button-outline-color),
       var(--calcite-button-outline-press)
     );
@@ -532,9 +532,9 @@
   a {
     @include btn-outline-clear-floating(
       transparent,
+      $blk-180,
       $blk-190,
       $blk-170,
-      $blk-210,
       $blk-220,
       $blk-220
     );

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -16,7 +16,6 @@
   --calcite-button-red-inline-underline: #{rgba($ui-red, 0.2)};
   --calcite-button-blue-solid-color: #{$blk-000};
   --calcite-button-red-solid-color: #{$blk-000};
-  --calcite-button-outline-background: #{$blk-000};
   --calcite-button-outline-color: #{$blk-230};
   --calcite-button-outline-color-press: #{$blk-230};
 }
@@ -35,7 +34,6 @@
   --calcite-button-red-inline-underline: #{rgba($ui-red-dark, 0.2)};
   --calcite-button-blue-solid-color: #{$blk-230};
   --calcite-button-red-solid-color: #{$blk-230};
-  --calcite-button-outline-background: #{$blk-220};
   --calcite-button-outline-color: #{$blk-000};
   --calcite-button-outline-color-press: #{$blk-000};
 }
@@ -280,7 +278,7 @@
   border: 1px solid $border-color;
   box-shadow: inset 0 0 0 1px transparent;
   &:hover {
-    border-color: 1px solid $border-color;
+    border-color: $border-color;
     box-shadow: inset 0 0 0 1px $border-color;
   }
   &:active,
@@ -337,7 +335,7 @@
   button,
   a {
     @include btn-outline-clear(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       var(--calcite-blue-accessible),
       var(--calcite-ui-blue-hover),
       var(--calcite-ui-blue-press),
@@ -350,7 +348,7 @@
   button,
   a {
     @include btn-outline-clear(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       var(--calcite-red-accessible),
       var(--calcite-ui-red-hover),
       var(--calcite-ui-red-press),
@@ -363,7 +361,7 @@
   button,
   a {
     @include btn-outline-clear(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       $blk-010,
       $blk-000,
       $blk-020,
@@ -376,7 +374,7 @@
   button,
   a {
     @include btn-outline-clear(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       $blk-200,
       $blk-180,
       $blk-220,
@@ -442,7 +440,7 @@
   button,
   a {
     @include btn-outline-clear-floating(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       var(--calcite-blue-accessible),
       var(--calcite-ui-blue-hover),
       var(--calcite-ui-blue-press),
@@ -455,7 +453,7 @@
   button,
   a {
     @include btn-outline-clear-floating(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       var(--calcite-red-accessible),
       var(--calcite-ui-red-hover),
       var(--calcite-ui-red-press),
@@ -468,7 +466,7 @@
   button,
   a {
     @include btn-outline-clear-floating(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       $blk-010,
       $blk-000,
       $blk-020,
@@ -481,7 +479,7 @@
   button,
   a {
     @include btn-outline-clear-floating(
-      var(--calcite-button-outline-background),
+      var(--calcite-ui-foreground),
       $blk-200,
       $blk-180,
       $blk-220,

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -178,29 +178,6 @@
   </div>
 
 
-  <h3>Type: Outline</h3>
-  <calcite-button title="blue outline button" appearance='outline'>blue outline button</calcite-button>
-  <calcite-button title="red outline button" appearance='outline' color='red'>red outline button</calcite-button>
-  <calcite-button title="light outline button" appearance='outline' color='light'>light outline button
-  </calcite-button>
-  <calcite-button title="dark outline button" appearance='outline' color='dark'>dark outline button
-  </calcite-button>
-  <br />
-  <br />
-  <h5>Theme="dark" on blue /red (no effect on light / dark except outline)</h5>
-  <div class="demo-background-dark">
-    <calcite-button theme="dark" title="blue outline button" appearance='outline'>blue outline button
-    </calcite-button>
-    <calcite-button theme="dark" title="red outline button" appearance='outline' color='red'>red outline button
-    </calcite-button>
-    <calcite-button theme="dark" title="light outline button" appearance='outline' color='light'>light outline
-      button
-    </calcite-button>
-    <calcite-button theme="dark" title="dark outline button" appearance='outline' color='dark'>dark outline button
-    </calcite-button>
-  </div>
-
-
   <h3>Type: Clear</h3>
   <calcite-button title="blue clear button" appearance='clear'>blue clear button</calcite-button>
   <calcite-button title="red clear button" appearance='clear' color='red'>red clear button</calcite-button>

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -15,7 +15,7 @@
     }
 
     .demo-background-dark {
-      background: #202020;
+      background: #2b2b2b;
       color: white;
       padding: 1rem;
     }

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -178,24 +178,6 @@
   </div>
 
 
-  <h3>Type: Clear</h3>
-  <calcite-button title="blue clear button" appearance='clear'>blue clear button</calcite-button>
-  <calcite-button title="red clear button" appearance='clear' color='red'>red clear button</calcite-button>
-
-  <calcite-button title="light clear button" appearance='clear' color='light'>light clear button</calcite-button>
-  <calcite-button title="dark clear button" appearance='clear' color='dark'>dark clear button</calcite-button>
-  <br />
-  <br />
-  <h5>Theme="dark" on blue /red (no effect on light / dark)</h5>
-  <div class="demo-background-dark">
-    <calcite-button theme="dark" title="blue clear button" appearance='clear'>blue clear button</calcite-button>
-    <calcite-button theme="dark" title="red clear button" appearance='clear' color='red'>red clear button
-    </calcite-button>
-    <calcite-button title="light clear button" appearance='clear' color='light'>light clear button
-    </calcite-button>
-    <calcite-button title="dark clear button" appearance='clear' color='dark'>dark clear button</calcite-button>
-  </div>
-
   <h3>Type: Outline</h3>
   <calcite-button title="blue outline button" appearance='outline'>blue outline button</calcite-button>
   <calcite-button title="red outline button" appearance='outline' color='red'>red outline button</calcite-button>
@@ -217,6 +199,25 @@
     <calcite-button theme="dark" title="dark outline button" appearance='outline' color='dark'>dark outline button
     </calcite-button>
   </div>
+
+  <h3>Type: Clear</h3>
+  <calcite-button title="blue clear button" appearance='clear'>blue clear button</calcite-button>
+  <calcite-button title="red clear button" appearance='clear' color='red'>red clear button</calcite-button>
+
+  <calcite-button title="light clear button" appearance='clear' color='light'>light clear button</calcite-button>
+  <calcite-button title="dark clear button" appearance='clear' color='dark'>dark clear button</calcite-button>
+  <br />
+  <br />
+  <h5>Theme="dark" on blue /red (no effect on light / dark)</h5>
+  <div class="demo-background-dark">
+    <calcite-button theme="dark" title="blue clear button" appearance='clear'>blue clear button</calcite-button>
+    <calcite-button theme="dark" title="red clear button" appearance='clear' color='red'>red clear button
+    </calcite-button>
+    <calcite-button title="light clear button" appearance='clear' color='light'>light clear button
+    </calcite-button>
+    <calcite-button title="dark clear button" appearance='clear' color='dark'>dark clear button</calcite-button>
+  </div>
+
 
   <h3>Type: Transparent</h3>
   <calcite-button title="blue transparent button" appearance='transparent' icon='circle'>


### PR DESCRIPTION
- demo page: dark theme bg color sample was wrong. Updated to 2b2b2b.
- outline buttons use calcite-ui-foreground(-dark) as background
- adjusted outline light/dark solid buttons (they no longer blend
with background on hover)
- updates to dark buttons border outline/clear: borders no longer blend
with background on hover