### PR TITLE
Fixes button tests for new calcite-hydrated attribute

### DIFF
--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -221,7 +221,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).not.toBeNull();
@@ -246,7 +246,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).toBeNull();
@@ -296,7 +296,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).not.toBeNull();
@@ -321,7 +321,7 @@ describe("calcite-button", () => {
     const loader = await page.find(
       "calcite-button >>> .calcite-button--loader"
     );
-    expect(element).toHaveClass("hydrated");
+    expect(element).toHaveAttribute("calcite-hydrated");
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).toBeNull();

--- a/src/components/calcite-loader/readme.md
+++ b/src/components/calcite-loader/readme.md
@@ -22,28 +22,28 @@ For instances when you don't have room for the full loader, you can use the smal
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property    | Attribute    | Description                                                        | Type                               | Default     |
 | ----------- | ------------ | ------------------------------------------------------------------ | ---------------------------------- | ----------- |
+| `active`    | `active`     | Show the loader                                                    | `boolean`                          | `false`     |
 | `inline`    | `inline`     | Inline loaders are smaller and will appear to the left of the text | `boolean`                          | `false`     |
-| `isActive`  | `is-active`  | Show the loader                                                    | `boolean`                          | `false`     |
 | `noPadding` | `no-padding` | Turn off spacing around the loader                                 | `boolean`                          | `undefined` |
+| `scale`     | `scale`      | Speficy the scale of the loader. Defaults to "m"                   | `"l" \| "m" \| "s"`                | `"m"`       |
 | `text`      | `text`       | Text which should appear under the loading indicator (optional)    | `string`                           | `""`        |
 | `type`      | `type`       | Use indeterminate if finding actual progress value is impossible   | `"determinate" \| "indeterminate"` | `undefined` |
 | `value`     | `value`      | Percent complete of 100, only valid for determinate indicators     | `number`                           | `0`         |
-
 
 ## Dependencies
 
 ### Used by
 
- - [calcite-button](../calcite-button)
- - [calcite-card](../calcite-card)
- - [calcite-scrim](../calcite-scrim)
+- [calcite-button](../calcite-button)
+- [calcite-card](../calcite-card)
+- [calcite-scrim](../calcite-scrim)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-button --> calcite-loader
@@ -52,6 +52,6 @@ graph TD;
   style calcite-loader fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_


### PR DESCRIPTION
- 🧪 - Updates button tests to check for `calcite-hydrated` attribute instead of `hydrated` class
- 📝 - Commits readme update for loader that didn't make it into prior PR