### PR TITLE
[Loader] Cleanup for isActive  -> active prop change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `calcite-split-button` - `primary-icon` prop has been removed - you can now use `primary-icon-start` and `primary-icon-end` props to position up to two icons.
 - `calcite-tab` - `isActive` prop is now `active` to be consistent with other components
 - `calcite-tab-title` - `isActive` prop is now `active` to be consistent with other components
+- `calcite-loader` - `isActive` prop is now `active` to be consistent with other components
 
 ### Added
 

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -126,7 +126,7 @@ export class CalciteButton {
 
     const loader = (
       <div class="calcite-button--loader">
-        <calcite-loader is-active inline></calcite-loader>
+        <calcite-loader active inline></calcite-loader>
       </div>
     );
 

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -79,7 +79,7 @@ export class CalciteCard {
         <div class="calcite-card-container">
           {this.loading ? (
             <div class="calcite-card-loader-container">
-              <calcite-loader is-active></calcite-loader>
+              <calcite-loader active></calcite-loader>
             </div>
           ) : null}
           <section class={{ [CSS.container]: true }} aria-busy={this.loading}>

--- a/src/components/calcite-loader/calcite-loader.e2e.ts
+++ b/src/components/calcite-loader/calcite-loader.e2e.ts
@@ -8,22 +8,20 @@ describe("calcite-loader", () => {
     expect(loader).toHaveAttribute("calcite-hydrated");
   });
 
-  it("becomes visible when is-active prop is set", async () => {
+  it("becomes visible when active prop is set", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-loader></calcite-loader>`);
     const loader = await page.find("calcite-loader");
-    let isVisible = await loader.isIntersectingViewport();
-    expect(isVisible).toBe(false);
-    loader.setProperty("is-active", true);
+    expect(await loader.isVisible()).not.toBe(true);
+    loader.setProperty("active", true);
     await page.waitForChanges();
-    isVisible = await loader.isIntersectingViewport();
-    expect(isVisible).toBe(false);
+    expect(await loader.isVisible()).toBe(true);
   });
 
   it("displays label from text prop", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<calcite-loader is-active text="testing"></calcite-loader>`
+      `<calcite-loader active text="testing"></calcite-loader>`
     );
     const elm = await page.find("calcite-loader >>> .loader__text");
     expect(elm).toEqualText("testing");
@@ -56,14 +54,16 @@ describe("calcite-loader", () => {
 
   it("displays inline with text from inline prop", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader is-active inline></calcite-loader>`);
+    await page.setContent(`<calcite-loader active inline></calcite-loader>`);
     const rect = await page.find("calcite-loader >>> circle");
     expect(rect).toEqualAttribute("r", "7.2");
   });
 
   it("validates scale and type properties", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader scale="bleep" type="bloop"></calcite-loader>`);
+    await page.setContent(
+      `<calcite-loader scale="bleep" type="bloop"></calcite-loader>`
+    );
     const loader = await page.find("calcite-loader");
     expect(loader).toEqualAttribute("scale", "m");
     expect(loader).toEqualAttribute("type", "indeterminate");

--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -21,10 +21,10 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
 */
 $segment-1-size: 10;
 $segment-1-growth: 40;
-$segment-1-duration: .72s;
+$segment-1-duration: 0.72s;
 $segment-2-size: 20;
 $segment-2-growth: 30;
-$segment-2-duration: .96s;
+$segment-2-duration: 0.96s;
 $segment-3-size: 5;
 $segment-3-growth: 45;
 $segment-3-duration: 1.16s;
@@ -48,24 +48,24 @@ $segment-3-duration: 1.16s;
 }
 
 :host([scale="s"]) {
-  --loader-size: #{ $loader-size-small + 1 }px;
-  --loader-size-inline: #{ $loader-size-small-inline + 1 }px;
+  --loader-size: #{$loader-size-small + 1}px;
+  --loader-size-inline: #{$loader-size-small-inline + 1}px;
   @include font-size(-3);
   .loader__percentage {
     font-size: 0.625rem;
   }
 }
 :host([scale="m"]) {
-  --loader-size: #{ $loader-size-medium + 1 }px;
-  --loader-size-inline: #{ $loader-size-medium-inline + 1 }px;
+  --loader-size: #{$loader-size-medium + 1}px;
+  --loader-size-inline: #{$loader-size-medium-inline + 1}px;
   @include font-size(-2);
   .loader__percentage {
     font-size: 0.875rem;
   }
 }
 :host([scale="l"]) {
-  --loader-size: #{ $loader-size-large + 1 }px;
-  --loader-size-inline: #{ $loader-size-large-inline + 1 }px;
+  --loader-size: #{$loader-size-large + 1}px;
+  --loader-size-inline: #{$loader-size-large-inline + 1}px;
   @include font-size(-1);
   .loader__percentage {
     font-size: 1.25rem;
@@ -129,9 +129,15 @@ $segment-3-duration: 1.16s;
 
 // in newer browsers use the stroke-dash-offset animation as it looks better
 @supports (display: grid) {
-  .loader__svg--1 { animation-name: loader-offset-1; }
-  .loader__svg--2 { animation-name: loader-offset-2; }
-  .loader__svg--3 { animation-name: loader-offset-3; }
+  .loader__svg--1 {
+    animation-name: loader-offset-1;
+  }
+  .loader__svg--2 {
+    animation-name: loader-offset-2;
+  }
+  .loader__svg--3 {
+    animation-name: loader-offset-3;
+  }
 }
 
 :host([type="determinate"]) {
@@ -185,14 +191,14 @@ $segment-3-duration: 1.16s;
 
 :host([complete]) {
   opacity: 0;
-  transform: scale(.75, .75);
+  transform: scale(0.75, 0.75);
   transform-origin: center;
   transition: opacity 200ms linear 1000ms, transform 200ms linear 1000ms;
 }
 
 :host([complete]) .loader__svgs {
   opacity: 0;
-  transform: scale(.75, .75);
+  transform: scale(0.75, 0.75);
   transform-origin: center;
   transition: opacity 180ms linear 800ms, transform 180ms linear 800ms;
 }
@@ -228,9 +234,24 @@ $segment-3-duration: 1.16s;
   }
 }
 
-@include generateSegment(1, $segment-1-size, $segment-1-growth, $segment-1-duration);
-@include generateSegment(2, $segment-2-size, $segment-2-growth, $segment-2-duration);
-@include generateSegment(3, $segment-3-size, $segment-3-growth, $segment-3-duration);
+@include generateSegment(
+  1,
+  $segment-1-size,
+  $segment-1-growth,
+  $segment-1-duration
+);
+@include generateSegment(
+  2,
+  $segment-2-size,
+  $segment-2-growth,
+  $segment-2-duration
+);
+@include generateSegment(
+  3,
+  $segment-3-size,
+  $segment-3-growth,
+  $segment-3-duration
+);
 
 @keyframes loader-color-shift {
   0% {

--- a/src/components/calcite-loader/calcite-loader.stories.js
+++ b/src/components/calcite-loader/calcite-loader.stories.js
@@ -1,45 +1,79 @@
-import { storiesOf } from '@storybook/html';
-import { withKnobs, text, number, boolean, color } from '@storybook/addon-knobs'
-import { darkBackground, parseReadme } from '../../../.storybook/helpers';
-import readme from './readme.md';
+import { storiesOf } from "@storybook/html";
+import {
+  withKnobs,
+  text,
+  number,
+  boolean,
+  color,
+  select,
+} from "@storybook/addon-knobs";
+import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import readme from "./readme.md";
 const notes = parseReadme(readme);
 
-storiesOf('Loader', module)
+storiesOf("Loader", module)
   .addDecorator(withKnobs)
-  .add('Indeterminate', () => `
+  .add(
+    "Simple",
+    () => `
     <calcite-loader
-      is-active="${boolean("is-active", true)}"
-      text="${text("text", "")}"
-    />
-  `, { notes })
-  .add('Determinate', () => `
-    <calcite-loader
-      is-active
-      type="determinate"
+      active
+      type="${select(
+        "type",
+        ["determinate", "indeterminate"],
+        "indeterminate"
+      )}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
       no-padding="${boolean("no-padding", false)}"
-      value="${number('value', 0, {range: true, min: 0, max: 100, step: 1})}"
+      value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
     />
-  `, { notes })
-  .add('Inline', () => `
+  `,
+    { notes }
+  )
+  .add(
+    "Inline",
+    () => `
+  <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
     <calcite-loader
+      scale="${select("scale", ["s", "m", "l"], "m")}"
       inline
-      is-active
-    /></calcite-loader>Next to some text
-  `, { notes })
-  .add('Dark mode', () => `
+      active
+    /></calcite-loader><span style="margin:0 10px">Next to some text</span>
+    </div>
+  `,
+    { notes }
+  )
+  .add(
+    "Dark mode",
+    () => `
     <calcite-loader
+      type="${select(
+        "type",
+        ["determinate", "indeterminate"],
+        "indeterminate"
+      )}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
       no-padding="${boolean("no-padding", false)}"
-      value="${number('value', 0, {range: true, min: 0, max: 100, step: 1})}"
-      is-active
+      value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
+      active
       theme="dark" />
-  `, { notes, backgrounds: darkBackground })
-  .add('Custom theme', () => `
+  `,
+    { notes, backgrounds: darkBackground }
+  )
+  .add(
+    "Custom theme",
+    () => `
     <calcite-loader
-
+    type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    no-padding="${boolean("no-padding", false)}"
+    value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
       style="
-        --calcite-loader-spot-light: ${color('spot-light', '#50ba5f')};
-        --calcite-loader-spot-dark: ${color('spot-dark', '#1a6324')};
-        --calcite-loader-spot: ${color('loader-spot', '#338033')};"
-      is-active
+        --calcite-loader-spot-light: ${color("spot-light", "#50ba5f")};
+        --calcite-loader-spot-dark: ${color("spot-dark", "#1a6324")};
+        --calcite-loader-spot: ${color("loader-spot", "#338033")};"
+      active
     />
-  `, { notes })
+  `,
+    { notes }
+  );

--- a/src/components/calcite-loader/readme.md
+++ b/src/components/calcite-loader/readme.md
@@ -1,15 +1,15 @@
 # calcite-loader
 
-The calcite-loader component can act as a determinate or indeterminate loading indicator. Use the `is-active` attribute to toggle visibility:
+The calcite-loader component can act as a determinate or indeterminate loading indicator. Use the `active` attribute to toggle visibility:
 
 ```html
-<calcite-loader text="Fetching data..." is-active></calcite-loader>
+<calcite-loader text="Fetching data..." active></calcite-loader>
 ```
 
 If you can calculate your progress, it's best to use the determinate version of the loader. Update the `value` of the element when progress is made:
 
 ```html
-<calcite-loader type="determinate" value="32" is-active></calcite-loader>
+<calcite-loader type="determinate" value="32" active></calcite-loader>
 ```
 
 The above will display a progress bar along the perimeter of the loader showing 32% complete.
@@ -17,33 +17,33 @@ The above will display a progress bar along the perimeter of the loader showing 
 For instances when you don't have room for the full loader, you can use the smaller `inline` version of the loader. The inline version is meant to sit to the left of text:
 
 ```html
-<p><calcite-loader is-active inline></calcite-loader> Inline loader</p>
+<p><calcite-loader active inline></calcite-loader> Inline loader</p>
 ```
 
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
 | Property    | Attribute    | Description                                                        | Type                               | Default     |
 | ----------- | ------------ | ------------------------------------------------------------------ | ---------------------------------- | ----------- |
+| `active`    | `active`     | Show the loader                                                    | `boolean`                          | `false`     |
 | `inline`    | `inline`     | Inline loaders are smaller and will appear to the left of the text | `boolean`                          | `false`     |
-| `isActive`  | `is-active`  | Show the loader                                                    | `boolean`                          | `false`     |
 | `noPadding` | `no-padding` | Turn off spacing around the loader                                 | `boolean`                          | `undefined` |
+| `scale`     | `scale`      | Speficy the scale of the loader. Defaults to "m"                   | `"l" \| "m" \| "s"`                | `"m"`       |
 | `text`      | `text`       | Text which should appear under the loading indicator (optional)    | `string`                           | `""`        |
 | `type`      | `type`       | Use indeterminate if finding actual progress value is impossible   | `"determinate" \| "indeterminate"` | `undefined` |
 | `value`     | `value`      | Percent complete of 100, only valid for determinate indicators     | `number`                           | `0`         |
-
 
 ## Dependencies
 
 ### Used by
 
- - [calcite-button](../calcite-button)
- - [calcite-card](../calcite-card)
- - [calcite-scrim](../calcite-scrim)
+- [calcite-button](../calcite-button)
+- [calcite-card](../calcite-card)
+- [calcite-scrim](../calcite-scrim)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-button --> calcite-loader
@@ -52,6 +52,6 @@ graph TD;
   style calcite-loader fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-scrim/calcite-scrim.tsx
+++ b/src/components/calcite-scrim/calcite-scrim.tsx
@@ -35,7 +35,7 @@ export class CalciteScrim {
 
   render() {
     const loaderNode = this.loading ? (
-      <calcite-loader is-active></calcite-loader>
+      <calcite-loader active></calcite-loader>
     ) : null;
 
     const scrimNode = <div class={CSS.scrim}>{loaderNode}</div>;

--- a/src/demos/calcite-loader.html
+++ b/src/demos/calcite-loader.html
@@ -12,10 +12,12 @@
       color: white;
       padding: 1rem;
     }
+
     h2 {
       text-align: center;
       padding-top: 6rem;
     }
+
     h2:first-of-type {
       padding-top: 2rem;
     }
@@ -78,9 +80,9 @@
     })();
   </script>
   <h2>Inline</h2>
-  <p style="text-align: center;">
-    <calcite-loader active inline></calcite-loader>Inline Loader
-  </p>
+  <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
+    <calcite-loader active inline></calcite-loader><span style="margin:0 10px">Inline Loader</span>
+  </div>
   <h2>Custom theme</h2>
   <style>
     calcite-loader.green {
@@ -88,8 +90,8 @@
       --calcite-ui-blue-2: #1a6324;
       --calcite-ui-blue-3: #338033;
     }
-    </style>
-    <calcite-loader active class="green"></calcite-loader>
+  </style>
+  <calcite-loader active class="green"></calcite-loader>
   <h2>Loading Text</h2>
   <calcite-loader active text="optional loading text&hellip;" type="indeterminate"></calcite-loader>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -341,16 +341,16 @@
           </calcite-tab-nav>
 
           <calcite-tab is-active>
-            <calcite-loader is-active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
         </calcite-tabs>
 
@@ -503,16 +503,16 @@
           </calcite-tab-nav>
 
           <calcite-tab is-active>
-            <calcite-loader is-active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 1&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 2&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 3&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
           <calcite-tab>
-            <calcite-loader is-active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
+            <calcite-loader active text="loading tab 4&hellip;" type="indeterminate"></calcite-loader>
           </calcite-tab>
         </calcite-tabs>
 


### PR DESCRIPTION
Follow up / some clean up for https://github.com/Esri/calcite-components/pull/709

- 🚨 - Adds changelog entry for breaking property change from `isActive` to `active`
- ♻️ - Updates instances of loader used in other components to new `active` prop
- 🧪 - Updates tests with new `active` property
- 📝 - Updates dev demo page with better spacing for inline loader
- 📚 - Updates storybook with better spacing for inline loader and knobs for configuration options
- ✨ - Formatting / Prettier changes

cc @asangma 