### PR TITLE
Alert updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Breaking Changes
+
+- `calcite-alert` - `open` and `close` methods have been removed. You can use the `active` prop to open or add an alert to the queue.
+- `calcite-alert` - `currentAlert` prop has been removed
+- `calcite-alert` - `alertQueue` prop has been removed (`queue` is emitted as a detail of the `calciteAlertOpen` and `calciteAlertClose` events)
+- `calcite-alert` - `alertQueueLength` prop has been removed
+
 ### Fixes
 
 - `calcite-modal` - turn off pointer events on hidden modals to prevent interaction (#549)
@@ -14,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `calcite-modal` - add `background-color` property for light grey backgrounds (#527)
+- `calcite-alert` - `intlClose` prop has been added to optionally provide a translated override of the English "close" text
 
 ## [v1.0.0-beta.32]
 

--- a/src/assets/demo/createAlert.js
+++ b/src/assets/demo/createAlert.js
@@ -7,16 +7,14 @@ function createExampleAlert(id) {
       id +
       " That thing you wanted to do didn't work as expected</div>",
     "<calcite-link slot='alert-link' title='my action' appearance='inline'>Take action</calcite-link>",
-    "</calcite-alert>"
+    "</calcite-alert>",
   ].join("\n");
 
   // if the id element doesn't exist, insert into page
   if (!document.querySelector("#" + id)) {
-    document
-      .querySelector("body")
-      .insertAdjacentHTML("afterend", exampleAlert);
+    document.querySelector("body").insertAdjacentHTML("beforeend", exampleAlert);
   }
 
   // open the alert we just created
-  document.querySelector("#" + id).open();
+  document.querySelector("#" + id).setAttribute("active", "");
 }

--- a/src/components/calcite-accordion/readme.md
+++ b/src/components/calcite-accordion/readme.md
@@ -6,15 +6,9 @@ A basic implementation looks like this:
 
 ```html
 <calcite-accordion>
-  <calcite-accordion-item item-title="Accordion Item"
-    >Accordion Section Content
-  </calcite-accordion-item>
-  <calcite-accordion-item item-title="Accordion Item 2" active
-    >Accordion Section Content
-  </calcite-accordion-item>
-  <calcite-accordion-item item-title="Accordion Item 3"
-    >>Accordion Section Content
-  </calcite-accordion-item>
+  <calcite-accordion-item item-title="Accordion Item">Accordion Section Content </calcite-accordion-item>
+  <calcite-accordion-item item-title="Accordion Item 2" active>Accordion Section Content </calcite-accordion-item>
+  <calcite-accordion-item item-title="Accordion Item 3">>Accordion Section Content </calcite-accordion-item>
 </calcite-accordion>
 ```
 

--- a/src/components/calcite-alert/calcite-alert.e2e.ts
+++ b/src/components/calcite-alert/calcite-alert.e2e.ts
@@ -79,7 +79,7 @@ describe("calcite-alert", () => {
     const page = await newE2EPage();
     await page.setContent(`
     <div>
-    <calcite-button id="button-1" onclick="document.querySelector('#alert-1').open()">open alert-1</calcite-button>
+    <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('active', '')">open alert-1</calcite-button>
     <calcite-alert id="alert-1">
     <div slot="alert-title">Title Text</div>
     <div slot="alert-message">Message Text</div>
@@ -108,9 +108,9 @@ describe("calcite-alert", () => {
     const page = await newE2EPage();
     await page.setContent(`
     <div>
-    <calcite-button id="button-1" onclick="document.querySelector('#alert-1').open()">open alert-1</calcite-button>
-    <calcite-button id="button-2" onclick="document.querySelector('#alert-2').open()">open alert-2</calcite-button>
-    <calcite-button id="button-3" onclick="document.querySelector('#alert-3').open()">open alert-3</calcite-button>
+    <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('active', '')">open alert-1</calcite-button>
+    <calcite-button id="button-2" onclick="document.querySelector('#alert-2').setAttribute('active', '')">open alert-2</calcite-button>
+    <calcite-button id="button-3" onclick="document.querySelector('#alert-3').setAttribute('active', '')">open alert-3</calcite-button>
     <calcite-alert id="alert-1">
     <div slot="alert-title">Title Text</div>
     <div slot="alert-message">Message Text</div>

--- a/src/components/calcite-alert/calcite-alert.resources.ts
+++ b/src/components/calcite-alert/calcite-alert.resources.ts
@@ -1,0 +1,3 @@
+export const TEXT = {
+  intlClose: "close"
+};

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -75,8 +75,7 @@
   pointer-events: none;
   z-index: 101;
   transform: translate3d(0, $baseline, 0);
-  transition: 300ms $easing-function, opacity 300ms $easing-function,
-    all 0.15s ease-in-out;
+  transition: 300ms $easing-function, opacity 300ms $easing-function, all 0.15s ease-in-out;
   border-top: 0px solid transparent;
   @media only screen and (max-width: $viewport-medium) {
     width: 100%;
@@ -93,7 +92,7 @@
   }
 }
 
-:host([active]) {
+:host([active]:not([queued])) {
   opacity: 1;
   max-height: 100%;
   transform: translate3d(0, -$baseline, 0);
@@ -129,8 +128,7 @@
 }
 
 @mixin alert-element-base() {
-  padding: var(--calcite-alert-spacing-token-small)
-    var(--calcite-alert-spacing-token-large);
+  padding: var(--calcite-alert-spacing-token-small) var(--calcite-alert-spacing-token-large);
   flex: 0 0 auto;
   transition: all 0.15s ease-in-out;
 
@@ -144,8 +142,7 @@
   flex: 1 1 auto;
   min-width: 0;
   word-wrap: break-word;
-  padding: var(--calcite-alert-spacing-token-small)
-    var(--calcite-alert-spacing-token-small)
+  padding: var(--calcite-alert-spacing-token-small) var(--calcite-alert-spacing-token-small)
     var(--calcite-alert-spacing-token-small) 0;
 
   &:first-of-type:not(:only-child) {
@@ -156,24 +153,21 @@
   }
 
   @media only screen and (max-width: $viewport-medium) {
-    padding: var(--calcite-alert-spacing-token-large)
-      var(--calcite-alert-spacing-token-small)
+    padding: var(--calcite-alert-spacing-token-large) var(--calcite-alert-spacing-token-small)
       var(--calcite-alert-spacing-token-large) 0;
   }
 }
 
 :host([dir="rtl"]) {
   .alert-content {
-    padding: var(--calcite-alert-spacing-token-small) 0
-      var(--calcite-alert-spacing-token-small)
+    padding: var(--calcite-alert-spacing-token-small) 0 var(--calcite-alert-spacing-token-small)
       var(--calcite-alert-spacing-token-small);
 
     &:first-of-type:not(:only-child) {
       padding-right: var(--calcite-alert-spacing-token-large);
     }
     @media only screen and (max-width: $viewport-medium) {
-      padding: var(--calcite-alert-spacing-token-large) 0
-        var(--calcite-alert-spacing-token-large)
+      padding: var(--calcite-alert-spacing-token-large) 0 var(--calcite-alert-spacing-token-large)
         var(--calcite-alert-spacing-token-small);
     }
   }
@@ -218,7 +212,7 @@
     border-radius: 0 0 0 var(--calcite-border-radius);
   }
 }
-.alert-count {
+.alert-queue-count {
   @include font-size(-2);
   display: flex;
   align-items: center;
@@ -235,6 +229,7 @@
   border-right: 0px solid transparent;
   cursor: default;
   transition: all 0.15s ease-in-out;
+  overflow: hidden;
 
   &.active {
     visibility: visible;
@@ -243,21 +238,19 @@
     width: $baseline * 2;
     border-left: 1px solid var(--calcite-ui-border-3);
     border-right: 1px solid var(--calcite-ui-border-3);
-
-    &:last-child {
-      border-right: 0px solid transparent;
-    }
   }
 
   @media only screen and (max-width: $viewport-medium) {
     border-radius: 0;
   }
 }
-:host([dir="rtl"]) {
-  &.active:last-child {
-    border-left: 1px solid var(--calcite-ui-border-3);
-    border-right: 0px solid transparent;
-  }
+
+:host([auto-dismiss]) > .alert-queue-count {
+  border-right: 0px solid transparent;
+}
+
+:host([auto-dismiss][dir="rtl"]) > .alert-queue-count {
+  border-left: 0px solid transparent;
 }
 
 .alert-dismiss-progress {
@@ -288,8 +281,8 @@
   right: initial;
 }
 
-$alertColors: "blue" var(--calcite-ui-blue-1), "red" var(--calcite-ui-red-1),
-  "yellow" var(--calcite-ui-yellow-1), "green" var(--calcite-ui-green-1);
+$alertColors: "blue" var(--calcite-ui-blue-1), "red" var(--calcite-ui-red-1), "yellow" var(--calcite-ui-yellow-1),
+  "green" var(--calcite-ui-green-1);
 
 @each $alertColor in $alertColors {
   $name: nth($alertColor, 1);

--- a/src/components/calcite-alert/calcite-alert.stories.js
+++ b/src/components/calcite-alert/calcite-alert.stories.js
@@ -14,11 +14,7 @@ storiesOf("Alert", module)
     theme="light"
     icon="${boolean("icon", true)}"
     auto-dismiss="${boolean("auto-dismiss", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
+    auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     active="${boolean("active", true)}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
@@ -38,11 +34,7 @@ storiesOf("Alert", module)
     theme="light"
     icon="${boolean("icon", true)}"
     auto-dismiss="${boolean("auto-dismiss", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
+    auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     active="${boolean("active", true)}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
@@ -61,11 +53,7 @@ storiesOf("Alert", module)
     theme="light"
     icon="${boolean("icon", true)}"
     auto-dismiss="${boolean("auto-dismiss", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
+    auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     active="${boolean("active", true)}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
@@ -84,11 +72,7 @@ storiesOf("Alert", module)
     theme="light"
     icon="${boolean("icon", true)}"
     auto-dismiss="${boolean("auto-dismiss", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
+    auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     active="${boolean("active", true)}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "yellow")}">
@@ -104,25 +88,19 @@ storiesOf("Alert", module)
     () => `
    <div>
     <h5>Open or add to queue</h5>
-    <calcite-button onclick=document.querySelector("#one").open()>Open Alert 1</calcite-button>
-    <calcite-button onclick=document.querySelector("#two").open()>Open Alert 2</calcite-button>
-    <calcite-button onclick=document.querySelector("[data-custom-id=my-id]").open()>Open Alert 3</calcite-button>
+    <calcite-button onclick='document.querySelector("#one").setAttribute("active", "")'>Open Alert 1</calcite-button>
+    <calcite-button onclick='document.querySelector("#two").setAttribute("active", "")'>Open Alert 2</calcite-button>
+    <calcite-button onclick='document.querySelector("[data-custom-id=my-id]").setAttribute("active", "")'>Open Alert 3</calcite-button>
     <br/>
     <br/>
     <h5>Close or remove from queue</h5>
-    <calcite-button color="red" onclick=document.querySelector("#one").close()>Close Alert 1</calcite-button>
-    <calcite-button color="red" onclick=document.querySelector("#two").close()>Close Alert 2</calcite-button>
-    <calcite-button color="red" onclick=document.querySelector("[data-custom-id=my-id]").close()>Close Alert 3</calcite-button>
+    <calcite-button color="red" onclick='document.querySelector("#one").removeAttribute("active")'>Close Alert 1</calcite-button>
+    <calcite-button color="red" onclick='document.querySelector("#two").removeAttribute("active")'>Close Alert 2</calcite-button>
+    <calcite-button color="red" onclick='document.querySelector("[data-custom-id=my-id]").removeAttribute("active")'>Close Alert 3</calcite-button>
       <calcite-alert
       id="one"
       theme="light"
       icon="${boolean("icon", true)}"
-      auto-dismiss="${boolean("auto-dismiss", false)}"
-      auto-dismiss-duration="${select(
-        "auto-dismiss-duration",
-        ["fast", "medium", "slow"],
-        "medium"
-      )}"
       color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
       <div slot="alert-title">Your great thing happened</div>
       <div slot="alert-message">
@@ -134,12 +112,6 @@ storiesOf("Alert", module)
     id="two"
     theme="light"
     icon="${boolean("icon-2", true)}"
-    auto-dismiss="${boolean("auto-dismiss-2", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration-2",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
     color="${select("color-2", ["green", "red", "yellow", "blue"], "blue")}">
     <div slot="alert-title">Your great thing happened</div>
     <div slot="alert-message">
@@ -151,12 +123,6 @@ storiesOf("Alert", module)
       data-custom-id="my-id"
       theme="light"
       icon="${boolean("icon-3", true)}"
-      auto-dismiss="${boolean("auto-dismiss-3", true)}"
-      auto-dismiss-duration="${select(
-        "auto-dismiss-duration-3",
-        ["fast", "medium", "slow"],
-        "medium"
-      )}"
       color="${select("color-3", ["green", "red", "yellow", "blue"], "red")}">
       <div slot="alert-title">That didn't work out</div>
       <div slot="alert-message">
@@ -175,11 +141,7 @@ storiesOf("Alert", module)
     theme="dark"
     icon="${boolean("icon", true)}"
     auto-dismiss="${boolean("auto-dismiss", false)}"
-  auto-dismiss-duration="${select(
-    "auto-dismiss-duration",
-    ["fast", "medium", "slow"],
-    "medium"
-  )}"
+  auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     active="${boolean("active", true)}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
@@ -187,7 +149,7 @@ storiesOf("Alert", module)
     <div slot="alert-message">
       That thing you wanted to do didn't work as expected
     </div>
-    <calcite-button theme="dark" slot="alert-link" title="my action">Retry</calcite-button>
+    <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
   </calcite-alert>
   `,
     { notes, backgrounds: darkBackground }
@@ -197,59 +159,41 @@ storiesOf("Alert", module)
     () => `
    <div>
     <h5 style="color:white">Open or add to queue</h5>
-    <calcite-button theme="dark" onclick=document.querySelector("#one").open()>Open Alert 1</calcite-button>
-    <calcite-button theme="dark" onclick=document.querySelector("#two").open()>Open Alert 2</calcite-button>
-    <calcite-button theme="dark" onclick=document.querySelector("[data-custom-id=my-id]").open()>Open Alert 3</calcite-button>
+    <calcite-button theme="dark" onclick='document.querySelector("#one").setAttribute("active", "")'>Open Alert 1</calcite-button>
+    <calcite-button theme="dark" onclick='document.querySelector("#two").setAttribute("active", "")'>Open Alert 2</calcite-button>
+    <calcite-button theme="dark" onclick='document.querySelector("[data-custom-id=my-id]").setAttribute("active", "")'>Open Alert 3</calcite-button>
     <br/>
     <br/>
     <h5 style="color:white">Close or remove from queue</h5>
-    <calcite-button theme="dark" color="red" onclick=document.querySelector("#one").close()>Close Alert 1</calcite-button>
-    <calcite-button theme="dark" color="red" onclick=document.querySelector("#two").close()>Close Alert 2</calcite-button>
-    <calcite-button theme="dark" color="red" onclick=document.querySelector("[data-custom-id=my-id]").close()>Close Alert 3</calcite-button>
+    <calcite-button theme="dark" color="red" onclick='document.querySelector("#one").removeAttribute("active")'>Close Alert 1</calcite-button>
+    <calcite-button theme="dark" color="red" onclick='document.querySelector("#two").removeAttribute("active")'>Close Alert 2</calcite-button>
+    <calcite-button theme="dark" color="red" onclick='document.querySelector("[data-custom-id=my-id]").removeAttribute("active")'>Close Alert 3</calcite-button>
       <calcite-alert
       id="one"
       theme="dark"
       icon="${boolean("icon", true)}"
-      auto-dismiss="${boolean("auto-dismiss", false)}"
-      auto-dismiss-duration="${select(
-        "auto-dismiss-duration",
-        ["fast", "medium", "slow"],
-        "medium"
-      )}"
       color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
       <div slot="alert-title">Your great thing happened</div>
       <div slot="alert-message">
         Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
       </div>
-      <calcite-button theme="dark" slot="alert-link" title="my action">View layer</calcite-link>
+      <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
     </calcite-alert>
     <calcite-alert
     id="two"
     theme="dark"
     icon="${boolean("icon-2", true)}"
-    auto-dismiss="${boolean("auto-dismiss-2", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration-2",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
     color="${select("color-2", ["green", "red", "yellow", "blue"], "blue")}">
     <div slot="alert-title">Your great thing happened</div>
     <div slot="alert-message">
     Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
     </div>
-    <calcite-button theme="dark" slot="alert-link" title="my action">View layer</calcite-link>
+    <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
     </calcite-alert>
     <calcite-alert
       data-custom-id="my-id"
       theme="dark"
       icon="${boolean("icon-3", true)}"
-      auto-dismiss="${boolean("auto-dismiss-3", true)}"
-      auto-dismiss-duration="${select(
-        "auto-dismiss-duration-3",
-        ["fast", "medium", "slow"],
-        "medium"
-      )}"
       color="${select("color-3", ["green", "red", "yellow", "blue"], "red")}">
       <div slot="alert-message">
         That thing you wanted to do didn't work out so well.
@@ -267,11 +211,7 @@ storiesOf("Alert", module)
     theme="light"
     icon="${boolean("icon", true)}"
     auto-dismiss="${boolean("auto-dismiss", false)}"
-    auto-dismiss-duration="${select(
-      "auto-dismiss-duration",
-      ["fast", "medium", "slow"],
-      "medium"
-    )}"
+    auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     active="${boolean("active", true)}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">

--- a/src/components/calcite-alert/readme.md
+++ b/src/components/calcite-alert/readme.md
@@ -21,64 +21,37 @@ A single instance of an alert. Multiple alerts will aggregate in a queue.
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
 | Property              | Attribute               | Description                                                                  | Type                                     | Default                              |
 | --------------------- | ----------------------- | ---------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------ |
 | `active`              | `active`                | Is the alert currently active or not                                         | `boolean`                                | `false`                              |
-| `alertQueue`          | --                      | a managed list of alerts                                                     | `string[]`                               | `[]`                                 |
-| `alertQueueLength`    | `alert-queue-length`    | a managed list of alerts                                                     | `number`                                 | `undefined`                          |
 | `autoDismiss`         | `auto-dismiss`          | Close the alert automatically (recommended for passive, non-blocking alerts) | `boolean`                                | `false`                              |
 | `autoDismissDuration` | `auto-dismiss-duration` | Duration of autoDismiss (only used with `autoDismiss`)                       | `"fast" \| "medium" \| "slow"`           | `this.autoDismiss ? "medium" : null` |
 | `color`               | `color`                 | Color for the alert (will apply to top border and icon)                      | `"blue" \| "green" \| "red" \| "yellow"` | `"blue"`                             |
-| `currentAlert`        | `current-alert`         | the determined current alert                                                 | `string`                                 | `undefined`                          |
 | `icon`                | `icon`                  | specify if the alert should display an icon                                  | `boolean`                                | `false`                              |
+| `intlClose`           | `intl-close`            | string to override English close text                                        | `string`                                 | `TEXT.intlClose`                     |
 | `scale`               | `scale`                 | specify the scale of the button, defaults to m                               | `"l" \| "m" \| "s"`                      | `"m"`                                |
 | `theme`               | `theme`                 | Select theme (light or dark)                                                 | `"dark" \| "light"`                      | `undefined`                          |
 
-
 ## Events
 
-| Event               | Description                   | Type               |
-| ------------------- | ----------------------------- | ------------------ |
-| `calciteAlertClose` | Fired when an alert is closed | `CustomEvent<any>` |
-| `calciteAlertOpen`  | Fired when an alert is opened | `CustomEvent<any>` |
-| `calciteAlertSync`  | Fired when an alert is opened | `CustomEvent<any>` |
-
+| Event                  | Description                                                         | Type               |
+| ---------------------- | ------------------------------------------------------------------- | ------------------ |
+| `calciteAlertClose`    | Fired when an alert is closed                                       | `CustomEvent<any>` |
+| `calciteAlertOpen`     | Fired when an alert is opened                                       | `CustomEvent<any>` |
+| `calciteAlertRegister` | Fired when an alert is added to dom - used to receive initial queue | `CustomEvent<any>` |
+| `calciteAlertSync`     | Fired to sync queue when opened or closed                           | `CustomEvent<any>` |
 
 ## Methods
 
-### `close() => Promise<void>`
-
-close alert and emit the closed alert
-
-#### Returns
-
-Type: `Promise<void>`
-
-
-
-### `open() => Promise<void>`
-
-open alert and emit the opened alert
-
-#### Returns
-
-Type: `Promise<void>`
-
-
-
 ### `setFocus() => Promise<void>`
 
-focus the close button, if present and requested
+focus either the slotted alert-link or the close button
 
 #### Returns
 
 Type: `Promise<void>`
-
-
-
 
 ## Slots
 
@@ -88,7 +61,6 @@ Type: `Promise<void>`
 | `"alert-message"` | Main text of the alert                                                       |
 | `"alert-title"`   | Title of the alert (optional)                                                |
 
-
 ## Dependencies
 
 ### Depends on
@@ -96,12 +68,13 @@ Type: `Promise<void>`
 - [calcite-icon](../calcite-icon)
 
 ### Graph
+
 ```mermaid
 graph TD;
   calcite-alert --> calcite-icon
   style calcite-alert fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-dropdown/readme.md
+++ b/src/components/calcite-dropdown/readme.md
@@ -30,10 +30,7 @@ You can combine groups in a single dropdown, with varying selection modes:
     <calcite-dropdown-item active>Potato</calcite-dropdown-item>
     <calcite-dropdown-item>Yam</calcite-dropdown-item>
   </calcite-dropdown-group>
-  <calcite-dropdown-group
-    group-title="Select none (useful for actions)"
-    selection-mode="none"
-  >
+  <calcite-dropdown-group group-title="Select none (useful for actions)" selection-mode="none">
     <calcite-dropdown-item>Plant beans</calcite-dropdown-item>
     <calcite-dropdown-item active>Add peas</calcite-dropdown-item>
   </calcite-dropdown-group>

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -8,13 +8,7 @@ calcite modal allows you to show a modal/dialog to your users. The modal handles
   <div slot="content">
     The actual content of the modal
   </div>
-  <calcite-button
-    slot="back"
-    color="light"
-    appearance="outline"
-    icon="chevron-left"
-    width="full"
-  >
+  <calcite-button slot="back" color="light" appearance="outline" icon="chevron-left" width="full">
     Back
   </calcite-button>
   <calcite-button slot="secondary" width="full" appearance="outline">

--- a/src/components/calcite-popover/readme.md
+++ b/src/components/calcite-popover/readme.md
@@ -7,14 +7,10 @@
 ### Manager
 
 ```html
-<calcite-popover reference-element="popover-button"
-  >Hello! I am some popover content!</calcite-popover
->
+<calcite-popover reference-element="popover-button">Hello! I am some popover content!</calcite-popover>
 
 <calcite-popover-manager
-  ><calcite-button id="popover-button"
-    >Clickable popover</calcite-button
-  ></calcite-popover-manager
+  ><calcite-button id="popover-button">Clickable popover</calcite-button></calcite-popover-manager
 >
 ```
 
@@ -49,7 +45,7 @@
 
 Type: `Promise<void>`
 
-### `setFocus(focusId?: FocusId) => Promise<void>`
+### `setFocus(focusId?: "close-button") => Promise<void>`
 
 #### Returns
 

--- a/src/components/calcite-stepper/readme.md
+++ b/src/components/calcite-stepper/readme.md
@@ -4,28 +4,16 @@ Calcite stepper can be used to present a stepper workflow to a user. It has conf
 
 ```html
 <calcite-stepper icon numbered id="my-example-stepper">
-  <calcite-stepper-item
-    item-title="Choose method"
-    item-subtitle="Add members without sending invitations"
-    complete
-  >
+  <calcite-stepper-item item-title="Choose method" item-subtitle="Add members without sending invitations" complete>
     Step 1 Content Goes Here
   </calcite-stepper-item>
   <calcite-stepper-item item-title="Compile member list" error>
     Step 2 Content Goes Here
   </calcite-stepper-item>
-  <calcite-stepper-item
-    item-title="Set member properties"
-    item-subtitle="Some subtext"
-    active
-  >
+  <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
     Step 3 Content Goes Here
   </calcite-stepper-item>
-  <calcite-stepper-item
-    item-title="Confirm and complete"
-    item-subtitle="Disabled example"
-    disabled
-  >
+  <calcite-stepper-item item-title="Confirm and complete" item-subtitle="Disabled example" disabled>
     Step 4 Content Goes Here
   </calcite-stepper-item>
 </calcite-stepper>

--- a/src/demos/calcite-alert.html
+++ b/src/demos/calcite-alert.html
@@ -17,44 +17,42 @@
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Alert</h1>
   <calcite-button title="1 Autodismiss, title, link, red" color="red" scale="s"
-    onclick="document.querySelector('#alert-one').open()">1 Autodismiss, title, link, red, small scale
+    onclick="document.querySelector('#alert-one').setAttribute('active', '')">1 Autodismiss, title, link, red, small
+    scale
   </calcite-button>
-  <calcite-button title="2 Icon, link, green" scale="s" onclick="document.querySelector('#alert-two').open()">2
+  <calcite-button title="2 Icon, link, green" scale="s"
+    onclick="document.querySelector('#alert-two').setAttribute('active', '')">2
     Icon, link, green</calcite-button>
-  <calcite-button title="3 Icon, dark theme" scale="s" onclick="document.querySelector('#alert-three').open()">3
+  <calcite-button title="3 Icon, dark theme" scale="s"
+    onclick="document.querySelector('#alert-three').setAttribute('active', '')">3
     Icon, dark theme</calcite-button>
-  <calcite-button title="4 Icon, title, yellow, link" scale="s" onclick="document.querySelector('#alert-four').open()">4
+  <calcite-button title="4 Icon, title, yellow, link" scale="s"
+    onclick="document.querySelector('#alert-four').setAttribute('active', '')">4
     Icon, title, yellow, link, large scale
   </calcite-button>
-  <calcite-button title="5 default" scale="s" onclick="document.querySelector('#alert-five').open()">5
+  <calcite-button title="5 default" scale="s"
+    onclick="document.querySelector('#alert-five').setAttribute('active', '')">5
     default</calcite-button>
-  <calcite-button title="6 Icon, title, link, red" scale="s" onclick="document.querySelector('#alert-six').open()">6
+  <calcite-button title="6 Icon, title, link, red" scale="s"
+    onclick="document.querySelector('#alert-six').setAttribute('active', '')">6
     Icon, title, link, red</calcite-button>
   <calcite-button title="7 title, link, green, dark theme" scale="s"
-    onclick="document.querySelector('#alert-seven').open()">7 title, link, green, dark theme
+    onclick="document.querySelector('#alert-seven').setAttribute('active', '')">7 title, link, green, dark theme
   </calcite-button>
   <calcite-button title="8 Autodismiss, icon, title, red" scale="s"
-    onclick="document.querySelector('#alert-eight').open()">8 Autodismiss, icon, title, red
+    onclick="document.querySelector('#alert-eight').setAttribute('active', '')">8 Autodismiss, icon, title, red
   </calcite-button>
   <calcite-button title="9 Autodismiss (fast),link, dark theme" scale="s"
-    onclick="document.querySelector('#alert-nine').open()">9 Autodismiss (fast),link, dark theme
+    onclick="document.querySelector('#alert-nine').setAttribute('active', '')">9 Autodismiss (fast),link, dark theme
   </calcite-button>
-  <calcite-button title="10 Autodismiss (medium)" scale="s" onclick="document.querySelector('#alert-ten').open()">
+  <calcite-button title="10 Autodismiss (medium)" scale="s"
+    onclick="document.querySelector('#alert-ten').setAttribute('active', '')">
     10 Autodismiss (medium)</calcite-button>
 
-  <calcite-button title="11 Autodismiss (slow),link" scale="s" onclick="document.querySelector('#alert-eleven').open()">
+  <calcite-button title="11 Autodismiss (slow),link" scale="s"
+    onclick="document.querySelector('#alert-eleven').setAttribute('active', '')">
     11 Autodismiss (slow),link
   </calcite-button>
-
-  <calcite-button title="12 Without ID - generate GUID" scale="s"
-    onclick="document.querySelector('[data-custom-id=myalert1]').open()">
-    12 Without ID - generate GUID</calcite-button>
-
-  <calcite-button title="13 Without ID - generate GUID" scale="s"
-    onclick="document.querySelector('[data-custom-id=myalert2]').open()">
-    13 Without ID - generate GUID
-  </calcite-button>
-
 
 
   <h5>You can use in combination with alerts inserted into the DOM programmatically</h5>
@@ -63,12 +61,12 @@
   <calcite-button title="created alert 2" onclick="createExampleAlert('created-2')">created alert 2
   </calcite-button>
   <h5>You can close opened alerts, or removed upcoming alerts from the queue</h5>
-  <calcite-button title="Close or remove alert 6" color="red"
-    onclick="document.querySelector('#alert-six').close()">Close or remove alert 6</calcite-button>
-  <calcite-button title="Close or remove alert 4" color="red"
-    onclick="document.querySelector('#alert-four').close()">Close or remove alert 4</calcite-button>
+  <calcite-button title="Close or remove alert 6" color="red" onclick="document.querySelector('#alert-six').removeAttribute('active')">
+    Close or remove alert 6</calcite-button>
+  <calcite-button title="Close or remove alert 4" color="red" onclick="document.querySelector('#alert-four').removeAttribute('active')">
+    Close or remove alert 4</calcite-button>
   <calcite-button title="Close or remove alert created 2" color="red"
-    onclick="document.querySelector('#created-2').close()">Close or remove alert created 2
+    onclick="document.querySelector('#created-2').removeAttribute('active')">Close or remove alert created 2
   </calcite-button>
   <h5>using the setFocus() method (once opened)</h5>
   <calcite-button onclick=document.querySelector('#alert-four').setFocus()>focus first alert 4 item


### PR DESCRIPTION
Resolves https://github.com/Esri/calcite-components/issues/570 - cc @jwasilgeo - can you give this a look over? It should work as desired, while still maintaining a queue if multiple are added to DOM with active present.

Resolves https://github.com/Esri/calcite-components/issues/456

**BREAKING**
- 🚨 - removes `open` and `close` methods in favor of `active` prop
- 🚨 - removes public `currentAlert`, `alertQueue`, and `alertQueueLength` props (queue and opened / closed element available as event details)

**ADDED**
- 🆕 - adds `intlClose` prop for translating button close label

**CHANGES**
- ♻️ - No longer assigns GUID or relies on internal alertId string for queue and active state management
- ♻️ - Updates tests, dev demos, Storybook
- ♻️ - Some generated `readme` updates.