### PR TITLE
📜 update the conventions document

### DIFF
--- a/conventions/README.md
+++ b/conventions/README.md
@@ -9,7 +9,7 @@ This is a living document defining our best practices and reasoning for authorin
 - [Light Theme/Dark Theme](#light-themedark-theme)
 - [Form Elements and Custom Inputs](#form-elements-and-custom-inputs)
 - [Component Responsibilities](#component-responsibilities)
-- [Event Namespacing](#event-namespacing)
+- [Event Names](#event-names)
 - [Private Events](#private-events)
 - [Event Details](#event-details)
 - [CSS Class Names](#css-class-names)
@@ -26,8 +26,8 @@ This is a living document defining our best practices and reasoning for authorin
 
 Generally adhere to and follow these best practices for authoring components.
 
-* [Google Web Component Best Practices](https://developers.google.com/web/fundamentals/web-components/best-practices)
-* [Custom Element Conformance - W3C Editor's Draft](https://w3c.github.io/webcomponents/spec/custom/#custom-element-conformance)
+- [Google Web Component Best Practices](https://developers.google.com/web/fundamentals/web-components/best-practices)
+- [Custom Element Conformance - W3C Editor's Draft](https://w3c.github.io/webcomponents/spec/custom/#custom-element-conformance)
 
 ## Color
 
@@ -68,72 +68,115 @@ You can then use the `:host()` selector to define your custom colors:
 
 **Discussed In**:
 
-* https://github.com/ArcGIS/calcite-components/pull/24/files/3446c89010e3ef0421803d68d627aba2e7c4bfa0);
-* https://github.com/ArcGIS/calcite-components/pull/24/files/3446c89010e3ef0421803d68d627aba2e7c4bfa0#issuecomment-497962263
-
-**Implemented In:**
-
-* [`<calcite-alert>`](../src/components/calcite-alert/calcite-alert.tsx);
-
+- https://github.com/Esri/calcite-components/pull/24/files/3446c89010e3ef0421803d68d627aba2e7c4bfa0#r289427838
 
 ## Light Theme/Dark Theme
 
-Similar to a color theme all components should implement a dark theme via a `theme` property.
+All components should allow developers to supply a `theme` property. This theme should _not_ have default value set:
 
 ```tsx
-export class CalciteComponent {
-
-// ...
-
-@Prop({ reflect: true }) theme: "light" | "dark" = 'light';
-
-// ...
+@Prop({ reflect: true }) theme: "light" | "dark";
 ```
 
-You can then use SASS or CSS variables to style your component. It is preferred to use CSS variables for this since they can use used an inherited by multiple child components. You can also interpolate colors from Calcite Web as shown below:
+In the [global CSS file](https://github.com/Esri/calcite-components/blob/master/src/assets/styles/global.scss), we specify the values of each color for both light and dark theme. This enables theming to be inherited throughout a component tree. Consider this valid example:
+
+```html
+<div theme="dark">
+  <calcite-button>Button text</calcite-button>
+  <calcite-date></calcite-date>
+</div>
+```
+
+This will cause both the button and the date picker to use the dark theme color variables declared in the global file. This makes it very easy for developers to move an entire app from light to dark and vice versa.
+
+To make this work, inside a component's SASS file, _you must use colors from the theme variables_. For example
 
 ```scss
-// calcite-tabs.scss
+// 🙅‍♀️ using the sass var will not correctly inherit or change in light/dark mode
 :host {
-  --calcite-tabs-color: #{$darkest-gray};
-  --calcite-tabs-border: #{$lighter-gray};
-  --calcite-tabs-border-hover: #{$light-gray};
-  --calcite-tabs-color-active: #{$off-black};
-  --calcite-tabs-border-active: #{$blue};
+  color: $ui-blue-1;
 }
 
-:host([theme="dark"]) {
-  --calcite-tabs-color: #{$lightest-gray};
-  --calcite-tabs-border: #{$darker-gray};
-  --calcite-tabs-border-hover: #{$gray};
-  --calcite-tabs-color-active: #{$off-white};
-  --calcite-tabs-border-active: #{$white};
+// 👍 using the CSS var will inherit correctly
+:host {
+  color: var(--calcite-ui-blue-1);
 }
 ```
 
-Using CSS variables you can then access these same variables in child components like `<calcite-tab-title>`:
+## Custom Themes
 
-```scss
-// calcite-tab.scss
-:host(:active),
-:host(:focus),
-:host(:hover) {
-  a {
-    outline: none;
-    text-decoration: none;
-    color: var(--calcite-tabs-color-active);
-    border-bottom-color: var(--calcite-tabs-border-hover);
-  }
+Since Calcite Components might be used in many different contexts such as configurable apps, multiple themes and appearances need to be supported. The most common use case for custom themes are applications where the end user needs to be able to customize brand colors and typography. To this end custom theming can be accomplished by overriding the [CSS Custom Properties (CSS Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) from the main light and dark themes with new values:
+
+```css
+:root {
+  --calcite-ui-blue-1: red;
 }
 ```
 
-This will fetch the variable `var(--calcite-tabs-color-active)` from its nearest parent (in this case `<calcite-tabs>`) which will have the appropriate light/dark variables set.
+You can apply these overrides to individual components as well:
 
-**Implemented In:**
+```css
+calcite-slider {
+  --calcite-ui-blue-1: red;
+}
+```
 
-* [`<calcite-tabs>`](../src/components/calcite-tabs/calcite-tabs.scss);
-* [`<calcite-tab-nav>`](../src/components/calcite-tab-nav/calcite-tab-nav.scss);
-* [`<calcite-tab>`](../src/components/calcite-tab/calcite-tab.scss);
+Or, add a class to the specific instance:
+
+```css
+.my-custom-theme {
+  --calcite-ui-blue-1: red;
+}
+```
+
+```html
+<calcite-slider class="my-custom-theme"></calcite-slider>
+```
+
+### Typography
+
+All components have been constructed to inherit their `font-family`. This enables you to change the font much like changing the colors:
+
+```css
+:root {
+  font-family: "Comic Sans";
+}
+```
+
+### Palette
+
+The current light theme colors and their hex values can be found below:
+
+| CSS variable name           | Hex value |
+| --------------------------- | --------- |
+| `--calcite-ui-blue-1`       | `#007ac2` |
+| `--calcite-ui-blue-2`       | `#2890ce` |
+| `--calcite-ui-blue-3`       | `#00619b` |
+| `--calcite-ui-green-1`      | `#35ac46` |
+| `--calcite-ui-green-2`      | `#50ba5f` |
+| `--calcite-ui-green-3`      | `#288835` |
+| `--calcite-ui-yellow-1`     | `#edd317` |
+| `--calcite-ui-yellow-2`     | `#f9e54e` |
+| `--calcite-ui-yellow-3`     | `#d9bc00` |
+| `--calcite-ui-red-1`        | `#d83020` |
+| `--calcite-ui-red-2`        | `#e65240` |
+| `--calcite-ui-red-3`        | `#a82b1e` |
+| `--calcite-ui-background`   | `#f8f8f8` |
+| `--calcite-ui-foreground-1` | `#ffffff` |
+| `--calcite-ui-foreground-2` | `#f3f3f3` |
+| `--calcite-ui-foreground-3` | `#eaeaea` |
+| `--calcite-ui-text-1`       | `#151515` |
+| `--calcite-ui-text-2`       | `#4a4a4a` |
+| `--calcite-ui-text-3`       | `#6a6a6a` |
+| `--calcite-ui-border-1`     | `#cacaca` |
+| `--calcite-ui-border-2`     | `#dfdfdf` |
+| `--calcite-ui-border-3`     | `#eaeaea` |
+| `--calcite-ui-border-4`     | `#9f9f9f` |
+| `--calcite-ui-border-5`     | `#757575` |
+
+**Discussed In**:
+
+- https://github.com/Esri/calcite-components/issues/507
 
 ## Form Elements and Custom Inputs
 
@@ -151,7 +194,7 @@ and
 ```html
 <calcite-checkbox>
   <!-- the <input> is the source of truth -->
-  <input type="checkbox" checked disabled>
+  <input type="checkbox" checked disabled />
 </calcite-checkbox>
 ```
 
@@ -161,136 +204,152 @@ Frameworks can use their native tools to interact with the provided `<input>` wh
 <div hidden>
   <slot>
     <!-- a default checkbox in case the user doesn't pass one-->
-    <input type="checkbox" checked disabled>
+    <input type="checkbox" checked disabled />
   </slot>
-<div>
+  <div></div>
+</div>
 ```
 
 Several interactions are required to properly implement:
 
-* If the `value`, `disabled`, `selected`, or `checked` properties on the input change, update the state of the custom input. The attributes of the passed input can be observed with a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe).
-* Update the state of the input when the user interacts with the custom input.
-* Focus the custom input when the user focuses the passed input. This allows the standard `<label>` element to be wrapped around the custom element.
-   ```html
-   <label>
-     My Checkbox
-     <calcite-checkbox>
-       <input type="checkbox" checked disabled>
-     </calcite-checkbox>
-   </label>
-   ```
+- If the `value`, `disabled`, `selected`, or `checked` properties on the input change, update the state of the custom input. The attributes of the passed input can be observed with a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe).
+- Update the state of the input when the user interacts with the custom input.
+- Focus the custom input when the user focuses the passed input. This allows the standard `<label>` element to be wrapped around the custom element.
+  ```html
+  <label>
+    My Checkbox
+    <calcite-checkbox>
+      <input type="checkbox" checked disabled />
+    </calcite-checkbox>
+  </label>
+  ```
 
 **Discussed In:**
 
-* https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289444267
-* https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497813876
-* https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497888962
-* https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497894715
+- https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289444267
+- https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497813876
+- https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497888962
+- https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497894715
 
 ## Component Responsibilities
 
-Calcite Components broadly targets 2 groups of projects inside Esri:
+Calcite Components broadly targets two groups of projects inside Esri:
 
-* **Sites** like [esri.com](https://esri.com) and [developers.arcgis.com](https://developers.arcgis.com).
-* **Apps** like [ArcGIS Online](https://arcgis.com), [Vector Tile Style Editor](https://developers.arcgis.com/vector-tile-style-editor), [Workforce](https://www.esri.com/en-us/arcgis/products/workforce/overview), [ArcGIS Hub](https://hub.arcgis.com) ect...
+- **Sites** like [esri.com](https://esri.com) and [developers.arcgis.com](https://developers.arcgis.com).
+- **Apps** like [ArcGIS Online](https://arcgis.com), [Vector Tile Style Editor](https://developers.arcgis.com/vector-tile-style-editor), [Workforce](https://www.esri.com/en-us/arcgis/products/workforce/overview), [ArcGIS Hub](https://hub.arcgis.com) etc...
 
 Components should present the the minimum possible implementation to be usable by both sites and apps and leave as much as possible to users.
 
 It is generally agreed on that components should not:
 
-* Make network requests. Authentication and the exact environment of hte request is difficult to mange and better left to the specific application or site.
-* Manage routing or manipulate the URL. managing the URL is the the domain and the specific site or app.
-* Implement any feature which can easily be achieved with simple CSS and HTML. E.x. it was decided that `<calcite-switch>` should not support `text` or `position` properties because those could be easily duplicated with CSS ([ref](https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289424140))
-* Implement any component which might replace a browser feature, without adding functionality that goes above and beyond what browser defaults would provide.
+- Make network requests. Authentication and the exact environment of the request is difficult to mange and better left to the specific application or site.
+- Manage routing or manipulate the URL. managing the URL is the the domain and the specific site or app.
+- Implement any feature which can easily be achieved with simple CSS and HTML. E.x. it was decided that `<calcite-switch>` should not support `text` or `position` properties because those could be easily duplicated with CSS ([ref](https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289424140))
+- Implement any component which might replace a browser feature, without adding functionality that goes above and beyond what browser defaults would provide.
 
 However components are allowed to:
 
-* Use or implement `localStorage` if there is specific use case.
-* Communicate with other components if a specific use case exists.
+- Use or implement `localStorage` if there is specific use case.
+- Communicate with other components if a specific use case exists.
 
 **Discussed In**:
 
-* [Should tabs support syncing and loading from localstorage](https://github.com/ArcGIS/calcite-components/pull/27) . **Yes** because such feature are difficult to impliment for **Sites** and would require lots of additional JavaScript work on the part of teams and authors
-* [Should switch support a label](https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289424140). **No** because label place
+- [Should tabs support syncing and loading from localstorage](https://github.com/ArcGIS/calcite-components/pull/27) . **Yes** because such feature are difficult to implement for **Sites** and would require lots of additional JavaScript work on the part of teams and authors
+- [Should switch support a label](https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289424140). **No** because label place
 
-## Event Namespacing
+## Event Names
 
 Event names should be treated like global variables since they can collide with any other event names and global variables. As such follow these guidelines when naming events.
 
-* Name events list `Component + Event name` for example the `change` event on `<calcite-tabs>` should be named `calciteTabsChange`.
-* Always prefix event names with `calcite` and never use an event name used by existing DOM standards https://developer.mozilla.org/en-US/docs/Web/Events.
-* For example:
-   * Bad: `change`
-   * Good: `calciteTabChange`
+- Name events list `Component + Event name` for example the `change` event on `<calcite-tabs>` should be named `calciteTabsChange`.
+- Always prefix event names with `calcite` and never use an event name used by existing DOM standards https://developer.mozilla.org/en-US/docs/Web/Events.
+- For example:
+  - Bad: `change`
+  - Good: `calciteTabChange`
 
 **Discussed In:**
 
-* https://github.com/ArcGIS/calcite-components/pull/24/files/3446c89010e3ef0421803d68d627aba2e7c4bfa0#discussion_r289430227
-* https://github.com/ArcGIS/calcite-components/pull/24/files/3446c89010e3ef0421803d68d627aba2e7c4bfa0#issuecomment-497962263
-
-**Implemented In:**
-
-* [`<calcite-tabs>`](../src/components/calcite-tabs/calcite-tabs.tsx);
-* [`<calcite-tab-nav>`](../src/components/calcite-tab-nav/calcite-tab-nav.tsx);
-* [`<calcite-tab>`](../src/components/calcite-tab/calcite-tab.tsx);
+- https://github.com/Esri/calcite-components/pull/24/files/3446c89010e3ef0421803d68d627aba2e7c4bfa0#r289430227
 
 ## Private Events
 
 If you need to use events to pass information inside your components for example to communicate between parents and children make sure you call `event.stopPropagation();` and `event.preventDefault();` to prevent the event from reaching outside the component.
 
-**Implemented In:**
-
-* [`<calcite-tabs>`](../src/components/calcite-tabs/calcite-tabs.tsx);
-* [`<calcite-tab-nav>`](../src/components/calcite-tab-nav/calcite-tab-nav.tsx);
-* [`<calcite-tab>`](../src/components/calcite-tab/calcite-tab.tsx);
-
 ## Event Details
 
 Only attach additional data to your event if that data cannot be determined from the state of the component. This is because events also get a reference to the component the fired the event also passes a reference to the component that fired the event. For example you do not need to pass anything exposed as a `@Prop()` in the event details.
 
-
 ```tsx
-  @Listen("calciteCustomEvent") customEventHandler(
-    event: CustomEvent
-  ) {
-    console.log(event.target.prop); // event.target is the component that fired the event.
-  }
+@Listen("calciteCustomEvent") customEventHandler(
+  event: CustomEvent
+) {
+  console.log(event.target.prop); // event.target is the component that fired the event.
+}
 ```
 
 `<calcite-tab-nav>` is also an example of this. The `event.details.tab` item contains the index of the selected tab or the tab name which cannot be easily determined from the state of `<calcite-tab-nav>` in some cases so it makes sense to include in the event.
 
-**Implemented In:**
-
-* [`<calcite-tab-nav>`](../src/components/calcite-tab-nav/calcite-tab-nav.tsx);
-
 ## CSS Class Names
 
-@TODO Discuss BEM
+Because most components utilize shadow DOM, there is far less concern over naming collisions in a global CSS namespace. In addition, it's better for file transfer times and easier to write if class names are shorter. For these reasons, full BEM is not necessary. Instead, we can omit the "Block", and use the host instead. Consider the following BEM markup:
 
-* https://github.com/ArcGIS/calcite-components/issues/28
-* https://github.com/ArcGIS/calcite-components/pull/24#discussion_r287462934
-* https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-495788683
-* https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497962263
+```html
+<div class="card">
+  <h3 class="card__title card__title--large">Title</h3>
+  <p class="card__text">Text</p>
+</div>
+```
+
+In a component using shadow DOM, this should instead be written as:
+
+```jsx
+<Host>
+  <h3 class="title title--large">Title</h3>
+  <p class="text">Text</p>
+</Host>
+```
+
+Notice `.card` does not appear anywhere. We would then apply styles to the host element itself:
+
+```scss
+:host {
+  // card styles here
+}
+
+.title {
+}
+.title--large {
+}
+.text {
+}
+```
+
+Modifier classes on the "block" (host element) can often be written by reflecting the prop and selecting it directly via an attribute selector:
+
+```scss
+:host([color="blue"]) {
+}
+```
+
+This builds a nice symmetry between the styling and the public API of a component.
+
+- https://github.com/ArcGIS/calcite-components/issues/28
+- https://github.com/ArcGIS/calcite-components/pull/24#discussion_r287462934
+- https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-495788683
+- https://github.com/ArcGIS/calcite-components/pull/24#issuecomment-497962263
 
 ## a11y
 
 In generally follow the guidelines and standards in these articles:
 
-* [Google Accessibility Overview](https://developers.google.com/web/fundamentals/accessibility/)
-* [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
-
-**Implemented In:**
-
-* [`<calcite-tabs>`](../src/components/calcite-tabs/calcite-tabs.tsx);
-* [`<calcite-tab-nav>`](../src/components/calcite-tab-nav/calcite-tab-nav.tsx);
-* [`<calcite-tab>`](../src/components/calcite-tab/calcite-tab.tsx);
-* [`<calcite-tab-title>`](../src/components/calcite-tab-title/calcite-tab-title.tsx);
+- [Google Accessibility Overview](https://developers.google.com/web/fundamentals/accessibility/)
+- [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
 
 ## i18n
 
 Components should require as a few text translations as possible. In general lets users supply text values via slots and attributes. The lets user handle translations with their apps.
 
-If you component involves formatting numbers or dates use the [`Intl` APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) for formating the display of numbers and dates in your component.
+If you component involves formatting numbers or dates use the [`Intl` APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) for formatting the display of numbers and dates in your component.
 
 To add RTL support to your components you should use the internal `getElementDir` helper to apply the `dir` attribute to your component. This means that your components `dir` attribute will always match the documents `dir`.
 
@@ -336,14 +395,18 @@ You can then implement direction specific CSS with CSS variables:
 
 Your component and its child components can then use `var(--calcite-tabs-tab-margin-start)` to access their proper values based on the direction of the document.
 
+### Translated strings
+
 In future it will likely become necessary to provide sting translations for components. An example would be the `aria-label` for the `<calcite-modal>` close button. Initial research looks promising and we could likely implement one of these approaches and set a `lang` for each component similar to how we set `dir`.
 
-* https://medium.com/stencil-tricks/implementing-internationalisation-i18n-with-stencil-5e6559554117 and https://codesandbox.io/s/43pmx55vo9
-* https://github.com/ionic-team/ionic-stencil-conference-app/issues/69
+- https://medium.com/stencil-tricks/implementing-internationalisation-i18n-with-stencil-5e6559554117 and https://codesandbox.io/s/43pmx55vo9
+- https://github.com/ionic-team/ionic-stencil-conference-app/issues/69
 
-*** **Implemented By:**
+Until we implement a `lang` facility and set up translations for all components, we have been allowing a small number of strings to be passed in as props. Props that represent translated strings should have the syntax: `text-label-x`, where `x` is the name for the string. For example, when providing a string from "Close", use the prop name `text-label-close`. In the component, these props should default to their English equivalent (this is useful for non-localized apps):
 
-* [`<calcite-tabs>`](../src/components/calcite-tabs/calcite-tabs.tsx);
+```
+@Prop() textLabelClose: string = 'Close';
+```
 
 ## Bundling and Loading
 
@@ -353,72 +416,9 @@ As a best practice we should follow [Ionic's configuration](https://github.com/i
 
 **Note:** This is highly likely to change as we move closer to our first release and as Stencil improves their documentation around their specific methods and build processes.
 
-## Custom Themes
-
-Since Calcite Components might be used in many different contexts such as configurable apps multiple themes and appearances need to be supported.
-
-This can be achived with [CSS Custom Properties (CSS Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). To allow consumers to theme your components from the outside define a custom property like:
-
-```css
-:host {
-  --calcite-tabs-border-active: #0079c1;
-}
-```
-
-To interpolate a SCSS variable into a CSS custom property you can do this:
-
-```scss
-:host {
-  --calcite-tabs-border-active: #{$blue};
-}
-```
-
-Once you property is defined you can use it in your component or any of your components children if it has child components. This will lookup the most specific (CSS selector) value of `--calcite-tabs-border-active` from this elements parents.
-
-```scss
-:host {
-  border-bottom: 1px solid var(--calcite-tabs-border-active);
-}
-```
-
-To override the value as a consumer you'll need to redefine the variable at a more specific selector. For example to make a new "green" class for tabs you could do:
-
-```css
-/** Makes green calcite tabs green. **/
-calcite-tabs.green {
-  --calcite-tabs-border-active: #338033;
-}
-calcite-tabs[theme="dark"].green {
-  --calcite-tabs-border-active: #5a9359;
-}
-```
-
-Then tabs like `<calcite-tabs class="green">` and ``<calcite-tabs class="green" theme="dark">` will use the new green colors.
-
-If you want to provide new values for ALL calcite tabs on the page you can simply redefine the variable with a tag selector:
-
-```css
-/** Makes ALL calcite tabs green. **/
-calcite-tabs {
-  --calcite-tabs-border-active: #338033;
-}
-calcite-tabs[theme="dark"] {
-  --calcite-tabs-border-active: #5a9359;
-}
-```
-
-**Discussed In**:
-
-* https://teams.microsoft.com/l/message/19:fd15b51dacd24e70895ec1218a54ae06@thread.skype/1559932065529?tenantId=aee6e3c9-711e-4c7c-bd27-04f2307db20d&groupId=56fae21a-9407-4943-859f-a9bfcf0bbad3&parentMessageId=1559932065529&teamName=Calcite&channelName=Calcite%20Components&createdTime=1559932065529
-
-*** **Implemented By:**
-
-* [`<calcite-tabs>`](../src/components/calcite-tabs/calcite-tabs.tsx);
-
 ## Unique IDs for Components
 
 Many times it is necessary for components to have a `id="something"` attribute for things like `<label>` and various `aria-*` properties. To safely generate a unique id for a component but to also allow a user supplied `id` attribute to work follow the following pattern:
-
 
 ```tsx
 import { guid } from "../../utils/guid";
@@ -426,19 +426,16 @@ import { guid } from "../../utils/guid";
 @Component({
   tag: "calcite-example",
   styleUrl: "calcite-example.scss",
-  shadow: true
+  shadow: true,
 })
 export class CalciteExample {
-
   // ...
 
   guid: string = `calcite-example-${guid()}`;
 
   render() {
     const id = this.el.id || this.guid;
-    return (
-      <Host id={id}></Host>
-    );
+    return <Host id={id}></Host>;
   }
 
   // ...
@@ -451,7 +448,7 @@ This will create a unique id attribute like `id="calcite-example-51af-0941-54ae-
 
 Stencil provide the capability to render web components on the server and seamlessly hydrate them on the client. This is handled by the `dist-hydrate-script` output target in `stencil.config.ts`.
 
-This generates a `hydrate` directory which expsoses `renderToString()` (for the server) and `hydrateDocument()` for the client.
+This generates a `hydrate` directory which exposes `renderToString()` (for the server) and `hydrateDocument()` for the client.
 
 Since many of the same lifecycle methods are called on the client and server you may need to differentiate any code that relies on browser APIs like so:
 
@@ -465,8 +462,7 @@ if (Build.isBrowser) {
 }
 ```
 
-
-Checking if the neccessary APIs are present is also acceptable:
+Checking if the necessary APIs are present is also acceptable:
 
 ```ts
 const elements = this.el.shadowRoot

--- a/conventions/README.md
+++ b/conventions/README.md
@@ -347,7 +347,7 @@ In generally follow the guidelines and standards in these articles:
 
 ## i18n
 
-Components should require as a few text translations as possible. In general lets users supply text values via slots and attributes. The lets user handle translations with their apps.
+Components should require as a few text translations as possible. In general, components should let users supply text values via slots and attributes; this lets a user handle translation within their apps.
 
 If you component involves formatting numbers or dates use the [`Intl` APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) for formatting the display of numbers and dates in your component.
 


### PR DESCRIPTION
The conventions write up was pretty out of date. Lots of advice we no longer use, links were broken, the only examples were tabs, etc. 

I've added new content about class names, rewritten the theming section, and given everything a general once over for spelling/accuracy. You can read through a non-diff version here: https://github.com/Esri/calcite-components/tree/conventions/conventions