### PR TITLE
Docs cleanup for tabs

### DIFF
--- a/src/components/calcite-tabs/readme.md
+++ b/src/components/calcite-tabs/readme.md
@@ -5,17 +5,16 @@ calcite-tabs uses several sub-components ([calcite-tab-nav](../calcite-tab-nav),
 ```html
 <calcite-tabs>
   <calcite-tab-nav slot="tab-nav">
-    <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
     <calcite-tab-title>Tab 2 Title</calcite-tab-title>
   </calcite-tab-nav>
 
-  <calcite-tab is-active>Tab 1 Content</calcite-tab>
+  <calcite-tab active>Tab 1 Content</calcite-tab>
   <calcite-tab>Tab 2 Content</calcite-tab>
 </calcite-tabs>
 ```
 
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
@@ -24,7 +23,6 @@ calcite-tabs uses several sub-components ([calcite-tab-nav](../calcite-tab-nav),
 | `layout` | `layout`  | Align tab titles to the edge or fully justify them across the tab nav ("center") | `"center" \| "inline"` | `"inline"`  |
 | `theme`  | `theme`   | Select theme (light or dark)                                                     | `"dark" \| "light"`    | `undefined` |
 
+---
 
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -48,7 +48,7 @@
 
   <h2>Just tab-nav</h2>
   <calcite-tab-nav>
-    <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
     <calcite-tab-title>Tab 2 Title</calcite-tab-title>
     <calcite-tab-title>Tab 3 Title</calcite-tab-title>
     <calcite-tab-title>Tab 4 Title</calcite-tab-title>
@@ -63,7 +63,7 @@
   </calcite-tab-nav>
 
   <calcite-tab-nav>
-    <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
     <calcite-tab-title>Tab 2 Title</calcite-tab-title>
     <calcite-tab-title>Tab 3 Title</calcite-tab-title>
     <calcite-tab-title>Tab 4 Title</calcite-tab-title>

--- a/src/index.html
+++ b/src/index.html
@@ -332,25 +332,25 @@
           <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
         </calcite-combobox>
         <calcite-date scale="m" value="2020-11-27" no-calendar-input="true" active></calcite-date>
-        <calcite-tabs is-active>
+        <calcite-tabs active>
           <calcite-tab-nav slot="tab-nav">
-            <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
             <calcite-tab-title>Tab 3 Title</calcite-tab-title>
             <calcite-tab-title>Tab 4 Title</calcite-tab-title>
           </calcite-tab-nav>
 
-          <calcite-tab is-active>
-            <calcite-loader is-active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
+          <calcite-tab active>
+            <calcite-loader active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
         </calcite-tabs>
 
@@ -494,25 +494,25 @@
           <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
         </calcite-combobox>
         <calcite-date scale="m" value="2020-11-27" no-calendar-input="true" active></calcite-date>
-        <calcite-tabs is-active>
+        <calcite-tabs active>
           <calcite-tab-nav slot="tab-nav">
-            <calcite-tab-title is-active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
             <calcite-tab-title>Tab 3 Title</calcite-tab-title>
             <calcite-tab-title>Tab 4 Title</calcite-tab-title>
           </calcite-tab-nav>
 
-          <calcite-tab is-active>
-            <calcite-loader is-active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
+          <calcite-tab active>
+            <calcite-loader active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
         </calcite-tabs>
 


### PR DESCRIPTION
I missed a few instances of "is-active" in the dev demos, this updates these to "active"