### PR TITLE
BREAKING: Cleanup/accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `calcite-accordion` - Fix for incorrect keyboard navigation behavior when a `calcite-accordion` was nested inside another `calcite-accordion`
+- `calcite-accordion` - Fix for incorrect display of `icon-position` when a `calcite-accordion` was nested inside another `calcite-accordion`
 
 ## [v1.0.0-beta.27] - May 26th 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Breaking Changes
+
+- `calcite-accordion` - `calciteAccordionItemHasChanged` event has been renamed to `calciteAccordionChange`
+- `calcite-accordion-item` - `calciteAccordionItemSelected` event has been renamed to `calciteAccordionItemSelect`
+- `calcite-accordion-item` - `closeCalciteAccordionItem` event has been renamed to `calciteAccordionItemClose`
+- `calcite-accordion-item` - `registerCalciteAccordionItem` event has been renamed to `calciteAccordionItemRegister`
+
+### Fixed
+
+- `calcite-accordion` - Fix for incorrect keyboard navigation behavior when a `calcite-accordion` was nested inside another `calcite-accordion`
+
 ## [v1.0.0-beta.27] - May 26th 2020
 
 ### Breaking Changes

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -26,7 +26,7 @@
 }
 
 // icon position variants for child
-:host-context([icon-position="start"]) {
+:host([icon-position="start"]) {
   --calcite-accordion-item-flex-direction: row-reverse;
   --calcite-accordion-item-icon-rotation: 90deg;
   --calcite-accordion-item-active-icon-rotation: 180deg;
@@ -37,7 +37,7 @@
     --calcite-accordion-item-spacing-unit
   );
 }
-:host-context([icon-position="end"]) {
+:host([icon-position="end"]) {
   --calcite-accordion-item-flex-direction: row;
   --calcite-accordion-item-icon-rotation: -90deg;
   --calcite-accordion-item-active-icon-rotation: 0deg;
@@ -48,7 +48,7 @@
   );
   --calcite-accordion-item-icon-spacing-end: 0;
 }
-:host-context([icon-position="end"]:not([icon-type="plus-minus"])) {
+:host([icon-position="end"]:not([icon-type="plus-minus"])) {
   --calcite-accordion-item-icon-rotation: 0deg;
   --calcite-accordion-item-active-icon-rotation: 180deg;
   --calcite-accordion-item-icon-rotation-rtl: 0deg;

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -9,7 +9,6 @@ import {
   Prop,
 } from "@stencil/core";
 import { getElementDir, getElementProp } from "../../utils/dom";
-import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
 
 @Component({
@@ -50,9 +49,9 @@ export class CalciteAccordionItem {
   //--------------------------------------------------------------------------
 
   @Event() calciteAccordionItemKeyEvent: EventEmitter;
-  @Event() calciteAccordionItemSelected: EventEmitter;
-  @Event() closeCalciteAccordionItem: EventEmitter;
-  @Event() registerCalciteAccordionItem: EventEmitter;
+  @Event() calciteAccordionItemSelect: EventEmitter;
+  @Event() calciteAccordionItemClose: EventEmitter;
+  @Event() calciteAccordionItemRegister: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -62,7 +61,8 @@ export class CalciteAccordionItem {
 
   componentDidLoad() {
     this.itemPosition = this.getItemPosition();
-    this.registerCalciteAccordionItem.emit({
+    this.calciteAccordionItemRegister.emit({
+      parent: this.parent,
       position: this.itemPosition,
     });
   }
@@ -129,16 +129,20 @@ export class CalciteAccordionItem {
         case "ArrowDown":
         case "Home":
         case "End":
-          this.calciteAccordionItemKeyEvent.emit({ item: e });
+          this.calciteAccordionItemKeyEvent.emit({
+            parent: this.parent,
+            item: e,
+          });
           e.preventDefault();
           break;
       }
     }
   }
 
-  @Listen("calciteAccordionItemHasChanged", { target: "parent" })
+  @Listen("calciteAccordionChange", { target: "parent" })
   updateActiveItemOnChange(event: CustomEvent) {
-    this.requestedAccordionItem = event.detail.requestedAccordionItem;
+    this.requestedAccordionItem = event.detail
+      .requestedAccordionItem as HTMLCalciteAccordionItemElement;
     this.determineActiveItem();
   }
 
@@ -148,14 +152,14 @@ export class CalciteAccordionItem {
   //
   //--------------------------------------------------------------------------
 
-  /** unique id for Accordion item */
-  private accordionItemId = `calcite-accordion-item-${guid()}`;
+  /** the containing accordion element */
+  private parent = this.el.parentElement as HTMLCalciteAccordionElement;
 
   /** position within parent */
-  private itemPosition: number;
+  private itemPosition: Number;
 
   /** the latest requested item */
-  private requestedAccordionItem: string;
+  private requestedAccordionItem: HTMLCalciteAccordionItemElement;
 
   /** what selection mode is the parent accordion in */
   private selectionMode = getElementProp(this.el, "selection-mode", "multi");
@@ -177,32 +181,29 @@ export class CalciteAccordionItem {
   private determineActiveItem() {
     switch (this.selectionMode) {
       case "multi":
-        if (this.accordionItemId === this.requestedAccordionItem)
-          this.active = !this.active;
+        if (this.el === this.requestedAccordionItem) this.active = !this.active;
         break;
 
       case "single":
-        if (this.accordionItemId === this.requestedAccordionItem)
-          this.active = !this.active;
+        if (this.el === this.requestedAccordionItem) this.active = !this.active;
         else this.active = false;
         break;
 
       case "single-persist":
-        this.active = this.accordionItemId === this.requestedAccordionItem;
+        this.active = this.el === this.requestedAccordionItem;
         break;
     }
   }
 
   private emitRequestedItem() {
-    this.calciteAccordionItemSelected.emit({
-      requestedAccordionItem: this.accordionItemId,
+    this.calciteAccordionItemSelect.emit({
+      requestedAccordionItem: this.el as HTMLCalciteAccordionItemElement,
     });
   }
 
   private getItemPosition() {
-    const parent = this.el.parentElement as HTMLCalciteAccordionElement;
     return Array.prototype.indexOf.call(
-      parent.querySelectorAll("calcite-accordion-item"),
+      this.parent.querySelectorAll("calcite-accordion-item"),
       this.el
     );
   }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -80,7 +80,12 @@ export class CalciteAccordionItem {
     );
 
     return (
-      <Host tabindex="0" aria-expanded={this.active.toString()} dir={dir}>
+      <Host
+        tabindex="0"
+        aria-expanded={this.active.toString()}
+        dir={dir}
+        icon-position={this.iconPosition}
+      >
         <div
           class="accordion-item-header"
           onClick={this.itemHeaderClickHandler}
@@ -166,6 +171,9 @@ export class CalciteAccordionItem {
 
   /** what icon type does the parent accordion specify */
   private iconType = getElementProp(this.el, "icon-type", "chevron");
+
+  /** what icon position does the parent accordion specify */
+  private iconPosition = getElementProp(this.el, "icon-position", "end");
 
   /** the scale of the parent accordion */
   private scale = getElementProp(this.el, "scale", "m");

--- a/src/components/calcite-accordion-item/readme.md
+++ b/src/components/calcite-accordion-item/readme.md
@@ -4,7 +4,6 @@ individual `calcite-accordion` item
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property       | Attribute       | Description                                                        | Type      | Default     |
@@ -14,16 +13,14 @@ individual `calcite-accordion` item
 | `itemSubtitle` | `item-subtitle` | pass a title for the accordion item                                | `string`  | `undefined` |
 | `itemTitle`    | `item-title`    | pass a title for the accordion item                                | `string`  | `undefined` |
 
-
 ## Events
 
 | Event                          | Description | Type               |
 | ------------------------------ | ----------- | ------------------ |
+| `calciteAccordionItemClose`    |             | `CustomEvent<any>` |
 | `calciteAccordionItemKeyEvent` |             | `CustomEvent<any>` |
-| `calciteAccordionItemSelected` |             | `CustomEvent<any>` |
-| `closeCalciteAccordionItem`    |             | `CustomEvent<any>` |
-| `registerCalciteAccordionItem` |             | `CustomEvent<any>` |
-
+| `calciteAccordionItemRegister` |             | `CustomEvent<any>` |
+| `calciteAccordionItemSelect`   |             | `CustomEvent<any>` |
 
 ## Dependencies
 
@@ -32,12 +29,13 @@ individual `calcite-accordion` item
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-accordion-item --> calcite-icon
   style calcite-accordion-item fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -24,36 +24,6 @@
   @include font-size(-1);
 }
 
-// icon position variants for child
-:host([icon-position="start"]) {
-  --calcite-accordion-item-flex-direction: row-reverse;
-  --calcite-accordion-item-icon-rotation: 90deg;
-  --calcite-accordion-item-active-icon-rotation: 180deg;
-  --calcite-accordion-item-icon-rotation-rtl: -90deg;
-  --calcite-accordion-item-active-icon-rotation-rtl: -180deg;
-  --calcite-accordion-item-icon-spacing-start: 0;
-  --calcite-accordion-item-icon-spacing-end: var(
-    --calcite-accordion-item-spacing-unit
-  );
-}
-:host([icon-position="end"]) {
-  --calcite-accordion-item-flex-direction: row;
-  --calcite-accordion-item-icon-rotation: -90deg;
-  --calcite-accordion-item-active-icon-rotation: 0deg;
-  --calcite-accordion-item-icon-rotation-rtl: 90deg;
-  --calcite-accordion-item-active-icon-rotation-rtl: 0deg;
-  --calcite-accordion-item-icon-spacing-start: var(
-    --calcite-accordion-item-spacing-unit
-  );
-  --calcite-accordion-item-icon-spacing-end: 0;
-}
-:host([icon-position="end"]:not([icon-type="plus-minus"])) {
-  --calcite-accordion-item-icon-rotation: 0deg;
-  --calcite-accordion-item-active-icon-rotation: 180deg;
-  --calcite-accordion-item-icon-rotation-rtl: 0deg;
-  --calcite-accordion-item-active-icon-rotation-rtl: -180deg;
-}
-
 :host {
   display: block;
   position: relative;

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -64,7 +64,7 @@ export class CalciteAccordion {
   //
   //--------------------------------------------------------------------------
 
-  @Event() calciteAccordionItemHasChanged: EventEmitter;
+  @Event() calciteAccordionChange: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -116,43 +116,47 @@ export class CalciteAccordion {
     e: CustomEvent
   ) {
     const item = e.detail.item;
-    const key = getKey(item.key);
-    let itemToFocus = e.target;
-    let isFirstItem = this.itemIndex(itemToFocus) === 0;
-    let isLastItem = this.itemIndex(itemToFocus) === this.items.length - 1;
-    switch (key) {
-      case "ArrowDown":
-        if (isLastItem) this.focusFirstItem();
-        else this.focusNextItem(itemToFocus);
-        break;
-      case "ArrowUp":
-        if (isFirstItem) this.focusLastItem();
-        else this.focusPrevItem(itemToFocus);
-        break;
-      case "Home":
-        this.focusFirstItem();
-        break;
-      case "End":
-        this.focusLastItem();
-        break;
+    const parent = e.detail.parent as HTMLCalciteAccordionElement;
+    if (this.el === parent) {
+      const key = getKey(item.key);
+      let itemToFocus = e.target;
+      let isFirstItem = this.itemIndex(itemToFocus) === 0;
+      let isLastItem = this.itemIndex(itemToFocus) === this.items.length - 1;
+      switch (key) {
+        case "ArrowDown":
+          if (isLastItem) this.focusFirstItem();
+          else this.focusNextItem(itemToFocus);
+          break;
+        case "ArrowUp":
+          if (isFirstItem) this.focusLastItem();
+          else this.focusPrevItem(itemToFocus);
+          break;
+        case "Home":
+          this.focusFirstItem();
+          break;
+        case "End":
+          this.focusLastItem();
+          break;
+      }
     }
   }
 
-  @Listen("registerCalciteAccordionItem") registerCalciteAccordionItem(
+  @Listen("calciteAccordionItemRegister") registerCalciteAccordionItem(
     e: CustomEvent
   ) {
     const item = {
       item: e.target as HTMLCalciteAccordionItemElement,
-      position: e.detail.position,
+      parent: e.detail.parent as HTMLCalciteAccordionElement,
+      position: e.detail.position as Number,
     };
-    this.items.push(item);
+    if (this.el === item.parent) this.items.push(item);
   }
 
-  @Listen("calciteAccordionItemSelected") updateActiveItemOnChange(
+  @Listen("calciteAccordionItemSelect") updateActiveItemOnChange(
     event: CustomEvent
   ) {
     this.requestedAccordionItem = event.detail.requestedAccordionItem;
-    this.calciteAccordionItemHasChanged.emit({
+    this.calciteAccordionChange.emit({
       requestedAccordionItem: this.requestedAccordionItem,
     });
   }
@@ -170,7 +174,7 @@ export class CalciteAccordion {
   private sorted = false;
 
   /** keep track of the requested item for multi mode */
-  private requestedAccordionItem: string = "";
+  private requestedAccordionItem: HTMLCalciteAccordionItemElement;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-accordion/readme.md
+++ b/src/components/calcite-accordion/readme.md
@@ -20,7 +20,6 @@ A basic implementation looks like this:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property        | Attribute        | Description                                                                                                                                                               | Type                                      | Default     |
@@ -32,14 +31,12 @@ A basic implementation looks like this:
 | `selectionMode` | `selection-mode` | specify the selection mode - multi (allow any number of open items), single (allow one open item), or single-persist (allow and require one open item), defaults to multi | `"multi" \| "single" \| "single-persist"` | `"multi"`   |
 | `theme`         | `theme`          | specify the theme of accordion, defaults to light                                                                                                                         | `"dark" \| "light"`                       | `undefined` |
 
-
 ## Events
 
-| Event                            | Description | Type               |
-| -------------------------------- | ----------- | ------------------ |
-| `calciteAccordionItemHasChanged` |             | `CustomEvent<any>` |
+| Event                        | Description | Type               |
+| ---------------------------- | ----------- | ------------------ |
+| `calciteAccordionItemChange` |             | `CustomEvent<any>` |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_


### PR DESCRIPTION
Resolves #457 

- BREAKING Updates various event names and typings
- Now uses typed element references to determine active items rather than generated GUID
- Fixes incorrect keyboard navigation behavior in instances of nested accordions within other accordions
  - Keyboard navigation with home/end/up/down will now cycle between items in the currently focused nested accordion, rather than incorrectly jump between items between all accordions in the child / parent tree
  - Users can tab between nested instances of calcite-accordion
- Removes host-context and explicitly sets icon-position on child items
  - this fixes instances where nested accordions could not adhere to their requested icon-position because they were incorrectly inheriting from a parent