### PR TITLE
scrim: set pointer events to none by default

### DIFF
--- a/src/components/calcite-scrim/calcite-scrim.scss
+++ b/src/components/calcite-scrim/calcite-scrim.scss
@@ -1,6 +1,7 @@
 :host {
   display: flex;
   position: relative;
+  pointer-events: none;
   --calcite-scrim-background: #{rgba($blk-000, 0.75)};
 }
 


### PR DESCRIPTION
scrim: set pointer events to none by default