### PR TITLE
fix(radio-group): Fix for label alignment

### DIFF
--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -36,7 +36,7 @@
   display: flex;
   flex-direction: column;
   cursor: pointer;
-  margin: 0 0 $baseline 0;
+  margin: 0 0 var(--calcite-label-margin-bottom, $baseline) 0;
 }
 
 :host([layout="inline"]) label {
@@ -68,8 +68,7 @@
 }
 
 // status
-$inputStatusColors: "invalid" var(--calcite-ui-red-1),
-  "valid" var(--calcite-ui-text-2), "idle" var(--calcite-ui-text-2);
+$inputStatusColors: "invalid" var(--calcite-ui-red-1), "valid" var(--calcite-ui-text-2), "idle" var(--calcite-ui-text-2);
 
 @each $statusColor in $inputStatusColors {
   $name: nth($statusColor, 1);


### PR DESCRIPTION
**Related Issue:** None

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Fix for label misalignment in `calcite-radio-group` caused by removing an optional css var in `calcite-label` cc @eriklharper 