### PR TITLE
Fixing `__spreadArrays` error in ES5 builds

### DIFF
--- a/src/components/calcite-stepper/calcite-stepper.tsx
+++ b/src/components/calcite-stepper/calcite-stepper.tsx
@@ -284,7 +284,7 @@ export class CalciteStepper {
       .sort((a, b) => a.position - b.position)
       .map((a) => a.item);
 
-    return [...new Set(items)];
+    return [...Array.from(new Set(items))];
   }
 
   private updateContent(content) {


### PR DESCRIPTION
Addresses #649 and #531 .