### PR TITLE
Ensure consistent styling of any slotted element in alert and notice

### DIFF
--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -14,10 +14,10 @@
   --calcite-alert-width: 40em;
   --calcite-alert-spacing-token-small: #{$baseline/2};
   --calcite-alert-spacing-token-large: #{$baseline/1.5};
-  @include slotted("alert-title", "div") {
+  @include slotted("alert-title", "*") {
     @include font-size(-2);
   }
-  @include slotted("alert-message", "div") {
+  @include slotted("alert-message", "*") {
     @include font-size(-3);
   }
   ::slotted(calcite-link) {
@@ -29,10 +29,10 @@
   --calcite-alert-width: 50em;
   --calcite-alert-spacing-token-small: #{$baseline/1.5};
   --calcite-alert-spacing-token-large: #{$baseline};
-  @include slotted("alert-title", "div") {
+  @include slotted("alert-title", "*") {
     @include font-size(-1);
   }
-  @include slotted("alert-message", "div") {
+  @include slotted("alert-message", "*") {
     @include font-size(-2);
   }
   ::slotted(calcite-link) {
@@ -44,10 +44,10 @@
   --calcite-alert-width: 60em;
   --calcite-alert-spacing-token-small: #{$baseline/1.25};
   --calcite-alert-spacing-token-large: #{$baseline * 1.25};
-  @include slotted("alert-title", "div") {
+  @include slotted("alert-title", "*") {
     @include font-size(0);
   }
-  @include slotted("alert-message", "div") {
+  @include slotted("alert-message", "*") {
     @include font-size(-1);
   }
   ::slotted(calcite-link) {
@@ -112,21 +112,24 @@
   }
 }
 
-@include slotted("alert-title", "div") {
+@include slotted("alert-title", "*") {
   @include font-size(0);
   color: var(--calcite-ui-text-1);
+  margin: 0;
   font-weight: 500;
 }
 
-@include slotted("alert-message", "div") {
+@include slotted("alert-message", "*") {
   display: inline;
+  margin: 0;
   margin-right: $baseline/2;
+  font-weight: 400;
   @include font-size(-1);
   color: var(--calcite-ui-text-2);
 }
 
 :host([dir="rtl"]) {
-  @include slotted("alert-message", "div") {
+  @include slotted("alert-message", "*") {
     margin-right: unset;
     margin-left: $baseline/2;
   }

--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -7,10 +7,10 @@
 :host([scale="s"]) {
   --calcite-notice-spacing-token-small: #{$baseline/2};
   --calcite-notice-spacing-token-large: #{$baseline/1.5};
-  @include slotted("notice-title", "div") {
+  @include slotted("notice-title", "*") {
     @include font-size(-2);
   }
-  @include slotted("notice-message", "div") {
+  @include slotted("notice-message", "*") {
     @include font-size(-3);
   }
   ::slotted(calcite-link) {
@@ -21,10 +21,10 @@
 :host([scale="m"]) {
   --calcite-notice-spacing-token-small: #{$baseline/1.5};
   --calcite-notice-spacing-token-large: #{$baseline};
-  @include slotted("notice-title", "div") {
+  @include slotted("notice-title", "*") {
     @include font-size(-1);
   }
-  @include slotted("notice-message", "div") {
+  @include slotted("notice-message", "*") {
     @include font-size(-2);
   }
   ::slotted(calcite-link) {
@@ -35,10 +35,10 @@
 :host([scale="l"]) {
   --calcite-notice-spacing-token-small: #{$baseline/1.25};
   --calcite-notice-spacing-token-large: #{$baseline * 1.25};
-  @include slotted("notice-title", "div") {
+  @include slotted("notice-title", "*") {
     @include font-size(0);
   }
-  @include slotted("notice-message", "div") {
+  @include slotted("notice-message", "*") {
     @include font-size(-1);
   }
   ::slotted(calcite-link) {
@@ -97,19 +97,22 @@
   box-shadow: $shadow-1;
 }
 
-@include slotted("notice-title", "div") {
+@include slotted("notice-title", "*") {
   color: var(--calcite-ui-text-1);
+  margin: 0;
   font-weight: 500;
 }
 
-@include slotted("notice-message", "div") {
+@include slotted("notice-message", "*") {
   display: inline;
+  margin: 0;
+  font-weight: 400;
   margin-right: var(--calcite-notice-spacing-token-small);
   color: var(--calcite-ui-text-2);
 }
 
 :host([dir="rtl"]) {
-  @include slotted("notice-message", "div") {
+  @include slotted("notice-message", "*") {
     margin-right: 0;
     margin-left: var(--calcite-notice-spacing-token-small);
   }


### PR DESCRIPTION
Addresses part of https://github.com/Esri/calcite-components/issues/645 cc @FelFly 

We were only styling slotted `div` elements - this ensures any slotted element will have consistent styling.