### PR TITLE
Remove unintended switch handle movement on hover in RTL

### DIFF
--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -141,11 +141,6 @@
   }
 }
 
-:host([dir="rtl"]:hover) .handle {
-  right: 1px;
-  left: auto;
-}
-
 :host([dir="rtl"][switched]) .handle {
   right: auto;
   left: -1px;


### PR DESCRIPTION
Fixes #624 cc @cosbyr 

- Remove unintended switch handle movement on hover in RTL

This used to be a hover animation we had for both RTL and LTR - looks like the RTL style never got removed.