### PR TITLE
fix dark theme in calcite-tree in ie11

### DIFF
--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -1,5 +1,6 @@
 @import "./node_modules/@esri/calcite-colors/colors.scss";
 @import "./node_modules/@esri/calcite-base/dist/_index.scss";
+@import "./themes";
 @import "_popper";
 
 @mixin slotted($selector, $tag, $scope: "") {

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -1,3 +1,8 @@
+:host-context([theme="dark"]) {
+  @include calcite-dark-theme();
+}
+
+
 :host {
   display: block;
   color: var(--calcite-tree-text);


### PR DESCRIPTION
Forgot this part, this fixes the colors for dark theme in ie11