### PR TITLE
fix(icon): always render in the target scale to avoid shifts in layout

### DIFF
--- a/src/components/calcite-icon/calcite-icon.e2e.ts
+++ b/src/components/calcite-icon/calcite-icon.e2e.ts
@@ -69,18 +69,6 @@ describe("calcite-icon", () => {
       expect(await path.getAttribute("d")).toBe(iconPathData);
     });
 
-    it("it does not render SVG for invalid icons", async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        `<calcite-icon icon="this-does-not-exist"></calcite-icon>`
-      );
-      await page.waitForChanges();
-
-      let svg = await page.find(`calcite-icon >>> svg`);
-
-      expect(svg).toBeNull();
-    });
-
     it("loads icon when it's close to viewport", async () => {
       const page = await newE2EPage();
       await page.setContent(
@@ -88,17 +76,13 @@ describe("calcite-icon", () => {
       );
       await page.waitForChanges();
 
-      const iconPathSelector = `calcite-icon >>> path`;
-
       const icon = await page.find(`calcite-icon`);
-      let path = await page.find(iconPathSelector);
+      let path = await page.find(`calcite-icon >>> path`);
 
-      expect(path).toBeNull();
+      expect(await path.getAttribute("d")).toBeNull();
 
       icon.setProperty("style", null);
       await page.waitForChanges();
-
-      path = await page.find(iconPathSelector);
 
       expect(await path.getAttribute("d")).toBeTruthy();
     });

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -6,7 +6,7 @@ import {
   Host,
   Prop,
   State,
-  Watch
+  Watch,
 } from "@stencil/core";
 import { CSS } from "./resources";
 import { getElementDir } from "../../utils/dom";
@@ -18,7 +18,7 @@ import { Theme } from "../../interfaces/common";
   assetsDirs: ["assets"],
   tag: "calcite-icon",
   styleUrl: "calcite-icon.scss",
-  shadow: true
+  shadow: true,
 })
 export class CalciteIcon {
   //--------------------------------------------------------------------------
@@ -40,7 +40,7 @@ export class CalciteIcon {
    * When true, the icon will be filled.
    */
   @Prop({
-    reflect: true
+    reflect: true,
   })
   filled: boolean = false;
 
@@ -48,7 +48,7 @@ export class CalciteIcon {
    * The name of the icon to display. The value of this property must match the icon name from https://esri.github.io/calcite-ui-icons/.
    */
   @Prop({
-    reflect: true
+    reflect: true,
   })
   icon: string = null;
 
@@ -56,7 +56,7 @@ export class CalciteIcon {
    * When true, the icon will be mirrored when the element direction is 'rtl'.
    */
   @Prop({
-    reflect: true
+    reflect: true,
   })
   mirrored: boolean = false;
 
@@ -64,7 +64,7 @@ export class CalciteIcon {
    * Icon scale. Can be "s" | "m" | "l".
    */
   @Prop({
-    reflect: true
+    reflect: true,
   })
   scale: Scale = "m";
 
@@ -80,7 +80,7 @@ export class CalciteIcon {
    * Icon theme. Can be "light" or "dark".
    */
   @Prop({
-    reflect: true
+    reflect: true,
   })
   theme: Theme;
 
@@ -119,21 +119,19 @@ export class CalciteIcon {
         aria-label={semantic ? textLabel : null}
         role={semantic ? "img" : null}
       >
-        {pathData ? (
-          <svg
-            class={{
-              [CSS.mirrored]: dir === "rtl" && mirrored,
-              svg: true
-            }}
-            xmlns="http://www.w3.org/2000/svg"
-            fill="currentColor"
-            height={size}
-            width={size}
-            viewBox={`0 0 ${size} ${size}`}
-          >
-            <path d={pathData} />
-          </svg>
-        ) : null}
+        <svg
+          class={{
+            [CSS.mirrored]: dir === "rtl" && mirrored,
+            svg: true,
+          }}
+          xmlns="http://www.w3.org/2000/svg"
+          fill="currentColor"
+          height={size}
+          width={size}
+          viewBox={`0 0 ${size} ${size}`}
+        >
+          <path d={pathData} />
+        </svg>
       </Host>
     );
   }
@@ -182,8 +180,8 @@ export class CalciteIcon {
     }
 
     this.intersectionObserver = new IntersectionObserver(
-      entries => {
-        entries.forEach(entry => {
+      (entries) => {
+        entries.forEach((entry) => {
           if (entry.isIntersecting) {
             this.intersectionObserver.disconnect();
             this.intersectionObserver = null;

--- a/src/components/calcite-icon/utils.ts
+++ b/src/components/calcite-icon/utils.ts
@@ -44,7 +44,7 @@ export async function fetchIcon({
       .then(resp => resp.json())
       .catch(() => {
         console.error(`"${id}" is not a valid calcite-ui-icon name`);
-        return null;
+        return "";
       });
   }
 


### PR DESCRIPTION
This addresses unnecessary shifts in layout caused by not rendering the SVG element until the path data is available.

Reverts c601720bb8756f848de03fc02d8274621bc2a94f

#432 