### PR TITLE
🧹bump calcite-ui-icons to latest 📦 v3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,9 +1291,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.0.0.tgz",
-      "integrity": "sha512-6F1FruRA5K5t9wDt/YtuTXFZPu8OMNuACkkoOg33RigpvUwIYCLp3A43hrxqDERXypWQW1XspO2ZCnyFFTfPJw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.2.0.tgz",
+      "integrity": "sha512-qNxqakZS8ilhxM1Puszm+vN9bFC8IlKQuasr9GTKVOtc/KqoxNm+L1YWkJsTVAEE5OS6c1FWUFy9w8lWgDJbYQ==",
       "dev": true
     },
     "@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "^2.1.0",
-    "@esri/calcite-ui-icons": "~3.0.0",
+    "@esri/calcite-ui-icons": "~3.2.0",
     "@stencil/core": "~1.11.3",
     "@stencil/sass": "^1.1.1",
     "@stencil/state-tunnel": "^1.0.1",


### PR DESCRIPTION
Published calcite-ui-icons to npm and bumped the dependency.