### PR TITLE
chore: add info about conventional commits to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,19 @@
 ## Summary
 
 <!--
+
+Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.
+
+Note: If your PR only has one commit and it is NOT semantic, you will need to either
+
+a. add another commit and wait for the check to update
+b. proceed to squash merge, but make sure the commit message is the same as the title.
+
+This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)
+
 If this is component-related, please verify that:
 
 - [ ] feature or fix has a corresponding test
 - [ ] changes have been tested with demo page in Edge
+
 -->


### PR DESCRIPTION
This adds info on the commit conventions we want to follow in PRs for future contributions, as well as extra details on a minor issue that may be confusing with the [`semantic-pull-requests`](https://github.com/zeke/semantic-pull-requests/) check.