### PR TITLE
Date updates, fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-pagination` - `num`, `start`, and `total` now refer to records not pages
 - `calcite-pagination` - `calcitePaginationUpdate` event now only fires in response to user input
 - `calcite-pagination` - `setPage` method removed
+- `calcite-date` - `show-calendar` prop changed to `active`
 
 ### Added
 
 - new component `calcite-link`
 - new `calcite-label`, `calcite-input`, and `calcite-input-message` components
 - `calcite-slider` can now be programmatically focused with the `setFocus()` method
+- `calcite-date` now has `scale` prop for small, medium, and large
 
 ### Fixed
 

--- a/src/components/calcite-date-day/calcite-date-day.scss
+++ b/src/components/calcite-date-day/calcite-date-day.scss
@@ -4,39 +4,66 @@
 
 :host {
   display: flex;
+  justify-content: center;
   outline: none;
   color: var(--calcite-ui-text-3);
-  padding: 0.3rem 0.4rem;
   cursor: pointer;
   width: calc(100% / 7);
   min-width: 0;
 }
 
+:host([scale="s"]) {
+  padding: 2px 0px;
+}
+
+:host([scale="m"]) {
+  padding: 4px 4px;
+}
+
+:host([scale="l"]) {
+  padding: 4px 4px;
+}
+
 :host .day {
   display: flex;
-  width: 100%;
   border-radius: 100%;
   @include font-size(-2);
   justify-content: center;
   align-items: center;
-  height: 2rem;
-  width: 2rem;
+  line-height: 1;
   color: var(--calcite-ui-text-3);
   transition: all $transition;
   background: none;
   box-shadow: 0 0 0 2px transparent, 0 0 0 0px transparent;
+  opacity: 0.4;
+}
+
+:host([scale="s"]) .day {
+  height: 27px;
+  width: 27px;
+  font-size: 12px;
+}
+
+:host([scale="m"]) .day {
+  height: 30px;
+  width: 30px;
+  font-size: 14px;
+}
+
+:host([scale="l"]) .day {
+  height: 42px;
+  width: 42px;
+  font-size: 16px;
 }
 
 :host([current-month]) .day {
-  color: var(--calcite-ui-text-1);
+  opacity: 1;
 }
 
 :host([disabled]) {
   cursor: default;
   pointer-events: none;
-  .day {
-    color: var(--calcite-ui-border-1);
-  }
+  opacity: 0.2;
 }
 
 :host(:hover),

--- a/src/components/calcite-date-day/calcite-date-day.tsx
+++ b/src/components/calcite-date-day/calcite-date-day.tsx
@@ -42,6 +42,8 @@ export class CalciteDateDay {
   @Prop({ reflect: true }) active: boolean = false;
   /** Locale to display the day in */
   @Prop() locale: string;
+  /** specify the scale of the date picker */
+  @Prop({ reflect: true }) scale: "s" | "m" | "l";
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-date-day/readme.md
+++ b/src/components/calcite-date-day/readme.md
@@ -2,18 +2,17 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property       | Attribute       | Description                                       | Type      | Default     |
-| -------------- | --------------- | ------------------------------------------------- | --------- | ----------- |
-| `active`       | `active`        | Date is actively in focus for keyboard navigation | `boolean` | `false`     |
-| `currentMonth` | `current-month` | Date is in the current month.                     | `boolean` | `false`     |
-| `day`          | `day`           | Day of the month to be shown.                     | `number`  | `undefined` |
-| `disabled`     | `disabled`      | Date is outside of range and can't be selected    | `boolean` | `false`     |
-| `locale`       | `locale`        | Locale to display the day in                      | `string`  | `undefined` |
-| `selected`     | `selected`      | Date is the current selected date of the picker   | `boolean` | `false`     |
-
+| Property       | Attribute       | Description                                       | Type                | Default     |
+| -------------- | --------------- | ------------------------------------------------- | ------------------- | ----------- |
+| `active`       | `active`        | Date is actively in focus for keyboard navigation | `boolean`           | `false`     |
+| `currentMonth` | `current-month` | Date is in the current month.                     | `boolean`           | `false`     |
+| `day`          | `day`           | Day of the month to be shown.                     | `number`            | `undefined` |
+| `disabled`     | `disabled`      | Date is outside of range and can't be selected    | `boolean`           | `false`     |
+| `locale`       | `locale`        | Locale to display the day in                      | `string`            | `undefined` |
+| `scale`        | `scale`         | specify the scale of the date picker              | `"l" \| "m" \| "s"` | `undefined` |
+| `selected`     | `selected`      | Date is the current selected date of the picker   | `boolean`           | `false`     |
 
 ## Events
 
@@ -21,20 +20,20 @@
 | ------------------ | ----------------------------- | ------------------ |
 | `calciteDaySelect` | Emitted when user selects day | `CustomEvent<any>` |
 
-
 ## Dependencies
 
 ### Used by
 
- - [calcite-date-month](../calcite-date-month)
+- [calcite-date-month](../calcite-date-month)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-date-month --> calcite-date-day
   style calcite-date-day fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-date-month-header/calcite-date-month-header.scss
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.scss
@@ -2,21 +2,46 @@
   @include calcite-theme-dark();
 }
 
-.month-year {
+.header {
   display: flex;
+  justify-content: space-between;
 }
 
-.right-icon,
-.left-icon {
-  color: var(--calcite-ui-text-3);
-  flex-grow: 1;
+:host([scale="s"]) .text {
+  font-size: 14px;
+  height: 16px;
+  padding: 8px 0;
+}
+
+:host([scale="m"]) .text {
+  font-size: 16px;
+  height: 16px;
+  padding: 16px 0;
+}
+
+:host([scale="l"]) .text {
+  font-size: 18px;
+  padding: 16px 0;
+}
+
+.chevron {
+  color: var(--calcite-ui-text-2);
+  flex-grow: 0 0 auto;
+  width: calc(100% / 7);
+  box-sizing: content-box;
   outline: none;
-  padding: 0;
+  padding: 0 4px;
+  margin: 0;
   border: none;
-  color: inherit;
   background-color: var(--calcite-ui-foreground-1);
   cursor: pointer;
   transition: all 0.15s ease-in-out;
+
+  @include focus-style-base();
+
+  &:focus {
+    @include focus-style-inset();
+  }
 
   &:hover,
   &:focus {
@@ -29,19 +54,18 @@
   }
 }
 
-.month-year-text {
-  padding: 0.5rem;
+.text {
+  flex: 1 1 auto;
   display: inline-flex;
-  flex-grow: 1;
-  width: 50%;
   justify-content: center;
+  line-height: 1.25;
 }
 
 .month,
 .year {
   color: var(--calcite-ui-text-1);
   background: var(--calcite-ui-foreground-1);
-  @include font-size(0);
+  font-size: inherit;
   font-weight: 500;
 }
 
@@ -52,12 +76,13 @@
   width: 3em;
   padding: 0;
   margin: 0 8px;
-  // todo: replace with upcoming focus styles
-  outline-offset: 0;
-  outline-color: rgba(0, 0, 0, 0);
-  transition: outline-offset 100ms ease-in-out, outline-color 100ms ease-in-out;
-  &:focus {
-    outline: 2px solid var(--calcite-ui-blue-1);
+  @include focus-style-base();
+  &:hover {
+    transition: outline-color 100ms ease-in-out;
+    outline: 2px solid var(--calcite-ui-border-2);
     outline-offset: 2px;
+  }
+  &:focus {
+    @include focus-style-outset();
   }
 }

--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -1,4 +1,12 @@
-import { Component, Element, Prop, Host, Event, h } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Prop,
+  Host,
+  Event,
+  h,
+  EventEmitter,
+} from "@stencil/core";
 import {
   getLocaleFormatData,
   replaceArabicNumerals,
@@ -6,7 +14,6 @@ import {
   getYear,
 } from "../../utils/locale";
 import { getElementDir } from "../../utils/dom";
-import { DateChangeEmitter } from "../../interfaces/Date";
 import { dateFromRange, nextMonth, prevMonth } from "../../utils/date";
 import { getKey } from "../../utils/key";
 
@@ -55,7 +62,7 @@ export class CalciteDateMonthHeader {
   /**
    *  Changes to active date
    */
-  @Event() calciteActiveDateChange: DateChangeEmitter;
+  @Event() calciteActiveDateChange: EventEmitter<Date>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -44,6 +44,8 @@ export class CalciteDateMonthHeader {
   @Prop() prevMonthLabel: string;
   /** Localized string for next month. */
   @Prop() nextMonthLabel: string;
+  /** specify the scale of the date picker */
+  @Prop({ reflect: true }) scale: "s" | "m" | "l";
 
   //--------------------------------------------------------------------------
   //
@@ -65,18 +67,24 @@ export class CalciteDateMonthHeader {
     const activeMonth = this.activeDate.getMonth();
     const localizedMonth = getMonths(this.locale)[activeMonth];
     const localizedYear = getYear(this.activeDate, this.locale);
+    const iconScale = this.scale === "l" ? "m" : "s";
     const dir = getElementDir(this.el);
     return (
       <Host dir={dir}>
-        <div class="month-year" aria-hidden="true">
+        <div class="header" aria-hidden="true">
           <button
-            class="left-icon"
+            class="chevron"
             aria-label={this.prevMonthLabel}
             onClick={() => this.selectPrevMonth()}
           >
-            <calcite-icon icon="chevron-left" scale="s" mirrored dir={dir} />
+            <calcite-icon
+              icon="chevron-left"
+              scale={iconScale}
+              mirrored
+              dir={dir}
+            />
           </button>
-          <div class="month-year-text">
+          <div class="text">
             <span class="month" role="heading">
               {localizedMonth}
             </span>
@@ -96,11 +104,16 @@ export class CalciteDateMonthHeader {
             />
           </div>
           <button
-            class="right-icon"
+            class="chevron"
             aria-label={this.nextMonthLabel}
             onClick={() => this.selectNextMonth()}
           >
-            <calcite-icon icon="chevron-right" scale="s" mirrored dir={dir} />
+            <calcite-icon
+              icon="chevron-right"
+              scale={iconScale}
+              mirrored
+              dir={dir}
+            />
           </button>
         </div>
       </Host>

--- a/src/components/calcite-date-month-header/readme.md
+++ b/src/components/calcite-date-month-header/readme.md
@@ -2,38 +2,37 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property         | Attribute          | Description                                                              | Type     | Default     |
-| ---------------- | ------------------ | ------------------------------------------------------------------------ | -------- | ----------- |
-| `activeDate`     | --                 | Focused date with indicator (will become selected date if user proceeds) | `Date`   | `undefined` |
-| `locale`         | `locale`           | User's language and region as BCP 47 formatted string.                   | `string` | `undefined` |
-| `max`            | --                 | Maximum date of the calendar above which is disabled.                    | `Date`   | `undefined` |
-| `min`            | --                 | Minimum date of the calendar below which is disabled.                    | `Date`   | `undefined` |
-| `nextMonthLabel` | `next-month-label` | Localized string for next month.                                         | `string` | `undefined` |
-| `prevMonthLabel` | `prev-month-label` | Localized string for previous month.                                     | `string` | `undefined` |
-| `selectedDate`   | --                 | Already selected date.                                                   | `Date`   | `undefined` |
-
+| Property         | Attribute          | Description                                                              | Type                | Default     |
+| ---------------- | ------------------ | ------------------------------------------------------------------------ | ------------------- | ----------- |
+| `activeDate`     | --                 | Focused date with indicator (will become selected date if user proceeds) | `Date`              | `undefined` |
+| `locale`         | `locale`           | User's language and region as BCP 47 formatted string.                   | `string`            | `undefined` |
+| `max`            | --                 | Maximum date of the calendar above which is disabled.                    | `Date`              | `undefined` |
+| `min`            | --                 | Minimum date of the calendar below which is disabled.                    | `Date`              | `undefined` |
+| `nextMonthLabel` | `next-month-label` | Localized string for next month.                                         | `string`            | `undefined` |
+| `prevMonthLabel` | `prev-month-label` | Localized string for previous month.                                     | `string`            | `undefined` |
+| `scale`          | `scale`            | specify the scale of the date picker                                     | `"l" \| "m" \| "s"` | `undefined` |
+| `selectedDate`   | --                 | Already selected date.                                                   | `Date`              | `undefined` |
 
 ## Events
 
-| Event                     | Description            | Type               |
-| ------------------------- | ---------------------- | ------------------ |
-| `calciteActiveDateChange` | Changes to active date | `CustomEvent<any>` |
-
+| Event                     | Description            | Type                |
+| ------------------------- | ---------------------- | ------------------- |
+| `calciteActiveDateChange` | Changes to active date | `CustomEvent<Date>` |
 
 ## Dependencies
 
 ### Used by
 
- - [calcite-date](../calcite-date)
+- [calcite-date](../calcite-date)
 
 ### Depends on
 
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-date-month-header --> calcite-icon
@@ -41,6 +40,6 @@ graph TD;
   style calcite-date-month-header fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-date-month/calcite-date-month.scss
+++ b/src/components/calcite-date-month/calcite-date-month.scss
@@ -3,26 +3,41 @@
 }
 
 .calender {
-  .week-headers {
-    display: flex;
-    flex-direction: row;
-    border-bottom: 1px solid var(--calcite-ui-border-3);
-    border-top: 1px solid var(--calcite-ui-border-3);
+  padding-bottom: 4px;
+}
 
-    .week-header {
-      color: var(--calcite-ui-text-2);
-      padding: 0.75rem 0;
-      text-transform: uppercase;
-      font-weight: 600;
-      font-size: 11px;
-      width: calc(100% / 7);
-      text-align: center;
-    }
-  }
+.week-headers {
+  display: flex;
+  flex-direction: row;
+  border-top: 1px solid var(--calcite-ui-border-3);
+  padding: 0 4px;
+}
 
-  .week-days {
-    outline: none;
-    display: flex;
-    flex-direction: row;
-  }
+.week-header {
+  color: var(--calcite-ui-text-3);
+  font-weight: 600;
+  width: calc(100% / 7);
+  text-align: center;
+}
+
+:host([scale="s"]) .week-header {
+  font-size: 12px;
+  padding: 16px 0 16px 0;
+}
+
+:host([scale="m"]) .week-header {
+  font-size: 12px;
+  padding: 24px 0 20px 0;
+}
+
+:host([scale="l"]) .week-header {
+  font-size: 14px;
+  padding: 32px 0 24px 0;
+}
+
+.week-days {
+  outline: none;
+  display: flex;
+  flex-direction: row;
+  padding: 0 4px;
 }

--- a/src/components/calcite-date-month/calcite-date-month.tsx
+++ b/src/components/calcite-date-month/calcite-date-month.tsx
@@ -42,6 +42,8 @@ export class CalciteDateMonth {
   @Prop() max: Date;
   /** User's language and region as BCP 47 formatted string. */
   @Prop() locale: string = "en-US";
+  /** specify the scale of the date picker */
+  @Prop({ reflect: true }) scale: "s" | "m" | "l";
 
   //--------------------------------------------------------------------------
   //
@@ -134,7 +136,10 @@ export class CalciteDateMonth {
     const month = this.activeDate.getMonth();
     const year = this.activeDate.getFullYear();
     const startOfWeek = getFirstDayOfWeek(this.locale);
-    const weekDays = getLocalizedWeekdays(this.locale);
+    const weekDays = getLocalizedWeekdays(
+      this.locale,
+      this.scale === "s" ? "narrow" : "short"
+    );
     const curMonDays = this.getCurrentMonthDays(month, year);
     const prevMonDays = this.getPrevMonthdays(month, year, startOfWeek);
     const nextMonDays = this.getNextMonthDays(month, year, startOfWeek);
@@ -143,6 +148,7 @@ export class CalciteDateMonth {
         const date = new Date(year, month - 1, day);
         return (
           <calcite-date-day
+            scale={this.scale}
             day={day}
             disabled={!inRange(date, this.min, this.max)}
             selected={sameDate(date, this.selectedDate)}
@@ -156,6 +162,7 @@ export class CalciteDateMonth {
         const active = sameDate(date, this.activeDate);
         return (
           <calcite-date-day
+            scale={this.scale}
             day={day}
             disabled={!inRange(date, this.min, this.max)}
             selected={sameDate(date, this.selectedDate)}
@@ -176,6 +183,7 @@ export class CalciteDateMonth {
         const date = new Date(year, month + 1, day);
         return (
           <calcite-date-day
+            scale={this.scale}
             day={day}
             disabled={!inRange(date, this.min, this.max)}
             selected={sameDate(date, this.selectedDate)}

--- a/src/components/calcite-date-month/readme.md
+++ b/src/components/calcite-date-month/readme.md
@@ -2,17 +2,16 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property       | Attribute | Description                                            | Type     | Default      |
-| -------------- | --------- | ------------------------------------------------------ | -------- | ------------ |
-| `activeDate`   | --        | Date currently active.                                 | `Date`   | `new Date()` |
-| `locale`       | `locale`  | User's language and region as BCP 47 formatted string. | `string` | `"en-US"`    |
-| `max`          | --        | Maximum date of the calendar above which is disabled.  | `Date`   | `undefined`  |
-| `min`          | --        | Minimum date of the calendar below which is disabled.  | `Date`   | `undefined`  |
-| `selectedDate` | --        | Already selected date.                                 | `Date`   | `undefined`  |
-
+| Property       | Attribute | Description                                            | Type                | Default      |
+| -------------- | --------- | ------------------------------------------------------ | ------------------- | ------------ |
+| `activeDate`   | --        | Date currently active.                                 | `Date`              | `new Date()` |
+| `locale`       | `locale`  | User's language and region as BCP 47 formatted string. | `string`            | `"en-US"`    |
+| `max`          | --        | Maximum date of the calendar above which is disabled.  | `Date`              | `undefined`  |
+| `min`          | --        | Minimum date of the calendar below which is disabled.  | `Date`              | `undefined`  |
+| `scale`        | `scale`   | specify the scale of the date picker                   | `"l" \| "m" \| "s"` | `undefined`  |
+| `selectedDate` | --        | Already selected date.                                 | `Date`              | `undefined`  |
 
 ## Events
 
@@ -21,18 +20,18 @@
 | `calciteActiveDateChange` | Active date for the user keyboard access. | `CustomEvent<any>` |
 | `calciteDateSelect`       | Event emitted when user selects the date. | `CustomEvent<any>` |
 
-
 ## Dependencies
 
 ### Used by
 
- - [calcite-date](../calcite-date)
+- [calcite-date](../calcite-date)
 
 ### Depends on
 
 - [calcite-date-day](../calcite-date-day)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-date-month --> calcite-date-day
@@ -40,6 +39,6 @@ graph TD;
   style calcite-date-month fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -1,6 +1,10 @@
 :host {
   display: inline-block;
   vertical-align: top;
+  width: 100%;
+  max-width: 312px;
+  position: relative;
+  overflow: visible;
 }
 
 ::slotted(input) {
@@ -46,10 +50,13 @@
 
 .calendar-picker-wrapper {
   position: absolute;
+  top: 100%;
   background-color: var(--calcite-ui-foreground-1);
   box-shadow: $shadow-2;
   opacity: 0;
+  max-width: 100%;
   visibility: hidden;
+  overflow: visible;
   transform: translate3d(0, -$baseline, 0);
   transition: all 0.15s ease-in-out;
   pointer-events: none;
@@ -59,9 +66,7 @@
 :host([show-calendar]) {
   background-color: var(--calcite-ui-foreground-1);
   border-radius: var(--calcite-border-radius);
-  border: 1px solid var(--calcite-ui-border-2);
   box-shadow: $shadow-2;
-  overflow: hidden;
 
   .calendar-picker-wrapper {
     opacity: 1;
@@ -71,7 +76,7 @@
   }
 
   .date-input-wrapper {
-    border: none;
+    border: 1px solid var(--calcite-ui-foreground-1);
     border-bottom: 1px solid var(--calcite-ui-border-3);
   }
 }

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -46,7 +46,7 @@
   z-index: 3;
 }
 
-:host([show-calendar]) {
+:host([active]) {
   background-color: var(--calcite-ui-foreground-1);
   border-radius: var(--calcite-border-radius);
   box-shadow: $shadow-2;

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -2,42 +2,24 @@
   display: inline-block;
   vertical-align: top;
   width: 100%;
-  max-width: 312px;
   position: relative;
   overflow: visible;
 }
 
-::slotted(input) {
+.slot {
   display: none;
 }
 
-.date-input-wrapper {
-  border: 1px solid var(--calcite-ui-border-1);
-  position: relative;
-
-  &:active,
-  &:focus {
-    border-color: transparent;
-    border-bottom: 1px solid var(--calcite-ui-border-3);
-  }
+:host([scale="s"]) {
+  max-width: 246px;
 }
 
-.date-input {
-  color: var(--calcite-ui-text-3);
-  background: var(--calcite-ui-foreground-1);
-  box-sizing: border-box;
-  border: none;
-  font-weight: 400;
-  @include font-size(0);
-  font-family: inherit;
-  padding: 0.75rem 2.5rem;
-  width: 100%;
-  margin: 0;
+:host([scale="m"]) {
+  max-width: 288px;
+}
 
-  &:active,
-  &:focus {
-    outline: none;
-  }
+:host([scale="l"]) {
+  max-width: 400px;
 }
 
 .calendar-icon {
@@ -54,7 +36,8 @@
   background-color: var(--calcite-ui-foreground-1);
   box-shadow: $shadow-2;
   opacity: 0;
-  max-width: 100%;
+  width: 100%;
+  line-height: 0; // fixes height in ie11
   visibility: hidden;
   overflow: visible;
   transform: translate3d(0, -$baseline, 0);

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -53,7 +53,7 @@
   transform: translate3d(0, -$baseline, 0);
   transition: all 0.15s ease-in-out;
   pointer-events: none;
-  z-index: 2;
+  z-index: 3;
 }
 
 :host([show-calendar]) {

--- a/src/components/calcite-date/calcite-date.stories.js
+++ b/src/components/calcite-date/calcite-date.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { withKnobs, select, text, boolean } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -50,10 +50,12 @@ storiesOf("Date", module)
     "Simple",
     () => `
     <calcite-date
+      scale="${select("scale", ["s", "m", "l"], "m")}"
       value="${text("value", "")}"
       min="${text("min", "2016-08-09")}"
       max="${text("max", "2023-12-18")}"
       locale="${select("locale", locales, "en-US")}"
+      no-calendar-input="${boolean("no-calendar-input")}"
       next-month-label="${text("next-month-label", "Next month")}"
       prev-month-label="${text("prev-month-label", "Previous month")}"
     ></calcite-date>
@@ -65,9 +67,11 @@ storiesOf("Date", module)
     () => `
     <calcite-date
       theme="dark"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
       value="${text("value", "")}"
       min="${text("min", "2016-08-09")}"
       max="${text("max", "2023-12-18")}"
+      no-calendar-input="${boolean("no-calendar-input")}"
       locale="${select("locale", locales, "en-US")}"
       next-month-label="${text("next-month-label", "Next month")}"
       prev-month-label="${text("prev-month-label", "Previous month")}"

--- a/src/components/calcite-date/calcite-date.stories.js
+++ b/src/components/calcite-date/calcite-date.stories.js
@@ -49,33 +49,54 @@ storiesOf("Date", module)
   .add(
     "Simple",
     () => `
+    <div style="width: 400px">
     <calcite-date
       scale="${select("scale", ["s", "m", "l"], "m")}"
       value="${text("value", "")}"
       min="${text("min", "2016-08-09")}"
       max="${text("max", "2023-12-18")}"
       locale="${select("locale", locales, "en-US")}"
-      no-calendar-input="${boolean("no-calendar-input")}"
       next-month-label="${text("next-month-label", "Next month")}"
       prev-month-label="${text("prev-month-label", "Previous month")}"
     ></calcite-date>
+    </div>
+  `,
+    { notes }
+  )
+  .add(
+    "No input",
+    () => `
+    <div style="width: 400px">
+    <calcite-date
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      value="${text("value", "")}"
+      min="${text("min", "2016-08-09")}"
+      max="${text("max", "2023-12-18")}"
+      locale="${select("locale", locales, "en-US")}"
+      active
+      no-calendar-input
+      next-month-label="${text("next-month-label", "Next month")}"
+      prev-month-label="${text("prev-month-label", "Previous month")}"
+    ></calcite-date>
+    </div>
   `,
     { notes }
   )
   .add(
     "Dark mode",
     () => `
+    <div style="width: 400px">
     <calcite-date
       theme="dark"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       value="${text("value", "")}"
       min="${text("min", "2016-08-09")}"
       max="${text("max", "2023-12-18")}"
-      no-calendar-input="${boolean("no-calendar-input")}"
       locale="${select("locale", locales, "en-US")}"
       next-month-label="${text("next-month-label", "Next month")}"
       prev-month-label="${text("prev-month-label", "Previous month")}"
     ></calcite-date>
+    </div>
 `,
     { notes, backgrounds: darkBackground }
   );

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -8,13 +8,13 @@ import {
   State,
   Listen,
   Build,
+  EventEmitter,
 } from "@stencil/core";
 import {
   parseDateString,
   getLocaleFormatData,
   DateFormattingData,
 } from "../../utils/locale";
-import { DateChangeEvent, DateChangeEmitter } from "../../interfaces/Date";
 import { getElementDir } from "../../utils/dom";
 import {
   dateFromRange,
@@ -50,7 +50,7 @@ export class CalciteDatePicker {
   /** Latest allowed date ("yyyy-mm-dd") */
   @Prop() max?: string;
   /** Expand or collapse when calendar does not have input */
-  @Prop({ reflect: true }) showCalendar: boolean = false;
+  @Prop({ reflect: true }) active: boolean = false;
   /** Localized string for "previous month" */
   @Prop() prevMonthLabel?: string = "previous month";
   /** Localized string for "next month" */
@@ -95,7 +95,7 @@ export class CalciteDatePicker {
   /**
    * Trigger calcite date change when a user changes the date.
    */
-  @Event() calciteDateChange: DateChangeEmitter;
+  @Event() calciteDateChange: EventEmitter<Date>;
 
   /**
    * Active date.
@@ -138,7 +138,7 @@ export class CalciteDatePicker {
               value={formattedDate}
               placeholder={this.localeData.placeholder}
               icon="calendar"
-              onCalciteInputFocus={() => (this.showCalendar = true)}
+              onCalciteInputFocus={() => (this.active = true)}
               onCalciteInputChange={(e) => this.input(e.detail.value)}
               onCalciteInputBlur={(e) => this.blur(e.detail)}
               scale={this.scale}
@@ -155,7 +155,7 @@ export class CalciteDatePicker {
             locale={this.locale}
             min={min}
             max={max}
-            onCalciteActiveDateChange={(e: DateChangeEvent) => {
+            onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
               this.activeDate = new Date(e.detail);
             }}
             dir={dir}
@@ -167,13 +167,13 @@ export class CalciteDatePicker {
             selectedDate={date}
             activeDate={activeDate}
             locale={this.locale}
-            onCalciteDateSelect={(e: DateChangeEvent) => {
+            onCalciteDateSelect={(e: CustomEvent<Date>) => {
               this.setValue(new Date(e.detail));
               this.activeDate = new Date(e.detail);
               this.calciteDateChange.emit(new Date(e.detail));
               this.reset();
             }}
-            onCalciteActiveDateChange={(e: DateChangeEvent) => {
+            onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
               this.activeDate = new Date(e.detail);
             }}
             dir={dir}
@@ -272,7 +272,7 @@ export class CalciteDatePicker {
       this.activeDate = new Date(this.valueAsDate);
     }
     if (!this.noCalendarInput) {
-      this.showCalendar = false;
+      this.active = false;
     }
   }
 

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -313,11 +313,15 @@ export class CalciteDatePicker {
   private getDateFromInput(value: string): Date | false {
     const { separator } = this.localeData;
     const { day, month, year } = parseDateString(value, this.locale);
+    const validDay = day > 0;
+    const validMonth = month > -1;
     const date = new Date(year, month, day);
     const validDate = !isNaN(date.getTime());
     const validLength = value.split(separator).filter((c) => c).length > 2;
     const validYear = year.toString().length > 3;
     if (
+      validDay &&
+      validMonth &&
       validDate &&
       validLength &&
       validYear &&

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -59,6 +59,8 @@ export class CalciteDatePicker {
   @Prop() locale?: string = "en-US";
   /** Show only calendar popup */
   @Prop() noCalendarInput?: boolean = false;
+  /** specify the scale of the date picker */
+  @Prop({ reflect: true }) scale: "s" | "m" | "l" = "m";
 
   //--------------------------------------------------------------------------
   //
@@ -126,18 +128,21 @@ export class CalciteDatePicker {
     const dir = getElementDir(this.el);
     return (
       <Host role="application" dir={dir}>
-        <slot></slot>
+        <div class="slot">
+          <slot></slot>
+        </div>
         {!this.noCalendarInput && (
-          <div class="date-input-wrapper" role="application">
-            <calcite-icon icon="calendar" class="calendar-icon" scale="s" />
-            <input
+          <div role="application">
+            <calcite-input
               type="text"
-              placeholder={this.localeData.placeholder}
               value={formattedDate}
-              class="date-input"
-              onFocus={() => (this.showCalendar = true)}
-              onInput={(e) => this.input((e.target as HTMLInputElement).value)}
-              onBlur={(e) => this.blur(e.target as HTMLInputElement)}
+              placeholder={this.localeData.placeholder}
+              icon="calendar"
+              onCalciteInputFocus={() => (this.showCalendar = true)}
+              onCalciteInputChange={(e) => this.input(e.detail.value)}
+              onCalciteInputBlur={(e) => this.blur(e.detail)}
+              scale={this.scale}
+              number-button-type="none"
             />
           </div>
         )}
@@ -154,6 +159,7 @@ export class CalciteDatePicker {
               this.activeDate = new Date(e.detail);
             }}
             dir={dir}
+            scale={this.scale}
           />
           <calcite-date-month
             min={min}
@@ -171,6 +177,7 @@ export class CalciteDatePicker {
               this.activeDate = new Date(e.detail);
             }}
             dir={dir}
+            scale={this.scale}
           />
         </div>
       </Host>

--- a/src/components/calcite-date/readme.md
+++ b/src/components/calcite-date/readme.md
@@ -18,48 +18,49 @@ Date also supports passing in a proxy input to make event handling and binding e
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property          | Attribute           | Description                                                 | Type      | Default            |
-| ----------------- | ------------------- | ----------------------------------------------------------- | --------- | ------------------ |
-| `locale`          | `locale`            | BCP 47 language tag for desired language and country format | `string`  | `"en-US"`          |
-| `max`             | `max`               | Latest allowed date ("yyyy-mm-dd")                          | `string`  | `undefined`        |
-| `min`             | `min`               | Earliest allowed date ("yyyy-mm-dd")                        | `string`  | `undefined`        |
-| `nextMonthLabel`  | `next-month-label`  | Localized string for "next month"                           | `string`  | `"next month"`     |
-| `noCalendarInput` | `no-calendar-input` | Show only calendar popup                                    | `boolean` | `false`            |
-| `prevMonthLabel`  | `prev-month-label`  | Localized string for "previous month"                       | `string`  | `"previous month"` |
-| `showCalendar`    | `show-calendar`     | Expand or collapse when calendar does not have input        | `boolean` | `false`            |
-| `value`           | `value`             | Selected date                                               | `string`  | `undefined`        |
-| `valueAsDate`     | --                  | Selected date as full date object                           | `Date`    | `undefined`        |
-
+| Property          | Attribute           | Description                                                 | Type                | Default            |
+| ----------------- | ------------------- | ----------------------------------------------------------- | ------------------- | ------------------ |
+| `active`          | `active`            | Expand or collapse when calendar does not have input        | `boolean`           | `false`            |
+| `locale`          | `locale`            | BCP 47 language tag for desired language and country format | `string`            | `"en-US"`          |
+| `max`             | `max`               | Latest allowed date ("yyyy-mm-dd")                          | `string`            | `undefined`        |
+| `min`             | `min`               | Earliest allowed date ("yyyy-mm-dd")                        | `string`            | `undefined`        |
+| `nextMonthLabel`  | `next-month-label`  | Localized string for "next month"                           | `string`            | `"next month"`     |
+| `noCalendarInput` | `no-calendar-input` | Show only calendar popup                                    | `boolean`           | `false`            |
+| `prevMonthLabel`  | `prev-month-label`  | Localized string for "previous month"                       | `string`            | `"previous month"` |
+| `scale`           | `scale`             | specify the scale of the date picker                        | `"l" \| "m" \| "s"` | `"m"`              |
+| `value`           | `value`             | Selected date                                               | `string`            | `undefined`        |
+| `valueAsDate`     | --                  | Selected date as full date object                           | `Date`              | `undefined`        |
 
 ## Events
 
-| Event               | Description                                               | Type               |
-| ------------------- | --------------------------------------------------------- | ------------------ |
-| `calciteDateChange` | Trigger calcite date change when a user changes the date. | `CustomEvent<any>` |
-
+| Event               | Description                                               | Type                |
+| ------------------- | --------------------------------------------------------- | ------------------- |
+| `calciteDateChange` | Trigger calcite date change when a user changes the date. | `CustomEvent<Date>` |
 
 ## Dependencies
 
 ### Depends on
 
-- [calcite-icon](../calcite-icon)
+- [calcite-input](../calcite-input)
 - [calcite-date-month-header](../calcite-date-month-header)
 - [calcite-date-month](../calcite-date-month)
 
 ### Graph
+
 ```mermaid
 graph TD;
-  calcite-date --> calcite-icon
+  calcite-date --> calcite-input
   calcite-date --> calcite-date-month-header
   calcite-date --> calcite-date-month
+  calcite-input --> calcite-progress
+  calcite-input --> calcite-icon
   calcite-date-month-header --> calcite-icon
   calcite-date-month --> calcite-date-day
   style calcite-date fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -92,6 +92,9 @@ export class CalciteInput {
   /** should the input autofocus */
   @Prop() autofocus: boolean = false;
 
+  /** explicitly whitelist placeholder attribute */
+  @Prop() placeholder: string;
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -238,6 +241,7 @@ export class CalciteInput {
           onFocus={() => this.inputFocusHandler()}
           onInput={(e) => this.inputChangeHandler(e)}
           value={this.value}
+          placeholder={this.placeholder || ""}
           required={this.required ? true : null}
           autofocus={this.autofocus ? true : null}
         />
@@ -249,6 +253,7 @@ export class CalciteInput {
             onFocus={() => this.inputFocusHandler()}
             onInput={(e) => this.inputChangeHandler(e)}
             required={this.required ? true : null}
+            placeholder={this.placeholder || ""}
             autofocus={this.autofocus ? true : null}
           >
             <slot />

--- a/src/components/calcite-progress/calcite-progress.scss
+++ b/src/components/calcite-progress/calcite-progress.scss
@@ -3,7 +3,6 @@
   display: block;
   height: 2px;
   width: 100%;
-  overflow: hidden;
 }
 
 .track,
@@ -17,6 +16,7 @@
   background: var(--calcite-ui-border-3);
   z-index: 0;
   width: 100%;
+  overflow: hidden;
 }
 
 .bar {

--- a/src/components/calcite-progress/calcite-progress.tsx
+++ b/src/components/calcite-progress/calcite-progress.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Host, Prop } from "@stencil/core";
 @Component({
   tag: "calcite-progress",
   styleUrl: "calcite-progress.scss",
-  shadow: true
+  shadow: true,
 })
 export class CalciteProgress {
   @Element() el: HTMLElement;
@@ -21,16 +21,17 @@ export class CalciteProgress {
     const isDeterminate = this.type === "determinate";
     const barStyles = isDeterminate ? { width: `${this.value * 100}%` } : {};
     return (
-      <Host class="calcite-progress">
-        <div class="track" />
-        <div
-          class={{
-            bar: true,
-            indeterminate: this.type === "indeterminate",
-            reversed: this.reversed
-          }}
-          style={ barStyles }
-        />
+      <Host>
+        <div class="track">
+          <div
+            class={{
+              bar: true,
+              indeterminate: this.type === "indeterminate",
+              reversed: this.reversed,
+            }}
+            style={barStyles}
+          />
+        </div>
         {this.text ? <div class="text">{this.text}</div> : null}
       </Host>
     );

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -26,7 +26,7 @@ describe("calcite-slider", () => {
       >
       </calcite-slider>
     `);
-    const button = await page.find("calcite-slider >>> .slider__thumb");
+    const button = await page.find("calcite-slider >>> .thumb");
     expect(button).toEqualAttribute("role", "slider");
     expect(button).toEqualAttribute("aria-label", "Yeah! Slider!");
     expect(button).toEqualAttribute("aria-valuenow", "23");
@@ -48,8 +48,8 @@ describe("calcite-slider", () => {
       >
       </calcite-slider>
     `);
-    const maxButton = await page.find("calcite-slider >>> .slider__thumb--max");
-    const minButton = await page.find("calcite-slider >>> .slider__thumb--min");
+    const maxButton = await page.find("calcite-slider >>> .thumb--max");
+    const minButton = await page.find("calcite-slider >>> .thumb--min");
     expect(minButton).toEqualAttribute("role", "slider");
     expect(maxButton).toEqualAttribute("role", "slider");
     expect(minButton).toEqualAttribute("aria-label", "Min Label");
@@ -77,7 +77,7 @@ describe("calcite-slider", () => {
       </calcite-slider>
     `);
     const slider = await page.find("calcite-slider");
-    const handle = await page.find("calcite-slider >>> .slider__thumb");
+    const handle = await page.find("calcite-slider >>> .thumb");
     await page.waitForChanges();
     let value = await slider.getProperty("value");
     expect(value).toBe(30);
@@ -112,7 +112,7 @@ describe("calcite-slider", () => {
       </calcite-slider>
     `);
     const slider = await page.find("calcite-slider");
-    const handle = await page.find("calcite-slider >>> .slider__thumb--max");
+    const handle = await page.find("calcite-slider >>> .thumb--max");
     await page.waitForChanges();
     let value = await slider.getProperty("value");
     expect(value).toBe(20);
@@ -133,7 +133,7 @@ describe("calcite-slider", () => {
       >
       </calcite-slider>
     `);
-    const ticks = await page.findAll("calcite-slider >>> .slider__tick");
+    const ticks = await page.findAll("calcite-slider >>> .tick");
     expect(ticks.length).toBe(11);
   });
 
@@ -150,7 +150,7 @@ describe("calcite-slider", () => {
       </calcite-slider>
     `);
     const slider = await page.find("calcite-slider");
-    const handle = await page.find("calcite-slider >>> .slider__thumb");
+    const handle = await page.find("calcite-slider >>> .thumb");
     const changeEvent = await slider.spyOnEvent("calciteSliderUpdate");
     expect(changeEvent).toHaveReceivedEventTimes(0);
     await handle.press("ArrowRight");

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -39,14 +39,14 @@ $tick-height: 4px;
 }
 
 // focus styles
-.slider__thumb {
+.thumb {
   @include focus-style-base();
   &:focus {
     @include focus-style-outset();
   }
 }
 
-.slider__thumb {
+.thumb {
   position: absolute;
   height: $thumb-size;
   width: $thumb-size;
@@ -56,10 +56,10 @@ $tick-height: 4px;
   background: transparent;
   cursor: pointer;
   font-family: inherit;
-  z-index: 3;
+  z-index: 2;
 }
 
-.slider__handle {
+.handle {
   position: absolute;
   top: 0;
   left: 0;
@@ -74,7 +74,7 @@ $tick-height: 4px;
     box-shadow 0.25s ease;
 }
 
-.slider__handle__label {
+.handle__label {
   position: absolute;
   left: 0;
   bottom: $thumb-size;
@@ -87,27 +87,27 @@ $tick-height: 4px;
   text-align: center;
 }
 
-.slider__thumb:hover .slider__handle {
+.thumb:hover .handle {
   border-width: 3px;
   border-color: var(--calcite-ui-blue-1);
   @include shadow(1, "hover");
 }
 
-.slider__thumb:focus,
-.slider__thumb--active {
-  z-index: 4;
-  .slider__handle {
+.thumb:focus,
+.thumb--active {
+  z-index: 3;
+  .handle {
     background-color: var(--calcite-ui-blue-1);
     border-color: var(--calcite-ui-blue-1);
     @include shadow(1, "press");
   }
 }
 
-.slider__thumb--precise {
+.thumb--precise {
   margin-top: -$thumb-size;
 }
 
-.slider__thumb--precise:after {
+.thumb--precise:after {
   content: "";
   display: block;
   position: absolute;
@@ -118,45 +118,45 @@ $tick-height: 4px;
   background-color: var(--calcite-ui-text-3);
   margin-left: -1px;
   margin-top: $thumb-padding;
-  z-index: 2;
+  z-index: 1;
 }
 
-.slider__thumb:hover.slider__thumb--precise:after,
-.slider__thumb:focus.slider__thumb--precise:after,
-.slider__thumb--active.slider__thumb--precise:after {
+.thumb:hover.thumb--precise:after,
+.thumb:focus.thumb--precise:after,
+.thumb--active.thumb--precise:after {
   background-color: var(--calcite-ui-blue-1);
 }
 
-.slider__thumb--precise.slider__thumb--min {
+.thumb--precise.thumb--min {
   margin-top: -$track-height;
-  .slider__handle__label {
+  .handle__label {
     bottom: unset;
     top: $thumb-size;
   }
 }
 
-.slider__thumb--precise.slider__thumb--min:after {
+.thumb--precise.thumb--min:after {
   top: 0;
   margin-top: 0;
 }
 
-.slider__track {
+.track {
   height: $track-height;
   border-radius: 0;
-  z-index: 2;
+  z-index: 1;
   background-color: var(--calcite-ui-border-2);
   transition: all 250ms ease-in;
   position: relative;
 }
 
-.slider__track__range {
+.track__range {
   position: absolute;
   top: 0;
   height: $track-height;
   background-color: var(--calcite-ui-blue-1);
 }
 
-.slider__tick {
+.tick {
   position: absolute;
   top: -$tick-height / 2;
   width: 2px;
@@ -169,11 +169,11 @@ $tick-height: 4px;
   background-color: var(--calcite-ui-border-1);
 }
 
-.slider__tick--active {
+.tick--active {
   background-color: var(--calcite-ui-blue-1);
 }
 
-.slider__tick__label {
+.tick__label {
   position: absolute;
   @include font-size(-3);
   font-weight: 500;
@@ -185,13 +185,13 @@ $tick-height: 4px;
   pointer-events: none;
 }
 
-.slider__tick__label--min {
+.tick__label--min {
   left: 0;
   margin: $thumb-size / 2 -3px;
   text-align: left;
 }
 
-.slider__tick__label--max {
+.tick__label--max {
   left: unset;
   right: 0;
   margin: $thumb-size / 2 -3px;

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -89,14 +89,14 @@ export class CalciteSlider {
 
     return (
       <Host id={id} is-range={this.isRange}>
-        <div class="slider__track">
-          <div class="slider__track__range" style={{ left, right }} />
-          <div class="slider__ticks">
+        <div class="track">
+          <div class="track__range" style={{ left, right }} />
+          <div class="ticks">
             {this.tickValues.map((number) => (
               <span
                 class={{
-                  slider__tick: true,
-                  "slider__tick--active": number >= min && number <= max,
+                  tick: true,
+                  "tick--active": number >= min && number <= max,
                 }}
                 style={{
                   left: `${this.getUnitInterval(number) * 100}%`,
@@ -105,9 +105,9 @@ export class CalciteSlider {
                 {this.labelTicks ? (
                   <span
                     class={{
-                      slider__tick__label: true,
-                      "slider__tick__label--min": number === this.min,
-                      "slider__tick__label--max": number === this.max,
+                      tick__label: true,
+                      "tick__label--min": number === this.min,
+                      "tick__label--max": number === this.max,
                     }}
                   >
                     {number}
@@ -135,15 +135,15 @@ export class CalciteSlider {
             disabled={this.disabled}
             style={{ left }}
             class={{
-              slider__thumb: true,
-              "slider__thumb--min": true,
-              "slider__thumb--active": this.dragProp === "minValue",
-              "slider__thumb--precise": this.precise,
+              thumb: true,
+              "thumb--min": true,
+              "thumb--active": this.dragProp === "minValue",
+              "thumb--precise": this.precise,
             }}
           >
-            <span class="slider__handle"></span>
+            <span class="handle"></span>
             {this.labelHandles ? (
-              <span class="slider__handle__label" aria-hidden="true">
+              <span class="handle__label" aria-hidden="true">
                 {this.minValue}
               </span>
             ) : (
@@ -168,15 +168,15 @@ export class CalciteSlider {
           disabled={this.disabled}
           style={{ right }}
           class={{
-            slider__thumb: true,
-            "slider__thumb--max": true,
-            "slider__thumb--active": this.dragProp === maxProp,
-            "slider__thumb--precise": this.precise,
+            thumb: true,
+            "thumb--max": true,
+            "thumb--active": this.dragProp === maxProp,
+            "thumb--precise": this.precise,
           }}
         >
-          <span class="slider__handle"></span>
+          <span class="handle"></span>
           {this.labelHandles ? (
-            <span class="slider__handle__label" aria-hidden="true">
+            <span class="handle__label" aria-hidden="true">
               {this[maxProp]}
             </span>
           ) : (

--- a/src/demos/calcite-date.html
+++ b/src/demos/calcite-date.html
@@ -41,13 +41,13 @@
   <h2>Scales</h2>
 
   <h3>Small</h3>
-  <calcite-date scale="s" value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+  <calcite-date scale="s" value="2000-11-27" no-calendar-input="true" active></calcite-date>
 
   <h3>Medium</h3>
-  <calcite-date scale="m" value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+  <calcite-date scale="m" value="2000-11-27" no-calendar-input="true" active></calcite-date>
 
   <h3>Large</h3>
-  <calcite-date scale="l" value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+  <calcite-date scale="l" value="2000-11-27" no-calendar-input="true" active></calcite-date>
 
   <h2>Inside Small Container</h2>
   <div style="width: 200px">
@@ -115,7 +115,7 @@
   </div>
 
   <h2>Always open</h2>
-  <calcite-date value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+  <calcite-date value="2000-11-27" no-calendar-input="true" active></calcite-date>
 
   <h2>Input Proxy</h2>
   <calcite-date>
@@ -138,7 +138,7 @@
     <calcite-date theme="dark" value="2019-08-23"></calcite-date>
 
     <h2>Always open</h2>
-    <calcite-date value="2000-11-27" theme="dark" no-calendar-input="true" show-calendar="true"></calcite-date>
+    <calcite-date value="2000-11-27" theme="dark" no-calendar-input="true" active></calcite-date>
   </div>
 </body>
 

--- a/src/demos/calcite-date.html
+++ b/src/demos/calcite-date.html
@@ -39,6 +39,11 @@
   <h2>Start day of locale</h2>
   <calcite-date locale="es"></calcite-date>
 
+  <h2>Inside Small Container</h2>
+  <div style="width: 200px">
+    <calcite-date value="2020-03-07"></calcite-date>
+  </div>
+
   <h2>Locale formatted dates</h2>
   <calcite-date value="2019-08-23" min="2019-08-09" max="2021-12-18" locale="th" id="locale"></calcite-date>
   <calcite-dropdown id="localePicker">

--- a/src/demos/calcite-date.html
+++ b/src/demos/calcite-date.html
@@ -12,8 +12,7 @@
       color: white;
       padding: 1rem 1rem 3rem 1rem;
     }
-
-    h2 {
+    h2, h3 {
       padding-top: 3rem;
     }
   </style>
@@ -39,9 +38,20 @@
   <h2>Start day of locale</h2>
   <calcite-date locale="es"></calcite-date>
 
+  <h2>Scales</h2>
+
+  <h3>Small</h3>
+  <calcite-date scale="s" value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+
+  <h3>Medium</h3>
+  <calcite-date scale="m" value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+
+  <h3>Large</h3>
+  <calcite-date scale="l" value="2000-11-27" no-calendar-input="true" show-calendar="true"></calcite-date>
+
   <h2>Inside Small Container</h2>
   <div style="width: 200px">
-    <calcite-date value="2020-03-07"></calcite-date>
+    <calcite-date value="2020-03-07" scale="s"></calcite-date>
   </div>
 
   <h2>Locale formatted dates</h2>

--- a/src/interfaces/Date.ts
+++ b/src/interfaces/Date.ts
@@ -1,9 +1,0 @@
-import { EventEmitter } from "@stencil/core";
-
-export interface DateChangeEmitter extends EventEmitter {
-  detail: Date;
-}
-
-export interface DateChangeEvent extends CustomEvent {
-  detail: Date;
-}

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -71,7 +71,7 @@ export function parseDateString(
     .map((part) => part.replace(".", ""));
   return {
     day: parseInt(values[order.indexOf(units.day)]),
-    month: Math.max(parseInt(values[order.indexOf(units.month)]) - 1, 0),
+    month: parseInt(values[order.indexOf(units.month)]) - 1,
     year: parseInt(values[order.indexOf(units.year)]) - (buddhist ? 543 : 0),
   };
 }

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -109,14 +109,14 @@ export function getYear(date: Date, locale: string): string {
 /**
  * Generate an array of localized week day names in the correct order
  */
-export function getLocalizedWeekdays(locale: string): string[] {
+export function getLocalizedWeekdays(locale: string, format: string = "short"): string[] {
   const startWeek = [];
   const endWeek = [];
   const date = new Date();
   for (let w = 1; w < 8; w++) {
     date.setDate(w);
     let day = new Intl.DateTimeFormat(locale, {
-      weekday: "short",
+      weekday: format,
     }).format(date);
     date.getDay() === getFirstDayOfWeek(locale) || startWeek.length > 0
       ? startWeek.push(day)


### PR DESCRIPTION
Sorry, other branch was deleted after I rebased, so reopening this pr. Several fixes, plus a bundle of `calcite-date` updates. This pr builds on top of the `key` work in #479 so that pr should probably be merged prior to this one.

### Small fixes

- 🐞 fix hidden progress text (#452)
- 🧹 remove BEM syntax from slider css classes

### Date fixes, enhancements
- 🐞 don't allow entering 0 for month or day (#307)
- 🐞 fix z-index collision between date and slider (#307)
- 🐞 size date dropdown to input width, fix 1px open movement (#308)
- ✨ use `calcite-input` in `calcite-date`
- ✨ add scale prop to date (#463)
- 🎨 clean up date styles (#446)
- 🚨 `show-calendar` now `active` in calcite date, 
- 🧹 v1 calcite date cleanup, better typing for events, more consistent props (#463)