### PR TITLE
Don't set default theme attributes

### DIFF
--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // scale variants for child
 :host([scale="s"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline/3};

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -8,34 +8,16 @@
   display: inline-block;
   width: auto;
   vertical-align: middle;
-  --calcite-blue-accessible: #{$h-bb-070};
-  --calcite-red-accessible: #{$h-rr-070};
-  --calcite-button-light: #{$blk-020};
-  --calcite-button-light-hover: #{$blk-010};
-  --calcite-button-light-press: #{$blk-030};
   --calcite-button-dark: #{$blk-180};
   --calcite-button-dark-hover: #{$blk-170};
   --calcite-button-dark-press: #{$blk-190};
-  --calcite-button-blue-solid-color: #{$blk-000};
-  --calcite-button-red-solid-color: #{$blk-000};
-  --calcite-button-outline-color: #{$blk-230};
-  --calcite-button-outline-color-press: #{$blk-230};
 }
 
 // dark theme
 :host([theme="dark"]) {
-  --calcite-blue-accessible: #{$d-bb-420};
-  --calcite-red-accessible: #{$d-rr-420};
-  --calcite-button-light: #{$blk-020};
-  --calcite-button-light-hover: #{$blk-030};
-  --calcite-button-light-press: #{$blk-010};
   --calcite-button-dark: #{$blk-180};
   --calcite-button-dark-hover: #{$blk-190};
   --calcite-button-dark-press: #{$blk-170};
-  --calcite-button-blue-solid-color: #{$blk-230};
-  --calcite-button-red-solid-color: #{$blk-230};
-  --calcite-button-outline-color: #{$blk-000};
-  --calcite-button-outline-color-press: #{$blk-000};
 }
 
 // fab variants
@@ -211,7 +193,7 @@
       var(--calcite-ui-blue-1),
       var(--calcite-ui-blue-2),
       var(--calcite-ui-blue-3),
-      var(--calcite-button-blue-solid-color)
+      var(--calcite-ui-foreground-1)
     );
   }
 }
@@ -222,7 +204,7 @@
       var(--calcite-ui-red-1),
       var(--calcite-ui-red-2),
       var(--calcite-ui-red-3),
-      var(--calcite-button-red-solid-color)
+      var(--calcite-ui-foreground-1)
     );
   }
 }
@@ -230,10 +212,10 @@
   button,
   a {
     @include btn-solid(
-      var(--calcite-button-light),
-      var(--calcite-button-light-hover),
-      var(--calcite-button-light-press),
-      $blk-220
+      var(--calcite-ui-foreground-3),
+      var(--calcite-ui-foreground-2),
+      var(--calcite-ui-border-2),
+      var(--calcite-ui-text-1)
     );
   }
 }
@@ -321,10 +303,10 @@
   a {
     @include btn-outline-clear(
       var(--calcite-ui-foreground-1),
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-2),
       var(--calcite-ui-blue-3),
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-3)
     );
   }
@@ -334,10 +316,10 @@
   a {
     @include btn-outline-clear(
       var(--calcite-ui-foreground-1),
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-2),
       var(--calcite-ui-red-3),
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-3)
     );
   }
@@ -347,11 +329,11 @@
   a {
     @include btn-outline-clear(
       var(--calcite-ui-foreground-1),
-      $blk-020,
-      $blk-010,
-      $blk-030,
-      var(--calcite-button-outline-color),
-      var(--calcite-button-outline-press)
+      var(--calcite-ui-foreground-3),
+      var(--calcite-ui-foreground-2),
+      var(--calcite-ui-border-2),
+      var(--calcite-ui-text-1),
+      var(--calcite-ui-text-1)
     );
   }
 }
@@ -363,8 +345,8 @@
       $blk-180,
       $blk-190,
       $blk-170,
-      var(--calcite-button-outline-color),
-      var(--calcite-button-outline-press)
+      var(--calcite-ui-text-1),
+      var(--calcite-ui-text-1)
     );
   }
 }
@@ -373,10 +355,10 @@
   a {
     @include btn-outline-clear(
       transparent,
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-2),
       var(--calcite-ui-blue-3),
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-3)
     );
   }
@@ -386,10 +368,10 @@
   a {
     @include btn-outline-clear(
       transparent,
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-2),
       var(--calcite-ui-red-3),
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-3)
     );
   }
@@ -399,11 +381,11 @@
   a {
     @include btn-outline-clear(
       transparent,
-      $blk-020,
-      $blk-010,
-      $blk-030,
-      $blk-005,
-      $blk-000
+      var(--calcite-ui-foreground-3),
+      var(--calcite-ui-foreground-2),
+      var(--calcite-ui-border-2),
+      var(--calcite-ui-background),
+      var(--calcite-ui-foreground-1)
     );
   }
 }
@@ -426,10 +408,10 @@
   a {
     @include btn-outline-clear-floating(
       var(--calcite-ui-foreground-1),
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-2),
       var(--calcite-ui-blue-3),
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-3)
     );
   }
@@ -439,10 +421,10 @@
   a {
     @include btn-outline-clear-floating(
       var(--calcite-ui-foreground-1),
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-2),
       var(--calcite-ui-red-3),
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-3)
     );
   }
@@ -452,11 +434,11 @@
   a {
     @include btn-outline-clear-floating(
       var(--calcite-ui-foreground-1),
-      $blk-020,
-      $blk-010,
-      $blk-030,
-      var(--calcite-button-outline-color),
-      var(--calcite-button-outline-press)
+      var(--calcite-ui-foreground-3),
+      var(--calcite-ui-foreground-2),
+      var(--calcite-ui-border-2),
+      var(--calcite-ui-text-1),
+      var(--calcite-ui-text-1)
     );
   }
 }
@@ -468,8 +450,8 @@
       $blk-180,
       $blk-190,
       $blk-170,
-      var(--calcite-button-outline-color),
-      var(--calcite-button-outline-press)
+      var(--calcite-ui-text-1),
+      var(--calcite-ui-text-1)
     );
   }
 }
@@ -478,10 +460,10 @@
   a {
     @include btn-outline-clear-floating(
       transparent,
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-2),
       var(--calcite-ui-blue-3),
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-3)
     );
   }
@@ -491,10 +473,10 @@
   a {
     @include btn-outline-clear-floating(
       transparent,
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-2),
       var(--calcite-ui-red-3),
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-3)
     );
   }
@@ -504,11 +486,11 @@
   a {
     @include btn-outline-clear-floating(
       transparent,
-      $blk-020,
-      $blk-010,
-      $blk-030,
-      $blk-005,
-      $blk-000
+      var(--calcite-ui-foreground-3),
+      var(--calcite-ui-foreground-2),
+      var(--calcite-ui-border-2),
+      var(--calcite-ui-background),
+      var(--calcite-ui-foreground-1)
     );
   }
 }
@@ -556,7 +538,7 @@
   button,
   a {
     @include btn-transparent(
-      var(--calcite-blue-accessible),
+      var(--calcite-ui-blue-3),
       var(--calcite-ui-blue-2),
       var(--calcite-ui-blue-3)
     );
@@ -567,7 +549,7 @@
   button,
   a {
     @include btn-transparent(
-      var(--calcite-red-accessible),
+      var(--calcite-ui-red-3),
       var(--calcite-ui-red-2),
       var(--calcite-ui-red-3)
     );
@@ -576,7 +558,11 @@
 :host([appearance="transparent"][color="light"]) {
   button,
   a {
-    @include btn-transparent($blk-010, $blk-000, $blk-020);
+    @include btn-transparent(
+      var(--calcite-ui-foreground-2),
+      var(--calcite-ui-foreground-1),
+      var(--calcite-ui-foreground-3)
+    );
   }
 }
 :host([appearance="transparent"][color="dark"]) {

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // theme variables
 // light theme
 :host {

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -9,7 +9,7 @@ import {
   State,
 } from "@stencil/core";
 
-import { getElementDir, getElementTheme } from "../../utils/dom";
+import { getElementDir } from "../../utils/dom";
 
 @Component({
   tag: "calcite-button",
@@ -52,7 +52,7 @@ export class CalciteButton {
     | "transparent" = "solid";
 
   /** Select theme (light or dark) */
-  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
+  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
   /** specify the scale of the button, defaults to m */
   @Prop({ mutable: true, reflect: true }) scale: "xs" | "s" | "m" | "l" | "xl" =
@@ -92,8 +92,6 @@ export class CalciteButton {
 
   connectedCallback() {
     // prop validations
-    let theme = ["light", "dark"];
-    if (!theme.includes(this.theme)) this.theme = "light";
 
     let appearance = ["solid", "outline", "clear", "transparent"];
     if (!appearance.includes(this.appearance)) this.appearance = "solid";
@@ -129,7 +127,6 @@ export class CalciteButton {
 
   render() {
     const dir = getElementDir(this.el);
-    const theme = getElementTheme(this.el);
     const attributes = this.getAttributes();
     const Tag = this.childElType;
 
@@ -155,7 +152,7 @@ export class CalciteButton {
     );
 
     return (
-      <Host hasText={this.hasText} dir={dir} theme={theme}>
+      <Host hasText={this.hasText} dir={dir}>
         <Tag
           {...attributes}
           onClick={(e) => this.handleClick(e)}

--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -6,7 +6,6 @@ You can programmatically focus a `calcite-button` with the `setFocus()` method:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property       | Attribute       | Description                                                                                        | Type                                               | Default     |
@@ -21,28 +20,22 @@ You can programmatically focus a `calcite-button` with the `setFocus()` method:
 | `loading`      | `loading`       | optionally add a calcite-loader component to the button, disabling interaction.                    | `boolean`                                          | `false`     |
 | `round`        | `round`         | optionally add a round style to the button                                                         | `boolean`                                          | `false`     |
 | `scale`        | `scale`         | specify the scale of the button, defaults to m                                                     | `"l" \| "m" \| "s" \| "xl" \| "xs"`                | `"m"`       |
-| `theme`        | `theme`         | Select theme (light or dark)                                                                       | `"dark" \| "light"`                                | `"light"`   |
+| `theme`        | `theme`         | Select theme (light or dark)                                                                       | `"dark" \| "light"`                                | `undefined` |
 | `width`        | `width`         | specify the width of the button, defaults to auto                                                  | `"auto" \| "full" \| "half"`                       | `"auto"`    |
-
 
 ## Methods
 
 ### `setFocus() => Promise<void>`
 
-
-
 #### Returns
 
 Type: `Promise<void>`
-
-
-
 
 ## Dependencies
 
 ### Used by
 
- - [calcite-split-button](../calcite-split-button)
+- [calcite-split-button](../calcite-split-button)
 
 ### Depends on
 
@@ -50,6 +43,7 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-button --> calcite-loader
@@ -58,6 +52,6 @@ graph TD;
   style calcite-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-card/calcite-card.scss
+++ b/src/components/calcite-card/calcite-card.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 :host {
   max-width: 100%;
   & .calcite-card-container {
@@ -53,7 +57,7 @@
   padding: $baseline/2;
   flex-direction: row;
   align-content: space-between;
-  justify-content: space-between
+  justify-content: space-between;
 }
 
 :host .card-content {

--- a/src/components/calcite-chip/calcite-chip.scss
+++ b/src/components/calcite-chip/calcite-chip.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // scale
 // todo update when new spacing modifiers are introduced to calcite-base
 :host([scale="xs"]) {
@@ -34,7 +38,7 @@
   display: inline-flex;
   align-items: center;
   justify-self: center;
-  background-color: var(--calcite-ui-background);
+  background-color: var(--calcite-ui-foreground-2);
   border-radius: 50px;
   color: var(--calcite-ui-text-1);
   font-weight: 500;

--- a/src/components/calcite-combobox-item/calcite-combobox-item.scss
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // todo update to font and spacing value when added to calcite-base
 :host([scale="xs"]) {
   font-size: 10px;

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // todo update to font and spacing value when added to calcite-base
 :host([scale="xs"]) {
   font-size: 10px;

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 :host {
   display: inline-block;
   vertical-align: top;

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // width
 :host([width="s"]) {
   --calcite-dropdown-width: 12.5em;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -9,11 +9,7 @@ import {
   Method,
   Prop,
 } from "@stencil/core";
-import {
-  getElementDir,
-  getElementProp,
-  getElementTheme,
-} from "../../utils/dom";
+import { getElementDir, getElementProp } from "../../utils/dom";
 
 @Component({
   tag: "calcite-input",
@@ -180,7 +176,6 @@ export class CalciteInput {
 
   render() {
     const dir = getElementDir(this.el);
-    const theme = getElementTheme(this.el);
     const attributes = this.getAttributes();
     const loader = (
       <div class="calcite-input-loading">
@@ -279,7 +274,7 @@ export class CalciteInput {
       );
 
     return (
-      <Host dir={dir} theme={theme}>
+      <Host dir={dir}>
         <div class="calcite-input-wrapper">
           {this.type === "number" && this.numberButtonType === "horizontal"
             ? numberButtonsHorizontalDown

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
   Listen,
 } from "@stencil/core";
-import { getElementDir, getElementTheme } from "../../utils/dom";
+import { getElementDir } from "../../utils/dom";
 
 @Component({
   tag: "calcite-label",
@@ -38,7 +38,7 @@ export class CalciteLabel {
   @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" = "m";
 
   /** specify theme of the lavel and its any child input / input messages */
-  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
+  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
   /** is the wrapped element positioned inline with the label slotted text */
   @Prop({ mutable: true, reflect: true }) layout:
@@ -59,9 +59,6 @@ export class CalciteLabel {
     let layout = ["inline", "inline-space-between", "default"];
     if (!layout.includes(this.layout)) this.layout = "default";
 
-    let theme = ["light", "dark"];
-    if (!theme.includes(this.theme)) this.theme = "light";
-
     let scale = ["s", "m", "l"];
     if (!scale.includes(this.scale)) this.scale = "m";
   }
@@ -78,9 +75,8 @@ export class CalciteLabel {
   render() {
     const attributes = this.getAttributes();
     const dir = getElementDir(this.el);
-    const theme = getElementTheme(this.el);
     return (
-      <Host theme={theme} dir={dir}>
+      <Host dir={dir}>
         <label {...attributes} ref={(el) => (this.slottedContent = el)}>
           <slot />
         </label>

--- a/src/components/calcite-label/readme.md
+++ b/src/components/calcite-label/readme.md
@@ -20,7 +20,6 @@ It allows consumers to set a `status` attribute that child `calcite-input` and `
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property | Attribute | Description                                                          | Type                                              | Default     |
@@ -28,8 +27,7 @@ It allows consumers to set a `status` attribute that child `calcite-input` and `
 | `layout` | `layout`  | is the wrapped element positioned inline with the label slotted text | `"default" \| "inline" \| "inline-space-between"` | `"default"` |
 | `scale`  | `scale`   | specify the scale of the input, defaults to m                        | `"l" \| "m" \| "s"`                               | `"m"`       |
 | `status` | `status`  | specify the status of the label and any child input / input messages | `"idle" \| "invalid" \| "valid"`                  | `"idle"`    |
-| `theme`  | `theme`   | specify theme of the lavel and its any child input / input messages  | `"dark" \| "light"`                               | `"light"`   |
-
+| `theme`  | `theme`   | specify theme of the lavel and its any child input / input messages  | `"dark" \| "light"`                               | `undefined` |
 
 ## Events
 
@@ -37,7 +35,6 @@ It allows consumers to set a `status` attribute that child `calcite-input` and `
 | --------------------------- | ----------- | ------------------ |
 | `calciteLabelSelectedEvent` |             | `CustomEvent<any>` |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-link/calcite-link.tsx
+++ b/src/components/calcite-link/calcite-link.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Host, Method, Prop } from "@stencil/core";
-import { getElementDir, getElementTheme } from "../../utils/dom";
+import { getElementDir } from "../../utils/dom";
 
 @Component({
   tag: "calcite-link",
@@ -35,7 +35,7 @@ export class CalciteLink {
     | "red" = "blue";
 
   /** Select theme (light or dark) */
-  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
+  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
   /** optionally pass a href - used to determine if the component should render as a link or an anchor */
   @Prop({ reflect: true }) href?: string;
@@ -58,8 +58,6 @@ export class CalciteLink {
 
   connectedCallback() {
     // prop validations
-    let theme = ["light", "dark"];
-    if (!theme.includes(this.theme)) this.theme = "light";
 
     let color = ["blue", "red", "dark", "light"];
     if (!color.includes(this.color)) this.color = "blue";
@@ -73,7 +71,6 @@ export class CalciteLink {
 
   render() {
     const dir = getElementDir(this.el);
-    const theme = getElementTheme(this.el);
     const attributes = this.getAttributes();
     const Tag = this.childElType;
     const role = this.childElType === "span" ? "link" : null;
@@ -84,7 +81,7 @@ export class CalciteLink {
     );
 
     return (
-      <Host dir={dir} theme={theme}>
+      <Host dir={dir}>
         <Tag
           {...attributes}
           role={role}

--- a/src/components/calcite-link/readme.md
+++ b/src/components/calcite-link/readme.md
@@ -6,7 +6,6 @@ You can programmatically focus a `calcite-link` with the `setFocus()` method:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property       | Attribute       | Description                                                                                      | Type                                   | Default     |
@@ -16,21 +15,15 @@ You can programmatically focus a `calcite-link` with the `setFocus()` method:
 | `href`         | `href`          | optionally pass a href - used to determine if the component should render as a link or an anchor | `string`                               | `undefined` |
 | `icon`         | `icon`          | optionally pass an icon to display - accepts Calcite UI icon names                               | `string`                               | `undefined` |
 | `iconPosition` | `icon-position` | optionally used with icon, select where to position the icon                                     | `"end" \| "start"`                     | `"start"`   |
-| `theme`        | `theme`         | Select theme (light or dark)                                                                     | `"dark" \| "light"`                    | `"light"`   |
-
+| `theme`        | `theme`         | Select theme (light or dark)                                                                     | `"dark" \| "light"`                    | `undefined` |
 
 ## Methods
 
 ### `setFocus() => Promise<void>`
 
-
-
 #### Returns
 
 Type: `Promise<void>`
-
-
-
 
 ## Dependencies
 
@@ -39,12 +32,13 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-link --> calcite-icon
   style calcite-link fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -1,3 +1,8 @@
+//ie11 fixes
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // scale variables
 :host([scale="s"]) {
   --calcite-notice-spacing-token-small: #{$baseline/2};

--- a/src/components/calcite-pagination/calcite-pagination.scss
+++ b/src/components/calcite-pagination/calcite-pagination.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // explicit px values until we add a spacing unit and new font scale to base
 :host([scale="s"]) {
   --calcite-pagination-spacing: 4px 8px;

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -1,3 +1,8 @@
+//ie11 fixes
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 :host {
   display: flex;
   align-self: stretch;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -1,3 +1,8 @@
+// ie11 fix
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 $thumb-size: 28px;
 $handle-size: 14px;
 $thumb-padding: ($thumb-size - $handle-size) / 2;

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -27,7 +27,7 @@ export class CalciteButtonWithDropdown {
     | "red" = "blue";
 
   /** select theme (light or dark), defaults to light */
-  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
+  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
   /** specify the scale of the control, defaults to m */
   @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" = "m";

--- a/src/components/calcite-split-button/readme.md
+++ b/src/components/calcite-split-button/readme.md
@@ -29,7 +29,7 @@ Basic Usage:
 | `primaryLabel`     | `primary-label`      | optionally pass an aria-label for the primary button                                                     | `string`                               | `undefined` |
 | `primaryText`      | `primary-text`       | text for primary action button                                                                           | `string`                               | `undefined` |
 | `scale`            | `scale`              | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                    | `"m"`       |
-| `theme`            | `theme`              | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                    | `"light"`   |
+| `theme`            | `theme`              | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                    | `undefined` |
 
 ## Events
 

--- a/src/components/calcite-stepper/calcite-stepper.tsx
+++ b/src/components/calcite-stepper/calcite-stepper.tsx
@@ -34,7 +34,7 @@ export class CalciteStepper {
   //--------------------------------------------------------------------------
 
   /** specify the theme of stepper, defaults to light */
-  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark" = "light";
+  @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
   /** specify the scale of stepper, defaults to m */
   @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" = "m";
@@ -75,9 +75,6 @@ export class CalciteStepper {
     // validate props
     let layout = ["horizontal", "vertical"];
     if (!layout.includes(this.layout)) this.layout = "horizontal";
-
-    let theme = ["light", "dark"];
-    if (!theme.includes(this.theme)) this.theme = "light";
 
     let scale = ["s", "m", "l"];
     if (!scale.includes(this.scale)) this.scale = "m";

--- a/src/components/calcite-stepper/readme.md
+++ b/src/components/calcite-stepper/readme.md
@@ -33,7 +33,6 @@ Calcite stepper can be used to present a stepper workflow to a user. It has conf
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property   | Attribute  | Description                                             | Type                         | Default        |
@@ -42,15 +41,13 @@ Calcite stepper can be used to present a stepper workflow to a user. It has conf
 | `layout`   | `layout`   | specify the layout of stepper, defaults to horizontal   | `"horizontal" \| "vertical"` | `"horizontal"` |
 | `numbered` | `numbered` | optionally display the number next to the step title    | `boolean`                    | `false`        |
 | `scale`    | `scale`    | specify the scale of stepper, defaults to m             | `"l" \| "m" \| "s"`          | `"m"`          |
-| `theme`    | `theme`    | specify the theme of stepper, defaults to light         | `"dark" \| "light"`          | `"light"`      |
-
+| `theme`    | `theme`    | specify the theme of stepper, defaults to light         | `"dark" \| "light"`          | `undefined`    |
 
 ## Events
 
 | Event                          | Description | Type               |
 | ------------------------------ | ----------- | ------------------ |
 | `calciteStepperItemHasChanged` |             | `CustomEvent<any>` |
-
 
 ## Methods
 
@@ -62,8 +59,6 @@ set the last step as active
 
 Type: `Promise<void>`
 
-
-
 ### `goToStep(num: number) => Promise<void>`
 
 set the requested step as active
@@ -71,8 +66,6 @@ set the requested step as active
 #### Returns
 
 Type: `Promise<void>`
-
-
 
 ### `nextStep() => Promise<void>`
 
@@ -82,8 +75,6 @@ set the next step as active
 
 Type: `Promise<void>`
 
-
-
 ### `prevStep() => Promise<void>`
 
 set the previous step as active
@@ -91,8 +82,6 @@ set the previous step as active
 #### Returns
 
 Type: `Promise<void>`
-
-
 
 ### `startStep() => Promise<void>`
 
@@ -102,9 +91,6 @@ set the first step as active
 
 Type: `Promise<void>`
 
+---
 
-
-
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -5,30 +5,13 @@
 // theme variables
 // light theme
 :host {
-  --calcite-switch-track-background: #{$blk-010};
-  --calcite-switch-track-border: #{$blk-040};
-  --calcite-switch-handle-background: #{$blk-000};
-  --calcite-switch-handle-border: #{$blk-100};
   --calcite-switch-hover-handle-border: var(--calcite-ui-blue-2);
-  --calcite-switch-hover-track-background: #{$blk-020};
-  --calcite-switch-hover-track-border: #{$blk-060};
   --calcite-switch-switched-track-background: var(--calcite-ui-blue-2);
   --calcite-switch-switched-track-border: var(--calcite-ui-blue-2);
   --calcite-switch-switched-handle-border: var(--calcite-ui-blue-1);
   --calcite-switch-switched-hover-track-background: var(--calcite-ui-blue-2);
   --calcite-switch-switched-hover-track-border: var(--calcite-ui-blue-2);
   --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-3);
-}
-
-// dark theme
-:host([theme="dark"]) {
-  // TODO: these need to reference the underlying calcite vars
-  --calcite-switch-track-background: #{$blk-190};
-  --calcite-switch-track-border: #{$blk-160};
-  --calcite-switch-handle-background: #{$blk-200};
-  --calcite-switch-handle-border: #{$blk-100};
-  --calcite-switch-hover-track-background: #{$blk-180};
-  --calcite-switch-hover-track-border: #{$blk-120};
 }
 
 :host([color="red"]) {
@@ -88,9 +71,9 @@
   vertical-align: top;
   width: var(--calcite-switch-track-width);
   height: var(--calcite-switch-track-height);
-  background-color: var(--calcite-switch-track-background);
+  background-color: var(--calcite-ui-foreground-2);
   border-radius: 30px;
-  border: 1px solid var(--calcite-switch-track-border);
+  border: 1px solid var(--calcite-ui-border-2);
   pointer-events: none;
   transition: all $transition;
 }
@@ -103,9 +86,9 @@
   top: -1px;
   left: -1px;
   right: auto;
-  background-color: var(--calcite-switch-handle-background);
+  background-color: var(--calcite-ui-foreground-1);
   border-radius: 30px;
-  border: 2px solid var(--calcite-switch-handle-border);
+  border: 2px solid var(--calcite-ui-border-4);
   pointer-events: none;
   transition: all $transition;
 }
@@ -113,8 +96,8 @@
 :host(:hover),
 :host(:focus) {
   .track {
-    background-color: var(--calcite-switch-hover-track-background);
-    border-color: var(--calcite-switch-hover-track-border);
+    background-color: var(--calcite-ui-foreground-3);
+    border-color: var(--calcite-ui-border-1);
   }
 
   .handle {

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 // theme variables
 // light theme
 :host {
@@ -18,6 +22,7 @@
 
 // dark theme
 :host([theme="dark"]) {
+  // TODO: these need to reference the underlying calcite vars
   --calcite-switch-track-background: #{$blk-190};
   --calcite-switch-track-border: #{$blk-160};
   --calcite-switch-handle-background: #{$blk-200};

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -36,7 +36,7 @@ export class CalciteSwitch {
   @Prop({ reflect: true, mutable: true }) scale: "s" | "m" | "l" = "m";
 
   /** The component's theme. */
-  @Prop({ reflect: true, mutable: true }) theme: "light" | "dark" = "light";
+  @Prop({ reflect: true, mutable: true }) theme: "light" | "dark";
 
   @Event() calciteSwitchChange: EventEmitter;
   @Event() change: EventEmitter;
@@ -71,8 +71,6 @@ export class CalciteSwitch {
 
   connectedCallback() {
     // prop validations
-    let theme = ["light", "dark"];
-    if (!theme.includes(this.theme)) this.theme = "light";
 
     let color = ["blue", "red"];
     if (!color.includes(this.color)) this.color = "blue";

--- a/src/components/calcite-switch/readme.md
+++ b/src/components/calcite-switch/readme.md
@@ -16,18 +16,16 @@ If you don't pass in an input, calcite-switch will act as the source of truth:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property   | Attribute  | Description                        | Type                | Default   |
-| ---------- | ---------- | ---------------------------------- | ------------------- | --------- |
-| `color`    | `color`    | What color the switch should be    | `"blue" \| "red"`   | `"blue"`  |
-| `name`     | `name`     | The name of the checkbox input     | `string`            | `""`      |
-| `scale`    | `scale`    | The scale of the switch            | `"l" \| "m" \| "s"` | `"m"`     |
-| `switched` | `switched` | True if the switch is initially on | `boolean`           | `false`   |
-| `theme`    | `theme`    | The component's theme.             | `"dark" \| "light"` | `"light"` |
-| `value`    | `value`    | The value of the checkbox input    | `string`            | `""`      |
-
+| Property   | Attribute  | Description                        | Type                | Default     |
+| ---------- | ---------- | ---------------------------------- | ------------------- | ----------- |
+| `color`    | `color`    | What color the switch should be    | `"blue" \| "red"`   | `"blue"`    |
+| `name`     | `name`     | The name of the checkbox input     | `string`            | `""`        |
+| `scale`    | `scale`    | The scale of the switch            | `"l" \| "m" \| "s"` | `"m"`       |
+| `switched` | `switched` | True if the switch is initially on | `boolean`           | `false`     |
+| `theme`    | `theme`    | The component's theme.             | `"dark" \| "light"` | `undefined` |
+| `value`    | `value`    | The value of the checkbox input    | `string`            | `""`        |
 
 ## Events
 
@@ -36,7 +34,6 @@ If you don't pass in an input, calcite-switch will act as the source of truth:
 | `calciteSwitchChange` |             | `CustomEvent<any>` |
 | `change`              |             | `CustomEvent<any>` |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -1,3 +1,7 @@
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
 :host {
   display: flex;
   flex-direction: column;

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -6,12 +6,9 @@ import {
   Event,
   EventEmitter,
   Listen,
-  h
+  h,
 } from "@stencil/core";
-import {
-  nodeListToArray,
-  getElementTheme
-} from "../../utils/dom";
+import { nodeListToArray } from "../../utils/dom";
 import { TreeSelectionMode } from "../../interfaces/TreeSelectionMode";
 import { TreeItemSelectDetail } from "../../interfaces/TreeItemSelect";
 import { TreeSelectDetail } from "../../interfaces/TreeSelect";
@@ -19,7 +16,7 @@ import { TreeSelectDetail } from "../../interfaces/TreeSelect";
 @Component({
   tag: "calcite-tree",
   styleUrl: "calcite-tree.scss",
-  shadow: true
+  shadow: true,
 })
 export class CalciteTree {
   //--------------------------------------------------------------------------
@@ -58,7 +55,7 @@ export class CalciteTree {
     const parent: HTMLCalciteTreeElement = this.el.parentElement.closest(
       "calcite-tree"
     );
-    this.theme = getElementTheme(this.el);
+    // this.theme = getElementTheme(this.el);
     this.lines = parent ? parent.lines : this.lines;
     this.scale = parent ? parent.scale : this.scale;
     this.selectionMode = parent ? parent.selectionMode : this.selectionMode;
@@ -66,7 +63,6 @@ export class CalciteTree {
   }
 
   render() {
-
     return (
       <Host
         tabindex={this.root ? "1" : undefined}
@@ -128,8 +124,8 @@ export class CalciteTree {
       (((this.selectionMode === TreeSelectionMode.Single ||
         this.selectionMode === TreeSelectionMode.Multi) &&
         childItems.length <= 0) ||
-        (this.selectionMode === TreeSelectionMode.Children ||
-          this.selectionMode === TreeSelectionMode.MultiChildren));
+        this.selectionMode === TreeSelectionMode.Children ||
+        this.selectionMode === TreeSelectionMode.MultiChildren);
 
     const shouldExpandTarget =
       this.selectionMode === TreeSelectionMode.Children ||
@@ -143,7 +139,7 @@ export class CalciteTree {
       }
 
       if (shouldSelectChildren) {
-        childItems.forEach(treeItem => {
+        childItems.forEach((treeItem) => {
           targetItems.push(treeItem);
         });
       }
@@ -153,7 +149,7 @@ export class CalciteTree {
           this.el.querySelectorAll("calcite-tree-item[selected]")
         ) as HTMLCalciteTreeItemElement[];
 
-        selectedItems.forEach(treeItem => {
+        selectedItems.forEach((treeItem) => {
           if (!targetItems.includes(treeItem)) {
             treeItem.selected = false;
           }
@@ -172,11 +168,11 @@ export class CalciteTree {
         (shouldModifyToCurrentSelection && target.selected) ||
         (shouldSelectChildren && e.detail.forceToggle)
       ) {
-        targetItems.forEach(treeItem => {
+        targetItems.forEach((treeItem) => {
           treeItem.selected = false;
         });
       } else {
-        targetItems.forEach(treeItem => {
+        targetItems.forEach((treeItem) => {
           treeItem.selected = true;
         });
       }
@@ -190,7 +186,7 @@ export class CalciteTree {
     this.calciteTreeSelect.emit({
       selected: (nodeListToArray(
         this.el.querySelectorAll("calcite-tree-item")
-      ) as HTMLCalciteTreeItemElement[]).filter(i => i.selected)
+      ) as HTMLCalciteTreeItemElement[]).filter((i) => i.selected),
     });
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -510,5 +510,36 @@
         </label>
       </div>
     </div>
+
+    <div class="demo demo-background-dark" theme="dark">
+      <div class="demo-column">
+        <calcite-stepper numbered="zom" icon="zar">
+          <calcite-stepper-item item-title="Choose method" complete>
+            Something before a div
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+              Something after a div
+              <div>a non calcite element div</div>
+              Something else
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 2 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 3 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 4 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+        </calcite-stepper>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -257,7 +257,14 @@
       </div>
       <div class="demo-column">
         <div>
-          <calcite-button>button</calcite-button>
+          <calcite-dropdown>
+            <calcite-button slot="dropdown-trigger">Dropdown</calcite-button>
+            <calcite-dropdown-group group-title="View">
+              <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+              <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+              <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+            </calcite-dropdown-group>
+          </calcite-dropdown>
           <calcite-button appearance='outline'>outline</calcite-button>
           <calcite-button color="light">light</calcite-button>
           <calcite-button color="red">red</calcite-button>
@@ -412,7 +419,14 @@
       </div>
       <div class="demo-column">
         <div>
-          <calcite-button>button</calcite-button>
+          <calcite-dropdown>
+            <calcite-button slot="dropdown-trigger">Dropdown</calcite-button>
+            <calcite-dropdown-group group-title="View">
+              <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+              <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+              <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+            </calcite-dropdown-group>
+          </calcite-dropdown>
           <calcite-button appearance='outline'>outline</calcite-button>
           <calcite-button color="light">light</calcite-button>
           <calcite-button color="red">red</calcite-button>

--- a/src/index.html
+++ b/src/index.html
@@ -9,11 +9,32 @@
     <title>Calcite Component Starter</title>
 
     <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
       .nav {
         list-style: none;
         display: flex;
         flex-direction: column;
         padding: 0;
+      }
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+      .demo {
+        display: flex;
+        align-items: flex-start;
+        padding-bottom: 4rem;
+      }
+      .demo-column {
+        flex: 1;
+        margin: 0 2rem;
+      }
+      .demo-column > * {
+        margin-top: 2rem;
       }
     </style>
     <link
@@ -26,7 +47,7 @@
   </head>
 
   <body>
-    <div class="example-container">
+    <div class="demo-column">
       <h2>Calcite Component Examples - WIP !</h2>
       <ul class="nav">
         <li>
@@ -165,6 +186,315 @@
           >
         </li>
       </ul>
+    </div>
+    <div class="demo">
+      <div class="demo-column">
+        <calcite-accordion>
+          <calcite-accordion-item item-title="Accordion Item"><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 2"><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 3 with a potentially two line title"><img
+              src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 4"><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 5" active>
+            <calcite-tree lines>
+              <calcite-tree-item>
+                Child 1
+              </calcite-tree-item>
+
+              <calcite-tree-item>
+                Child 2
+
+                <calcite-tree slot="children">
+                  <calcite-tree-item>
+                    Grandchild 1
+                  </calcite-tree-item>
+
+                  <calcite-tree-item>
+                    Grandchild 2
+                    <calcite-tree slot="children">
+                      <calcite-tree-item>
+                        Great-Grandchild 1
+                      </calcite-tree-item>
+                      <calcite-tree-item>
+                        Great-Grandchild 2
+                      </calcite-tree-item>
+                    </calcite-tree>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+              <calcite-tree-item>
+                Child 3
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-accordion-item>
+        </calcite-accordion>
+        <calcite-notice color="red" id="notice-one" scale="s" active dismissible>
+          <div slot="notice-title">Something failed dismissible</div>
+          <div slot="notice-message">
+            That thing you wanted to do didn't work as expected
+          </div>
+          <calcite-link slot="notice-link" title="my action">Retry</calcite-link>
+        </calcite-notice>
+        <calcite-notice icon color="green" scale="m" active dismissible>
+          <div slot="notice-title">Something worked</div>
+          <div slot="notice-message">
+            That thing you wanted to do worked as expected
+          </div>
+        </calcite-notice>
+        <calcite-label>
+          My Great Radio Group
+          <calcite-radio-group>
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </calcite-label>
+      </div>
+      <div class="demo-column">
+        <div>
+          <calcite-button>button</calcite-button>
+          <calcite-button appearance='outline'>outline</calcite-button>
+          <calcite-button color="light">light</calcite-button>
+          <calcite-button color="red">red</calcite-button>
+        </div>
+        <div>
+          <calcite-card selected selectable>
+            <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+
+            <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+            <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
+              overly verbose.</span>
+            <calcite-link slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+          </calcite-card>
+        </div>
+        <div>
+          <label>
+            <calcite-checkbox indeterminate><input type="checkbox" name="" value=""></calcite-checkbox>
+            Initially indeterminate and unchecked
+          </label>
+        </div>
+        <div>
+          <calcite-chip active="" icon="camera-flash-on">
+            Camera Flash On
+          </calcite-chip>
+          <calcite-chip active="" icon="check-circle">
+            Siamese Cat
+          </calcite-chip>
+        </div>
+        <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+        max-label="Temperature range (upper)"></calcite-slider>
+      </div>
+      <div class="demo-column">
+        <calcite-combobox label="test" placeholder="combobox">
+          <calcite-combobox-item value="Trees" text-label="Trees">
+            <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+            <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+            <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Flowers" text-label="Flowers">
+            <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+            <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+            <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Animals" text-label="Animals">
+            <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+            <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+            <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+          <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+          <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+        </calcite-combobox>
+        <calcite-date scale="m" value="2020-11-27" no-calendar-input="true" active></calcite-date>
+        <calcite-tabs is-active>
+          <calcite-tab-nav slot="tab-nav">
+            <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+          </calcite-tab-nav>
+
+          <calcite-tab is-active>
+            <calcite-loader is-active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+          <calcite-tab>
+            <calcite-loader is-active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+          <calcite-tab>
+            <calcite-loader is-active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+          <calcite-tab>
+            <calcite-loader is-active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+        </calcite-tabs>
+
+        <label>
+          <calcite-switch scale="m" switched="true" color="red"> </calcite-switch>
+          Red switch scale medium
+        </label>
+      </div>
+    </div>
+
+    <div class="demo demo-background-dark" theme="dark">
+      <div class="demo-column">
+        <calcite-accordion>
+          <calcite-accordion-item item-title="Accordion Item"><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 2"><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 3 with a potentially two line title"><img
+              src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 4"><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 5" active>
+            <calcite-tree lines>
+              <calcite-tree-item>
+                Child 1
+              </calcite-tree-item>
+
+              <calcite-tree-item>
+                Child 2
+
+                <calcite-tree slot="children">
+                  <calcite-tree-item>
+                    Grandchild 1
+                  </calcite-tree-item>
+
+                  <calcite-tree-item>
+                    Grandchild 2
+                    <calcite-tree slot="children">
+                      <calcite-tree-item>
+                        Great-Grandchild 1
+                      </calcite-tree-item>
+                      <calcite-tree-item>
+                        Great-Grandchild 2
+                      </calcite-tree-item>
+                    </calcite-tree>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+              <calcite-tree-item>
+                Child 3
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-accordion-item>
+        </calcite-accordion>
+        <calcite-notice color="red" id="notice-one" scale="s" active dismissible>
+          <div slot="notice-title">Something failed dismissible</div>
+          <div slot="notice-message">
+            That thing you wanted to do didn't work as expected
+          </div>
+          <calcite-link slot="notice-link" title="my action">Retry</calcite-link>
+        </calcite-notice>
+        <calcite-notice icon color="green" scale="m" active dismissible>
+          <div slot="notice-title">Something worked</div>
+          <div slot="notice-message">
+            That thing you wanted to do worked as expected
+          </div>
+        </calcite-notice>
+        <calcite-label>
+          My Great Radio Group
+          <calcite-radio-group>
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </calcite-label>
+      </div>
+      <div class="demo-column">
+        <div>
+          <calcite-button>button</calcite-button>
+          <calcite-button appearance='outline'>outline</calcite-button>
+          <calcite-button color="light">light</calcite-button>
+          <calcite-button color="red">red</calcite-button>
+        </div>
+        <div>
+          <calcite-card selected selectable>
+            <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+
+            <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+            <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
+              overly verbose.</span>
+            <calcite-link slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+          </calcite-card>
+        </div>
+        <div>
+          <label>
+            <calcite-checkbox indeterminate><input type="checkbox" name="" value=""></calcite-checkbox>
+            Initially indeterminate and unchecked
+          </label>
+        </div>
+        <div>
+          <calcite-chip active="" icon="camera-flash-on">
+            Camera Flash On
+          </calcite-chip>
+          <calcite-chip active="" icon="check-circle">
+            Siamese Cat
+          </calcite-chip>
+        </div>
+        <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+        max-label="Temperature range (upper)"></calcite-slider>
+      </div>
+      <div class="demo-column">
+        <calcite-combobox label="test" placeholder="combobox">
+          <calcite-combobox-item value="Trees" text-label="Trees">
+            <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+            <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+            <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Flowers" text-label="Flowers">
+            <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+            <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+            <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Animals" text-label="Animals">
+            <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+            <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+            <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+          <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+          <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+        </calcite-combobox>
+        <calcite-date scale="m" value="2020-11-27" no-calendar-input="true" active></calcite-date>
+        <calcite-tabs is-active>
+          <calcite-tab-nav slot="tab-nav">
+            <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+          </calcite-tab-nav>
+
+          <calcite-tab is-active>
+            <calcite-loader is-active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+          <calcite-tab>
+            <calcite-loader is-active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+          <calcite-tab>
+            <calcite-loader is-active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+          <calcite-tab>
+            <calcite-loader is-active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
+          </calcite-tab>
+        </calcite-tabs>
+
+        <label>
+          <calcite-switch scale="m" switched="true" color="red"> </calcite-switch>
+          Red switch scale medium
+        </label>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Mainly trying to make components easier to theme as per #507 . Basically, by setting the `theme` attribute on all the components we were making it hard to override the css vars. This stops setting theme if the prop isn't passed in, and allows components to inherit their theme. 

Getting this to work in ie required adding the dark theme variables to all components, not just nested ones. When IE11 support is dropped we will be able to remove these. 

Also started moving some of the remaining components that use their own configurable theming variables over to the normal global ones. This covers most of #546 , but not the dark button. Some of the dark button colors are not available in our global css vars.

In order to make it easier for me to test/troubleshoot theming I've added a "sticker sheet" to the index file as well. 

<img width="1249" alt="Screen Shot 2020-05-08 at 9 23 32 AM" src="https://user-images.githubusercontent.com/1031758/81426144-a52ccb00-910d-11ea-96fa-3060f0010ec0.png">
<img width="1225" alt="Screen Shot 2020-05-08 at 9 23 50 AM" src="https://user-images.githubusercontent.com/1031758/81426151-a78f2500-910d-11ea-8d51-9398c2ae75e4.png">
