### PR TITLE
[calcite-accordion] Update display of icon-position=end icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-input` - will now properly position a requested `icon` if `prefix-text` is also set
 - `calcite-switch` - will now properly display in RTL
 
+### Updated
+
+- `calcite-accordion` - styling of `icon-position=end` icons has been updated for `chevron` and `caret` values - it will now display upward when a `calcite-accordion-item` is collapsed, and downward when expanded
+
 ## [v1.0.0-beta.26] - May 18th 2020
 
 ### Breaking Changes

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -40,13 +40,19 @@
 :host-context([icon-position="end"]) {
   --calcite-accordion-item-flex-direction: row;
   --calcite-accordion-item-icon-rotation: -90deg;
-  --calcite-accordion-item-active-icon-rotation: -180deg;
+  --calcite-accordion-item-active-icon-rotation: 0deg;
   --calcite-accordion-item-icon-rotation-rtl: 90deg;
-  --calcite-accordion-item-active-icon-rotation-rtl: 180deg;
+  --calcite-accordion-item-active-icon-rotation-rtl: 0deg;
   --calcite-accordion-item-icon-spacing-start: var(
     --calcite-accordion-item-spacing-unit
   );
   --calcite-accordion-item-icon-spacing-end: 0;
+}
+:host-context([icon-position="end"]:not([icon-type="plus-minus"])) {
+  --calcite-accordion-item-icon-rotation: 0deg;
+  --calcite-accordion-item-active-icon-rotation: 180deg;
+  --calcite-accordion-item-icon-rotation-rtl: 0deg;
+  --calcite-accordion-item-active-icon-rotation-rtl: -180deg;
 }
 
 :host {

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -39,13 +39,19 @@
 :host([icon-position="end"]) {
   --calcite-accordion-item-flex-direction: row;
   --calcite-accordion-item-icon-rotation: -90deg;
-  --calcite-accordion-item-active-icon-rotation: -180deg;
+  --calcite-accordion-item-active-icon-rotation: 0deg;
   --calcite-accordion-item-icon-rotation-rtl: 90deg;
-  --calcite-accordion-item-active-icon-rotation-rtl: 180deg;
+  --calcite-accordion-item-active-icon-rotation-rtl: 0deg;
   --calcite-accordion-item-icon-spacing-start: var(
     --calcite-accordion-item-spacing-unit
   );
   --calcite-accordion-item-icon-spacing-end: 0;
+}
+:host([icon-position="end"]:not([icon-type="plus-minus"])) {
+  --calcite-accordion-item-icon-rotation: 0deg;
+  --calcite-accordion-item-active-icon-rotation: 180deg;
+  --calcite-accordion-item-icon-rotation-rtl: 0deg;
+  --calcite-accordion-item-active-icon-rotation-rtl: -180deg;
 }
 
 :host {


### PR DESCRIPTION
Fixes #289 cc @TheBlueDog @bstifle 

- Updates rotation of icon-position=end icons for chevron and caret values (does not affect plus-minus)
- Updates some rotation values to more consistently animate in LTR and RTL
- Update changelog

Example: 
<img width="734" alt="Screen Shot 2020-05-20 at 10 54 10 AM" src="https://user-images.githubusercontent.com/4733155/82480854-49592f00-9a89-11ea-8f6e-1e7d53eb724e.png">
