### PR TITLE
Update label styling

### DIFF
--- a/src/components/calcite-input-message/calcite-input-message.scss
+++ b/src/components/calcite-input-message/calcite-input-message.scss
@@ -1,6 +1,5 @@
 // theme variables
 :host([scale="s"]) {
-  font-size: 12px;
   --calcite-input-message-spacing-value: 4px;
   .calcite-input-message-icon {
     margin-top: -2px;
@@ -8,12 +7,10 @@
 }
 
 :host([scale="m"]) {
-  font-size: 14px;
   --calcite-input-message-spacing-value: 8px;
 }
 
 :host([scale="l"]) {
-  font-size: 16px;
   --calcite-input-message-spacing-value: 12px;
 }
 

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -5,17 +5,17 @@
 
 // temporary hardcoded values until new font scale and padding is added to calcite-base
 :host([scale="s"]) label {
-  font-size: var(--calcite-label-font-size, 10px);
+  font-size: var(--calcite-label-font-size, 12px);
   --calcite-label-spacing-value: 8px;
 }
 
 :host([scale="m"]) label {
-  font-size: var(--calcite-label-font-size, 14px);
+  font-size: var(--calcite-label-font-size, 16px);
   --calcite-label-spacing-value: 12px;
 }
 
 :host([scale="l"]) label {
-  font-size: var(--calcite-label-font-size, 18px);
+  font-size: var(--calcite-label-font-size, 20px);
   --calcite-label-spacing-value: 16px;
 }
 
@@ -35,7 +35,6 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  font-weight: 500;
   cursor: pointer;
   margin: 0 0 var(--calcite-label-margin-bottom, $baseline) 0;
 }

--- a/src/components/calcite-radio-button/calcite-radio-button.scss
+++ b/src/components/calcite-radio-button/calcite-radio-button.scss
@@ -41,7 +41,6 @@
     min-width: 12px;
     max-width: 12px;
   }
-  --calcite-label-font-size: 12px;
 }
 :host([scale="s"][checked]),
 :host(:hover[scale="s"][checked][disabled]) {
@@ -65,7 +64,6 @@
     min-width: 16px;
     max-width: 16px;
   }
-  --calcite-label-font-size: 16px;
 }
 :host([scale="m"][checked]),
 :host(:hover[scale="m"][checked][disabled]) {
@@ -90,7 +88,6 @@
     min-width: 20px;
     max-width: 20px;
   }
-  --calcite-label-font-size: 20px;
 }
 :host([scale="l"][checked]),
 :host(:hover[scale="l"][checked][disabled]) {


### PR DESCRIPTION
Small style updates based on feedback from @asangma / Mitch (can never tag him)...

@eriklharper - I removed the overrides from radio-group as the labels now display at that size by default.

Update font-weight and size of calcite-label
Removes explicitly defined label size from calcite-radio-button as it's no longer needed
Calcite-input-message no longer has font-size set, so it should display at same scale as container.

Resolves #582 