### PR TITLE
feat(dropdown): focus on active item when opened

### DIFF
--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -5,12 +5,12 @@ import {
   EventEmitter,
   h,
   Host,
-  Prop
+  Prop,
+  VNode
 } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { ENTER, SPACE } from "../../utils/keys";
 import { getElementDir } from "../../utils/dom";
-import { VNode } from "@stencil/core";
 
 /**
  * @slot thumbnail - A slot for adding a thumnail to the card.

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.e2e.ts
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.e2e.ts
@@ -1,11 +1,19 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { renders } from "../../tests/commonTests";
 
-describe("calcite-dropdown", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+describe("calcite-dropdown-item", () => {
+  it("renders", () => renders("calcite-dropdown-item"));
 
-    await page.setContent("<calcite-dropdown></calcite-dropdown>");
-    const element = await page.find("calcite-dropdown");
-    expect(element).toHaveClass("hydrated");
+  it("can be focused", async () => {
+    const page = await newE2EPage({
+      html: "<calcite-dropdown-item></calcite-dropdown-item>"
+    });
+    const element = await page.find("calcite-dropdown-item");
+
+    await element.callMethod("setFocus");
+
+    expect(await page.evaluate(() => document.activeElement.tagName)).toEqual(
+      "CALCITE-DROPDOWN-ITEM"
+    );
   });
 });

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -6,6 +6,7 @@ import {
   h,
   Host,
   Listen,
+  Method,
   Prop
 } from "@stencil/core";
 import {
@@ -65,6 +66,18 @@ export class CalciteDropdownItem {
 
   //--------------------------------------------------------------------------
   //
+  //  Public Methods
+  //
+  //--------------------------------------------------------------------------
+
+  /** Focuses the selected item. */
+  @Method()
+  async setFocus(): Promise<void> {
+    this.el.focus();
+  }
+
+  //--------------------------------------------------------------------------
+  //
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
@@ -85,14 +98,14 @@ export class CalciteDropdownItem {
         class="dropdown-item-icon-start"
         icon={this.iconStart}
         scale={iconScale}
-      ></calcite-icon>
+      />
     );
     const iconEndEl = (
       <calcite-icon
         class="dropdown-item-icon-end"
         icon={this.iconEnd}
         scale={iconScale}
-      ></calcite-icon>
+      />
     );
 
     const slottedContent =
@@ -113,7 +126,6 @@ export class CalciteDropdownItem {
     );
     return (
       <Host
-
         tabindex="0"
         role="menuitem"
         selection-mode={this.selectionMode}

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -26,6 +26,19 @@
 | `registerCalciteDropdownItem`  |             | `CustomEvent<any>` |
 
 
+## Methods
+
+### `setFocus() => Promise<void>`
+
+Focuses the selected item.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Dependencies
 
 ### Depends on

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -242,11 +242,17 @@ describe("calcite-dropdown", () => {
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
     expect(group1).toEqualAttribute("selection-mode", "multi");
     await trigger.click();
+    await page.waitForChanges();
     await item1.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item2.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item3.click();
+    await page.waitForChanges();
     expect(item1).toHaveAttribute("active");
     expect(item2).not.toHaveAttribute("active");
     expect(item3).toHaveAttribute("active");
@@ -278,9 +284,14 @@ describe("calcite-dropdown", () => {
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
     expect(group1).toEqualAttribute("selection-mode", "single");
     await trigger.click();
+    await page.waitForChanges();
     await item1.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item3.click();
+    await page.waitForChanges();
+
     expect(item1).not.toHaveAttribute("active");
     expect(item2).not.toHaveAttribute("active");
     expect(item3).toHaveAttribute("active");
@@ -382,18 +393,31 @@ describe("calcite-dropdown", () => {
     expect(group3).toEqualAttribute("selection-mode", "none");
 
     await trigger.click();
+    await page.waitForChanges();
     await item1.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item2.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item3.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item4.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item6.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item7.click();
+    await page.waitForChanges();
     await trigger.click();
+    await page.waitForChanges();
     await item9.click();
     await page.waitForChanges();
 
@@ -431,5 +455,127 @@ describe("calcite-dropdown", () => {
     expect(elementAsLink).toEqualAttribute("href", "google.com");
     expect(elementAsLink).toEqualAttribute("rel", "noopener noreferrer");
     expect(elementAsLink).toEqualAttribute("target", "_blank");
+  });
+
+  it("should focus the first item on open when there is none", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-dropdown>
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group>
+      <calcite-dropdown-item id="1">1</calcite-dropdown-item>
+      <calcite-dropdown-item id="2">2</calcite-dropdown-item>
+      <calcite-dropdown-item id="3">3</calcite-dropdown-item>
+      <calcite-dropdown-item id="4">4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+      </calcite-dropdown>`
+    });
+
+    const element = await page.find("calcite-dropdown");
+    await element.click();
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("1");
+  });
+
+  it("should focus the first active item on open", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-dropdown>
+        <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+        <calcite-dropdown-group>
+          <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-3" active>3</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>`
+    });
+
+    const element = await page.find("calcite-dropdown");
+    await element.click();
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-3");
+  });
+
+  it("should focus the first active item on open", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-dropdown>
+        <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+        <calcite-dropdown-group selection-mode="multi">
+          <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-2" active>2</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-4" active>4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>`
+    });
+
+    const element = await page.find("calcite-dropdown");
+    await element.click();
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-2");
+  });
+
+  // unskip when stencil is upgraded to >= 1.11.2
+  it.skip("focused item should be in view when long", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-dropdown>
+      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+      <calcite-dropdown-group>
+        <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-11">11</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-12">12</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-13">13</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-14">14</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-15">15</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-16">16</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-17">17</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-18">18</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-19">19</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-20">20</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-21">21</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-22">22</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-23">23</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-24">24</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-25">25</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-26">26</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-27">27</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-28">28</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-29">29</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-30">30</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-41">41</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-42">42</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-43">43</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-44">44</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-45">45</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-46">46</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-47">47</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-48">48</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-49">49</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-50" active>50</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>`);
+    await page.waitForChanges();
+
+    const element = await page.find("calcite-dropdown");
+    await element.click();
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-50");
+
+    const item = await page.find("#item-50");
+
+    expect(await item.isIntersectingViewport()).toBe(true);
   });
 });

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -61,7 +61,7 @@
 
 :host .calcite-dropdown-wrapper {
   transform: translate3d(0, -$baseline, 0);
-  transition: all 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out, max-height 0.15s;
   visibility: hidden;
   opacity: 0;
   display: block;

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -53,7 +53,8 @@
 :host([active]) .calcite-dropdown-wrapper {
   transform: translate3d(0, 0, 0);
   opacity: 1;
-  max-height: 100vh;
+  max-height: 90vh;
+  overflow-y: auto;
   visibility: visible;
   pointer-events: initial;
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -281,7 +281,9 @@ export class CalciteDropdown {
     this.active = !this.active;
     const animationDelayInMs = 50;
 
-    setTimeout(() => this.focusOnFirstActiveOrFirstItem(), animationDelayInMs);
+    if (this.active) {
+      setTimeout(() => this.focusOnFirstActiveOrFirstItem(), animationDelayInMs);
+    }
   }
 
   private sortItems = (items: any[]): any[] =>

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -1,16 +1,23 @@
-import { Component, Element, h, Host, Listen, Prop } from "@stencil/core";
 import {
-  UP,
+  Component,
+  Element,
+  h,
+  Host,
+  Listen,
+  Prop,
+} from "@stencil/core";
+import {
   DOWN,
-  TAB,
+  END,
   ENTER,
   ESCAPE,
   HOME,
-  END,
-  SPACE
+  SPACE,
+  TAB,
+  UP
 } from "../../utils/keys";
 
-import { guid } from "../../utils/guid";
+import { focusElement } from "../../utils/dom";
 
 @Component({
   tag: "calcite-dropdown",
@@ -83,14 +90,13 @@ export class CalciteDropdown {
   }
 
   render() {
-    const expanded = this.active.toString();
     return (
-      <Host active={this.active} id={this.dropdownId}>
+      <Host>
         <slot
           name="dropdown-trigger"
           aria-haspopup="true"
-          aria-expanded={expanded}
-        ></slot>
+          aria-expanded={this.active.toString()}
+        />
         <div class="calcite-dropdown-wrapper" role="menu">
           <slot />
         </div>
@@ -106,13 +112,13 @@ export class CalciteDropdown {
 
   @Listen("click") openDropdown(e) {
     if (e.target.getAttribute("slot") === "dropdown-trigger") {
-      this.openCalciteDropdown(e);
+      this.openCalciteDropdown();
       e.preventDefault();
     }
   }
 
   @Listen("click", { target: "window" }) closeCalciteDropdownOnClick(e) {
-    if (this.active && e.target.offsetParent.id !== this.dropdownId)
+    if (this.active && e.target.offsetParent !== this.el)
       this.closeCalciteDropdown();
   }
 
@@ -129,7 +135,7 @@ export class CalciteDropdown {
         switch (e.keyCode) {
           case SPACE:
           case ENTER:
-            this.openCalciteDropdown(e);
+            this.openCalciteDropdown();
             break;
           case ESCAPE:
             this.closeCalciteDropdown();
@@ -141,9 +147,9 @@ export class CalciteDropdown {
     }
   }
 
-  @Listen("mouseenter") mouseoverHandler(e) {
+  @Listen("mouseenter") mouseoverHandler() {
     if (this.type === "hover") {
-      this.openCalciteDropdown(e);
+      this.openCalciteDropdown();
     }
   }
 
@@ -216,10 +222,6 @@ export class CalciteDropdown {
   /** keep track of whether the groups have been sorted so we don't re-sort */
   private sorted = false;
 
-  /** unique id for dropdown */
-  /** @internal */
-  private dropdownId = `calcite-dropdown-${guid()}`;
-
   //--------------------------------------------------------------------------
   //
   //  Private Methods
@@ -229,6 +231,12 @@ export class CalciteDropdown {
   private closeCalciteDropdown() {
     this.active = false;
     this.trigger.focus();
+  }
+
+  private focusOnFirstActiveOrFirstItem(): void {
+    this.getFocusableElement(
+      this.items.find(item => item.active) || this.items[0]
+    );
   }
 
   private focusFirstItem() {
@@ -257,24 +265,30 @@ export class CalciteDropdown {
     return this.items.indexOf(e);
   }
 
-  private getFocusableElement(item) {
-    const target =
-      item && item.attributes.isLink
-        ? item.shadowRoot.querySelector("a")
-        : (item as HTMLCalciteDropdownItemElement);
-    target.focus();
+  private getFocusableElement(item): void {
+    if (!item) {
+      return;
+    }
+
+    const target = item.attributes.isLink
+      ? item.shadowRoot.querySelector("a")
+      : (item as HTMLCalciteDropdownItemElement);
+
+    focusElement(target);
   }
 
-  private openCalciteDropdown(e) {
+  private openCalciteDropdown() {
     this.active = !this.active;
-    // if invoked by key, focus item, and accomodate animation time
-    if (!e.detail && e.type !== "mouseenter") {
-      setTimeout(() => this.focusFirstItem(), 50);
-    }
+    const animationDelayInMs = 50;
+
+    setTimeout(() => this.focusOnFirstActiveOrFirstItem(), animationDelayInMs);
   }
 
   private sortItems = (items: any[]): any[] =>
     items
       .sort((a, b) => a.position - b.position)
-      .concat.apply([], this.items.map(item => item.items));
+      .concat.apply(
+        [],
+        this.items.map(item => item.items)
+      );
 }

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -280,6 +280,41 @@
       </calcite-dropdown-group>
     </calcite-dropdown>
   </div>
+
+  <h3>Long dropdown content should allow scrolling</h3>
+
+  <calcite-dropdown>
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group>
+      <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-11">11</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-12">12</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-13">13</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-14">14</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-15">15</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-16">16</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-17">17</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-18">18</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-19">19</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-20">20</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-21">21</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-22">22</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-23">23</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-24">24</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-25" active>25</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+
+
 </body>
 
 </html>

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -20,6 +20,18 @@ export function getElementProp(el: HTMLElement, prop, value) {
   return closestWithProp ? closestWithProp.getAttribute(prop) : value;
 }
 
+export interface CalciteFocusableElement extends HTMLElement {
+  setFocus?: () => void;
+}
+
+export function focusElement(el: CalciteFocusableElement): void {
+  if (!el) {
+    return;
+  }
+
+  typeof el.setFocus === "function" ? el.setFocus() : el.focus();
+}
+
 export function hasSlottedContent(el: HTMLSlotElement) {
   const assignedNodes = el && el.assignedNodes();
   return assignedNodes && assignedNodes.length > 0;


### PR DESCRIPTION
Related issue: #396 

This adds the following enhancements to the dropdown: 

* Focuses the first active item or first one if there's none.
* Enables scrolling for long list of items.
* Fixes item focusing (it wasn't working before).
* Adds utility to help focus components or native elements.
* Fixes some tests and typings.
* Minor cleanup.

cc @dhrumil83