### PR TITLE
feat(calcite-link): add scale prop and additional value option of "inherit"

### DIFF
--- a/src/components/calcite-link/calcite-link.scss
+++ b/src/components/calcite-link/calcite-link.scss
@@ -16,6 +16,22 @@
   --calcite-link-red-underline: #{rgba($d-rr-420, 0.4)};
 }
 
+:host([scale="inherit"]) {
+  --calcite-link-font-size: inherit;
+}
+
+:host([scale="s"]) {
+  --calcite-link-font-size: 12px;
+}
+
+:host([scale="m"]) {
+  --calcite-link-font-size: 16px;
+}
+
+:host([scale="l"]) {
+  --calcite-link-font-size: 20px;
+}
+
 // link base
 :host a,
 :host span {
@@ -27,7 +43,7 @@
   border-radius: 0;
   border: none;
   line-height: inherit;
-  font-size: inherit;
+  font-size: var(--calcite-link-font-size);
   font-family: inherit;
   -webkit-appearance: none;
   cursor: pointer;

--- a/src/components/calcite-link/calcite-link.tsx
+++ b/src/components/calcite-link/calcite-link.tsx
@@ -37,6 +37,10 @@ export class CalciteLink {
   /** Select theme (light or dark) */
   @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
+  /** specify the scale of the link, defaults to inherit */
+  @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" | "inherit" =
+    "inherit";
+
   /** optionally pass a href - used to determine if the component should render as a link or an anchor */
   @Prop({ reflect: true }) href?: string;
 
@@ -75,9 +79,14 @@ export class CalciteLink {
     const Tag = this.childElType;
     const role = this.childElType === "span" ? "link" : null;
     const tabIndex = this.childElType === "span" ? 0 : null;
+    const iconScale = this.scale === "l" ? "m" : "s";
 
     const iconEl = (
-      <calcite-icon class="calcite-link--icon" icon={this.icon} scale="s" />
+      <calcite-icon
+        class="calcite-link--icon"
+        icon={this.icon}
+        scale={iconScale}
+      />
     );
 
     return (


### PR DESCRIPTION
Per our discussion in the design sync. 
This is what I was thinking.

* Adds `scale` property to calcite-link
* Adds `inherit` as a possible value for `scale`.

cc @julio8a @paulcpederson