### PR TITLE
Fix increment and decrement of number type input when min/max is 0

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -189,7 +189,7 @@ describe("calcite-input", () => {
 
   });
 
-  it("correctly increment and decrements value when number buttons are clicked", async () => {
+  it("correctly increments and decrements value when number buttons are clicked", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-input type="number" value="3"></calcite-input>
@@ -213,7 +213,9 @@ describe("calcite-input", () => {
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("4");
   });
-  it("correctly increment and decrements value when number buttons are clicked and step is set", async () => {
+
+
+  it("correctly increments and decrements value when number buttons are clicked and step is set", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-input type="number" step="10" value="15"></calcite-input>
@@ -237,5 +239,90 @@ describe("calcite-input", () => {
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("25");
+  });
+
+  it("correctly stops decrementing value when min is set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" min="10" value="12"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    expect(element.getAttribute("value")).toBe("12");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("11");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+  });
+  it("correctly stops incrementing value when max is set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" max="10" value="8"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(element.getAttribute("value")).toBe("8");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("9");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+  });
+  it("correctly stops decrementing value when min is 0", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" min="0" value="2"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    expect(element.getAttribute("value")).toBe("2");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("1");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+  });
+  it("correctly stops incrementing value when max is 0", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" max="0" value="-2"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(element.getAttribute("value")).toBe("-2");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("-1");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
   });
 });

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -47,6 +47,7 @@ calcite-input input {
   color: var(--calcite-ui-text-1);
   order: 3;
   font-weight: 400;
+  margin-top: 4px;
 }
 
 calcite-input input[type="search"]::-webkit-search-decoration {
@@ -236,7 +237,6 @@ calcite-input input[type="number"] {
 
 calcite-input[number-button-type="vertical"] .calcite-input-wrapper {
   flex-direction: row;
-  margin-top: 4px;
   display: flex;
 }
 

--- a/src/components/calcite-input/calcite-input.stories.js
+++ b/src/components/calcite-input/calcite-input.stories.js
@@ -43,6 +43,9 @@ storiesOf("Input", module)
         ["none", "horizontal", "vertical"],
         "horizontal"
       )}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
       loading="${boolean("loading", false)}"
@@ -108,6 +111,9 @@ storiesOf("Input", module)
         "horizontal",
         "Input"
       )}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
       prefix-text="${text("prefix-text", "", "Input")}"
       suffix-text="${text("suffix-text", "", "Input")}"
       loading="${boolean("loading", false, "Input")}"
@@ -166,6 +172,9 @@ storiesOf("Input", module)
         ["none", "horizontal", "vertical"],
         "horizontal"
       )}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
       loading="${boolean("loading", false)}"
@@ -206,13 +215,15 @@ storiesOf("Input", module)
         "text"
       )}"
       alignment="${select("alignment", ["start", "end"], "start")}"
-
       appearance="${select("appearance", ["default", "minimal"], "default")}"
       number-button-type="${select(
         "number-button-type",
         ["none", "horizontal", "vertical"],
         "horizontal"
       )}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
       loading="${boolean("loading", false)}"
@@ -307,6 +318,9 @@ storiesOf("Input", module)
         ["none", "horizontal", "vertical"],
         "horizontal"
       )}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
       loading="${boolean("loading", false)}"

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -421,11 +421,11 @@ export class CalciteInput {
 
       switch (e.target.dataset.adjustment) {
         case "up":
-          if (!inputMax || inputVal < inputMax)
+          if ((!inputMax && inputMax !== 0) || inputVal < inputMax)
             this.childEl.value = (inputVal += inputStep).toString();
           break;
         case "down":
-          if (!inputMin || inputVal > inputMin)
+          if ((!inputMin && inputMin !== 0) || inputVal > inputMin)
             this.childEl.value = (inputVal -= inputStep).toString();
           break;
       }

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -168,6 +168,18 @@
             </calcite-input>
           </calcite-label>
           <calcite-label>
+            with max set to 0
+            <calcite-input max="0" step="10" value="-40" type="number" number-button-type="vertical"
+              placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label>
+            with min set to 0
+            <calcite-input min="0" max="100" step="10" value="40" type="number" number-button-type="horizontal"
+              placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label>
             with button and min max step set
             <calcite-input min="-100" max="100" step="10" value="40" type="number" number-button-type="horizontal"
               placeholder="0">


### PR DESCRIPTION
Handles cases where min or max are set to 0
Adds dev demo example
Adds min, max, step knobs to Storybook
Adds more tests around number buttons for number type input
Fixes margin only being applied to a certain input type
 -- This will eventually get added to the label wrapping an input and not the input itself re: https://github.com/Esri/calcite-components/issues/480 but for now, it fixes an inconsistency where it was only being added to number type button vertical

cc @kellyhutchins