### PR TITLE
feat(dropdown): specify max items to display before scrolling is enabled

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -6,14 +6,15 @@ import {
   h,
   Host,
   Listen,
-  Prop
+  Prop,
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
+import { GroupRegistration, ItemRegistration } from "../../interfaces/Dropdown";
 
 @Component({
   tag: "calcite-dropdown-group",
   styleUrl: "calcite-dropdown-group.scss",
-  shadow: true
+  shadow: true,
 })
 export class CalciteDropdownGroup {
   //--------------------------------------------------------------------------
@@ -46,7 +47,7 @@ export class CalciteDropdownGroup {
   //--------------------------------------------------------------------------
 
   @Event() calciteDropdownItemHasChanged: EventEmitter;
-  @Event() registerCalciteDropdownGroup: EventEmitter;
+  @Event() registerCalciteDropdownGroup: EventEmitter<GroupRegistration>;
 
   //--------------------------------------------------------------------------
   //
@@ -63,17 +64,20 @@ export class CalciteDropdownGroup {
 
   componentDidLoad() {
     this.groupPosition = this.getGroupPosition();
-    this.items = this.sortItems(this.items);
+    this.items = this.sortItems(this.items) as HTMLCalciteDropdownItemElement[];
     this.registerCalciteDropdownGroup.emit({
       items: this.items,
       position: this.groupPosition,
-      groupId: this.dropdownGroupId
+      groupId: this.dropdownGroupId,
+      titleEl: this.titleEl,
     });
   }
 
   render() {
     const groupTitle = this.groupTitle ? (
-      <span class="dropdown-title">{this.groupTitle}</span>
+      <span class="dropdown-title" ref={(node) => (this.titleEl = node)}>
+        {this.groupTitle}
+      </span>
     ) : null;
 
     return (
@@ -91,14 +95,13 @@ export class CalciteDropdownGroup {
   //--------------------------------------------------------------------------
 
   @Listen("registerCalciteDropdownItem") registerCalciteDropdownItem(
-    event: CustomEvent
+    event: CustomEvent<ItemRegistration>
   ) {
     const item = {
       item: event.target as HTMLCalciteDropdownItemElement,
-      position: event.detail.position
+      position: event.detail.position,
     };
     this.items.push(item);
-    this.requestedDropdownItem = event.detail.requestedDropdownItem;
   }
 
   @Listen("calciteDropdownItemSelected") updateActiveItemOnChange(
@@ -108,7 +111,7 @@ export class CalciteDropdownGroup {
     this.requestedDropdownItem = event.detail.requestedDropdownItem;
     this.calciteDropdownItemHasChanged.emit({
       requestedDropdownGroup: this.requestedDropdownGroup,
-      requestedDropdownItem: this.requestedDropdownItem
+      requestedDropdownItem: this.requestedDropdownItem,
     });
   }
 
@@ -133,6 +136,8 @@ export class CalciteDropdownGroup {
   /** the requested item */
   private requestedDropdownItem: string;
 
+  private titleEl: HTMLSpanElement = null;
+
   //--------------------------------------------------------------------------
   //
   //  Private Methods
@@ -147,5 +152,5 @@ export class CalciteDropdownGroup {
   }
 
   private sortItems = (items: any[]): any[] =>
-    items.sort((a, b) => a.position - b.position).map(a => a.item);
+    items.sort((a, b) => a.position - b.position).map((a) => a.item);
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../utils/keys";
 import { getElementDir, getElementProp } from "../../utils/dom";
 import { guid } from "../../utils/guid";
+import { ItemRegistration } from "../../interfaces/Dropdown";
 
 @Component({
   tag: "calcite-dropdown-item",
@@ -61,7 +62,7 @@ export class CalciteDropdownItem {
   @Event() calciteDropdownItemKeyEvent: EventEmitter;
   @Event() calciteDropdownItemSelected: EventEmitter;
   @Event() closeCalciteDropdown: EventEmitter;
-  @Event() registerCalciteDropdownItem: EventEmitter;
+  @Event() registerCalciteDropdownItem: EventEmitter<ItemRegistration>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -517,11 +517,11 @@ describe("calcite-dropdown", () => {
     expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-2");
   });
 
-  // unskip when stencil is upgraded to >= 1.11.2
-  it.skip("focused item should be in view when long", async () => {
-    const page = await newE2EPage();
+  describe("scrolling", () => {
+    it("focused item should be in view when long", async () => {
+      const page = await newE2EPage();
 
-    await page.setContent(`<calcite-dropdown>
+      await page.setContent(`<calcite-dropdown>
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group>
         <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -566,16 +566,55 @@ describe("calcite-dropdown", () => {
         <calcite-dropdown-item id="item-50" active>50</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>`);
-    await page.waitForChanges();
+      await page.waitForChanges();
 
-    const element = await page.find("calcite-dropdown");
-    await element.click();
-    await page.waitForChanges();
+      const element = await page.find("calcite-dropdown");
+      await element.click();
+      await page.waitForChanges();
 
-    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-50");
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual(
+        "item-50"
+      );
 
-    const item = await page.find("#item-50");
+      const item = await page.find("#item-50");
 
-    expect(await item.isIntersectingViewport()).toBe(true);
+      expect(await item.isIntersectingViewport()).toBe(true);
+    });
+
+    it("control max items displayed", async () => {
+      const page = await newE2EPage();
+
+      const maxItemsToDisplay = 7;
+
+      await page.setContent(`<calcite-dropdown max-items-to-display="${maxItemsToDisplay}">
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group group-title="First group">
+      <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group group-title="Second group">
+      <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>`);
+      await page.waitForChanges();
+
+      const element = await page.find("calcite-dropdown");
+      await element.click();
+      await page.waitForChanges();
+
+      const items = await page.findAll("calcite-dropdown-item");
+
+      for (let i = 0; i < items.length; i++) {
+        expect(await items[i].isIntersectingViewport()).toBe(i <= maxItemsToDisplay);
+      }
+    });
   });
+
 });

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -584,9 +584,9 @@ describe("calcite-dropdown", () => {
     it("control max items displayed", async () => {
       const page = await newE2EPage();
 
-      const maxItemsToDisplay = 7;
+      const maxItems = 7;
 
-      await page.setContent(`<calcite-dropdown max-items-to-display="${maxItemsToDisplay}">
+      await page.setContent(`<calcite-dropdown max-items="${maxItems}">
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group group-title="First group">
       <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -612,7 +612,7 @@ describe("calcite-dropdown", () => {
       const items = await page.findAll("calcite-dropdown-item");
 
       for (let i = 0; i < items.length; i++) {
-        expect(await items[i].isIntersectingViewport()).toBe(i <= maxItemsToDisplay);
+        expect(await items[i].isIntersectingViewport()).toBe(i <= maxItems);
       }
     });
   });

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.js
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { withKnobs, number, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -275,6 +275,35 @@ storiesOf("Dropdown", module)
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
         <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
         <calcite-dropdown-item>Title</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+  `,
+    { notes }
+  )
+  .add(
+    "Scrolling after certain items",
+    () => `
+    <calcite-dropdown
+      alignment="${select("alignment", ["start", "center", "end"], "start")}"
+      max-items-to-display="${number("max-items-to-display", 7, { min: 0, max: 10, step: 1 })}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      width="${select("width", ["s", "m", "l"], "m")}"
+      type="${select("type", ["click", "hover"], "click")}"
+    >
+      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+      <calcite-dropdown-group group-title="First group">
+        <calcite-dropdown-item>1</calcite-dropdown-item>
+        <calcite-dropdown-item>2</calcite-dropdown-item>
+        <calcite-dropdown-item>3</calcite-dropdown-item>
+        <calcite-dropdown-item>4</calcite-dropdown-item>
+        <calcite-dropdown-item>5</calcite-dropdown-item>
+      </calcite-dropdown-group>
+      <calcite-dropdown-group group-title="Second group">
+        <calcite-dropdown-item>6</calcite-dropdown-item>
+        <calcite-dropdown-item>7</calcite-dropdown-item>
+        <calcite-dropdown-item>8</calcite-dropdown-item>
+        <calcite-dropdown-item>9</calcite-dropdown-item>
+        <calcite-dropdown-item>10</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
   `,

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.js
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.js
@@ -285,7 +285,7 @@ storiesOf("Dropdown", module)
     () => `
     <calcite-dropdown
       alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      max-items-to-display="${number("max-items-to-display", 7, { min: 0, max: 10, step: 1 })}"
+      max-items="${number("max-items", 7, { min: 0, max: 10, step: 1 })}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -239,6 +239,7 @@ export class CalciteDropdown {
   /** created list of dropdown items */
   private items = [];
 
+  /** specifies the item wrapper height; it is updated when maxItemsToDisplay is > 0  **/
   private maxScrollerHeight = 0;
 
   /** keep track of whether the groups have been sorted so we don't re-sort */

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -85,21 +85,7 @@ export class CalciteDropdown {
         (a, b) => a.position - b.position
       ) as GroupRegistration[];
 
-      const { maxItemsToDisplay } = this;
-      let itemsToProcess = 0;
-
-      groups.forEach((group) => {
-        if (maxItemsToDisplay > 0 && itemsToProcess < maxItemsToDisplay) {
-          this.maxScrollerHeight += group?.titleEl?.offsetHeight || 0;
-
-          group.items.forEach((item) => {
-            if (itemsToProcess < maxItemsToDisplay) {
-              this.maxScrollerHeight += item.offsetHeight;
-              itemsToProcess += 1;
-            }
-          });
-        }
-      });
+      this.maxScrollerHeight = this.getMaxScrollerHeight(groups);
 
       this.items = groups.reduce(
         (items, group) => [...items, ...group.items],
@@ -253,6 +239,27 @@ export class CalciteDropdown {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private getMaxScrollerHeight(groups: GroupRegistration[]): number {
+    const { maxItemsToDisplay } = this;
+    let itemsToProcess = 0;
+    let maxScrollerHeight = 0;
+
+    groups.forEach((group) => {
+      if (maxItemsToDisplay > 0 && itemsToProcess < maxItemsToDisplay) {
+        maxScrollerHeight += group?.titleEl?.offsetHeight || 0;
+
+        group.items.forEach((item) => {
+          if (itemsToProcess < maxItemsToDisplay) {
+            maxScrollerHeight += item.offsetHeight;
+            itemsToProcess += 1;
+          }
+        });
+      }
+    });
+
+    return maxScrollerHeight;
+  }
 
   private closeCalciteDropdown() {
     this.active = false;

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -42,7 +42,7 @@ export class CalciteDropdown {
     | "end" = "start";
 
   /** specify the max items to display before showing the scroller, must be greater than 0 **/
-  @Prop() maxItemsToDisplay: number = 0;
+  @Prop() maxItems: number = 0;
 
   /** specify the theme of the dropdown, defaults to light */
   @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
@@ -225,7 +225,7 @@ export class CalciteDropdown {
   /** created list of dropdown items */
   private items = [];
 
-  /** specifies the item wrapper height; it is updated when maxItemsToDisplay is > 0  **/
+  /** specifies the item wrapper height; it is updated when maxItems is > 0  **/
   private maxScrollerHeight = 0;
 
   /** keep track of whether the groups have been sorted so we don't re-sort */
@@ -241,16 +241,16 @@ export class CalciteDropdown {
   //--------------------------------------------------------------------------
 
   private getMaxScrollerHeight(groups: GroupRegistration[]): number {
-    const { maxItemsToDisplay } = this;
+    const { maxItems } = this;
     let itemsToProcess = 0;
     let maxScrollerHeight = 0;
 
     groups.forEach((group) => {
-      if (maxItemsToDisplay > 0 && itemsToProcess < maxItemsToDisplay) {
+      if (maxItems > 0 && itemsToProcess < maxItems) {
         maxScrollerHeight += group?.titleEl?.offsetHeight || 0;
 
         group.items.forEach((item) => {
-          if (itemsToProcess < maxItemsToDisplay) {
+          if (itemsToProcess < maxItems) {
             maxScrollerHeight += item.offsetHeight;
             itemsToProcess += 1;
           }

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../utils/keys";
 
 import { focusElement } from "../../utils/dom";
+import { GroupRegistration } from "../../interfaces/Dropdown";
 
 @Component({
   tag: "calcite-dropdown",
@@ -39,6 +40,9 @@ export class CalciteDropdown {
     | "start"
     | "center"
     | "end" = "start";
+
+  /** specify the max items to display before showing the scroller, must be greater than 0 **/
+  @Prop() maxItemsToDisplay: number = 0;
 
   /** specify the theme of the dropdown, defaults to light */
   @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
@@ -77,12 +81,38 @@ export class CalciteDropdown {
       "[slot=dropdown-trigger]"
     ) as HTMLSlotElement;
     if (!this.sorted) {
-      this.items = this.sortItems(this.items);
+      const groups = this.items.sort(
+        (a, b) => a.position - b.position
+      ) as GroupRegistration[];
+
+      const { maxItemsToDisplay } = this;
+      let itemsToProcess = 0;
+
+      groups.forEach((group) => {
+        if (maxItemsToDisplay > 0 && itemsToProcess < maxItemsToDisplay) {
+          this.maxScrollerHeight += group?.titleEl?.offsetHeight || 0;
+
+          group.items.forEach((item) => {
+            if (itemsToProcess < maxItemsToDisplay) {
+              this.maxScrollerHeight += item.offsetHeight;
+              itemsToProcess += 1;
+            }
+          });
+        }
+      });
+
+      this.items = groups.reduce(
+        (items, group) => [...items, ...group.items],
+        []
+      );
+
       this.sorted = true;
     }
   }
 
   render() {
+    const { maxScrollerHeight } = this;
+
     return (
       <Host>
         <slot
@@ -90,7 +120,13 @@ export class CalciteDropdown {
           aria-haspopup="true"
           aria-expanded={this.active.toString()}
         />
-        <div class="calcite-dropdown-wrapper" role="menu">
+        <div
+          class="calcite-dropdown-wrapper"
+          role="menu"
+          style={{
+            maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "",
+          }}
+        >
           <slot />
         </div>
       </Host>
@@ -184,14 +220,14 @@ export class CalciteDropdown {
     }
   }
 
-  @Listen("registerCalciteDropdownGroup") registerCalciteDropdownGroup(
-    e: CustomEvent
-  ) {
-    const items = {
-      items: e.detail.items,
-      position: e.detail.position,
-    };
-    this.items.push(items);
+  @Listen("registerCalciteDropdownGroup") registerCalciteDropdownGroup({
+    detail: { items, position, titleEl },
+  }: CustomEvent<GroupRegistration>) {
+    this.items.push({
+      items: items,
+      position: position,
+      titleEl,
+    });
   }
 
   //--------------------------------------------------------------------------
@@ -200,14 +236,16 @@ export class CalciteDropdown {
   //
   //--------------------------------------------------------------------------
 
-  /** trigger element */
-  private trigger: HTMLSlotElement;
-
   /** created list of dropdown items */
   private items = [];
 
+  private maxScrollerHeight = 0;
+
   /** keep track of whether the groups have been sorted so we don't re-sort */
   private sorted = false;
+
+  /** trigger element */
+  private trigger: HTMLSlotElement;
 
   //--------------------------------------------------------------------------
   //
@@ -275,12 +313,4 @@ export class CalciteDropdown {
       );
     }
   }
-
-  private sortItems = (items: any[]): any[] =>
-    items
-      .sort((a, b) => a.position - b.position)
-      .concat.apply(
-        [],
-        this.items.map((item) => item.items)
-      );
 }

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -283,7 +283,7 @@
 
   <h3>Can control amount of items displayed</h3>
 
-  <calcite-dropdown max-items-to-display="7">
+  <calcite-dropdown max-items="7">
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group group-title="First group">
       <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -281,6 +281,26 @@
     </calcite-dropdown>
   </div>
 
+  <h3>Can control amount of items displayed</h3>
+
+  <calcite-dropdown max-items-to-display="7">
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group group-title="First group">
+      <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group group-title="Second group">
+      <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
+      <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+
   <h3>Long dropdown content should allow scrolling</h3>
 
   <calcite-dropdown>
@@ -313,8 +333,6 @@
       <calcite-dropdown-item id="item-25" active>25</calcite-dropdown-item>
     </calcite-dropdown-group>
   </calcite-dropdown>
-
-
 </body>
 
 </html>

--- a/src/interfaces/Dropdown.ts
+++ b/src/interfaces/Dropdown.ts
@@ -1,0 +1,15 @@
+export interface ItemRegistration {
+  position: number;
+}
+
+export interface GroupRegistration {
+  items: HTMLCalciteDropdownItemElement[];
+  position: number;
+  groupId: string;
+  titleEl: HTMLSpanElement;
+}
+
+export interface RegisteredItem {
+  item: HTMLCalciteDropdownItemElement;
+  position: number;
+}


### PR DESCRIPTION
#431 

This adds a new `calcite-dropdown` prop (`maxItems`) to allow users to specify the number of items to display before the scroller shows up. **Note**: group titles don't count as items. For example, if you have a two groups of 5 items each and set the max to 7, you will see the following:

<img width="248" alt="Screen Shot 2020-04-03 at 8 40 18 AM" src="https://user-images.githubusercontent.com/197440/78379140-ca667080-7586-11ea-9d03-f558d309927a.png">

See the demo for more details on ☝️.

This also types some of the registration events and caught a bug ([`requestedDropdownItem`](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx#L101) isn't in the register item event payload).

I'm open to suggestions on the prop name. 😄 

@dhrumil83 