### PR TITLE
feat(radio-group): add selected value in calciteRadioGroupChange event detail

### DIFF
--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -70,31 +70,37 @@ describe("calcite-radio-group", () => {
       let selected = await element.find("calcite-radio-group-item[checked]");
       let value = await selected.getProperty("value");
       expect(value).toBe("2");
+      expect(spy).toHaveNthReceivedEventDetail(0, "2");
 
       await element.press("ArrowRight");
       selected = await element.find("calcite-radio-group-item[checked]");
       value = await selected.getProperty("value");
       expect(value).toBe("3");
+      expect(spy).toHaveNthReceivedEventDetail(1, "3");
 
       await element.press("ArrowRight");
       selected = await element.find("calcite-radio-group-item[checked]");
       value = await selected.getProperty("value");
       expect(value).toBe("1");
+      expect(spy).toHaveNthReceivedEventDetail(2, "1");
 
       await element.press("ArrowLeft");
       selected = await element.find("calcite-radio-group-item[checked]");
       value = await selected.getProperty("value");
       expect(value).toBe("3");
+      expect(spy).toHaveNthReceivedEventDetail(3, "3");
 
       await element.press("ArrowLeft");
       selected = await element.find("calcite-radio-group-item[checked]");
       value = await selected.getProperty("value");
       expect(value).toBe("2");
+      expect(spy).toHaveNthReceivedEventDetail(4, "2");
 
       await element.press("ArrowLeft");
       selected = await element.find("calcite-radio-group-item[checked]");
       value = await selected.getProperty("value");
       expect(value).toBe("1");
+      expect(spy).toHaveNthReceivedEventDetail(5, "1");
 
       expect(spy).toHaveReceivedEventTimes(6);
     });

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -67,7 +67,7 @@ export class CalciteRadioGroup {
 
     if (match) {
       this.selectItem(match);
-      this.calciteRadioGroupChange.emit();
+      this.calciteRadioGroupChange.emit(match.value);
     } else if (items[0]) {
       items[0].tabIndex = 0;
     }
@@ -234,7 +234,7 @@ export class CalciteRadioGroup {
   //--------------------------------------------------------------------------
 
   @Event()
-  calciteRadioGroupChange: EventEmitter;
+  calciteRadioGroupChange: EventEmitter<any>;
 
   // --------------------------------------------------------------------------
   //


### PR DESCRIPTION
This updates custom events to include the selected value in the event's `detail` prop.

#470 