### PR TITLE
chore: add GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.md
+++ b/.github/ISSUE_TEMPLATE/accessibility.md
@@ -1,0 +1,21 @@
+---
+name: Accessibility
+about: Report an accessibility issue in a component.
+title: "A11y: "
+labels: a11y, bug 🐞, 0 - new, p - high :point_up_2:
+assignees: ""
+---
+
+### Summary
+
+### Actual Behavior
+
+### Expected Behavior
+
+### Reproduction Steps
+
+1.
+
+### Relevant Info <!--(e.g. Browser, OS, Mobile)-->
+
+### Working W3C Example/Tutorial <!--(Link to valid w3c example for reference)-->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug
+about: Report a bug in a component.
+title: "Bug: "
+labels: bug 🐞, 0 - new
+assignees: ""
+---
+
+### Summary
+
+### Actual Behavior
+
+### Expected Behavior
+
+### Reproduction Steps
+
+1.
+
+### Relevant Info <!--(e.g. Browser, OS, Mobile)-->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,13 @@
+---
+name: Documentation
+about: Report issues with documentation.
+title: "Docs: "
+labels: docs 📓, 0 - new
+assignees: ""
+---
+
+### Description <!--(e.g. Helpful Details)-->
+
+### Which Component
+
+### Resources <!--(e.g. code snippets)-->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,17 @@
+---
+name: Enhancement
+about: Request for a feature to be added to an existing component.
+title: "Enhancement: "
+labels: enhancement ✨, 0 - new
+assignees: ""
+---
+
+### Description
+
+### Acceptance Criteria <!--(a.k.a. Requirements, Desired new behavior)-->
+
+### Relevant Info <!--(e.g. Dependencies, Blockers, Helpful Details)-->
+
+#### Which Component
+
+#### Example Use Case

--- a/.github/ISSUE_TEMPLATE/new-component.md
+++ b/.github/ISSUE_TEMPLATE/new-component.md
@@ -1,0 +1,17 @@
+---
+name: New Component
+about: Request for a new component to be added.
+title: "New Component: "
+labels: new component 🆕, 0 - new
+assignees: ""
+---
+
+### Description
+
+#### User Stories
+
+### Acceptance Criteria <!--(a.k.a. Requirements)-->
+
+#### Out of Scope <!--(anything not v1)-->
+
+### Helpful Details

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Request for information - not code changes.
+title: "Question: "
+labels: question❔, 0 - new
+assignees: ""
+---
+
+### Question
+
+### Helpful Details <!--(e.g. Context, Topic)-->

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,11 @@
+---
+name: Research
+about: Request an investigation into a specific topic.
+title: "Research: "
+labels: 0 - new, research 🔬
+assignees: ""
+---
+
+### Background <!-- What's the topic? What info do we already have? -->
+
+### Desired Outcome <!-- What additional information do we need about this topic? -->

--- a/.github/ISSUE_TEMPLATE/tooling.md
+++ b/.github/ISSUE_TEMPLATE/tooling.md
@@ -1,0 +1,13 @@
+---
+name: Tooling
+about: Request improvements to our component workflow.
+title: "Tooling: "
+labels: tooling 🛠️, 0 - new
+assignees: ""
+---
+
+## Summary <!-- pain point -->
+
+## Measure of Success <!-- desired outcome -->
+
+### Resources <!--(e.g. links to libraries or code snippets)-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+**Related Issue:** #
+
+## Summary
+
+<!--
+If this is component-related, please verify that:
+
+- [ ] feature or fix has a corresponding test
+- [ ] changes have been tested with demo page in Edge
+-->

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true


### PR DESCRIPTION
Adds issue/PR templates to help keep contributions consistent.

Labels from templates may need tweaking after installing since I'm not sure if they'll match as is. Another option is to get rid of emojis in labels to make it easier to keep these in sync.