### PR TITLE
refactor(calcite-dropdown)!: rename events and stop propagation of internal ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-accordion-item` - `calciteAccordionItemSelected` event has been renamed to `calciteAccordionItemSelect`
 - `calcite-accordion-item` - `closeCalciteAccordionItem` event has been renamed to `calciteAccordionItemClose`
 - `calcite-accordion-item` - `registerCalciteAccordionItem` event has been renamed to `calciteAccordionItemRegister`
+- `calcite-dropdown-group` - `registerCalciteItemHasChanged` event has been renamed to `calciteDropdownItemChange`
+- `calcite-dropdown-group` - `registerCalciteDropdownGroup` event has been renamed to `calciteDropdownGroupRegister`
+- `calcite-dropdown-item` - `registerCalciteDropdownItem` event has been renamed to `calciteDropdownItemRegister`
+- `calcite-dropdown-item` - `calciteDropdownItemSelected` event has been renamed to `calciteDropdownItemSelect`
+- `calcite-dropdown-item` - `closeCalciteDropdown` event has been renamed to `calciteDropdownClose`
 
 ### Fixed
 

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -46,8 +46,8 @@ export class CalciteDropdownGroup {
   //
   //--------------------------------------------------------------------------
 
-  @Event() calciteDropdownItemHasChanged: EventEmitter;
-  @Event() registerCalciteDropdownGroup: EventEmitter<GroupRegistration>;
+  @Event() calciteDropdownGroupRegister: EventEmitter<GroupRegistration>;
+  @Event() calciteDropdownItemChange: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -65,7 +65,7 @@ export class CalciteDropdownGroup {
   componentDidLoad() {
     this.groupPosition = this.getGroupPosition();
     this.items = this.sortItems(this.items) as HTMLCalciteDropdownItemElement[];
-    this.registerCalciteDropdownGroup.emit({
+    this.calciteDropdownGroupRegister.emit({
       items: this.items,
       position: this.groupPosition,
       groupId: this.dropdownGroupId,
@@ -94,7 +94,7 @@ export class CalciteDropdownGroup {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("registerCalciteDropdownItem") registerCalciteDropdownItem(
+  @Listen("calciteDropdownItemRegister") registerCalciteDropdownItem(
     event: CustomEvent<ItemRegistration>
   ) {
     const item = {
@@ -102,14 +102,16 @@ export class CalciteDropdownGroup {
       position: event.detail.position,
     };
     this.items.push(item);
+
+    event.stopPropagation();
   }
 
-  @Listen("calciteDropdownItemSelected") updateActiveItemOnChange(
+  @Listen("calciteDropdownItemSelect") updateActiveItemOnChange(
     event: CustomEvent
   ) {
     this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
     this.requestedDropdownItem = event.detail.requestedDropdownItem;
-    this.calciteDropdownItemHasChanged.emit({
+    this.calciteDropdownItemChange.emit({
       requestedDropdownGroup: this.requestedDropdownGroup,
       requestedDropdownItem: this.requestedDropdownItem,
     });

--- a/src/components/calcite-dropdown-group/readme.md
+++ b/src/components/calcite-dropdown-group/readme.md
@@ -2,7 +2,6 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property        | Attribute        | Description                                                                                                                                                           | Type                            | Default     |
@@ -10,15 +9,13 @@
 | `groupTitle`    | `group-title`    | optionally set a group title for display                                                                                                                              | `string`                        | `undefined` |
 | `selectionMode` | `selection-mode` | specify the selection mode - multi (allow any number of (or no) active items), single (allow and require one active item), none (no active items), defaults to single | `"multi" \| "none" \| "single"` | `"single"`  |
 
-
 ## Events
 
-| Event                           | Description | Type                             |
-| ------------------------------- | ----------- | -------------------------------- |
-| `calciteDropdownItemHasChanged` |             | `CustomEvent<any>`               |
-| `registerCalciteDropdownGroup`  |             | `CustomEvent<GroupRegistration>` |
+| Event                          | Description | Type                             |
+| ------------------------------ | ----------- | -------------------------------- |
+| `calciteDropdownGroupRegister` |             | `CustomEvent<GroupRegistration>` |
+| `calciteDropdownItemChange`    |             | `CustomEvent<any>`               |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -11,7 +11,7 @@ import {
 } from "@stencil/core";
 import { getElementDir, getElementProp } from "../../utils/dom";
 import { guid } from "../../utils/guid";
-import { ItemRegistration } from "../../interfaces/Dropdown";
+import { ItemKeyboardEvent, ItemRegistration } from "../../interfaces/Dropdown";
 import { getKey } from "../../utils/key";
 
 @Component({
@@ -50,10 +50,10 @@ export class CalciteDropdownItem {
   //
   //--------------------------------------------------------------------------
 
-  @Event() calciteDropdownItemKeyEvent: EventEmitter;
-  @Event() calciteDropdownItemSelected: EventEmitter;
-  @Event() closeCalciteDropdown: EventEmitter;
-  @Event() registerCalciteDropdownItem: EventEmitter<ItemRegistration>;
+  @Event() calciteDropdownClose: EventEmitter;
+  @Event() calciteDropdownItemKeyEvent: EventEmitter<ItemKeyboardEvent>;
+  @Event() calciteDropdownItemRegister: EventEmitter<ItemRegistration>;
+  @Event() calciteDropdownItemSelect: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -75,7 +75,7 @@ export class CalciteDropdownItem {
 
   componentDidLoad() {
     this.itemPosition = this.getItemPosition();
-    this.registerCalciteDropdownItem.emit({
+    this.calciteDropdownItemRegister.emit({
       position: this.itemPosition,
     });
   }
@@ -149,7 +149,7 @@ export class CalciteDropdownItem {
     this.emitRequestedItem();
   }
 
-  @Listen("keydown") keyDownHandler(e) {
+  @Listen("keydown") keyDownHandler(e: KeyboardEvent): void {
     switch (getKey(e.key)) {
       case " ":
         this.emitRequestedItem();
@@ -163,25 +163,25 @@ export class CalciteDropdownItem {
         if (this.href) this.childLink.click();
         break;
       case "Escape":
-        this.closeCalciteDropdown.emit();
+        this.calciteDropdownClose.emit();
         break;
       case "Tab":
       case "ArrowUp":
       case "ArrowDown":
       case "Home":
       case "End":
-        this.calciteDropdownItemKeyEvent.emit({ item: e });
+        this.calciteDropdownItemKeyEvent.emit({ keyboardEvent: e });
         break;
     }
     e.preventDefault();
   }
 
-  @Listen("registerCalciteDropdownGroup", { target: "parent" })
+  @Listen("calciteDropdownGroupRegister", { target: "parent" })
   registerCalciteDropdownGroup(event: CustomEvent) {
     this.currentDropdownGroup = event.detail.groupId;
   }
 
-  @Listen("calciteDropdownItemHasChanged", { target: "parent" })
+  @Listen("calciteDropdownItemChange", { target: "parent" })
   updateActiveItemOnChange(event: CustomEvent) {
     this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
     this.requestedDropdownItem = event.detail.requestedDropdownItem;
@@ -240,11 +240,11 @@ export class CalciteDropdownItem {
   }
 
   private emitRequestedItem() {
-    this.calciteDropdownItemSelected.emit({
+    this.calciteDropdownItemSelect.emit({
       requestedDropdownItem: this.dropdownItemId,
       requestedDropdownGroup: this.currentDropdownGroup,
     });
-    this.closeCalciteDropdown.emit();
+    this.calciteDropdownClose.emit();
   }
 
   private getAttributes() {

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -2,7 +2,6 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute    | Description                                                                                | Type      | Default     |
@@ -12,16 +11,14 @@
 | `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of an item - accepts calcite ui icon names   | `string`  | `undefined` |
 | `iconStart` | `icon-start` | optionally pass an icon to display at the start of an item - accepts calcite ui icon names | `string`  | `undefined` |
 
-
 ## Events
 
 | Event                         | Description | Type                            |
 | ----------------------------- | ----------- | ------------------------------- |
+| `calciteDropdownClose`        |             | `CustomEvent<any>`              |
 | `calciteDropdownItemKeyEvent` |             | `CustomEvent<any>`              |
-| `calciteDropdownItemSelected` |             | `CustomEvent<any>`              |
-| `closeCalciteDropdown`        |             | `CustomEvent<any>`              |
-| `registerCalciteDropdownItem` |             | `CustomEvent<ItemRegistration>` |
-
+| `calciteDropdownItemRegister` |             | `CustomEvent<ItemRegistration>` |
+| `calciteDropdownItemSelect`   |             | `CustomEvent<any>`              |
 
 ## Methods
 
@@ -33,9 +30,6 @@ Focuses the selected item.
 
 Type: `Promise<void>`
 
-
-
-
 ## Dependencies
 
 ### Depends on
@@ -43,12 +37,13 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-dropdown-item --> calcite-icon
   style calcite-dropdown-item fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/interfaces/Dropdown.ts
+++ b/src/interfaces/Dropdown.ts
@@ -2,6 +2,10 @@ export interface ItemRegistration {
   position: number;
 }
 
+export interface ItemKeyboardEvent {
+  keyboardEvent: KeyboardEvent;
+}
+
 export interface GroupRegistration {
   items: HTMLCalciteDropdownItemElement[];
   position: number;


### PR DESCRIPTION
This tackles the event renaming part of #464. 

BREAKING CHANGE: The following calcite-dropdown events have been renamed:

* calciteDropdownItemHasChanged => calciteDropdownItemChange
* registerCalciteDropdownGroup => calciteDropdownGroupRegister
* calciteDropdownItemSelected => calciteDropdownItemSelect
* closeCalciteDropdown => calciteDropdownClose
* registerCalciteDropdownItem => calciteDropdownItemRegister