### PR TITLE
use hydrated attribute rather than class for FOUC prevention

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -7,10 +7,6 @@
     left: -999999px;
   }
 
-  :host([aria-hidden="true"]) {
-    pointer-events: none;
-  }
-
   :host([aria-hidden="false"]) {
     box-shadow: $shadow-2;
   }

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -22,7 +22,7 @@
   overflow: hidden;
 }
 
-[hydrated][aria-hidden="true"] {
+[calcite-hydrated][aria-hidden="true"] {
   visibility: hidden;
   pointer-events: none;
 }

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -22,6 +22,7 @@
   overflow: hidden;
 }
 
-.hydrated--invisible {
+[hydrated][aria-hidden="true"] {
   visibility: hidden;
+  pointer-events: none;
 }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.e2e.ts
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.e2e.ts
@@ -1,11 +1,5 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { renders } from "../../tests/commonTests";
 
 describe("calcite-accordion-item", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent("<calcite-accordion-item></calcite-accordion-item>");
-    const element = await page.find("calcite-accordion-item");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("renders", async () => renders("calcite-accordion-item"));
 });

--- a/src/components/calcite-accordion/calcite-accordion.e2e.ts
+++ b/src/components/calcite-accordion/calcite-accordion.e2e.ts
@@ -1,20 +1,8 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { renders } from "../../tests/commonTests";
 
 describe("calcite-accordion", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion>
-    <calcite-accordion-item item-title="Accordion Title 1" id="1">Accordion Item Content
-    </calcite-accordion-item>
-    <calcite-accordion-item item-title="Accordion Title 1" id="2" active>Accordion Item Content
-    </calcite-accordion-item>
-    <calcite-accordion-item item-title="Accordion Title 3" id="3">Accordion Item Content
-    </calcite-accordion-item>
-    </calcite-accordion>`);
-    const element = await page.find("calcite-accordion");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("renders", async () => renders("calcite-accordion"));
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
@@ -85,9 +73,15 @@ describe("calcite-accordion", () => {
     <calcite-accordion-item item-title="Accordion Title 3" icon="car" id="3">Accordion Item Content
     </calcite-accordion-item>
     </calcite-accordion>`);
-    const icon1 = await page.find("calcite-accordion-item[id='1'] >>> .accordion-item-icon");
-    const icon2 = await page.find("calcite-accordion-item[id='2'] >>> .accordion-item-icon");
-    const icon3 = await page.find("calcite-accordion-item[id='3'] >>> .accordion-item-icon");
+    const icon1 = await page.find(
+      "calcite-accordion-item[id='1'] >>> .accordion-item-icon"
+    );
+    const icon2 = await page.find(
+      "calcite-accordion-item[id='2'] >>> .accordion-item-icon"
+    );
+    const icon3 = await page.find(
+      "calcite-accordion-item[id='3'] >>> .accordion-item-icon"
+    );
     expect(icon1).not.toBe(null);
     expect(icon2).toBe(null);
     expect(icon3).not.toBe(null);

--- a/src/components/calcite-alert/calcite-alert.e2e.ts
+++ b/src/components/calcite-alert/calcite-alert.e2e.ts
@@ -70,7 +70,7 @@ describe("calcite-alert", () => {
     const element = await page.find("calcite-alert");
     const close = await page.find("calcite-alert >>> .alert-close");
     const icon = await page.find("calcite-alert >>> .alert-icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(close).not.toBeNull();
     expect(icon).not.toBeNull();
   });

--- a/src/components/calcite-alert/calcite-alert.e2e.ts
+++ b/src/components/calcite-alert/calcite-alert.e2e.ts
@@ -1,17 +1,8 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { renders } from "../../tests/commonTests";
 
 describe("calcite-alert", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-alert>
-    <div slot="alert-title">Title Text</div>
-    <div slot="alert-message">Message Text</div>
-    <a slot="alert-link" href="">Action</a>
-    </calcite-alert>`);
-    const element = await page.find("calcite-alert");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("renders", async () => renders("calcite-alert", true));
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
@@ -24,7 +15,6 @@ describe("calcite-alert", () => {
     const element = await page.find("calcite-alert");
     const close = await page.find("calcite-alert >>> .alert-close");
     const icon = await page.find("calcite-alert >>> .alert-icon");
-    expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(close).not.toBeNull();
     expect(icon).toBeNull();
@@ -42,7 +32,6 @@ describe("calcite-alert", () => {
     const element = await page.find("calcite-alert");
     const close = await page.find("calcite-alert >>> .alert-close");
     const icon = await page.find("calcite-alert >>> .alert-icon");
-    expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("auto-dismiss-duration", "medium");
     expect(close).not.toBeNull();
@@ -62,7 +51,6 @@ describe("calcite-alert", () => {
     const close = await page.find("calcite-alert >>> .alert-close");
     const icon = await page.find("calcite-alert >>> .alert-icon");
 
-    expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "yellow");
     expect(element).toEqualAttribute("auto-dismiss-duration", "fast");
     expect(element).toEqualAttribute("theme", "dark");
@@ -82,7 +70,7 @@ describe("calcite-alert", () => {
     const element = await page.find("calcite-alert");
     const close = await page.find("calcite-alert >>> .alert-close");
     const icon = await page.find("calcite-alert >>> .alert-icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(close).not.toBeNull();
     expect(icon).not.toBeNull();
   });
@@ -107,12 +95,12 @@ describe("calcite-alert", () => {
 
     await button1.click();
     // wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, 400));
     expect(await alert1.isVisible()).toBe(true);
 
     await alertclose1.click();
     // wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, 400));
     expect(await alert1.isVisible()).not.toBe(true);
   });
 
@@ -151,17 +139,17 @@ describe("calcite-alert", () => {
 
     await button1.click();
     // wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, 400));
     await alertclose1.click();
 
     await button2.click();
     // wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, 400));
     await alertclose2.click();
 
     await button3.click();
     // wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, 400));
 
     expect(await alert1.isVisible()).not.toBe(true);
     expect(await alert2.isVisible()).not.toBe(true);

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -83,10 +83,6 @@
     max-width: 100%;
     border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
   }
-
-  &:host(.hydrated) {
-    visibility: hidden !important;
-  }
 }
 
 // focus styles
@@ -103,9 +99,6 @@
   transform: translate3d(0, -$baseline, 0);
   pointer-events: initial;
   border-top-width: 3px;
-  &:host(.hydrated) {
-    visibility: visible !important;
-  }
 
   @media only screen and (max-width: $viewport-medium) {
     transform: translate3d(0, 0, 0);

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -157,9 +157,10 @@ export class CalciteAlert {
       : this.autoDismiss
       ? "alert"
       : "alertdialog";
+    const hidden = this.active ? "false" : "true";
 
     return (
-      <Host active={this.active} role={role} dir={dir}>
+      <Host active={this.active} role={role} dir={dir} aria-hidden={hidden}>
         {this.icon ? this.setIcon() : null}
         <div class="alert-content">
           <slot name="alert-title"></slot>

--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -13,7 +13,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("scale", "m");
@@ -35,7 +35,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("scale", "m");
@@ -59,7 +59,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(element).toEqualAttribute("appearance", "outline");
     expect(element).toEqualAttribute("scale", "l");
@@ -83,7 +83,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(element).toEqualAttribute("appearance", "outline");
     expect(element).toEqualAttribute("scale", "l");
@@ -106,7 +106,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsButton).toBeNull();
     expect(elementAsLink).toHaveClass("mycustomclass");
@@ -129,7 +129,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(elementAsButton).toHaveClass("mycustomclass");
@@ -151,7 +151,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("scale", "m");
@@ -174,7 +174,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(icon).not.toBeNull();
@@ -193,7 +193,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(icon).not.toBeNull();

--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -13,7 +13,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("scale", "m");
@@ -35,7 +35,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("scale", "m");
@@ -59,7 +59,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(element).toEqualAttribute("appearance", "outline");
     expect(element).toEqualAttribute("scale", "l");
@@ -83,7 +83,7 @@ describe("calcite-button", () => {
       "calcite-button >>> .calcite-button--loader"
     );
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(element).toEqualAttribute("appearance", "outline");
     expect(element).toEqualAttribute("scale", "l");
@@ -106,7 +106,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsButton).toBeNull();
     expect(elementAsLink).toHaveClass("mycustomclass");
@@ -129,7 +129,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(elementAsButton).toHaveClass("mycustomclass");
@@ -151,7 +151,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("scale", "m");
@@ -174,7 +174,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(icon).not.toBeNull();
@@ -193,7 +193,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(icon).not.toBeNull();

--- a/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-checkbox", () => {
 
     const calciteCheckbox = await page.find("calcite-checkbox");
 
-    expect(calciteCheckbox).toHaveAttribute("hydrated");
+    expect(calciteCheckbox).toHaveAttribute("calcite-hydrated");
     expect(calciteCheckbox).toEqualAttribute("role", "checkbox");
     expect(calciteCheckbox).not.toHaveAttribute("checked");
     expect(calciteCheckbox).not.toHaveAttribute("indeterminate");

--- a/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-checkbox", () => {
 
     const calciteCheckbox = await page.find("calcite-checkbox");
 
-    expect(calciteCheckbox).toHaveClass("hydrated");
+    expect(calciteCheckbox).toHaveAttribute("hydrated");
     expect(calciteCheckbox).toEqualAttribute("role", "checkbox");
     expect(calciteCheckbox).not.toHaveAttribute("checked");
     expect(calciteCheckbox).not.toHaveAttribute("indeterminate");
@@ -136,7 +136,7 @@ describe("calcite-checkbox", () => {
     expect(calciteCheckbox).not.toHaveAttribute("checked");
     expect(input).not.toHaveAttribute("checked");
 
-    await page.$eval("input", element => {
+    await page.$eval("input", (element) => {
       element.setAttribute("checked", "");
     });
 

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.e2e.ts
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-dropdown", () => {
 
     await page.setContent("<calcite-dropdown></calcite-dropdown>");
     const element = await page.find("calcite-dropdown");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.e2e.ts
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-dropdown", () => {
 
     await page.setContent("<calcite-dropdown></calcite-dropdown>");
     const element = await page.find("calcite-dropdown");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -41,7 +41,7 @@ describe("calcite-dropdown", () => {
     </calcite-dropdown>`);
 
     const element = await page.find("calcite-dropdown");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -41,7 +41,7 @@ describe("calcite-dropdown", () => {
     </calcite-dropdown>`);
 
     const element = await page.find("calcite-dropdown");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-example/calcite-example.e2e.ts
+++ b/src/components/calcite-example/calcite-example.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-example", () => {
 
     await page.setContent("<calcite-example></calcite-example>");
     const element = await page.find("calcite-example");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/components/calcite-example/calcite-example.e2e.ts
+++ b/src/components/calcite-example/calcite-example.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-example", () => {
 
     await page.setContent("<calcite-example></calcite-example>");
     const element = await page.find("calcite-example");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-input-message", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-input-message></calcite-input-message>");
     const input = await page.find("calcite-input-message");
-    expect(input).toHaveAttribute("hydrated");
+    expect(input).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-input-message", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-input-message></calcite-input-message>");
     const input = await page.find("calcite-input-message");
-    expect(input).toHaveClass("hydrated");
+    expect(input).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-input", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-input></calcite-input>");
     const input = await page.find("calcite-input");
-    expect(input).toHaveAttribute("hydrated");
+    expect(input).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-input", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-input></calcite-input>");
     const input = await page.find("calcite-input");
-    expect(input).toHaveClass("hydrated");
+    expect(input).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-label/calcite-label.e2e.ts
+++ b/src/components/calcite-label/calcite-label.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-label", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-label></calcite-label>");
     const label = await page.find("calcite-label");
-    expect(label).toHaveAttribute("hydrated");
+    expect(label).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-label/calcite-label.e2e.ts
+++ b/src/components/calcite-label/calcite-label.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-label", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-label></calcite-label>");
     const label = await page.find("calcite-label");
-    expect(label).toHaveClass("hydrated");
+    expect(label).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-link/calcite-link.e2e.ts
+++ b/src/components/calcite-link/calcite-link.e2e.ts
@@ -10,7 +10,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
@@ -25,7 +25,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
@@ -40,7 +40,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
@@ -57,7 +57,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
@@ -73,7 +73,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
     expect(elementAsLink).toHaveClass("mycustomclass");
@@ -92,7 +92,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
     expect(elementAsSpan).toHaveClass("mycustomclass");
@@ -102,14 +102,12 @@ describe("calcite-link", () => {
 
   it("validates incorrect props", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-link color="zip">Continue</calcite-link>`
-    );
+    await page.setContent(`<calcite-link color="zip">Continue</calcite-link>`);
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
@@ -123,7 +121,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
     expect(icon).not.toBeNull();

--- a/src/components/calcite-link/calcite-link.e2e.ts
+++ b/src/components/calcite-link/calcite-link.e2e.ts
@@ -10,7 +10,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
@@ -25,7 +25,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
@@ -40,7 +40,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
@@ -57,7 +57,7 @@ describe("calcite-link", () => {
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
@@ -73,7 +73,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
     expect(elementAsLink).toHaveClass("mycustomclass");
@@ -92,7 +92,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
     expect(elementAsSpan).toHaveClass("mycustomclass");
@@ -107,7 +107,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
@@ -121,7 +121,7 @@ describe("calcite-link", () => {
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const icon = await page.find("calcite-link >>> .calcite-link--icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
     expect(icon).not.toBeNull();

--- a/src/components/calcite-loader/calcite-loader.e2e.ts
+++ b/src/components/calcite-loader/calcite-loader.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-loader", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-loader></calcite-loader>");
     const loader = await page.find("calcite-loader");
-    expect(loader).toHaveClass("hydrated");
+    expect(loader).toHaveAttribute("hydrated");
   });
 
   it("becomes visible when is-active prop is set", async () => {

--- a/src/components/calcite-loader/calcite-loader.e2e.ts
+++ b/src/components/calcite-loader/calcite-loader.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-loader", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-loader></calcite-loader>");
     const loader = await page.find("calcite-loader");
-    expect(loader).toHaveAttribute("hydrated");
+    expect(loader).toHaveAttribute("calcite-hydrated");
   });
 
   it("becomes visible when is-active prop is set", async () => {

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-modal></calcite-modal>");
     const element = await page.find("calcite-modal");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   it("adds closeLabel property to close button", async () => {
@@ -96,9 +96,9 @@ describe("calcite-modal accessibility checks", () => {
     let $button1;
     let $button2;
     let $close;
-    await page.$eval(".btn-1", elm => ($button1 = elm));
-    await page.$eval(".btn-2", elm => ($button2 = elm));
-    await page.$eval("calcite-modal", elm => {
+    await page.$eval(".btn-1", (elm) => ($button1 = elm));
+    await page.$eval(".btn-2", (elm) => ($button2 = elm));
+    await page.$eval("calcite-modal", (elm) => {
       $close = elm.shadowRoot.querySelector(".modal__close");
     });
     await modal.callMethod("open");

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-modal></calcite-modal>");
     const element = await page.find("calcite-modal");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   it("adds closeLabel property to close button", async () => {

--- a/src/components/calcite-notice/calcite-notice.e2e.ts
+++ b/src/components/calcite-notice/calcite-notice.e2e.ts
@@ -10,7 +10,7 @@ describe("calcite-notice", () => {
     <calcite-link slot="notice-link" href="">Action</calcite-link>
     </calcite-notice>`);
     const element = await page.find("calcite-notice");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {
@@ -24,7 +24,7 @@ describe("calcite-notice", () => {
     const element = await page.find("calcite-notice");
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(close).toBeNull();
     expect(icon).toBeNull();
@@ -42,7 +42,7 @@ describe("calcite-notice", () => {
     const element = await page.find("calcite-notice");
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(close).toBeNull();
     expect(icon).toBeNull();
@@ -61,7 +61,7 @@ describe("calcite-notice", () => {
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
 
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(element).toEqualAttribute("color", "yellow");
     expect(element).toEqualAttribute("theme", "dark");
     expect(close).not.toBeNull();
@@ -80,7 +80,7 @@ describe("calcite-notice", () => {
     const element = await page.find("calcite-notice");
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
     expect(close).not.toBeNull();
     expect(icon).not.toBeNull();
   });
@@ -102,7 +102,7 @@ describe("calcite-notice", () => {
 
     await noticeclose1.click();
     // wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    await new Promise((resolve) => setTimeout(resolve, 400));
     expect(await notice1.isVisible()).not.toBe(true);
   });
 });

--- a/src/components/calcite-notice/calcite-notice.e2e.ts
+++ b/src/components/calcite-notice/calcite-notice.e2e.ts
@@ -10,7 +10,7 @@ describe("calcite-notice", () => {
     <calcite-link slot="notice-link" href="">Action</calcite-link>
     </calcite-notice>`);
     const element = await page.find("calcite-notice");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {
@@ -24,7 +24,7 @@ describe("calcite-notice", () => {
     const element = await page.find("calcite-notice");
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(close).toBeNull();
     expect(icon).toBeNull();
@@ -42,7 +42,7 @@ describe("calcite-notice", () => {
     const element = await page.find("calcite-notice");
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(close).toBeNull();
     expect(icon).toBeNull();
@@ -61,7 +61,7 @@ describe("calcite-notice", () => {
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
 
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(element).toEqualAttribute("color", "yellow");
     expect(element).toEqualAttribute("theme", "dark");
     expect(close).not.toBeNull();
@@ -80,7 +80,7 @@ describe("calcite-notice", () => {
     const element = await page.find("calcite-notice");
     const close = await page.find("calcite-notice >>> .notice-close");
     const icon = await page.find("calcite-notice >>> .notice-icon");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(close).not.toBeNull();
     expect(icon).not.toBeNull();
   });

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -20,9 +20,8 @@ import {
 import { StrictModifiers, Placement, Instance as Popper } from "@popperjs/core";
 import { VNode } from "@stencil/core/internal/stencil-core";
 import { guid } from "../../utils/guid";
-import { HOST_CSS } from "../../utils/dom";
 
-type FocusId = "close-button";
+export type FocusId = "close-button";
 
 /**
  * @slot image - A slot for adding an image. The image will appear above the other slot content.
@@ -358,9 +357,6 @@ export class CalcitePopover {
     return (
       <Host
         role="dialog"
-        class={{
-          [HOST_CSS.hydratedInvisible]: !displayed,
-        }}
         aria-hidden={!displayed ? "true" : "false"}
         id={this.getId()}
       >

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-slider", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-slider></calcite-slider>");
     const element = await page.find("calcite-slider");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   it("becomes inactive from disabled prop", async () => {

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-slider", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-slider></calcite-slider>");
     const element = await page.find("calcite-slider");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   it("becomes inactive from disabled prop", async () => {

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-split-button", () => {
       <calcite-split-button>
       </calcite-split-button>`);
     const element = await page.find("calcite-split-button");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-split-button", () => {
       <calcite-split-button>
       </calcite-split-button>`);
     const element = await page.find("calcite-split-button");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-stepper-item/calcite-stepper-item.e2e.ts
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-stepper-item", () => {
 
     await page.setContent("<calcite-stepper-item></calcite-stepper-item>");
     const element = await page.find("calcite-stepper-item");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-stepper-item/calcite-stepper-item.e2e.ts
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-stepper-item", () => {
 
     await page.setContent("<calcite-stepper-item></calcite-stepper-item>");
     const element = await page.find("calcite-stepper-item");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/components/calcite-stepper/calcite-stepper.e2e.ts
+++ b/src/components/calcite-stepper/calcite-stepper.e2e.ts
@@ -20,7 +20,7 @@ describe("calcite-stepper", () => {
       </calcite-stepper-item>
     </calcite-stepper>`);
     const element = await page.find("calcite-stepper");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-stepper/calcite-stepper.e2e.ts
+++ b/src/components/calcite-stepper/calcite-stepper.e2e.ts
@@ -20,7 +20,7 @@ describe("calcite-stepper", () => {
       </calcite-stepper-item>
     </calcite-stepper>`);
     const element = await page.find("calcite-stepper");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   it("renders default props when none are provided", async () => {

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-switch", () => {
 
     const calciteSwitch = await page.find("calcite-switch");
 
-    expect(calciteSwitch).toHaveClass("hydrated");
+    expect(calciteSwitch).toHaveAttribute("hydrated");
     expect(calciteSwitch).toEqualAttribute("role", "checkbox");
     expect(calciteSwitch).toHaveAttribute("switched");
   });

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-switch", () => {
 
     const calciteSwitch = await page.find("calcite-switch");
 
-    expect(calciteSwitch).toHaveAttribute("hydrated");
+    expect(calciteSwitch).toHaveAttribute("calcite-hydrated");
     expect(calciteSwitch).toEqualAttribute("role", "checkbox");
     expect(calciteSwitch).toHaveAttribute("switched");
   });

--- a/src/components/calcite-tab-nav/calcite-tab-nav.e2e.ts
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tab-nav", () => {
 
     await page.setContent("<calcite-tab-nav></calcite-tab-nav>");
     const element = await page.find("calcite-tab-nav");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/components/calcite-tab-nav/calcite-tab-nav.e2e.ts
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tab-nav", () => {
 
     await page.setContent("<calcite-tab-nav></calcite-tab-nav>");
     const element = await page.find("calcite-tab-nav");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-tab-title/calcite-tab-title.e2e.ts
+++ b/src/components/calcite-tab-title/calcite-tab-title.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tab-title", () => {
 
     await page.setContent("<calcite-tab-title></calcite-tab-title>");
     const element = await page.find("calcite-tab-title");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-tab-title/calcite-tab-title.e2e.ts
+++ b/src/components/calcite-tab-title/calcite-tab-title.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tab-title", () => {
 
     await page.setContent("<calcite-tab-title></calcite-tab-title>");
     const element = await page.find("calcite-tab-title");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/components/calcite-tab/calcite-tab.e2e.ts
+++ b/src/components/calcite-tab/calcite-tab.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tab", () => {
 
     await page.setContent("<calcite-tab></calcite-tab>");
     const element = await page.find("calcite-tab");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-tab/calcite-tab.e2e.ts
+++ b/src/components/calcite-tab/calcite-tab.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tab", () => {
 
     await page.setContent("<calcite-tab></calcite-tab>");
     const element = await page.find("calcite-tab");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/components/calcite-tabs/calcite-tabs.e2e.ts
+++ b/src/components/calcite-tabs/calcite-tabs.e2e.ts
@@ -20,7 +20,7 @@ describe("calcite-tabs", () => {
       </calcite-tabs>
     `);
     const element = await page.find("calcite-tabs");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
 
     const results = await page.compareScreenshot();
 
@@ -48,7 +48,7 @@ describe("calcite-tabs", () => {
       </div>
     `);
     const element = await page.find("calcite-tabs");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
 
     const results = await page.compareScreenshot();
 

--- a/src/components/calcite-tabs/calcite-tabs.e2e.ts
+++ b/src/components/calcite-tabs/calcite-tabs.e2e.ts
@@ -20,7 +20,7 @@ describe("calcite-tabs", () => {
       </calcite-tabs>
     `);
     const element = await page.find("calcite-tabs");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
 
     const results = await page.compareScreenshot();
 
@@ -48,7 +48,7 @@ describe("calcite-tabs", () => {
       </div>
     `);
     const element = await page.find("calcite-tabs");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
 
     const results = await page.compareScreenshot();
 

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -17,7 +17,6 @@ import {
   createPopper,
   updatePopper,
 } from "../../utils/popper";
-import { HOST_CSS } from "../../utils/dom";
 
 @Component({
   tag: "calcite-tooltip",
@@ -256,9 +255,6 @@ export class CalciteTooltip {
     return (
       <Host
         role="tooltip"
-        class={{
-          [HOST_CSS.hydratedInvisible]: !displayed,
-        }}
         aria-hidden={!displayed ? "true" : "false"}
         id={this.getId()}
       >

--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -6,7 +6,7 @@ describe("calcite-tree", () => {
 
     await page.setContent("<calcite-tree></calcite-tree>");
     const element = await page.find("calcite-tree");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 
   // click on icon
@@ -28,7 +28,9 @@ describe("calcite-tree", () => {
     const icon = await page.find('#firstItem >>> [data-test-id="icon"]');
     await icon.click();
 
-    const childContainer = await page.find('#firstItem >>> [data-test-id="calcite-tree-children"]');
+    const childContainer = await page.find(
+      '#firstItem >>> [data-test-id="calcite-tree-children"]'
+    );
     const isVisible = await childContainer.isVisible();
     expect(isVisible).toBe(true);
   });
@@ -43,7 +45,7 @@ describe("calcite-tree", () => {
       </calcite-tree-item>
     </calcite-tree>`);
 
-    const anchor = await page.find('#firstItem a');
+    const anchor = await page.find("#firstItem a");
     await anchor.click();
 
     await page.waitForChanges();
@@ -60,7 +62,7 @@ describe("calcite-tree", () => {
       </calcite-tree-item>
     </calcite-tree>`);
 
-    const item = await page.find('#firstItem');
+    const item = await page.find("#firstItem");
     await item.click();
 
     await page.waitForChanges();
@@ -84,7 +86,7 @@ describe("calcite-tree", () => {
     </calcite-tree>`);
 
     await page.waitForChanges();
-    const item = await page.find('#secondItem');
+    const item = await page.find("#secondItem");
     await item.click();
 
     await page.waitForChanges();

--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -6,7 +6,7 @@ describe("calcite-tree", () => {
 
     await page.setContent("<calcite-tree></calcite-tree>");
     const element = await page.find("calcite-tree");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 
   // click on icon

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tree", () => {
 
     await page.setContent("<calcite-tree></calcite-tree>");
     const element = await page.find("calcite-tree");
-    expect(element).toHaveAttribute("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
   });
 });

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -6,6 +6,6 @@ describe("calcite-tree", () => {
 
     await page.setContent("<calcite-tree></calcite-tree>");
     const element = await page.find("calcite-tree");
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("hydrated");
   });
 });

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -57,12 +57,15 @@ export async function accessible(componentTagOrHTML: TagOrHTML): Promise<void> {
   ).toHaveNoViolations();
 }
 
-export async function renders(componentTagOrHTML: TagOrHTML): Promise<void> {
+export async function renders(
+  componentTagOrHTML: TagOrHTML,
+  invisible?: true
+): Promise<void> {
   const page = await simplePageSetup(componentTagOrHTML);
   const element = await page.find(getTag(componentTagOrHTML));
 
-  expect(element).toHaveClass("hydrated");
-  expect(await element.isVisible()).toBe(true);
+  expect(element).toHaveAttribute("hydrated");
+  expect(await element.isVisible()).toBe(!invisible);
 }
 
 export async function reflects(

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -64,7 +64,7 @@ export async function renders(
   const page = await simplePageSetup(componentTagOrHTML);
   const element = await page.find(getTag(componentTagOrHTML));
 
-  expect(element).toHaveAttribute("hydrated");
+  expect(element).toHaveAttribute("calcite-hydrated");
   expect(await element.isVisible()).toBe(!invisible);
 }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -56,10 +56,6 @@ export function getDescribedByElement<T extends HTMLElement>(
   return (id && document.getElementById(id)) || null;
 }
 
-export const HOST_CSS = {
-  hydratedInvisible: "hydrated--invisible",
-};
-
 export function hasLabel(labelEl: HTMLCalciteLabelElement, el: HTMLElement) {
   return labelEl.shadowRoot.contains(el) || labelEl.contains(el);
 }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -79,6 +79,9 @@ export const config: Config = {
       "^/assets/(.*)$": "<rootDir>/src/tests/iconPathDataStub.js",
     },
   },
+  hydratedFlag: {
+    selector: "attribute",
+  },
   extras: {
     appendChildSlotFix: true,
     slotChildNodesFix: true,

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -81,6 +81,7 @@ export const config: Config = {
   },
   hydratedFlag: {
     selector: "attribute",
+    name: "calcite-hydrated",
   },
   extras: {
     appendChildSlotFix: true,


### PR DESCRIPTION
We were using these components in a react/preact environment and ran into an issue. Namely, if you want to set the class attribute of a component inside of render, it will clobber the `hydrated` class. 

```
<my-component class={props.isGreen ? "green" : "red" } />
```

This causes the component to disappear because components must have the `hydrated` class. This is super confusing for a consuming developer and basically means you need to wrap all of our components in an additional layer of dom to use classes at all. Reading through the google best practices, it seems this is a known problem:

> Elements that need to express their state should do so using attributes. The class attribute is generally considered to be owned by the developer using your element, and writing to it yourself may inadvertently stomp on developer classes.
> — [_Custom Element Best Practices_](https://developers.google.com/web/fundamentals/web-components/best-practices#do-not-self-apply-classes) 

This pr leverages a stencil config option (`hydratedFlag: { selector: "attribute" }`) to use an attribute instead of a class. I've also gone through every host element checking that they don't apply classes to themselves. I was able to remove all of them other than the `calcite-modal` one. I'll try to update that in a future pr. 

There are a couple situations where we don't want the element to be visible when it gets the hydrated attr (alert, popover, tooltip). These are all cases where when it's hidden we want `aria-hidden` to be `true`, so for now I'm leaning on this attribute to show them. This removes the need for an extra class (and important rules). We could choose a different attribute for this in the future (like `hydrated-hidden` or something).

The biggest changeset was updating all the tests to check for an attribute instead of a class to see if something rendered. For a couple tests I also moved their bespoke "renders" test to use the standard render test from `commonTests.ts`.