### PR TITLE
fix release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Please refer to the [Stencil testing documentation](https://stenciljs.com/docs/t
 
 ### Documenting a component
 
-Calcite Components utlizes [Storybook](https://storybook.js.org/) for documenting components. Adding a new component is very simple:
+Calcite Components utilizes [Storybook](https://storybook.js.org/) for documenting components. Adding a new component is very simple:
 
 1. Create a new file inside your component directory like `calcite-X.stories.js`
 2. Write stories (see below)
@@ -88,17 +88,19 @@ To release a new version of Calcite Components you must:
 1. Be on a Mac or Linux machine (the publish script is a shell script).
 1. Be a member of the [@esri](https://www.npmjs.com/org/esri) organization on npm.
 1. Be a member of the admin team for [Calcite Components](https://github.com/Esri/calcite-components).
-1. Run `npm run release:prepare`. This will:
-   - Run a new build with `npm run build`.
-   - Increment the version in `package.json` with `npm version`
+1. Make sure you have a remote named `origin` pointing to [Esri/calcite-components](https://github.com/Esri/calcite-components).
+1. Make sure you are up to date with `master`.
+1. Run `npm run release:prepare` to increment version in `package.json`.
 1. Make any changes to the `CHANGELOG.md` file, and update the example script tags and stylesheet src in `readme.md`. Make a new entry for the release and summarize any changes.
 1. Run `npm run release:publish`. This will run the [`support/release.sh`](https://github.com/Esri/calcite-components/blob/master/support/release.sh) file which will:
    - Create a new commit on the master branch for the version.
    - Checkout a temporary branch for the release.
+   - Clean the old `dist` folder
+   - Run a new build
    - Force add the built files on the version branch.
    - Tag the version branch.
    - Push both the version tag and the master branch to GitHub. This results in a tag with the built files.
    - Publish to NPM.
    - Create a ZIP file of the built files.
-   - Create a new release on GitHub with the ZIP file and the CHANGELOG.md entry for the release.
+   - Create a new release on GitHub with the ZIP file and the `CHANGELOG.md` entry for the release.
    - Checkout the master branch and reset everything back to the last commit (i.e. the release commit).

--- a/support/release.sh
+++ b/support/release.sh
@@ -11,6 +11,12 @@ git commit -am "v$VERSION" --no-verify
 # Checkout a temp branch for release
 git checkout -b publish_v$VERSION
 
+# clean the dist folder
+rm -rf dist/
+
+# ensure a new build is run
+npm run build
+
 # force add built files so they appear in git only on this tag
 git add dist --force
 git add hydrate --force


### PR DESCRIPTION
Going through the release script step by step manually, I noticed that when I checked out a new temporary branch, the dist folder was actually missing a whole bunch of stuff. So I've removed the build that happens prior to prerelease and added both a full clean and rebuild in the temporary branch to the release script. 

I also added notes about the branch requirements for the release script to work.