### PR TITLE
[calcite-switch] Fix RTL display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `calcite-input` - will now properly position a requested `icon` if `prefix-text` is also set
+- `calcite-switch` - will now properly display in RTL
 
 ## [v1.0.0-beta.26] - May 18th 2020
 

--- a/src/components/calcite-switch/calcite-switch.stories.js
+++ b/src/components/calcite-switch/calcite-switch.stories.js
@@ -1,12 +1,14 @@
-import { storiesOf } from '@storybook/html';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs'
-import { darkBackground, parseReadme } from '../../../.storybook/helpers';
-import readme from './readme.md';
+import { storiesOf } from "@storybook/html";
+import { withKnobs, boolean, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import readme from "./readme.md";
 const notes = parseReadme(readme);
 
-storiesOf('Switch', module)
+storiesOf("Switch", module)
   .addDecorator(withKnobs)
-  .add('Simple', () => `
+  .add(
+    "Simple",
+    () => `
     <label>
       <calcite-switch
         name="setting"
@@ -17,6 +19,43 @@ storiesOf('Switch', module)
       ></calcite-switch>
       Enable setting
     </label>
-  `, { notes })
-  .add('Dark mode', () => `<calcite-switch theme="dark"></calcite-switch>`,
-   { notes, backgrounds: darkBackground });
+  `,
+    { notes }
+  )
+  .add(
+    "Dark mode",
+    () => `
+    <div style="color:white">
+      <label>
+      <calcite-switch
+        theme="dark"
+        name="setting"
+        value="enabled"
+        switched="${boolean("switched", true)}"
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        color="${select("color", ["blue", "red"], "blue")}"
+      ></calcite-switch>
+      Enable setting
+    </label>
+    </div>`,
+    {
+      notes,
+      backgrounds: darkBackground,
+    }
+  )
+  .add(
+    "RTL",
+    () => `
+      <label>
+      <calcite-switch
+        dir="rtl"
+        name="setting"
+        value="enabled"
+        switched="${boolean("switched", true)}"
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        color="${select("color", ["blue", "red"], "blue")}"
+      ></calcite-switch>
+      Enable setting
+    </label>`,
+    { notes }
+  );

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -10,6 +10,7 @@ import {
   Watch,
   Build,
 } from "@stencil/core";
+import { getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 
 @Component({
@@ -89,8 +90,11 @@ export class CalciteSwitch {
   }
 
   render() {
+    const dir = getElementDir(this.el);
+
     return (
       <Host
+        dir={dir}
         role="checkbox"
         aria-checked={this.switched.toString()}
         tabIndex={this.tabIndex}

--- a/src/demos/calcite-switch.html
+++ b/src/demos/calcite-switch.html
@@ -140,6 +140,124 @@
       <calcite-switch theme="dark"></calcite-switch>
       Switch with no wrapping <code>label</code>.
     </div>
+  </div>
+  <h3>RTL Set Directly on Switch</h3>
+  <div>
+    <label>
+      <calcite-switch dir="rtl"> </calcite-switch>
+      Example
+    </label>
+  </div>
+  <br />
+  <div>
+    <label>
+      <calcite-switch switched="true" dir="rtl"> </calcite-switch>
+      Example
+    </label>
+  </div>
+  <div dir="rtl">
+    <h3>RTL Inherited from Container</h3>
+    <div>
+      <calcite-switch>
+        <input id="proxySwitchCheckbox" type="checkbox" />
+      </calcite-switch>
+      <span id='proxySwitchSpan'>
+        With a proxy <code>input</code> element and changes on click.
+      </span>
+      <script>
+        var proxySwitchSpan = document.getElementById(
+          "proxySwitchSpan"
+        );
+        var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
+
+        proxySwitchSpan.addEventListener('click', function () {
+          proxySwitchCheckbox.hasAttribute('checked') ?
+            proxySwitchCheckbox.removeAttribute('checked') :
+            proxySwitchCheckbox.setAttribute('checked', '')
+        })
+      </script>
+    </div>
+    <br />
+    <div>
+      <label>
+        <calcite-switch scale="s" switched="true" color="red"> </calcite-switch>
+        Red switch scale small
+      </label>
+    </div>
+    <br />
+    <div>
+      <label>
+        <calcite-switch scale="m" switched="true" color="red"> </calcite-switch>
+        Red switch scale medium
+      </label>
+    </div>
+    <br />
+    <div>
+      <label>
+        <calcite-switch scale="l" switched="true" color="red"> </calcite-switch>
+        Red switch scale large
+      </label>
+    </div>
+    <br />
+    <div>
+      <calcite-switch></calcite-switch>
+      Switch with no wrapping <code>label</code>.
+    </div>
+    <br />
+    <div class="demo-background-dark">
+      <div>
+        <label>
+          <calcite-switch theme="dark" id="basicSwitch2" switched="true"></calcite-switch>
+          Without a proxy <code>input</code> element and listening for "calciteSwitchChange".
+          <script>
+            var basicSwitch = document.getElementById("basicSwitch2");
+
+            basicSwitch.addEventListener("calciteSwitchChange", function (
+              e
+            ) {
+              console.log(
+                "Basic switch changed by <calcite-switch>",
+                e.target.switched
+              );
+            });
+          </script>
+        </label>
+      </div>
+      <br />
+      <div>
+        <calcite-switch theme="dark">
+          <input id="proxySwitchCheckbox" type="checkbox" />
+        </calcite-switch>
+        <span id='proxySwitchSpan'>
+          With a proxy <code>input</code> element and changes on click.
+        </span>
+        <script>
+          var proxySwitchSpan = document.getElementById(
+            "proxySwitchSpan"
+          );
+          var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
+
+          proxySwitchSpan.addEventListener('click', function () {
+            proxySwitchCheckbox.hasAttribute('checked') ?
+              proxySwitchCheckbox.removeAttribute('checked') :
+              proxySwitchCheckbox.setAttribute('checked', '')
+          })
+        </script>
+      </div>
+      <br />
+      <div>
+        <label>
+          <calcite-switch theme="dark" switched="true" color="red"> </calcite-switch>
+          Red switch
+        </label>
+      </div>
+      <br />
+      <div>
+        <calcite-switch theme="dark"></calcite-switch>
+        Switch with no wrapping <code>label</code>.
+      </div>
+    </div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Fixes #602  cc @MikeTschudi

- Adds lookup for RTL
- Updates story, dev demo, changelog

We weren't looking up for a wrapping RTL, should be fixed now:

<img width="825" alt="Screen Shot 2020-05-19 at 2 30 05 PM" src="https://user-images.githubusercontent.com/4733155/82380413-430d7900-99dd-11ea-8110-4ed147cf2c18.png">
