### PR TITLE
🐞Fix tabs in ie11

### DIFF
--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -35,11 +35,7 @@ export class CalciteRadioGroupItem {
   /**
    * Indicates whether the control is checked.
    */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  checked = false;
+  @Prop({ reflect: true, mutable: true }) checked = false;
 
   @Watch("checked")
   protected handleCheckedChange(): void {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -41,7 +41,7 @@ export class CalciteSlider {
   //
   //--------------------------------------------------------------------------
   /** Select theme (light or dark) */
-  @Prop({ reflectToAttr: true }) theme: "light" | "dark";
+  @Prop({ reflect: true }) theme: "light" | "dark";
   /** Disable and gray out the slider */
   @Prop({ reflect: true, mutable: true }) disabled: boolean = false;
   /** Minimum selectable value */

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -1,15 +1,9 @@
 .tab-nav {
   display: flex;
-  justify-content: var(--calcite-tabs-layout);
   overflow: auto;
+  justify-content: flex-start;
 }
 
-::slotted(calcite-tab-title) {
-  margin-right: var(--calcite-tabs-tab-margin-start);
-  margin-left: var(--calcite-tabs-tab-margin-end);
-}
-
-:host-context([dir="rtl"]) ::slotted(calcite-tab-title) {
-  margin-right: var(--calcite-tabs-tab-margin-end);
-  margin-left: var(--calcite-tabs-tab-margin-start);
+:host([layout="center"]) .tab-nav {
+  justify-content: center;
 }

--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -43,6 +43,9 @@ export class CalciteTabNav {
    */
   @Prop() syncId: string;
 
+  /** @internal Parent tabs component layout value */
+  @Prop({ reflect: true, mutable: true }) layout: "center" | "inline";
+
   /**
    * @internal
    */
@@ -84,6 +87,10 @@ export class CalciteTabNav {
         tab: this.selectedTab
       });
     }
+  }
+
+  componentWillRender() {
+    this.layout = this.el.closest("calcite-tabs")?.layout;
   }
 
   render() {

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -1,6 +1,27 @@
+$tab-margin: 1.25rem;
+
 :host {
-  flex: 0 1 var(--calcite-tabs-tab-basis);
+  flex: 0 1 auto;
   outline: none;
+  margin-right: $tab-margin;
+  margin-inline-start: 0;
+  margin-inline-end: $tab-margin;
+}
+
+// only ie11 and chrome will run this, others have logical properties
+:host-context([dir="rtl"]) {
+  margin-right: 0;
+  margin-left: $tab-margin;
+}
+
+:host-context([theme="dark"]){
+  @include calcite-theme-dark();
+}
+
+:host([layout="center"]) {
+  flex-basis: 200px;
+  text-align: center;
+  margin: 0 $tab-margin;
 }
 
 :host(:active),
@@ -34,5 +55,4 @@ a {
   outline: none;
   width: 100%;
   display: block;
-  text-align: var(--calcite-tabs-tab-text-align);
 }

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -39,21 +39,13 @@ export class CalciteTabTitle {
    * Optionally include a unique name for the tab title,
    * be sure to also set this name on the associated tab.
    */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  tab?: string;
+  @Prop({ reflect: true, mutable: true }) tab?: string;
 
-  /**
-   * Show this tab title as selected
-   */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  isActive: boolean = false;
+  /** Show this tab title as selected */
+  @Prop({ reflect: true, mutable: true }) isActive: boolean = false;
 
+  /** @internal Parent tabs component layout value */
+  @Prop({ reflect: true, mutable: true }) layout: "center" | "inline";
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -66,6 +58,10 @@ export class CalciteTabTitle {
         tab: this.tab
       });
     }
+  }
+
+  componentWillRender() {
+    this.layout = this.el.closest("calcite-tabs")?.layout;
   }
 
   render() {

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -40,7 +40,7 @@ export class CalciteTabTitle {
    * be sure to also set this name on the associated tab.
    */
   @Prop({
-    reflectToAttr: true,
+    reflect: true,
     mutable: true
   })
   tab?: string;
@@ -49,7 +49,7 @@ export class CalciteTabTitle {
    * Show this tab title as selected
    */
   @Prop({
-    reflectToAttr: true,
+    reflect: true,
     mutable: true
   })
   isActive: boolean = false;

--- a/src/components/calcite-tab/calcite-tab.tsx
+++ b/src/components/calcite-tab/calcite-tab.tsx
@@ -39,7 +39,7 @@ export class CalciteTab {
    * be sure to also set this name on the associated title.
    */
   @Prop({
-    reflectToAttr: true,
+    reflect: true,
     mutable: true
   })
   tab: string;
@@ -48,7 +48,7 @@ export class CalciteTab {
    * Show this tab
    */
   @Prop({
-    reflectToAttr: true,
+    reflect: true,
     mutable: true
   })
   isActive: boolean = false;

--- a/src/components/calcite-tab/calcite-tab.tsx
+++ b/src/components/calcite-tab/calcite-tab.tsx
@@ -38,20 +38,12 @@ export class CalciteTab {
    * Optionally include a unique name for this tab,
    * be sure to also set this name on the associated title.
    */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  tab: string;
+  @Prop({ reflect: true, mutable: true }) tab: string;
 
   /**
    * Show this tab
    */
-  @Prop({
-    reflect: true,
-    mutable: true
-  })
-  isActive: boolean = false;
+  @Prop({ reflect: true, mutable: true }) isActive: boolean = false;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -1,25 +1,6 @@
 :host {
   display: flex;
   flex-direction: column;
-
-  --calcite-tabs-layout: flex-start;
-  --calcite-tabs-tab-basis: auto;
-  --calcite-tabs-tab-text-align: start;
-  --calcite-tabs-tab-margin-start: 1.25rem;
-  --calcite-tabs-tab-margin-end: 0;
-}
-
-:host-context([dir="rtl"]) {
-  --calcite-tabs-tab-margin-start: 0;
-  --calcite-tabs-tab-margin-end: 1.25rem;
-}
-
-:host([layout="center"]) {
-  --calcite-tabs-layout: center;
-  --calcite-tabs-tab-basis: 200px;
-  --calcite-tabs-tab-text-align: center;
-  --calcite-tabs-tab-margin-start: 1.25rem;
-  --calcite-tabs-tab-margin-end: 1.25rem;
 }
 
 section {

--- a/src/components/calcite-tabs/calcite-tabs.tsx
+++ b/src/components/calcite-tabs/calcite-tabs.tsx
@@ -32,7 +32,7 @@ export class CalciteTabs {
    * Select theme (light or dark)
    */
   @Prop({
-    reflectToAttr: true
+    reflect: true
   })
   theme: "light" | "dark";
 
@@ -40,7 +40,7 @@ export class CalciteTabs {
    * Align tab titles to the edge or fully justify them across the tab nav ("center")
    */
   @Prop({
-    reflectToAttr: true
+    reflect: true
   })
   layout: "center" | "inline" = "inline";
 
@@ -51,7 +51,6 @@ export class CalciteTabs {
   //--------------------------------------------------------------------------
 
   render() {
-
     return (
       <Host>
         <slot name="tab-nav" />

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -214,15 +214,35 @@
     <calcite-tab>Tab 4 Content</calcite-tab>
   </calcite-tabs>
 
+  <h1 class="leader-1">Centered RTL</h1>
+
+  <calcite-tabs layout="center" dir="rtl">
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab is-active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+    <calcite-tab>Tab 5 Content</calcite-tab>
+    <calcite-tab>Tab 6 Content</calcite-tab>
+  </calcite-tabs>
+
   <h1 class="leader-1">Custom Colors</h1>
 
   <style>
     calcite-tabs.green {
-      --calcite-tabs-border-active: #338033;
+      --calcite-ui-blue-1: #338033;
     }
 
     calcite-tabs[theme="dark"].green {
-      --calcite-tabs-border-active: #5a9359;
+      --calcite-ui-blue-1: #5a9359;
     }
   </style>
   <calcite-tabs class="green">


### PR DESCRIPTION
#377 - updates tabs so that they work on ie11. 

Basically the strategy of setting a whole bunch of vars on a parent component is a non-starter for ie11. What I've been doing is using `.closest` to find the anscestor with the set attribute and then cloning that to the child host pre-render. I've been making these un-documented (`@internal`) props so they don't show up in storybook or anything.