### PR TITLE
BREAKING - checkbox prop change, various style updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Breaking Changes
+
+- `calcite-checkbox` - `size` prop is now `scale` to be consistent with other components
+
 ## [v1.0.0-beta.25] - Apr 28th 2020
 
 ### Breaking Changes

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -192,7 +192,8 @@
   & .accordion-item-icon {
     color: var(--calcite-ui-text-1);
   }
-  & .accordion-item-expand {
+
+  & .accordion-item-expand-icon {
     color: var(--calcite-ui-text-1);
   }
   & .accordion-item-subtitle {
@@ -209,7 +210,7 @@
   & .accordion-item-icon {
     color: var(--calcite-ui-text-1);
   }
-  & .accordion-item-expand {
+  & .accordion-item-expand-icon {
     color: var(--calcite-ui-text-1);
   }
   & .accordion-item-subtitle {

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -269,6 +269,7 @@
   width: 100%;
   height: 3px;
   z-index: 103;
+  border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
 
   &:after {
     height: 3px;
@@ -276,7 +277,7 @@
     right: 0;
     display: block;
     position: absolute;
-    border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
+    border-radius: 0 var(--calcite-border-radius) 0 0;
     content: "";
     background-color: var(--calcite-alert-dismiss-progress-background);
     z-index: 104;
@@ -314,7 +315,11 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
     width: 0;
     opacity: 0.8;
   }
+  90% {
+    border-radius: 0 var(--calcite-border-radius) 0 0;
+  }
   100% {
+    border-radius: var(--calcite-border-radius) 0 0 0;
     width: 100%;
     opacity: 1;
   }

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -145,7 +145,10 @@ export class CalciteCard {
         onClick={() => this.cardSelectClick()}
         onKeyDown={(e) => this.cardSelectKeyDown(e)}
       >
-        <calcite-checkbox checked={this.selected}></calcite-checkbox>
+        <calcite-checkbox
+          theme={this.theme}
+          checked={this.selected}
+        ></calcite-checkbox>
       </div>
     );
   }

--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -1,12 +1,27 @@
+// scale
+:host([scale="s"]) {
+  --calcite-checkbox-size: 12px;
+  top: 0.1em;
+}
+:host([scale="m"]) {
+  --calcite-checkbox-size: 16px;
+  top: 0.15em;
+}
+:host([scale="l"]) {
+  --calcite-checkbox-size: 20px;
+  top: 0.25em;
+}
 ::slotted(input) {
   display: none;
 }
-
 :host {
-  display: inline-block;
+  display: inline-flex;
   cursor: pointer;
+  position: relative;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+  width: var(--calcite-checkbox-size);
+  height: var(--calcite-checkbox-size);
 }
 
 //focus
@@ -17,62 +32,24 @@
   @include focus-style-outset();
 }
 
-.check-svg {
-  width: 20px;
-  height: 20px;
+:host .check-svg {
+  width: var(--calcite-checkbox-size);
+  height: var(--calcite-checkbox-size);
   overflow: hidden;
   display: inline-block;
-  background-color: white;
-  border: 1px solid $blk-130;
-  vertical-align: -0.25em;
-  margin-right: 0.25em;
+  background-color: var(--calcite-ui-background);
+  border: 1px solid var(--calcite-ui-border-1);
+  fill: var(--calcite-ui-background);
   pointer-events: none;
-  transition: all 150ms linear;
+  transition: $transition;
   box-sizing: border-box;
-}
-
-:host([theme="dark"]) {
-  .check-svg {
-    background-color: transparent;
-    border-color: $blk-020;
-  }
-}
-
-:host([theme="dark"][disabled]) {
-  .check-svg {
-    border-color: $blk-130;
-    background-color: $blk-200;
-  }
-}
-
-:host([theme="dark"][checked]),
-:host([theme="dark"][indeterminate]) {
-  .check-svg {
-    background-color: $v-bb-140;
-  }
-}
-
-:host([size="large"]) {
-  .check-svg {
-    width: 24px;
-    height: 24px;
-  }
-}
-
-:host([size="small"]) {
-  .check-svg {
-    width: 16px;
-    height: 16px;
-  }
 }
 
 :host([disabled]) {
   pointer-events: none;
   cursor: default;
-
   .check-svg {
-    background-color: $blk-010;
-    border-color: $blk-020;
+    background-color: var(--calcite-ui-foreground-2);
   }
 }
 
@@ -87,12 +64,16 @@
 :host([checked]),
 :host([indeterminate]) {
   .check-svg {
-    background-color: $ui-blue-1;
-    border: 1px solid $ui-blue-1;
+    background-color: var(--calcite-ui-blue-1);
+    border-color: var(--calcite-ui-blue-1);
   }
 }
 
 :host(:hover),
 :host(:focus) {
   outline: none;
+  .check-svg {
+    border-color: var(--calcite-ui-blue-1);
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-blue-1);
+  }
 }

--- a/src/components/calcite-checkbox/calcite-checkbox.stories.js
+++ b/src/components/calcite-checkbox/calcite-checkbox.stories.js
@@ -1,30 +1,38 @@
-import { storiesOf } from '@storybook/html';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs'
-import { darkBackground, parseReadme } from '../../../.storybook/helpers';
-import readme from './readme.md';
+import { storiesOf } from "@storybook/html";
+import { withKnobs, boolean, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import readme from "./readme.md";
 const notes = parseReadme(readme);
 
-storiesOf('Checkbox', module)
+storiesOf("Checkbox", module)
   .addDecorator(withKnobs)
-  .add('Simple', () => `
+  .add(
+    "Simple",
+    () => `
     <label>
       <calcite-checkbox
-        checked=${boolean('checked', true)}
-        disabled=${boolean('disabled', false)}
-        indeterminate=${boolean('indeterminate', false)}
-        size=${select('size', {large: 'large', small: 'small'}, 'small')}
+        checked=${boolean("checked", true)}
+        disabled=${boolean("disabled", false)}
+        indeterminate=${boolean("indeterminate", false)}
+        scale="${select("scale", ["s", "m", "l"], "m")}"
       ></calcite-checkbox>
       Text for the checkbox
     </label>
-  `, { notes })
-  .add('Dark mode', () => `
+  `,
+    { notes }
+  )
+  .add(
+    "Dark mode",
+    () => `
     <label>
       <calcite-checkbox
         theme="dark"
-        checked=${boolean('checked', true)}
-        disabled=${boolean('disabled', false)}
-        indeterminate=${boolean('indeterminate', false)}
-        size=${select('size', {large: 'large', small: 'small'}, 'small')}
+        checked=${boolean("checked", true)}
+        disabled=${boolean("disabled", false)}
+        indeterminate=${boolean("indeterminate", false)}
+        scale="${select("scale", ["s", "m", "l"], "m")}"
       ></calcite-checkbox>
     </label>
-`, { notes, backgrounds: darkBackground });
+`,
+    { notes, backgrounds: darkBackground }
+  );

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -36,8 +36,8 @@ export class CalciteCheckbox {
   /** The value of the checkbox input */
   @Prop({ reflect: true, mutable: true }) value?: string = "";
 
-  /** Size of the checkbox  */
-  @Prop({ reflect: true }) size?: "small" | "large" = null;
+  /** specify the scale of the checkbox, defaults to m */
+  @Prop({ reflect: true, mutable: true }) scale: "s" | "m" | "l" = "m";
 
   /** True if the checkbox is disabled */
   @Prop({ reflect: true }) disabled?: boolean = false;
@@ -87,6 +87,8 @@ export class CalciteCheckbox {
 
   connectedCallback() {
     this.setupProxyInput();
+    let scale = ["s", "m", "l"];
+    if (!scale.includes(this.scale)) this.scale = "m";
   }
 
   disconnectedCallback() {
@@ -116,7 +118,7 @@ export class CalciteCheckbox {
         tabindex={this.disabled ? "-1" : "0"}
       >
         <svg class="check-svg" viewBox="0 0 16 16">
-          <path d={this.getPath()} fill="white" />
+          <path d={this.getPath()} />
         </svg>
         <slot />
       </Host>

--- a/src/components/calcite-checkbox/readme.md
+++ b/src/components/calcite-checkbox/readme.md
@@ -18,19 +18,17 @@ If you don't pass in an input, calcite-checkbox will act as the source of truth:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property        | Attribute       | Description                                                                                                                                   | Type                 | Default     |
-| --------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----------- |
-| `checked`       | `checked`       | True if the checkbox is initially checked                                                                                                     | `boolean`            | `false`     |
-| `disabled`      | `disabled`      | True if the checkbox is disabled                                                                                                              | `boolean`            | `false`     |
-| `indeterminate` | `indeterminate` | True if the checkbox is initially indeterminate, which is independent from its checked state https://css-tricks.com/indeterminate-checkboxes/ | `boolean`            | `false`     |
-| `name`          | `name`          | The name of the checkbox input                                                                                                                | `string`             | `""`        |
-| `size`          | `size`          | Size of the checkbox                                                                                                                          | `"large" \| "small"` | `null`      |
-| `theme`         | `theme`         | Determines what theme to use                                                                                                                  | `"dark" \| "light"`  | `undefined` |
-| `value`         | `value`         | The value of the checkbox input                                                                                                               | `string`             | `""`        |
-
+| Property        | Attribute       | Description                                                                                                                                   | Type                | Default     |
+| --------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `checked`       | `checked`       | True if the checkbox is initially checked                                                                                                     | `boolean`           | `false`     |
+| `disabled`      | `disabled`      | True if the checkbox is disabled                                                                                                              | `boolean`           | `false`     |
+| `indeterminate` | `indeterminate` | True if the checkbox is initially indeterminate, which is independent from its checked state https://css-tricks.com/indeterminate-checkboxes/ | `boolean`           | `false`     |
+| `name`          | `name`          | The name of the checkbox input                                                                                                                | `string`            | `""`        |
+| `scale`         | `scale`         | specify the scale of the checkbox, defaults to m                                                                                              | `"l" \| "m" \| "s"` | `"m"`       |
+| `theme`         | `theme`         | Determines what theme to use                                                                                                                  | `"dark" \| "light"` | `undefined` |
+| `value`         | `value`         | The value of the checkbox input                                                                                                               | `string`            | `""`        |
 
 ## Events
 
@@ -38,20 +36,20 @@ If you don't pass in an input, calcite-checkbox will act as the source of truth:
 | ----------------------- | ------------------------------------------------ | ------------------ |
 | `calciteCheckboxChange` | Emitted when the checkbox checked status changes | `CustomEvent<any>` |
 
-
 ## Dependencies
 
 ### Used by
 
- - [calcite-card](../calcite-card)
+- [calcite-card](../calcite-card)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-card --> calcite-checkbox
   style calcite-checkbox fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-input-message/calcite-input-message.scss
+++ b/src/components/calcite-input-message/calcite-input-message.scss
@@ -2,6 +2,9 @@
 :host([scale="s"]) {
   font-size: 12px;
   --calcite-input-message-spacing-value: 4px;
+  .calcite-input-message-icon {
+    margin-top: -2px;
+  }
 }
 
 :host([scale="m"]) {
@@ -72,14 +75,12 @@
   flex-shrink: 0;
   pointer-events: none;
   transition: $transition;
-  margin: 0 $baseline/2 0 0;
-  line-height: inherit;
-  z-index: 9;
+  margin: -1px $baseline/2 0 0;
   transition: $transition;
 }
 
 :host([dir="rtl"]) .calcite-input-message-icon {
-  margin: 0 0 0 $baseline/2;
+  margin: -1px 0 0 $baseline/2;
 }
 // status
 $inputStatusColors: "invalid" var(--calcite-ui-red-1) var(--calcite-ui-red-1)

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -114,6 +114,7 @@
 
   .handle {
     border-color: var(--calcite-switch-hover-handle-border);
+    box-shadow: inset 0 0 0 1px var(--calcite-switch-hover-handle-border);
     right: auto;
   }
 }
@@ -137,6 +138,8 @@
   }
   .handle {
     border-color: var(--calcite-switch-switched-hover-handle-border);
+    box-shadow: inset 0 0 0 1px
+      var(--calcite-switch-switched-hover-handle-border);
   }
 }
 

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -16,3 +16,7 @@
   overflow: hidden;
   @include font-size(-3);
 }
+
+:host([theme="dark"]) .container {
+  background: var(--calcite-ui-foreground-2);
+}

--- a/src/demos/calcite-checkbox.html
+++ b/src/demos/calcite-checkbox.html
@@ -56,24 +56,24 @@
 
   <div>
     <label>
-      <calcite-checkbox size='large'></calcite-checkbox>
+      <calcite-checkbox scale="l"></calcite-checkbox>
       Large checkbox
     </label>
   </div>
   <div>
     <label>
-      <calcite-checkbox size='small'></calcite-checkbox>
+      <calcite-checkbox scale="s"></calcite-checkbox>
       Small checkbox
     </label>
   </div>
-  <div style='background-color: black; color: white; padding: 5px;'>
+  <div style='background-color: #222; color: white; padding: 5px;'>
     <label>
-      <calcite-checkbox theme='dark' size='large'></calcite-checkbox>
+      <calcite-checkbox theme='dark' scale="l"></calcite-checkbox>
       Dark large
     </label>
   </div>
 
-  <div style='background-color: black; color: white; padding: 5px;'>
+  <div style='background-color: #222; color: white; padding: 5px;'>
     <label>
       <calcite-checkbox theme='dark' disabled></calcite-checkbox>
       Dark disabled
@@ -81,15 +81,15 @@
   </div>
 
 
-  <div style='background-color: black; color: white; padding: 5px;'>
+  <div style='background-color: #222; color: white; padding: 5px;'>
     <label>
       <calcite-checkbox theme='dark' checked disabled></calcite-checkbox>
       Dark checked disabled
     </label>
   </div>
-  <div style='background-color: black; color: white; padding: 5px;'>
+  <div style='background-color: #222; color: white; padding: 5px; margin-bottom:5px'>
     <label>
-      <calcite-checkbox theme='dark' indeterminate disabled size='small'></calcite-checkbox>
+      <calcite-checkbox theme='dark' indeterminate disabled scale="s"></calcite-checkbox>
       Dark indeterminate disabled small
     </label>
   </div>


### PR DESCRIPTION
BREAKING: calcite-checkbox "size" prop is now "scale"

Tooltip: dark background needs to use level-2 (Fix #521)
Switch: hover state border increase to 3px (Fix #520)
Input-message: text centering (Fix #517)
Checkbox: styling fixes (Fix #515)
Card: checkbox spacing, Dark theme checkbox (Fix #514)
Alert: remove autodismiss bar border radius (Fix #513)
Accordion: caret color hover (Fix #512)