### PR TITLE
Modal Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-modal` - `close-label` prop is now renamed to `intl-close` for consistency (#466)
 - `calcite-modal` - `open` and `close` methods removed in favor of `active` prop (#466)
+- `calcite-modal` - `size => width`, which can be passed standard (s/m/l) or custom width in px (#239)
+- `calcite-modal` - `fullscreen` made it's own prop (#466)
+- `calcite-modal` - new `scale` prop for setting UI scale of modal (#466);
 - `calcite-date` - `prevMonthLabel` and `nextMonthLabel` updated to `intlPrevMonth` and `intlNextMonth` (#97)
 - `calcite-switch` - `switched` boolean has been added to `calciteSwitchChange` event detail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Breaking Changes
 
 - `calcite-modal` - `close-label` prop is now renamed to `intl-close` for consistency (#466)
+- `calcite-modal` - `open` and `close` methods removed in favor of `active` prop (#466)
 - `calcite-date` - `prevMonthLabel` and `nextMonthLabel` updated to `intlPrevMonth` and `intlNextMonth` (#97)
 - `calcite-switch` - `switched` boolean has been added to `calciteSwitchChange` event detail
 

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -28,7 +28,7 @@ describe("calcite-modal properties", () => {
   it("focuses the firstFocus element on load", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-      <calcite-modal>
+      <calcite-modal active>
         <h3 slot="header">Title</h3>
         <p slot="content">This is the content <button class="test">test</button></p>
       </calcite-modal>
@@ -39,7 +39,6 @@ describe("calcite-modal properties", () => {
       $button = elm.querySelector(".test");
     });
     modal.setProperty("firstFocus", $button);
-    await modal.callMethod("open");
     await page.waitForChanges();
     expect(document.activeElement).toEqual($button);
   });
@@ -49,16 +48,16 @@ describe("calcite-modal properties", () => {
     const mockCallBack = jest.fn();
     await page.exposeFunction("beforeClose", mockCallBack);
     await page.setContent(`
-      <calcite-modal></calcite-modal>
+      <calcite-modal active></calcite-modal>
     `);
     const modal = await page.find("calcite-modal");
     await page.$eval("calcite-modal", (elm: any) => {
       elm.beforeClose = this.beforeClose;
     });
     await page.waitForChanges();
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
-    await modal.callMethod("close");
+    await modal.setProperty("active", false);
     await page.waitForChanges();
     expect(mockCallBack).toBeCalled();
   });
@@ -71,7 +70,7 @@ describe("calcite-modal events", () => {
     const modal = await page.find("calcite-modal");
     const changeEvent = await modal.spyOnEvent("calciteModalOpen");
     expect(changeEvent).toHaveReceivedEventTimes(0);
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
     await page.waitFor(400);
     expect(changeEvent).toHaveReceivedEventTimes(1);
@@ -81,10 +80,10 @@ describe("calcite-modal events", () => {
     await page.setContent(`<calcite-modal></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     const changeEvent = await modal.spyOnEvent("calciteModalClose");
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
     expect(changeEvent).toHaveReceivedEventTimes(0);
-    await modal.callMethod("close");
+    await modal.setProperty("active", false);
     await page.waitForChanges();
     await page.waitFor(400);
     expect(changeEvent).toHaveReceivedEventTimes(1);
@@ -111,7 +110,7 @@ describe("calcite-modal accessibility checks", () => {
     await page.$eval("calcite-modal", (elm) => {
       $close = elm.shadowRoot.querySelector(".modal__close");
     });
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
     expect(document.activeElement).toEqual($close);
     await page.keyboard.press("Tab");
@@ -138,9 +137,9 @@ describe("calcite-modal accessibility checks", () => {
       $button = elm;
       $button.focus();
     });
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
-    await modal.callMethod("close");
+    await modal.setProperty("active", false);
     await page.waitForChanges();
     expect(document.activeElement).toEqual($button);
   });
@@ -157,23 +156,23 @@ describe("calcite-modal accessibility checks", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
-    expect(modal).toHaveClass("is-active");
+    expect(modal).toHaveAttribute("is-active");
     await page.keyboard.press("Escape");
     await page.waitForChanges();
-    expect(modal).not.toHaveClass("is-active");
+    expect(modal).not.toHaveAttribute("is-active");
   });
 
   it("does not close when Escape is pressed and disable-escape is set", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal disable-escape></calcite-modal>`);
     const modal = await page.find("calcite-modal");
-    await modal.callMethod("open");
+    await modal.setProperty("active", true);
     await page.waitForChanges();
-    expect(modal).toHaveClass("is-active");
+    expect(modal).toHaveAttribute("is-active");
     await page.keyboard.press("Escape");
     await page.waitForChanges();
-    expect(modal).toHaveClass("is-active");
+    expect(modal).toHaveAttribute("is-active");
   });
 });

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -27,7 +27,7 @@ describe("calcite-modal properties", () => {
 
   it("sets custom width correctly", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal size="400"></calcite-modal>`);
+    await page.setContent(`<calcite-modal width="400"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("active", true);
     await page.waitForChanges();

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -25,6 +25,19 @@ describe("calcite-modal properties", () => {
     expect(closeButton).toBe(null);
   });
 
+  it("sets custom width correctly", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal size="400"></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    const style = await page.$eval("calcite-modal", (elm) => {
+      const m = elm.shadowRoot.querySelector(".modal");
+      return window.getComputedStyle(m).getPropertyValue("width");
+    });
+    expect(style).toEqual("400px");
+  });
+
   it("focuses the firstFocus element on load", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -54,7 +54,7 @@
   }
 }
 
-:host(.is-active) {
+:host([is-active]) {
   visibility: visible !important;
   opacity: 1;
   transition-delay: 0ms;
@@ -261,7 +261,7 @@ slot[name="primary"] {
   }
 }
 
-:host(.is-active[size="fullscreen"]) {
+:host([is-active][size="fullscreen"]) {
   .modal {
     transform: translate3D(0, 0, 0) scale(1);
   }

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -13,6 +13,30 @@
   visibility: hidden !important;
   transition: visibility 0ms linear 300ms, opacity 300ms $easing-function;
   z-index: 101;
+  --calcite-modal-title-padding: 12px 16px;
+  --calcite-modal-title-text: 20px;
+  --calcite-modal-content-padding: 16px;
+  --calcite-modal-content-text: 16px;
+  --calcite-modal-close-padding: 12px;
+  --calcite-modal-footer-padding: 12px;
+}
+
+:host([scale="s"]) {
+  --calcite-modal-title-padding: 8px 12px;
+  --calcite-modal-title-text: 18px;
+  --calcite-modal-content-padding: 12px;
+  --calcite-modal-content-text: 14px;
+  --calcite-modal-close-padding: 8px;
+  --calcite-modal-footer-padding: 8px;
+}
+
+:host([scale="l"]) {
+  --calcite-modal-title-padding: 16px 20px;
+  --calcite-modal-title-text: 26px;
+  --calcite-modal-content-padding: 20px;
+  --calcite-modal-content-text: 18px;
+  --calcite-modal-close-padding: 16px;
+  --calcite-modal-footer-padding: 16px;
 }
 
 .scrim {
@@ -88,7 +112,7 @@
 }
 
 .modal__close {
-  padding: 0.75rem;
+  padding: var(--calcite-modal-close-padding);
   margin: 0;
   order: 2;
   flex: 0 0 auto;
@@ -101,8 +125,9 @@
   outline: none;
   cursor: pointer;
   border-radius: 0 var(--calcite-border-radius) 0 0;
-  svg {
+  calcite-icon {
     pointer-events: none;
+    vertical-align: -2px;
   }
   &:hover,
   &:focus {
@@ -120,7 +145,7 @@
 .modal__title {
   display: flex;
   align-items: center;
-  padding: $baseline / 2 $baseline;
+  padding: var(--calcite-modal-title-padding);
   flex: 1 1 auto;
   order: 1;
   min-width: 0;
@@ -129,7 +154,7 @@
 @include slotted("header", "*") {
   margin: 0;
   font-weight: 400;
-  @include font-size(2);
+  font-size: var(--calcite-modal-title-text);
   color: var(--calcite-ui-text-1);
 }
 
@@ -149,11 +174,12 @@
 }
 
 .modal__content--spaced {
-  padding: $baseline;
+  padding: var(--calcite-modal-content-padding);
 }
 
 @include slotted("content", "*") {
-  @include font-size(0);
+  font-size: var(--calcite-modal-content-text);
+  line-height: 1.5;
 }
 
 /**
@@ -163,7 +189,7 @@
   display: flex;
   flex: 0 0 auto;
   justify-content: space-between;
-  padding: $baseline/1.25 $baseline * 0.75;
+  padding: var(--calcite-modal-footer-padding);
   margin-top: auto;
   box-sizing: border-box;
   border-radius: 0 0 var(--calcite-border-radius) var(--calcite-border-radius);
@@ -201,13 +227,13 @@ slot[name="primary"] {
  * Sizes
  */
 @mixin modal-size($size, $width) {
-  :host([size="#{$size}"]) {
+  :host([width="#{$size}"]) {
     .modal {
       max-width: $width;
     }
   }
   @media screen and (max-width: $width + 2 * $baseline) {
-    :host([size="#{$size}"]) {
+    :host([width="#{$size}"]) {
       .modal {
         height: 100%;
         max-height: 100%;
@@ -225,24 +251,24 @@ slot[name="primary"] {
         flex: inherit;
       }
     }
-    :host([size="#{$size}"][docked]) {
+    :host([width="#{$size}"][docked]) {
       align-items: flex-end;
     }
   }
 }
 
-:host([size="small"]) .modal {
+:host([width="small"]) .modal {
   width: auto;
 }
 
-@include modal-size("small", 32rem);
-@include modal-size("medium", 48rem);
-@include modal-size("large", 94rem);
+@include modal-size("s", 32rem);
+@include modal-size("m", 48rem);
+@include modal-size("l", 94rem);
 
 /**
  * Fullscreen
  */
-:host([size="fullscreen"]) {
+:host([fullscreen]) {
   background-color: transparent;
   .modal {
     transform: translate3D(0, 20px, 0) scale(0.95);
@@ -261,7 +287,7 @@ slot[name="primary"] {
   }
 }
 
-:host([is-active][size="fullscreen"]) {
+:host([is-active][fullscreen]) {
   .modal {
     transform: translate3D(0, 0, 0) scale(1);
   }

--- a/src/components/calcite-modal/calcite-modal.stories.js
+++ b/src/components/calcite-modal/calcite-modal.stories.js
@@ -7,11 +7,9 @@ const notes = parseReadme(readme);
 storiesOf('Modal', module)
   .addDecorator(withKnobs)
   .add('Simple', () => {
-    setTimeout(function () {
-      document.querySelector('calcite-modal').open();
-    }, 200);
     return `
       <calcite-modal
+        active="${boolean("active", true)}"
         color="${select("color", {blue: "blue", red: "red", none: null}, null)}"
         size="${select("size", ["small", "medium", "large", "fullscreen"], "small")}"
         docked="${boolean("docked", false)}"
@@ -32,12 +30,10 @@ storiesOf('Modal', module)
     `;
   }, { notes })
   .add('Dark mode', () => {
-    setTimeout(function () {
-      document.querySelector('calcite-modal').open();
-    }, 200);
     return `
       <calcite-modal
         theme="dark"
+        active="${boolean("active", true)}"
         color="${select("color", {blue: "blue", red: "red", none: null}, null)}"
         size="${select("size", ["small", "medium", "large", "fullscreen"], "small")}"
         docked="${boolean("docked", false)}"

--- a/src/components/calcite-modal/calcite-modal.stories.js
+++ b/src/components/calcite-modal/calcite-modal.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs'
+import { withKnobs, boolean, select, text, number } from '@storybook/addon-knobs'
 import { darkBackground, parseReadme } from '../../../.storybook/helpers';
 import readme from './readme.md';
 const notes = parseReadme(readme);
@@ -21,6 +21,25 @@ storiesOf('Modal', module)
         <div slot="content">
           <p>
             The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
+          </p>
+        </div>
+        <calcite-button slot="back" color="light" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
+        <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+        <calcite-button slot="primary" width="full">Save</calcite-button>
+      </calcite-modal>
+    `;
+  }, { notes })
+  .add('Custom Size', () => {
+    return `
+      <calcite-modal
+        active
+        size="${number("size", 500)}"
+      >
+        <h3 slot="header">Custom Size</h3>
+        <div slot="content">
+          <p>
+            By passing a number rather than "small", "medium", "large", or "fullscreen", you can set your own max width for the modal.
+            Below this size, the modal will become fullscreen.
           </p>
         </div>
         <calcite-button slot="back" color="light" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>

--- a/src/components/calcite-modal/calcite-modal.stories.js
+++ b/src/components/calcite-modal/calcite-modal.stories.js
@@ -11,7 +11,9 @@ storiesOf('Modal', module)
       <calcite-modal
         active="${boolean("active", true)}"
         color="${select("color", {blue: "blue", red: "red", none: null}, null)}"
-        size="${select("size", ["small", "medium", "large", "fullscreen"], "small")}"
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        width="${select("width", ["s", "m", "l"], "s")}"
+        fullscreen="${boolean("fullscreen", false)}"
         docked="${boolean("docked", false)}"
         disable-escape="${boolean("disable-escape", false)}"
         no-padding="${boolean("no-padding", false)}"
@@ -33,7 +35,7 @@ storiesOf('Modal', module)
     return `
       <calcite-modal
         active
-        size="${number("size", 500)}"
+        width="${number("width", 500)}"
       >
         <h3 slot="header">Custom Size</h3>
         <div slot="content">
@@ -54,7 +56,9 @@ storiesOf('Modal', module)
         theme="dark"
         active="${boolean("active", true)}"
         color="${select("color", {blue: "blue", red: "red", none: null}, null)}"
-        size="${select("size", ["small", "medium", "large", "fullscreen"], "small")}"
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        width="${select("width", ["s", "m", "l"], "s")}"
+        fullscreen="${boolean("fullscreen", false)}"
         docked="${boolean("docked", false)}"
         disable-escape="${boolean("disable-escape", false)}"
         no-padding="${boolean("no-padding", false)}"

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -49,13 +49,12 @@ export class CalciteModal {
   @Prop() firstFocus?: HTMLElement;
   /** Flag to disable the default close on escape behavior */
   @Prop() disableEscape?: boolean;
-  /** Set the overall size of the modal. Can use stock sizes or pass a number (pixels) */
-  @Prop({ reflect: true }) size:
-    | "small"
-    | "medium"
-    | "large"
-    | "fullscreen"
-    | number;
+  /** specify the scale of modal, defaults to m */
+  @Prop({ reflect: true }) scale: "s" | "m" | "l" = "m";
+  /** Set the width of the modal. Can use stock sizes or pass a number (in pixels) */
+  @Prop({ reflect: true }) width: "s" | "m" | "l" | number = "m";
+  /** Set the modal to always be fullscreen (overrides width) */
+  @Prop({ reflect: true }) fullscreen: boolean;
   /** Adds a color bar at the top for visual impact,
    * Use color to add importance to destructive/workflow dialogs. */
   @Prop({ reflect: true }) color?: "red" | "blue";
@@ -69,6 +68,13 @@ export class CalciteModal {
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
+  componentWillLoad() {
+    // when modal initially renders, if active was set we need to open as watcher doesn't fire
+    if (this.active) {
+      this.open();
+    }
+  }
+
   render() {
     const dir = getElementDir(this.el);
     return (
@@ -132,14 +138,14 @@ export class CalciteModal {
   }
 
   renderStyle(): VNode {
-    const hasCustomWidth = !isNaN(parseInt(`${this.size}`));
+    const hasCustomWidth = !isNaN(parseInt(`${this.width}`));
     return hasCustomWidth ? (
       <style>
         {`
         .modal {
-          max-width: ${this.size}px;
+          max-width: ${this.width}px;
         }
-        @media screen and (max-width: ${this.size}px) {
+        @media screen and (max-width: ${this.width}px) {
           .modal {
             height: 100%;
             max-height: 100%;

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -49,9 +49,13 @@ export class CalciteModal {
   @Prop() firstFocus?: HTMLElement;
   /** Flag to disable the default close on escape behavior */
   @Prop() disableEscape?: boolean;
-  /** Set the overall size of the modal */
-  @Prop({ reflect: true }) size: "small" | "medium" | "large" | "fullscreen" =
-    "small";
+  /** Set the overall size of the modal. Can use stock sizes or pass a number (pixels) */
+  @Prop({ reflect: true }) size:
+    | "small"
+    | "medium"
+    | "large"
+    | "fullscreen"
+    | number;
   /** Adds a color bar at the top for visual impact,
    * Use color to add importance to destructive/workflow dialogs. */
   @Prop({ reflect: true }) color?: "red" | "blue";
@@ -65,25 +69,12 @@ export class CalciteModal {
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
-  renderCloseButton(): VNode {
-    return !this.disableCloseButton ? (
-      <button
-        class="modal__close"
-        aria-label={this.intlClose}
-        title={this.intlClose}
-        ref={(el) => (this.closeButtonEl = el)}
-        onClick={() => this.close()}
-      >
-        <calcite-icon icon="x" scale="l"></calcite-icon>
-      </button>
-    ) : null;
-  }
-
   render() {
     const dir = getElementDir(this.el);
     return (
       <Host dir={dir} role="dialog" aria-modal="true" is-active={this.isActive}>
         <calcite-scrim class="scrim" theme="dark"></calcite-scrim>
+        {this.renderStyle()}
         <div class="modal">
           <div
             data-focus-fence="true"
@@ -124,6 +115,51 @@ export class CalciteModal {
         </div>
       </Host>
     );
+  }
+
+  renderCloseButton(): VNode {
+    return !this.disableCloseButton ? (
+      <button
+        class="modal__close"
+        aria-label={this.intlClose}
+        title={this.intlClose}
+        ref={(el) => (this.closeButtonEl = el)}
+        onClick={() => this.close()}
+      >
+        <calcite-icon icon="x" scale="l"></calcite-icon>
+      </button>
+    ) : null;
+  }
+
+  renderStyle(): VNode {
+    const hasCustomWidth = !isNaN(parseInt(`${this.size}`));
+    return hasCustomWidth ? (
+      <style>
+        {`
+        .modal {
+          max-width: ${this.size}px;
+        }
+        @media screen and (max-width: ${this.size}px) {
+          .modal {
+            height: 100%;
+            max-height: 100%;
+            width: 100%;
+            max-width: 100%;
+            margin: 0;
+            border-radius: 0;
+          }
+          .modal__content {
+            flex: 1 1 auto;
+            max-height: unset;
+          }
+          .modal__header,
+          .modal__footer {
+            flex: inherit;
+          }
+        }
+      `}
+      </style>
+    ) : null;
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -56,19 +56,21 @@ modal.beforeClose = beforeClose;
 
 ## Properties
 
-| Property             | Attribute              | Description                                                                                                 | Type                                                       | Default                   |
-| -------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------- |
-| `active`             | `active`               | Add the active attribute to open the modal                                                                  | `boolean`                                                  | `undefined`               |
-| `beforeClose`        | --                     | Optionally pass a function to run before close                                                              | `(el: HTMLElement) => Promise<void>`                       | `() => Promise.resolve()` |
-| `color`              | `color`                | Adds a color bar at the top for visual impact, Use color to add importance to destructive/workflow dialogs. | `"blue" \| "red"`                                          | `undefined`               |
-| `disableCloseButton` | `disable-close-button` | Disables the display a close button within the Modal                                                        | `boolean`                                                  | `undefined`               |
-| `disableEscape`      | `disable-escape`       | Flag to disable the default close on escape behavior                                                        | `boolean`                                                  | `undefined`               |
-| `docked`             | `docked`               | Prevent the modal from taking up the entire screen on mobile                                                | `boolean`                                                  | `undefined`               |
-| `firstFocus`         | --                     | Specify an element to focus when the modal is first opened                                                  | `HTMLElement`                                              | `undefined`               |
-| `intlClose`          | `intl-close`           | Aria label for the close button                                                                             | `string`                                                   | `"Close"`                 |
-| `noPadding`          | `no-padding`           | Turn off spacing around the content area slot                                                               | `boolean`                                                  | `undefined`               |
-| `size`               | `size`                 | Set the overall size of the modal. Can use stock sizes or pass a number (pixels)                            | `"fullscreen" \| "large" \| "medium" \| "small" \| number` | `undefined`               |
-| `theme`              | `theme`                | Select theme (light or dark)                                                                                | `"dark" \| "light"`                                        | `undefined`               |
+| Property             | Attribute              | Description                                                                                                 | Type                                 | Default                   |
+| -------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------- |
+| `active`             | `active`               | Add the active attribute to open the modal                                                                  | `boolean`                            | `undefined`               |
+| `beforeClose`        | --                     | Optionally pass a function to run before close                                                              | `(el: HTMLElement) => Promise<void>` | `() => Promise.resolve()` |
+| `color`              | `color`                | Adds a color bar at the top for visual impact, Use color to add importance to destructive/workflow dialogs. | `"blue" \| "red"`                    | `undefined`               |
+| `disableCloseButton` | `disable-close-button` | Disables the display a close button within the Modal                                                        | `boolean`                            | `undefined`               |
+| `disableEscape`      | `disable-escape`       | Flag to disable the default close on escape behavior                                                        | `boolean`                            | `undefined`               |
+| `docked`             | `docked`               | Prevent the modal from taking up the entire screen on mobile                                                | `boolean`                            | `undefined`               |
+| `firstFocus`         | --                     | Specify an element to focus when the modal is first opened                                                  | `HTMLElement`                        | `undefined`               |
+| `fullscreen`         | `fullscreen`           | Set the modal to always be fullscreen (overrides width)                                                     | `boolean`                            | `undefined`               |
+| `intlClose`          | `intl-close`           | Aria label for the close button                                                                             | `string`                             | `"Close"`                 |
+| `noPadding`          | `no-padding`           | Turn off spacing around the content area slot                                                               | `boolean`                            | `undefined`               |
+| `scale`              | `scale`                | specify the scale of modal, defaults to m                                                                   | `"l" \| "m" \| "s"`                  | `"m"`                     |
+| `theme`              | `theme`                | Select theme (light or dark)                                                                                | `"dark" \| "light"`                  | `undefined`               |
+| `width`              | `width`                | Set the width of the modal. Can use stock sizes or pass a number (in pixels)                                | `"l" \| "m" \| "s" \| number`        | `"m"`                     |
 
 ## Events
 

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -56,19 +56,19 @@ modal.beforeClose = beforeClose;
 
 ## Properties
 
-| Property             | Attribute              | Description                                                                                                  | Type                                             | Default                   |
-| -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------------- |
-| `active`             | `active`               | Set to true to open the modal                                                                                | `boolean`                                        | `undefined`               |
-| `beforeClose`        | --                     | Optionally pass a function to run before close                                                               | `(el: HTMLElement) => Promise<void>`             | `() => Promise.resolve()` |
-| `color`              | `color`                | Adds a color bar at the top for visual impact, Use color to add importance to desctructive/workflow dialogs. | `"blue" \| "red"`                                | `undefined`               |
-| `disableCloseButton` | `disable-close-button` | Disables the display a close button within the Modal                                                         | `boolean`                                        | `undefined`               |
-| `disableEscape`      | `disable-escape`       | Flag to disable the default close on escape behavior                                                         | `boolean`                                        | `undefined`               |
-| `docked`             | `docked`               | Prevent the modal from taking up the entire screen on mobile                                                 | `boolean`                                        | `undefined`               |
-| `firstFocus`         | --                     | Specify an element to focus when the modal is first opened                                                   | `HTMLElement`                                    | `undefined`               |
-| `intlClose`          | `intl-close`           | Aria label for the close button                                                                              | `string`                                         | `"Close"`                 |
-| `noPadding`          | `no-padding`           | Turn off spacing around the content area slot                                                                | `boolean`                                        | `undefined`               |
-| `size`               | `size`                 | Set the overall size of the modal                                                                            | `"fullscreen" \| "large" \| "medium" \| "small"` | `"small"`                 |
-| `theme`              | `theme`                | Select theme (light or dark)                                                                                 | `"dark" \| "light"`                              | `undefined`               |
+| Property             | Attribute              | Description                                                                                                 | Type                                                       | Default                   |
+| -------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------- |
+| `active`             | `active`               | Add the active attribute to open the modal                                                                  | `boolean`                                                  | `undefined`               |
+| `beforeClose`        | --                     | Optionally pass a function to run before close                                                              | `(el: HTMLElement) => Promise<void>`                       | `() => Promise.resolve()` |
+| `color`              | `color`                | Adds a color bar at the top for visual impact, Use color to add importance to destructive/workflow dialogs. | `"blue" \| "red"`                                          | `undefined`               |
+| `disableCloseButton` | `disable-close-button` | Disables the display a close button within the Modal                                                        | `boolean`                                                  | `undefined`               |
+| `disableEscape`      | `disable-escape`       | Flag to disable the default close on escape behavior                                                        | `boolean`                                                  | `undefined`               |
+| `docked`             | `docked`               | Prevent the modal from taking up the entire screen on mobile                                                | `boolean`                                                  | `undefined`               |
+| `firstFocus`         | --                     | Specify an element to focus when the modal is first opened                                                  | `HTMLElement`                                              | `undefined`               |
+| `intlClose`          | `intl-close`           | Aria label for the close button                                                                             | `string`                                                   | `"Close"`                 |
+| `noPadding`          | `no-padding`           | Turn off spacing around the content area slot                                                               | `boolean`                                                  | `undefined`               |
+| `size`               | `size`                 | Set the overall size of the modal. Can use stock sizes or pass a number (pixels)                            | `"fullscreen" \| "large" \| "medium" \| "small" \| number` | `undefined`               |
+| `theme`              | `theme`                | Select theme (light or dark)                                                                                | `"dark" \| "light"`                                        | `undefined`               |
 
 ## Events
 
@@ -99,15 +99,15 @@ Type: `Promise<void>`
 
 ### Depends on
 
-- [calcite-icon](../calcite-icon)
 - [calcite-scrim](../calcite-scrim)
+- [calcite-icon](../calcite-icon)
 
 ### Graph
 
 ```mermaid
 graph TD;
-  calcite-modal --> calcite-icon
   calcite-modal --> calcite-scrim
+  calcite-modal --> calcite-icon
   calcite-scrim --> calcite-loader
   style calcite-modal fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -28,18 +28,17 @@ calcite modal allows you to show a modal/dialog to your users. The modal handles
 
 Notice above we've used the `aria-labelledby` attribute, relating it to the title of the modal. In order to ensure good accessibility, it's recommended that you use either an `aria-label` or `aria-labelledby` attribute so screen readers can infer what the subject matter of your modal is.
 
-To open a modal, use the `open` method directly on the element:
+To open a modal, add the `active` prop:
 
-```js
-const modal = document.querySelector("calcite-modal");
-modal.open();
+```html
+<calcite-modal active></calcite-modal>
 ```
 
-The `open` method returns a promise which will resolve when the animation has completed:
+Once the opening animation is complete, the `calciteModalOpen` event will be fired.
 
-```js
-modal.open().then((el) => console.log(el)); // => <calcite-modal> element
-```
+To close the modal, simply remove the attribute. This will run your before close method (if provided, see below) and fire the `calciteModalClose` event after the animation and teardown is complete.
+
+### beforeClose
 
 If you'd like to perform some actions prior to closing (ie. warning users they will lose their changes) you can pass a function to the `beforeClose` property. This method will be called prior to close and should return a Promise:
 
@@ -51,7 +50,6 @@ function beforeClose() {
   });
 }
 modal.beforeClose = beforeClose;
-modal.open();
 ```
 
 <!-- Auto Generated Below -->
@@ -60,6 +58,7 @@ modal.open();
 
 | Property             | Attribute              | Description                                                                                                  | Type                                             | Default                   |
 | -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------------- |
+| `active`             | `active`               | Set to true to open the modal                                                                                | `boolean`                                        | `undefined`               |
 | `beforeClose`        | --                     | Optionally pass a function to run before close                                                               | `(el: HTMLElement) => Promise<void>`             | `() => Promise.resolve()` |
 | `color`              | `color`                | Adds a color bar at the top for visual impact, Use color to add importance to desctructive/workflow dialogs. | `"blue" \| "red"`                                | `undefined`               |
 | `disableCloseButton` | `disable-close-button` | Disables the display a close button within the Modal                                                         | `boolean`                                        | `undefined`               |
@@ -80,14 +79,6 @@ modal.open();
 
 ## Methods
 
-### `close() => Promise<HTMLElement>`
-
-Close the modal, first running the `beforeClose` method
-
-#### Returns
-
-Type: `Promise<HTMLElement>`
-
 ### `focusElement(el?: HTMLElement) => Promise<void>`
 
 Focus first interactive element
@@ -95,14 +86,6 @@ Focus first interactive element
 #### Returns
 
 Type: `Promise<void>`
-
-### `open() => Promise<HTMLElement>`
-
-Open the modal
-
-#### Returns
-
-Type: `Promise<HTMLElement>`
 
 ### `scrollContent(top?: number, left?: number) => Promise<void>`
 

--- a/src/demos/calcite-modal.html
+++ b/src/demos/calcite-modal.html
@@ -23,7 +23,7 @@
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Modal</h1>
 
-  <calcite-modal class="js-modal-1" size="small">
+  <calcite-modal class="js-modal-1" width="s">
     <h3 slot="header">Small Modal</h3>
     <div slot="content">
       <p>
@@ -35,7 +35,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-2" size="medium">
+  <calcite-modal class="js-modal-2" width="m">
     <h3 slot="header">Medium Modal</h3>
     <div slot="content">
       <table>
@@ -58,7 +58,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-3" size="large">
+  <calcite-modal class="js-modal-3" width="l">
     <h3 slot="header">Large modal</h3>
     <div slot="content">
       <p>This modal will be fullscreen until it is as wide as the calcite-web grid's max-width. This enables you
@@ -68,7 +68,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-4" size="fullscreen">
+  <calcite-modal class="js-modal-4" fullscreen>
     <h3 slot="header">Fullscreen modal</h3>
     <div slot="content">
       <p>This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your
@@ -138,12 +138,48 @@
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-12" size="500">
+  <calcite-modal class="js-modal-12" width="500">
     <h3 slot="header">Modal title</h3>
     <div slot="content">
       <p>This modal will be 500 pixels wide on larger screens and become fullscreen below that.</p>
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+  </calcite-modal>
+  <calcite-modal class="js-modal-13" width="s" scale="s">
+    <h3 slot="header">Small Scale</h3>
+    <div slot="content">
+      <p>
+        This is the small scale modal. It is meant to work with other components at the small scale (like buttons, etc).
+      </p>
+    </div>
+    <calcite-button scale="s" slot="back" width="full" color="light" appearance="outline"
+      icon="chevron-left" width="full">Back</calcite-button>
+    <calcite-button scale="s" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button scale="s" slot="primary" width="full">Save</calcite-button>
+  </calcite-modal>
+  <calcite-modal class="js-modal-14" width="s" scale="m">
+    <h3 slot="header">Medium Scale</h3>
+    <div slot="content">
+      <p>
+        This is the medium scale modal. It is the default scale and is meant to work with other components at the medium scale.
+      </p>
+    </div>
+    <calcite-button scale="m" slot="back" width="full" color="light" appearance="outline"
+      icon="chevron-left" width="full">Back</calcite-button>
+    <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
+  </calcite-modal>
+  <calcite-modal class="js-modal-15" width="s" scale="l">
+    <h3 slot="header">Large Scale</h3>
+    <div slot="content">
+      <p>
+        This is the large scale modal. It is meant to work with other components at the large scale (like buttons, etc).
+      </p>
+    </div>
+    <calcite-button scale="l" slot="back" width="full" color="light" appearance="outline"
+      icon="chevron-left" width="full">Back</calcite-button>
+    <calcite-button scale="l" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button scale="l" slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
   <ul>
     <li>
@@ -185,7 +221,18 @@
       <calcite-link onClick="openModal('.js-modal-12')">Custom Width
       </calcite-link>
     </li>
-
+    <li>
+      <calcite-link onClick="openModal('.js-modal-13')">Scale Small
+      </calcite-link>
+    </li>
+    <li>
+      <calcite-link onClick="openModal('.js-modal-14')">Scale Medium
+      </calcite-link>
+    </li>
+    <li>
+      <calcite-link onClick="openModal('.js-modal-15')">Scale Large
+      </calcite-link>
+    </li>
   </ul>
   <script>
     function openModal(selector) {

--- a/src/demos/calcite-modal.html
+++ b/src/demos/calcite-modal.html
@@ -179,7 +179,7 @@
   </ul>
   <script>
     function openModal(selector) {
-      document.querySelector(selector).open();
+      document.querySelector(selector).active = true;
     }
   </script>
   </calcite-tab>

--- a/src/demos/calcite-modal.html
+++ b/src/demos/calcite-modal.html
@@ -138,7 +138,13 @@
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
   </calcite-modal>
-
+  <calcite-modal class="js-modal-12" size="500">
+    <h3 slot="header">Modal title</h3>
+    <div slot="content">
+      <p>This modal will be 500 pixels wide on larger screens and become fullscreen below that.</p>
+    </div>
+    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+  </calcite-modal>
   <ul>
     <li>
       <calcite-link onClick="openModal('.js-modal-1')">Small Modal</calcite-link>
@@ -173,6 +179,10 @@
     </li>
     <li>
       <calcite-link onClick="openModal('.js-modal-11')">No Close Button
+      </calcite-link>
+    </li>
+    <li>
+      <calcite-link onClick="openModal('.js-modal-12')">Custom Width
       </calcite-link>
     </li>
 


### PR DESCRIPTION
- **Open and close modal via an `active` prop rather than imperative methods.** This makes it much easier to use the modal in frameworks with unidirectional data flow.
- **Add `scale` prop to alter the size/padding.** This makes modal consistent with other scalable components.
- **Change `size` prop to `width`**. Also align the sizes with the syntax we use for scale (`"s" | "m" | "l"`)
- **Add ability to set custom modal widths.** Now `width` can also be passed a number. This allows devs to set a custom width for in-between modal sizes.
- **Move `fullscreen` to its own prop.**
- **Stop setting class on host.** This was the last instance of setting a class on the host element, so I've also removed it (#700)

I went down a lot of different roads trying to do custom sizes in a more eloquent way, but because css vars can't be used in media-queries and we need the modal to go fullscreen once the custom size is in the viewport, writing a style tag conditionally seemed like the only way. If anybody has better ideas I'm definitely all 👂 