### PR TITLE
fix(button): update hasText when textContent is set after initial render

### DIFF
--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -112,6 +112,11 @@ export class CalciteButton {
       : this.appearance === "inline"
       ? "span"
       : "button";
+    this.setupTextContentObserver();
+  }
+
+  disconnectedCallback() {
+    this.observer.disconnect();
   }
 
   componentWillLoad() {
@@ -120,10 +125,6 @@ export class CalciteButton {
       const elType = this.el.getAttribute("type");
       this.type = this.childElType === "button" && elType ? elType : "submit";
     }
-  }
-
-  componentDidUpdate() {
-    this.updateHasText();
   }
 
   render() {
@@ -192,6 +193,9 @@ export class CalciteButton {
   //
   //--------------------------------------------------------------------------
 
+  /** watches for changing text content **/
+  private observer: MutationObserver;
+
   /** if button type is present, assign as prop */
   private type?: string;
 
@@ -206,6 +210,15 @@ export class CalciteButton {
 
   private updateHasText() {
     this.hasText = this.el.textContent.length > 0;
+  }
+
+  private setupTextContentObserver() {
+    if (Build.isBrowser) {
+      this.observer = new MutationObserver(() => {
+        this.updateHasText();
+      });
+      this.observer.observe(this.el, { childList: true, subtree: true });
+    }
   }
 
   private getAttributes() {


### PR DESCRIPTION
This restores `MutationObserver` logic to update button's state:

> When the issue occurs, the element's textContent gets set after initial lifecycle methods and when that happens it does not trigger a re-render, so hasText isn't recalculated. Restoring MutationObserver fixes this in my testing.

☝️ from #434 

Revert "Remove mutationObserver in button for hasText prop (#436)"

This reverts commit eec7a7a1f74e611ffbd8e5fc4c12ee9663aa2486.

