### PR TITLE
Updates to pagination component API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Breaking Changes
 
 - `calcite-button` no longer accepts `inline` as a value for `appearance` - you can instead
+- `calcite-pagination` - `backgroundStyle` property removed (always transparent)
+- `calcite-pagination` - `num`, `start`, and `total` now refer to records not pages
+- `calcite-pagination` - `calcitePaginationUpdate` event now only fires in response to user input
+- `calcite-pagination` - `setPage` method removed
 
 ### Added
 
 - new component `calcite-link`
 - new `calcite-label`, `calcite-input`, and `calcite-input-message` components
 - `calcite-slider` can now be programmatically focused with the `setFocus()` method
+
+### Fixed
+
+- `calcite-pagination` - pages and next/previous can now be navigated with keyboard
 
 ## [v1.0.0-beta.24] - Apr 8th 2020
 

--- a/src/components/calcite-pagination/calcite-pagination.e2e.ts
+++ b/src/components/calcite-pagination/calcite-pagination.e2e.ts
@@ -11,7 +11,7 @@ describe("calcite-pagination", () => {
   describe('ellipsis rendering', () => {
     it("should not render either ellipsis when total pages is less than or equal to 5", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="5"></calcite-pagination>`);
+      await page.setContent(`<calcite-pagination total="80"></calcite-pagination>`);
 
       const startEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisStart}`);
       const endEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisEnd}`);
@@ -20,15 +20,14 @@ describe("calcite-pagination", () => {
     });
     it("should render start ellipsis when total pages is over 5 and the selected page more than 4 from the starting page", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="6" num="5"></calcite-pagination>`);
+      await page.setContent(`<calcite-pagination start="101" total="140" num="20"></calcite-pagination>`);
 
       const startEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisStart}`);
       expect(startEllipsis).not.toBeNull();
     });
     it("should render end ellipsis when total pages is over 5 and the selected page more than 3 from the final page", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="6" num="2"></calcite-pagination>`);
-
+      await page.setContent(`<calcite-pagination start="801" total="1200" num="100"></calcite-pagination>`);
       const endEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisEnd}`);
       expect(endEllipsis).not.toBeNull();
     });
@@ -38,7 +37,7 @@ describe("calcite-pagination", () => {
     let pagination: E2EElement;
     beforeEach( async () => {
       page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="2" num="1"></calcite-pagination>`);
+      await page.setContent(`<calcite-pagination start="1" total="124" num="20"></calcite-pagination>`);
       pagination = await page.find("calcite-pagination");
     });
     it("next button should increase selected page by 1 when clicked", async () => {
@@ -60,7 +59,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
     it("previous button should decrease selected page by 1", async () => {
-      await pagination.setAttribute("num", "2");
+      await pagination.setAttribute("start", "21");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
@@ -72,8 +71,8 @@ describe("calcite-pagination", () => {
       expect(selectedPage.innerText).toBe("1");
       expect(toggleSpy).toHaveReceivedEventTimes(1);
     });
-    it('next button should be disabled when selected page equals the end page', async () => {
-      await pagination.setAttribute("num", "2");
+    it('next button should be disabled on last page', async () => {
+      await pagination.setAttribute("start", "121");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
@@ -87,7 +86,7 @@ describe("calcite-pagination", () => {
   describe("page buttons", () => {
     it("should switch selected page to the page that's clicked", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="3"></calcite-pagination>`);
+      await page.setContent(`<calcite-pagination start="1" total="36" num="10"></calcite-pagination>`);
       const toggleSpy = await page.spyOnEvent("calcitePaginationUpdate");
 
       await page.evaluate(() => {
@@ -114,9 +113,9 @@ describe("calcite-pagination", () => {
       });
       const properties = await eventDetail.getProperties();
       expect(eventDetail).toBeDefined();
-      expect(properties.get("num")._remoteObject.value).toBe(2);
-      expect(properties.get("start")._remoteObject.value).toBe(1);
-      expect(properties.get("total")._remoteObject.value).toBe(3);
+      expect(properties.get("num")._remoteObject.value).toBe(10);
+      expect(properties.get("start")._remoteObject.value).toBe(11);
+      expect(properties.get("total")._remoteObject.value).toBe(36);
 
       await pages[2].click();
       await page.waitForChanges();

--- a/src/components/calcite-pagination/calcite-pagination.scss
+++ b/src/components/calcite-pagination/calcite-pagination.scss
@@ -1,14 +1,11 @@
 :host {
   display: inline-flex;
-  background-color: var(--calcite-ui-foreground-1);
+  background-color: transparent;
   writing-mode: horizontal-tb;
-}
-:host(.backgroundColor) {
-  background-color: var(--calcite-ui-background);
 }
 
 // focus styles
-:host a {
+:host button {
   @include focus-style-base();
   &:focus {
     @include focus-style-inset();
@@ -20,8 +17,13 @@
 .page {
   display: flex;
   align-items: center;
+  background-color: transparent;
   border-top: 3px solid transparent;
+  border-right: none;
   border-bottom: 3px solid transparent;
+  border-left: none;
+  font-family: inherit;
+  @include font-size(0);
   color: var(--calcite-ui-text-3);
   cursor: pointer;
   &:hover {
@@ -51,6 +53,7 @@
   }
   &.is-disabled {
     background-color: transparent;
+    pointer-events: none;
     & > svg {
       opacity: 0.3;
     }

--- a/src/components/calcite-pagination/calcite-pagination.stories.js
+++ b/src/components/calcite-pagination/calcite-pagination.stories.js
@@ -1,21 +1,36 @@
+import { storiesOf } from "@storybook/html";
 import { withKnobs, number, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
-
-export default {
-  title: "Pagination",
-  decorators: [ withKnobs ],
-  parameters: { notes }
-};
-
-export const simple = () =>
-  `<calcite-pagination
-    start="${number("Start", 1)}"
-    total="${number("Total", 3)}"
-    num="${number("Num", 1)}"
-    dir="${select("dir", ["ltr", "rtl"],"ltr")}"
-    theme="${select("Theme", ["light", "dark"] ,"light")}"
-    background-style="${select("Background Style", ["backgroundColor", "foregroundColor"] ,"foregroundColor")}">
-  </calcite-pagination>`;
+storiesOf("Pagination", module)
+.addDecorator(withKnobs)
+.add(
+  "Simple",
+  () => `
+    <calcite-pagination
+      start="${number("start", 1)}"
+      total="${number("total", 128)}"
+      num="${number("num", 20)}"
+      dir="${select("dir", ["ltr", "rtl"],"ltr")}"
+      theme="light"
+    >
+    </calcite-pagination>
+  `,
+  { notes }
+)
+.add(
+  "Dark Mode",
+  () => `
+    <calcite-pagination
+      start="${number("start", 1)}"
+      total="${number("total", 128)}"
+      num="${number("num", 20)}"
+      dir="${select("dir", ["ltr", "rtl"],"ltr")}"
+      theme="dark"
+    >
+    </calcite-pagination>
+  `,
+  { notes, backgrounds: darkBackground }
+);

--- a/src/components/calcite-pagination/readme.md
+++ b/src/components/calcite-pagination/readme.md
@@ -1,60 +1,60 @@
 # calcite-pagination
 
-<!-- Auto Generated Below -->
+Calcite pagination allows users to select a page from a paginated API. The component is meant to interface with responses from ArcGIS REST services, so the props share names with [response properties](https://developers.arcgis.com/rest/users-groups-and-items/search.htm) from various search endpoints.
 
+For example, after querying the search API, you'll get back a response similar to the following:
+
+```JSON
+{
+  "total": 2021,
+  "start": 1,
+  "num": 100,
+  "results": []
+}
+```
+
+These can be passed straight to the `calcite-pagination` component:
+
+```html
+<calcite-pagination start="1" num="100" total="2021"></calcite-pagination>
+```
+
+<!-- Auto Generated Below -->
 
 ## Properties
 
-| Property            | Attribute             | Description                                                                    | Type                                     | Default              |
-| ------------------- | --------------------- | ------------------------------------------------------------------------------ | ---------------------------------------- | -------------------- |
-| `backgroundStyle`   | `background-style`    | Change between foreground colors or background colors for container background | `"backgroundColor" \| "foregroundColor"` | `"foregroundColor"`  |
-| `num`               | `num`                 | starting selected index                                                        | `number`                                 | `1`                  |
-| `start`             | `start`               | starting number of the pagination                                              | `number`                                 | `1`                  |
-| `textLabelNext`     | `text-label-next`     | title of the next button                                                       | `string`                                 | `TEXT.nextLabel`     |
-| `textLabelPrevious` | `text-label-previous` | title of the previous button                                                   | `string`                                 | `TEXT.previousLabel` |
-| `theme`             | `theme`               | specify the theme of accordion, defaults to light                              | `"dark" \| "light"`                      | `undefined`          |
-| `total`             | `total`               | ending number of the pagination                                                | `number`                                 | `2`                  |
-
+| Property            | Attribute             | Description                                       | Type                | Default              |
+| ------------------- | --------------------- | ------------------------------------------------- | ------------------- | -------------------- |
+| `num`               | `num`                 | number of items per page                          | `number`            | `20`                 |
+| `start`             | `start`               | index of item that should begin the page          | `number`            | `1`                  |
+| `textLabelNext`     | `text-label-next`     | title of the next button                          | `string`            | `TEXT.nextLabel`     |
+| `textLabelPrevious` | `text-label-previous` | title of the previous button                      | `string`            | `TEXT.previousLabel` |
+| `theme`             | `theme`               | specify the theme of accordion, defaults to light | `"dark" \| "light"` | `undefined`          |
+| `total`             | `total`               | total number of items                             | `number`            | `0`                  |
 
 ## Events
 
-| Event                     | Description                                 | Type               |
-| ------------------------- | ------------------------------------------- | ------------------ |
-| `calcitePaginationUpdate` | Emitted whenever the selected page changes. | `CustomEvent<any>` |
-
+| Event                     | Description                                 | Type                                   |
+| ------------------------- | ------------------------------------------- | -------------------------------------- |
+| `calcitePaginationUpdate` | Emitted whenever the selected page changes. | `CustomEvent<CalcitePaginationDetail>` |
 
 ## Methods
 
 ### `nextPage() => Promise<void>`
 
-When called, selected page will increment by 1.
+Go to the next page of results
 
 #### Returns
 
 Type: `Promise<void>`
-
-
 
 ### `previousPage() => Promise<void>`
 
-When called, selected page will decrement by 1.
+Go to the previous page of results
 
 #### Returns
 
 Type: `Promise<void>`
-
-
-
-### `setPage(num: number) => Promise<void>`
-
-Set selected page to a specific page number. Will not go below start or above total.
-
-#### Returns
-
-Type: `Promise<void>`
-
-
-
 
 ## Dependencies
 
@@ -63,12 +63,13 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-pagination --> calcite-icon
   style calcite-pagination fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/demos/calcite-pagination.html
+++ b/src/demos/calcite-pagination.html
@@ -10,19 +10,69 @@
   <link rel="stylesheet" href="../build/calcite.css" />
   <script type="module" src="../build/calcite.esm.js"></script>
   <script nomodule src="../build/calcite.js"></script>
+  <style>
+    .demo-background-dark {
+      background: #2b2b2b;
+      color: white;
+      padding: 1rem;
+    }
+    .demo-spaced {
+      margin: 8px 0;
+    }
+  </style>
 </head>
 
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Pagination</h1>
+
   <h2>Basic</h2>
-  <calcite-pagination></calcite-pagination>
-  <h2>Dark Theme</h2>
-  <calcite-pagination theme="dark"></calcite-pagination>
-  <h2>Many pages - BackgroundColor Background Style</h2>
-  <calcite-pagination total="10" background-style="backgroundColor"></calcite-pagination>
-  <h2>4 Digit Numbers</h2>
-  <calcite-pagination total="2000" num="1995"></calcite-pagination>
+  <div class="demo-spaced">
+    <calcite-pagination total="46" num="10"></calcite-pagination>
+  </div>
+
+  <div class="demo-background-dark">
+    <h2>Dark Theme</h2>
+    <calcite-pagination total="46" num="10" theme="dark"></calcite-pagination>
+  </div>
+
+  <h2>Many pages, ellipsis examples</h2>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="101"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="201"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="301"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="401"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="501"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="601"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="701"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="801"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="901"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="1001"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="1200" num="100" start="1101"></calcite-pagination>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
I'm not sure how I didn't catch this in the initial code review for pagination, but basically the props were not what we were intending them to mean. I think the initial dev on this just misunderstood the intent or hadn't used ArcGIS REST services before. 

The idea was for devs to have the ability to pass props straight from a JSON response from our search API's directly into the component. Previously, the component was expecting you to pass in _page_ count/values. So the dev would have to compute these prior to setting the properties. They were also confusingly named exactly what is sent back. This pr updates the API so that it works in tandem with the APIs it's meant to support. 

Other improvements:

- using `button` elements instead of anchors with no href and a tabindex. This allows keyboard users to navigate pages which they couldn't before. 
- improved storybook story
- better `readme.md` documentation of what the component is/does
- typed event detail for the update event

Breaking changes:
- 🚨 `start`, `num`, and `total` all now refer to records instead of pages
- 🚨 `backgroundStyle` property is removed in favor of having the background be transparent. 
- 🚨 `setPage` method removed. Set the start prop to update pagination
