### PR TITLE
📚 create new boolean helper

### DIFF
--- a/.storybook/helpers.js
+++ b/.storybook/helpers.js
@@ -1,4 +1,5 @@
 import * as icons from "@esri/calcite-ui-icons";
+import { boolean as booleanKnob } from "@storybook/addon-knobs";
 
 export const darkBackground = [{ name: 'Dark', value: '#202020', default: true }]
 
@@ -9,3 +10,12 @@ export const parseReadme = (str) => str.replace(/ \\\| /g, ' | ');
 export const iconNames = Object.keys(icons)
   .filter(iconName => iconName.endsWith("16"))
   .map(iconName => iconName.replace("16", ""));
+
+// custom boolean will start up a knob but only add the prop if it is true
+// if you'd insead like `attr="true|false" set the standalone option to false
+export const boolean = (prop, value, standalone = true) => {
+  const knob = booleanKnob(prop, value);
+  const propValue = (standalone && knob) || !standalone ? prop : "";
+  const attrValue = standalone ? "" : `="${knob}"`;
+  return `${propValue}${attrValue}`;
+}

--- a/src/components/calcite-alert/readme.md
+++ b/src/components/calcite-alert/readme.md
@@ -23,16 +23,16 @@ A single instance of an alert. Multiple alerts will aggregate in a queue.
 
 ## Properties
 
-| Property              | Attribute               | Description                                                                  | Type                                     | Default                              |
-| --------------------- | ----------------------- | ---------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------ |
-| `active`              | `active`                | Is the alert currently active or not                                         | `boolean`                                | `false`                              |
-| `autoDismiss`         | `auto-dismiss`          | Close the alert automatically (recommended for passive, non-blocking alerts) | `boolean`                                | `false`                              |
-| `autoDismissDuration` | `auto-dismiss-duration` | Duration of autoDismiss (only used with `autoDismiss`)                       | `"fast" \| "medium" \| "slow"`           | `this.autoDismiss ? "medium" : null` |
-| `color`               | `color`                 | Color for the alert (will apply to top border and icon)                      | `"blue" \| "green" \| "red" \| "yellow"` | `"blue"`                             |
-| `icon`                | `icon`                  | specify if the alert should display an icon                                  | `boolean`                                | `false`                              |
-| `intlClose`           | `intl-close`            | string to override English close text                                        | `string`                                 | `TEXT.intlClose`                     |
-| `scale`               | `scale`                 | specify the scale of the button, defaults to m                               | `"l" \| "m" \| "s"`                      | `"m"`                                |
-| `theme`               | `theme`                 | Select theme (light or dark)                                                 | `"dark" \| "light"`                      | `undefined`                          |
+| Property              | Attribute               | Description                                                                  | Type                                     | Default                               |
+| --------------------- | ----------------------- | ---------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------- |
+| `active`              | `active`                | Is the alert currently active or not                                         | `boolean`                                | `false`                               |
+| `autoDismiss`         | `auto-dismiss`          | Close the alert automatically (recommended for passive, non-blocking alerts) | `boolean`                                | `false`                               |
+| `autoDismissDuration` | `auto-dismiss-duration` | Duration of autoDismiss (only used with `autoDismiss`)                       | `"fast" \| "medium" \| "slow"`           | `this .autoDismiss ? "medium" : null` |
+| `color`               | `color`                 | Color for the alert (will apply to top border and icon)                      | `"blue" \| "green" \| "red" \| "yellow"` | `"blue"`                              |
+| `icon`                | `icon`                  | specify if the alert should display an icon                                  | `boolean`                                | `false`                               |
+| `intlClose`           | `intl-close`            | string to override English close text                                        | `string`                                 | `TEXT.intlClose`                      |
+| `scale`               | `scale`                 | specify the scale of the button, defaults to m                               | `"l" \| "m" \| "s"`                      | `"m"`                                 |
+| `theme`               | `theme`                 | Select theme (light or dark)                                                 | `"dark" \| "light"`                      | `undefined`                           |
 
 ## Events
 

--- a/src/components/calcite-button/calcite-button.stories.js
+++ b/src/components/calcite-button/calcite-button.stories.js
@@ -1,9 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
 import {
   darkBackground,
   iconNames,
   parseReadme,
+  boolean
 } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -21,11 +22,11 @@ storiesOf("Button", module)
       )}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      round="${boolean("round", false)}"
-      floating="${boolean("floating", false)}"
+      ${boolean("round", false)}
+      ${boolean("floating", false)}
       href="${text("href", "")}"
-      loading="${boolean("loading", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
     >
    ${text("text", "button text here")}
     </calcite-button>
@@ -43,11 +44,11 @@ storiesOf("Button", module)
       )}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      round="${boolean("round", false)}"
-      floating="${boolean("floating", false)}"
+      ${boolean("round", false)}
+      ${boolean("floating", false)}
       href="${text("href", "")}"
-      loading="${boolean("loading", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
       icon-start="${select("icon-start", iconNames, iconNames[0])}">
       ${text("text", "button text here")}
     </calcite-button>
@@ -65,11 +66,11 @@ storiesOf("Button", module)
       )}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      round="${boolean("round", false)}"
-      floating="${boolean("floating", false)}"
+      ${boolean("round", false)}
+      ${boolean("floating", false)}
       href="${text("href", "")}"
-      loading="${boolean("loading", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
       icon-end="${select("icon-end", iconNames, iconNames[0])}">
       ${text("text", "button text here")}
     </calcite-button>
@@ -87,11 +88,11 @@ storiesOf("Button", module)
       )}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      round="${boolean("round", false)}"
-      floating="${boolean("floating", false)}"
+      ${boolean("round", false)}
+      ${boolean("floating", false)}
       href="${text("href", "")}"
-      loading="${boolean("loading", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
       icon-start="${select("icon-start", iconNames, iconNames[0])}"
       icon-end="${select("icon-end", iconNames, iconNames[0])}">
       ${text("text", "button text here")}
@@ -166,8 +167,8 @@ storiesOf("Button", module)
   <div class="sticky-example" style="position: -webkit-sticky;position: sticky;bottom: 10px;margin: 0 auto;">
   <calcite-button
   id="calcite-fab-tooltip"
-  round="${boolean("round", true)}"
-  floating="${boolean("floating", true)}"
+  ${boolean("round", true)}
+  ${boolean("floating", true)}
   width="${select("width", ["auto", "half", "full"], "auto")}"
   icon-start="${select("icon-start", iconNames, iconNames[0])}"
   appearance="${select("appearance", ["solid", "outline"], "solid")}"
@@ -203,8 +204,8 @@ storiesOf("Button", module)
 
     <div class="sticky-example" style="position: -webkit-sticky;position: sticky;bottom: 10px;margin: 0 auto;">
     <calcite-button
-    round="${boolean("round", true)}"
-    floating="${boolean("floating", true)}"
+    ${boolean("round", true)}
+    ${boolean("floating", true)}
     width="${select("width", ["auto", "half", "full"], "auto")}"
     icon-start="${select("icon-start", iconNames, iconNames[0])}"
     appearance="${select("appearance", ["solid", "outline"], "solid")}"
@@ -229,11 +230,11 @@ storiesOf("Button", module)
     )}"
     color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    round="${boolean("round", false)}"
-    floating="${boolean("floating", false)}"
+    ${boolean("round", false)}
+    ${boolean("floating", false)}
     href="${text("href", "")}"
-    loading="${boolean("loading", false)}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
     icon-start="${select("icon-start", iconNames, iconNames[0])}"
     icon-end="${select("icon-end", iconNames, iconNames[0])}"
     >
@@ -267,8 +268,8 @@ storiesOf("Button", module)
     <calcite-button
     theme="dark"
     id="calcite-fab-tooltip"
-    round="${boolean("round", true)}"
-    floating="${boolean("floating", true)}"
+    ${boolean("round", true)}
+    ${boolean("floating", true)}
     width="${select("width", ["auto", "half", "full"], "auto")}"
     icon-start="${select("icon-start", iconNames, iconNames[0])}"
     appearance="${select("appearance", ["solid", "outline"], "solid")}"
@@ -304,8 +305,8 @@ storiesOf("Button", module)
   <div class="sticky-example" style="position: -webkit-sticky;position: sticky;bottom: 10px;margin: 0 auto;">
   <calcite-button
   theme="dark"
-  round="${boolean("round", true)}"
-  floating="${boolean("floating", true)}"
+  ${boolean("round", true)}
+  ${boolean("floating", true)}
   width="${select("width", ["auto", "half", "full"], "auto")}"
   icon-start="${select("icon-start", iconNames, iconNames[0])}"
   appearance="${select("appearance", ["solid", "outline"], "solid")}"

--- a/src/components/calcite-card/calcite-card.stories.js
+++ b/src/components/calcite-card/calcite-card.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean, select } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -11,8 +11,8 @@ storiesOf("Card", module)
     () => `
     <div style="width:260px">
     <calcite-card
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
     <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
     <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -27,8 +27,8 @@ storiesOf("Card", module)
     () => `
     <div style="width:260px">
     <calcite-card
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
     <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
     <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -45,8 +45,8 @@ storiesOf("Card", module)
     () => `
     <div style="width:260px">
       <calcite-card
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
       <img slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">Untitled experience</h3>
@@ -61,8 +61,8 @@ storiesOf("Card", module)
     () => `
     <div style="width:260px">
       <calcite-card
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
       <img slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My perhaps multiline card title</h3>
@@ -80,8 +80,8 @@ storiesOf("Card", module)
     () => `
     <div style="width:260px">
       <calcite-card
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
       <img slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My great project that might wrap two lines</h3>
@@ -107,8 +107,8 @@ storiesOf("Card", module)
     () => `
     <div style="width:260px">
       <calcite-card
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
         <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
         <h3 slot="title">Portland Businesses</h3>
@@ -152,8 +152,8 @@ storiesOf("Card", module)
     <div style="width:260px">
     <calcite-card
       theme="dark"
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
     <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
     <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -169,8 +169,8 @@ storiesOf("Card", module)
     <div style="width:260px">
     <calcite-card
     theme="dark"
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
     <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
     <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -188,8 +188,8 @@ storiesOf("Card", module)
     <div style="width:260px">
       <calcite-card
       theme="dark"
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
       <img slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">Untitled experience</h3>
@@ -205,8 +205,8 @@ storiesOf("Card", module)
     <div style="width:260px">
       <calcite-card
       theme="dark"
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
       <img slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My perhaps multiline card title</h3>
@@ -225,8 +225,8 @@ storiesOf("Card", module)
     <div style="width:260px">
       <calcite-card
       theme="dark"
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
       <img slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My great project that might wrap two lines</h3>
@@ -253,8 +253,8 @@ storiesOf("Card", module)
     <div style="width:260px">
       <calcite-card
       theme="dark"
-      loading=${boolean("loading", false)}
-      selectable=${boolean("selectable", false)}
+      ${boolean("loading", false)}
+      ${boolean("selectable", false)}
       >
         <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
         <h3 slot="title">Portland Businesses</h3>

--- a/src/components/calcite-checkbox/calcite-checkbox.stories.js
+++ b/src/components/calcite-checkbox/calcite-checkbox.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean, select } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -11,9 +11,9 @@ storiesOf("Checkbox", module)
     () => `
     <label>
       <calcite-checkbox
-        checked=${boolean("checked", true)}
-        disabled=${boolean("disabled", false)}
-        indeterminate=${boolean("indeterminate", false)}
+        ${boolean("checked", true)}
+        ${boolean("disabled", false)}
+        ${boolean("indeterminate", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
       ></calcite-checkbox>
       Text for the checkbox
@@ -27,9 +27,9 @@ storiesOf("Checkbox", module)
     <label>
       <calcite-checkbox
         theme="dark"
-        checked=${boolean("checked", true)}
-        disabled=${boolean("disabled", false)}
-        indeterminate=${boolean("indeterminate", false)}
+        ${boolean("checked", true)}
+        ${boolean("disabled", false)}
+        ${boolean("indeterminate", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
       ></calcite-checkbox>
     </label>

--- a/src/components/calcite-chip/calcite-chip.stories.js
+++ b/src/components/calcite-chip/calcite-chip.stories.js
@@ -1,9 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, boolean } from "@storybook/addon-knobs";
+import { withKnobs, select } from "@storybook/addon-knobs";
 import {
   darkBackground,
   iconNames,
   parseReadme,
+  boolean
 } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -22,7 +23,7 @@ storiesOf("Chip", module)
       ["blue", "red", "yellow", "green", "grey"],
       "grey"
     )}"
-    dismissible="${boolean("dismissible", false)}"
+    ${boolean("dismissible", false)}
     >My great chip</calcite-chip>
     </div>
   `,
@@ -41,7 +42,7 @@ storiesOf("Chip", module)
       ["blue", "red", "yellow", "green", "grey"],
       "grey"
     )}"
-    dismissible="${boolean("dismissible", false)}"
+    ${boolean("dismissible", false)}
     >
     My great chip</calcite-chip>
     </div>
@@ -60,7 +61,7 @@ storiesOf("Chip", module)
       ["blue", "red", "yellow", "green", "grey"],
       "grey"
     )}"
-    dismissible="${boolean("dismissible", false)}"
+    ${boolean("dismissible", false)}
     >
     <img slot="chip-image" src="https://placekitten.com/50/50" />
     My great chip</calcite-chip>
@@ -81,7 +82,7 @@ storiesOf("Chip", module)
       ["blue", "red", "yellow", "green", "grey"],
       "grey"
     )}"
-    dismissible="${boolean("dismissible", false)}"
+    ${boolean("dismissible", false)}
     >My great chip</calcite-chip>
     </div>
   `,
@@ -100,7 +101,7 @@ storiesOf("Chip", module)
       ["blue", "red", "yellow", "green", "grey"],
       "grey"
     )}"
-    dismissible="${boolean("dismissible", false)}"
+    ${boolean("dismissible", false)}
     >My great chip</calcite-chip>
     </div>
   `,

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.js
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, number, select, boolean } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, number, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-dropdown-group/readme.md";
 import readme3 from "../calcite-dropdown-item/readme.md";
@@ -20,8 +20,8 @@ storiesOf("Dropdown", module)
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
-      disable-close-on-select="${boolean("disable close on select", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disable-close-on-select", false)}
+      ${boolean("disabled", false)}
     >
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group selection-mode="${select(
@@ -45,8 +45,8 @@ storiesOf("Dropdown", module)
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
-      disable-close-on-select="${boolean("disable close on select", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disable-close-on-select", false)}
+      ${boolean("disabled", false)}
     >
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group selection-mode="${select(
@@ -88,8 +88,8 @@ storiesOf("Dropdown", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
-    disable-close-on-select="${boolean("disable close on select", false)}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
   >
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group group-title="Select one">
@@ -118,8 +118,8 @@ storiesOf("Dropdown", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
-    disable-close-on-select="${boolean("disable close on select", false)}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
   >
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group selection-mode="none" group-title="Select one">
@@ -141,8 +141,8 @@ storiesOf("Dropdown", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
-    disable-close-on-select="${boolean("disable close on select", false)}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
   >
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group selection-mode="none" group-title="Select one">
@@ -165,8 +165,8 @@ storiesOf("Dropdown", module)
       scale="${select("scale", ["s", "m", "l"], "m")}"
        width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
-      disable-close-on-select="${boolean("disable close on select", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disable-close-on-select", false)}
+      ${boolean("disabled", false)}
     >
       <calcite-button slot="dropdown-trigger" theme="dark">Open Dropdown</calcite-button>
       <calcite-dropdown-group selection-mode="${select(
@@ -191,8 +191,8 @@ storiesOf("Dropdown", module)
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
-      disable-close-on-select="${boolean("disable close on select", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disable-close-on-select", false)}
+      ${boolean("disabled", false)}
     >
       <calcite-button theme="dark" slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group selection-mode="${select(
@@ -234,8 +234,8 @@ storiesOf("Dropdown", module)
     alignment="${select("alignment", ["start", "center", "end"], "start")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
-    disable-close-on-select="${boolean("disable close on select", false)}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
   >
     <calcite-button theme="dark" slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group group-title="Select one">
@@ -265,8 +265,8 @@ storiesOf("Dropdown", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["s", "m", "l"], "m")}"
     type="${select("type", ["click", "hover"], "click")}"
-    disable-close-on-select="${boolean("disable close on select", false)}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
   >
     <calcite-button theme="dark" slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group selection-mode="none" group-title="Select one">
@@ -289,8 +289,8 @@ storiesOf("Dropdown", module)
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
-      disable-close-on-select="${boolean("disable close on select", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disable-close-on-select", false)}
+      ${boolean("disabled", false)}
     >
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group selection-mode="${select(
@@ -315,8 +315,8 @@ storiesOf("Dropdown", module)
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["s", "m", "l"], "m")}"
       type="${select("type", ["click", "hover"], "click")}"
-      disable-close-on-select="${boolean("disable close on select", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disable-close-on-select", false)}
+      ${boolean("disabled", false)}
     >
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group group-title="First group">

--- a/src/components/calcite-icon/calcite-icon.stories.js
+++ b/src/components/calcite-icon/calcite-icon.stories.js
@@ -1,8 +1,9 @@
-import {withKnobs, select, boolean} from "@storybook/addon-knobs";
+import {withKnobs, select} from "@storybook/addon-knobs";
 import {
   darkBackground,
   iconNames,
-  parseReadme
+  parseReadme,
+  boolean
 } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
@@ -14,28 +15,29 @@ export default {
   parameters: { notes }
 };
 
-export const simple = () =>
-  `<calcite-icon icon="${select(
-    "icon",
-    iconNames,
-    iconNames[0]
-  )}" scale="${select("size", ["s", "m", "l"], "m")}" filled="${boolean(
-    "filled",
-    false
-  )}"></calcite-icon>`;
+export const simple = () => `
+  <calcite-icon
+    icon="${select("icon", iconNames, iconNames[0])}"
+    scale="${select("size", ["s", "m", "l"], "m")}"
+    ${boolean("filled", false)}
+  ></calcite-icon>
+`;
 
-export const RTL = () =>
-  `<calcite-icon dir="rtl" icon="arrowBoldLeft" mirror="${boolean(
-    "mirror",
-    false
-  )}"></calcite-icon>`;
+export const RTL = () => `
+  <calcite-icon
+    dir="rtl"
+    icon="arrowBoldLeft"
+    ${boolean("mirror", false)}
+  ></calcite-icon>
+`;
 
-export const darkMode = () =>
-  `<calcite-icon dir="rtl" icon="${select(
-    "icon",
-    iconNames,
-    iconNames[0]
-  )}" theme="dark"></calcite-icon>`;
+export const darkMode = () => `
+  <calcite-icon
+    dir="rtl"
+    icon="${select("icon", iconNames, iconNames[0])}"
+    theme="dark"
+  ></calcite-icon>
+`;
 
 darkMode.story = {
   parameters: {

--- a/src/components/calcite-input/calcite-input.stories.js
+++ b/src/components/calcite-input/calcite-input.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, boolean, text } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -48,14 +48,14 @@ storiesOf("Input", module)
       step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
-      loading="${boolean("loading", false)}"
-      clearable="${boolean("clearable", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
       value="${text("value", "")}"
       placeholder="${text("placeholder", "Placeholder text")}">
     </calcite-input>
     <calcite-input-message
-    active="${boolean("input-message-active", false)}"
+    ${boolean("input-message-active", false)}
     type="${select("input message type", ["default", "floating"], "default")}"
     status="${select(
       "input message status",
@@ -118,15 +118,15 @@ storiesOf("Input", module)
       step="${text("step", "", "Input")}"
       prefix-text="${text("prefix-text", "", "Input")}"
       suffix-text="${text("suffix-text", "", "Input")}"
-      loading="${boolean("loading", false, "Input")}"
-      autofocus="${boolean("autofocus", false, "Input")}"
-      required="${boolean("required", false, "Input")}"
+      ${boolean("loading", false, "Input")}
+      ${boolean("autofocus", false, "Input")}
+      ${boolean("required", false, "Input")}
       value="${text("value", "", "Input")}"
       placeholder="${text("placeholder", "Placeholder text", "Input")}">
     </calcite-input>
     <calcite-input-message
-    active="${boolean("active", true, "Input Message")}"
-    icon="${boolean("icon", true, "Input Message")}"
+    ${boolean("active", true, "Input Message")}
+    ${boolean("icon", true, "Input Message")}
     type="${select(
       "type",
       ["default", "floating"],
@@ -179,9 +179,9 @@ storiesOf("Input", module)
       step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
-      loading="${boolean("loading", false)}"
-      clearable="${boolean("clearable", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
       value="${text("value", "")}"
       placeholder="${text("placeholder", "Placeholder text")}">
     </calcite-input>
@@ -230,15 +230,15 @@ storiesOf("Input", module)
       step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
-      loading="${boolean("loading", false)}"
-      clearable="${boolean("clearable", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
       value="${text("value", "")}"
       placeholder="${text("placeholder", "Placeholder text")}">
       <calcite-button slot="input-action">${text("action button text", "Go")}</calcite-button>
     </calcite-input>
     <calcite-input-message
-    active="${boolean("input-message-active", false)}"
+    ${boolean("input-message-active", false)}
     type="${select("input message type", ["default", "floating"], "default")}"
     status="${select(
       "input message status",
@@ -265,14 +265,14 @@ storiesOf("Input", module)
     ${text("label text", "My great label")}
     <calcite-input
       type="textarea"
-      loading="${boolean("loading", false)}"
-      clearable="${boolean("clearable", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
       value="${text("value", "")}"
       placeholder="${text("placeholder", "Placeholder text")}">
     </calcite-input>
     <calcite-input-message
-    active="${boolean("input-message-active", false)}"
+    ${boolean("input-message-active", false)}
     type="${select("input message type", ["default", "floating"], "default")}"
     status="${select(
       "input message status",
@@ -326,14 +326,14 @@ storiesOf("Input", module)
       step="${text("step", "")}"
       prefix-text="${text("prefix-text", "")}"
       suffix-text="${text("suffix-text", "")}"
-      loading="${boolean("loading", false)}"
-      clearable="${boolean("clearable", false)}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
       value="${text("value", "")}"
       placeholder="${text("placeholder", "Placeholder text")}">
     </calcite-input>
     <calcite-input-message
-    active="${boolean("calcite-input-message-active", false)}"
+    ${boolean("calcite-input-message-active", false)}
     type="${select("input message type", ["default", "floating"], "default")}"
     status="${select(
       "input message status",

--- a/src/components/calcite-label/calcite-label.stories.js
+++ b/src/components/calcite-label/calcite-label.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, boolean, text } from "@storybook/addon-knobs";
+import { withKnobs } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);

--- a/src/components/calcite-link/calcite-link.stories.js
+++ b/src/components/calcite-link/calcite-link.stories.js
@@ -2,10 +2,9 @@ import { storiesOf } from "@storybook/html";
 import {
   withKnobs,
   text,
-  boolean,
   select
 } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import * as icons from "../../../node_modules/@esri/calcite-ui-icons";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -31,7 +30,7 @@ storiesOf("Link", module)
     Some wrapping text <calcite-link
       href="${text("href", "")}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disabled", false)}
     >
    ${text("text", "link text here")}</calcite-link>
    around the link
@@ -53,7 +52,7 @@ storiesOf("Link", module)
     Some wrapping text <calcite-link
       href="${text("href", "")}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disabled", false)}
       icon-start="${select("icon-start", iconNames, iconNames[0])}">
       ${text("text", "link text here")}</calcite-link>
       around the link
@@ -75,7 +74,7 @@ storiesOf("Link", module)
     Some wrapping text <calcite-link
       href="${text("href", "")}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disabled", false)}
       icon-end="${select("icon-end", iconNames, iconNames[0])}">
       ${text("text", "link text here")}</calcite-link>
       around the link
@@ -97,7 +96,7 @@ storiesOf("Link", module)
     Some wrapping text <calcite-link
       href="${text("href", "")}"
       color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      disabled="${boolean("disabled", false)}"
+      ${boolean("disabled", false)}
       icon-start="${select("icon-start", iconNames, iconNames[0])}"
       icon-end="${select("icon-end", iconNames, iconNames[0])}">
       ${text("text", "link text here")}</calcite-link>
@@ -121,7 +120,7 @@ storiesOf("Link", module)
     theme="dark"
     color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
     href="${text("href", "")}"
-    disabled="${boolean("disabled", false)}"
+    ${boolean("disabled", false)}
     icon="${select("icon", iconNames, iconNames[0])}"
     icon-position="${select("icon-position", ["start", "end"], "end")}">
     ${text("text", "link text here")}

--- a/src/components/calcite-loader/calcite-loader.stories.js
+++ b/src/components/calcite-loader/calcite-loader.stories.js
@@ -1,13 +1,11 @@
 import { storiesOf } from "@storybook/html";
 import {
   withKnobs,
-  text,
   number,
-  boolean,
   color,
   select,
 } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -24,7 +22,7 @@ storiesOf("Loader", module)
         "indeterminate"
       )}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      no-padding="${boolean("no-padding", false)}"
+      ${boolean("no-padding", false)}
       value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
     />
   `,
@@ -53,7 +51,7 @@ storiesOf("Loader", module)
         "indeterminate"
       )}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      no-padding="${boolean("no-padding", false)}"
+      ${boolean("no-padding", false)}
       value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
       active
       theme="dark" />
@@ -66,7 +64,7 @@ storiesOf("Loader", module)
     <calcite-loader
     type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    no-padding="${boolean("no-padding", false)}"
+    ${boolean("no-padding", false)}
     value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
       style="
         --calcite-loader-spot-light: ${color("spot-light", "#50ba5f")};

--- a/src/components/calcite-modal/calcite-modal.stories.js
+++ b/src/components/calcite-modal/calcite-modal.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/html';
-import { withKnobs, boolean, select, text, number } from '@storybook/addon-knobs'
-import { darkBackground, parseReadme } from '../../../.storybook/helpers';
+import { withKnobs, select, text, number } from '@storybook/addon-knobs'
+import { darkBackground, parseReadme, boolean } from '../../../.storybook/helpers';
 import readme from './readme.md';
 const notes = parseReadme(readme);
 
@@ -9,15 +9,15 @@ storiesOf('Modal', module)
   .add('Simple', () => {
     return `
       <calcite-modal
-        active="${boolean("active", true)}"
+        ${boolean("active", true)}
         color="${select("color", {blue: "blue", red: "red", none: null}, null)}"
         background-color="${select("background-color", ["white", "grey"], "white")}"
         scale="${select("scale", ["s", "m", "l"], "m")}"
         width="${select("width", ["s", "m", "l"], "s")}"
-        fullscreen="${boolean("fullscreen", false)}"
-        docked="${boolean("docked", false)}"
-        disable-escape="${boolean("disable-escape", false)}"
-        no-padding="${boolean("no-padding", false)}"
+        ${boolean("fullscreen", false)}
+        ${boolean("docked", false)}
+        ${boolean("disable-escape", false)}
+        ${boolean("no-padding", false)}
         close-label="${text("close-label", "Close")}"
       >
         <h3 slot="header">Small Modal</h3>
@@ -55,15 +55,15 @@ storiesOf('Modal', module)
     return `
       <calcite-modal
         theme="dark"
-        active="${boolean("active", true)}"
+        ${boolean("active", true)}
         color="${select("color", {blue: "blue", red: "red", none: null}, null)}"
         background-color="${select("background-color", ["white", "grey"], "white")}"
         scale="${select("scale", ["s", "m", "l"], "m")}"
         width="${select("width", ["s", "m", "l"], "s")}"
-        fullscreen="${boolean("fullscreen", false)}"
-        docked="${boolean("docked", false)}"
-        disable-escape="${boolean("disable-escape", false)}"
-        no-padding="${boolean("no-padding", false)}"
+        ${boolean("fullscreen", false)}
+        ${boolean("docked", false)}
+        ${boolean("disable-escape", false)}
+        ${boolean("no-padding", false)}
         close-label="${text("close-label", "Close")}"
       >
         <h3 slot="header">Small Modal</h3>

--- a/src/components/calcite-notice/calcite-notice.stories.js
+++ b/src/components/calcite-notice/calcite-notice.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, boolean } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -12,9 +12,9 @@ storiesOf("Notice", module)
     <div style="width:600px;max-width:100%;text-align:center;">
     <calcite-notice
     theme="light"
-    icon="${boolean("icon", true)}"
-    active="${boolean("active", true)}"
-    dismissible="${boolean("dismissible", true)}"
+    ${boolean("icon", true)}
+    ${boolean("active", true)}
+    ${boolean("dismissible", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["auto", "half", "full"], "auto")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
@@ -34,9 +34,9 @@ storiesOf("Notice", module)
     <div style="width:600px;max-width:100%;text-align:center;">
     <calcite-notice
     theme="dark"
-    icon="${boolean("icon", true)}"
-    active="${boolean("active", true)}"
-    dismissible="${boolean("dismissible", false)}"
+    ${boolean("icon", true)}
+    ${boolean("active", true)}
+    ${boolean("dismissible", false)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["auto", "half", "full"], "auto")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
@@ -55,9 +55,9 @@ storiesOf("Notice", module)
       <div dir="rtl" style="width:600px;max-width:100%;text-align:center;">
       <calcite-notice
       theme="light"
-      icon="${boolean("icon", true)}"
-      active="${boolean("active", true)}"
-      dismissible="${boolean("dismissible", true)}"
+      ${boolean("icon", true)}
+      ${boolean("active", true)}
+      ${boolean("dismissible", true)}
       width="${select("width", ["auto", "half", "full"], "auto")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       color="${select(

--- a/src/components/calcite-popover/calcite-popover.stories.js
+++ b/src/components/calcite-popover/calcite-popover.stories.js
@@ -1,12 +1,11 @@
 import { storiesOf } from "@storybook/html";
 import {
   withKnobs,
-  boolean,
   select,
   number,
   text
 } from "@storybook/addon-knobs";
-import { parseReadme } from "../../../.storybook/helpers";
+import { parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -53,14 +52,14 @@ storiesOf("Popover", module)
         ${referenceElementHTML}
         <calcite-popover
           theme="light"
-          close-button="${boolean("close-button", false)}"
-          disable-flip="${boolean("disable-flip", false)}"
-          disable-pointer="${boolean("disable-pointer", false)}"
+          ${boolean("close-button", false)}
+          ${boolean("disable-flip", false)}
+          ${boolean("disable-pointer", false)}
           reference-element="reference-element"
           placement="${select("placement", calcite_placements, "auto")}"
           offset-distance="${number("offset-distance", 6)}"
           offset-skidding="${number("offset-skidding", 0)}"
-          open="${boolean("open", true)}"
+          ${boolean("open", true)}
           text-close="${text("text-close", "Close")}"
         >
           ${contentHTML}
@@ -78,14 +77,14 @@ storiesOf("Popover", module)
         ${referenceElementHTML}
         <calcite-popover
           theme="dark"
-          close-button="${boolean("close-button", false)}"
-          disable-flip="${boolean("disable-flip", false)}"
-          disable-pointer="${boolean("disable-pointer", false)}"
+          ${boolean("close-button", false)}
+          ${boolean("disable-flip", false)}
+          ${boolean("disable-pointer", false)}
           reference-element="reference-element"
           placement="${select("placement", calcite_placements, "auto")}"
           offset-distance="${number("offset-distance", 6)}"
           offset-skidding="${number("offset-skidding", 0)}"
-          open="${boolean("open", true)}"
+          ${boolean("open", true)}
           text-close="${text("text-close", "Close")}"
         >
           ${contentHTML}

--- a/src/components/calcite-popover/readme.md
+++ b/src/components/calcite-popover/readme.md
@@ -45,7 +45,7 @@
 
 Type: `Promise<void>`
 
-### `setFocus(focusId?: "close-button") => Promise<void>`
+### `setFocus(focusId?: FocusId) => Promise<void>`
 
 #### Returns
 

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.js
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.js
@@ -1,8 +1,7 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, boolean } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
-import readme2 from "../calcite-radio-button/readme.md";
 
 const notes = parseReadme(readme);
 
@@ -13,8 +12,8 @@ storiesOf("Radio Button Group", module)
     () => `
     <calcite-radio-button-group
       name="simple"
-      disabled="${boolean("disabled", false)}"
-      hidden="${boolean("hidden", false)}"
+      ${boolean("disabled", false)}
+      ${boolean("hidden", false)}
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >
@@ -32,8 +31,8 @@ storiesOf("Radio Button Group", module)
     <calcite-radio-button-group
       theme="dark"
       name="dark"
-      disabled="${boolean("disabled", false)}"
-      hidden="${boolean("hidden", false)}"
+      ${boolean("disabled", false)}
+      ${boolean("hidden", false)}
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >

--- a/src/components/calcite-radio-button/calcite-radio-button.stories.js
+++ b/src/components/calcite-radio-button/calcite-radio-button.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, boolean, text } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
 const notes = parseReadme(readme);
@@ -11,10 +11,10 @@ storiesOf("Radio Button", module)
     "Light Theme",
     () => `
       <calcite-radio-button
-        checked="${boolean("checked", false)}"
-        disabled="${boolean("disabled", false)}"
-        hidden="${boolean("hidden", false)}"
-        focused="${boolean("focused", false)}"
+        ${boolean("checked", false)}
+        ${boolean("disabled", false)}
+        ${boolean("hidden", false)}
+        ${boolean("focused", false)}
         name="simple"
         scale="${select("scale", ["s", "m", "l"], "m")}"
         value="value"
@@ -28,10 +28,10 @@ storiesOf("Radio Button", module)
     "Dark Theme",
     () => `
     <calcite-radio-button
-      checked="${boolean("checked", false)}"
-      disabled="${boolean("disabled", false)}"
-      hidden="${boolean("hidden", false)}"
-      focused="${boolean("focused", false)}"
+      ${boolean("checked", false)}
+      ${boolean("disabled", false)}
+      ${boolean("hidden", false)}
+      ${boolean("focused", false)}
       name="dark"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       theme="dark"

--- a/src/components/calcite-scrim/calcite-scrim.stories.js
+++ b/src/components/calcite-scrim/calcite-scrim.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -12,7 +12,7 @@ storiesOf("Scrim", module)
     <div
     style="position: relative; width: 400px; height: 400px; overflow: auto;"
   ><calcite-scrim
-      loading="${boolean("loading", false)}"
+      ${boolean("loading", false)}
     >
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       <ul>
@@ -32,7 +32,7 @@ storiesOf("Scrim", module)
     style="position: relative; width: 400px; height: 400px; overflow: auto;"
   ><calcite-scrim
       theme="dark"
-      loading="${boolean("loading", false)}"
+      ${boolean("loading", false)}
     >
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       <ul>

--- a/src/components/calcite-slider/calcite-slider.stories.js
+++ b/src/components/calcite-slider/calcite-slider.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/html';
-import { withKnobs, text, number, boolean, array } from '@storybook/addon-knobs'
-import { darkBackground, parseReadme } from '../../../.storybook/helpers';
+import { withKnobs, text, number, array } from '@storybook/addon-knobs'
+import { darkBackground, parseReadme, boolean } from '../../../.storybook/helpers';
 import readme from './readme.md';
 const notes = parseReadme(readme);
 
@@ -13,13 +13,13 @@ storiesOf('Slider', module)
       value="${number('value', 50)}"
       step="${number('step', 1)}"
       label="${text('label', 'Temperature')}"
-      disabled="${boolean('disabled', false)}"
-      label-handles="${boolean('label-handles', false)}"
-      label-ticks="${boolean('label-ticks', false)}"
+      ${boolean('disabled', false)}
+      ${boolean('label-handles', false)}
+      ${boolean('label-ticks', false)}
       ticks="${number('ticks', undefined)}
       page-step="${number('page-step', false)}"
-      precise="${boolean('precise', false)}"
-      snap="${boolean('snap', true)}"
+      ${boolean('precise', false)}
+      ${boolean('snap', true)}
     ></calcite-slider>
   `, { notes })
   .add('Range', () => `
@@ -31,11 +31,11 @@ storiesOf('Slider', module)
       max-label="${text('max-label', 'Temperature, upper bound')}"
       max-value="${number('max-value', 75)}"
       step="${number('step', 1)}"
-      label-handles="${boolean('label-handles', false)}"
-      label-ticks="${boolean('label-ticks', false)}"
+      ${boolean('label-handles', false)}
+      ${boolean('label-ticks', false)}
       ticks="${number('ticks', 20)}"
-      precise="${boolean('precise', false)}"
-      snap="${boolean('snap', true)}"
+      ${boolean('precise', false)}
+      ${boolean('snap', true)}
     ></calcite-slider>
   `, { notes })
   .add('Histogram', () => {

--- a/src/components/calcite-split-button/calcite-split-button.stories.js
+++ b/src/components/calcite-split-button/calcite-split-button.stories.js
@@ -1,9 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, text, select, boolean } from "@storybook/addon-knobs";
+import { withKnobs, text, select } from "@storybook/addon-knobs";
 import {
   darkBackground,
   iconNames,
   parseReadme,
+  boolean
 } from "../../../.storybook/helpers";
 import * as icons from "../../../node_modules/@esri/calcite-ui-icons";
 import readme from "./readme.md";
@@ -18,8 +19,8 @@ storiesOf("Split Button", module)
     <calcite-split-button
         color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
         scale="${select("size", ["s", "m", "l"], "m")}"
-        loading="${boolean("loading", false)}"
-        disabled="${boolean("disabled", false)}"
+        ${boolean("loading", false)}
+        ${boolean("disabled", false)}
         primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
         primary-label="${text("primary-label", "Primary Option")}"
@@ -44,8 +45,8 @@ storiesOf("Split Button", module)
     <calcite-split-button
         color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
         scale="${select("size", ["s", "m", "l"], "m")}"
-        loading="${boolean("loading", false)}"
-        disabled="${boolean("disabled", false)}"
+        ${boolean("loading", false)}
+        ${boolean("disabled", false)}
         primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
         primary-label="${text("primary-label", "Primary Option")}"
@@ -70,8 +71,8 @@ storiesOf("Split Button", module)
     <calcite-split-button
         color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
         scale="${select("size", ["s", "m", "l"], "m")}"
-        loading="${boolean("loading", false)}"
-        disabled="${boolean("disabled", false)}"
+        ${boolean("loading", false)}
+        ${boolean("disabled", false)}
         primary-icon-start="${select("primary-icon-end", iconNames, iconNames[0])}"
         primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
@@ -98,8 +99,8 @@ storiesOf("Split Button", module)
       <calcite-split-button
           color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
           scale="${select("size", ["s", "m", "l"], "m")}"
-          loading="${boolean("loading", false)}"
-          disabled="${boolean("disabled", false)}"
+          ${boolean("loading", false)}
+          ${boolean("disabled", false)}
           primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
           primary-text="${text("primary-text", "Primary Option")}"
           dropdown-label="${text("dropdown-label", "Additional Options")}"
@@ -124,8 +125,8 @@ storiesOf("Split Button", module)
     <calcite-split-button
         color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
         scale="${select("size", ["s", "m", "l"], "m")}"
-        loading="${boolean("loading", false)}"
-        disabled="${boolean("disabled", false)}"
+        ${boolean("loading", false)}
+        ${boolean("disabled", false)}
         primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
         dropdown-label="${text("dropdown-label", "Additional Options")}"

--- a/src/components/calcite-stepper/calcite-stepper.stories.js
+++ b/src/components/calcite-stepper/calcite-stepper.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean, select, text } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-stepper-item/readme.md";
 
@@ -17,8 +17,8 @@ storiesOf("Stepper", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    numbered="${boolean("numbered", true)}"
-    icon="${boolean("icon", true)}">
+    ${boolean("numbered", true)}
+    ${boolean("icon", true)}"
     <calcite-stepper-item item-title="${text(
       "item-1-title",
       "Choose method"
@@ -56,8 +56,8 @@ storiesOf("Stepper", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    numbered="${boolean("numbered", true)}"
-    icon="${boolean("icon", true)}">
+    ${boolean("numbered", true)}
+    ${boolean("icon", true)}"
     <calcite-stepper-item item-title="${text(
       "item-1-title",
       "Choose method"
@@ -93,8 +93,8 @@ storiesOf("Stepper", module)
     scale="${select("scale", ["s", "m", "l"], "m")}"
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    numbered="${boolean("numbered", true)}"
-    icon="${boolean("icon", true)}">
+    ${boolean("numbered", true)}
+    ${boolean("icon", true)}"
     <calcite-stepper-item item-title="${text(
       "item-1-title",
       "Choose method"
@@ -131,8 +131,8 @@ storiesOf("Stepper", module)
       <div dir="rtl">
       <calcite-stepper
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-      numbered="${boolean("numbered", true)}"
-      icon="${boolean("icon", true)}">
+      ${boolean("numbered", true)}
+      ${boolean("icon", true)}"
       <calcite-stepper-item item-title="${text(
         "item-1-title",
         "Choose method"

--- a/src/components/calcite-switch/calcite-switch.stories.js
+++ b/src/components/calcite-switch/calcite-switch.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean, select } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -13,7 +13,7 @@ storiesOf("Switch", module)
       <calcite-switch
         name="setting"
         value="enabled"
-        switched="${boolean("switched", true)}"
+        ${boolean("switched", true)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
         color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
@@ -31,7 +31,7 @@ storiesOf("Switch", module)
         theme="dark"
         name="setting"
         value="enabled"
-        switched="${boolean("switched", true)}"
+        ${boolean("switched", true)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
         color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
@@ -51,7 +51,7 @@ storiesOf("Switch", module)
         dir="rtl"
         name="setting"
         value="enabled"
-        switched="${boolean("switched", true)}"
+        ${boolean("switched", true)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
         color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>

--- a/src/components/calcite-tooltip/calcite-tooltip.stories.js
+++ b/src/components/calcite-tooltip/calcite-tooltip.stories.js
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
 import {
   withKnobs,
-  boolean,
   select,
   number
 } from "@storybook/addon-knobs";
-import { parseReadme } from "../../../.storybook/helpers";
+import { parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
@@ -50,7 +49,7 @@ storiesOf("Tooltip", module)
           placement="${select("placement", calcite_placements, "auto")}"
           offset-distance="${number("offset-distance", 6)}"
           offset-skidding="${number("offset-skidding", 0)}"
-          open="${boolean("open", true)}"
+          ${boolean("open", true)}
         >
           ${contentHTML}
         </calcite-tooltip>
@@ -71,7 +70,7 @@ storiesOf("Tooltip", module)
           placement="${select("placement", calcite_placements, "auto")}"
           offset-distance="${number("offset-distance", 6)}"
           offset-skidding="${number("offset-skidding", 0)}"
-          open="${boolean("open", true)}"
+          ${boolean("open", true)}
         >
           ${contentHTML}
         </calcite-tooltip>

--- a/src/components/calcite-tree/calcite-tree.stories.js
+++ b/src/components/calcite-tree/calcite-tree.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/html';
-import { withKnobs, select, boolean } from '@storybook/addon-knobs'
-import { darkBackground, parseReadme } from '../../../.storybook/helpers';
+import { withKnobs, select } from '@storybook/addon-knobs'
+import { darkBackground, parseReadme, boolean } from '../../../.storybook/helpers';
 import readme from './readme.md';
 const notes = parseReadme(readme);
 const treeItems = `
@@ -43,7 +43,7 @@ storiesOf('Tree', module)
   .addDecorator(withKnobs)
   .add('Simple', () => `
     <calcite-tree
-      lines="${boolean("lines", false)}"
+      ${boolean("lines", false)}
       selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
       size="${select("size", ["s", "m"], "m")}"
     >
@@ -53,7 +53,7 @@ storiesOf('Tree', module)
   .add('Dark mode', () => `
     <calcite-tree
       theme="dark"
-      lines="${boolean("lines", false)}"
+      ${boolean("lines", false)}
       selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
       size="${select("size", ["s", "m"], "m")}"
     >


### PR DESCRIPTION
This fixes a lot of the different stories. Essentially a storybook update broke some of our stories where components were using the `boolean` knob. This knob has never really functioned how we want it to (ie it renders `attr=false` rather than just not being there...). 

I've created a storybook helper which starts up a boolean knob and returns the correct prop so rather than getting `attr="true" | attr="false` you'll get `attr` or nothing.