### PR TITLE
Add explicit start/end icons to button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-label` - `calciteLabelSelectedEvent` event has been renamed to `calciteLabelFocus`
 - `calcite-button` - `icon-position` and `icon` props have been removed - you can now use `icon-start` and `icon-end` props to position up to two icons.
+- `calcite-link` - `icon-position` and `icon` props have been removed - you can now use `icon-start` and `icon-end` props to position up to two icons.
 - `calcite-split-button` - `primary-icon` prop has been removed - you can now use `primary-icon-start` and `primary-icon-end` props to position up to two icons.
 
 ### Added
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-input` - adds `clearable` prop to display a clear button when field has a value - this also enables clearing of value while focused and using `Escape` key.
 - `calcite-input` - adds `disabled` prop
 - `calcite-button` - `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
+- `calcite-link` - `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
 - `calcite-split-button` - `primary-icon-start` and `primary-icon-end` props have been added for explicit positioning of up to two icons.
 - `calcite-split-button` - `dropdown-icon-type` prop now accepts an `overflow` value for an additional icon option.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Breaking Changes
 
 - `calcite-label` - `calciteLabelSelectedEvent` event has been renamed to `calciteLabelFocus`
+- `calcite-button` - `icon-position` and `icon` props have been removed - you can now use `icon-start` and `icon-end` props to position up to two icons.
+- `calcite-split-button` - `primary-icon` prop has been removed - you can now use `primary-icon-start` and `primary-icon-end` props to position up to two icons.
 
 ### Added
 
@@ -19,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-dropdown` now has a `disabled` prop.
 - `calcite-input` - adds `clearable` prop to display a clear button when field has a value - this also enables clearing of value while focused and using `Escape` key.
 - `calcite-input` - adds `disabled` prop
+- `calcite-button` - `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
+- `calcite-split-button` - `dropdown-icon-type` prop now accepts an `overflow` value for an additional icon option.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-input` - adds `clearable` prop to display a clear button when field has a value - this also enables clearing of value while focused and using `Escape` key.
 - `calcite-input` - adds `disabled` prop
 - `calcite-button` - `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
+- `calcite-split-button` - `primary-icon-start` and `primary-icon-end` props have been added for explicit positioning of up to two icons.
 - `calcite-split-button` - `dropdown-icon-type` prop now accepts an `overflow` value for an additional icon option.
 
 ### Fixed

--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -8,7 +8,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -20,7 +25,8 @@ describe("calcite-button", () => {
     expect(element).toEqualAttribute("width", "auto");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
@@ -30,7 +36,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -42,7 +53,8 @@ describe("calcite-button", () => {
     expect(element).toEqualAttribute("width", "auto");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsButton).toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
@@ -54,7 +66,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -66,7 +83,8 @@ describe("calcite-button", () => {
     expect(element).toEqualAttribute("width", "half");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
@@ -78,7 +96,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -90,7 +113,8 @@ describe("calcite-button", () => {
     expect(element).toEqualAttribute("width", "half");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsButton).toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
@@ -102,7 +126,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -113,7 +142,8 @@ describe("calcite-button", () => {
     expect(elementAsLink).toEqualAttribute("href", "google.com");
     expect(elementAsLink).toEqualAttribute("rel", "noopener noreferrer");
     expect(elementAsLink).toEqualAttribute("target", "_blank");
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
@@ -125,7 +155,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -135,7 +170,8 @@ describe("calcite-button", () => {
     expect(elementAsButton).toHaveClass("mycustomclass");
     expect(elementAsButton).toEqualAttribute("type", "reset");
     expect(elementAsButton).toEqualAttribute("name", "myname");
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
@@ -147,7 +183,12 @@ describe("calcite-button", () => {
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
@@ -158,45 +199,158 @@ describe("calcite-button", () => {
     expect(element).toEqualAttribute("width", "auto");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
-  it("renders with an icon", async () => {
+  it("renders with an icon-start", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<calcite-button icon='plus'>Continue</calcite-button>`
+      `<calcite-button icon-start='plus'>Continue</calcite-button>`
     );
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
     expect(element).toHaveClass("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
-    expect(icon).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).toBeNull();
     expect(loader).toBeNull();
   });
 
-  it("renders with a loader and an icon element when both icon and loader are present", async () => {
+  it("renders with an icon-end", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<calcite-button loading icon='plus'>Continue</calcite-button>`
+      `<calcite-button icon-end='plus'>Continue</calcite-button>`
     );
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
-    const icon = await page.find("calcite-button >>> .calcite-button--icon");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
     expect(element).toHaveClass("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
-    expect(icon).not.toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).not.toBeNull();
+    expect(loader).toBeNull();
+  });
+
+  it("renders with an icon-start and icon-end", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-button icon-start='plus' icon-end='plus'>Continue</calcite-button>`
+    );
+    const element = await page.find("calcite-button");
+    const elementAsButton = await page.find("calcite-button >>> button");
+    const elementAsLink = await page.find("calcite-button >>> a");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
+    const loader = await page.find(
+      "calcite-button >>> .calcite-button--loader"
+    );
+    expect(element).toHaveClass("hydrated");
+    expect(elementAsLink).toBeNull();
+    expect(elementAsButton).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).not.toBeNull();
+    expect(loader).toBeNull();
+  });
+
+  it("renders with a loader and an icon-start when both icon-start and loader are requested", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-button loading icon-start='plus'>Continue</calcite-button>`
+    );
+    const element = await page.find("calcite-button");
+    const elementAsButton = await page.find("calcite-button >>> button");
+    const elementAsLink = await page.find("calcite-button >>> a");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
+    const loader = await page.find(
+      "calcite-button >>> .calcite-button--loader"
+    );
+    expect(element).toHaveClass("hydrated");
+    expect(elementAsLink).toBeNull();
+    expect(elementAsButton).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).toBeNull();
+    expect(loader).not.toBeNull();
+  });
+
+  it("renders with a loader and an icon-end when both icon-end and loader are requested", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-button loading icon-end='plus'>Continue</calcite-button>`
+    );
+    const element = await page.find("calcite-button");
+    const elementAsButton = await page.find("calcite-button >>> button");
+    const elementAsLink = await page.find("calcite-button >>> a");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
+    const loader = await page.find(
+      "calcite-button >>> .calcite-button--loader"
+    );
+    expect(element).toHaveClass("hydrated");
+    expect(elementAsLink).toBeNull();
+    expect(elementAsButton).not.toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).not.toBeNull();
+    expect(loader).not.toBeNull();
+  });
+
+  it("renders with a loader and an icon-start and icon-end when all are requested", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-button loading icon-start='plus' icon-end='plus'>Continue</calcite-button>`
+    );
+    const element = await page.find("calcite-button");
+    const elementAsButton = await page.find("calcite-button >>> button");
+    const elementAsLink = await page.find("calcite-button >>> a");
+    const iconStart = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-button >>> .calcite-button--icon.icon-end"
+    );
+    const loader = await page.find(
+      "calcite-button >>> .calcite-button--loader"
+    );
+    expect(element).toHaveClass("hydrated");
+    expect(elementAsLink).toBeNull();
+    expect(elementAsButton).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).not.toBeNull();
     expect(loader).not.toBeNull();
   });
 
@@ -209,7 +363,9 @@ describe("calcite-button", () => {
 
   it("hastext is false when text is not present", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button icon='plus'></calcite-button>`);
+    await page.setContent(
+      `<calcite-button icon-start='plus'></calcite-button>`
+    );
     const element = await page.find("calcite-button");
     expect(element).not.toHaveAttribute("hastext");
   });

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -96,6 +96,12 @@
   font-size: $font-size;
 }
 
+@mixin btn-scale-notext-two-icons($font-size, $size) {
+  height: $size;
+  width: $size * 1.5;
+  font-size: $font-size;
+}
+
 // button width
 :host([width="auto"]) {
   width: auto;
@@ -128,22 +134,36 @@
   }
 }
 // icon positioning and styles
-:host([hastext][icon-position="start"]) .calcite-button--icon {
+:host([hastext]) .calcite-button--icon.icon-start {
   margin-right: $baseline/3;
 }
 
-:host([hastext][icon-position="start"][dir="rtl"]) .calcite-button--icon {
+:host([hastext][dir="rtl"]) .calcite-button--icon.icon-start {
   margin-right: 0;
   margin-left: $baseline/3;
 }
 
-:host([hastext][icon-position="end"]) .calcite-button--icon {
+:host([hastext]) .calcite-button--icon.icon-end {
   margin-left: $baseline/3;
 }
 
-:host([hastext][icon-position="end"][dir="rtl"]) .calcite-button--icon {
+:host([hastext][dir="rtl"]) .calcite-button--icon.icon-end {
   margin-left: 0;
   margin-right: $baseline/3;
+}
+
+// compensate for spacing when no hastext and two icons
+:host([icon-start][icon-end]) {
+  .calcite-button--icon:first-child {
+    margin-right: $baseline/3;
+  }
+}
+
+:host([icon-start][icon-end][dir="rtl"]) {
+  .calcite-button--icon:first-child {
+    margin-right: 0;
+    margin-left: $baseline/3;
+  }
 }
 
 .calcite-button--loader {
@@ -591,5 +611,19 @@ $btnScales2: "s" 12px 32px, "m" 16px 44px, "l" 20px 56px;
   :host([scale="#{$name}"]:not([hastext])) button,
   :host([scale="#{$name}"]:not([hastext])) a {
     @include btn-scale-notext($font-size, $size);
+  }
+}
+
+// generate fab scales
+$btnScales3: "s" 12px 32px, "m" 16px 44px, "l" 20px 56px;
+
+@each $btnScale in $btnScales3 {
+  $name: nth($btnScale, 1);
+  $font-size: nth($btnScale, 2);
+  $size: nth($btnScale, 3);
+
+  :host([scale="#{$name}"][icon-start][icon-end]:not([hastext])) button,
+  :host([scale="#{$name}"][icon-start][icon-end]:not([hastext])) a {
+    @include btn-scale-notext-two-icons($font-size, $size);
   }
 }

--- a/src/components/calcite-button/calcite-button.stories.js
+++ b/src/components/calcite-button/calcite-button.stories.js
@@ -3,7 +3,7 @@ import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 import {
   darkBackground,
   iconNames,
-  parseReadme
+  parseReadme,
 } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -33,7 +33,7 @@ storiesOf("Button", module)
     { notes }
   )
   .add(
-    "With icon",
+    "With icon-start",
     () => `
     <calcite-button
       appearance="${select(
@@ -48,8 +48,52 @@ storiesOf("Button", module)
       href="${text("href", "")}"
       loading="${boolean("loading", false)}"
       disabled="${boolean("disabled", false)}"
-      icon="${select("icon", iconNames, iconNames[0])}"
-      icon-position="${select("icon-position", ["start", "end"], "start")}">
+      icon-start="${select("icon-start", iconNames, iconNames[0])}">
+      ${text("text", "button text here")}
+    </calcite-button>
+  `,
+    { notes }
+  )
+  .add(
+    "With icon-end",
+    () => `
+    <calcite-button
+      appearance="${select(
+        "appearance",
+        ["solid", "clear", "outline", "transparent"],
+        "solid"
+      )}"
+      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      round="${boolean("round", false)}"
+      floating="${boolean("floating", false)}"
+      href="${text("href", "")}"
+      loading="${boolean("loading", false)}"
+      disabled="${boolean("disabled", false)}"
+      icon-end="${select("icon-end", iconNames, iconNames[0])}">
+      ${text("text", "button text here")}
+    </calcite-button>
+  `,
+    { notes }
+  )
+  .add(
+    "With icon-start and icon-end",
+    () => `
+    <calcite-button
+      appearance="${select(
+        "appearance",
+        ["solid", "clear", "outline", "transparent"],
+        "solid"
+      )}"
+      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      round="${boolean("round", false)}"
+      floating="${boolean("floating", false)}"
+      href="${text("href", "")}"
+      loading="${boolean("loading", false)}"
+      disabled="${boolean("disabled", false)}"
+      icon-start="${select("icon-start", iconNames, iconNames[0])}"
+      icon-end="${select("icon-end", iconNames, iconNames[0])}">
       ${text("text", "button text here")}
     </calcite-button>
   `,
@@ -61,8 +105,7 @@ storiesOf("Button", module)
     <div style="width: 480px; max-width: 100%; background-color: #fff">
       <calcite-button
         width="${select("width", ["auto", "half", "full"], "auto")}"
-        icon="${select("icon", iconNames, iconNames[0])}"
-        icon-position="${select("icon-position", ["start", "end"], "start")}">
+        icon-start="${select("icon-start", iconNames, iconNames[0])}">
         ${text("text", "button text here")}
       </calcite-button>
     </div>
@@ -91,7 +134,8 @@ storiesOf("Button", module)
       "solid"
     )}"
     color="${select("color-2", ["blue", "red", "dark", "light"], "blue")}"
-    icon="${select("icon", iconNames, iconNames[0])}">
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
+    >
     ${text("text-2", "Some long string")}
     </calcite-button>
   </div>
@@ -125,7 +169,7 @@ storiesOf("Button", module)
   round="${boolean("round", true)}"
   floating="${boolean("floating", true)}"
   width="${select("width", ["auto", "half", "full"], "auto")}"
-  icon="${select("icon", iconNames, iconNames[0])}"
+  icon-start="${select("icon-start", iconNames, iconNames[0])}"
   appearance="${select("appearance", ["solid", "outline"], "solid")}"
   color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
   scale="${select("scale", ["s", "m", "l"], "m")}"></calcite-button>
@@ -162,7 +206,7 @@ storiesOf("Button", module)
     round="${boolean("round", true)}"
     floating="${boolean("floating", true)}"
     width="${select("width", ["auto", "half", "full"], "auto")}"
-    icon="${select("icon", iconNames, iconNames[0])}"
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
     appearance="${select("appearance", ["solid", "outline"], "solid")}"
     color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
     scale="${select("scale", ["s", "m", "l"], "m")}">
@@ -190,7 +234,9 @@ storiesOf("Button", module)
     href="${text("href", "")}"
     loading="${boolean("loading", false)}"
     disabled="${boolean("disabled", false)}"
-    icon="${select("icon", iconNames, iconNames[0])}">
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
+    icon-end="${select("icon-end", iconNames, iconNames[0])}"
+    >
     ${text("text", "button text here")}
   </calcite-button>
   `,
@@ -224,7 +270,7 @@ storiesOf("Button", module)
     round="${boolean("round", true)}"
     floating="${boolean("floating", true)}"
     width="${select("width", ["auto", "half", "full"], "auto")}"
-    icon="${select("icon", iconNames, iconNames[0])}"
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
     appearance="${select("appearance", ["solid", "outline"], "solid")}"
     color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"></calcite-button>
@@ -261,7 +307,7 @@ storiesOf("Button", module)
   round="${boolean("round", true)}"
   floating="${boolean("floating", true)}"
   width="${select("width", ["auto", "half", "full"], "auto")}"
-  icon="${select("icon", iconNames, iconNames[0])}"
+  icon-start="${select("icon-start", iconNames, iconNames[0])}"
   appearance="${select("appearance", ["solid", "outline"], "solid")}"
   color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
   scale="${select("scale", ["s", "m", "l"], "m")}">

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -73,12 +73,11 @@ export class CalciteButton {
   /** optionally pass a href - used to determine if the component should render as a button or an anchor */
   @Prop({ reflect: true }) href?: string;
 
-  /** optionally pass an icon to display - accepts Calcite UI icon names  */
-  @Prop({ reflect: true }) icon?: string;
+  /** optionally pass an icon to display at the start of a button - accepts calcite ui icon names  */
+  @Prop({ reflect: true }) iconStart?: string;
 
-  /** optionally used with icon, select where to position the icon */
-  @Prop({ reflect: true, mutable: true }) iconPosition?: "start" | "end" =
-    "start";
+  /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
+  @Prop({ reflect: true }) iconEnd?: string;
 
   /** is the button disabled  */
   @Prop({ reflect: true }) disabled?: boolean;
@@ -103,10 +102,6 @@ export class CalciteButton {
 
     let width = ["auto", "half", "full"];
     if (!width.includes(this.width)) this.width = "auto";
-
-    let iconPosition = ["start", "end"];
-    if (this.icon !== null && !iconPosition.includes(this.iconPosition))
-      this.iconPosition = "start";
 
     this.childElType = this.href ? "a" : "button";
     this.setupTextContentObserver();
@@ -137,10 +132,18 @@ export class CalciteButton {
 
     const iconScale = this.scale === "l" ? "m" : "s";
 
-    const iconEl = (
+    const iconStartEl = (
       <calcite-icon
-        class="calcite-button--icon"
-        icon={this.icon}
+        class="calcite-button--icon icon-start"
+        icon={this.iconStart}
+        scale={iconScale}
+      />
+    );
+
+    const iconEndEl = (
+      <calcite-icon
+        class="calcite-button--icon icon-end"
+        icon={this.iconEnd}
         scale={iconScale}
       />
     );
@@ -155,9 +158,9 @@ export class CalciteButton {
           ref={(el) => (this.childEl = el)}
         >
           {this.loading ? loader : null}
-          {this.icon && this.iconPosition === "start" ? iconEl : null}
+          {this.iconStart ? iconStartEl : null}
           <slot />
-          {this.icon && this.iconPosition === "end" ? iconEl : null}
+          {this.iconEnd ? iconEndEl : null}
         </Tag>
       </Host>
     );
@@ -215,8 +218,8 @@ export class CalciteButton {
       "color",
       "dir",
       "hasText",
-      "icon",
-      "iconPosition",
+      "icon-start",
+      "icon-end",
       "id",
       "loading",
       "scale",

--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -6,43 +6,36 @@ You can programmatically focus a `calcite-button` with the `setFocus()` method:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property       | Attribute       | Description                                                                                        | Type                                               | Default     |
-| -------------- | --------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
-| `appearance`   | `appearance`    | specify the appearance style of the button, defaults to solid.                                     | `"clear" \| "outline" \| "solid" \| "transparent"` | `"solid"`   |
-| `color`        | `color`         | specify the color of the button, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
-| `disabled`     | `disabled`      | is the button disabled                                                                             | `boolean`                                          | `undefined` |
-| `floating`     | `floating`      | optionally add a floating style to the button - this should be positioned fixed or sticky          | `boolean`                                          | `false`     |
-| `href`         | `href`          | optionally pass a href - used to determine if the component should render as a button or an anchor | `string`                                           | `undefined` |
-| `icon`         | `icon`          | optionally pass an icon to display - accepts Calcite UI icon names                                 | `string`                                           | `undefined` |
-| `iconPosition` | `icon-position` | optionally used with icon, select where to position the icon                                       | `"end" \| "start"`                                 | `"start"`   |
-| `loading`      | `loading`       | optionally add a calcite-loader component to the button, disabling interaction.                    | `boolean`                                          | `false`     |
-| `round`        | `round`         | optionally add a round style to the button                                                         | `boolean`                                          | `false`     |
-| `scale`        | `scale`         | specify the scale of the button, defaults to m                                                     | `"l" \| "m" \| "s"`                                | `"m"`       |
-| `theme`        | `theme`         | Select theme (light or dark)                                                                       | `"dark" \| "light"`                                | `undefined` |
-| `width`        | `width`         | specify the width of the button, defaults to auto                                                  | `"auto" \| "full" \| "half"`                       | `"auto"`    |
-
+| Property     | Attribute    | Description                                                                                        | Type                                               | Default     |
+| ------------ | ------------ | -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `appearance` | `appearance` | specify the appearance style of the button, defaults to solid.                                     | `"clear" \| "outline" \| "solid" \| "transparent"` | `"solid"`   |
+| `color`      | `color`      | specify the color of the button, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
+| `disabled`   | `disabled`   | is the button disabled                                                                             | `boolean`                                          | `undefined` |
+| `floating`   | `floating`   | optionally add a floating style to the button - this should be positioned fixed or sticky          | `boolean`                                          | `false`     |
+| `href`       | `href`       | optionally pass a href - used to determine if the component should render as a button or an anchor | `string`                                           | `undefined` |
+| `iconEnd`    | `icon-end`   | optionally pass an icon to display at the end of a button - accepts calcite ui icon names          | `string`                                           | `undefined` |
+| `iconStart`  | `icon-start` | optionally pass an icon to display at the start of a button - accepts calcite ui icon names        | `string`                                           | `undefined` |
+| `loading`    | `loading`    | optionally add a calcite-loader component to the button, disabling interaction.                    | `boolean`                                          | `false`     |
+| `round`      | `round`      | optionally add a round style to the button                                                         | `boolean`                                          | `false`     |
+| `scale`      | `scale`      | specify the scale of the button, defaults to m                                                     | `"l" \| "m" \| "s"`                                | `"m"`       |
+| `theme`      | `theme`      | Select theme (light or dark)                                                                       | `"dark" \| "light"`                                | `undefined` |
+| `width`      | `width`      | specify the width of the button, defaults to auto                                                  | `"auto" \| "full" \| "half"`                       | `"auto"`    |
 
 ## Methods
 
 ### `setFocus() => Promise<void>`
 
-
-
 #### Returns
 
 Type: `Promise<void>`
-
-
-
 
 ## Dependencies
 
 ### Used by
 
- - [calcite-split-button](../calcite-split-button)
+- [calcite-split-button](../calcite-split-button)
 
 ### Depends on
 
@@ -50,6 +43,7 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-button --> calcite-loader
@@ -58,6 +52,6 @@ graph TD;
   style calcite-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-card/calcite-card.stories.js
+++ b/src/components/calcite-card/calcite-card.stories.js
@@ -88,9 +88,9 @@ storiesOf("Card", module)
       <span slot="subtitle">Johnathan Smith</span>
       <span slot="footer-leading">Nov 25, 2018</span>
       <div slot="footer-trailing">
-        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon='circle'>
+        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start='circle'>
         </calcite-button>
-        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon='circle'>
+        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start='circle'>
         </calcite-button>
       </div>
     </calcite-card>
@@ -122,12 +122,12 @@ storiesOf("Card", module)
           <br />
           View Count: 0
         </div>
-        <calcite-button slot="footer-leading" color="light" scale="s" icon='circle'></calcite-button>
+        <calcite-button slot="footer-leading" color="light" scale="s" icon-start='circle'></calcite-button>
         <div slot="footer-trailing">
-          <calcite-button scale="s" color="light" id="card-icon-test-2" icon='circle'></calcite-button>
-          <calcite-button scale="s" color="light" id="card-icon-test-1" icon='circle'></calcite-button>
+          <calcite-button scale="s" color="light" id="card-icon-test-2" icon-start='circle'></calcite-button>
+          <calcite-button scale="s" color="light" id="card-icon-test-1" icon-start='circle'></calcite-button>
           <calcite-dropdown>
-            <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="light" icon='circle'></calcite-button>
+            <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="light" icon-start='circle'></calcite-button>
             <calcite-dropdown-group selection-mode="none">
               <calcite-dropdown-item>View details</calcite-dropdown-item>
               <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
@@ -233,9 +233,9 @@ storiesOf("Card", module)
       <span slot="subtitle">Johnathan Smith</span>
       <span slot="footer-leading">Nov 25, 2018</span>
       <div slot="footer-trailing">
-        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon='circle'>
+        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start='circle'>
         </calcite-button>
-        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon='circle'>
+        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start='circle'>
         </calcite-button>
       </div>
     </calcite-card>
@@ -268,12 +268,12 @@ storiesOf("Card", module)
           <br />
           View Count: 0
         </div>
-        <calcite-button slot="footer-leading" color="dark" scale="s" icon='circle'></calcite-button>
+        <calcite-button slot="footer-leading" color="dark" scale="s" icon-start='circle'></calcite-button>
         <div slot="footer-trailing">
-          <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-2" icon='circle'></calcite-button>
-          <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-1" icon='circle'></calcite-button>
+          <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-2" icon-start='circle'></calcite-button>
+          <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-1" icon-start='circle'></calcite-button>
           <calcite-dropdown>
-            <calcite-button theme="dark" color="dark" id="card-icon-test-5" slot="dropdown-trigger" scale="s" icon='circle'></calcite-button>
+            <calcite-button theme="dark" color="dark" id="card-icon-test-5" slot="dropdown-trigger" scale="s" icon-start='circle'></calcite-button>
             <calcite-dropdown-group selection-mode="none">
               <calcite-dropdown-item>View details</calcite-dropdown-item>
               <calcite-dropdown-item>Duplicate</calcite-dropdown-item>

--- a/src/components/calcite-link/calcite-link.e2e.ts
+++ b/src/components/calcite-link/calcite-link.e2e.ts
@@ -8,13 +8,19 @@ describe("calcite-link", () => {
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
 
     expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
   it("renders as a link with default props", async () => {
@@ -23,13 +29,19 @@ describe("calcite-link", () => {
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
 
     expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
   it("renders as a span with requested props", async () => {
@@ -38,13 +50,19 @@ describe("calcite-link", () => {
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
 
     expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
   it("renders as a link with requested props", async () => {
@@ -55,13 +73,19 @@ describe("calcite-link", () => {
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
 
     expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "red");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
   it("passes attributes to rendered child link", async () => {
@@ -72,7 +96,13 @@ describe("calcite-link", () => {
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
+
     expect(element).toHaveClass("hydrated");
     expect(elementAsLink).not.toBeNull();
     expect(elementAsSpan).toBeNull();
@@ -80,7 +110,8 @@ describe("calcite-link", () => {
     expect(elementAsLink).toEqualAttribute("href", "google.com");
     expect(elementAsLink).toEqualAttribute("rel", "noopener noreferrer");
     expect(elementAsLink).toEqualAttribute("target", "_blank");
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
   it("passes attributes to rendered child span", async () => {
@@ -91,41 +122,101 @@ describe("calcite-link", () => {
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
+
     expect(element).toHaveClass("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
     expect(elementAsSpan).toHaveClass("mycustomclass");
     expect(elementAsSpan).toEqualAttribute("name", "myname");
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
   it("validates incorrect props", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-link color="zip">Continue</calcite-link>`
-    );
+    await page.setContent(`<calcite-link color="zip">Continue</calcite-link>`);
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
     expect(element).toHaveClass("hydrated");
     expect(element).toEqualAttribute("color", "blue");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
-    expect(icon).toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).toBeNull();
   });
 
-  it("renders with an icon", async () => {
+  it("renders with an icon-start", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link icon='plus'>Continue</calcite-link>`);
+    await page.setContent(
+      `<calcite-link icon-start='plus'>Continue</calcite-link>`
+    );
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
-    const icon = await page.find("calcite-link >>> .calcite-link--icon");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
     expect(element).toHaveClass("hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsSpan).not.toBeNull();
-    expect(icon).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).toBeNull();
+  });
+  it("renders with an icon-end", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-link icon-end='plus'>Continue</calcite-link>`
+    );
+    const element = await page.find("calcite-link");
+    const elementAsSpan = await page.find("calcite-link >>> span");
+    const elementAsLink = await page.find("calcite-link >>> a");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
+    expect(element).toHaveClass("hydrated");
+    expect(elementAsLink).toBeNull();
+    expect(elementAsSpan).not.toBeNull();
+    expect(iconStart).toBeNull();
+    expect(iconEnd).not.toBeNull();
+  });
+
+  it("renders with an icon-start and icon-end", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-link icon-start='plus' icon-end='plus'>Continue</calcite-link>`
+    );
+    const element = await page.find("calcite-link");
+    const elementAsSpan = await page.find("calcite-link >>> span");
+    const elementAsLink = await page.find("calcite-link >>> a");
+    const iconStart = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-start"
+    );
+    const iconEnd = await page.find(
+      "calcite-link >>> .calcite-link--icon.icon-end"
+    );
+    expect(element).toHaveClass("hydrated");
+    expect(elementAsLink).toBeNull();
+    expect(elementAsSpan).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).not.toBeNull();
   });
 });

--- a/src/components/calcite-link/calcite-link.scss
+++ b/src/components/calcite-link/calcite-link.scss
@@ -61,39 +61,22 @@
   }
 }
 // icon positioning and styles
-:host([icon-position="start"]) .calcite-link--icon {
+:host .calcite-link--icon.icon-start {
   margin-right: $baseline/3;
 }
 
-:host([icon-position="start"][dir="rtl"]) .calcite-link--icon {
+:host([dir="rtl"]) .calcite-link--icon.icon-start {
   margin-right: 0;
   margin-left: $baseline/3;
 }
 
-:host([icon-position="end"]) .calcite-link--icon {
+:host .calcite-link--icon.icon-end {
   margin-left: $baseline/3;
 }
 
-:host([icon-position="end"][dir="rtl"]) .calcite-link--icon {
+:host([dir="rtl"]) .calcite-link--icon.icon-end {
   margin-left: 0;
   margin-right: $baseline/3;
-}
-
-:host([icon-position="start"]) .calcite-link--icon {
-  margin-right: $baseline/4;
-}
-
-:host([icon-position="start"][dir="rtl"]) .calcite-link--icon {
-  margin-left: $baseline/4;
-  margin-right: 0;
-}
-
-:host([icon-position="end"]) .calcite-link--icon {
-  margin-left: $baseline/4;
-}
-:host([icon-position="end"][dir="rtl"]) .calcite-link--icon {
-  margin-left: 0;
-  margin-right: $baseline/4;
 }
 
 // inline

--- a/src/components/calcite-link/calcite-link.stories.js
+++ b/src/components/calcite-link/calcite-link.stories.js
@@ -40,7 +40,7 @@ storiesOf("Link", module)
     { notes }
   )
   .add(
-    "With icon",
+    "With icon-start",
     () => `
     <div style="font-size: ${select(
       "containing font size",
@@ -54,8 +54,52 @@ storiesOf("Link", module)
       href="${text("href", "")}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
       disabled="${boolean("disabled", false)}"
-      icon="${select("icon", iconNames, iconNames[0])}"
-      icon-position="${select("icon-position", ["start", "end"], "end")}">
+      icon-start="${select("icon-start", iconNames, iconNames[0])}">
+      ${text("text", "link text here")}</calcite-link>
+      around the link
+      </div>
+  `,
+    { notes }
+  )
+  .add(
+    "With icon-end",
+    () => `
+    <div style="font-size: ${select(
+      "containing font size",
+      ["12", "14", "16", "18", "20", "24", "32"],
+      "16"
+    )}px; font-weight: ${select(
+      "containing font weight",
+      ["300", "400", "500", "700"], "400"
+    )};">
+    Some wrapping text <calcite-link
+      href="${text("href", "")}"
+      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+      disabled="${boolean("disabled", false)}"
+      icon-end="${select("icon-end", iconNames, iconNames[0])}">
+      ${text("text", "link text here")}</calcite-link>
+      around the link
+      </div>
+  `,
+    { notes }
+  )
+  .add(
+    "With icon-start and icon-end",
+    () => `
+    <div style="font-size: ${select(
+      "containing font size",
+      ["12", "14", "16", "18", "20", "24", "32"],
+      "16"
+    )}px; font-weight: ${select(
+      "containing font weight",
+      ["300", "400", "500", "700"], "400"
+    )};">
+    Some wrapping text <calcite-link
+      href="${text("href", "")}"
+      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+      disabled="${boolean("disabled", false)}"
+      icon-start="${select("icon-start", iconNames, iconNames[0])}"
+      icon-end="${select("icon-end", iconNames, iconNames[0])}">
       ${text("text", "link text here")}</calcite-link>
       around the link
       </div>

--- a/src/components/calcite-link/calcite-link.tsx
+++ b/src/components/calcite-link/calcite-link.tsx
@@ -40,12 +40,11 @@ export class CalciteLink {
   /** optionally pass a href - used to determine if the component should render as a link or an anchor */
   @Prop({ reflect: true }) href?: string;
 
-  /** optionally pass an icon to display - accepts Calcite UI icon names  */
-  @Prop({ reflect: true }) icon?: string;
+  /** optionally pass an icon to display at the start of a button - accepts calcite ui icon names  */
+  @Prop({ reflect: true }) iconStart?: string;
 
-  /** optionally used with icon, select where to position the icon */
-  @Prop({ reflect: true, mutable: true }) iconPosition?: "start" | "end" =
-    "start";
+  /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
+  @Prop({ reflect: true }) iconEnd?: string;
 
   /** is the link disabled  */
   @Prop({ reflect: true }) disabled?: boolean;
@@ -62,10 +61,6 @@ export class CalciteLink {
     let color = ["blue", "red", "dark", "light"];
     if (!color.includes(this.color)) this.color = "blue";
 
-    let iconPosition = ["start", "end"];
-    if (this.icon !== null && !iconPosition.includes(this.iconPosition))
-      this.iconPosition = "start";
-
     this.childElType = this.href ? "a" : "span";
   }
 
@@ -80,8 +75,20 @@ export class CalciteLink {
       ? 0
       : null;
 
-    const iconEl = (
-      <calcite-icon class="calcite-link--icon" icon={this.icon} scale="s" />
+    const iconStartEl = (
+      <calcite-icon
+        class="calcite-link--icon icon-start"
+        icon={this.iconStart}
+        scale="s"
+      />
+    );
+
+    const iconEndEl = (
+      <calcite-icon
+        class="calcite-link--icon icon-end"
+        icon={this.iconEnd}
+        scale="s"
+      />
     );
 
     return (
@@ -92,9 +99,9 @@ export class CalciteLink {
           tabIndex={tabIndex}
           ref={(el) => (this.childEl = el)}
         >
-          {this.icon && this.iconPosition === "start" ? iconEl : null}
+          {this.iconStart ? iconStartEl : null}
           <slot />
-          {this.icon && this.iconPosition === "end" ? iconEl : null}
+          {this.iconEnd ? iconEndEl : null}
         </Tag>
       </Host>
     );

--- a/src/components/calcite-link/readme.md
+++ b/src/components/calcite-link/readme.md
@@ -6,31 +6,24 @@ You can programmatically focus a `calcite-link` with the `setFocus()` method:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property       | Attribute       | Description                                                                                      | Type                                   | Default     |
-| -------------- | --------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------- | ----------- |
-| `color`        | `color`         | specify the color of the link, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"` | `"blue"`    |
-| `disabled`     | `disabled`      | is the link disabled                                                                             | `boolean`                              | `undefined` |
-| `href`         | `href`          | optionally pass a href - used to determine if the component should render as a link or an anchor | `string`                               | `undefined` |
-| `icon`         | `icon`          | optionally pass an icon to display - accepts Calcite UI icon names                               | `string`                               | `undefined` |
-| `iconPosition` | `icon-position` | optionally used with icon, select where to position the icon                                     | `"end" \| "start"`                     | `"start"`   |
-| `theme`        | `theme`         | Select theme (light or dark)                                                                     | `"dark" \| "light"`                    | `undefined` |
-
+| Property    | Attribute    | Description                                                                                      | Type                                   | Default     |
+| ----------- | ------------ | ------------------------------------------------------------------------------------------------ | -------------------------------------- | ----------- |
+| `color`     | `color`      | specify the color of the link, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"` | `"blue"`    |
+| `disabled`  | `disabled`   | is the link disabled                                                                             | `boolean`                              | `undefined` |
+| `href`      | `href`       | optionally pass a href - used to determine if the component should render as a link or an anchor | `string`                               | `undefined` |
+| `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of a button - accepts calcite ui icon names        | `string`                               | `undefined` |
+| `iconStart` | `icon-start` | optionally pass an icon to display at the start of a button - accepts calcite ui icon names      | `string`                               | `undefined` |
+| `theme`     | `theme`      | Select theme (light or dark)                                                                     | `"dark" \| "light"`                    | `undefined` |
 
 ## Methods
 
 ### `setFocus() => Promise<void>`
 
-
-
 #### Returns
 
 Type: `Promise<void>`
-
-
-
 
 ## Dependencies
 
@@ -39,12 +32,13 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-link --> calcite-icon
   style calcite-link fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -62,19 +62,57 @@ describe("calcite-split-button", () => {
     expect(dropdownButton).toEqualAttribute("aria-label", "more actions");
   });
 
-  it("renders primaryText + primaryIcon as inner content of primary button", async () => {
+  it("renders primaryText without icons as inner content of primary button", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-      <calcite-split-button primary-text="primary action" primary-icon="save">
+      <calcite-split-button primary-text="primary action">
       </calcite-split-button>`);
     const primaryButton = await page.find(
       "calcite-split-button >>> calcite-button"
     );
-    const icon = await page.find(
-      "calcite-split-button >>> calcite-button >>> .calcite-button--icon"
+
+    expect(primaryButton).toEqualText("primary action");
+    expect(primaryButton).not.toHaveAttribute("icon-start");
+    expect(primaryButton).not.toHaveAttribute("icon-end");
+  });
+
+  it("renders primaryText + primary-icon-start as inner content of primary button", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-split-button primary-text="primary action" primary-icon-start="save">
+      </calcite-split-button>`);
+    const primaryButton = await page.find(
+      "calcite-split-button >>> calcite-button"
+    );
+
+    expect(primaryButton).toEqualText("primary action");
+    expect(primaryButton).toEqualAttribute("icon-start", "save");
+    expect(primaryButton).not.toHaveAttribute("icon-end");
+  });
+
+  it("renders primaryText + primary-icon-end as inner content of primary button", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-split-button primary-text="primary action" primary-icon-end="save">
+      </calcite-split-button>`);
+    const primaryButton = await page.find(
+      "calcite-split-button >>> calcite-button"
     );
     expect(primaryButton).toEqualText("primary action");
-    expect(icon).not.toBeNull();
+    expect(primaryButton).not.toHaveAttribute("icon-start");
+    expect(primaryButton).toEqualAttribute("icon-end", "save");
+  });
+  it("renders primaryText + primary-icon-end and primary-icon-start as inner content of primary button", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-split-button primary-text="primary action" primary-icon-start="save" primary-icon-end="save">
+      </calcite-split-button>`);
+    const primaryButton = await page.find(
+      "calcite-split-button >>> calcite-button"
+    );
+    expect(primaryButton).toEqualText("primary action");
+    expect(primaryButton).toEqualAttribute("icon-start", "save");
+    expect(primaryButton).toEqualAttribute("icon-end", "save");
   });
 
   it("changes the size and width of the dropdown + primary button based on scale", async () => {

--- a/src/components/calcite-split-button/calcite-split-button.stories.js
+++ b/src/components/calcite-split-button/calcite-split-button.stories.js
@@ -20,13 +20,66 @@ storiesOf("Split Button", module)
         scale="${select("size", ["s", "m", "l"], "m")}"
         loading="${boolean("loading", false)}"
         disabled="${boolean("disabled", false)}"
-        primary-icon="${select("primary-icon", iconNames, iconNames[0])}"
+        primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
         primary-label="${text("primary-label", "Primary Option")}"
         dropdown-label="${text("dropdown-label", "Additional Options")}"
         dropdown-icon-type="${select(
           "dropdown-icon-type",
-          ["chevron", "caret", "ellipsis"],
+          ["chevron", "caret", "ellipsis", "overflow"],
+          "chevron"
+        )}">
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>
+  `,
+    { notes }
+  )
+  .add(
+    "Simple primary-icon-end",
+    () => `
+    <calcite-split-button
+        color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+        scale="${select("size", ["s", "m", "l"], "m")}"
+        loading="${boolean("loading", false)}"
+        disabled="${boolean("disabled", false)}"
+        primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
+        primary-text="${text("primary-text", "Primary Option")}"
+        primary-label="${text("primary-label", "Primary Option")}"
+        dropdown-label="${text("dropdown-label", "Additional Options")}"
+        dropdown-icon-type="${select(
+          "dropdown-icon-type",
+          ["chevron", "caret", "ellipsis", "overflow"],
+          "chevron"
+        )}">
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>
+  `,
+    { notes }
+  )
+  .add(
+    "Simple primary-icon-start and primary-icon-end",
+    () => `
+    <calcite-split-button
+        color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+        scale="${select("size", ["s", "m", "l"], "m")}"
+        loading="${boolean("loading", false)}"
+        disabled="${boolean("disabled", false)}"
+        primary-icon-start="${select("primary-icon-end", iconNames, iconNames[0])}"
+        primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
+        primary-text="${text("primary-text", "Primary Option")}"
+        primary-label="${text("primary-label", "Primary Option")}"
+        dropdown-label="${text("dropdown-label", "Additional Options")}"
+        dropdown-icon-type="${select(
+          "dropdown-icon-type",
+          ["chevron", "caret", "ellipsis", "overflow"],
           "chevron"
         )}">
       <calcite-dropdown-group selection-mode="none">
@@ -47,12 +100,12 @@ storiesOf("Split Button", module)
           scale="${select("size", ["s", "m", "l"], "m")}"
           loading="${boolean("loading", false)}"
           disabled="${boolean("disabled", false)}"
-          primary-icon="${select("primary-icon", iconNames, iconNames[0])}"
+          primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
           primary-text="${text("primary-text", "Primary Option")}"
           dropdown-label="${text("dropdown-label", "Additional Options")}"
           dropdown-icon-type="${select(
             "dropdown-icon-type",
-            ["chevron", "caret", "ellipsis"],
+            ["chevron", "caret", "ellipsis", "overflow"],
             "chevron"
           )}">
         <calcite-dropdown-group selection-mode="none">
@@ -73,12 +126,12 @@ storiesOf("Split Button", module)
         scale="${select("size", ["s", "m", "l"], "m")}"
         loading="${boolean("loading", false)}"
         disabled="${boolean("disabled", false)}"
-        primary-icon="${select("primary-icon", iconNames, iconNames[0])}"
+        primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
         dropdown-label="${text("dropdown-label", "Additional Options")}"
         dropdown-icon-type="${select(
           "dropdown-icon-type",
-          ["chevron", "caret", "ellipsis"],
+          ["chevron", "caret", "ellipsis", "overflow"],
           "chevron"
         )}">
         theme="dark">

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -35,13 +35,17 @@ export class CalciteSplitButton {
   @Prop({ mutable: true, reflect: true }) dropdownIconType:
     | "chevron"
     | "caret"
-    | "ellipsis" = "chevron";
+    | "ellipsis"
+    | "overflow" = "chevron";
 
   /** text for primary action button  */
   @Prop({ reflect: true }) primaryText: string;
 
-  /** optionally pass an icon to display on the primary button - accepts Calcite UI icon names  */
-  @Prop({ reflect: true }) primaryIcon?: string;
+  /** optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names  */
+  @Prop({ reflect: true }) primaryIconStart?: string;
+
+  /** optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names  */
+  @Prop({ reflect: true }) primaryIconEnd?: string;
 
   /** optionally pass an aria-label for the primary button */
   @Prop({ reflect: true }) primaryLabel?: string;
@@ -79,7 +83,7 @@ export class CalciteSplitButton {
 
   @Watch("dropdownIconType")
   validateDropdownIconType() {
-    let dropdownIconType = ["chevron", "caret", "ellipsis"];
+    let dropdownIconType = ["chevron", "caret", "ellipsis", "overflow"];
     if (!dropdownIconType.includes(this.dropdownIconType))
       this.dropdownIconType = "chevron";
   }
@@ -102,8 +106,8 @@ export class CalciteSplitButton {
             color={this.color}
             scale={this.scale}
             loading={this.loading}
-            icon={this.primaryIcon}
-            iconPosition="start"
+            icon-start={this.primaryIconStart ? this.primaryIconStart : null}
+            icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
             disabled={this.disabled}
             theme={this.theme}
             onClick={this.calciteSplitButtonPrimaryClickHandler}
@@ -128,7 +132,7 @@ export class CalciteSplitButton {
               color={this.color}
               disabled={this.disabled}
               theme={this.theme}
-              icon={this.dropdownIcon}
+              icon-start={this.dropdownIcon}
             />
             <slot />
           </calcite-dropdown>
@@ -145,6 +149,8 @@ export class CalciteSplitButton {
       ? "chevronDown"
       : this.dropdownIconType === "caret"
       ? "caretDown"
-      : "ellipsis";
+      : this.dropdownIconType === "ellipsis"
+      ? "ellipsis"
+      : "handle-vertical";
   }
 }

--- a/src/components/calcite-split-button/readme.md
+++ b/src/components/calcite-split-button/readme.md
@@ -5,7 +5,7 @@ The calcite-split-button control is one that combines a button with a dropdown m
 Basic Usage:
 
 ```html
-<calcite-split-button primary-icon="save" primary-text="Primary Option">
+<calcite-split-button primary-icon-start="save" primary-text="Primary Option">
   <calcite-dropdown-group selection-mode="none">
     <calcite-dropdown-item>Option 2</calcite-dropdown-item>
     <calcite-dropdown-item>Option 3</calcite-dropdown-item>
@@ -16,29 +16,27 @@ Basic Usage:
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property           | Attribute            | Description                                                                                              | Type                                   | Default     |
-| ------------------ | -------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------- |
-| `color`            | `color`              | specify the color of the control, defaults to blue                                                       | `"blue" \| "dark" \| "light" \| "red"` | `"blue"`    |
-| `disabled`         | `disabled`           | is the control disabled                                                                                  | `boolean`                              | `undefined` |
-| `dropdownIconType` | `dropdown-icon-type` | specify the icon used for the dropdown menu, defaults to chevron                                         | `"caret" \| "chevron" \| "ellipsis"`   | `"chevron"` |
-| `dropdownLabel`    | `dropdown-label`     | aria label for overflow button                                                                           | `string`                               | `undefined` |
-| `loading`          | `loading`            | optionally add a calcite-loader component to the control, disabling interaction. with the primary button | `boolean`                              | `false`     |
-| `primaryIcon`      | `primary-icon`       | optionally pass an icon to display on the primary button - accepts Calcite UI icon names                 | `string`                               | `undefined` |
-| `primaryLabel`     | `primary-label`      | optionally pass an aria-label for the primary button                                                     | `string`                               | `undefined` |
-| `primaryText`      | `primary-text`       | text for primary action button                                                                           | `string`                               | `undefined` |
-| `scale`            | `scale`              | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                    | `"m"`       |
-| `theme`            | `theme`              | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                    | `undefined` |
-
+| Property           | Attribute            | Description                                                                                              | Type                                               | Default     |
+| ------------------ | -------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `color`            | `color`              | specify the color of the control, defaults to blue                                                       | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
+| `disabled`         | `disabled`           | is the control disabled                                                                                  | `boolean`                                          | `undefined` |
+| `dropdownIconType` | `dropdown-icon-type` | specify the icon used for the dropdown menu, defaults to chevron                                         | `"caret" \| "chevron" \| "ellipsis" \| "overflow"` | `"chevron"` |
+| `dropdownLabel`    | `dropdown-label`     | aria label for overflow button                                                                           | `string`                                           | `undefined` |
+| `loading`          | `loading`            | optionally add a calcite-loader component to the control, disabling interaction. with the primary button | `boolean`                                          | `false`     |
+| `primaryIconEnd`   | `primary-icon-end`   | optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names      | `string`                                           | `undefined` |
+| `primaryIconStart` | `primary-icon-start` | optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names    | `string`                                           | `undefined` |
+| `primaryLabel`     | `primary-label`      | optionally pass an aria-label for the primary button                                                     | `string`                                           | `undefined` |
+| `primaryText`      | `primary-text`       | text for primary action button                                                                           | `string`                                           | `undefined` |
+| `scale`            | `scale`              | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                                | `"m"`       |
+| `theme`            | `theme`              | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                                | `undefined` |
 
 ## Events
 
 | Event                            | Description                              | Type               |
 | -------------------------------- | ---------------------------------------- | ------------------ |
 | `calciteSplitButtonPrimaryClick` | fired when the primary button is clicked | `CustomEvent<any>` |
-
 
 ## Dependencies
 
@@ -48,6 +46,7 @@ Basic Usage:
 - [calcite-dropdown](../calcite-dropdown)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-split-button --> calcite-button
@@ -57,6 +56,6 @@ graph TD;
   style calcite-split-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -32,11 +32,24 @@
   <h1>Calcite Button</h1>
   <h3>Side by Side test</h3>
   <div style="width:300px;position:relative;display:flex;">
-    <calcite-button icon="plus" appearance="transparent" width="half">Field
+    <calcite-button icon-start="plus" appearance="transparent" width="half">Field
     </calcite-button>
-    <calcite-button icon="plus" appearance="transparent" width="half">Long Expression
+    <calcite-button icon-start="plus" appearance="transparent" width="half">Long Expression
     </calcite-button>
   </div>
+  <h3>Icons</h3>
+  <calcite-button icon-start="plus">Field
+  </calcite-button>
+  <calcite-button icon-end="plus">Long Expression
+  </calcite-button>
+  <calcite-button icon-start="layer" icon-end="chevron-down">Long Expression
+  </calcite-button>
+  <calcite-button icon-start="layer" icon-end="chevron-down" loading>Loading
+  </calcite-button>
+  <calcite-button icon-start="layer" icon-end="chevron-down"></calcite-button>
+  <calcite-button icon-start="layer" icon-end="chevron-down" loading></calcite-button>
+  <calcite-button dir="rtl" icon-start="plus" icon-end="plus"></calcite-button>
+
   <h3>FAB with custom positioned container</h3>
 
   <div style="height:300px;width:200px;overflow:scroll;position:relative;display:inline-flex;flex-direction:column">
@@ -57,7 +70,30 @@
     libero aliquam, imperdiet ipsum sed, volutpat nisl.
 
     <div class="sticky-example" id="calcite-fab-tooltip">
-      <calcite-button round floating icon="plus"></calcite-button>
+      <calcite-button round floating icon-start="plus"></calcite-button>
+    </div>
+    <calcite-tooltip theme="dark" placement="top" reference-element="calcite-fab-tooltip">Add new
+    </calcite-tooltip>
+  </div>
+  <div style="height:300px;width:200px;overflow:scroll;position:relative;display:inline-flex;flex-direction:column">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut varius, sem id ullamcorper volutpat, nibh risus
+    semper tellus, quis ultrices nisl metus in nunc. Aenean ut eleifend lectus. Mauris rutrum dolor felis, at
+    volutpat massa aliquam a. In sit amet tortor lobortis, scelerisque dui quis, sodales tellus. Pellentesque
+    lobortis ligula nunc, ac convallis lacus sollicitudin id. Etiam bibendum mi sit amet enim auctor, eget porta
+    massa hendrerit. Phasellus in ex ut diam dictum mattis. Sed cursus placerat enim ut dignissim. Donec venenatis
+    maximus consequat.
+
+    Mauris sit amet odio mattis, aliquet quam sit amet, egestas leo. Ut auctor leo in tortor maximus, in aliquet
+    mauris venenatis. Curabitur fringilla odio sed hendrerit ornare. Donec sodales augue lacus, laoreet vulputate
+    odio feugiat id. Aliquam viverra a purus ultrices molestie. Integer faucibus urna felis, at feugiat eros
+    malesuada quis. Morbi luctus urna quis risus molestie egestas. Vestibulum magna est, mollis vitae tempor quis,
+    pulvinar aliquet erat. Maecenas a elit ut purus porttitor auctor. Suspendisse id ligula consectetur, venenatis
+    quam eget, aliquam erat. Sed lobortis sapien id scelerisque fringilla. Quisque eget erat a augue condimentum
+    ullamcorper a semper lorem. Nunc elementum rutrum pharetra. Sed consequat sem eget ex lacinia posuere. Duis a
+    libero aliquam, imperdiet ipsum sed, volutpat nisl.
+
+    <div class="sticky-example" id="calcite-fab-tooltip">
+      <calcite-button floating icon-start="plus" icon-end="layer"></calcite-button>
     </div>
     <calcite-tooltip theme="dark" placement="top" reference-element="calcite-fab-tooltip">Add new
     </calcite-tooltip>
@@ -80,7 +116,7 @@
     libero aliquam, imperdiet ipsum sed, volutpat nisl.
 
     <div class="sticky-example">
-      <calcite-button scale="s" floating appearance="outline" icon="plus"></calcite-button>
+      <calcite-button scale="s" floating appearance="outline" icon-start="plus"></calcite-button>
     </div>
   </div>
 
@@ -102,14 +138,14 @@
     libero aliquam, imperdiet ipsum sed, volutpat nisl.
 
     <div class="sticky-example">
-      <calcite-button round floating icon="plus">Do this thing
+      <calcite-button round floating icon-start="plus">Do this thing
       </calcite-button>
     </div>
   </div>
 
 
   <h3>Normal Lockup</h3>
-  <calcite-button color="light" appearance='outline' icon="chevronLeft">
+  <calcite-button color="light" appearance='outline' icon-start="chevronLeft">
     Back</calcite-button>
   <calcite-button appearance='outline'>Cancel</calcite-button>
   <calcite-button>Submit</calcite-button>
@@ -219,9 +255,9 @@
 
 
   <h3>Type: Transparent</h3>
-  <calcite-button title="blue transparent button" appearance='transparent' icon='circle'>
+  <calcite-button title="blue transparent button" appearance='transparent' icon-start='circle'>
     transparent and icon</calcite-button>
-  <calcite-button title="blue transparent button" icon-position="end" appearance='transparent' icon='circle'>
+  <calcite-button title="blue transparent button" appearance='transparent' icon-start='circle'>
     transparent and end icon</calcite-button>
   <calcite-button title="blue transparent button" appearance='transparent'>blue transparent button
   </calcite-button>
@@ -241,16 +277,18 @@
     <calcite-button theme="dark" title="red transparent button" appearance='transparent' color='red'>red
       transparent button
     </calcite-button>
-    <calcite-button theme="dark" title="light transparent button" appearance='transparent' color='light'>light transparent
+    <calcite-button theme="dark" title="light transparent button" appearance='transparent' color='light'>light
+      transparent
       button
     </calcite-button>
-    <calcite-button theme="dark" title="dark transparent button" appearance='transparent' color='dark'>dark transparent button
+    <calcite-button theme="dark" title="dark transparent button" appearance='transparent' color='dark'>dark transparent
+      button
     </calcite-button>
   </div>
 
   <h3>Disabled</h3>
   <calcite-button title="blue solid button" disabled>blue solid button</calcite-button>
-  <calcite-button icon='launch' title="dark solid button" color='dark' disabled>dark solid button</calcite-button>
+  <calcite-button icon-start='launch' title="dark solid button" color='dark' disabled>dark solid button</calcite-button>
   <calcite-button title="blue clear button" appearance='clear' disabled>blue clear button</calcite-button>
   <calcite-button title="blue clear button" appearance='transparent' disabled>blue clear button</calcite-button>
   </calcite-button>
@@ -258,7 +296,7 @@
   <br />
   <div class="demo-background-dark">
     <calcite-button theme="dark" title="blue solid button" disabled>blue solid button</calcite-button>
-    <calcite-button theme="dark" icon='launch' title="dark solid button" color='dark' disabled>dark solid button
+    <calcite-button theme="dark" icon-start='launch' title="dark solid button" color='dark' disabled>dark solid button
     </calcite-button>
     <calcite-button theme="dark" title="blue clear button" appearance='clear' disabled>blue clear button
     </calcite-button>
@@ -272,9 +310,9 @@
   <calcite-button title="s scale button" scale='s'>s scale button</calcite-button>
 
   <h3>Scales with icons</h3>
-  <calcite-button title="l scale button" icon="check-circle" scale='l'>l scale button</calcite-button>
-  <calcite-button title="m / default scale button" icon="check-circle">m / default scale button</calcite-button>
-  <calcite-button title="s scale button" icon="check-circle" scale='s'>s scale button</calcite-button>
+  <calcite-button title="l scale button" icon-start="check-circle" scale='l'>l scale button</calcite-button>
+  <calcite-button title="m / default scale button" icon-start="check-circle">m / default scale button</calcite-button>
+  <calcite-button title="s scale button" icon-start="check-circle" scale='s'>s scale button</calcite-button>
 
   <h3>Widths</h3>
   <calcite-button title="Auto / default width button">Auto / default width button</calcite-button>
@@ -282,9 +320,9 @@
   <calcite-button title="half width button" width='half'>half width button</calcite-button>
   <br />
   <calcite-button title="full width button" width='full'>full width button</calcite-button>
-  <calcite-button title="full width button" icon='check-circle' width='full'>full width button with icon
+  <calcite-button title="full width button" icon-start='check-circle' width='full'>full width button with icon
   </calcite-button>
-  <calcite-button title="full width button" icon-position="end" icon='check-circle' width='full'>full width button with
+  <calcite-button title="full width button" icon-start='check-circle' width='full'>full width button with
     icon </calcite-button>
 
   <h3>Anchor links</h3>
@@ -294,7 +332,7 @@
   <calcite-button href='http://google.com' title="full width button" rel="noopener noreferrer" target="_blank">
     External anchor
   </calcite-button>
-  <calcite-button href='http://google.com' appearance="outline" icon="launch" title="full width button"
+  <calcite-button href='http://google.com' appearance="outline" icon-start="launch" title="full width button"
     rel="noopener noreferrer" target="_blank">External anchor with icon
   </calcite-button>
 
@@ -309,20 +347,19 @@
 
   <h3>Icons, and icons in combination with loader</h3>
   <h5>pass path data - recommend using Calcite UI Icon Filled variants @ 24.</h5>
-  <calcite-button appearance="outline" color="light" icon='check-circle'></calcite-button>
-  <calcite-button onclick="loadingButton(this, 3000)" icon='check-circle'></calcite-button>
-  <calcite-button appearance="outline" color="dark" icon-position="end" icon='check-circle'>
+  <calcite-button appearance="outline" color="light" icon-start='check-circle'></calcite-button>
+  <calcite-button onclick="loadingButton(this, 3000)" icon-start='check-circle'></calcite-button>
+  <calcite-button appearance="outline" color="dark" icon-start='check-circle'>
     Download icon end</calcite-button>
-  <calcite-button scale="l" appearance="outline" icon='download-to'>
+  <calcite-button scale="l" appearance="outline" icon-start='download-to'>
     Download</calcite-button>
-  <calcite-button icon='download-to'>
+  <calcite-button icon-start='download-to'>
     <em>Download</em></calcite-button>
-  <calcite-button color='red' icon='trash'>
+  <calcite-button color='red' icon-start='trash'>
     Delete this</calcite-button>
-  <calcite-button color='red' appearance="outline" onclick="loadingButton(this, 3000)" icon='trash'>
+  <calcite-button color='red' appearance="outline" onclick="loadingButton(this, 3000)" icon-start='trash'>
     Delete this (loader)</calcite-button>
-  <calcite-button color='red' scale="l" appearance="outline" icon-position="end" onclick="loadingButton(this, 3000)"
-    icon='trash'>
+  <calcite-button color='red' scale="l" appearance="outline" onclick="loadingButton(this, 3000)" icon-start='trash'>
     Delete this (loader)</calcite-button>
 
 </body>

--- a/src/demos/calcite-card.html
+++ b/src/demos/calcite-card.html
@@ -62,12 +62,12 @@
           <br />
           View Count: 0
         </div>
-        <calcite-button slot="footer-leading" color="light" scale="s" icon='circle'></calcite-button>
+        <calcite-button slot="footer-leading" color="light" scale="s" icon-start='circle'></calcite-button>
         <div slot="footer-trailing">
-          <calcite-button scale="s" color="light" id="card-icon-test-2" icon='circle'></calcite-button>
-          <calcite-button scale="s" color="light" id="card-icon-test-1" icon='circle'></calcite-button>
+          <calcite-button scale="s" color="light" id="card-icon-test-2" icon-start='circle'></calcite-button>
+          <calcite-button scale="s" color="light" id="card-icon-test-1" icon-start='circle'></calcite-button>
           <calcite-dropdown>
-            <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="light" icon='circle'>
+            <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="light" icon-start='circle'>
             </calcite-button>
             <calcite-dropdown-group selection-mode="none">
               <calcite-dropdown-item>View details</calcite-dropdown-item>
@@ -92,9 +92,9 @@
         <span slot="subtitle">Johnathan Smith</span>
         <span slot="footer-leading">Nov 25, 2018</span>
         <div slot="footer-trailing">
-          <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon='circle'>
+          <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start='circle'>
           </calcite-button>
-          <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon='circle'>
+          <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start='circle'>
           </calcite-button>
         </div>
       </calcite-card>
@@ -189,12 +189,12 @@
             <br />
             View Count: 0
           </div>
-          <calcite-button theme="dark" slot="footer-leading" color="dark" scale="s" icon='circle'></calcite-button>
+          <calcite-button theme="dark" slot="footer-leading" color="dark" scale="s" icon-start='circle'></calcite-button>
           <div slot="footer-trailing">
-            <calcite-button theme="dark" scale="s" color="dark" id="card-icon-test-3" icon='circle'></calcite-button>
-            <calcite-button theme="dark" scale="s" color="dark" id="card-icon-test-4" icon='circle'></calcite-button>
+            <calcite-button theme="dark" scale="s" color="dark" id="card-icon-test-3" icon-start='circle'></calcite-button>
+            <calcite-button theme="dark" scale="s" color="dark" id="card-icon-test-4" icon-start='circle'></calcite-button>
             <calcite-dropdown theme="dark">
-              <calcite-button slot="dropdown-trigger" theme="dark" scale="s" color="dark" icon='circle'>
+              <calcite-button slot="dropdown-trigger" theme="dark" scale="s" color="dark" icon-start='circle'>
               </calcite-button>
               <calcite-dropdown-group selection-mode="none">
                 <calcite-dropdown-item>View details</calcite-dropdown-item>

--- a/src/demos/calcite-link.html
+++ b/src/demos/calcite-link.html
@@ -46,10 +46,17 @@
   <br />
 
   <h3>Tooltip trigger</h3>
-  <calcite-link icon="information" icon-position="start" id="tooltip-example">span to gain focus</calcite-link>
+  <calcite-link icon-start="information" id="tooltip-example">span to gain focus</calcite-link>
   <calcite-tooltip placement="top" reference-element="tooltip-example">Lorem Ipsum is simply
     of the printing and typesetting industry. Lorem Ipsum has been the industry's standard printer of type and
     scrambled it to make a type specimen book.</calcite-tooltip>
+  <h3>Icons</h3>
+
+
+  <calcite-link icon-start="information">example text</calcite-link><br /><br />
+  <calcite-link icon-end="information">example text</calcite-link><br /><br />
+  <calcite-link icon-start="information" icon-end="information">example text</calcite-link>
+  <br /><br />
   <h3>Inline links</h3>
 
   A <calcite-link title="in the middle">link with no href in the middle</calcite-link>
@@ -59,32 +66,33 @@
   A <calcite-link title="in the middle" href="/">in the middle</calcite-link> of
   some
   text.<br />
-  A <calcite-link href="/" title="in the middle that might be long enough to wrap to illustrate animation"
-    color='red'>in the middle that might be long enough to wrap to illustrate animation</calcite-link> of some
+  A <calcite-link href="/" title="in the middle that might be long enough to wrap to illustrate animation" color='red'>
+    in the middle that might be long enough to wrap to illustrate animation</calcite-link> of some
   text.<br />
   A link <calcite-link href="http://google.com" color='light' rel="noopener noreferrer" target="_blank"
-    title="in the middle with an icon" icon='launch'>to Google with an
+    title="in the middle with an icon" icon-start='launch'>to Google with an
     icon</calcite-link> in some text.<br />
 
   A link <calcite-link href="http://google.com" rel="noopener noreferrer" target="_blank"
-    title="in the middle with an icon" color='dark' icon='launch'>in the middle</calcite-link> of some text.<br /><br />
-  <div class="demo-background-dark"><br/>
+    title="in the middle with an icon" color='dark' icon-start='launch'>in the middle</calcite-link> of some
+  text.<br /><br />
+  <div class="demo-background-dark"><br />
     A link <calcite-link theme="dark" href="http://google.com" rel="noopener noreferrer" target="_blank"
       title="in the middle" color='red'>to Google.</calcite-link>
     <br />
     A link <calcite-link href="http://google.com" color='light' rel="noopener noreferrer" target="_blank"
-      title="in the middle with an icon" icon='launch' icon-position="end"> to
+      title="in the middle with an icon" icon-start='launch'>to
       Google with an
       icon</calcite-link> in some text.<br />
     A link <calcite-link href="http://google.com" color='light' rel="noopener noreferrer" target="_blank"
-      title="in the middle with an icon" icon='launch'>to Google with an
+      title="in the middle with an icon" icon-start='launch'>to Google with an
       icon</calcite-link> in some text.<br />
     A link <calcite-link href="http://google.com" color='light' rel="noopener noreferrer" target="_blank"
-      title="in the middle with an icon" icon='launch'>to Google with an
+      title="in the middle with an icon" icon-start='launch'>to Google with an
       icon</calcite-link> in some text.<br />
 
     <h3> A link <calcite-link href="http://google.com" color='light' rel="noopener noreferrer" target="_blank"
-        title="in the middle with an icon" icon='launch'>to Google with an
+        title="in the middle with an icon" icon-start='launch'>to Google with an
         icon</calcite-link> in some text.</h3> <br />
 </body>
 

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -18,12 +18,13 @@
   <script type="module" src="../build/calcite.esm.js"></script>
   <script nomodule src="../build/calcite.js"></script>
 </head>
+
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Split Button</h1>
   <div style="width:1200px;position:relative;">
     <h3>Example with Custom Dropdown Content</h3>
-    <calcite-split-button primary-icon='save' primary-text="Primary Option">
+    <calcite-split-button primary-icon-start='save' primary-text="Primary Option">
       <calcite-dropdown-group selection-mode="none">
         <calcite-dropdown-item>Option 2</calcite-dropdown-item>
         <calcite-dropdown-item>Option 3</calcite-dropdown-item>
@@ -33,7 +34,21 @@
 
     <h3>Example with Custom Dropdown Content (RTL)</h3>
     <div dir="rtl">
-      <calcite-split-button primary-icon='save' primary-text="Primary Option">
+      <calcite-split-button primary-icon-start='save' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button primary-icon-end='save' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button primary-icon-start='save' primary-icon-end='layer' primary-text="Primary Option">
         <calcite-dropdown-group selection-mode="none">
           <calcite-dropdown-item>Option 2</calcite-dropdown-item>
           <calcite-dropdown-item>Option 3</calcite-dropdown-item>
@@ -43,7 +58,7 @@
     </div>
 
     <h3>Color</h3>
-    <div  style='display:flex;flex-direction:row;justify-content:space-between'>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
       <calcite-split-button primary-text="Primary Option"></calcite-split-button>
       <calcite-split-button color='red' primary-text="Primary Option"></calcite-split-button>
       <calcite-split-button color='light' primary-text="Primary Option"></calcite-split-button>
@@ -116,23 +131,52 @@
       </script>
     </div>
 
+
+    <h3>Scale (two icons)</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button primary-icon-start="plus" primary-icon-end="layer" scale='s' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button primary-icon-start="plus" primary-icon-end="layer" scale='m' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button primary-icon-start="plus" primary-icon-end="layer" scale='l' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <script>
+        document.addEventListener('calciteSplitButtonPrimaryClick', () => alert('primary action'))
+      </script>
+    </div>
+
     <h3>Scale (when `primary-text` is empty)</h3>
     <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-icon='save'>
+      <calcite-split-button scale='s' primary-icon-start='save'>
         <calcite-dropdown-group selection-mode="none">
           <calcite-dropdown-item>Option 2</calcite-dropdown-item>
           <calcite-dropdown-item>Option 3</calcite-dropdown-item>
           <calcite-dropdown-item>Option 4</calcite-dropdown-item>
         </calcite-dropdown-group>
       </calcite-split-button>
-      <calcite-split-button scale='m' primary-icon='save'>
+      <calcite-split-button scale='m' primary-icon-start='save'>
         <calcite-dropdown-group selection-mode="none">
           <calcite-dropdown-item>Option 2</calcite-dropdown-item>
           <calcite-dropdown-item>Option 3</calcite-dropdown-item>
           <calcite-dropdown-item>Option 4</calcite-dropdown-item>
         </calcite-dropdown-group>
       </calcite-split-button>
-      <calcite-split-button scale='l' primary-icon='save'>
+      <calcite-split-button scale='l' primary-icon-start='save'>
         <calcite-dropdown-group selection-mode="none">
           <calcite-dropdown-item>Option 2</calcite-dropdown-item>
           <calcite-dropdown-item>Option 3</calcite-dropdown-item>
@@ -141,6 +185,79 @@
       </calcite-split-button>
     </div>
 
+    <h3>Scale (primary-icon-end)(when `primary-text` is empty)</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button scale='s' primary-icon-end='save'>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='m' primary-icon-end='save'>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='l' primary-icon-end='save'>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+    </div>
+
+    <h3>Scale (primary-icon-end and -start)(when `primary-text` is empty)</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button scale='s' primary-icon-end='save' primary-icon-start="layer">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='m' primary-icon-end='save' primary-icon-start="layer">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='l' primary-icon-end='save' primary-icon-start="layer">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+    </div>
+    <h3>Scale (when `dropdown-icon-type` is 'chevron' (default))</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button scale='s' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='m' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='l' primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+    </div>
     <h3>Scale (when `dropdown-icon-type` is 'caret')</h3>
     <div style='display:flex;flex-direction:row;justify-content:space-between'>
       <calcite-split-button scale='s' primary-text="Primary Option" dropdown-icon-type='caret'>
@@ -189,8 +306,33 @@
         </calcite-dropdown-group>
       </calcite-split-button>
     </div>
+    <h3>Scale (when `dropdown-icon-type` is 'overflow')</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button scale='s' primary-text="Primary Option" dropdown-icon-type='overflow'>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='m' primary-text="Primary Option" dropdown-icon-type='overflow'>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button scale='l' primary-text="Primary Option" dropdown-icon-type='overflow'>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+    </div>
     </br>
     </br>
   </div>
 </body>
+
 </html>


### PR DESCRIPTION
Resolves #665 

Breaking change to allow up to two icons in start / end positions on icons - should solve for some previously unaccounted for use cases - includes styling updates and handles two icons positioned together without text. Applies to `calcite-button`, `calcite-link`, `calcite-split-button` (with some slight syntactical differences to match the existing API in split-button).

 Also adds an additional `dropdown-icon-type` value of `overflow` to `calcite-split-button`.

- 🚨 **BREAKING** - `calcite-button` - `icon-position` and `icon` props have been removed - you can now use `icon-start` and `icon-end` props to position up to two icons.
- 🚨 **BREAKING** - `calcite-link` - `icon-position` and `icon` props have been removed - you can now use `icon-start` and `icon-end` props to position up to two icons.
- 🚨 **BREAKING** - `calcite-split-button` - `primary-icon` prop has been removed - you can now use `primary-icon-start` and `primary-icon-end` props to position up to two icons.

- ➕ - `calcite-button` - `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
- ➕ - `calcite-link` - `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
- ➕ - `calcite-split-button` - `primary-icon-start` and `primary-icon-end` props have been added for explicit positioning of up to two icons.
- ➕ - `calcite-split-button` - `dropdown-icon-type` prop now accepts an `overflow` value for an additional icon option.
- 📖 - Update readmes, dev demos, tests, storybooks