### PR TITLE
Text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixes
 
 - `calcite-input` - fixed missing icons in firefox
+- `calcite-date` - fixed small margin/gap above input
 
 ## [v1.0.0-beta.25] - Apr 28th 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-dropdown` - will now properly open and close when children of the `dropdown-trigger` slot are acted on.
 - `:root` styles now include some text rendering improvements
 
+### Fixes
+
+- `calcite-input` - fixed missing icons in firefox
+
 ## [v1.0.0-beta.25] - Apr 28th 2020
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `calcite-dropdown` - will now properly open and close when children of the `dropdown-trigger` slot are acted on.
+- `:root` styles now include some text rendering improvements
 
 ## [v1.0.0-beta.25] - Apr 28th 2020
 

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -3,6 +3,9 @@
 
 :root {
   font-family: $avenir-family;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   --calcite-border-radius: 3px;
   @include calcite-theme-light();
 }

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -50,7 +50,7 @@
   z-index: 3;
 }
 
-.input input {
+.input .calcite-input-wrapper {
   margin-top: 0;
 }
 

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -117,6 +117,7 @@ calcite-input[dir="rtl"][icon] input {
   top: calc(50% - 9px);
   left: $baseline/2;
   margin: 1px auto 0;
+  z-index: 1;
 }
 
 calcite-input[dir="rtl"] .calcite-input-icon {


### PR DESCRIPTION
Two very small bug fixes plus some additional properties to help text rendering. 

```css
  text-rendering: optimizeLegibility;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
```

To my eyes, this makes the text in the browser feel a lot closer to the text in the designs (ie. weight is closer to what it looks like in sketch). Interested to get @bstifle  and @julio8a 's opinion on if this is better?

| Before | After |
| ------ | ----- |
| <img width="289" alt="Screen Shot 2020-05-06 at 2 52 42 PM" src="https://user-images.githubusercontent.com/1031758/81232475-dab8a380-8fa9-11ea-9ed0-411c3d69df86.png"> | <img width="291" alt="Screen Shot 2020-05-06 at 2 56 53 PM" src="https://user-images.githubusercontent.com/1031758/81232473-d9877680-8fa9-11ea-9039-f765e63abd8f.png"> |

You can see the 300 weight is lighter, which feels more like the Sketch version:

<img width="287" alt="Screen Shot 2020-05-06 at 3 00 17 PM" src="https://user-images.githubusercontent.com/1031758/81232790-603c5380-8faa-11ea-978c-7db8645798f1.png">

Thoughts?
