### PR TITLE
532/slider enhancements

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -48,8 +48,8 @@ describe("calcite-slider", () => {
       >
       </calcite-slider>
     `);
-    const maxButton = await page.find("calcite-slider >>> .thumb--max");
-    const minButton = await page.find("calcite-slider >>> .thumb--min");
+    const maxButton = await page.find("calcite-slider >>> .thumb--value");
+    const minButton = await page.find("calcite-slider >>> .thumb--minValue");
     expect(minButton).toEqualAttribute("role", "slider");
     expect(maxButton).toEqualAttribute("role", "slider");
     expect(minButton).toEqualAttribute("aria-label", "Min Label");
@@ -112,7 +112,7 @@ describe("calcite-slider", () => {
       </calcite-slider>
     `);
     const slider = await page.find("calcite-slider");
-    const handle = await page.find("calcite-slider >>> .thumb--max");
+    const handle = await page.find("calcite-slider >>> .thumb--value");
     await page.waitForChanges();
     let value = await slider.getProperty("value");
     expect(value).toBe(20);

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -119,6 +119,18 @@ $tick-height: 4px;
     transform: translate(-50%, -26px);
   }
 }
+:host([has-histogram][label-handles]) {
+  .thumb {
+    transform: translate(7px, -8px);
+    .handle__label {
+      margin-bottom: unset;
+      margin-top: 5px;
+    }
+  }
+  .thumb--min {
+    transform: translate(-50%, -8px);
+  }
+}
 :host([precise]) {
   .thumb {
     transform: translate(7px, -21px);
@@ -165,6 +177,18 @@ $tick-height: 4px;
   }
   .thumb--min {
     transform: translate(-50%, -2px);
+  }
+}
+:host([has-histogram][precise][label-handles][is-range][ticks]) {
+  .thumb {
+    transform: translate(50%, -3px);
+    .handle__label {
+      margin-bottom: unset;
+      margin-top: 5px;
+    }
+  }
+  .thumb--min {
+    transform: translate(-50%, -3px);
   }
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -76,9 +76,6 @@ $tick-height: 4px;
       height: 26px;
     }
   }
-  &.thumb--min .handle {
-    left: -7px;
-  }
 
   &:hover {
     .handle {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -105,6 +105,9 @@ $tick-height: 4px;
     right: -7px;
   }
 }
+.handle__label--visible-copy {
+  opacity: 0;
+}
 
 .thumb:focus,
 .thumb--active {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -63,7 +63,7 @@ $tick-height: 4px;
     width: $handle-size;
     box-sizing: border-box;
     border-radius: 100%;
-    background-color: var(--calcite-ui-foreground-1);
+    // background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
@@ -105,23 +105,19 @@ $tick-height: 4px;
   &--obscured-left {
     transform: translate(-7px, -50%);
   }
-}
-.handle__label--invisible-copy {
-  opacity: 0;
+  &--invisible-copy {
+    opacity: 0;
+  }
 }
 
 .thumb:focus,
 .thumb--active {
   z-index: 3;
   .handle {
-    background-color: var(--calcite-ui-blue-1);
+    // background-color: var(--calcite-ui-blue-1);
     border-color: var(--calcite-ui-blue-1);
     @include shadow(1, "press");
   }
-}
-
-.thumb--precise {
-  margin-top: -$thumb-size;
 }
 
 .thumb--precise:after {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -52,9 +52,10 @@ $tick-height: 4px;
   z-index: 2;
   outline: none;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid-gap: 5px;
+  justify-items: center;
+  transform: translate(7px, -8px);
 
   .handle {
     @include focus-style-base();
@@ -62,7 +63,7 @@ $tick-height: 4px;
     width: $handle-size;
     box-sizing: border-box;
     border-radius: 100%;
-    background-color: var(--calcite-ui-foreground-1);
+    // background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
@@ -85,6 +86,11 @@ $tick-height: 4px;
     outline-offset: 6px;
   }
 }
+:host([label-handles]) {
+  .thumb {
+    transform: translate(49%, -26px);
+  }
+}
 
 .handle__label {
   transition: transform 150ms;
@@ -93,10 +99,10 @@ $tick-height: 4px;
   line-height: 1;
   color: var(--calcite-ui-text-3);
   &--obscured-right {
-    transform: translate(calc(-100% + 7px), -50%);
+    transform: translateX(-25%);
   }
   &--obscured-left {
-    transform: translate(-7px, -50%);
+    transform: translateX(25%);
   }
   &--invisible-copy {
     opacity: 0;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -225,6 +225,7 @@ $tick-height: 4px;
   left: 0;
   margin: $thumb-size / 2 -3px;
   text-align: left;
+  transition: opacity 150ms;
 }
 
 .tick__label--max {
@@ -232,6 +233,7 @@ $tick-height: 4px;
   right: 0;
   margin: $thumb-size / 2 -3px;
   text-align: right;
+  transition: opacity 50ms;
 }
 
 .graph {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -59,10 +59,10 @@ $tick-height: 4px;
 
   .handle__label {
     transition: transform 150ms;
-    @include font-size(-3);
+    @include font-size(-4);
     font-weight: 500;
     line-height: 1;
-    color: var(--calcite-ui-text-3);
+    color: var(--calcite-ui-text-2);
     margin-bottom: 5px;
     &.copy {
       opacity: 0;
@@ -169,7 +169,7 @@ $tick-height: 4px;
 }
 :host([precise][label-handles]) {
   .thumb {
-    transform: translate(50%, -39px);
+    transform: translate(50%, -38px);
   }
   .thumb--min {
     transform: translate(-50%, -2px);
@@ -185,7 +185,7 @@ $tick-height: 4px;
 }
 :host([precise][ticks][label-handles]) {
   .thumb {
-    transform: translate(50%, -38px);
+    transform: translate(50%, -37px);
   }
   .thumb--min {
     transform: translate(-50%, -3px);
@@ -264,9 +264,9 @@ $tick-height: 4px;
 
 .tick__label {
   position: absolute;
-  @include font-size(-3);
+  @include font-size(-4);
   font-weight: 500;
-  color: var(--calcite-ui-text-3);
+  color: var(--calcite-ui-text-2);
   width: 4em;
   margin: $thumb-size / 2 -2em;
   text-align: center;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -110,10 +110,6 @@ $tick-height: 4px;
 }
 .thumb--min {
   transform: translate(-7px, -8px);
-  .handle__label {
-    margin-bottom: unset;
-    margin-top: 5px;
-  }
 }
 :host([label-handles]) {
   .thumb {
@@ -128,6 +124,18 @@ $tick-height: 4px;
     transform: translate(7px, -21px);
   }
   .thumb--min {
+    transform: translate(-7px, -2px);
+    .handle__label {
+      margin-bottom: unset;
+      margin-top: 5px;
+    }
+  }
+}
+:host([precise][ticks]) {
+  .thumb {
+    transform: translate(7px, -20px);
+  }
+  .thumb--min {
     transform: translate(-7px, -3px);
   }
 }
@@ -139,9 +147,12 @@ $tick-height: 4px;
     transform: translate(-50%, -2px);
   }
 }
-:host([precise][label-ticks]) {
-  .handle-extension {
-    height: 8px;
+:host([precise][ticks][label-handles]) {
+  .thumb {
+    transform: translate(50%, -38px);
+  }
+  .thumb--min {
+    transform: translate(-50%, -3px);
   }
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -120,36 +120,44 @@ $tick-height: 4px;
   }
 }
 
-.thumb--precise:after {
-  content: "";
-  display: block;
-  position: absolute;
-  top: $handle-size;
-  left: 50%;
-  width: 2px;
-  height: $thumb-padding;
-  background-color: var(--calcite-ui-text-3);
-  margin-left: -1px;
-  margin-top: $thumb-padding;
-  z-index: 1;
+.thumb--precise {
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: $handle-size;
+    left: 50%;
+    width: 2px;
+    height: $thumb-padding;
+    background-color: var(--calcite-ui-text-3);
+    margin-left: -1px;
+    z-index: 1;
+  }
+  &.thumb--min {
+    margin-top: 21px;
+    .handle__label {
+      bottom: unset;
+      top: $thumb-size;
+    }
+    &:after {
+      top: -14px;
+      margin-top: 0;
+    }
+  }
+  &.thumb--max {
+    .handle {
+      top: -5px;
+    }
+    &:after {
+      top: 2px;
+    }
+  }
 }
 
 .thumb:hover.thumb--precise:after,
 .thumb:focus.thumb--precise:after,
 .thumb--active.thumb--precise:after {
   background-color: var(--calcite-ui-blue-1);
-}
-
-.thumb--precise.thumb--min {
-  margin-top: 21px;
-  .handle__label {
-    bottom: unset;
-    top: $thumb-size;
-  }
-  &:after {
-    top: -14px;
-    margin-top: 0;
-  }
 }
 
 .track {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -52,9 +52,9 @@ $tick-height: 4px;
   z-index: 2;
   outline: none;
   padding: 0;
-  display: grid;
-  grid-gap: 5px;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   transform: translate(7px, -8px);
 
   .handle {
@@ -79,27 +79,39 @@ $tick-height: 4px;
     .handle {
       box-shadow: 0 0 0 3px var(--calcite-ui-blue-1) inset;
     }
+    .handle-extension {
+      background-color: var(--calcite-ui-blue-1);
+    }
   }
 
-  &:focus .handle {
-    @include focus-style-outset();
-    outline-offset: 6px;
+  &:focus {
+    .handle {
+      @include focus-style-outset();
+      outline-offset: 6px;
+    }
+    .handle-extension {
+      background-color: var(--calcite-ui-blue-1);
+    }
   }
 }
 :host([label-handles]) {
   .thumb {
-    transform: translate(49%, -26px);
+    transform: translate(50%, -26px);
   }
 }
 :host([precise]) {
   .thumb {
-    grid-gap: 0;
     transform: translate(7px, -21px);
   }
 }
 :host([precise][label-handles]) {
   .thumb {
-    transform: translate(49%, -34px);
+    transform: translate(50%, -39px);
+  }
+}
+:host([precise][label-ticks]) {
+  .handle-extension {
+    height: 8px;
   }
 }
 
@@ -109,6 +121,7 @@ $tick-height: 4px;
   font-weight: 500;
   line-height: 1;
   color: var(--calcite-ui-text-3);
+  margin-bottom: 5px;
   &.copy {
     opacity: 0;
     position: absolute;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -277,10 +277,8 @@ $tick-height: 4px;
   width: 2px;
   height: $tick-height;
   left: var(--calcite-ui-border-1-offset);
-  margin-left: -3px;
+  margin-left: -2px;
   border: 1px solid var(--calcite-ui-foreground-1);
-  border-right-width: 2px;
-  border-left-width: 2px;
   background-color: var(--calcite-ui-border-1);
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -141,16 +141,15 @@ $tick-height: 4px;
 }
 
 .thumb--precise.thumb--min {
-  margin-top: -$track-height;
+  margin-top: 21px;
   .handle__label {
     bottom: unset;
     top: $thumb-size;
   }
-}
-
-.thumb--precise.thumb--min:after {
-  top: 0;
-  margin-top: 0;
+  &:after {
+    top: -14px;
+    margin-top: 0;
+  }
 }
 
 .track {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -43,40 +43,49 @@ $tick-height: 4px;
   margin-bottom: $thumb-size + $thumb-padding;
 }
 
-// focus styles
-.thumb {
-  @include focus-style-base();
-  &:focus {
-    @include focus-style-outset();
-  }
-}
-
 .thumb {
   position: absolute;
-  height: $thumb-size;
-  width: $thumb-size;
-  margin: -15px;
+  top: -5px;
   box-sizing: border-box;
   border: none;
   background: transparent;
   cursor: pointer;
   font-family: inherit;
   z-index: 2;
-}
+  outline: none;
 
-.handle {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: $handle-size;
-  width: $handle-size;
-  margin: $thumb-padding;
-  box-sizing: border-box;
-  border-radius: 100%;
-  background-color: var(--calcite-ui-foreground-1);
-  border: 2px solid var(--calcite-ui-text-3);
-  transition: border 0.25s ease, background-color 0.25s ease,
-    box-shadow 0.25s ease;
+  .handle {
+    @include focus-style-base();
+    position: absolute;
+    top: 6px;
+    height: $handle-size;
+    width: $handle-size;
+    box-sizing: border-box;
+    border-radius: 100%;
+    background-color: var(--calcite-ui-foreground-1);
+    box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
+    transition: border 0.25s ease, background-color 0.25s ease,
+      box-shadow 0.25s ease;
+    &:after {
+      content: "";
+      position: absolute;
+      top: -6px;
+      left: -6px;
+      width: 26px;
+      height: 26px;
+    }
+  }
+
+  &:hover {
+    .handle {
+      box-shadow: 0 0 0 3px var(--calcite-ui-blue-1) inset;
+    }
+  }
+
+  &:focus .handle {
+    @include focus-style-outset();
+    outline-offset: 6px;
+  }
 }
 
 .handle__label {
@@ -90,12 +99,6 @@ $tick-height: 4px;
   line-height: 1;
   color: var(--calcite-ui-text-3);
   text-align: center;
-}
-
-.thumb:hover .handle {
-  border-width: 3px;
-  border-color: var(--calcite-ui-blue-1);
-  @include shadow(1, "hover");
 }
 
 .thumb:focus,

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -35,20 +35,20 @@ $tick-height: 4px;
  * with text elements to prevent overlap
  */
 :host([label-handles]),
-:host([precise]) {
+:host([precise]:not([precise="false"])) {
   margin-top: $handle-size + $thumb-padding;
 }
 
 :host([label-ticks]),
-:host([precise][is-range]) {
+:host([precise]:not([precise="false"])[is-range]) {
   margin-bottom: $handle-size + $thumb-padding;
 }
 
-:host([precise][label-handles]) {
+:host([precise]:not([precise="false"])[label-handles]) {
   margin-top: $thumb-size + $thumb-padding;
 }
 
-:host([precise][label-handles][is-range]) {
+:host([precise]:not([precise="false"])[label-handles][is-range]) {
   margin-bottom: $thumb-size + $thumb-padding;
 }
 
@@ -157,7 +157,7 @@ $tick-height: 4px;
     transform: translate(-50%, -8px);
   }
 }
-:host([precise]) {
+:host([precise]:not([precise="false"])) {
   .thumb {
     transform: translate(7px, -21px);
   }
@@ -169,7 +169,7 @@ $tick-height: 4px;
     }
   }
 }
-:host([has-histogram][precise]) {
+:host([has-histogram][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(7px, -2px);
   }
@@ -177,7 +177,7 @@ $tick-height: 4px;
     transform: translate(-50%, -2px);
   }
 }
-:host([precise][ticks]) {
+:host([ticks][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(7px, -20px);
   }
@@ -185,7 +185,7 @@ $tick-height: 4px;
     transform: translate(-7px, -3px);
   }
 }
-:host([has-histogram][precise][ticks]) {
+:host([has-histogram][ticks][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(7px, -3px);
   }
@@ -193,7 +193,7 @@ $tick-height: 4px;
     transform: translate(-50%, -3px);
   }
 }
-:host([precise][label-handles]) {
+:host([label-handles][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(50%, -38px);
   }
@@ -201,7 +201,7 @@ $tick-height: 4px;
     transform: translate(-50%, -2px);
   }
 }
-:host([has-histogram][precise][label-handles]) {
+:host([has-histogram][label-handles][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(50%, -2px);
   }
@@ -209,7 +209,7 @@ $tick-height: 4px;
     transform: translate(-50%, -2px);
   }
 }
-:host([precise][ticks][label-handles]) {
+:host([ticks][label-handles][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(50%, -37px);
   }
@@ -217,7 +217,7 @@ $tick-height: 4px;
     transform: translate(-50%, -3px);
   }
 }
-:host([has-histogram][precise][ticks][label-handles]) {
+:host([has-histogram][ticks][label-handles][precise]:not([precise="false"])) {
   .thumb {
     transform: translate(50%, -3px);
   }
@@ -318,7 +318,7 @@ $tick-height: 4px;
 :host([has-histogram][label-handles]) {
   @include histogramEndcaps();
 }
-:host([has-histogram][precise]) {
+:host([has-histogram][precise]:not([precise="false"])) {
   @include histogramEndcaps();
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -67,6 +67,8 @@ $tick-height: 4px;
   transform: translate(7px, -8px);
 
   .handle__label {
+    background-color: rgba(255, 0, 0, 0.3);
+    box-sizing: border-box;
     transition: transform 150ms;
     @include font-size(-4);
     font-weight: 500;
@@ -80,7 +82,20 @@ $tick-height: 4px;
       top: 0;
     }
     &--minValue.hyphen::after {
-      content: " \2014";
+      content: "\2014";
+      display: inline-block;
+      width: 1em;
+    }
+    &--minValue.hyphen.max-offset::after {
+      margin-right: 1em;
+    }
+    &--value.hyphen::before {
+      content: "\2014";
+      display: inline-block;
+      width: 1em;
+    }
+    &--value.hyphen.min-offset::before {
+      margin-left: 1em;
     }
   }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -52,13 +52,12 @@ $tick-height: 4px;
   z-index: 2;
   outline: none;
   padding: 0;
-  top: 0;
-  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   .handle {
     @include focus-style-base();
-    position: absolute;
-    transform: translate(-50%, -50%);
     height: $handle-size;
     width: $handle-size;
     box-sizing: border-box;
@@ -67,14 +66,12 @@ $tick-height: 4px;
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
-    &:after {
-      content: "";
-      position: absolute;
-      top: -6px;
-      left: -6px;
-      width: 26px;
-      height: 26px;
-    }
+  }
+
+  .handle-extension {
+    width: 2px;
+    height: $thumb-padding;
+    background-color: var(--calcite-ui-text-3);
   }
 
   &:hover {
@@ -90,10 +87,6 @@ $tick-height: 4px;
 }
 
 .handle__label {
-  position: absolute;
-  bottom: 0;
-  top: -5px;
-  transform: translate(-50%, -50%);
   transition: transform 150ms;
   @include font-size(-3);
   font-weight: 500;
@@ -107,6 +100,8 @@ $tick-height: 4px;
   }
   &--invisible-copy {
     opacity: 0;
+    position: absolute;
+    top: 0;
   }
 }
 
@@ -131,17 +126,6 @@ $tick-height: 4px;
     background-color: var(--calcite-ui-text-3);
     margin-left: -1px;
     z-index: 1;
-  }
-  &.thumb--min {
-    margin-top: 21px;
-    .handle__label {
-      bottom: unset;
-      top: 19px;
-    }
-    &:after {
-      top: -14px;
-      margin-top: 0;
-    }
   }
   &.thumb--max {
     .handle__label {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -67,8 +67,6 @@ $tick-height: 4px;
   transform: translate(7px, -8px);
 
   .handle__label {
-    background-color: rgba(255, 0, 0, 0.3);
-    box-sizing: border-box;
     transition: transform 150ms;
     @include font-size(-4);
     font-weight: 500;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -52,12 +52,13 @@ $tick-height: 4px;
   z-index: 2;
   outline: none;
   padding: 0;
+  top: 0;
+  bottom: 0;
 
   .handle {
     @include focus-style-base();
     position: absolute;
-    top: -8px;
-    left: -7px;
+    transform: translate(-50%, -50%);
     height: $handle-size;
     width: $handle-size;
     box-sizing: border-box;
@@ -93,19 +94,22 @@ $tick-height: 4px;
 
 .handle__label {
   position: absolute;
-  bottom: 14px;
+  bottom: 0;
+  top: -5px;
+  transform: translate(-50%, -50%);
+  transition: transform 150ms;
   @include font-size(-3);
   font-weight: 500;
   line-height: 1;
   color: var(--calcite-ui-text-3);
-  &--visible {
-    left: 0;
+  &--obscured-right {
+    transform: translate(calc(-100% + 7px), -50%);
   }
-  &--obscured {
-    right: -7px;
+  &--obscured-left {
+    transform: translate(-7px, -50%);
   }
 }
-.handle__label--visible-copy {
+.handle__label--invisible-copy {
   opacity: 0;
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -57,13 +57,27 @@ $tick-height: 4px;
   align-items: center;
   transform: translate(7px, -8px);
 
+  .handle__label {
+    transition: transform 150ms;
+    @include font-size(-3);
+    font-weight: 500;
+    line-height: 1;
+    color: var(--calcite-ui-text-3);
+    margin-bottom: 5px;
+    &.copy {
+      opacity: 0;
+      position: absolute;
+      top: 0;
+    }
+  }
+
   .handle {
     @include focus-style-base();
     height: $handle-size;
     width: $handle-size;
     box-sizing: border-box;
     border-radius: 100%;
-    // background-color: var(--calcite-ui-foreground-1);
+    background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
@@ -94,38 +108,40 @@ $tick-height: 4px;
     }
   }
 }
+.thumb--min {
+  transform: translate(-7px, -8px);
+  .handle__label {
+    margin-bottom: unset;
+    margin-top: 5px;
+  }
+}
 :host([label-handles]) {
   .thumb {
     transform: translate(50%, -26px);
+  }
+  .thumb--min {
+    transform: translate(-50%, -26px);
   }
 }
 :host([precise]) {
   .thumb {
     transform: translate(7px, -21px);
   }
+  .thumb--min {
+    transform: translate(-7px, -3px);
+  }
 }
 :host([precise][label-handles]) {
   .thumb {
     transform: translate(50%, -39px);
   }
+  .thumb--min {
+    transform: translate(-50%, -2px);
+  }
 }
 :host([precise][label-ticks]) {
   .handle-extension {
     height: 8px;
-  }
-}
-
-.handle__label {
-  transition: transform 150ms;
-  @include font-size(-3);
-  font-weight: 500;
-  line-height: 1;
-  color: var(--calcite-ui-text-3);
-  margin-bottom: 5px;
-  &.copy {
-    opacity: 0;
-    position: absolute;
-    top: 0;
   }
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -127,7 +127,7 @@ $tick-height: 4px;
   &:focus {
     .handle {
       @include focus-style-outset();
-      outline-offset: 6px;
+      outline-offset: 2px;
     }
     .handle-extension {
       background-color: var(--calcite-ui-blue-1);

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -199,30 +199,6 @@ $tick-height: 4px;
     transform: translate(-50%, -3px);
   }
 }
-:host([has-histogram][precise][label-handles][is-range]) {
-  .thumb {
-    transform: translate(50%, -2px);
-    .handle__label {
-      margin-bottom: unset;
-      margin-top: 5px;
-    }
-  }
-  .thumb--min {
-    transform: translate(-50%, -2px);
-  }
-}
-:host([has-histogram][precise][label-handles][is-range][ticks]) {
-  .thumb {
-    transform: translate(50%, -3px);
-    .handle__label {
-      margin-bottom: unset;
-      margin-top: 5px;
-    }
-  }
-  .thumb--min {
-    transform: translate(-50%, -3px);
-  }
-}
 
 .thumb:focus,
 .thumb--active {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -155,6 +155,18 @@ $tick-height: 4px;
     transform: translate(-50%, -3px);
   }
 }
+:host([has-histogram][precise][label-handles][is-range]) {
+  .thumb {
+    transform: translate(50%, -2px);
+    .handle__label {
+      margin-bottom: unset;
+      margin-top: 5px;
+    }
+  }
+  .thumb--min {
+    transform: translate(-50%, -2px);
+  }
+}
 
 .thumb:focus,
 .thumb--active {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -63,7 +63,7 @@ $tick-height: 4px;
     width: $handle-size;
     box-sizing: border-box;
     border-radius: 100%;
-    // background-color: var(--calcite-ui-foreground-1);
+    background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
@@ -114,8 +114,7 @@ $tick-height: 4px;
 .thumb--active {
   z-index: 3;
   .handle {
-    // background-color: var(--calcite-ui-blue-1);
-    border-color: var(--calcite-ui-blue-1);
+    background-color: var(--calcite-ui-blue-1);
     @include shadow(1, "press");
   }
 }

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -45,18 +45,19 @@ $tick-height: 4px;
 
 .thumb {
   position: absolute;
-  top: -5px;
   border: none;
   background: transparent;
   cursor: pointer;
   font-family: inherit;
   z-index: 2;
   outline: none;
+  padding: 0;
 
   .handle {
     @include focus-style-base();
     position: absolute;
-    top: 6px;
+    top: -8px;
+    left: -7px;
     height: $handle-size;
     width: $handle-size;
     box-sizing: border-box;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -143,12 +143,28 @@ $tick-height: 4px;
     }
   }
 }
+:host([has-histogram][precise]) {
+  .thumb {
+    transform: translate(7px, -2px);
+  }
+  .thumb--min {
+    transform: translate(-50%, -2px);
+  }
+}
 :host([precise][ticks]) {
   .thumb {
     transform: translate(7px, -20px);
   }
   .thumb--min {
     transform: translate(-7px, -3px);
+  }
+}
+:host([has-histogram][precise][ticks]) {
+  .thumb {
+    transform: translate(7px, -3px);
+  }
+  .thumb--min {
+    transform: translate(-50%, -3px);
   }
 }
 :host([precise][label-handles]) {
@@ -159,9 +175,25 @@ $tick-height: 4px;
     transform: translate(-50%, -2px);
   }
 }
+:host([has-histogram][precise][label-handles]) {
+  .thumb {
+    transform: translate(7px, -2px);
+  }
+  .thumb--min {
+    transform: translate(-50%, -2px);
+  }
+}
 :host([precise][ticks][label-handles]) {
   .thumb {
     transform: translate(50%, -38px);
+  }
+  .thumb--min {
+    transform: translate(-50%, -3px);
+  }
+}
+:host([has-histogram][precise][ticks][label-handles]) {
+  .thumb {
+    transform: translate(50%, -3px);
   }
   .thumb--min {
     transform: translate(-50%, -3px);

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -79,6 +79,9 @@ $tick-height: 4px;
       position: absolute;
       top: 0;
     }
+    &--minValue.hyphen::after {
+      content: " \2014";
+    }
   }
 
   .handle {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -117,14 +117,14 @@ $tick-height: 4px;
     }
   }
 }
-.thumb--min {
+.thumb--minValue {
   transform: translate(-7px, -8px);
 }
 :host([label-handles]) {
   .thumb {
     transform: translate(50%, -25px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -25px);
   }
 }
@@ -136,7 +136,7 @@ $tick-height: 4px;
       margin-top: 5px;
     }
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -8px);
   }
 }
@@ -144,7 +144,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(7px, -21px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-7px, -2px);
     .handle__label {
       margin-bottom: unset;
@@ -156,7 +156,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(7px, -2px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -2px);
   }
 }
@@ -164,7 +164,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(7px, -20px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-7px, -3px);
   }
 }
@@ -172,7 +172,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(7px, -3px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -3px);
   }
 }
@@ -180,7 +180,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(50%, -38px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -2px);
   }
 }
@@ -188,7 +188,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(50%, -2px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -2px);
   }
 }
@@ -196,7 +196,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(50%, -37px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -3px);
   }
 }
@@ -204,7 +204,7 @@ $tick-height: 4px;
   .thumb {
     transform: translate(50%, -3px);
   }
-  .thumb--min {
+  .thumb--minValue {
     transform: translate(-50%, -3px);
   }
 }

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -77,7 +77,7 @@ $tick-height: 4px;
     width: $handle-size;
     box-sizing: border-box;
     border-radius: 100%;
-    background-color: var(--calcite-ui-foreground-1);
+    // background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
@@ -113,15 +113,15 @@ $tick-height: 4px;
 }
 :host([label-handles]) {
   .thumb {
-    transform: translate(50%, -26px);
+    transform: translate(50%, -25px);
   }
   .thumb--min {
-    transform: translate(-50%, -26px);
+    transform: translate(-50%, -25px);
   }
 }
 :host([has-histogram][label-handles]) {
   .thumb {
-    transform: translate(7px, -8px);
+    transform: translate(50%, -8px);
     .handle__label {
       margin-bottom: unset;
       margin-top: 5px;
@@ -177,7 +177,7 @@ $tick-height: 4px;
 }
 :host([has-histogram][precise][label-handles]) {
   .thumb {
-    transform: translate(7px, -2px);
+    transform: translate(50%, -2px);
   }
   .thumb--min {
     transform: translate(-50%, -2px);
@@ -204,7 +204,7 @@ $tick-height: 4px;
 .thumb--active {
   z-index: 3;
   .handle {
-    background-color: var(--calcite-ui-blue-1);
+    // background-color: var(--calcite-ui-blue-1);
     @include shadow(1, "press");
   }
 }

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -93,15 +93,17 @@ $tick-height: 4px;
 
 .handle__label {
   position: absolute;
-  left: 0;
-  bottom: $thumb-size;
-  width: $thumb-size;
-  height: 0.75em;
+  bottom: 14px;
   @include font-size(-3);
   font-weight: 500;
   line-height: 1;
   color: var(--calcite-ui-text-3);
-  text-align: center;
+  &--visible {
+    left: 0;
+  }
+  &--obscured {
+    right: -7px;
+  }
 }
 
 .thumb:focus,

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -289,6 +289,13 @@ $tick-height: 4px;
   transition: opacity 50ms;
 }
 
+:host([has-histogram]) {
+  .tick__label--min,
+  .tick__label--max {
+    margin: 6px -3px;
+  }
+}
+
 .graph {
   width: 100%;
   height: 48px;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -46,7 +46,6 @@ $tick-height: 4px;
 .thumb {
   position: absolute;
   top: -5px;
-  box-sizing: border-box;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -74,6 +73,9 @@ $tick-height: 4px;
       width: 26px;
       height: 26px;
     }
+  }
+  &.thumb--min .handle {
+    left: -7px;
   }
 
   &:hover {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -73,7 +73,8 @@ $tick-height: 4px;
     line-height: 1;
     color: var(--calcite-ui-text-2);
     margin-bottom: 5px;
-    &.copy {
+    &.static,
+    &.transformed {
       opacity: 0;
       position: absolute;
       top: 0;

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -293,6 +293,8 @@ $tick-height: 4px;
   .tick__label--min,
   .tick__label--max {
     margin: 6px -3px;
+    font-weight: 300;
+    color: var(--calcite-ui-text-3);
   }
 }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -84,16 +84,10 @@ $tick-height: 4px;
       display: inline-block;
       width: 1em;
     }
-    &--minValue.hyphen.max-offset::after {
-      margin-right: 1em;
-    }
     &--value.hyphen::before {
       content: "\2014";
       display: inline-block;
       width: 1em;
-    }
-    &--value.hyphen.min-offset::before {
-      margin-left: 1em;
     }
   }
 

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -137,7 +137,7 @@ $tick-height: 4px;
     margin-top: 21px;
     .handle__label {
       bottom: unset;
-      top: $thumb-size;
+      top: 19px;
     }
     &:after {
       top: -14px;
@@ -145,6 +145,9 @@ $tick-height: 4px;
     }
   }
   &.thumb--max {
+    .handle__label {
+      top: -14px;
+    }
     .handle {
       top: -5px;
     }

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -9,6 +9,15 @@ $thumb-padding: ($thumb-size - $handle-size) / 2;
 $track-height: 2px;
 $tick-height: 4px;
 
+@mixin histogramEndcaps() {
+  .tick__label--min,
+  .tick__label--max {
+    margin: 6px -3px;
+    font-weight: 300;
+    color: var(--calcite-ui-text-3);
+  }
+}
+
 :host {
   display: block;
   padding: $handle-size / 2 0;
@@ -77,7 +86,7 @@ $tick-height: 4px;
     width: $handle-size;
     box-sizing: border-box;
     border-radius: 100%;
-    // background-color: var(--calcite-ui-foreground-1);
+    background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
     transition: border 0.25s ease, background-color 0.25s ease,
       box-shadow 0.25s ease;
@@ -204,7 +213,7 @@ $tick-height: 4px;
 .thumb--active {
   z-index: 3;
   .handle {
-    // background-color: var(--calcite-ui-blue-1);
+    background-color: var(--calcite-ui-blue-1);
     @include shadow(1, "press");
   }
 }
@@ -289,13 +298,11 @@ $tick-height: 4px;
   transition: opacity 50ms;
 }
 
-:host([has-histogram]) {
-  .tick__label--min,
-  .tick__label--max {
-    margin: 6px -3px;
-    font-weight: 300;
-    color: var(--calcite-ui-text-3);
-  }
+:host([has-histogram][label-handles]) {
+  @include histogramEndcaps();
+}
+:host([has-histogram][precise]) {
+  @include histogramEndcaps();
 }
 
 .graph {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -91,6 +91,17 @@ $tick-height: 4px;
     transform: translate(49%, -26px);
   }
 }
+:host([precise]) {
+  .thumb {
+    grid-gap: 0;
+    transform: translate(7px, -21px);
+  }
+}
+:host([precise][label-handles]) {
+  .thumb {
+    transform: translate(49%, -34px);
+  }
+}
 
 .handle__label {
   transition: transform 150ms;
@@ -98,13 +109,7 @@ $tick-height: 4px;
   font-weight: 500;
   line-height: 1;
   color: var(--calcite-ui-text-3);
-  &--obscured-right {
-    transform: translateX(-25%);
-  }
-  &--obscured-left {
-    transform: translateX(25%);
-  }
-  &--invisible-copy {
+  &.copy {
     opacity: 0;
     position: absolute;
     top: 0;
@@ -117,32 +122,6 @@ $tick-height: 4px;
   .handle {
     background-color: var(--calcite-ui-blue-1);
     @include shadow(1, "press");
-  }
-}
-
-.thumb--precise {
-  &:after {
-    content: "";
-    display: block;
-    position: absolute;
-    top: $handle-size;
-    left: 50%;
-    width: 2px;
-    height: $thumb-padding;
-    background-color: var(--calcite-ui-text-3);
-    margin-left: -1px;
-    z-index: 1;
-  }
-  &.thumb--max {
-    .handle__label {
-      top: -14px;
-    }
-    .handle {
-      top: -5px;
-    }
-    &:after {
-      top: 2px;
-    }
   }
 }
 

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -16,6 +16,8 @@ import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
 import { DataSeries } from "../../interfaces/Graph";
 
+const Fragment = (props, children) => [...children];
+
 type activeSliderProperty = "minValue" | "maxValue" | "value" | "minMaxValue";
 type OutOfViewport = "left" | "right" | "none";
 
@@ -122,6 +124,270 @@ export class CalciteSlider {
     const left = `${this.getUnitInterval(min) * 100}%`;
     const right = `${100 - this.getUnitInterval(max) * 100}%`;
 
+    const minLabel = (
+      <Fragment>
+        <span
+          class={{
+            handle__label: true,
+            "handle__label--obscured-right":
+              this.minValueLabelObscured === "right" && true,
+            "handle__label--obscured-left":
+              this.minValueLabelObscured === "left" && true,
+          }}
+          aria-hidden="true"
+        >
+          {this.minValue}
+        </span>
+        <span
+          id="handle__label--minValue"
+          class="handle__label handle__label--invisible-copy"
+          aria-hidden="true"
+        >
+          {this.minValue}
+        </span>
+      </Fragment>
+    );
+
+    const label = (
+      <Fragment>
+        <span
+          class={{
+            handle__label: true,
+            "handle__label--obscured-right":
+              this.valueLabelObscured === "right" && true,
+            "handle__label--obscured-left":
+              this.valueLabelObscured === "left" && true,
+          }}
+          aria-hidden="true"
+        >
+          {this[maxProp]}
+        </span>
+        <span
+          id="handle__label--value"
+          class="handle__label handle__label--invisible-copy"
+          aria-hidden="true"
+        >
+          {this[maxProp]}
+        </span>
+      </Fragment>
+    );
+
+    const handle = (
+      <button
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.isRange ? this.maxLabel : this.minLabel}
+        aria-valuenow={this[maxProp]}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ right }}
+        class={{
+          thumb: true,
+          "thumb--max": true,
+          "thumb--active":
+            this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
+        }}
+      >
+        <div class="handle"></div>
+      </button>
+    );
+
+    const labeledHandle = (
+      <button
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.isRange ? this.maxLabel : this.minLabel}
+        aria-valuenow={this[maxProp]}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ right }}
+        class={{
+          thumb: true,
+          "thumb--max": true,
+          "thumb--active":
+            this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
+        }}
+      >
+        {label}
+        <div class="handle"></div>
+      </button>
+    );
+
+    const preciseHandle = (
+      <button
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.isRange ? this.maxLabel : this.minLabel}
+        aria-valuenow={this[maxProp]}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ right }}
+        class={{
+          thumb: true,
+          "thumb--max": true,
+          "thumb--active":
+            this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
+          "thumb--precise": true,
+        }}
+      >
+        <div class="handle"></div>
+        <div class="handle-extension"></div>
+      </button>
+    );
+
+    const labeledPreciseHandle = (
+      <button
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.isRange ? this.maxLabel : this.minLabel}
+        aria-valuenow={this[maxProp]}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ right }}
+        class={{
+          thumb: true,
+          "thumb--max": true,
+          "thumb--active":
+            this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
+          "thumb--precise": true,
+        }}
+      >
+        {label}
+        <div class="handle"></div>
+        <div class="handle-extension"></div>
+      </button>
+    );
+
+    const minHandle = (
+      <button
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.minLabel}
+        aria-valuenow={this.minValue}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ left }}
+        class={{
+          thumb: true,
+          "thumb--min": true,
+          "thumb--active": this.dragProp === "minValue",
+        }}
+      >
+        <div class="handle"></div>
+      </button>
+    );
+
+    const minLabeledHandle = (
+      <button
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.minLabel}
+        aria-valuenow={this.minValue}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ left }}
+        class={{
+          thumb: true,
+          "thumb--min": true,
+          "thumb--active": this.dragProp === "minValue",
+        }}
+      >
+        {minLabel}
+        <div class="handle"></div>
+      </button>
+    );
+
+    const minPreciseHandle = (
+      <button
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.minLabel}
+        aria-valuenow={this.minValue}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ left }}
+        class={{
+          thumb: true,
+          "thumb--min": true,
+          "thumb--active": this.dragProp === "minValue",
+          "thumb--precise": true,
+        }}
+      >
+        <div class="handle-extension"></div>
+        <div class="handle"></div>
+      </button>
+    );
+
+    const minLabeledPreciseHandle = (
+      <button
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.minLabel}
+        aria-valuenow={this.minValue}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ left }}
+        class={{
+          thumb: true,
+          "thumb--min": true,
+          "thumb--active": this.dragProp === "minValue",
+          "thumb--precise": true,
+        }}
+      >
+        <div class="handle-extension"></div>
+        <div class="handle"></div>
+        {label}
+      </button>
+    );
+
     return (
       <Host id={id} is-range={this.isRange}>
         {this.renderGraph()}
@@ -148,111 +414,21 @@ export class CalciteSlider {
             ))}
           </div>
         </div>
-        {this.isRange ? (
-          <button
-            ref={(el) => (this.minHandle = el as HTMLButtonElement)}
-            onFocus={() => (this.activeProp = "minValue")}
-            onBlur={() => (this.activeProp = null)}
-            onMouseDown={() => this.dragStart("minValue")}
-            onTouchStart={(e) => this.dragStart("minValue", e)}
-            role="slider"
-            aria-orientation="horizontal"
-            aria-label={this.minLabel}
-            aria-valuenow={this.minValue}
-            aria-valuemin={this.min}
-            aria-valuemax={this.max}
-            disabled={this.disabled}
-            style={{ left }}
-            class={{
-              thumb: true,
-              "thumb--min": true,
-              "thumb--active": this.dragProp === "minValue",
-              "thumb--precise": this.precise,
-            }}
-          >
-            {this.labelHandles ? (
-              <span
-                class={{
-                  handle__label: true,
-                  "handle__label--obscured-right":
-                    this.minValueLabelObscured === "right" && true,
-                  "handle__label--obscured-left":
-                    this.minValueLabelObscured === "left" && true,
-                }}
-                aria-hidden="true"
-              >
-                {this.minValue}
-              </span>
-            ) : (
-              ""
-            )}
-            {this.labelHandles ? (
-              <span
-                id="handle__label--minValue"
-                class="handle__label handle__label--invisible-copy"
-                aria-hidden="true"
-              >
-                {this.minValue}
-              </span>
-            ) : (
-              ""
-            )}
-            <span class="handle"></span>
-          </button>
-        ) : (
-          ""
-        )}
-        <button
-          ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-          onFocus={() => (this.activeProp = maxProp)}
-          onBlur={() => (this.activeProp = null)}
-          onMouseDown={() => this.dragStart(maxProp)}
-          onTouchStart={(e) => this.dragStart(maxProp, e)}
-          role="slider"
-          aria-orientation="horizontal"
-          aria-label={this.isRange ? this.maxLabel : this.minLabel}
-          aria-valuenow={this[maxProp]}
-          aria-valuemin={this.min}
-          aria-valuemax={this.max}
-          disabled={this.disabled}
-          style={{ right }}
-          class={{
-            thumb: true,
-            "thumb--max": true,
-            "thumb--active":
-              this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
-            "thumb--precise": this.precise,
-          }}
-        >
-          {this.labelHandles ? (
-            <span
-              class={{
-                handle__label: true,
-                "handle__label--obscured-right":
-                  this.valueLabelObscured === "right" && true,
-                "handle__label--obscured-left":
-                  this.valueLabelObscured === "left" && true,
-              }}
-              aria-hidden="true"
-            >
-              {this[maxProp]}
-            </span>
-          ) : (
-            ""
-          )}
-          {this.labelHandles ? (
-            <span
-              id="handle__label--value"
-              class="handle__label handle__label--invisible-copy"
-              aria-hidden="true"
-            >
-              {this[maxProp]}
-            </span>
-          ) : (
-            ""
-          )}
-          <span class="handle"></span>
-        </button>
+        {!this.precise && !this.labelHandles && this.isRange ? minHandle : null}
+        {!this.precise && this.labelHandles && this.isRange
+          ? minLabeledHandle
+          : null}
+        {this.precise && !this.labelHandles && this.isRange
+          ? minPreciseHandle
+          : null}
+        {this.precise && this.labelHandles && this.isRange
+          ? minLabeledPreciseHandle
+          : null}
+
+        {!this.precise && !this.labelHandles ? handle : null}
+        {!this.precise && this.labelHandles ? labeledHandle : null}
+        {this.precise && !this.labelHandles ? preciseHandle : null}
+        {this.precise && this.labelHandles ? labeledPreciseHandle : null}
       </Host>
     );
   }
@@ -617,21 +793,21 @@ export class CalciteSlider {
    * @param $div2
    * @returns {boolean}
    */
-  private isColliding(div1, div2) {
-    const d1_height = div1.offsetHeight;
-    const d1_width = div1.offsetWidth;
-    const d1_distance_from_top = div1.offsetTop + d1_height;
-    const d1_distance_from_left = div1.offsetLeft + d1_width;
+  private isColliding(element1, element2): boolean {
+    const element1_height = element1.offsetHeight;
+    const element1_width = element1.offsetWidth;
+    const element1_distance_from_top = element1.offsetTop + element1_height;
+    const element1_distance_from_left = element1.offsetLeft + element1_width;
 
-    const d2_height = div2.offsetHeight;
-    const d2_width = div2.offsetWidth;
-    const d2_distance_from_top = div2.offsetTop + d2_height;
-    const d2_distance_from_left = div2.offsetLeft + d2_width;
+    const element2_height = element2.offsetHeight;
+    const element2_width = element2.offsetWidth;
+    const element2_distance_from_top = element2.offsetTop + element2_height;
+    const element2_distance_from_left = element2.offsetLeft + element2_width;
     const not_colliding =
-      d1_distance_from_top < div2.offsetTop ||
-      div1.offsetTop > d2_distance_from_top ||
-      d1_distance_from_left < div2.offsetTop ||
-      div1.offsetLeft > d2_distance_from_left;
+      element1_distance_from_top < element2.offsetTop ||
+      element1.offsetTop > element2_distance_from_top ||
+      element1_distance_from_left < element2.offsetTop ||
+      element1.offsetLeft > element2_distance_from_left;
 
     return !not_colliding;
   }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -16,8 +16,6 @@ import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
 import { DataSeries } from "../../interfaces/Graph";
 
-const Fragment = (props, children) => [...children];
-
 type activeSliderProperty = "minValue" | "maxValue" | "value" | "minMaxValue";
 
 @Component({
@@ -103,14 +101,11 @@ export class CalciteSlider {
         const minValueButton = this.el.shadowRoot.querySelector(
           "button.thumb--min"
         );
-        console.log(minValueButton);
         const minTickLabel = this.el.shadowRoot.querySelector(
           ".tick__label--min"
         );
-        console.log(minTickLabel);
         const isMinColliding = this.isColliding(minValueButton, minTickLabel);
         this.minTickLabelObscured = isMinColliding ? true : false;
-        console.log(`isMinColliding:${isMinColliding}`);
       }
     }
   }
@@ -122,34 +117,6 @@ export class CalciteSlider {
     const maxProp = this.isRange ? "maxValue" : "value";
     const left = `${this.getUnitInterval(min) * 100}%`;
     const right = `${100 - this.getUnitInterval(max) * 100}%`;
-
-    const minLabel = (
-      <Fragment>
-        <span class="handle__label handle__label--minValue" aria-hidden="true">
-          {this.minValue}
-        </span>
-        <span
-          class="handle__label handle__label--minValue copy"
-          aria-hidden="true"
-        >
-          {this.minValue}
-        </span>
-      </Fragment>
-    );
-
-    const label = (
-      <Fragment>
-        <span class="handle__label handle__label--value" aria-hidden="true">
-          {this[maxProp]}
-        </span>
-        <span
-          class="handle__label handle__label--value copy"
-          aria-hidden="true"
-        >
-          {this[maxProp]}
-        </span>
-      </Fragment>
-    );
 
     const handle = (
       <button
@@ -199,7 +166,15 @@ export class CalciteSlider {
             this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
         }}
       >
-        {label}
+        <span class="handle__label handle__label--value" aria-hidden="true">
+          {this[maxProp]}
+        </span>
+        <span
+          class="handle__label handle__label--value copy"
+          aria-hidden="true"
+        >
+          {this[maxProp]}
+        </span>
         <div class="handle"></div>
       </button>
     );
@@ -255,7 +230,15 @@ export class CalciteSlider {
           "thumb--precise": true,
         }}
       >
-        {label}
+        <span class="handle__label handle__label--value" aria-hidden="true">
+          {this[maxProp]}
+        </span>
+        <span
+          class="handle__label handle__label--value copy"
+          aria-hidden="true"
+        >
+          {this[maxProp]}
+        </span>
         <div class="handle"></div>
         <div class="handle-extension"></div>
       </button>
@@ -307,7 +290,15 @@ export class CalciteSlider {
           "thumb--active": this.dragProp === "minValue",
         }}
       >
-        {minLabel}
+        <span class="handle__label handle__label--minValue" aria-hidden="true">
+          {this.minValue}
+        </span>
+        <span
+          class="handle__label handle__label--minValue copy"
+          aria-hidden="true"
+        >
+          {this.minValue}
+        </span>
         <div class="handle"></div>
       </button>
     );
@@ -363,7 +354,15 @@ export class CalciteSlider {
       >
         <div class="handle-extension"></div>
         <div class="handle"></div>
-        {minLabel}
+        <span class="handle__label handle__label--minValue" aria-hidden="true">
+          {this.minValue}
+        </span>
+        <span
+          class="handle__label handle__label--minValue copy"
+          aria-hidden="true"
+        >
+          {this.minValue}
+        </span>
       </button>
     );
 

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -363,7 +363,7 @@ export class CalciteSlider {
       >
         <div class="handle-extension"></div>
         <div class="handle"></div>
-        {label}
+        {minLabel}
       </button>
     );
 

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -198,35 +198,33 @@ export class CalciteSlider {
             "thumb--precise": this.precise,
           }}
         >
+          {this.labelHandles ? (
+            <span
+              class={{
+                handle__label: true,
+                "handle__label--obscured-right":
+                  this.handleLabelObscured === "right" && true,
+                "handle__label--obscured-left":
+                  this.handleLabelObscured === "left" && true,
+              }}
+              aria-hidden="true"
+            >
+              {this[maxProp]}
+            </span>
+          ) : (
+            ""
+          )}
+          {this.labelHandles ? (
+            <span
+              class="handle__label handle__label--invisible-copy"
+              aria-hidden="true"
+            >
+              {this[maxProp]}
+            </span>
+          ) : (
+            ""
+          )}
           <span class="handle"></span>
-          {this.labelHandles ? (
-            <span
-              class={{
-                handle__label: true,
-                "handle__label--visible": !this.handleLabelObscured,
-                "handle__label--obscured": this.handleLabelObscured,
-              }}
-              aria-hidden="true"
-            >
-              {this[maxProp]}
-            </span>
-          ) : (
-            ""
-          )}
-          {this.labelHandles ? (
-            <span
-              class={{
-                handle__label: true,
-                "handle__label--visible": true,
-                "handle__label--visible-copy": true,
-              }}
-              aria-hidden="true"
-            >
-              {this[maxProp]}
-            </span>
-          ) : (
-            ""
-          )}
         </button>
       </Host>
     );
@@ -378,7 +376,7 @@ export class CalciteSlider {
   /** @internal */
   @State() private maxValueDragRange: number = null;
   /** @internal */
-  @State() private handleLabelObscured: boolean = false;
+  @State() private handleLabelObscured: "left" | "right" | "none" = "none";
 
   //--------------------------------------------------------------------------
   //
@@ -388,12 +386,10 @@ export class CalciteSlider {
   private isHandleLabelObscured() {
     if (this.labelHandles) {
       const element = this.el.shadowRoot.querySelector(
-        ".handle__label--visible-copy"
+        ".handle__label--invisible-copy"
       );
       if (element) {
-        this.handleLabelObscured = this.isOutOfViewport(element).any
-          ? true
-          : false;
+        this.handleLabelObscured = this.isOutOfViewport(element);
       }
     }
   }
@@ -520,31 +516,23 @@ export class CalciteSlider {
     const range = this.max - this.min;
     return (num - this.min) / range;
   }
-  /*!
-   * Check if an element is out of the viewport
-   * (c) 2018 Chris Ferdinandi, MIT License, https://gomakethings.com
+  /**
+   * Checks if an element is out of the viewport on either the left or right side
    * @link https://gomakethings.com/how-to-check-if-any-part-of-an-element-is-out-of-the-viewport-with-vanilla-js/
-   * @param  {Node}  elem The element to check
-   * @return {Object}     A set of booleans for each side of the element
+   * @return {string} "left", "right" or "none"
    * @internal
    */
   private isOutOfViewport(elem: any) {
-    // Get element's bounding
-    var bounding = elem.getBoundingClientRect();
-
-    // Check if it's out of the viewport on each side
-    var out = {} as Record<string, any>;
-    out.top = bounding.top < 0;
-    out.left = bounding.left < 0;
-    out.bottom =
-      bounding.bottom >
-      (window.innerHeight || document.documentElement.clientHeight);
-    out.right =
+    const bounding = elem.getBoundingClientRect();
+    if (bounding.left < 0) {
+      return "left";
+    }
+    if (
       bounding.right >
-      (window.innerWidth || document.documentElement.clientWidth);
-    out.any = out.top || out.left || out.bottom || out.right;
-    out.all = out.top && out.left && out.bottom && out.right;
-
-    return out;
+      (window.innerWidth || document.documentElement.clientWidth)
+    ) {
+      return "right";
+    }
+    return "none";
   }
 }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -92,6 +92,10 @@ export class CalciteSlider {
     this.calciteSliderUpdate.emit();
   }
 
+  componentDidRender() {
+    this.isHandleLabelObscured();
+  }
+
   render() {
     const id = this.el.id || this.guid;
     const min = this.minValue || this.min;
@@ -99,10 +103,6 @@ export class CalciteSlider {
     const maxProp = this.isRange ? "maxValue" : "value";
     const left = `${this.getUnitInterval(min) * 100}%`;
     const right = `${100 - this.getUnitInterval(max) * 100}%`;
-
-    console.clear();
-    const isLabelOutOfViewport = this.handleLabelOutOfViewport();
-    console.log(`render ${isLabelOutOfViewport}`);
 
     return (
       <Host id={id} is-range={this.isRange}>
@@ -200,15 +200,27 @@ export class CalciteSlider {
         >
           <span class="handle"></span>
           {this.labelHandles ? (
-            <span
-              class={{
-                handle__label: true,
-                "handle__label--visible": !isLabelOutOfViewport,
-                "handle__label--obscured": isLabelOutOfViewport,
-              }}
-              aria-hidden="true"
-            >
-              {this[maxProp]}
+            <span>
+              <span
+                class={{
+                  handle__label: true,
+                  "handle__label--visible": !this.handleLabelObscured,
+                  "handle__label--obscured": this.handleLabelObscured,
+                }}
+                aria-hidden="true"
+              >
+                {this[maxProp]}
+              </span>
+              <span
+                class={{
+                  handle__label: true,
+                  "handle__label--visible": true,
+                  "handle__label--visible-copy": true,
+                }}
+                aria-hidden="true"
+              >
+                {this[maxProp]}
+              </span>
             </span>
           ) : (
             ""
@@ -363,23 +375,25 @@ export class CalciteSlider {
   @State() private minValueDragRange: number = null;
   /** @internal */
   @State() private maxValueDragRange: number = null;
+  /** @internal */
+  @State() private handleLabelObscured: boolean = false;
 
   //--------------------------------------------------------------------------
   //
   //  Private Methods
   //
   //--------------------------------------------------------------------------
-  private handleLabelOutOfViewport(): boolean {
+  private isHandleLabelObscured() {
     if (this.labelHandles) {
-      const handleLabelElement = this.el.shadowRoot.querySelector(
-        ".handle__label"
+      const element = this.el.shadowRoot.querySelector(
+        ".handle__label--visible-copy"
       );
-      if (handleLabelElement) {
-        return this.isOutOfViewport(handleLabelElement).any;
+      if (element) {
+        this.handleLabelObscured = this.isOutOfViewport(element).any
+          ? true
+          : false;
       }
-      return false;
     }
-    return false;
   }
   private generateTickValues(): number[] {
     const ticks = [];

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -616,8 +616,8 @@ export class CalciteSlider {
           width={300}
           height={48}
           data={this.histogram}
-          highlightMin={this.isRange ? this.minValue : null}
-          highlightMax={this.isRange ? this.maxValue : null}
+          highlightMin={this.isRange ? this.minValue : this.min}
+          highlightMax={this.isRange ? this.maxValue : this.value}
         />
       </div>
     ) : null;

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -1031,7 +1031,11 @@ export class CalciteSlider {
       minValueLabelTransformed &&
       valueLabelTransformed
     ) {
-      if (valueLabelOffset > 0) {
+      if (
+        valueLabelOffset > 0 ||
+        valueLabel.getBoundingClientRect().right >
+          this.el.getBoundingClientRect().right
+      ) {
         const valueLabelTransformedOverlap = this.getRangeLabelOverlap(
           minValueLabelStatic,
           valueLabelTransformed
@@ -1048,7 +1052,11 @@ export class CalciteSlider {
           minValueLabel.style.marginRight = "0px";
         }
         valueLabel.style.marginLeft = "0px";
-      } else if (minValueLabelOffset > 0) {
+      } else if (
+        minValueLabelOffset > 0 ||
+        minValueLabel.getBoundingClientRect().left <
+          this.el.getBoundingClientRect().left
+      ) {
         const minValueLabelTransformedOverlap = this.getRangeLabelOverlap(
           minValueLabelTransformed,
           valueLabelStatic

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -200,27 +200,29 @@ export class CalciteSlider {
         >
           <span class="handle"></span>
           {this.labelHandles ? (
-            <span>
-              <span
-                class={{
-                  handle__label: true,
-                  "handle__label--visible": !this.handleLabelObscured,
-                  "handle__label--obscured": this.handleLabelObscured,
-                }}
-                aria-hidden="true"
-              >
-                {this[maxProp]}
-              </span>
-              <span
-                class={{
-                  handle__label: true,
-                  "handle__label--visible": true,
-                  "handle__label--visible-copy": true,
-                }}
-                aria-hidden="true"
-              >
-                {this[maxProp]}
-              </span>
+            <span
+              class={{
+                handle__label: true,
+                "handle__label--visible": !this.handleLabelObscured,
+                "handle__label--obscured": this.handleLabelObscured,
+              }}
+              aria-hidden="true"
+            >
+              {this[maxProp]}
+            </span>
+          ) : (
+            ""
+          )}
+          {this.labelHandles ? (
+            <span
+              class={{
+                handle__label: true,
+                "handle__label--visible": true,
+                "handle__label--visible-copy": true,
+              }}
+              aria-hidden="true"
+            >
+              {this[maxProp]}
             </span>
           ) : (
             ""

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -100,6 +100,10 @@ export class CalciteSlider {
     const left = `${this.getUnitInterval(min) * 100}%`;
     const right = `${100 - this.getUnitInterval(max) * 100}%`;
 
+    console.clear();
+    const isLabelOutOfViewport = this.handleLabelOutOfViewport();
+    console.log(`render ${isLabelOutOfViewport}`);
+
     return (
       <Host id={id} is-range={this.isRange}>
         {this.renderGraph()}
@@ -196,7 +200,14 @@ export class CalciteSlider {
         >
           <span class="handle"></span>
           {this.labelHandles ? (
-            <span class="handle__label" aria-hidden="true">
+            <span
+              class={{
+                handle__label: true,
+                "handle__label--visible": !isLabelOutOfViewport,
+                "handle__label--obscured": isLabelOutOfViewport,
+              }}
+              aria-hidden="true"
+            >
               {this[maxProp]}
             </span>
           ) : (
@@ -358,6 +369,18 @@ export class CalciteSlider {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+  private handleLabelOutOfViewport(): boolean {
+    if (this.labelHandles) {
+      const handleLabelElement = this.el.shadowRoot.querySelector(
+        ".handle__label"
+      );
+      if (handleLabelElement) {
+        return this.isOutOfViewport(handleLabelElement).any;
+      }
+      return false;
+    }
+    return false;
+  }
   private generateTickValues(): number[] {
     const ticks = [];
     let current = this.min;
@@ -480,5 +503,32 @@ export class CalciteSlider {
     num = this.bound(num);
     const range = this.max - this.min;
     return (num - this.min) / range;
+  }
+  /*!
+   * Check if an element is out of the viewport
+   * (c) 2018 Chris Ferdinandi, MIT License, https://gomakethings.com
+   * @link https://gomakethings.com/how-to-check-if-any-part-of-an-element-is-out-of-the-viewport-with-vanilla-js/
+   * @param  {Node}  elem The element to check
+   * @return {Object}     A set of booleans for each side of the element
+   * @internal
+   */
+  private isOutOfViewport(elem: any) {
+    // Get element's bounding
+    var bounding = elem.getBoundingClientRect();
+
+    // Check if it's out of the viewport on each side
+    var out = {} as Record<string, any>;
+    out.top = bounding.top < 0;
+    out.left = bounding.left < 0;
+    out.bottom =
+      bounding.bottom >
+      (window.innerHeight || document.documentElement.clientHeight);
+    out.right =
+      bounding.right >
+      (window.innerWidth || document.documentElement.clientWidth);
+    out.any = out.top || out.left || out.bottom || out.right;
+    out.all = out.top && out.left && out.bottom && out.right;
+
+    return out;
   }
 }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -1115,8 +1115,12 @@ export class CalciteSlider {
       return;
     }
 
-    const minHandle = this.el.shadowRoot.querySelector(".thumb--minValue");
-    const maxHandle = this.el.shadowRoot.querySelector(".thumb--value");
+    const minHandle: HTMLButtonElement | null = this.el.shadowRoot.querySelector(
+      ".thumb--minValue"
+    );
+    const maxHandle: HTMLButtonElement | null = this.el.shadowRoot.querySelector(
+      ".thumb--value"
+    );
 
     const minTickLabel: HTMLSpanElement | null = this.el.shadowRoot.querySelector(
       ".tick__label--min"
@@ -1126,12 +1130,12 @@ export class CalciteSlider {
     );
 
     if (!minHandle && maxHandle && minTickLabel && maxTickLabel) {
-      if (this.isMinTickLabelObscured(minTickLabel.offsetParent, maxHandle)) {
+      if (this.isMinTickLabelObscured(minTickLabel, maxHandle)) {
         minTickLabel.style.opacity = "0";
       } else {
         minTickLabel.style.opacity = "1";
       }
-      if (this.isMaxTickLabelObscured(maxTickLabel.offsetParent, maxHandle)) {
+      if (this.isMaxTickLabelObscured(maxTickLabel, maxHandle)) {
         maxTickLabel.style.opacity = "0";
       } else {
         maxTickLabel.style.opacity = "1";
@@ -1140,16 +1144,16 @@ export class CalciteSlider {
 
     if (minHandle && maxHandle && minTickLabel && maxTickLabel) {
       if (
-        this.isMinTickLabelObscured(minTickLabel.offsetParent, minHandle) ||
-        this.isMinTickLabelObscured(minTickLabel.offsetParent, maxHandle)
+        this.isMinTickLabelObscured(minTickLabel, minHandle) ||
+        this.isMinTickLabelObscured(minTickLabel, maxHandle)
       ) {
         minTickLabel.style.opacity = "0";
       } else {
         minTickLabel.style.opacity = "1";
       }
       if (
-        this.isMaxTickLabelObscured(maxTickLabel.offsetParent, minHandle) ||
-        (this.isMaxTickLabelObscured(maxTickLabel.offsetParent, maxHandle) &&
+        this.isMaxTickLabelObscured(maxTickLabel, minHandle) ||
+        (this.isMaxTickLabelObscured(maxTickLabel, maxHandle) &&
           this.hasHistogram)
       ) {
         maxTickLabel.style.opacity = "0";
@@ -1201,19 +1205,25 @@ export class CalciteSlider {
     return 0;
   }
 
-  private isMinTickLabelObscured(minLabel, handle) {
-    const minLabelRight = minLabel.offsetLeft + minLabel.offsetWidth;
-    const handleLeft = handle.offsetLeft;
-    if (handleLeft < minLabelRight) {
+  private isMinTickLabelObscured(
+    minLabel: HTMLSpanElement,
+    handle: HTMLButtonElement
+  ) {
+    const minLabelBounds = minLabel.getBoundingClientRect();
+    const handleBounds = handle.getBoundingClientRect();
+    if (handleBounds.left < minLabelBounds.right) {
       return true;
     }
     return false;
   }
 
-  private isMaxTickLabelObscured(maxLabel, handle) {
-    const maxLabelLeft = maxLabel.offsetLeft;
-    const handleRight = handle.offsetLeft + handle.offsetWidth;
-    if (handleRight > maxLabelLeft) {
+  private isMaxTickLabelObscured(
+    maxLabel: HTMLSpanElement,
+    handle: HTMLButtonElement
+  ) {
+    const maxLabelBounds = maxLabel.getBoundingClientRect();
+    const handleBounds = handle.getBoundingClientRect();
+    if (handleBounds.right > maxLabelBounds.left) {
       return true;
     }
     return false;

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -1025,34 +1025,45 @@ export class CalciteSlider {
       valueLabelTransformed
     ) {
       if (valueLabelOffset > 0) {
-        const labelOverlap = this.getRangeLabelOverlap(
+        const labelTransformedOverlap = this.getRangeLabelOverlap(
           minValueLabelTransformed,
           valueLabelTransformed
         );
-        minValueLabel.style.marginRight = `${
-          labelOverlap !== 0 ? labelOverlap * 2 + valueLabelOffset + 5 : 0
-        }px`;
+        if (labelTransformedOverlap > 0) {
+          minValueLabel.classList.add("hyphen");
+          minValueLabel.style.marginRight = `${
+            labelTransformedOverlap * 2 + valueLabelOffset
+          }px`;
+        } else {
+          minValueLabel.classList.remove("hyphen");
+          minValueLabel.style.marginRight = "0px";
+        }
         valueLabel.style.marginLeft = "0px";
       } else if (minValueLabelOffset > 0) {
-        const labelOverlap = this.getRangeLabelOverlap(
+        const labelTransformedOverlap = this.getRangeLabelOverlap(
           minValueLabelTransformed,
           valueLabelTransformed
         );
         minValueLabel.style.marginRight = "0px";
         valueLabel.style.marginLeft = `${
-          labelOverlap !== 0 ? labelOverlap * 2 + minValueLabelOffset + 5 : 0
+          labelTransformedOverlap !== 0
+            ? labelTransformedOverlap * 2 + minValueLabelOffset
+            : 0
         }px`;
       } else {
-        const labelStaticOverlap = this.getRangeLabelOverlap(
-          minValueLabelStatic,
-          valueLabelStatic
+        const labelTransformedOverlap = this.getRangeLabelOverlap(
+          minValueLabelTransformed,
+          valueLabelTransformed
         );
-        minValueLabel.style.marginRight = `${
-          labelStaticOverlap !== 0 ? labelStaticOverlap + 5 : 0
-        }px`;
-        valueLabel.style.marginLeft = `${
-          labelStaticOverlap !== 0 ? labelStaticOverlap + 5 : 0
-        }px`;
+        if (labelTransformedOverlap > 0) {
+          minValueLabel.classList.add("hyphen");
+          minValueLabel.style.marginRight = `${labelTransformedOverlap + 10}px`;
+          valueLabel.style.marginLeft = `${labelTransformedOverlap + 10}px`;
+        } else {
+          minValueLabel.classList.remove("hyphen");
+          minValueLabel.style.marginRight = "0px";
+          valueLabel.style.marginLeft = "0px";
+        }
       }
     }
   }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -599,7 +599,7 @@ export class CalciteSlider {
     );
     if (this.labelTicks) {
       if (this.isRange) {
-        if (this.precise) {
+        if (this.precise || this.labelHandles) {
           if (isMinTickLabel || isMaxTickLabel) {
             return tickLabel;
           } else {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -598,15 +598,15 @@ export class CalciteSlider {
       </span>
     );
     if (this.labelTicks) {
-      if (this.isRange) {
-        if (this.precise || this.labelHandles) {
-          if (isMinTickLabel || isMaxTickLabel) {
-            return tickLabel;
-          } else {
-            return null;
-          }
+      if (this.hasHistogram || (this.isRange && this.precise)) {
+        if (
+          (this.precise || this.labelHandles) &&
+          (isMinTickLabel || isMaxTickLabel)
+        ) {
+          return tickLabel;
+        } else {
+          return null;
         }
-        return tickLabel;
       }
       return tickLabel;
     }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -111,6 +111,7 @@ export class CalciteSlider {
     const min = this.minValue || this.min;
     const max = this.maxValue || this.value;
     const maxProp = this.isRange ? "maxValue" : "value";
+    const value = this[maxProp];
     const left = `${this.getUnitInterval(min) * 100}%`;
     const right = `${100 - this.getUnitInterval(max) * 100}%`;
 
@@ -124,7 +125,7 @@ export class CalciteSlider {
         role="slider"
         aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={this[maxProp]}
+        aria-valuenow={value}
         aria-valuemin={this.min}
         aria-valuemax={this.max}
         disabled={this.disabled}
@@ -150,7 +151,7 @@ export class CalciteSlider {
         role="slider"
         aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={this[maxProp]}
+        aria-valuenow={value}
         aria-valuemin={this.min}
         aria-valuemax={this.max}
         disabled={this.disabled}
@@ -163,13 +164,13 @@ export class CalciteSlider {
         }}
       >
         <span class="handle__label handle__label--value" aria-hidden="true">
-          {this[maxProp]}
+          {value ? value.toLocaleString() : value}
         </span>
         <span
           class="handle__label handle__label--value copy"
           aria-hidden="true"
         >
-          {this[maxProp]}
+          {value ? value.toLocaleString() : value}
         </span>
         <div class="handle"></div>
       </button>
@@ -185,7 +186,7 @@ export class CalciteSlider {
         role="slider"
         aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={this[maxProp]}
+        aria-valuenow={value}
         aria-valuemin={this.min}
         aria-valuemax={this.max}
         disabled={this.disabled}
@@ -213,7 +214,7 @@ export class CalciteSlider {
         role="slider"
         aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={this[maxProp]}
+        aria-valuenow={value}
         aria-valuemin={this.min}
         aria-valuemax={this.max}
         disabled={this.disabled}
@@ -227,13 +228,13 @@ export class CalciteSlider {
         }}
       >
         <span class="handle__label handle__label--value" aria-hidden="true">
-          {this[maxProp]}
+          {value ? value.toLocaleString() : value}
         </span>
         <span
           class="handle__label handle__label--value copy"
           aria-hidden="true"
         >
-          {this[maxProp]}
+          {value ? value.toLocaleString() : value}
         </span>
         <div class="handle"></div>
         <div class="handle-extension"></div>
@@ -250,7 +251,7 @@ export class CalciteSlider {
         role="slider"
         aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={this[maxProp]}
+        aria-valuenow={value}
         aria-valuemin={this.min}
         aria-valuemax={this.max}
         disabled={this.disabled}
@@ -266,13 +267,13 @@ export class CalciteSlider {
         <div class="handle-extension"></div>
         <div class="handle"></div>
         <span class="handle__label handle__label--value" aria-hidden="true">
-          {this[maxProp]}
+          {value ? value.toLocaleString() : value}
         </span>
         <span
           class="handle__label handle__label--value copy"
           aria-hidden="true"
         >
-          {this[maxProp]}
+          {value ? value.toLocaleString() : value}
         </span>
       </button>
     );
@@ -324,13 +325,13 @@ export class CalciteSlider {
         }}
       >
         <span class="handle__label handle__label--minValue" aria-hidden="true">
-          {this.minValue}
+          {this.minValue && this.minValue.toLocaleString()}
         </span>
         <span
           class="handle__label handle__label--minValue copy"
           aria-hidden="true"
         >
-          {this.minValue}
+          {this.minValue && this.minValue.toLocaleString()}
         </span>
         <div class="handle"></div>
       </button>
@@ -388,13 +389,13 @@ export class CalciteSlider {
         <div class="handle-extension"></div>
         <div class="handle"></div>
         <span class="handle__label handle__label--minValue" aria-hidden="true">
-          {this.minValue}
+          {this.minValue && this.minValue.toLocaleString()}
         </span>
         <span
           class="handle__label handle__label--minValue copy"
           aria-hidden="true"
         >
-          {this.minValue}
+          {this.minValue && this.minValue.toLocaleString()}
         </span>
       </button>
     );
@@ -477,7 +478,7 @@ export class CalciteSlider {
           "tick__label--max": isMaxTickLabel,
         }}
       >
-        {tick}
+        {tick.toLocaleString()}
       </span>
     );
     if (this.labelTicks) {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -10,6 +10,7 @@ import {
   h,
   State,
   VNode,
+  Watch,
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
@@ -68,6 +69,11 @@ export class CalciteSlider {
   @Prop() precise?: boolean;
   /** Display a histogram above the slider */
   @Prop() histogram?: DataSeries;
+  @Watch("histogram") histogramWatcher(newHistogram) {
+    this.hasHistogram = newHistogram ? true : false;
+  }
+  /** Indicates if a histogram is present */
+  @Prop({ reflect: true, mutable: true }) hasHistogram: boolean = false;
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -79,6 +85,9 @@ export class CalciteSlider {
     this.value = this.bound(this.value);
     if (this.snap) {
       this.value = this.getClosestStep(this.value);
+    }
+    if (this.histogram) {
+      this.hasHistogram = true;
     }
     this.calciteSliderUpdate.emit();
   }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -97,12 +97,15 @@ export class CalciteSlider {
     this.adjustObscuredHandleLabel("value");
     if (this.isRange) {
       this.adjustObscuredHandleLabel("minValue");
-      if (this.precise && this.labelTicks) {
-        this.hideObscuredBoundingTrackLabels("min");
-        if (this.hasHistogram && this.labelHandles) {
-          this.hideObscuredBoundingTrackLabels("both");
-        }
-      }
+    }
+    if (!this.hasHistogram && this.precise && this.labelTicks && this.isRange) {
+      this.hideObscuredBoundingTrackLabels("min");
+    }
+    if (this.hasHistogram && this.labelTicks && !this.isRange) {
+      this.hideObscuredBoundingTrackLabels("max");
+    }
+    if (this.hasHistogram && this.labelTicks && this.isRange) {
+      this.hideObscuredBoundingTrackLabels("both");
     }
   }
 
@@ -597,17 +600,69 @@ export class CalciteSlider {
         {tick.toLocaleString()}
       </span>
     );
-    if (this.labelTicks) {
-      if (this.hasHistogram || (this.isRange && this.precise)) {
-        if (
-          (this.precise || this.labelHandles) &&
-          (isMinTickLabel || isMaxTickLabel)
-        ) {
-          return tickLabel;
-        } else {
-          return null;
-        }
-      }
+    if (this.labelTicks && !this.hasHistogram && !this.isRange) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      !this.hasHistogram &&
+      this.isRange &&
+      !this.precise &&
+      !this.labelHandles
+    ) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      !this.hasHistogram &&
+      this.isRange &&
+      !this.precise &&
+      this.labelHandles
+    ) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      !this.hasHistogram &&
+      this.isRange &&
+      this.precise &&
+      (isMinTickLabel || isMaxTickLabel)
+    ) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      this.hasHistogram &&
+      !this.precise &&
+      !this.labelHandles
+    ) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      this.hasHistogram &&
+      this.precise &&
+      !this.labelHandles &&
+      (isMinTickLabel || isMaxTickLabel)
+    ) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      this.hasHistogram &&
+      !this.precise &&
+      this.labelHandles &&
+      (isMinTickLabel || isMaxTickLabel)
+    ) {
+      return tickLabel;
+    }
+    if (
+      this.labelTicks &&
+      this.hasHistogram &&
+      this.precise &&
+      this.labelHandles &&
+      (isMinTickLabel || isMaxTickLabel)
+    ) {
       return tickLabel;
     }
     return null;
@@ -894,7 +949,9 @@ export class CalciteSlider {
       }
     }
   }
-  private hideObscuredBoundingTrackLabels(whichHandles: "min" | "both") {
+  private hideObscuredBoundingTrackLabels(
+    whichHandles: "min" | "max" | "both"
+  ) {
     const minHandle = this.el.shadowRoot.querySelector(`.thumb--min`);
     const minTickLabel = this.el.shadowRoot.querySelector(".tick__label--min");
     const maxTickLabel = this.el.shadowRoot.querySelector(".tick__label--max");
@@ -912,6 +969,8 @@ export class CalciteSlider {
         } else {
           (minTickLabel as HTMLSpanElement).style.opacity = "1";
         }
+        break;
+      case "max":
         if (
           this.isMaxBoundingLabelObscured(
             (maxTickLabel as HTMLElement).offsetParent,

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -239,6 +239,34 @@ export class CalciteSlider {
       </button>
     );
 
+    const histogramPreciseHandle = (
+      <button
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.isRange ? this.maxLabel : this.minLabel}
+        aria-valuenow={value}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ right }}
+        class={{
+          thumb: true,
+          "thumb--max": true,
+          "thumb--active":
+            this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
+          "thumb--precise": true,
+        }}
+      >
+        <div class="handle-extension"></div>
+        <div class="handle"></div>
+      </button>
+    );
+
     const labeledPreciseHandle = (
       <button
         ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
@@ -517,7 +545,14 @@ export class CalciteSlider {
           !this.precise &&
           this.labelHandles &&
           labeledHandle}
-        {this.precise && !this.labelHandles && preciseHandle}
+        {!this.hasHistogram &&
+          this.precise &&
+          !this.labelHandles &&
+          preciseHandle}
+        {this.hasHistogram &&
+          this.precise &&
+          !this.labelHandles &&
+          histogramPreciseHandle}
         {!this.hasHistogram &&
           this.precise &&
           this.labelHandles &&
@@ -529,12 +564,6 @@ export class CalciteSlider {
         {this.hasHistogram &&
           this.precise &&
           this.labelHandles &&
-          !this.isRange &&
-          labeledPreciseHandle}
-        {this.hasHistogram &&
-          this.precise &&
-          this.labelHandles &&
-          this.isRange &&
           histogramLabeledPreciseHandle}
       </Host>
     );

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -120,29 +120,17 @@ export class CalciteSlider {
             style={{ left, right }}
           />
           <div class="ticks">
-            {this.tickValues.map((number) => (
+            {this.tickValues.map((tick) => (
               <span
                 class={{
                   tick: true,
-                  "tick--active": number >= min && number <= max,
+                  "tick--active": tick >= min && tick <= max,
                 }}
                 style={{
-                  left: `${this.getUnitInterval(number) * 100}%`,
+                  left: `${this.getUnitInterval(tick) * 100}%`,
                 }}
               >
-                {this.labelTicks ? (
-                  <span
-                    class={{
-                      tick__label: true,
-                      "tick__label--min": number === this.min,
-                      "tick__label--max": number === this.max,
-                    }}
-                  >
-                    {number}
-                  </span>
-                ) : (
-                  ""
-                )}
+                {this.renderTickLabel(tick)}
               </span>
             ))}
           </div>
@@ -269,6 +257,35 @@ export class CalciteSlider {
       </div>
     ) : null;
   }
+
+  private renderTickLabel(tick: number): VNode {
+    const tickLabel = (
+      <span
+        class={{
+          tick__label: true,
+          "tick__label--min": tick === this.min,
+          "tick__label--max": tick === this.max,
+        }}
+      >
+        {tick}
+      </span>
+    );
+    if (this.labelTicks) {
+      if (this.isRange) {
+        if (this.precise) {
+          if (tick === this.min || tick === this.max) {
+            return tickLabel;
+          } else {
+            return null;
+          }
+        }
+        return tickLabel;
+      }
+      return tickLabel;
+    }
+    return null;
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Event Listeners

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -176,6 +176,41 @@ export class CalciteSlider {
       </button>
     );
 
+    const histogramLabeledHandle = (
+      <button
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.isRange ? this.maxLabel : this.minLabel}
+        aria-valuenow={value}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ right }}
+        class={{
+          thumb: true,
+          "thumb--max": true,
+          "thumb--active":
+            this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
+        }}
+      >
+        <div class="handle"></div>
+        <span class="handle__label handle__label--value" aria-hidden="true">
+          {value ? value.toLocaleString() : value}
+        </span>
+        <span
+          class="handle__label handle__label--value copy"
+          aria-hidden="true"
+        >
+          {value ? value.toLocaleString() : value}
+        </span>
+      </button>
+    );
+
     const preciseHandle = (
       <button
         ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
@@ -337,6 +372,40 @@ export class CalciteSlider {
       </button>
     );
 
+    const minHistogramLabeledHandle = (
+      <button
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onBlur={() => (this.activeProp = null)}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        role="slider"
+        aria-orientation="horizontal"
+        aria-label={this.minLabel}
+        aria-valuenow={this.minValue}
+        aria-valuemin={this.min}
+        aria-valuemax={this.max}
+        disabled={this.disabled}
+        style={{ left }}
+        class={{
+          thumb: true,
+          "thumb--min": true,
+          "thumb--active": this.dragProp === "minValue",
+        }}
+      >
+        <div class="handle"></div>
+        <span class="handle__label handle__label--minValue" aria-hidden="true">
+          {this.minValue && this.minValue.toLocaleString()}
+        </span>
+        <span
+          class="handle__label handle__label--minValue copy"
+          aria-hidden="true"
+        >
+          {this.minValue && this.minValue.toLocaleString()}
+        </span>
+      </button>
+    );
+
     const minPreciseHandle = (
       <button
         ref={(el) => (this.minHandle = el as HTMLButtonElement)}
@@ -426,29 +495,47 @@ export class CalciteSlider {
             ))}
           </div>
         </div>
-        {!this.precise && !this.labelHandles && this.isRange ? minHandle : null}
-        {!this.precise && this.labelHandles && this.isRange
-          ? minLabeledHandle
-          : null}
-        {this.precise && !this.labelHandles && this.isRange
-          ? minPreciseHandle
-          : null}
-        {this.precise && this.labelHandles && this.isRange
-          ? minLabeledPreciseHandle
-          : null}
+        {!this.precise && !this.labelHandles && this.isRange && minHandle}
+        {!this.hasHistogram &&
+          !this.precise &&
+          this.labelHandles &&
+          this.isRange &&
+          minLabeledHandle}
+        {this.precise && !this.labelHandles && this.isRange && minPreciseHandle}
+        {this.precise &&
+          this.labelHandles &&
+          this.isRange &&
+          minLabeledPreciseHandle}
+        {this.hasHistogram &&
+          !this.precise &&
+          this.labelHandles &&
+          this.isRange &&
+          minHistogramLabeledHandle}
 
-        {!this.precise && !this.labelHandles ? handle : null}
-        {!this.precise && this.labelHandles ? labeledHandle : null}
-        {this.precise && !this.labelHandles ? preciseHandle : null}
-        {!this.hasHistogram && this.precise && this.labelHandles
-          ? labeledPreciseHandle
-          : null}
-        {this.hasHistogram && this.precise && this.labelHandles && !this.isRange
-          ? labeledPreciseHandle
-          : null}
-        {this.hasHistogram && this.precise && this.labelHandles && this.isRange
-          ? histogramLabeledPreciseHandle
-          : null}
+        {!this.precise && !this.labelHandles && handle}
+        {!this.hasHistogram &&
+          !this.precise &&
+          this.labelHandles &&
+          labeledHandle}
+        {this.precise && !this.labelHandles && preciseHandle}
+        {!this.hasHistogram &&
+          this.precise &&
+          this.labelHandles &&
+          labeledPreciseHandle}
+        {this.hasHistogram &&
+          !this.precise &&
+          this.labelHandles &&
+          histogramLabeledHandle}
+        {this.hasHistogram &&
+          this.precise &&
+          this.labelHandles &&
+          !this.isRange &&
+          labeledPreciseHandle}
+        {this.hasHistogram &&
+          this.precise &&
+          this.labelHandles &&
+          this.isRange &&
+          histogramLabeledPreciseHandle}
       </Host>
     );
   }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -1005,7 +1005,6 @@ export class CalciteSlider {
     const minValueLabelTransformed: HTMLSpanElement | null = this.el.shadowRoot.querySelector(
       `.handle__label--minValue.transformed`
     );
-
     const valueLabel: HTMLSpanElement | null = this.el.shadowRoot.querySelector(
       `.handle__label--value`
     );
@@ -1015,7 +1014,6 @@ export class CalciteSlider {
     const valueLabelTransformed: HTMLSpanElement | null = this.el.shadowRoot.querySelector(
       `.handle__label--value.transformed`
     );
-
     if (
       minValueLabel &&
       valueLabel &&
@@ -1025,42 +1023,52 @@ export class CalciteSlider {
       valueLabelTransformed
     ) {
       if (valueLabelOffset > 0) {
-        const labelTransformedOverlap = this.getRangeLabelOverlap(
-          minValueLabelTransformed,
+        const valueLabelTransformedOverlap = this.getRangeLabelOverlap(
+          minValueLabelStatic,
           valueLabelTransformed
         );
-        if (labelTransformedOverlap > 0) {
+        if (valueLabelTransformedOverlap > 0) {
           minValueLabel.classList.add("hyphen");
+          minValueLabel.classList.add("max-offset");
           minValueLabel.style.marginRight = `${
-            labelTransformedOverlap * 2 + valueLabelOffset
+            valueLabelTransformedOverlap * 2
           }px`;
         } else {
           minValueLabel.classList.remove("hyphen");
+          minValueLabel.classList.remove("max-offset");
           minValueLabel.style.marginRight = "0px";
         }
         valueLabel.style.marginLeft = "0px";
       } else if (minValueLabelOffset > 0) {
-        const labelTransformedOverlap = this.getRangeLabelOverlap(
+        const minValueLabelTransformedOverlap = this.getRangeLabelOverlap(
           minValueLabelTransformed,
-          valueLabelTransformed
+          valueLabelStatic
         );
+        if (minValueLabelTransformedOverlap > 0) {
+          valueLabel.classList.add("hyphen");
+          valueLabel.classList.add("min-offset");
+          valueLabel.style.marginLeft = `${
+            minValueLabelTransformedOverlap * 2
+          }px`;
+        } else {
+          valueLabel.classList.remove("hyphen");
+          valueLabel.classList.remove("min-offset");
+          valueLabel.style.marginLeft = "0px";
+        }
         minValueLabel.style.marginRight = "0px";
-        valueLabel.style.marginLeft = `${
-          labelTransformedOverlap !== 0
-            ? labelTransformedOverlap * 2 + minValueLabelOffset
-            : 0
-        }px`;
       } else {
-        const labelTransformedOverlap = this.getRangeLabelOverlap(
-          minValueLabelTransformed,
-          valueLabelTransformed
+        const labelStaticOverlap = this.getRangeLabelOverlap(
+          minValueLabelStatic,
+          valueLabelStatic
         );
-        if (labelTransformedOverlap > 0) {
+        if (labelStaticOverlap > 0) {
           minValueLabel.classList.add("hyphen");
-          minValueLabel.style.marginRight = `${labelTransformedOverlap + 10}px`;
-          valueLabel.style.marginLeft = `${labelTransformedOverlap + 10}px`;
+          valueLabel.classList.add("hyphen");
+          minValueLabel.style.marginRight = `${labelStaticOverlap}px`;
+          valueLabel.style.marginLeft = `${labelStaticOverlap}px`;
         } else {
           minValueLabel.classList.remove("hyphen");
+          valueLabel.classList.remove("hyphen");
           minValueLabel.style.marginRight = "0px";
           valueLabel.style.marginLeft = "0px";
         }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -977,6 +977,9 @@ export class CalciteSlider {
     if (!this.hasHistogram && this.isRange && !this.precise) {
       return;
     }
+    if (this.hasHistogram && !this.precise && !this.labelHandles) {
+      return;
+    }
 
     const minHandle = this.el.shadowRoot.querySelector(".thumb--min");
     const maxHandle = this.el.shadowRoot.querySelector(".thumb--max");

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -98,15 +98,7 @@ export class CalciteSlider {
     if (this.isRange) {
       this.adjustObscuredHandleLabel("minValue");
     }
-    if (!this.hasHistogram && this.precise && this.labelTicks && this.isRange) {
-      this.hideObscuredBoundingTrackLabels("min");
-    }
-    if (this.hasHistogram && this.labelTicks && !this.isRange) {
-      this.hideObscuredBoundingTrackLabels("max");
-    }
-    if (this.hasHistogram && this.labelTicks && this.isRange) {
-      this.hideObscuredBoundingTrackLabels("both");
-    }
+    this.hideObscuredBoundingTickLabels();
   }
 
   render() {
@@ -949,70 +941,84 @@ export class CalciteSlider {
       }
     }
   }
-  private hideObscuredBoundingTrackLabels(
-    whichHandles: "min" | "max" | "both"
-  ) {
-    const minHandle = this.el.shadowRoot.querySelector(`.thumb--min`);
-    const minTickLabel = this.el.shadowRoot.querySelector(".tick__label--min");
-    const maxTickLabel = this.el.shadowRoot.querySelector(".tick__label--max");
-    switch (whichHandles) {
-      default:
-        break;
-      case "min":
-        if (
-          this.isMinBoundingLabelObscured(
-            (minTickLabel as HTMLElement).offsetParent,
-            minHandle
-          )
-        ) {
-          (minTickLabel as HTMLSpanElement).style.opacity = "0";
-        } else {
-          (minTickLabel as HTMLSpanElement).style.opacity = "1";
-        }
-        break;
-      case "max":
-        if (
-          this.isMaxBoundingLabelObscured(
-            (maxTickLabel as HTMLElement).offsetParent,
-            minHandle
-          )
-        ) {
-          (maxTickLabel as HTMLSpanElement).style.opacity = "0";
-        } else {
-          (maxTickLabel as HTMLSpanElement).style.opacity = "1";
-        }
-        break;
-      case "both":
-        const maxHandle = this.el.shadowRoot.querySelector(`.thumb--max`);
-        if (
-          this.isMinBoundingLabelObscured(
-            (minTickLabel as HTMLElement).offsetParent,
-            minHandle
-          ) ||
-          this.isMinBoundingLabelObscured(
-            (minTickLabel as HTMLElement).offsetParent,
-            maxHandle
-          )
-        ) {
-          (minTickLabel as HTMLSpanElement).style.opacity = "0";
-        } else {
-          (minTickLabel as HTMLSpanElement).style.opacity = "1";
-        }
-        if (
-          this.isMaxBoundingLabelObscured(
-            (maxTickLabel as HTMLElement).offsetParent,
-            minHandle
-          ) ||
-          this.isMaxBoundingLabelObscured(
-            (maxTickLabel as HTMLElement).offsetParent,
-            maxHandle
-          )
-        ) {
-          (maxTickLabel as HTMLSpanElement).style.opacity = "0";
-        } else {
-          (maxTickLabel as HTMLSpanElement).style.opacity = "1";
-        }
-        break;
+  private hideObscuredBoundingTickLabels() {
+    if (
+      !this.hasHistogram &&
+      !this.isRange &&
+      !this.labelHandles &&
+      !this.precise
+    ) {
+      return;
+    }
+    if (
+      !this.hasHistogram &&
+      !this.isRange &&
+      this.labelHandles &&
+      !this.precise
+    ) {
+      return;
+    }
+    if (
+      !this.hasHistogram &&
+      !this.isRange &&
+      !this.labelHandles &&
+      this.precise
+    ) {
+      return;
+    }
+    if (
+      !this.hasHistogram &&
+      !this.isRange &&
+      this.labelHandles &&
+      this.precise
+    ) {
+      return;
+    }
+    if (!this.hasHistogram && this.isRange && !this.precise) {
+      return;
+    }
+
+    const minHandle = this.el.shadowRoot.querySelector(".thumb--min");
+    const maxHandle = this.el.shadowRoot.querySelector(".thumb--max");
+
+    const minTickLabel: HTMLSpanElement | null = this.el.shadowRoot.querySelector(
+      ".tick__label--min"
+    );
+    const maxTickLabel: HTMLSpanElement | null = this.el.shadowRoot.querySelector(
+      ".tick__label--max"
+    );
+
+    if (!minHandle && maxHandle && minTickLabel && maxTickLabel) {
+      if (this.isMinTickLabelObscured(minTickLabel.offsetParent, maxHandle)) {
+        minTickLabel.style.opacity = "0";
+      } else {
+        minTickLabel.style.opacity = "1";
+      }
+      if (this.isMaxTickLabelObscured(maxTickLabel.offsetParent, maxHandle)) {
+        maxTickLabel.style.opacity = "0";
+      } else {
+        maxTickLabel.style.opacity = "1";
+      }
+    }
+
+    if (minHandle && maxHandle && minTickLabel && maxTickLabel) {
+      if (
+        this.isMinTickLabelObscured(minTickLabel.offsetParent, minHandle) ||
+        this.isMinTickLabelObscured(minTickLabel.offsetParent, maxHandle)
+      ) {
+        minTickLabel.style.opacity = "0";
+      } else {
+        minTickLabel.style.opacity = "1";
+      }
+      if (
+        this.isMaxTickLabelObscured(maxTickLabel.offsetParent, minHandle) ||
+        (this.isMaxTickLabelObscured(maxTickLabel.offsetParent, maxHandle) &&
+          this.hasHistogram)
+      ) {
+        maxTickLabel.style.opacity = "0";
+      } else {
+        maxTickLabel.style.opacity = "1";
+      }
     }
   }
   /**
@@ -1035,7 +1041,7 @@ export class CalciteSlider {
     return 0;
   }
 
-  private isMinBoundingLabelObscured(minLabel, handle) {
+  private isMinTickLabelObscured(minLabel, handle) {
     const minLabelRight = minLabel.offsetLeft + minLabel.offsetWidth;
     const handleLeft = handle.offsetLeft;
     if (handleLeft < minLabelRight) {
@@ -1044,7 +1050,7 @@ export class CalciteSlider {
     return false;
   }
 
-  private isMaxBoundingLabelObscured(maxLabel, handle) {
+  private isMaxTickLabelObscured(maxLabel, handle) {
     const maxLabelLeft = maxLabel.offsetLeft;
     const handleRight = handle.offsetLeft + handle.offsetWidth;
     if (handleRight > maxLabelLeft) {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -98,6 +98,19 @@ export class CalciteSlider {
     this.isHandleLabelObscured("value");
     if (this.isRange) {
       this.isHandleLabelObscured("minValue");
+      if (this.precise && this.labelTicks) {
+        const minValueButton = this.el.shadowRoot.querySelector(
+          "button.thumb--min"
+        );
+        console.log(minValueButton);
+        const minTickLabel = this.el.shadowRoot.querySelector(
+          ".tick__label--min"
+        );
+        console.log(minTickLabel);
+        const isMinColliding = this.isColliding(minValueButton, minTickLabel);
+        this.minTickLabelObscured = isMinColliding ? true : false;
+        console.log(`isMinColliding:${isMinColliding}`);
+      }
     }
   }
 
@@ -259,13 +272,21 @@ export class CalciteSlider {
   }
 
   private renderTickLabel(tick: number): VNode {
+    const isMinTickLabel = tick === this.min;
+    const isMaxTickLabel = tick === this.max;
+    const isObscured =
+      (isMinTickLabel && this.minTickLabelObscured) ||
+      (isMaxTickLabel && this.maxTickLabelObscured)
+        ? true
+        : false;
     const tickLabel = (
       <span
         class={{
           tick__label: true,
-          "tick__label--min": tick === this.min,
-          "tick__label--max": tick === this.max,
+          "tick__label--min": isMinTickLabel,
+          "tick__label--max": isMaxTickLabel,
         }}
+        style={{ opacity: isObscured ? "0" : "1" }}
       >
         {tick}
       </span>
@@ -273,7 +294,7 @@ export class CalciteSlider {
     if (this.labelTicks) {
       if (this.isRange) {
         if (this.precise) {
-          if (tick === this.min || tick === this.max) {
+          if (isMinTickLabel || isMaxTickLabel) {
             return tickLabel;
           } else {
             return null;
@@ -422,6 +443,10 @@ export class CalciteSlider {
   @State() private valueLabelObscured: OutOfViewport = "none";
   /** @internal */
   @State() private minValueLabelObscured: OutOfViewport = "none";
+  /** @internal */
+  @State() private minTickLabelObscured: boolean = false;
+  /** @internal */
+  @State() private maxTickLabelObscured: boolean = false;
 
   //--------------------------------------------------------------------------
   //
@@ -581,5 +606,33 @@ export class CalciteSlider {
       return "right";
     }
     return "none";
+  }
+  /**
+   * Detects if two elements are colliding
+   *
+   * Credit goes to BC on Stack Overflow, cleaned up a little bit
+   *
+   * @link http://stackoverflow.com/questions/5419134/how-to-detect-if-two-divs-touch-with-jquery
+   * @param $div1
+   * @param $div2
+   * @returns {boolean}
+   */
+  private isColliding(div1, div2) {
+    const d1_height = div1.offsetHeight;
+    const d1_width = div1.offsetWidth;
+    const d1_distance_from_top = div1.offsetTop + d1_height;
+    const d1_distance_from_left = div1.offsetLeft + d1_width;
+
+    const d2_height = div2.offsetHeight;
+    const d2_width = div2.offsetWidth;
+    const d2_distance_from_top = div2.offsetTop + d2_height;
+    const d2_distance_from_left = div2.offsetLeft + d2_width;
+    const not_colliding =
+      d1_distance_from_top < div2.offsetTop ||
+      div1.offsetTop > d2_distance_from_top ||
+      d1_distance_from_left < div2.offsetTop ||
+      div1.offsetLeft > d2_distance_from_left;
+
+    return !not_colliding;
   }
 }

--- a/src/demos/calcite-radio-button.html
+++ b/src/demos/calcite-radio-button.html
@@ -65,10 +65,13 @@
 
                   <hr>
 
-                  <calcite-radio-button name="s-disabled-single" scale="s" value="stencil" checked>Stencil</calcite-radio-button>
-                  <calcite-radio-button name="s-disabled-single" scale="s" value="react" disabled>React</calcite-radio-button>
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="stencil" checked>Stencil
+                  </calcite-radio-button>
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="react" disabled>React
+                  </calcite-radio-button>
                   <calcite-radio-button name="s-disabled-single" scale="s" value="ember">Ember</calcite-radio-button>
-                  <calcite-radio-button name="s-disabled-single" scale="s" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="angular">Angular
+                  </calcite-radio-button>
 
                   <h3>Scale m (default)</h3>
                   <calcite-radio-button name="m" value="stencil" checked>Stencil</calcite-radio-button>
@@ -91,10 +94,13 @@
 
                   <hr>
 
-                  <calcite-radio-button name="l-disabled-single" scale="l" value="stencil" checked>Stencil</calcite-radio-button>
-                  <calcite-radio-button name="l-disabled-single" scale="l" value="react" disabled>React</calcite-radio-button>
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="stencil" checked>Stencil
+                  </calcite-radio-button>
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="react" disabled>React
+                  </calcite-radio-button>
                   <calcite-radio-button name="l-disabled-single" scale="l" value="ember">Ember</calcite-radio-button>
-                  <calcite-radio-button name="l-disabled-single" scale="l" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="angular">Angular
+                  </calcite-radio-button>
 
                   <h3>Uses value as label if missing</h3>
                   <calcite-radio-button name="valueAsLabel" value="1" checked></calcite-radio-button>
@@ -121,8 +127,10 @@
                   <calcite-radio-button name="firstCheckedWinsFirst2" value="2" checked></calcite-radio-button>
                   <calcite-radio-button name="firstCheckedWinsFirst2" value="3"></calcite-radio-button>
                   <hr>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirst2" value="1" checked></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirst2" value="2" checked disabled></calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirst2" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirst2" value="2" checked disabled>
+                  </calcite-radio-button>
                   <calcite-radio-button name="firstCheckedWinsDisabledSingleFirst2" value="3"></calcite-radio-button>
 
                   <h3>Only one checked value (first wins, second two checked)</h3>
@@ -131,34 +139,44 @@
                   <calcite-radio-button name="firstCheckedWinsSecond2" value="3" checked></calcite-radio-button>
                   <hr>
                   <calcite-radio-button name="firstCheckedWinsDisabledSingleSecond2" value="1"></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleSecond2" value="2" checked disabled></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleSecond2" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleSecond2" value="2" checked disabled>
+                  </calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleSecond2" value="3" checked>
+                  </calcite-radio-button>
 
                   <h3>Only one checked value (first wins, first and last checked)</h3>
                   <calcite-radio-button name="firstCheckedWinsFirstLast" value="1" checked></calcite-radio-button>
                   <calcite-radio-button name="firstCheckedWinsFirstLast" value="2"></calcite-radio-button>
                   <calcite-radio-button name="firstCheckedWinsFirstLast" value="3" checked></calcite-radio-button>
                   <hr>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirstLast" value="1" checked></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirstLast" value="2" disabled></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirstLast" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirstLast" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirstLast" value="2" disabled>
+                  </calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsDisabledSingleFirstLast" value="3" checked>
+                  </calcite-radio-button>
 
                   <h3>Only one checked value (first wins, all checked)</h3>
                   <calcite-radio-button name="firstCheckedWinsAll" value="1" checked></calcite-radio-button>
                   <calcite-radio-button name="firstCheckedWinsAll" value="2" checked></calcite-radio-button>
                   <calcite-radio-button name="firstCheckedWinsAll" value="3" checked></calcite-radio-button>
                   <hr>
-                  <calcite-radio-button name="firstCheckedWinsAllDisabledSingle" value="1" checked></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsAllDisabledSingle" value="2" checked disabled></calcite-radio-button>
-                  <calcite-radio-button name="firstCheckedWinsAllDisabledSingle" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsAllDisabledSingle" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsAllDisabledSingle" value="2" checked disabled>
+                  </calcite-radio-button>
+                  <calcite-radio-button name="firstCheckedWinsAllDisabledSingle" value="3" checked>
+                  </calcite-radio-button>
 
-              </div>
-              <div class="dark">
+                </div>
+                <div class="dark">
                   <h3>Scale s</h3>
-                  <calcite-radio-button theme="dark" name="s-dark" scale="s" value="stencil" checked>Stencil</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="s-dark" scale="s" value="stencil" checked>Stencil
+                  </calcite-radio-button>
                   <calcite-radio-button theme="dark" name="s-dark" scale="s" value="react">React</calcite-radio-button>
                   <calcite-radio-button theme="dark" name="s-dark" scale="s" value="ember">Ember</calcite-radio-button>
-                  <calcite-radio-button theme="dark" name="s-dark" scale="s" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="s-dark" scale="s" value="angular">Angular
+                  </calcite-radio-button>
 
                   <hr>
 
@@ -166,100 +184,142 @@
                     Stencil</calcite-radio-button>
                   <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="react" disabled>
                     React</calcite-radio-button>
-                  <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="ember">Ember</calcite-radio-button>
-                  <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="ember">Ember
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="angular">Angular
+                  </calcite-radio-button>
 
                   <h3>Scale m (default)</h3>
-                  <calcite-radio-button theme="dark" name="m-dark" value="stencil" checked>Stencil</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="m-dark" value="stencil" checked>Stencil
+                  </calcite-radio-button>
                   <calcite-radio-button theme="dark" name="m-dark" value="react">React</calcite-radio-button>
                   <calcite-radio-button theme="dark" name="m-dark" value="ember">Ember</calcite-radio-button>
                   <calcite-radio-button theme="dark" name="m-dark" value="angular">Angular</calcite-radio-button>
 
                   <hr>
 
-                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="stencil" checked>Stencil</calcite-radio-button>
-                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="react" disabled>React</calcite-radio-button>
-                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="ember">Ember</calcite-radio-button>
-                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="stencil" checked>Stencil
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="react" disabled>React
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="ember">Ember
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="angular">Angular
+                  </calcite-radio-button>
 
                   <h3>Scale l</h3>
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="stencil" checked>Stencil</calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="react">React</calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="ember">Ember</calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark" scale="l" value="stencil" checked>Stencil
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark" scale="l" value="react">React</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark" scale="l" value="ember">Ember</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark" scale="l" value="angular">Angular
+                  </calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="stencil" checked>Stencil</calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="react" disabled>React</calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="ember">Ember</calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="angular">Angular</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="stencil" checked>
+                    Stencil</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="react" disabled>
+                    React</calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="ember">Ember
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="angular">Angular
+                  </calcite-radio-button>
 
                   <h3>Uses value as label if missing</h3>
-                    <calcite-radio-button theme="dark" name="valueAsLabelDark" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="valueAsLabelDark" value="2"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="valueAsLabelDark" value="3"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="valueAsLabelDark" value="1" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="valueAsLabelDark" value="2"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="valueAsLabelDark" value="3"></calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="2" disabled></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="3"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="2" disabled>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="3">
+                  </calcite-radio-button>
 
                   <h3>None checked</h3>
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="1"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="2"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="3"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="noneCheckedDark" value="1"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="noneCheckedDark" value="2"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="noneCheckedDark" value="3"></calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="1"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="2" disabled></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="3"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="1">
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="2" disabled>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="3">
+                  </calcite-radio-button>
 
                   <h3>Only one checked value (first wins, first two checked)</h3>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirst2" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirst2" value="2" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirst2" value="3"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirst2" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirst2" value="2" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirst2" value="3"></calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirst2" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirst2" value="2" checked disabled></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirst2" value="3"></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirst2" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirst2" value="2" checked
+                    disabled></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirst2" value="3">
+                  </calcite-radio-button>
 
                   <h3>Only one checked value (first wins, second two checked)</h3>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkSecond2" value="1"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkSecond2" value="2" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkSecond2" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkSecond2" value="1">
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkSecond2" value="2" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkSecond2" value="3" checked>
+                  </calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleSecond2" value="1"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleSecond2" value="2" checked disabled></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleSecond2" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleSecond2" value="1">
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleSecond2" value="2" checked
+                    disabled></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleSecond2" value="3" checked>
+                  </calcite-radio-button>
 
                   <h3>Only one checked value (first wins, first and last checked)</h3>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirstLast" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirstLast" value="2"></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirstLast" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirstLast" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirstLast" value="2">
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkFirstLast" value="3" checked>
+                  </calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirstLast" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirstLast" value="2" disabled></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirstLast" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirstLast" value="1"
+                    checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirstLast" value="2"
+                    disabled></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkDisabledSingleFirstLast" value="3"
+                    checked></calcite-radio-button>
 
                   <h3>Only one checked value (first wins, all checked)</h3>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAll" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAll" value="2" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAll" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAll" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAll" value="2" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAll" value="3" checked>
+                  </calcite-radio-button>
 
-                    <hr>
+                  <hr>
 
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAllDisabledSingle" value="1" checked></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAllDisabledSingle" value="2" checked disabled></calcite-radio-button>
-                    <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAllDisabledSingle" value="3" checked></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAllDisabledSingle" value="1" checked>
+                  </calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAllDisabledSingle" value="2" checked
+                    disabled></calcite-radio-button>
+                  <calcite-radio-button theme="dark" name="firstCheckedWinsDarkAllDisabledSingle" value="3" checked>
+                  </calcite-radio-button>
 
                 </div>
               </div>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -24,11 +24,12 @@
 
 <body>
   <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Slider</h1>
+  <!-- <h1>Calcite Slider</h1>
 
-  <h3>Single Value</h3>
+  <h3>Single Value</h3> -->
   <calcite-slider id="mySlider" min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>
-  <!-- <calcite-slider id="mySlider" min="0" max="1000" value="0" step="1" label="Temperature" ></calcite-slider>
+  <calcite-slider id="mySlider" min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
+  <calcite-slider id="mySlider" min="0" max="1000" value="0" step="1" label="Temperature" ></calcite-slider>
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
   </calcite-slider>
@@ -89,7 +90,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script> -->
+  </script>
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -93,7 +93,7 @@
     <h3>Histogram with Ticks and Precise Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
 
-    <h3>Histogram with Ticks and Labeled Precise Handle</h3>
+    <h3>Histogram with Ticks and Precise Labeled Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise></calcite-slider>
 
     <h3>Histogram with Labeled Ticks</h3>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -23,7 +23,7 @@
 </head>
 
 <body>
-  <calcite-button href="/">Home</calcite-button>
+  <!-- <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Slider</h1>
 
   <h2>Single Value</h2>
@@ -83,12 +83,12 @@
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks></calcite-slider>
 
   <h3>Precise Handle with Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-ticks></calcite-slider>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-ticks></calcite-slider> -->
 
   <h3>Precise Labeled Handle with Labeled Ticks</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="10000" ticks="10000" label="Temperature" precise label-handles label-ticks></calcite-slider>
 
-  <div style="max-width: 400px">
+  <!-- <div style="max-width: 400px">
 
     <h3>Histogram</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
@@ -139,7 +139,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script>
+  </script> -->
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -27,7 +27,7 @@
   <h1>Calcite Slider</h1>
 
   <h3>Single Value</h3>
-  <calcite-slider id="mySlider" min="0" max="1000" value="1000" step="1" label="Temperature" label-handles></calcite-slider>
+  <calcite-slider id="mySlider" min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>
   <!-- <calcite-slider id="mySlider" min="0" max="1000" value="0" step="1" label="Temperature" ></calcite-slider>
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -26,17 +26,17 @@
   <calcite-button href="/">Home</calcite-button>
   <!-- <h1>Calcite Slider</h1>
 
-  <h3>Single Value</h3> -->
+  <h3>Single Value</h3>
   <calcite-slider id="mySlider" min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>
   <calcite-slider id="mySlider" min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
   <calcite-slider id="mySlider" min="0" max="1000" value="0" step="1" label="Temperature" ></calcite-slider>
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
-  </calcite-slider>
+  </calcite-slider> -->
   <h3>Range</h3>
   <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
     max-label="Temperature range (upper)"></calcite-slider>
-  <h3>Ticks</h3>
+  <!-- <h3>Ticks</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider>
   <h3>Handle Labels</h3>
   <calcite-slider min="0" max="100" min-value="23" max-value="46" step="1" ticks="10" label-handles precise
@@ -90,7 +90,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script>
+  </script> -->
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -207,6 +207,8 @@
         <h3>Histogram with Labeled Handles</h3>
         <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
           max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+        <calcite-slider min="-100" max="0" min-value="-100" max-value="0" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
 
         <h3>Histogram with Precise Handles</h3>
         <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -85,7 +85,7 @@
   <h3>Precise Labeled Handle with Labeled Ticks</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="10000" ticks="10000" label="Temperature" precise label-handles label-ticks></calcite-slider>
 
-  <!-- <div style="max-width: 400px">
+  <div style="max-width: 400px">
 
     <h3>Histogram</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
@@ -136,7 +136,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script> -->
+  </script>
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -27,30 +27,29 @@
   <!-- <h1>Calcite Slider</h1>
 
   <h3>Single Value</h3>
-  <calcite-slider id="mySlider" min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>
-  <calcite-slider id="mySlider" min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
-  <calcite-slider id="mySlider" min="0" max="1000" value="0" step="1" label="Temperature" ></calcite-slider>
+  <calcite-slider min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
   </calcite-slider> -->
   <h3>Range</h3>
-  <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-    max-label="Temperature range (upper)"></calcite-slider>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
+    max-label="Temperature range (upper)" label-handles></calcite-slider>
   <!-- <h3>Ticks</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider> -->
   <h3>Handle Labels</h3>
   <calcite-slider min="0" max="100" min-value="23" max-value="46" step="1" ticks="10" label-handles precise
     label="Temperature"></calcite-slider>
-  <h3>Tick Labels</h3>
+  <!-- <h3>Tick Labels</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks label="Temperature">
-  </calcite-slider>
+  </calcite-slider> -->
   <h3>"Precise" handle</h3>
   <calcite-slider min="0" max="100" value="23" step="1" label="Temperature" precise></calcite-slider>
   <h3>"Precise" Range</h3>
   <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
     max-label="Temperature range (upper)" precise></calcite-slider>
 
-  <div style="max-width: 400px">
+  <!-- <div style="max-width: 400px">
     <h3>Histogram</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
     <h3>Histogram Range</h3>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -32,22 +32,29 @@
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
   </calcite-slider> -->
+
   <h3>Range</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
+    max-label="Temperature range (upper)"></calcite-slider>
+
+  <h3>Precise Range</h3>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+    min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
+
+  <h3>Range Handle Labels</h3>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
     max-label="Temperature range (upper)" label-handles></calcite-slider>
+
+  <h3>Precise Range Handle Labels</h3>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+    min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles></calcite-slider>
+
   <!-- <h3>Ticks</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider> -->
-  <h3>Handle Labels</h3>
-  <calcite-slider min="0" max="100" min-value="23" max-value="46" step="1" ticks="10" label-handles precise
-    label="Temperature"></calcite-slider>
+
   <!-- <h3>Tick Labels</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks label="Temperature">
   </calcite-slider> -->
-  <h3>"Precise" handle</h3>
-  <calcite-slider min="0" max="100" value="23" step="1" label="Temperature" precise></calcite-slider>
-  <h3>"Precise" Range</h3>
-  <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-    max-label="Temperature range (upper)" precise></calcite-slider>
 
   <!-- <div style="max-width: 400px">
     <h3>Histogram</h3>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -31,11 +31,11 @@
   <h3>Handle</h3>
   <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
 
-  <h3>Precise Handle</h3>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise></calcite-slider>
-
   <h3>Labeled Handle</h3>
   <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
+
+  <h3>Precise Handle</h3>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise></calcite-slider>
 
   <h3>Precise Labeled Handle</h3>
   <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles></calcite-slider>
@@ -83,9 +83,9 @@
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-ticks></calcite-slider>
 
   <h3>Precise Labeled Handle with Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-handles label-ticks></calcite-slider>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="10000" ticks="10000" label="Temperature" precise label-handles label-ticks></calcite-slider>
 
-  <div style="max-width: 400px">
+  <!-- <div style="max-width: 400px">
 
     <h3>Histogram</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
@@ -136,7 +136,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script>
+  </script> -->
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -12,6 +12,7 @@
       color: white;
       padding: 1rem;
     }
+
     h3 {
       margin-top: 24px;
     }
@@ -23,7 +24,7 @@
 </head>
 
 <body>
-  <!-- <calcite-button href="/">Home</calcite-button>
+  <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Slider</h1>
 
   <h2>Single Value</h2>
@@ -38,32 +39,66 @@
   <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise></calcite-slider>
 
   <h3>Precise Labeled Handle</h3>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles></calcite-slider>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
+  </calcite-slider>
 
-  <h3>Handle with Ticks</h3>
+  <h3>Ticks</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider>
 
-  <h3>Handle with Labeled Ticks</h3>
+  <h3>Labeled Ticks</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks label="Temperature"></calcite-slider>
 
-  <h3>Precise Handle with Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature"></calcite-slider>
+  <h3>Labeled Ticks with Precise Handle</h3>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+  </calcite-slider>
 
-  <h3>Precise Labeled Handle with Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise label="Temperature"></calcite-slider>
+  <h3>Labeled Ticks with Precise Labeled Handle</h3>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise
+    label="Temperature"></calcite-slider>
 
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
 
+  <div style="max-width: 400px">
+    <h3>Histogram</h3>
+    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+
+    <h3>Histogram Labeled Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+
+    <h3>Histogram Precise Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+
+    <h3>Histogram Precise Labeled Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise></calcite-slider>
+
+    <h3>Histogram Ticks</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+
+    <h3>Histogram Labeled Ticks</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks></calcite-slider>
+
+    <h3>Histogram Labeled Ticks with Precise Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+    </calcite-slider>
+
+    <h3>Histogram Labeled Ticks with Precise Labeled Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
+      precise></calcite-slider>
+
+    <h3>Histogram Disabled</h3>
+    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+  </div>
+
   <h2>Range</h2>
 
   <h3>Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
-    max-label="Temperature range (upper)"></calcite-slider>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+    min-label="Temperature range (lower)" max-label="Temperature range (upper)"></calcite-slider>
 
   <h3>Labeled Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
-    max-label="Temperature range (upper)" label-handles></calcite-slider>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+    min-label="Temperature range (lower)" max-label="Temperature range (upper)" label-handles></calcite-slider>
 
   <h3>Precise Handles</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
@@ -73,30 +108,67 @@
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
     min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles></calcite-slider>
 
-  <h3>Handles with Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"></calcite-slider>
+  <h3>Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+  </calcite-slider>
 
-  <h3>Precise Handles with Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise></calcite-slider>
+  <h3>Ticks with Precise Handles</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise>
+  </calcite-slider>
 
-  <h3>Handles with Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks></calcite-slider>
+  <h3>Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks>
+  </calcite-slider>
 
-  <h3>Precise Handle with Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-ticks></calcite-slider> -->
+  <h3>Labeled Ticks with Precise Handles</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
+    label-ticks></calcite-slider>
 
-  <h3>Precise Labeled Handle with Labeled Ticks</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="10000" ticks="10000" label="Temperature" precise label-handles label-ticks></calcite-slider>
+  <h3>Labeled Ticks with Precise Labeled Handles</h3>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="10000" ticks="10000"
+    label="Temperature" precise label-handles label-ticks></calcite-slider>
 
-  <!-- <div style="max-width: 400px">
+  <div style="max-width: 400px">
 
     <h3>Histogram</h3>
-    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
-
-    <h3>Histogram Range</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
 
+    <h3>Histogram Labeled Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+      max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+
+    <h3>Histogram Precise Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+      max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
+
+    <h3>Histogram Precise Labeled Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+      max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
+
+    <h3>Histogram Ticks</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+
+    <h3>Histogram Ticks with Precise Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
+    </calcite-slider>
+
+    <h3>Histogram Labeled Ticks</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
+    </calcite-slider>
+
+    <h3>Histogram Labeled Ticks with Precise Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks precise>
+    </calcite-slider>
+
+    <h3>Histogram Labeled Ticks with Precise Labeled Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles label-ticks precise>
+    </calcite-slider>
   </div>
 
   <div class="demo-background-dark" theme="dark">
@@ -139,7 +211,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script> -->
+  </script>
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -27,10 +27,8 @@
   <h1>Calcite Slider</h1>
 
   <h3>Single Value</h3>
-  <div style="background: #CCC; border: 1px solid black; padding: 10px;">
-    <!-- <calcite-slider id="mySlider" min="0" max="1000000" value="1000000" step="1" label="Temperature" label-handles></calcite-slider> -->
-    <calcite-slider id="mySlider" min="0" max="1000000" value="0" step="1" label="Temperature" ></calcite-slider>
-  </div>
+  <calcite-slider id="mySlider" min="0" max="1000" value="1000" step="1" label="Temperature" label-handles></calcite-slider>
+  <!-- <calcite-slider id="mySlider" min="0" max="1000" value="0" step="1" label="Temperature" ></calcite-slider>
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
   </calcite-slider>
@@ -91,7 +89,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script>
+  </script> -->
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -22,9 +22,9 @@
   <script nomodule src="../build/calcite.js"></script>
 </head>
 
-<body>
+<body><!--
   <calcite-button href="/">Home</calcite-button>
-  <!-- <h1>Calcite Slider</h1>
+  <h1>Calcite Slider</h1>
 
   <h3>Single Value</h3>
   <calcite-slider min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -76,6 +76,9 @@
   <h3>Handles with Ticks</h3>
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"></calcite-slider>
 
+  <h3>Precise Handles with Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise></calcite-slider>
+
   <h3>Handles with Labeled Ticks</h3>
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks></calcite-slider>
 

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -8,12 +8,10 @@
   <title>Calcite Slider</title>
   <style>
     body {
-      margin: 0;
+      margin: 20px;
     }
     .demo-background-light {
-      border-top: 1px solid #202020;
-      border-right: 1px solid #202020;
-      border-bottom: 1px solid #202020;
+      border: 1px solid #202020;
       padding: 1rem;
     }
     .demo-background-dark {
@@ -69,6 +67,8 @@
 
         <h3>Ticks with Labeled Handle</h3>
         <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+        </calcite-slider>
+        <calcite-slider min="-100" max="0" value="0" step="10" ticks="10" label="Temperature" label-handles>
         </calcite-slider>
 
         <h3>Ticks with Precise Handle</h3>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -43,10 +43,22 @@
   </calcite-slider>
 
   <h3>Ticks</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider>
+  <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+
+  <h3>Ticks with Labeled Handle</h3>
+  <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles></calcite-slider>
+
+  <h3>Ticks with Precise Handle</h3>
+  <calcite-slider min="0" max="100" value="50" step="10" ticks="10" label="Temperature" precise></calcite-slider>
+
+  <h3>Ticks with Precise Labeled Handle</h3>
+  <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise></calcite-slider>
 
   <h3>Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks label="Temperature"></calcite-slider>
+  <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature"></calcite-slider>
+
+  <h3>Labeled Ticks with Labeled Handle</h3>
+  <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles label-ticks></calcite-slider>
 
   <h3>Labeled Ticks with Precise Handle</h3>
   <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
@@ -63,26 +75,38 @@
     <h3>Histogram</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
 
-    <h3>Histogram Labeled Handle</h3>
+    <h3>Histogram with Labeled Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
 
-    <h3>Histogram Precise Handle</h3>
+    <h3>Histogram with Precise Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
 
-    <h3>Histogram Precise Labeled Handle</h3>
+    <h3>Histogram with Precise Labeled Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise></calcite-slider>
 
-    <h3>Histogram Ticks</h3>
+    <h3>Histogram with Ticks</h3>
     <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
 
-    <h3>Histogram Labeled Ticks</h3>
+    <h3>Histogram with Ticks and Labeled Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles></calcite-slider>
+
+    <h3>Histogram with Ticks and Precise Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
+
+    <h3>Histogram with Ticks and Labeled Precise Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise></calcite-slider>
+
+    <h3>Histogram with Labeled Ticks</h3>
     <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks></calcite-slider>
 
-    <h3>Histogram Labeled Ticks with Precise Handle</h3>
+    <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks></calcite-slider>
+
+    <h3>Histogram with Labeled Ticks and Precise Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
     </calcite-slider>
 
-    <h3>Histogram Labeled Ticks with Precise Labeled Handle</h3>
+    <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
     <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
       precise></calcite-slider>
 
@@ -112,20 +136,30 @@
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
   </calcite-slider>
 
+  <h3>Ticks with Labeled Handles</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles></calcite-slider>
+
   <h3>Ticks with Precise Handles</h3>
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise>
+  </calcite-slider>
+
+  <h3>Ticks with Precise Labeled Handles</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles precise>
   </calcite-slider>
 
   <h3>Labeled Ticks</h3>
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks>
   </calcite-slider>
 
+  <h3>Labeled Ticks with Labeled Handles</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles label-ticks></calcite-slider>
+
   <h3>Labeled Ticks with Precise Handles</h3>
   <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
     label-ticks></calcite-slider>
 
   <h3>Labeled Ticks with Precise Labeled Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="10000" ticks="10000"
+  <calcite-slider min="10000" max="100000" min-value="30000" max-value="80000" step="10000" ticks="10000"
     label="Temperature" precise label-handles label-ticks></calcite-slider>
 
   <div style="max-width: 400px">
@@ -134,38 +168,52 @@
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
 
-    <h3>Histogram Labeled Handles</h3>
+    <h3>Histogram with Labeled Handles</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
 
-    <h3>Histogram Precise Handles</h3>
+    <h3>Histogram with Precise Handles</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
 
-    <h3>Histogram Precise Labeled Handles</h3>
+    <h3>Histogram with Precise Labeled Handles</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
 
-    <h3>Histogram Ticks</h3>
+    <h3>Histogram with Ticks</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
       min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
 
-    <h3>Histogram Ticks with Precise Handles</h3>
+    <h3>Histogram with Ticks and Labeled Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+
+    <h3>Histogram with Ticks and Precise Handles</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
       min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
     </calcite-slider>
 
-    <h3>Histogram Labeled Ticks</h3>
+    <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles precise>
+    </calcite-slider>
+
+    <h3>Histogram with Labeled Ticks</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
       min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
     </calcite-slider>
 
-    <h3>Histogram Labeled Ticks with Precise Handles</h3>
+    <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles label-ticks>
+    </calcite-slider>
+
+    <h3>Histogram with Labeled Ticks and Precise Handles</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
       min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks precise>
     </calcite-slider>
 
-    <h3>Histogram Labeled Ticks with Precise Labeled Handles</h3>
+    <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
       min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles label-ticks precise>
     </calcite-slider>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -22,60 +22,100 @@
   <script nomodule src="../build/calcite.js"></script>
 </head>
 
-<body><!--
+<body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Slider</h1>
 
-  <h3>Single Value</h3>
-  <calcite-slider min="0" max="1000" value="800" step="1" label="Temperature" label-handles></calcite-slider>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
-  <h3>Disabled</h3>
-  <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
-  </calcite-slider> -->
+  <h2>Single Value</h2>
 
-  <h3>Range</h3>
+  <h3>Handle</h3>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+
+  <h3>Precise Handle</h3>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise></calcite-slider>
+
+  <h3>Labeled Handle</h3>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
+
+  <h3>Precise Labeled Handle</h3>
+  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles></calcite-slider>
+
+  <h3>Handle with Ticks</h3>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider>
+
+  <h3>Handle with Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks label="Temperature"></calcite-slider>
+
+  <h3>Precise Handle with Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature"></calcite-slider>
+
+  <h3>Precise Labeled Handle with Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise label="Temperature"></calcite-slider>
+
+  <h3>Disabled</h3>
+  <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+
+  <h2>Range</h2>
+
+  <h3>Handles</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
     max-label="Temperature range (upper)"></calcite-slider>
 
-  <h3>Precise Range</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-    min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
-
-  <h3>Range Handle Labels</h3>
+  <h3>Labeled Handles</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1" min-label="Temperature range (lower)"
     max-label="Temperature range (upper)" label-handles></calcite-slider>
 
-  <h3>Precise Range Handle Labels</h3>
+  <h3>Precise Handles</h3>
+  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+    min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
+
+  <h3>Precise Labeled Handles</h3>
   <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
     min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles></calcite-slider>
 
-  <!-- <h3>Ticks</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label="Temperature"></calcite-slider> -->
+  <h3>Handles with Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"></calcite-slider>
 
-  <!-- <h3>Tick Labels</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks label="Temperature">
-  </calcite-slider> -->
+  <h3>Handles with Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks></calcite-slider>
 
-  <!-- <div style="max-width: 400px">
+  <h3>Precise Handle with Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-ticks></calcite-slider>
+
+  <h3>Precise Labeled Handle with Labeled Ticks</h3>
+  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise label-handles label-ticks></calcite-slider>
+
+  <div style="max-width: 400px">
+
     <h3>Histogram</h3>
     <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+
     <h3>Histogram Range</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+
   </div>
+
   <div class="demo-background-dark" theme="dark">
+
     <h3>Dark Theme</h3>
     <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
       max-label="Temperature range (upper)" theme="dark" label-ticks ticks="10"></calcite-slider>
+
     <div style="max-width: 400px">
+
       <h3>Histogram Range</h3>
       <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
         max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+
     </div>
+
   </div>
+
   <h3>Event Listener</h3>
   <calcite-slider id="sliderEvents" min="0" max="100" value="50" step="1" label="Temperature"></calcite-slider>
   <p>Current slider value is: <span id="sliderEventDisplay"></span></p>
+
   <script>
     (function () {
       var label = document.getElementById("sliderEventDisplay");
@@ -96,7 +136,7 @@
     [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
       graphElement.histogram = histogram;
     });
-  </script> -->
+  </script>
 </body>
 
 </html>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -7,10 +7,24 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Calcite Slider</title>
   <style>
+    body {
+      margin: 0;
+    }
+    .demo-background-light {
+      border-top: 1px solid #202020;
+      border-right: 1px solid #202020;
+      border-bottom: 1px solid #202020;
+      padding: 1rem;
+    }
     .demo-background-dark {
       background: #202020;
       color: white;
       padding: 1rem;
+    }
+    .two-columns {
+      display: grid;
+      grid-template-columns: 350px 350px;
+      grid-gap: 20px;
     }
 
     h3 {
@@ -21,218 +35,451 @@
   <link rel="stylesheet" href="../build/calcite.css" />
   <script type="module" src="../build/calcite.esm.js"></script>
   <script nomodule src="../build/calcite.js"></script>
+  <script type="module" src="./helpers/demo-form.js"></script>
+  <script type="module" src="./helpers/demo-spacer.js"></script>
 </head>
 
 <body>
+
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Slider</h1>
 
-  <h2>Single Value</h2>
+  <div class="two-columns">
+    <div class="demo-background-light">
+      <h2>Single Value</h2>
 
-  <h3>Handle</h3>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+      <demo-spacer>
 
-  <h3>Labeled Handle</h3>
-  <calcite-slider min="100" max="1000" value="1000" step="10" label="Temperature" label-handles></calcite-slider>
+        <h3>Handle</h3>
+        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
 
-  <h3>Precise Handle</h3>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise></calcite-slider>
+        <h3>Labeled Handle</h3>
+        <calcite-slider min="100" max="1000" value="1000" step="10" label="Temperature" label-handles></calcite-slider>
 
-  <h3>Precise Labeled Handle</h3>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
-  </calcite-slider>
+        <h3>Precise Handle</h3>
+        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+        </calcite-slider>
 
-  <h3>Ticks</h3>
-  <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+        <h3>Precise Labeled Handle</h3>
+        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
+        </calcite-slider>
 
-  <h3>Ticks with Labeled Handle</h3>
-  <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles></calcite-slider>
+        <h3>Ticks</h3>
+        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
 
-  <h3>Ticks with Precise Handle</h3>
-  <calcite-slider min="0" max="100" value="50" step="10" ticks="10" label="Temperature" precise></calcite-slider>
+        <h3>Ticks with Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+        </calcite-slider>
 
-  <h3>Ticks with Precise Labeled Handle</h3>
-  <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise></calcite-slider>
+        <h3>Ticks with Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="50" step="10" ticks="10" label="Temperature" precise></calcite-slider>
 
-  <h3>Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature"></calcite-slider>
+        <h3>Ticks with Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
+        </calcite-slider>
 
-  <h3>Labeled Ticks with Labeled Handle</h3>
-  <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles label-ticks></calcite-slider>
+        <h3>Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+        </calcite-slider>
 
-  <h3>Labeled Ticks with Precise Handle</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
-  </calcite-slider>
+        <h3>Labeled Ticks with Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles label-ticks>
+        </calcite-slider>
 
-  <h3>Labeled Ticks with Precise Labeled Handle</h3>
-  <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise
-    label="Temperature"></calcite-slider>
+        <h3>Labeled Ticks with Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+        </calcite-slider>
 
-  <h3>Disabled</h3>
-  <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+        <h3>Labeled Ticks with Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise
+          label="Temperature"></calcite-slider>
 
-  <div style="max-width: 400px">
-    <h3>Histogram</h3>
-    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+        <h3>Disabled</h3>
+        <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
 
-    <h3>Histogram with Labeled Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+        <h3>Histogram</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
 
-    <h3>Histogram with Precise Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+        <h3>Histogram with Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
 
-    <h3>Histogram with Precise Labeled Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise></calcite-slider>
+        <h3>Histogram with Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
 
-    <h3>Histogram with Ticks</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+        <h3>Histogram with Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+        </calcite-slider>
 
-    <h3>Histogram with Ticks and Labeled Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles></calcite-slider>
+        <h3>Histogram with Ticks</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
 
-    <h3>Histogram with Ticks and Precise Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
+        <h3>Histogram with Ticks and Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
+        </calcite-slider>
 
-    <h3>Histogram with Ticks and Precise Labeled Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise></calcite-slider>
+        <h3>Histogram with Ticks and Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
 
-    <h3>Histogram with Labeled Ticks</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks></calcite-slider>
+        <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks></calcite-slider>
+        <h3>Histogram with Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks and Precise Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
-    </calcite-slider>
+        <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles
+          label-ticks>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
-    <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
-      precise></calcite-slider>
+        <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+        </calcite-slider>
 
-    <h3>Histogram Disabled</h3>
-    <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
-  </div>
+        <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
+          precise></calcite-slider>
 
-  <h2>Range</h2>
+        <h3>Histogram Disabled</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+      </demo-spacer>
 
-  <h3>Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-    min-label="Temperature range (lower)" max-label="Temperature range (upper)"></calcite-slider>
+      <h2>Range</h2>
 
-  <h3>Labeled Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-    min-label="Temperature range (lower)" max-label="Temperature range (upper)" label-handles></calcite-slider>
+      <demo-spacer>
+        <h3>Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)"></calcite-slider>
 
-  <h3>Precise Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-    min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
+        <h3>Labeled Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" label-handles></calcite-slider>
 
-  <h3>Precise Labeled Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-    min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles></calcite-slider>
+        <h3>Precise Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
 
-  <h3>Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
-  </calcite-slider>
+        <h3>Precise Labeled Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles>
+        </calcite-slider>
 
-  <h3>Ticks with Labeled Handles</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles></calcite-slider>
+        <h3>Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+        </calcite-slider>
 
-  <h3>Ticks with Precise Handles</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise>
-  </calcite-slider>
+        <h3>Ticks with Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
+          label-handles></calcite-slider>
 
-  <h3>Ticks with Precise Labeled Handles</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles precise>
-  </calcite-slider>
+        <h3>Ticks with Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
+          precise>
+        </calcite-slider>
 
-  <h3>Labeled Ticks</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks>
-  </calcite-slider>
+        <h3>Ticks with Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
+          label-handles precise>
+        </calcite-slider>
 
-  <h3>Labeled Ticks with Labeled Handles</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles label-ticks></calcite-slider>
+        <h3>Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
+          label-ticks>
+        </calcite-slider>
 
-  <h3>Labeled Ticks with Precise Handles</h3>
-  <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
-    label-ticks></calcite-slider>
+        <h3>Labeled Ticks with Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
+          label-handles label-ticks></calcite-slider>
 
-  <h3>Labeled Ticks with Precise Labeled Handles</h3>
-  <calcite-slider min="10000" max="100000" min-value="30000" max-value="80000" step="10000" ticks="10000"
-    label="Temperature" precise label-handles label-ticks></calcite-slider>
+        <h3>Labeled Ticks with Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
+          label-ticks></calcite-slider>
 
-  <div style="max-width: 400px">
+        <h3>Labeled Ticks with Precise Labeled Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="30000" max-value="80000" step="10000" ticks="10000"
+          label="Temperature" precise label-handles label-ticks></calcite-slider>
 
-    <h3>Histogram</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-      max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+        <h3>Histogram</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
 
-    <h3>Histogram with Labeled Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-      max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+        <h3>Histogram with Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
 
-    <h3>Histogram with Precise Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-      max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
+        <h3>Histogram with Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
 
-    <h3>Histogram with Precise Labeled Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-      max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
+        <h3>Histogram with Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
 
-    <h3>Histogram with Ticks</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+        <h3>Histogram with Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram">
+        </calcite-slider>
 
-    <h3>Histogram with Ticks and Labeled Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+        <h3>Histogram with Ticks and Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram"
+          label-handles>
+        </calcite-slider>
 
-    <h3>Histogram with Ticks and Precise Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
-    </calcite-slider>
+        <h3>Histogram with Ticks and Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
+        </calcite-slider>
 
-    <h3>Histogram with Ticks and Precise Labeled Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles precise>
-    </calcite-slider>
+        <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
+          precise>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
-    </calcite-slider>
+        <h3>Histogram with Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles label-ticks>
-    </calcite-slider>
+        <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
+          label-ticks>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks and Precise Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks precise>
-    </calcite-slider>
+        <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks
+          precise>
+        </calcite-slider>
 
-    <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-      min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles label-ticks precise>
-    </calcite-slider>
-  </div>
+        <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
+          label-ticks precise>
+        </calcite-slider>
 
-  <div class="demo-background-dark" theme="dark">
-
-    <h3>Dark Theme</h3>
-    <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-      max-label="Temperature range (upper)" theme="dark" label-ticks ticks="10"></calcite-slider>
-
-    <div style="max-width: 400px">
-
-      <h3>Histogram Range</h3>
-      <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-        max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
-
+      </demo-spacer>
     </div>
 
+    <div class="demo-background-dark" theme="dark">
+
+      <h2>Single Value</h2>
+
+      <demo-spacer>
+
+        <h3>Handle</h3>
+        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+
+        <h3>Labeled Handle</h3>
+        <calcite-slider min="100" max="1000" value="1000" step="10" label="Temperature" label-handles></calcite-slider>
+
+        <h3>Precise Handle</h3>
+        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+        </calcite-slider>
+
+        <h3>Precise Labeled Handle</h3>
+        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
+        </calcite-slider>
+
+        <h3>Ticks</h3>
+        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+
+        <h3>Ticks with Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+        </calcite-slider>
+
+        <h3>Ticks with Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="50" step="10" ticks="10" label="Temperature" precise></calcite-slider>
+
+        <h3>Ticks with Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
+        </calcite-slider>
+
+        <h3>Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+        </calcite-slider>
+
+        <h3>Labeled Ticks with Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles label-ticks>
+        </calcite-slider>
+
+        <h3>Labeled Ticks with Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+        </calcite-slider>
+
+        <h3>Labeled Ticks with Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise
+          label="Temperature"></calcite-slider>
+
+        <h3>Disabled</h3>
+        <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+
+        <h3>Histogram</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+
+        <h3>Histogram with Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+
+        <h3>Histogram with Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+
+        <h3>Histogram with Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+        </calcite-slider>
+
+        <h3>Histogram with Ticks</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+
+        <h3>Histogram with Ticks and Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
+        </calcite-slider>
+
+        <h3>Histogram with Ticks and Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
+
+        <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
+          precise></calcite-slider>
+
+        <h3>Histogram Disabled</h3>
+        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+      </demo-spacer>
+
+      <h2>Range</h2>
+
+      <demo-spacer>
+        <h3>Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)"></calcite-slider>
+
+        <h3>Labeled Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" label-handles></calcite-slider>
+
+        <h3>Precise Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
+
+        <h3>Precise Labeled Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles>
+        </calcite-slider>
+
+        <h3>Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+        </calcite-slider>
+
+        <h3>Ticks with Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
+          label-handles></calcite-slider>
+
+        <h3>Ticks with Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise>
+        </calcite-slider>
+
+        <h3>Ticks with Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles
+          precise>
+        </calcite-slider>
+
+        <h3>Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks>
+        </calcite-slider>
+
+        <h3>Labeled Ticks with Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles
+          label-ticks></calcite-slider>
+
+        <h3>Labeled Ticks with Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
+          label-ticks></calcite-slider>
+
+        <h3>Labeled Ticks with Precise Labeled Handles</h3>
+        <calcite-slider min="10000" max="100000" min-value="30000" max-value="80000" step="10000" ticks="10000"
+          label="Temperature" precise label-handles label-ticks></calcite-slider>
+
+        <h3>Histogram</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+
+        <h3>Histogram with Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+
+        <h3>Histogram with Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
+
+        <h3>Histogram with Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
+          max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
+
+        <h3>Histogram with Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram">
+        </calcite-slider>
+
+        <h3>Histogram with Ticks and Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles>
+        </calcite-slider>
+
+        <h3>Histogram with Ticks and Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
+        </calcite-slider>
+
+        <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
+          precise>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
+          label-ticks>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks
+          precise>
+        </calcite-slider>
+
+        <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
+          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
+          label-ticks precise>
+        </calcite-slider>
+
+      </demo-spacer>
+
+    </div>
   </div>
 
   <h3>Event Listener</h3>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -27,7 +27,10 @@
   <h1>Calcite Slider</h1>
 
   <h3>Single Value</h3>
-  <calcite-slider id="mySlider" min="0" max="100" value="25" step="1" label="Temperature"></calcite-slider>
+  <div style="background: #CCC; border: 1px solid black; padding: 10px;">
+    <!-- <calcite-slider id="mySlider" min="0" max="1000000" value="1000000" step="1" label="Temperature" label-handles></calcite-slider> -->
+    <calcite-slider id="mySlider" min="0" max="1000000" value="0" step="1" label="Temperature" ></calcite-slider>
+  </div>
   <h3>Disabled</h3>
   <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled>
   </calcite-slider>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -32,7 +32,7 @@
   <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
 
   <h3>Labeled Handle</h3>
-  <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" label-handles></calcite-slider>
+  <calcite-slider min="100" max="1000" value="1000" step="10" label="Temperature" label-handles></calcite-slider>
 
   <h3>Precise Handle</h3>
   <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise></calcite-slider>


### PR DESCRIPTION
I have 3 out of the four features complete from the original issue https://github.com/Esri/calcite-components/issues/532.  These features are the top left, top right and bottom left features in this diagram:

![image](https://user-images.githubusercontent.com/821864/84432932-5f6a9300-abe2-11ea-87d9-f26500055705.png)


I need some more information about the inactive story, so I thought it best to break that out into its own ticket.

Be sure to check out the revamped demo page for this component when you run this branch: http://localhost:3333/demos/calcite-slider.html. I drastically altered it so that I could see every possible iteration and it makes for a comprehensive way of looking at the new features.

Last To-dos:
- [x] Add single value histogram shading
- [x] Fix small-value overlap issues
- [x] Prevent horizontal "jumping" effect when handles butt right up against each other before spreading further part when the hyphen appears
- [x] Prevent hyphenated range labels from extending past edge of slider in cases where the label on one side doesn't exceed the handle width, such as this case:

![image](https://user-images.githubusercontent.com/821864/84538403-71ae0500-aca6-11ea-889f-e0380b9018d6.png)
