### PR TITLE
add VNode type import to existing @stencil/core import

### DIFF
--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -10,16 +10,16 @@ import {
   Method,
   State,
   Watch,
+  VNode
 } from "@stencil/core";
 import { queryShadowRoot, isHidden, isFocusable } from "@a11y/focus-trap";
 import { getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-import { VNode } from "@stencil/core/internal/stencil-core";
 
 @Component({
   tag: "calcite-modal",
   styleUrl: "calcite-modal.scss",
-  shadow: true,
+  shadow: true
 })
 export class CalciteModal {
   //--------------------------------------------------------------------------
@@ -37,8 +37,7 @@ export class CalciteModal {
   /** Add the active attribute to open the modal */
   @Prop() active?: boolean;
   /** Optionally pass a function to run before close */
-  @Prop() beforeClose: (el: HTMLElement) => Promise<void> = () =>
-    Promise.resolve();
+  @Prop() beforeClose: (el: HTMLElement) => Promise<void> = () => Promise.resolve();
   /** Disables the display a close button within the Modal */
   @Prop() disableCloseButton?: boolean;
   /** Aria label for the close button */
@@ -84,11 +83,7 @@ export class CalciteModal {
         <calcite-scrim class="scrim" theme="dark"></calcite-scrim>
         {this.renderStyle()}
         <div class="modal">
-          <div
-            data-focus-fence="true"
-            tabindex="0"
-            onFocus={this.focusLastElement.bind(this)}
-          />
+          <div data-focus-fence="true" tabindex="0" onFocus={this.focusLastElement.bind(this)} />
           <div class="modal__header">
             {this.renderCloseButton()}
             <header class="modal__title">
@@ -98,7 +93,7 @@ export class CalciteModal {
           <div
             class={{
               modal__content: true,
-              "modal__content--spaced": !this.noPadding,
+              "modal__content--spaced": !this.noPadding
             }}
             ref={(el) => (this.modalContent = el)}
           >
@@ -115,11 +110,7 @@ export class CalciteModal {
               <slot name="primary" />
             </span>
           </div>
-          <div
-            data-focus-fence="true"
-            tabindex="0"
-            onFocus={this.focusFirstElement.bind(this)}
-          />
+          <div data-focus-fence="true" tabindex="0" onFocus={this.focusFirstElement.bind(this)} />
         </div>
       </Host>
     );
@@ -213,10 +204,7 @@ export class CalciteModal {
   }
 
   /** Set the scroll top of the modal content */
-  @Method() async scrollContent(
-    top: number = 0,
-    left: number = 0
-  ): Promise<void> {
+  @Method() async scrollContent(top: number = 0, left: number = 0): Promise<void> {
     if (this.modalContent) {
       if (this.modalContent.scrollTo) {
         this.modalContent.scrollTo({ top, left, behavior: "smooth" });
@@ -279,11 +267,9 @@ export class CalciteModal {
   }
 
   private focusLastElement() {
-    const focusableElements = queryShadowRoot(
-      this.el,
-      isHidden,
-      isFocusable
-    ).filter((el) => !el.getAttribute("data-focus-fence"));
+    const focusableElements = queryShadowRoot(this.el, isHidden, isFocusable).filter(
+      (el) => !el.getAttribute("data-focus-fence")
+    );
     if (focusableElements.length > 0) {
       focusableElements[focusableElements.length - 1].focus();
     } else {

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -9,16 +9,16 @@ import {
   State,
   Watch,
   h,
+  VNode
 } from "@stencil/core";
 import { CSS, ARIA_DESCRIBED_BY, POPOVER_REFERENCE, TEXT } from "./resources";
 import {
   CalcitePlacement,
   defaultOffsetDistance,
   createPopper,
-  updatePopper,
+  updatePopper
 } from "../../utils/popper";
 import { StrictModifiers, Placement, Instance as Popper } from "@popperjs/core";
-import { VNode } from "@stencil/core/internal/stencil-core";
 import { guid } from "../../utils/guid";
 
 export type FocusId = "close-button";
@@ -30,7 +30,7 @@ export type FocusId = "close-button";
 @Component({
   tag: "calcite-popover",
   styleUrl: "calcite-popover.scss",
-  shadow: true,
+  shadow: true
 })
 export class CalcitePopover {
   // --------------------------------------------------------------------------
@@ -183,7 +183,7 @@ export class CalcitePopover {
           el,
           modifiers,
           placement,
-          popper,
+          popper
         })
       : this.createPopper();
   }
@@ -254,27 +254,27 @@ export class CalcitePopover {
       disableFlip,
       disablePointer,
       offsetDistance,
-      offsetSkidding,
+      offsetSkidding
     } = this;
     const flipModifier: Partial<StrictModifiers> = {
       name: "flip",
-      enabled: !disableFlip,
+      enabled: !disableFlip
     };
 
     if (flipPlacements) {
       flipModifier.options = {
-        fallbackPlacements: flipPlacements,
+        fallbackPlacements: flipPlacements
       };
     }
 
     const arrowModifier: Partial<StrictModifiers> = {
       name: "arrow",
-      enabled: !disablePointer,
+      enabled: !disablePointer
     };
 
     if (arrowEl) {
       arrowModifier.options = {
-        element: arrowEl,
+        element: arrowEl
       };
     }
 
@@ -282,8 +282,8 @@ export class CalcitePopover {
       name: "offset",
       enabled: true,
       options: {
-        offset: [offsetSkidding, offsetDistance],
-      },
+        offset: [offsetSkidding, offsetDistance]
+      }
     };
 
     return [arrowModifier, flipModifier, offsetModifier];
@@ -299,7 +299,7 @@ export class CalcitePopover {
       modifiers,
       open,
       placement,
-      referenceEl,
+      referenceEl
     });
   }
 
@@ -355,11 +355,7 @@ export class CalcitePopover {
     ) : null;
 
     return (
-      <Host
-        role="dialog"
-        aria-hidden={!displayed ? "true" : "false"}
-        id={this.getId()}
-      >
+      <Host role="dialog" aria-hidden={!displayed ? "true" : "false"} id={this.getId()}>
         {arrowNode}
         <div class={CSS.container}>
           {this.renderImage()}


### PR DESCRIPTION
Seeing some issues in TS apps on beta 32. The `VNode` type is available in stencil core directly, and it is better to have this on the existing import anyways IMO.

Note sure why all the formatting was committed I think this is Husky...