### PR TITLE
Adds vertical layout option to radio group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-slider` can now be programmatically focused with the `setFocus()` method
 - `calcite-date` now has `scale` prop for small, medium, and large
 - `calcite-radio-group` now has an `appearance` prop that accepts `outline` or `solid` (default) values
+- `calcite-radio-group` now has a `layout` prop that accepts `vertical` or `horizontal` (default) values
 - `calcite-input` can now be programmatically focused with the `setFocus()` method
 
 ### Fixed

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -1,10 +1,11 @@
 :host {
   display: flex;
+  align-self: stretch;
   background-color: var(--calcite-ui-foreground-1);
   color: var(--calcite-ui-text-3);
   cursor: pointer;
   line-height: 1.25;
-  margin: 0.25rem -1px 0 0px;
+  margin: 0 -1px 0 0;
   border: 1px solid var(--calcite-ui-border-1);
   box-shadow: inset 0 0 0 1px transparent;
   box-sizing: border-box;
@@ -13,6 +14,9 @@
   cursor: pointer;
 }
 
+:host([layout="vertical"]) {
+  margin: 0 0 -1px 0;
+}
 // focus styles
 :host {
   @include focus-style-base();
@@ -52,7 +56,7 @@
 }
 
 :host([appearance="outline"][checked]) {
-  background-color: var(--calcite-foreground);
+  background-color: var(--calcite-ui-foreground-1);
   border-color: var(--calcite-ui-blue-1);
   box-shadow: inset 0 0 0 1px var(--calcite-ui-blue-1);
   color: var(--calcite-ui-blue-1);

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -86,6 +86,7 @@ export class CalciteRadioGroupItem {
     const { checked, useFallback, value } = this;
     const scale = getElementProp(this.el, "scale", "m");
     const appearance = getElementProp(this.el, "appearance", "m");
+    const layout = getElementProp(this.el, "layout", "m");
 
     return (
       <Host
@@ -93,6 +94,7 @@ export class CalciteRadioGroupItem {
         aria-checked={checked.toString()}
         scale={scale}
         appearance={appearance}
+        layout={layout}
       >
         <label>
           <slot>{useFallback ? value : ""}</slot>

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -185,21 +185,25 @@ describe("calcite-radio-group", () => {
   it("renders requested props", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      "<calcite-radio-group theme='dark' scale='l'></calcite-radio-group>"
+      "<calcite-radio-group theme='dark' scale='l' layout='vertical' appearance='outline'></calcite-radio-group>"
     );
     const element = await page.find("calcite-radio-group");
     expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("scale", "l");
+    expect(element).toEqualAttribute("layout", "vertical");
+    expect(element).toEqualAttribute("appearance", "outline");
   });
 
   it("validates incorrect props", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      "<calcite-radio-group scale='zap'></calcite-radio-group>"
+      "<calcite-radio-group scale='zap' layout='zop' apperance='zat'></calcite-radio-group>"
     );
 
     const element = await page.find("calcite-radio-group");
     expect(element).toEqualAttribute("scale", "m");
+    expect(element).toEqualAttribute("layout", "horizontal");
+    expect(element).toEqualAttribute("appearance", "solid");
   });
 
   it("renders default props", async () => {
@@ -207,6 +211,8 @@ describe("calcite-radio-group", () => {
     await page.setContent("<calcite-radio-group></calcite-radio-group>");
     const element = await page.find("calcite-radio-group");
     expect(element).toEqualAttribute("scale", "m");
+    expect(element).toEqualAttribute("layout", "horizontal");
+    expect(element).toEqualAttribute("appearance", "solid");
   });
 
   it("passes requested scale prop to child components", async () => {
@@ -275,13 +281,15 @@ describe("calcite-radio-group", () => {
           <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
           <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
           <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
-        </calcite-radio-group>`
+        </calcite-radio-group>`,
       });
 
       const element = await page.find("calcite-radio-group");
       await element.callMethod("setFocus");
 
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-1");
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual(
+        "child-1"
+      );
     });
 
     it("focuses the selected item", async () => {
@@ -290,13 +298,15 @@ describe("calcite-radio-group", () => {
           <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
           <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
           <calcite-radio-group-item id="child-3" value="3" checked>three</calcite-radio-group-item>
-        </calcite-radio-group>`
+        </calcite-radio-group>`,
       });
 
       const element = await page.find("calcite-radio-group");
       await element.callMethod("setFocus");
 
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-3");
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual(
+        "child-3"
+      );
     });
   });
 });

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -1,5 +1,12 @@
 :host {
   display: flex;
+  margin-top: 0.25rem;
+}
+
+:host([layout="vertical"]) {
+  flex-direction: column;
+  align-items: start;
+  align-self: flex-start;
 }
 
 ::slotted(calcite-radio-group-item[checked]),

--- a/src/components/calcite-radio-group/calcite-radio-group.stories.js
+++ b/src/components/calcite-radio-group/calcite-radio-group.stories.js
@@ -14,6 +14,7 @@ storiesOf("Radio Group", module)
     "Simple",
     () => `
     <calcite-radio-group
+      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >
@@ -31,6 +32,7 @@ storiesOf("Radio Group", module)
     <calcite-label>
     My great radio group
     <calcite-radio-group
+      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >
@@ -48,6 +50,7 @@ storiesOf("Radio Group", module)
     () => `
     <calcite-radio-group
       theme="dark"
+      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -76,13 +76,16 @@ export class CalciteRadioGroup {
   /** The component's theme. */
   @Prop({ reflect: true }) theme: "light" | "dark";
 
-  /** The scale of the button */
+  /** The scale of the radio group */
   @Prop({ reflect: true }) scale: "s" | "m" | "l";
 
   /** specify the appearance style of the radio group, defaults to solid. */
   @Prop({ mutable: true, reflect: true }) appearance: "solid" | "outline" =
     "solid";
 
+  /** specify the layout of the radio group, defaults to horizontal */
+  @Prop({ mutable: true, reflect: true }) layout: "horizontal" | "vertical" =
+    "horizontal";
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -97,6 +100,9 @@ export class CalciteRadioGroup {
 
     let appearance = ["solid", "outline"];
     if (!appearance.includes(this.appearance)) this.appearance = "solid";
+
+    let layout = ["horizontal", "vertical"];
+    if (!layout.includes(this.layout)) this.layout = "horizontal";
 
     const items = this.getItems();
     let lastChecked = Array.from(items)

--- a/src/components/calcite-radio-group/readme.md
+++ b/src/components/calcite-radio-group/readme.md
@@ -4,13 +4,14 @@
 
 ## Properties
 
-| Property       | Attribute    | Description                                                         | Type                               | Default     |
-| -------------- | ------------ | ------------------------------------------------------------------- | ---------------------------------- | ----------- |
-| `appearance`   | `appearance` | specify the appearance style of the radio group, defaults to solid. | `"outline" \| "solid"`             | `"solid"`   |
-| `name`         | `name`       | The group's name. Gets submitted with the form.                     | `string`                           | `undefined` |
-| `scale`        | `scale`      | The scale of the button                                             | `"l" \| "m" \| "s"`                | `undefined` |
-| `selectedItem` | --           | The group's selected item.                                          | `HTMLCalciteRadioGroupItemElement` | `undefined` |
-| `theme`        | `theme`      | The component's theme.                                              | `"dark" \| "light"`                | `undefined` |
+| Property       | Attribute    | Description                                                         | Type                               | Default        |
+| -------------- | ------------ | ------------------------------------------------------------------- | ---------------------------------- | -------------- |
+| `appearance`   | `appearance` | specify the appearance style of the radio group, defaults to solid. | `"outline" \| "solid"`             | `"solid"`      |
+| `layout`       | `layout`     | specify the layout of the radio group, defaults to horizontal       | `"horizontal" \| "vertical"`       | `"horizontal"` |
+| `name`         | `name`       | The group's name. Gets submitted with the form.                     | `string`                           | `undefined`    |
+| `scale`        | `scale`      | The scale of the radio group                                        | `"l" \| "m" \| "s"`                | `undefined`    |
+| `selectedItem` | --           | The group's selected item.                                          | `HTMLCalciteRadioGroupItemElement` | `undefined`    |
+| `theme`        | `theme`      | The component's theme.                                              | `"dark" \| "light"`                | `undefined`    |
 
 ## Events
 

--- a/src/demos/calcite-radio-group.html
+++ b/src/demos/calcite-radio-group.html
@@ -22,164 +22,196 @@
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Radio Group</h1>
-  <h3 class="leader-1">Simple</h3>
+  <div style="width:600px;max-width:100%">
+    <h3 class="leader-1">Simple</h3>
 
-  <calcite-radio-group>
-    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-  </calcite-radio-group>
-
-  <h3 class="leader-1">Wrapped with calcite-label</h3>
-
-  <calcite-label>
-    My Great Radio Group
     <calcite-radio-group>
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
       <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
     </calcite-radio-group>
-  </calcite-label>
+
+    <h3 class="leader-1">Wrapped with calcite-label</h3>
+
+    <calcite-label>
+      My Great Radio Group
+      <calcite-radio-group>
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
 
 
-  <calcite-label>
-    My Great Radio Appearance Outline
-    <calcite-radio-group appearance="outline">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-    </calcite-radio-group>
-  </calcite-label>
+    <calcite-label>
+      My Great Radio Appearance Outline
+      <calcite-radio-group appearance="outline">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
 
+    <calcite-label scale="l">
+      Inherit L scale from parent label
+      <calcite-radio-group appearance="outline">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
 
-  <calcite-label scale="s">
-    Inherit scale from parent label
-    <calcite-radio-group appearance="outline">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-    </calcite-radio-group>
-  </calcite-label>
+    <calcite-label scale="s">
+      Inherit S scale from parent label
+      <calcite-radio-group appearance="outline">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
 
-  <h3 class="leader-1">Scale s</h3>
+    <calcite-label>
+      My Great Radio Layout Vertical
+      <calcite-radio-group layout="vertical">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular or another item">Angular or another item</calcite-radio-group-item>
+        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
 
-  <calcite-radio-group scale="s">
-    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-  </calcite-radio-group>
+    <calcite-label>
+      My Great Radio Layout Vertical Outline
+      <calcite-radio-group layout="vertical" appearance="outline">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
 
-  <h3 class="leader-1">Scale m</h3>
-
-  <calcite-radio-group scale="m">
-    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-  </calcite-radio-group>
-
-  <h3 class="leader-1">Scale l</h3>
-
-  <calcite-radio-group scale="l">
-    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-  </calcite-radio-group>
-
-  <h3 class="leader-1">With labels</h3>
-
-  <calcite-radio-group>
-    <calcite-radio-group-item value="1">Uno</calcite-radio-group-item>
-    <calcite-radio-group-item value="2" checked>Dos</calcite-radio-group-item>
-    <calcite-radio-group-item value="3">Tres</calcite-radio-group-item>
-  </calcite-radio-group>
-
-  <h3 class="leader-1">Uses value as label if missing</h3>
-
-  <calcite-radio-group>
-    <calcite-radio-group-item value="1"></calcite-radio-group-item>
-    <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-    <calcite-radio-group-item value="3"></calcite-radio-group-item>
-  </calcite-radio-group>
-
-  <h3 class="leader-1">None checked</h3>
-
-  <calcite-radio-group>
-    <calcite-radio-group-item value="1"></calcite-radio-group-item>
-    <calcite-radio-group-item value="2"></calcite-radio-group-item>
-    <calcite-radio-group-item value="3"></calcite-radio-group-item>
-  </calcite-radio-group>
-
-  <h3 class="leader-1">Only one selected value (last wins)</h3>
-
-  <calcite-radio-group>
-    <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
-    <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-    <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
-  </calcite-radio-group>
-  <br />
-  <br />
-  <div class="demo-background-dark">
-    <h3 class="leader-1">Dark theme</h3>
-
-    <calcite-radio-group theme="dark">
-      <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
-    </calcite-radio-group>
 
     <h3 class="leader-1">Scale s</h3>
-    <calcite-radio-group theme="dark" scale="s">
+
+    <calcite-radio-group scale="s">
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
       <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
     </calcite-radio-group>
 
     <h3 class="leader-1">Scale m</h3>
-    <calcite-radio-group theme="dark" scale="m">
+
+    <calcite-radio-group scale="m">
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
       <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
     </calcite-radio-group>
 
     <h3 class="leader-1">Scale l</h3>
-    <calcite-radio-group theme="dark" scale="l">
+
+    <calcite-radio-group scale="l">
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
       <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
     </calcite-radio-group>
-  </div>
-  <h3 class="leader-1">RTL</h3>
 
-  <calcite-radio-group dir="rtl">
-    <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
-    <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-    <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
-  </calcite-radio-group>
+    <h3 class="leader-1">With labels</h3>
 
-  <h3 class="leader-1">External inputs</h3>
+    <calcite-radio-group>
+      <calcite-radio-group-item value="1">Uno</calcite-radio-group-item>
+      <calcite-radio-group-item value="2" checked>Dos</calcite-radio-group-item>
+      <calcite-radio-group-item value="3">Tres</calcite-radio-group-item>
+    </calcite-radio-group>
 
-  <calcite-radio-group name="grouped">
-    <calcite-radio-group-item><input type="radio" slot="input" value="1"></calcite-radio-group-item>
-    <calcite-radio-group-item><input type="radio" slot="input" value="2"></calcite-radio-group-item>
-    <calcite-radio-group-item><input type="radio" slot="input" value="3"></calcite-radio-group-item>
-  </calcite-radio-group>
+    <h3 class="leader-1">Uses value as label if missing</h3>
 
-  <h3 class="leader-1">Within form</h3>
+    <calcite-radio-group>
+      <calcite-radio-group-item value="1"></calcite-radio-group-item>
+      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+      <calcite-radio-group-item value="3"></calcite-radio-group-item>
+    </calcite-radio-group>
 
-  <form>
-    <label>
-      Choose wisely
-      <calcite-radio-group name="within-form">
-        <calcite-radio-group-item value="1"></calcite-radio-group-item>
-        <calcite-radio-group-item value="2"></calcite-radio-group-item>
-        <calcite-radio-group-item value="3"></calcite-radio-group-item>
+    <h3 class="leader-1">None checked</h3>
+
+    <calcite-radio-group>
+      <calcite-radio-group-item value="1"></calcite-radio-group-item>
+      <calcite-radio-group-item value="2"></calcite-radio-group-item>
+      <calcite-radio-group-item value="3"></calcite-radio-group-item>
+    </calcite-radio-group>
+
+    <h3 class="leader-1">Only one selected value (last wins)</h3>
+
+    <calcite-radio-group>
+      <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
+      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+      <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
+    </calcite-radio-group>
+    <br />
+    <br />
+    <div class="demo-background-dark">
+      <h3 class="leader-1">Dark theme</h3>
+
+      <calcite-radio-group theme="dark">
+        <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
+        <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+        <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
       </calcite-radio-group>
-    </label>
-  </form>
+
+      <h3 class="leader-1">Scale s</h3>
+      <calcite-radio-group theme="dark" scale="s">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">Scale m</h3>
+      <calcite-radio-group theme="dark" scale="m">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">Scale l</h3>
+      <calcite-radio-group theme="dark" scale="l">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+    </div>
+    <h3 class="leader-1">RTL</h3>
+
+    <calcite-radio-group dir="rtl">
+      <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
+      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+      <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
+    </calcite-radio-group>
+
+    <h3 class="leader-1">External inputs</h3>
+
+    <calcite-radio-group name="grouped">
+      <calcite-radio-group-item><input type="radio" slot="input" value="1"></calcite-radio-group-item>
+      <calcite-radio-group-item><input type="radio" slot="input" value="2"></calcite-radio-group-item>
+      <calcite-radio-group-item><input type="radio" slot="input" value="3"></calcite-radio-group-item>
+    </calcite-radio-group>
+
+    <h3 class="leader-1">Within form</h3>
+
+    <form>
+      <label>
+        Choose wisely
+        <calcite-radio-group name="within-form">
+          <calcite-radio-group-item value="1"></calcite-radio-group-item>
+          <calcite-radio-group-item value="2"></calcite-radio-group-item>
+          <calcite-radio-group-item value="3"></calcite-radio-group-item>
+        </calcite-radio-group>
+      </label>
+    </form>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Feature add re: https://github.com/Esri/calcite-components/issues/501 cc @jwasilgeo

- Adds style for vertical layout
  - Width of containing `calcite-radio-group` will expand to the widest child when in `layout=vertical`
  - Doesn't try to handle overflow or max-height, users can set that on a wrapping container if desired

- Adds test, story, changelog for vertical layout