### PR TITLE
Fix Notice RTL padding

### DIFF
--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -105,7 +105,7 @@
 
 :host([dir="rtl"]) {
   @include slotted("notice-message", "div") {
-    margin-right: unset;
+    margin-right: 0;
     margin-left: var(--calcite-notice-spacing-token-small);
   }
 }

--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -120,6 +120,8 @@
 
 .notice-content {
   @include notice-element-base;
+  display: flex;
+  flex-direction: column;
   flex: 1 1 auto;
   min-width: 0;
   word-wrap: break-word;
@@ -130,20 +132,23 @@
   &:first-of-type:not(:only-child) {
     padding-left: var(--calcite-notice-spacing-token-large);
   }
-  &:only-child {
-    padding: var(--calcite-notice-spacing-token-small);
+  &:only-of-type {
+    padding: var(--calcite-notice-spacing-token-small)
+      var(--calcite-notice-spacing-token-large);
   }
 }
 
-:host([dir="rtl"]) {
-  .notice-content {
-    padding: var(--calcite-notice-spacing-token-small) 0
-      var(--calcite-notice-spacing-token-small)
-      var(--calcite-notice-spacing-token-small);
+:host([dir="rtl"]) .notice-content {
+  padding: var(--calcite-notice-spacing-token-small) 0
+    var(--calcite-notice-spacing-token-small)
+    var(--calcite-notice-spacing-token-small);
 
-    &:first-of-type:not(:only-child) {
-      padding-right: var(--calcite-notice-spacing-token-large);
-    }
+  &:first-of-type:not(:only-child) {
+    padding-right: var(--calcite-notice-spacing-token-large);
+  }
+  &:only-of-type {
+    padding: var(--calcite-notice-spacing-token-small)
+      var(--calcite-notice-spacing-token-large);
   }
 }
 .notice-icon {

--- a/src/demos/calcite-notice.html
+++ b/src/demos/calcite-notice.html
@@ -28,7 +28,14 @@
   </calcite-button>
   <br />
   <br />
-
+  <calcite-notice color="red" id="notice-one" scale="s" active dismissible>
+    <div slot="notice-title">Something failed dismissible</div>
+    <div slot="notice-message">
+      That thing you wanted to do didn't work as expected
+    </div>
+    <calcite-link slot="notice-link" title="my action">Retry</calcite-link>
+  </calcite-notice>
+  <br /> <br />
   <calcite-notice color="red" id="notice-one" scale="s" active dismissible>
     <div slot="notice-title">Something failed dismissible</div>
     <div slot="notice-message">
@@ -92,9 +99,51 @@
   <br />
   <calcite-notice icon color="green" size="l" id="notice-five" active dismissible>
     <div slot="notice-message">
-      That thing you wanted to do didn't work as expected
+      <div>
+        That thing you wanted to do didn't work as expected
+      </div>
+      <div>
+        A second slotted div
+      </div>
     </div>
-    <calcite-link slot="notice-link" title="my action">Retry</calcite-link>
+  </calcite-notice>
+  <br />
+  <br />
+  <calcite-notice color="green" size="l" id="notice-five" active>
+    <div slot="notice-message">
+      <div>
+        That thing you wanted to do didn't work as expected
+      </div>
+      <div>
+        A second slotted div
+      </div>
+    </div>
+  </calcite-notice>
+  <br />
+  <br />
+  <calcite-notice color="green" size="l" id="notice-five" active>
+    <div slot="notice-title">Welcome to your new website</div>
+    <div slot="notice-message">
+      <div>
+        That thing you wanted to do didn't work as expected
+      </div>
+      <div>
+        A second slotted div
+      </div>
+    </div>
+  </calcite-notice>
+  <br />
+  <br />
+  <calcite-notice dismissible color="green" size="l" id="notice-five" active>
+    <div slot="notice-title">Welcome to your new website</div>
+    <div slot="notice-message">
+      <div>
+        That thing you wanted to do didn't work as expected
+      </div>
+      <div>
+        A second slotted div
+      </div>
+    </div>
   </calcite-notice>
 </body>
 


### PR DESCRIPTION
Fixes #533 cc @MikeTschudi

The following markup
```
<calcite-notice width="full" dir="rtl" active>
    <div slot="notice-title">Welcome to your new website</div>
    <div slot="notice-message">
      <div>
        That thing you wanted to do worked pretty well
      </div>
      <ul>
        <li>LI item</li>
        <li>LI item</li>
      </ul>
      <div>
        A second slotted div
      </div>
    </div>
  </calcite-notice>
```
(or when `dir="rtl"` is set on a parent container)

results in :
<img width="499" alt="Screen Shot 2020-04-29 at 4 30 18 PM" src="https://user-images.githubusercontent.com/4733155/80656738-bf441a80-8a36-11ea-8361-1a083e4b7bea.png">

