### PR TITLE
build(deps): move @types/color as a dependency so the public types resolve properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5349,7 +5349,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.1.tgz",
       "integrity": "sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==",
-      "dev": true,
       "requires": {
         "@types/color-convert": "*"
       }
@@ -5358,7 +5357,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
-      "dev": true,
       "requires": {
         "@types/color-name": "*"
       }
@@ -5366,8 +5364,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",
-    "@popperjs/core": "^2.4.4"
+    "@popperjs/core": "^2.4.4",
+    "@types/color": "3.0.1"
   },
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
@@ -59,7 +60,6 @@
     "@storybook/cli": "5.3.19",
     "@storybook/html": "5.3.19",
     "@storybook/storybook-deployer": "2.8.6",
-    "@types/color": "3.0.1",
     "@types/jest": "25.2.3",
     "@types/jest-axe": "^3.2.2",
     "@types/puppeteer": "1.20.2",


### PR DESCRIPTION
v1.0.0-beta.34 will cause a build issue in a consuming Stencil project unless `@types/color` is installed locally.