### PR TITLE
chore(switch): add switched to event detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- `calcite-switch` - `switched` boolean has been added to `calciteSwitchChange` event detail
+
 ## [v1.0.0-beta.31]
 
 ### Breaking Changes

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -79,6 +79,7 @@ describe("calcite-switch", () => {
     await calciteSwitch.click();
 
     expect(changeEvent).toHaveReceivedEventTimes(1);
+    expect(changeEvent).toHaveFirstReceivedEventDetail({ switched: true });
   });
 
   // Not sure why this is failing

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -160,6 +160,8 @@ export class CalciteSwitch {
   private updateSwitch(e) {
     e.preventDefault();
     this.switched = !this.switched;
-    this.calciteSwitchChange.emit();
+    this.calciteSwitchChange.emit({
+      switched: this.switched
+    });
   }
 }


### PR DESCRIPTION
#474 also asks to remove `change`, but I am not seeing it in der.