### PR TITLE
IE 11 Accordion style fixes

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -1,3 +1,66 @@
+//ie11 fixes
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
+// scale variants for child
+:host-context([scale="s"]) {
+  --calcite-accordion-item-spacing-unit: #{$baseline/3};
+  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
+    var(--calcite-accordion-item-spacing-unit);
+  @include font-size(-3);
+}
+
+:host-context([scale="m"]) {
+  --calcite-accordion-item-spacing-unit: #{$baseline/2};
+  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
+    var(--calcite-accordion-item-spacing-unit);
+  @include font-size(-2);
+}
+
+:host-context([scale="l"]) {
+  --calcite-accordion-item-spacing-unit: #{$baseline};
+  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
+    var(--calcite-accordion-item-spacing-unit);
+  @include font-size(-1);
+}
+
+// icon position variants for child
+:host-context([icon-position="start"]) {
+  --calcite-accordion-item-flex-direction: row-reverse;
+  --calcite-accordion-item-icon-rotation: 90deg;
+  --calcite-accordion-item-active-icon-rotation: 180deg;
+  --calcite-accordion-item-icon-rotation-rtl: -90deg;
+  --calcite-accordion-item-active-icon-rotation-rtl: -180deg;
+  --calcite-accordion-item-icon-spacing-start: 0;
+  --calcite-accordion-item-icon-spacing-end: var(
+    --calcite-accordion-item-spacing-unit
+  );
+}
+:host-context([icon-position="end"]) {
+  --calcite-accordion-item-flex-direction: row;
+  --calcite-accordion-item-icon-rotation: -90deg;
+  --calcite-accordion-item-active-icon-rotation: -180deg;
+  --calcite-accordion-item-icon-rotation-rtl: 90deg;
+  --calcite-accordion-item-active-icon-rotation-rtl: 180deg;
+  --calcite-accordion-item-icon-spacing-start: var(
+    --calcite-accordion-item-spacing-unit
+  );
+  --calcite-accordion-item-icon-spacing-end: 0;
+}
+
+:host {
+  --calcite-accordion-item-background: var(--calcite-ui-foreground-1);
+}
+
+:host-context([appearance="minimal"]) {
+  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
+}
+
+:host-context([appearance="transparent"]) {
+  --calcite-accordion-item-border: transparent;
+  --calcite-accordion-item-background: transparent;
+}
 :host {
   display: flex;
   flex-direction: column;
@@ -7,6 +70,7 @@
   text-decoration: none;
   outline: none;
   position: relative;
+  --calcite-accordion-item-border: var(--calcite-ui-border-2);
 }
 
 :host([active]) {
@@ -54,7 +118,7 @@
   transform: rotate(var(--calcite-accordion-item-icon-rotation));
 }
 
-:host-context([dir="rtl"]) .accordion-item-icon {
+:host([dir="rtl"]) .accordion-item-icon {
   margin-left: var(--calcite-accordion-item-icon-spacing-end);
   margin-right: var(--calcite-accordion-item-icon-spacing-start);
   transform: rotate(var(--calcite-accordion-item-icon-rotation-rtl));
@@ -72,10 +136,11 @@
 :host .accordion-item-header-text {
   margin-right: auto;
   flex-direction: column;
+  flex: 1;
   text-align: initial;
 }
 
-:host-context([dir="rtl"]) .accordion-item-header-text {
+:host([dir="rtl"]) .accordion-item-header-text {
   margin-left: auto;
   margin-right: 0;
 }
@@ -91,7 +156,7 @@
 :host .accordion-item-subtitle {
   color: var(--calcite-ui-text-3);
 }
-:host-context([dir="rtl"]) .accordion-item-title {
+:host([dir="rtl"]) .accordion-item-title {
   margin-right: 0;
   margin-left: auto;
 }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -9,7 +9,7 @@ import {
   Prop
 } from "@stencil/core";
 import { UP, DOWN, ENTER, HOME, END, SPACE } from "../../utils/keys";
-import { getElementProp } from "../../utils/dom";
+import { getElementDir, getElementProp } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 
 @Component({
@@ -64,13 +64,13 @@ export class CalciteAccordionItem {
   }
 
   render() {
-
+    const dir = getElementDir(this.el);
     return (
-      <Host tabindex="0" aria-expanded={this.active.toString()}>
+      <Host tabindex="0" aria-expanded={this.active.toString()} dir={dir}>
         <div class="accordion-item-header" onClick={this.itemHeaderClickHander}>
           <div class="accordion-item-header-text">
-          <span class="accordion-item-title">{this.itemTitle}</span>
-          <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
+            <span class="accordion-item-title">{this.itemTitle}</span>
+            <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
           </div>
           <calcite-icon
             class="accordion-item-icon"


### PR DESCRIPTION
Similar to https://github.com/Esri/calcite-components/pull/423 - fixes IE11 by doubling up on variables with host-context and explicitly re-including the theme variables for nested child component. Re-adds Dir to `host` as well.