### PR TITLE
Allow active attribute for alert to launch alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-dropdown` - will now properly open and close when children of the `dropdown-trigger` slot are acted on.
 
+### Updated
+
+- `calcite-alert` - now handles (by calling `open`) having an `active` attribute when added to DOM.
+
 ## [v1.0.0-beta.25] - Apr 28th 2020
 
 ### Breaking Changes

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -118,11 +118,18 @@ export class CalciteAlert {
     if (!scale.includes(this.scale)) this.scale = "m";
 
     let durations = ["slow", "medium", "fast"];
+
     if (
       this.autoDismissDuration !== null &&
       !durations.includes(this.autoDismissDuration)
     ) {
       this.autoDismissDuration = "medium";
+    }
+
+    // if active attribute in dom, remove attribute and open with method
+    if (this.active) {
+      this.active = false;
+      this.open();
     }
   }
 

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -126,7 +126,6 @@ export class CalciteAlert {
       this.autoDismissDuration = "medium";
     }
 
-    // if active attribute in dom, remove attribute and open with method
     if (this.active) {
       this.active = false;
       this.open();


### PR DESCRIPTION
Adds a check on connectedCallback for 'active' attribute - if present remove the attribute from DOM and call the open method

This should resolve #570 - cc @jwasilgeo if you want to check this out to verify, but it should solve because it removes the attribute from DOM and calls `open` internally so it should handle queuing.