### PR TITLE
chore(linting): include TS files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "*.{json,md}": ["prettier --write"],
   "*.scss": ["prettier --write"],
-  "*.tsx": ["prettier --write"]
+  "*.{ts,tsx}": ["prettier --write"]
 }


### PR DESCRIPTION
I forgot to include TS files in the auto-linting PR (https://github.com/Esri/calcite-components/pull/426). :sweat_smile: 