### PR TITLE
create types for using calcite components with preact + typescript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,18 @@ const loader = document.querySelector(
 loader.isActive = true;
 ```
 
+### TypeScript with Preact
+
+For preact applications using TypeScript, you must an additional file to your `tsconfig.json`:
+
+```
+"files": [
+  "node_modules/@esri/calcite-components/dist/types/preact.d.ts"
+],
+```
+
+This allows you to use custom tags and provides auto-complete for calcite-components. See the [Preact + TypeScript example](https://github.com/ArcGIS/calcite-components-examples/tree/master/preact-typescript) for more details.
+
 ## Browser Support
 
 | <img src="https://raw.githubusercontent.com/godban/browsers-support-badges/master/src/images/edge.png" alt="IE / Edge" width="16px" height="16px" /></br>IE / Edge | <img src="https://raw.githubusercontent.com/godban/browsers-support-badges/master/src/images/firefox.png" alt="Firefox" width="16px" height="16px" /></br>Firefox | <img src="https://raw.githubusercontent.com/godban/browsers-support-badges/master/src/images/chrome.png" alt="Chrome" width="16px" height="16px" /></br>Chrome | <img src="https://raw.githubusercontent.com/godban/browsers-support-badges/master/src/images/safari.png" alt="Safari" width="16px" height="16px" /></br>Safari |

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -28,7 +28,7 @@ import { getKey } from "../../utils/key";
   styleUrl: "calcite-date.scss",
   shadow: true,
 })
-export class CalciteDatePicker {
+export class CalciteDate {
   //--------------------------------------------------------------------------
   //
   //  Element

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -15,7 +15,7 @@ import { getElementDir } from "../../utils/dom";
   styleUrl: "calcite-split-button.scss",
   shadow: true,
 })
-export class CalciteButtonWithDropdown {
+export class CalciteSplitButton {
   @Element() el: HTMLElement;
 
   /** specify the color of the control, defaults to blue */

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,5 +1,6 @@
 import { Config } from "@stencil/core";
 import { sass } from "@stencil/sass";
+import { generatePreactTypes } from "./support/preact";
 
 export const config: Config = {
   namespace: "calcite",
@@ -56,6 +57,7 @@ export const config: Config = {
     { type: "dist-hydrate-script" },
     { type: "dist" },
     { type: "docs-readme" },
+    { type: "custom", name: "preact", generator: generatePreactTypes },
     {
       type: "www",
       baseUrl: "https://stenciljs.com/",

--- a/support/preact.ts
+++ b/support/preact.ts
@@ -1,0 +1,49 @@
+import { join } from "path";
+
+export const generatePreactTypes = async (
+  config,
+  compilerCtx,
+  buildCtx
+): Promise<void> => {
+  const { typesDir } = config.outputTargets.find((o) => o.typesDir);
+  const outputPath = join(typesDir, "preact.d.ts");
+  const types = buildCtx.components.map(getType).join("\n");
+  await compilerCtx.fs.writeFile(outputPath, getTemplate(types));
+};
+
+function getTemplate(types: string): String {
+  return `
+import { JSXInternal } from "preact/src/jsx";
+import { JSX } from "./components";
+
+declare module "preact/src/jsx" {
+  namespace JSXInternal {
+    interface IntrinsicElements {
+      ${types};
+    }
+  }
+}
+  `;
+}
+
+function getType({ events, tagName, componentClassName }) {
+  if (!events?.length) {
+    return `
+      "${tagName}": JSX.${componentClassName} & JSXInternal.HTMLAttributes<HTML${componentClassName}Element>`;
+  } else {
+    const stencilEvents = events
+      .map(({ name }) => `"on${capitalize(name)}"`)
+      .join(" | ");
+    const preactEvents = events
+      .map(({ name }) => `"on${name}"?: (event: CustomEvent<any>) => void;`)
+      .join("\n        ");
+    return `
+      "${tagName}": Omit<JSX.${componentClassName}, ${stencilEvents}> & JSXInternal.HTMLAttributes<HTML${componentClassName}Element> & {
+        ${preactEvents}
+      }`;
+  }
+}
+
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
While setting up CC with a preact project that used TypeScript I ran into a lot of problems. First, you get the "Property 'insert-calcite-tag-name' does not exist on type 'JSX.IntrinsicElements':

- https://github.com/ionic-team/stencil/issues/1090
- https://github.com/ionic-team/stencil/issues/1636

So you have to augment the intrinsic elements types with the custom tag names from calcite components. After you do that, then you realize that the event names don't work in preact if you use the events from the provided types. Ie `onDropdownClose` will never fire, you have to use `ondropdownClose`:

- https://github.com/preactjs/preact/issues/2592

This is a temporary fix that uses a custom output target to generate an additional typescript file for preact. If we get the ds framework bindings up and running, we may be able to get rid of this, but for now it allows cc to be used in the TS + preact project by importing these types. **note** this ts file expects preact as a peer dependency.

/cc @nathan-barrett 