### PR TITLE
feat(dropdown)!: add selectedItems property and calciteDropdownSelect event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-dropdown-group` - `registerCalciteItemHasChanged` event has been renamed to `calciteDropdownItemChange`
 - `calcite-dropdown-group` - `registerCalciteDropdownGroup` event has been renamed to `calciteDropdownGroupRegister`
 - `calcite-dropdown-item` - `registerCalciteDropdownItem` event has been renamed to `calciteDropdownItemRegister`
-- `calcite-dropdown-item` - `calciteDropdownItemSelected` event has been renamed to `calciteDropdownItemSelect`
+- `calcite-dropdown-item` - `calciteDropdownItemSelected` event has been renamed to `calciteDropdownItemSelect` and is now internal.
 - `calcite-dropdown-item` - `closeCalciteDropdown` event has been renamed to `calciteDropdownClose`
+
+### Added
+
+- `calcite-dropdown` now has a read-only `selectedItems` prop that contains all selected items.
+- `calcite-dropdown` now emits `calciteDropdownSelect` when an item selection changes.
 
 ### Fixed
 

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -97,11 +97,16 @@ export class CalciteDropdownGroup {
   @Listen("calciteDropdownItemRegister") registerCalciteDropdownItem(
     event: CustomEvent<ItemRegistration>
   ) {
-    const item = {
-      item: event.target as HTMLCalciteDropdownItemElement,
+    const item = event.target as HTMLCalciteDropdownItemElement;
+
+    if (this.selectionMode === "none") {
+      item.active = false;
+    }
+
+    this.items.push({
+      item,
       position: event.detail.position,
-    };
-    this.items.push(item);
+    });
 
     event.stopPropagation();
   }
@@ -109,6 +114,10 @@ export class CalciteDropdownGroup {
   @Listen("calciteDropdownItemSelect") updateActiveItemOnChange(
     event: CustomEvent
   ) {
+    if (this.selectionMode === "none") {
+      return;
+    }
+
     this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
     this.requestedDropdownItem = event.detail.requestedDropdownItem;
     this.calciteDropdownItemChange.emit({

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -115,6 +115,7 @@ export class CalciteDropdownGroup {
     event: CustomEvent
   ) {
     if (this.selectionMode === "none") {
+      event.stopPropagation();
       return;
     }
 

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -73,7 +73,7 @@ export class CalciteDropdownItem {
   //
   //--------------------------------------------------------------------------
 
-  componentDidLoad() {
+  componentWillLoad() {
     this.itemPosition = this.getItemPosition();
     this.calciteDropdownItemRegister.emit({
       position: this.itemPosition,

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -13,12 +13,12 @@
 
 ## Events
 
-| Event                         | Description | Type                            |
-| ----------------------------- | ----------- | ------------------------------- |
-| `calciteDropdownClose`        |             | `CustomEvent<any>`              |
-| `calciteDropdownItemKeyEvent` |             | `CustomEvent<any>`              |
-| `calciteDropdownItemRegister` |             | `CustomEvent<ItemRegistration>` |
-| `calciteDropdownItemSelect`   |             | `CustomEvent<any>`              |
+| Event                         | Description | Type                             |
+| ----------------------------- | ----------- | -------------------------------- |
+| `calciteDropdownClose`        |             | `CustomEvent<any>`               |
+| `calciteDropdownItemKeyEvent` |             | `CustomEvent<ItemKeyboardEvent>` |
+| `calciteDropdownItemRegister` |             | `CustomEvent<ItemRegistration>`  |
+| `calciteDropdownItemSelect`   |             | `CustomEvent<any>`               |
 
 ## Methods
 

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,6 +1,27 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
 
 describe("calcite-dropdown", () => {
+  /**
+   * Test helper for selected calcite-dropdown items. Expects items to have IDs to test against.
+   */
+  async function assertSelectedItems(
+    page: E2EPage,
+    expectedItemIds: string[]
+  ): Promise<void> {
+    const selectedItemIds = await page.evaluate(() => {
+      const dropdown = document.querySelector<HTMLCalciteDropdownElement>(
+        "calcite-dropdown"
+      );
+      return dropdown.selectedItems.map((item) => item.id);
+    });
+
+    expect(selectedItemIds).toHaveLength(expectedItemIds.length);
+
+    expectedItemIds.forEach((itemId, index) =>
+      expect(selectedItemIds[index]).toEqual(itemId)
+    );
+  }
+
   it("renders", async () => {
     const page = await newE2EPage();
     await page.setContent(`
@@ -240,22 +261,28 @@ describe("calcite-dropdown", () => {
     const item1 = await element.find("calcite-dropdown-item[id='item-1']");
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
     expect(group1).toEqualAttribute("selection-mode", "multi");
     await trigger.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-2"]);
     await item1.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-2"]);
     await trigger.click();
     await page.waitForChanges();
     await item2.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1"]);
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-3"]);
     expect(item1).toHaveAttribute("active");
     expect(item2).not.toHaveAttribute("active");
     expect(item3).toHaveAttribute("active");
+    expect(itemChangeSpy).toHaveReceivedEventTimes(3);
   });
 
   it("renders just one active item when group is in single selection mode", async () => {
@@ -282,19 +309,24 @@ describe("calcite-dropdown", () => {
     const item1 = await element.find("calcite-dropdown-item[id='item-1']");
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
     expect(group1).toEqualAttribute("selection-mode", "single");
+    await assertSelectedItems(page, ["item-2"]);
     await trigger.click();
     await page.waitForChanges();
     await item1.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1"]);
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-3"]);
 
     expect(item1).not.toHaveAttribute("active");
     expect(item2).not.toHaveAttribute("active");
     expect(item3).toHaveAttribute("active");
+    expect(itemChangeSpy).toHaveReceivedEventTimes(2);
   });
 
   it("renders no active item when group is in none selection mode (and removes any active state set in dom)", async () => {
@@ -321,16 +353,25 @@ describe("calcite-dropdown", () => {
     const item1 = await element.find("calcite-dropdown-item[id='item-1']");
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
     expect(group1).toEqualAttribute("selection-mode", "none");
+    await assertSelectedItems(page, []);
     await trigger.click();
     await item1.click();
+    await page.waitForChanges();
+    await assertSelectedItems(page, []);
     await trigger.click();
     await item2.click();
+    await page.waitForChanges();
+    await assertSelectedItems(page, []);
     await trigger.click();
     await item3.click();
+    await page.waitForChanges();
+    await assertSelectedItems(page, []);
     expect(item1).not.toHaveAttribute("active");
     expect(item2).not.toHaveAttribute("active");
     expect(item3).not.toHaveAttribute("active");
+    expect(itemChangeSpy).toHaveReceivedEventTimes(0);
   });
 
   it("renders the correct active state when parent contains groups of assorted selection modes", async () => {
@@ -387,39 +428,48 @@ describe("calcite-dropdown", () => {
     const item7 = await element.find("calcite-dropdown-item[id='item-7']");
     const item8 = await element.find("calcite-dropdown-item[id='item-8']");
     const item9 = await element.find("calcite-dropdown-item[id='item-9']");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
 
     expect(group1).toEqualAttribute("selection-mode", "multi");
     expect(group2).toEqualAttribute("selection-mode", "single");
     expect(group3).toEqualAttribute("selection-mode", "none");
+    await assertSelectedItems(page, ["item-2", "item-5"]);
 
     await trigger.click();
     await page.waitForChanges();
     await item1.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-2", "item-5"]);
     await trigger.click();
     await page.waitForChanges();
     await item2.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-5"]);
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-3", "item-5"]);
     await trigger.click();
     await page.waitForChanges();
     await item4.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-3", "item-4"]);
     await trigger.click();
     await page.waitForChanges();
     await item6.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-3", "item-6"]);
     await trigger.click();
     await page.waitForChanges();
     await item7.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-3", "item-6"]);
     await trigger.click();
     await page.waitForChanges();
     await item9.click();
     await page.waitForChanges();
+    await assertSelectedItems(page, ["item-1", "item-3", "item-6"]);
 
     expect(item1).toHaveAttribute("active");
     expect(item2).not.toHaveAttribute("active");
@@ -430,6 +480,7 @@ describe("calcite-dropdown", () => {
     expect(item7).not.toHaveAttribute("active");
     expect(item8).not.toHaveAttribute("active");
     expect(item9).not.toHaveAttribute("active");
+    expect(itemChangeSpy).toHaveReceivedEventTimes(5);
   });
 
   it("renders a calcite-dropdown-item with child anchor link with passed attributes if href is present", async () => {
@@ -450,7 +501,9 @@ describe("calcite-dropdown", () => {
       </calcite-dropdown-group>
       </calcite-dropdown>`
     );
-    const elementAsLink = await page.find("calcite-dropdown-item[id='item-2'] >>> a");
+    const elementAsLink = await page.find(
+      "calcite-dropdown-item[id='item-2'] >>> a"
+    );
     expect(elementAsLink).not.toBeNull();
     expect(elementAsLink).toEqualAttribute("href", "google.com");
     expect(elementAsLink).toEqualAttribute("rel", "noopener noreferrer");
@@ -467,7 +520,7 @@ describe("calcite-dropdown", () => {
       <calcite-dropdown-item id="3">3</calcite-dropdown-item>
       <calcite-dropdown-item id="4">4</calcite-dropdown-item>
       </calcite-dropdown-group>
-      </calcite-dropdown>`
+      </calcite-dropdown>`,
     });
 
     const element = await page.find("calcite-dropdown");
@@ -487,14 +540,16 @@ describe("calcite-dropdown", () => {
           <calcite-dropdown-item id="item-3" active>3</calcite-dropdown-item>
           <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
         </calcite-dropdown-group>
-      </calcite-dropdown>`
+      </calcite-dropdown>`,
     });
 
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
 
-    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-3");
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual(
+      "item-3"
+    );
   });
 
   it("should focus the first active item on open", async () => {
@@ -507,14 +562,16 @@ describe("calcite-dropdown", () => {
           <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
           <calcite-dropdown-item id="item-4" active>4</calcite-dropdown-item>
         </calcite-dropdown-group>
-      </calcite-dropdown>`
+      </calcite-dropdown>`,
     });
 
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
 
-    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-2");
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual(
+      "item-2"
+    );
   });
 
   describe("scrolling", () => {
@@ -616,5 +673,4 @@ describe("calcite-dropdown", () => {
       }
     });
   });
-
 });

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -261,7 +261,7 @@ describe("calcite-dropdown", () => {
     const item1 = await element.find("calcite-dropdown-item[id='item-1']");
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
-    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownSelect");
     expect(group1).toEqualAttribute("selection-mode", "multi");
     await trigger.click();
     await page.waitForChanges();
@@ -309,7 +309,7 @@ describe("calcite-dropdown", () => {
     const item1 = await element.find("calcite-dropdown-item[id='item-1']");
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
-    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownSelect");
     expect(group1).toEqualAttribute("selection-mode", "single");
     await assertSelectedItems(page, ["item-2"]);
     await trigger.click();
@@ -353,7 +353,7 @@ describe("calcite-dropdown", () => {
     const item1 = await element.find("calcite-dropdown-item[id='item-1']");
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
-    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownSelect");
     expect(group1).toEqualAttribute("selection-mode", "none");
     await assertSelectedItems(page, []);
     await trigger.click();
@@ -428,7 +428,7 @@ describe("calcite-dropdown", () => {
     const item7 = await element.find("calcite-dropdown-item[id='item-7']");
     const item8 = await element.find("calcite-dropdown-item[id='item-8']");
     const item9 = await element.find("calcite-dropdown-item[id='item-9']");
-    const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemChange");
+    const itemChangeSpy = await element.spyOnEvent("calciteDropdownSelect");
 
     expect(group1).toEqualAttribute("selection-mode", "multi");
     expect(group2).toEqualAttribute("selection-mode", "single");

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -1,4 +1,13 @@
-import { Component, Element, h, Host, Listen, Prop } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+} from "@stencil/core";
 import { focusElement } from "../../utils/dom";
 import {
   GroupRegistration,
@@ -124,9 +133,12 @@ export class CalciteDropdown {
 
   //--------------------------------------------------------------------------
   //
-  //  Event Listeners
+  //  Events
   //
   //--------------------------------------------------------------------------
+
+  /** fires when a dropdown item has been selected or deselected **/
+  @Event() calciteDropdownSelect: EventEmitter<void>;
 
   @Listen("click") openDropdown(e) {
     if (e.target === this.trigger || this.trigger.contains(e.target)) {
@@ -214,8 +226,12 @@ export class CalciteDropdown {
     e.stopPropagation();
   }
 
-  @Listen("calciteDropdownItemSelect") handleItemSelect(): void {
+  @Listen("calciteDropdownItemSelect") handleItemSelect(
+    event: CustomEvent
+  ): void {
     this.updateSelectedItems();
+    event.stopPropagation();
+    this.calciteDropdownSelect.emit();
   }
 
   @Listen("calciteDropdownGroupRegister") registerCalciteDropdownGroup(

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -41,6 +41,13 @@ export class CalciteDropdown {
   /** specify the theme of the dropdown, defaults to light */
   @Prop({ mutable: true, reflect: true }) theme: "light" | "dark";
 
+  /**
+   * **read-only** The currently selected items
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) selectedItems: HTMLCalciteDropdownItemElement[] = [];
+
   /** specify the scale of dropdown, defaults to m */
   @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" = "m";
 
@@ -207,6 +214,10 @@ export class CalciteDropdown {
     e.stopPropagation();
   }
 
+  @Listen("calciteDropdownItemSelect") handleItemSelect(): void {
+    this.updateSelectedItems();
+  }
+
   @Listen("calciteDropdownGroupRegister") registerCalciteDropdownGroup(
     e: CustomEvent<GroupRegistration>
   ) {
@@ -221,6 +232,8 @@ export class CalciteDropdown {
     });
 
     e.stopPropagation();
+
+    this.updateSelectedItems();
   }
 
   //--------------------------------------------------------------------------
@@ -246,6 +259,16 @@ export class CalciteDropdown {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private updateSelectedItems(): void {
+    const items = Array.from(
+      this.el.querySelectorAll<HTMLCalciteDropdownItemElement>(
+        "calcite-dropdown-item"
+      )
+    );
+
+    this.selectedItems = items.filter((item) => item.active);
+  }
 
   private getMaxScrollerHeight(groups: GroupRegistration[]): number {
     const { maxItems } = this;

--- a/src/components/calcite-dropdown/readme.md
+++ b/src/components/calcite-dropdown/readme.md
@@ -55,6 +55,12 @@ You can combine groups in a single dropdown, with varying selection modes:
 | `type`          | `type`      | specify whether the dropdown is opened by hover or click of the trigger element         | `"click" \| "hover"`               | `"click"`   |
 | `width`         | `width`     | specify the width of dropdown, defaults to m                                            | `"l" \| "m" \| "s"`                | `"m"`       |
 
+## Events
+
+| Event                   | Description                                     | Type                |
+| ----------------------- | ----------------------------------------------- | ------------------- |
+| `calciteDropdownSelect` | fires when a dropdown item has been selected \* | `CustomEvent<void>` |
+
 ## Dependencies
 
 ### Used by

--- a/src/components/calcite-dropdown/readme.md
+++ b/src/components/calcite-dropdown/readme.md
@@ -42,33 +42,33 @@ You can combine groups in a single dropdown, with varying selection modes:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property    | Attribute   | Description                                                                            | Type                           | Default     |
-| ----------- | ----------- | -------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
-| `active`    | `active`    |                                                                                        | `boolean`                      | `false`     |
-| `alignment` | `alignment` | specify the alignment of dropdown, defaults to start                                   | `"center" \| "end" \| "start"` | `"start"`   |
-| `maxItems`  | `max-items` | specify the max items to display before showing the scroller, must be greater than 0 * | `number`                       | `0`         |
-| `scale`     | `scale`     | specify the scale of dropdown, defaults to m                                           | `"l" \| "m" \| "s"`            | `"m"`       |
-| `theme`     | `theme`     | specify the theme of the dropdown, defaults to light                                   | `"dark" \| "light"`            | `undefined` |
-| `type`      | `type`      | specify whether the dropdown is opened by hover or click of the trigger element        | `"click" \| "hover"`           | `"click"`   |
-| `width`     | `width`     | specify the width of dropdown, defaults to m                                           | `"l" \| "m" \| "s"`            | `"m"`       |
-
+| Property        | Attribute   | Description                                                                             | Type                               | Default     |
+| --------------- | ----------- | --------------------------------------------------------------------------------------- | ---------------------------------- | ----------- |
+| `active`        | `active`    |                                                                                         | `boolean`                          | `false`     |
+| `alignment`     | `alignment` | specify the alignment of dropdown, defaults to start                                    | `"center" \| "end" \| "start"`     | `"start"`   |
+| `maxItems`      | `max-items` | specify the max items to display before showing the scroller, must be greater than 0 \* | `number`                           | `0`         |
+| `scale`         | `scale`     | specify the scale of dropdown, defaults to m                                            | `"l" \| "m" \| "s"`                | `"m"`       |
+| `selectedItems` | --          | **read-only** The currently selected items                                              | `HTMLCalciteDropdownItemElement[]` | `[]`        |
+| `theme`         | `theme`     | specify the theme of the dropdown, defaults to light                                    | `"dark" \| "light"`                | `undefined` |
+| `type`          | `type`      | specify whether the dropdown is opened by hover or click of the trigger element         | `"click" \| "hover"`               | `"click"`   |
+| `width`         | `width`     | specify the width of dropdown, defaults to m                                            | `"l" \| "m" \| "s"`                | `"m"`       |
 
 ## Dependencies
 
 ### Used by
 
- - [calcite-split-button](../calcite-split-button)
+- [calcite-split-button](../calcite-split-button)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-split-button --> calcite-dropdown
   style calcite-dropdown fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/demos/calcite-date.html
+++ b/src/demos/calcite-date.html
@@ -103,8 +103,8 @@
     </calcite-dropdown-group>
   </calcite-dropdown>
   <script>
-    document.getElementById("localePicker").addEventListener("calciteDropdownItemSelected", function (e) {
-      document.getElementById("locale").locale = e.target.getAttribute("data-locale")
+    document.getElementById("localePicker").addEventListener("calciteDropdownSelect", function (e) {
+      document.getElementById("locale").locale = e.target.selectedItems[0].getAttribute("data-locale");
     });
   </script>
 


### PR DESCRIPTION
Related issue #464 

This adds a 'read-only' `selectedItems` convenience property to the dropdown (akin to `HTMLSelectElement#selectedOptions`). 

Additionally, `calciteDropdownSelect` is now is emitted when an item is selected/deselected.

cc @kstinson14 

### Notes

* This leverages the existing `calciteDropdownItemChange` event, which fires when items are selected. This event is now internal.
* The property isn't a true read-only prop and can be overridden by users. 
* There is no corresponding attribute for this.
* Moves item registration logic to `componentWillLoad` to avoid re-rendering warnings from build.
* Groups no longer process item selection when `selectionMode === "none"`.
* `selectedItem` updates could be optimized in the future once the internal dropdown `items` property stays fixed (it currently changes type during initialization).