### PR TITLE
BREAKING: Input and Input Message cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Breaking Changes
+
+- `calcite-input` - `calciteInputChange` has been renamed to `calciteInputInput`
+
 ### Fixed
 
 - `calcite-input` - will now properly position a requested `icon` if `prefix-text` is also set
@@ -17,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Updated
 
 - `calcite-accordion` - styling of `icon-position=end` icons has been updated for `chevron` and `caret` values - it will now display upward when a `calcite-accordion-item` is collapsed, and downward when expanded
+- `calcite-input` - when `status="valid"`, icon (if present) will appear green
 
 ## [v1.0.0-beta.26] - May 18th 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking Changes
 
-- `calcite-input` - `calciteInputChange` has been renamed to `calciteInputInput`
+- `calcite-input` - `calciteInputChange` event has been renamed to `calciteInputInput`
 
 ### Fixed
 

--- a/src/assets/demo/validateInput.js
+++ b/src/assets/demo/validateInput.js
@@ -1,7 +1,7 @@
 // example for validating inputs and adding messages
 function detectInputChanges(id) {
   const input = document.querySelector(id);
-  input.addEventListener("calciteInputChange", logChange);
+  input.addEventListener("calciteInputInput", logInput);
   input.addEventListener("calciteInputFocus", logFocus);
   input.addEventListener("calciteInputBlur", logBlur);
 }
@@ -24,7 +24,7 @@ function logBlur(event) {
     targetNotice.innerHTML = `<span slot="notice-message"><b>#${event.detail.element.id}</b> was blurred</span>`;
 }
 
-function logChange(event) {
+function logInput(event) {
   let targetNotice = document.querySelector(
     `#validate-input-example-change-notice`
   );
@@ -35,7 +35,7 @@ function logChange(event) {
 
 function validateInput(id) {
   const input = document.querySelector(id);
-  input.addEventListener("calciteInputChange", validatePasswordExample);
+  input.addEventListener("calciteInputInput", validatePasswordExample);
   input.addEventListener(
     "calciteInputFocus",
     validatePasswordExampleFocusMessage

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -139,7 +139,7 @@ export class CalciteDatePicker {
               placeholder={this.localeData.placeholder}
               icon="calendar"
               onCalciteInputFocus={() => (this.active = true)}
-              onCalciteInputChange={(e) => this.input(e.detail.value)}
+              onCalciteInputInput={(e) => this.input(e.detail.value)}
               onCalciteInputBlur={(e) => this.blur(e.detail)}
               scale={this.scale}
               number-button-type="none"

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -16,32 +16,29 @@ describe("calcite-input-message", () => {
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "idle");
-    expect(element).toEqualAttribute("appearance", "default");
     expect(element).toEqualAttribute("type", "default");
   });
 
   it("renders default props when invalid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input-message status="zip" theme="zap" appearance="zom" type="zur"></calcite-input-message>
+    <calcite-input-message status="zip" theme="zap" type="zur"></calcite-input-message>
     `);
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "idle");
-    expect(element).toEqualAttribute("appearance", "default");
     expect(element).toEqualAttribute("type", "default");
   });
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input-message status="valid" theme="dark" appearance="minimal" type="floating"></calcite-input-message>
+    <calcite-input-message status="valid" theme="dark" type="floating"></calcite-input-message>
     `);
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "valid");
     expect(element).toEqualAttribute("theme", "dark");
-    expect(element).toEqualAttribute("appearance", "minimal");
     expect(element).toEqualAttribute("type", "floating");
   });
 

--- a/src/components/calcite-input-message/calcite-input-message.scss
+++ b/src/components/calcite-input-message/calcite-input-message.scss
@@ -37,6 +37,7 @@
   visibility: hidden;
   opacity: 0;
   height: 0;
+  pointer-events: none;
 }
 
 :host([active]) {

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -23,10 +23,6 @@ export class CalciteInputMessage {
 
   @Prop({ reflect: true, mutable: true }) active: boolean = false;
 
-  /** specify the appearance type - minimal or default */
-  @Prop({ mutable: true, reflect: true }) appearance: "default" | "minimal" =
-    "default";
-
   /** optionally display an icon based on status */
   @Prop({ reflect: true }) icon: boolean;
 
@@ -50,10 +46,6 @@ export class CalciteInputMessage {
   //--------------------------------------------------------------------------
   connectedCallback() {
     // validate props
-
-    let appearance = ["default", "minimal"];
-    if (!appearance.includes(this.appearance)) this.appearance = "default";
-
     let statusOptions = ["invalid", "valid", "idle"];
     if (!statusOptions.includes(this.status))
       this.status = getElementProp(this.el.parentElement, "status", "idle");

--- a/src/components/calcite-input-message/readme.md
+++ b/src/components/calcite-input-message/readme.md
@@ -26,19 +26,16 @@ Displays a contextual message to a user. Allows the passing of content, links, e
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property     | Attribute    | Description                                                                                                                      | Type                             | Default     |
-| ------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
-| `active`     | `active`     |                                                                                                                                  | `boolean`                        | `false`     |
-| `appearance` | `appearance` | specify the appearance type - minimal or default                                                                                 | `"default" \| "minimal"`         | `"default"` |
-| `icon`       | `icon`       | optionally display an icon based on status                                                                                       | `boolean`                        | `undefined` |
-| `scale`      | `scale`      | specify the scale of the input, defaults to m                                                                                    | `"l" \| "m" \| "s"`              | `undefined` |
-| `status`     | `status`     | specify the status of the input field, determines message and icons                                                              | `"idle" \| "invalid" \| "valid"` | `undefined` |
-| `theme`      | `theme`      | specify the theme, defaults to light                                                                                             | `"dark" \| "light"`              | `undefined` |
-| `type`       | `type`       | specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input) | `"default" \| "floating"`        | `"default"` |
-
+| Property | Attribute | Description                                                                                                                      | Type                             | Default     |
+| -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
+| `active` | `active`  |                                                                                                                                  | `boolean`                        | `false`     |
+| `icon`   | `icon`    | optionally display an icon based on status                                                                                       | `boolean`                        | `undefined` |
+| `scale`  | `scale`   | specify the scale of the input, defaults to m                                                                                    | `"l" \| "m" \| "s"`              | `undefined` |
+| `status` | `status`  | specify the status of the input field, determines message and icons                                                              | `"idle" \| "invalid" \| "valid"` | `undefined` |
+| `theme`  | `theme`   | specify the theme, defaults to light                                                                                             | `"dark" \| "light"`              | `undefined` |
+| `type`   | `type`    | specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input) | `"default" \| "floating"`        | `"default"` |
 
 ## Dependencies
 
@@ -47,12 +44,13 @@ Displays a contextual message to a user. Allows the passing of content, links, e
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-input-message --> calcite-icon
   style calcite-input-message fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -412,3 +412,16 @@ calcite-input[type="file"] textarea {
   background-color: $blk-005;
   text-align: center;
 }
+
+// status
+$inputStatusColors: "invalid" var(--calcite-ui-red-1),
+  "valid" var(--calcite-ui-green-1), "idle" var(--calcite-ui-text-2);
+
+@each $statusColor in $inputStatusColors {
+  $name: nth($statusColor, 1);
+  $color: nth($statusColor, 2);
+
+  calcite-input[status="#{$name}"] .calcite-input-icon {
+    color: $color;
+  }
+}

--- a/src/components/calcite-input/calcite-input.stories.js
+++ b/src/components/calcite-input/calcite-input.stories.js
@@ -32,12 +32,12 @@ storiesOf("Input", module)
           "search",
           "file",
           "time",
-          "date"
+          "date",
         ],
         "text"
       )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
       alignment="${select("alignment", ["start", "end"], "start")}"
-      appearance="${select("appearance", ["default", "minimal"], "default")}"
       number-button-type="${select(
         "number-button-type",
         ["none", "horizontal", "vertical"],
@@ -93,27 +93,27 @@ storiesOf("Input", module)
           "search",
           "file",
           "time",
-          "date"
+          "date",
         ],
         "text",
         "Input"
       )}"
-      alignment="${select("alignment", ["start", "end"], "start", "Input")}"
-      appearance="${select(
-        "appearance",
-        ["default", "minimal"],
-        "default",
+      status="${select(
+        "status",
+        ["idle", "invalid", "valid"],
+        "idle",
         "Input"
       )}"
+      alignment="${select("alignment", ["start", "end"], "start", "Input")}"
       number-button-type="${select(
         "number-button-type",
         ["none", "horizontal", "vertical"],
         "horizontal",
         "Input"
       )}"
-      min="${text("min", "")}"
-      max="${text("max", "")}"
-      step="${text("step", "")}"
+      min="${text("min", "", "Input")}"
+      max="${text("max", "", "Input")}"
+      step="${text("step", "", "Input")}"
       prefix-text="${text("prefix-text", "", "Input")}"
       suffix-text="${text("suffix-text", "", "Input")}"
       loading="${boolean("loading", false, "Input")}"
@@ -160,13 +160,13 @@ storiesOf("Input", module)
           "search",
           "file",
           "time",
-          "date"
+          "date",
         ],
         "text"
       )}"
 
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
       alignment="${select("alignment", ["start", "end"], "start")}"
-      appearance="${select("appearance", ["default", "minimal"], "default")}"
       number-button-type="${select(
         "number-button-type",
         ["none", "horizontal", "vertical"],
@@ -210,12 +210,12 @@ storiesOf("Input", module)
           "search",
           "file",
           "time",
-          "date"
+          "date",
         ],
         "text"
       )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
       alignment="${select("alignment", ["start", "end"], "start")}"
-      appearance="${select("appearance", ["default", "minimal"], "default")}"
       number-button-type="${select(
         "number-button-type",
         ["none", "horizontal", "vertical"],
@@ -263,7 +263,6 @@ storiesOf("Input", module)
     ${text("label text", "My great label")}
     <calcite-input
       type="textarea"
-      appearance="${select("appearance", ["default", "minimal"], "default")}"
       loading="${boolean("loading", false)}"
       value="${text("value", "")}"
       placeholder="${text("placeholder", "Placeholder text")}">
@@ -307,12 +306,12 @@ storiesOf("Input", module)
           "search",
           "file",
           "time",
-          "date"
+          "date",
         ],
         "text"
       )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
       alignment="${select("alignment", ["start", "end"], "start")}"
-      appearance="${select("appearance", ["default", "minimal"], "default")}"
       number-button-type="${select(
         "number-button-type",
         ["none", "horizontal", "vertical"],

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -165,7 +165,7 @@ export class CalciteInput {
   }
 
   componentWillUpdate() {
-    this.calciteInputChange.emit({
+    this.calciteInputInput.emit({
       element: this.childEl as HTMLInputElement,
       value: this.value,
     });
@@ -241,7 +241,7 @@ export class CalciteInput {
           {...attributes}
           onBlur={() => this.inputBlurHandler()}
           onFocus={() => this.inputFocusHandler()}
-          onInput={(e) => this.inputChangeHandler(e)}
+          onInput={(e) => this.inputInputHandler(e)}
           type={this.type}
           min={this.min}
           max={this.max}
@@ -257,7 +257,7 @@ export class CalciteInput {
             {...attributes}
             onBlur={() => this.inputBlurHandler()}
             onFocus={() => this.inputFocusHandler()}
-            onInput={(e) => this.inputChangeHandler(e)}
+            onInput={(e) => this.inputInputHandler(e)}
             required={this.required ? true : null}
             placeholder={this.placeholder || ""}
             autofocus={this.autofocus ? true : null}
@@ -313,7 +313,7 @@ export class CalciteInput {
 
   @Event() calciteInputFocus: EventEmitter;
   @Event() calciteInputBlur: EventEmitter;
-  @Event() calciteInputChange: EventEmitter;
+  @Event() calciteInputInput: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -361,9 +361,9 @@ export class CalciteInput {
     this.childEl.focus();
   }
 
-  private inputChangeHandler(e) {
+  private inputInputHandler(e) {
     this.value = e.target.value;
-    this.calciteInputChange.emit({
+    this.calciteInputInput.emit({
       element: this.childEl as HTMLInputElement,
       value: this.value,
     });

--- a/src/components/calcite-input/readme.md
+++ b/src/components/calcite-input/readme.md
@@ -8,8 +8,6 @@
 
 `loading` = boolean - defaults to `false`
 
-`appearance` = [`minimal`/`default`] - defaults to `default`
-
 `alignment` = [`start`/`end`] - defaults to `start` - specify the alignment of the value / placeholder inside the input. Useful for aligning numbers, etc.
 
 `icon` = boolean / string - defaults to false. You can use "icon" to default to a recommended icon for that field type (will only work on `tel`, `email`, `password`, `search`, `date`, `time`). You can also pass a valid calcite ui icon string to set a custom icon. We recommend using "icon" / default icon on the above field types for consistency across apps.
@@ -33,7 +31,6 @@ In addition to custom attributes, you can pass any attribute to `<calcite-input>
 - `file` type replaces browser "file" input with custom replacement
 
 - `tel`, `email`, `password`, `search`, `date`, `time` types will add type-specific icons by default
--
 
 ### Slots
 
@@ -122,7 +119,6 @@ Using a wrapping `calcite-input` component lets consumers set the status attribu
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property           | Attribute            | Description                                                         | Type                                                                                                                                                                                   | Default      |
@@ -135,25 +131,23 @@ Using a wrapping `calcite-input` component lets consumers set the status attribu
 | `min`              | `min`                | input min                                                           | `string`                                                                                                                                                                               | `""`         |
 | `numberButtonType` | `number-button-type` | specify the placement of the number buttons                         | `"horizontal" \| "none" \| "vertical"`                                                                                                                                                 | `"vertical"` |
 | `placeholder`      | `placeholder`        | explicitly whitelist placeholder attribute                          | `string`                                                                                                                                                                               | `undefined`  |
-| `prefixText`       | `prefix-text`        | optionally add prefix  *                                            | `string`                                                                                                                                                                               | `undefined`  |
+| `prefixText`       | `prefix-text`        | optionally add prefix \*                                            | `string`                                                                                                                                                                               | `undefined`  |
 | `required`         | `required`           | is the input required                                               | `boolean`                                                                                                                                                                              | `false`      |
 | `scale`            | `scale`              | specify the scale of the input, defaults to m                       | `"l" \| "m" \| "s"`                                                                                                                                                                    | `undefined`  |
 | `status`           | `status`             | specify the status of the input field, determines message and icons | `"idle" \| "invalid" \| "valid"`                                                                                                                                                       | `undefined`  |
 | `step`             | `step`               | input step                                                          | `string`                                                                                                                                                                               | `""`         |
-| `suffixText`       | `suffix-text`        | optionally add suffix  *                                            | `string`                                                                                                                                                                               | `undefined`  |
+| `suffixText`       | `suffix-text`        | optionally add suffix \*                                            | `string`                                                                                                                                                                               | `undefined`  |
 | `theme`            | `theme`              | specify the alignment of dropdown, defaults to left                 | `"dark" \| "light"`                                                                                                                                                                    | `undefined`  |
 | `type`             | `type`               | specify the input type                                              | `"color" \| "date" \| "datetime-local" \| "email" \| "file" \| "image" \| "month" \| "number" \| "password" \| "search" \| "tel" \| "text" \| "textarea" \| "time" \| "url" \| "week"` | `"text"`     |
 | `value`            | `value`              | input value                                                         | `string`                                                                                                                                                                               | `""`         |
 
-
 ## Events
 
-| Event                | Description | Type               |
-| -------------------- | ----------- | ------------------ |
-| `calciteInputBlur`   |             | `CustomEvent<any>` |
-| `calciteInputChange` |             | `CustomEvent<any>` |
-| `calciteInputFocus`  |             | `CustomEvent<any>` |
-
+| Event               | Description | Type               |
+| ------------------- | ----------- | ------------------ |
+| `calciteInputBlur`  |             | `CustomEvent<any>` |
+| `calciteInputFocus` |             | `CustomEvent<any>` |
+| `calciteInputInput` |             | `CustomEvent<any>` |
 
 ## Methods
 
@@ -165,14 +159,11 @@ focus the rendered child element
 
 Type: `Promise<void>`
 
-
-
-
 ## Dependencies
 
 ### Used by
 
- - [calcite-date](../calcite-date)
+- [calcite-date](../calcite-date)
 
 ### Depends on
 
@@ -180,6 +171,7 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-input --> calcite-progress
@@ -188,6 +180,6 @@ graph TD;
   style calcite-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -60,6 +60,7 @@
     margin-left: $baseline/2;
   }
 }
+
 // status
 $inputStatusColors: "invalid" var(--calcite-ui-red-1),
   "valid" var(--calcite-ui-text-2), "idle" var(--calcite-ui-text-2);


### PR DESCRIPTION
Some various input / input-message updates

Resolves #614 cc @noahmulfinger
Resolves #617 cc @noahmulfinger
Resolves #595 cc @jcfranco 

- BREAKING: `calciteInputChange` event renamed to the more accurate `calciteInputInput`
- Fix for calcite-input-message cursor being visible when inactive
- Inputs now control their own icon fill color (for instances when used outside calcite-label and inherited css is not available)
- "valid" inputs will now color their icon green, if present cc @noahmulfinger
- Removes unused "appearance" prop on calcite-input-message
- Update calcite-date to use new calcite-input event name cc @paulcpederson 
- Cleanup storybook
- Update readme