### PR TITLE
🚨 remove filled prop on calcite-icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Breaking Changes
+- `calcite-icon` - `filled` prop removed (use `F` at end of icon name)
+
+### Added
+- Support for icons which use multiple paths + opacity
+
 ## [v1.0.0-beta.22] - Apr 3, 2020
 
 ### Breaking Changes
@@ -329,6 +337,8 @@ Fix issue with previous release.
 
 First initial beta release.
 
+[v1.0.0-beta.22]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.21...v1.0.0-beta.22 "v1.0.0-beta.22"
+[v1.0.0-beta.21]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.20...v1.0.0-beta.21 "v1.0.0-beta.21"
 [v1.0.0-beta.20]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.19...v1.0.0-beta.20 "v1.0.0-beta.20"
 [v1.0.0-beta.19]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.18...v1.0.0-beta.19 "v1.0.0-beta.19"
 [v1.0.0-beta.18]: https://github.com/Esri/calcite-components/compare/v1.0.0-beta.17...v1.0.0-beta.18 "v1.0.0-beta.18"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "^2.1.0",
-    "@esri/calcite-ui-icons": "~3.0.0-beta.7",
+    "@esri/calcite-ui-icons": "~3.0.0",
     "@stencil/core": "~1.11.3",
     "@stencil/sass": "^1.1.1",
     "@stencil/state-tunnel": "^1.0.1",

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -13,6 +13,7 @@ import { getElementDir } from "../../utils/dom";
 import { fetchIcon, scaleToPx } from "./utils";
 import { Scale } from "../../interfaces/Icon";
 import { Theme } from "../../interfaces/common";
+import { CalciteIconPath, CalciteMultiPathEntry } from "@esri/calcite-ui-icons";
 
 @Component({
   assetsDirs: ["assets"],
@@ -122,11 +123,11 @@ export class CalciteIcon {
           width={size}
           viewBox={`0 0 ${size} ${size}`}
         >
-          {paths.map((path) =>
+          {paths.map((path: string | CalciteMultiPathEntry) =>
             typeof path === "string" ? (
               <path d={path} />
             ) : (
-              <path d={path.d} opacity={path.opacity || 1} />
+              <path d={path.d} opacity={"opacity" in path ? path.opacity : 1} />
             )
           )}
         </svg>
@@ -143,7 +144,7 @@ export class CalciteIcon {
   private intersectionObserver: IntersectionObserver;
 
   @State()
-  private pathData: string;
+  private pathData: CalciteIconPath;
 
   @State()
   private visible = false;

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -37,14 +37,6 @@ export class CalciteIcon {
   //--------------------------------------------------------------------------
 
   /**
-   * When true, the icon will be filled.
-   */
-  @Prop({
-    reflect: true,
-  })
-  filled: boolean = false;
-
-  /**
    * The name of the icon to display. The value of this property must match the icon name from https://esri.github.io/calcite-ui-icons/.
    */
   @Prop({
@@ -113,7 +105,7 @@ export class CalciteIcon {
     const dir = getElementDir(el);
     const size = scaleToPx[scale];
     const semantic = !!textLabel;
-
+    const paths = [].concat(pathData || "");
     return (
       <Host
         aria-label={semantic ? textLabel : null}
@@ -130,7 +122,13 @@ export class CalciteIcon {
           width={size}
           viewBox={`0 0 ${size} ${size}`}
         >
-          <path d={pathData} />
+          {paths.map((path) =>
+            typeof path === "string" ? (
+              <path d={path} />
+            ) : (
+              <path d={path.d} opacity={path.opacity || 1} />
+            )
+          )}
         </svg>
       </Host>
     );
@@ -157,16 +155,15 @@ export class CalciteIcon {
   //--------------------------------------------------------------------------
 
   @Watch("icon")
-  @Watch("filled")
   @Watch("scale")
   private async loadIconPathData(): Promise<void> {
-    const { filled, icon, scale, visible } = this;
+    const { icon, scale, visible } = this;
 
     if (!Build.isBrowser || !icon || !visible) {
       return;
     }
 
-    this.pathData = await fetchIcon({ icon, scale, filled });
+    this.pathData = await fetchIcon({ icon, scale });
   }
 
   private waitUntilVisible(callback: () => void): void {

--- a/src/components/calcite-icon/utils.ts
+++ b/src/components/calcite-icon/utils.ts
@@ -4,7 +4,6 @@ import { Scale } from "../../interfaces/Icon";
 export interface FetchIconProps {
   icon: string;
   scale: Scale;
-  filled: boolean;
 }
 
 /**
@@ -29,16 +28,16 @@ export const scaleToPx: Record<Scale, number> = {
 
 export async function fetchIcon({
   icon,
-  scale,
-  filled
+  scale
 }: FetchIconProps): Promise<string> {
   const size = scaleToPx[scale];
-  const id = `${normalizeIconName(icon)}${size}${filled ? "F" : ""}`;
+  const needsF = icon.charAt(icon.length - 1) === "F";
+  const iconName = needsF ? icon.substring(0, icon.length - 1): icon;
+  const id = `${normalizeIconName(iconName)}${size}${needsF ? "F" : ""}`;
 
   if (iconCache[id]) {
     return iconCache[id];
   }
-
   if (!requestCache[id]) {
     requestCache[id] = fetch(getAssetPath(`./assets/${id}.json`))
       .then(resp => resp.json())

--- a/src/components/calcite-icon/utils.ts
+++ b/src/components/calcite-icon/utils.ts
@@ -1,5 +1,6 @@
 import { getAssetPath } from "@stencil/core";
 import { Scale } from "../../interfaces/Icon";
+import { CalciteIconPath } from "@esri/calcite-ui-icons";
 
 export interface FetchIconProps {
   icon: string;
@@ -11,14 +12,14 @@ export interface FetchIconProps {
  * Exported for testing purposes.
  * @private
  */
-export const iconCache: Record<string, string> = {};
+export const iconCache: Record<string, CalciteIconPath> = {};
 
 /**
  * Icon request cache.
  * Exported for testing purposes.
  * @private
  */
-export const requestCache: Record<string, Promise<any>> = {};
+export const requestCache: Record<string, Promise<CalciteIconPath>> = {};
 
 export const scaleToPx: Record<Scale, number> = {
   s: 16,
@@ -29,11 +30,11 @@ export const scaleToPx: Record<Scale, number> = {
 export async function fetchIcon({
   icon,
   scale
-}: FetchIconProps): Promise<string> {
+}: FetchIconProps): Promise<CalciteIconPath> {
   const size = scaleToPx[scale];
-  const needsF = icon.charAt(icon.length - 1) === "F";
-  const iconName = needsF ? icon.substring(0, icon.length - 1): icon;
-  const id = `${normalizeIconName(iconName)}${size}${needsF ? "F" : ""}`;
+  const filled = icon.charAt(icon.length - 1) === "F";
+  const iconName = filled ? icon.substring(0, icon.length - 1): icon;
+  const id = `${normalizeIconName(iconName)}${size}${filled ? "F" : ""}`;
 
   if (iconCache[id]) {
     return iconCache[id];

--- a/src/components/calcite-stepper-item/calcite-stepper-item.tsx
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.tsx
@@ -196,21 +196,16 @@ export class CalciteStepperItem {
 
   private setIcon() {
     var path = this.active
-      ? "circle"
+      ? "circleF"
       : this.error
-      ? "exclamationMarkCircle"
+      ? "exclamationMarkCircleF"
       : this.complete
-      ? "checkCircle"
+      ? "checkCircleF"
       : "circle";
-
-    // todo when calcite-icon is updated
-    // remove this and use circle-filled icon name
-    var filled = this.error || this.complete || this.active;
 
     return (
       <calcite-icon
         icon={path}
-        filled={filled}
         scale="s"
         class="stepper-item-icon"
       />

--- a/src/demos/calcite-icon.html
+++ b/src/demos/calcite-icon.html
@@ -36,6 +36,11 @@
   <calcite-icon icon="basemap" text-label="Select a basemap"></calcite-icon>
   <calcite-icon icon="camera" text-label="Upload an image"></calcite-icon>
 
+  <h2>Multipath</h2>
+  <calcite-icon icon="imageLayer" scale="s"></calcite-icon>
+  <calcite-icon icon="imageLayer" scale="m"></calcite-icon>
+  <calcite-icon icon="imageLayer" scale="l"></calcite-icon>
+
   <h2>Scale can be "s" | "m" | "l"</h2>
   <calcite-icon icon="aZ" scale="s"></calcite-icon>
   <calcite-icon icon="basemap" scale="m"></calcite-icon>


### PR DESCRIPTION
We won't be able to merge this until the corresponding pr is merged into the icons repository and we cut a new release over there.

Essentially they removed most of the filled icons a couple releases ago, making our `filled` prop virtually useless. 

Some select icons still have a filled variant, but now that is handled via a different icon name. This pr updates our icon component to reflect those changes. 