### PR TITLE
Dropdown accessibility improvements

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -74,13 +74,17 @@ export class CalciteDropdownGroup {
 
   render() {
     const groupTitle = this.groupTitle ? (
-      <span class="dropdown-title" ref={(node) => (this.titleEl = node)}>
+      <span
+        class="dropdown-title"
+        ref={(node) => (this.titleEl = node)}
+        aria-hidden="true"
+      >
         {this.groupTitle}
       </span>
     ) : null;
 
     return (
-      <Host>
+      <Host title={this.groupTitle} role="menu">
         {groupTitle}
         <slot />
       </Host>

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -122,13 +122,25 @@ export class CalciteDropdownItem {
         {slottedContent}
       </a>
     );
+
+    const itemRole = this.href
+      ? null
+      : this.selectionMode === "single"
+      ? "menuitemradio"
+      : this.selectionMode === "multi"
+      ? "menuitemcheckbox"
+      : "menuitem";
+
+    const itemAria =
+      this.selectionMode !== "none" ? this.active.toString() : null;
+
     return (
       <Host
         dir={dir}
         tabindex="0"
-        role="menuitem"
+        role={itemRole}
+        aria-checked={itemAria}
         selection-mode={this.selectionMode}
-        aria-selected={this.active.toString()}
         isLink={this.href}
       >
         {this.selectionMode === "multi" ? (

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -123,13 +123,7 @@ export class CalciteDropdownItem {
       </a>
     );
 
-    const itemRole = this.href
-      ? null
-      : this.selectionMode === "single"
-      ? "menuitemradio"
-      : this.selectionMode === "multi"
-      ? "menuitemcheckbox"
-      : "menuitem";
+    const itemRole = this.determineItemRole();
 
     const itemAria =
       this.selectionMode !== "none" ? this.active.toString() : null;
@@ -141,7 +135,7 @@ export class CalciteDropdownItem {
         role={itemRole}
         aria-checked={itemAria}
         selection-mode={this.selectionMode}
-        isLink={this.href}
+        isLink={!!this.href}
       >
         {this.selectionMode === "multi" ? (
           <calcite-icon
@@ -250,6 +244,27 @@ export class CalciteDropdownItem {
         this.active = false;
         break;
     }
+  }
+
+  private determineItemRole() {
+    let itemRole = null;
+    // items that are rendered as links should not have a role assigned
+    if (!this.href) {
+      switch (this.selectionMode) {
+        case "multi":
+          itemRole = "menuitemcheckbox";
+          break;
+
+        case "single":
+          itemRole = "menuitemradio";
+          break;
+
+        case "none":
+          itemRole = "menuitem";
+          break;
+      }
+    }
+    return itemRole;
   }
 
   private emitRequestedItem() {

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -897,4 +897,76 @@ describe("calcite-dropdown", () => {
     await page.waitForChanges();
     expect(await dropdownWrapper.isVisible()).toBe(false);
   });
+
+  it("correct role and aria properties are applied based on selection type", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-dropdown>
+    <calcite-button slot="dropdown-trigger" id="trigger">Open dropdown</calcite-button>
+    <calcite-dropdown-group id="group-1" selection-mode="multi">
+    <calcite-dropdown-item id="item-1">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-2" active>
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-3" active>
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group id="group-2" selection-mode="single">
+    <calcite-dropdown-item id="item-4">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-5" active>
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group id="group-3" selection-mode="none">
+    <calcite-dropdown-item id="item-6">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-7" href="google.com">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    </calcite-dropdown-group>
+    </calcite-dropdown>`);
+
+    const element = await page.find("calcite-dropdown");
+    const group1 = await element.find("calcite-dropdown-group[id='group-1']");
+    const group2 = await element.find("calcite-dropdown-group[id='group-2']");
+    const group3 = await element.find("calcite-dropdown-group[id='group-3']");
+    const item1 = await element.find("calcite-dropdown-item[id='item-1']");
+    const item2 = await element.find("calcite-dropdown-item[id='item-2']");
+    const item3 = await element.find("calcite-dropdown-item[id='item-3']");
+    const item4 = await element.find("calcite-dropdown-item[id='item-4']");
+    const item5 = await element.find("calcite-dropdown-item[id='item-5']");
+    const item6 = await element.find("calcite-dropdown-item[id='item-6']");
+    const item7 = await element.find("calcite-dropdown-item[id='item-7']");
+
+    expect(group1).toEqualAttribute("role", "menu");
+    expect(group2).toEqualAttribute("role", "menu");
+    expect(group3).toEqualAttribute("role", "menu");
+
+    expect(item1).toEqualAttribute("role", "menuitemcheckbox");
+    expect(item1).toEqualAttribute("aria-checked", "false");
+
+    expect(item2).toEqualAttribute("role", "menuitemcheckbox");
+    expect(item2).toEqualAttribute("aria-checked", "true");
+
+    expect(item3).toEqualAttribute("role", "menuitemcheckbox");
+    expect(item3).toEqualAttribute("aria-checked", "true");
+
+    expect(item4).toEqualAttribute("role", "menuitemradio");
+    expect(item4).toEqualAttribute("aria-checked", "false");
+
+    expect(item5).toEqualAttribute("role", "menuitemradio");
+    expect(item5).toEqualAttribute("aria-checked", "true");
+
+    expect(item6).toEqualAttribute("role", "menuitem");
+    expect(item6).not.toHaveAttribute("aria-checked");
+
+    expect(item7).not.toHaveAttribute("role");
+    expect(item7).not.toHaveAttribute("aria-checked");
+  });
 });

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -127,8 +127,8 @@ export class CalciteDropdown {
           aria-expanded={this.active.toString()}
         />
         <div
+          tabIndex={-1}
           class="calcite-dropdown-wrapper"
-          role="menu"
           style={{
             maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "",
           }}


### PR DESCRIPTION
cc @MikeTschudi

Resolves #674 
Resolves #675 

Additionally if a dropdown-item renders as a link (if a href attribute is present) - role is not added to the item so a screenreader can accurately interpret the content.

- Updates tests