### PR TITLE
feat(color): add appearance property to support embedded use cases

### DIFF
--- a/src/components/calcite-color/calcite-color.e2e.ts
+++ b/src/components/calcite-color/calcite-color.e2e.ts
@@ -12,6 +12,10 @@ describe("calcite-color", () => {
   it("reflects", async () =>
     reflects("calcite-color", [
       {
+        propertyName: "appearance",
+        value: "minimal"
+      },
+      {
         propertyName: "scale",
         value: "m"
       },
@@ -25,6 +29,10 @@ describe("calcite-color", () => {
 
   it("has defaults", async () =>
     defaults("calcite-color", [
+      {
+        propertyName: "appearance",
+        defaultValue: "default"
+      },
       {
         propertyName: "scale",
         defaultValue: "m"

--- a/src/components/calcite-color/calcite-color.scss
+++ b/src/components/calcite-color/calcite-color.scss
@@ -4,14 +4,10 @@ $gap: 8px;
 $gap--small: 4px;
 $gap--large: 12px;
 
-:host {
-  border: 1px solid var(--calcite-ui-border-1);
-  display: inline-block;
-  background-color: var(--calcite-ui-foreground-1);
-}
-
 :host([scale="s"]) {
-  width: 156px;
+  .container {
+    width: 156px;
+  }
 
   .saved-colors {
     grid-template-columns: repeat(auto-fill, minmax(20px, 1fr));
@@ -32,11 +28,15 @@ $gap--large: 12px;
 }
 
 :host([scale="m"]) {
-  width: 272px;
+  .container {
+    width: 272px;
+  }
 }
 
 :host([scale="l"]) {
-  width: 420px;
+  .container {
+    width: 420px;
+  }
 
   .color-field-and-slider {
     margin-bottom: -20px;
@@ -73,6 +73,18 @@ $gap--large: 12px;
   .color-mode-container {
     flex-grow: 0;
   }
+}
+
+:host([appearance="minimal"]) {
+  .container {
+    border: none;
+  }
+}
+
+.container {
+  display: inline-block;
+  border: 1px solid var(--calcite-ui-border-1);
+  background-color: var(--calcite-ui-foreground-1);
 }
 
 .color-field-and-slider {

--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -4,7 +4,6 @@ import {
   Event,
   EventEmitter,
   h,
-  Host,
   Method,
   Prop,
   State,
@@ -47,6 +46,9 @@ export class CalciteColor {
   //  Public properties
   //
   //--------------------------------------------------------------------------
+
+  /** specify the appearance - default (containing border), or minimal (no containing border) */
+  @Prop({ reflect: true }) appearance: "default" | "minimal" = "default";
 
   /**
    * Internal prop for advanced use-cases.
@@ -348,7 +350,7 @@ export class CalciteColor {
     const elementDir = getElementDir(el);
 
     return (
-      <Host>
+      <div class={CSS.container}>
         <canvas
           class={{
             [CSS.colorFieldAndSlider]: true,
@@ -437,7 +439,7 @@ export class CalciteColor {
             ]}
           </div>
         </div>
-      </Host>
+      </div>
     );
   }
 

--- a/src/components/calcite-color/resources.ts
+++ b/src/components/calcite-color/resources.ts
@@ -1,6 +1,7 @@
 import Color from "color";
 
 export const CSS = {
+  container: "container",
   controlSection: "control-section",
   hexOptions: "color-hex-options",
   section: "section",


### PR DESCRIPTION
**Related Issue:** #750 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Adds `appearance` prop for color component. The value can be `default` (border) or `minimal` (borderless).
