### PR TITLE
Removes :host-context from dropdown

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -78,7 +78,7 @@
   pointer-events: none;
 }
 
-:host-context([dir="rtl"]) .calcite-dropdown-wrapper {
+:host([dir="rtl"]) .calcite-dropdown-wrapper {
   right: 0;
   left: unset;
 }


### PR DESCRIPTION
Ensures RTL is adhered to in Safari / Firefox now that it's explicitly defined on component.