### PR TITLE
Remove mutationObserver in button for hasText prop

### DIFF
--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -112,11 +112,6 @@ export class CalciteButton {
       : this.appearance === "inline"
       ? "span"
       : "button";
-    this.setupTextContentObserver();
-  }
-
-  disconnectedCallback() {
-    this.observer.disconnect();
   }
 
   componentWillLoad() {
@@ -125,6 +120,10 @@ export class CalciteButton {
       const elType = this.el.getAttribute("type");
       this.type = this.childElType === "button" && elType ? elType : "submit";
     }
+  }
+
+  componentDidUpdate() {
+    this.updateHasText();
   }
 
   render() {
@@ -193,9 +192,6 @@ export class CalciteButton {
   //
   //--------------------------------------------------------------------------
 
-  /** watches for changing text content **/
-  private observer: MutationObserver;
-
   /** if button type is present, assign as prop */
   private type?: string;
 
@@ -210,15 +206,6 @@ export class CalciteButton {
 
   private updateHasText() {
     this.hasText = this.el.textContent.length > 0;
-  }
-
-  private setupTextContentObserver() {
-    if (Build.isBrowser) {
-      this.observer = new MutationObserver(() => {
-        this.updateHasText();
-      });
-      this.observer.observe(this.el, { childList: true, subtree: true });
-    }
   }
 
   private getAttributes() {


### PR DESCRIPTION
This is an attempted fix for https://github.com/Esri/calcite-components/issues/434

Without a reproduction case I don't know if this will solve it, but, because this change was added in the last release it seems... likely? 

@kstinson14 I  * believe * this will accomplish what you were looking for with the mutationObserver, determining if "hasText" is true if the component updates. Please let me know if this doesn't work!