### PR TITLE
[calcite-tree] Add break-word for long wrapping tree items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-input` - will now properly position a requested `icon` if `prefix-text` is also set
 - `calcite-switch` - will now properly display in RTL
-- `calcite-tree` - will now propertly wrap long, unbroken strings
+- `calcite-tree` - will now property wrap long, unbroken strings in `calcite-tree-item` children
 
 ## [v1.0.0-beta.26] - May 18th 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-input` - will now properly position a requested `icon` if `prefix-text` is also set
 - `calcite-switch` - will now properly display in RTL
+- `calcite-tree` - will now propertly wrap long, unbroken strings
 
 ## [v1.0.0-beta.26] - May 18th 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-input` - will now properly position a requested `icon` if `prefix-text` is also set
 - `calcite-switch` - will now properly display in RTL
-- `calcite-tree` - will now property wrap long, unbroken strings in `calcite-tree-item` children
+- `calcite-tree` - will now properly wrap long, unbroken strings in `calcite-tree-item` children
 
 ## [v1.0.0-beta.26] - May 18th 2020
 

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -85,9 +85,9 @@
   color: inherit;
   @include font-size(-2);
   text-decoration: none !important;
-  max-width: 100%;
   word-wrap: break-word;
-  word-break: break-word;
+  overflow-wrap: break-word;
+  min-width: 0;
 
   &:hover {
     text-decoration: none !important;
@@ -95,6 +95,7 @@
 }
 
 ::slotted(a) {
+  width: 100%;
   text-decoration: none;
 }
 // focus styles
@@ -112,7 +113,6 @@
   padding-left: var(--calcite-tree-children-padding-start);
   padding-right: var(--calcite-tree-children-padding-end);
   position: relative;
-
   transform: scaleY(0);
   opacity: 0;
   overflow: hidden;

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -88,6 +88,7 @@
   word-wrap: break-word;
   overflow-wrap: break-word;
   min-width: 0;
+  max-width: 100%;
 
   &:hover {
     text-decoration: none !important;

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -87,6 +87,7 @@
   text-decoration: none !important;
   max-width: 100%;
   word-wrap: break-word;
+  word-break: break-word;
 
   &:hover {
     text-decoration: none !important;


### PR DESCRIPTION
Fixes #605 cc @MikeTschudi

I don't think this will cause unexpected changes for anyone?

- Add `word-break: break-word` to slotted children to prevent overflow of long, unbroken strings
- Updates changelog


| Before  | After |
| ------------- | ------------- |
| <img width="189" alt="Screen Shot 2020-05-20 at 11 17 12 AM" src="https://user-images.githubusercontent.com/4733155/82482767-2da35800-9a8c-11ea-9a1b-98ec9c1163c9.png"> | <img width="189" alt="Screen Shot 2020-05-20 at 11 17 24 AM" src="https://user-images.githubusercontent.com/4733155/82482787-3562fc80-9a8c-11ea-82cd-452a7cc42968.png"> |