### PR TITLE
IE 11 Dropdown style fixes

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -1,3 +1,21 @@
+// ie11 theme
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
+// ie11
+:host-context([scale="s"]) {
+  --calcite-dropdown-group-padding: #{$baseline/3 0};
+}
+
+:host-context([scale="m"]) {
+  --calcite-dropdown-group-padding: #{$baseline/2 0};
+}
+
+:host-context([scale="l"]) {
+  --calcite-dropdown-group-padding: #{$baseline/1.5 0};
+}
+
 :host .dropdown-title {
   display: block;
   margin: 0 $baseline/1.5 -1px $baseline/1.5;

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -1,3 +1,39 @@
+// ie11 theme
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
+// ie11
+:host-context([scale="s"]) {
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5
+    $baseline * 1.5};
+}
+
+:host-context([scale="m"]) {
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3
+    $baseline * 1.5};
+}
+
+:host-context([scale="l"]) {
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2
+    $baseline * 1.5};
+}
+
+:host-context([dir="rtl"][scale="s"]) {
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5
+    $baseline/1.5};
+}
+
+:host-context([dir="rtl"][scale="m"]) {
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3
+    $baseline / 1.5};
+}
+
+:host-context([dir="rtl"][scale="l"]) {
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2
+    $baseline / 1.5};
+}
+
 @mixin itemStyling {
   display: flex;
   flex-grow: 1;


### PR DESCRIPTION
Fixes for IE11 dropdown... preferring the duplication of CSS vars in each nested child file to setting the scale and dir and theme explicitly on the component host in the .tsx file... Neither is really nice