### PR TITLE
feat: add custom element bundle for tree-shaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4029,12 +4029,12 @@
       "dev": true
     },
     "@stencil/core": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.16.3.tgz",
-      "integrity": "sha512-58AwSCktkDKXc45U0Q+AXvWtmEAZs37DOt9SC2LEypYL6YnVHGiL2lekbvA5R3JYzPFVasg+vmDHVouqSr/zMA==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.17.2.tgz",
+      "integrity": "sha512-jNEpBxoQFk6J1kSmm84AL/qgN0hySmKN5FZ0Pr16RAZU2TwKRLE1W2V8GcJXOFqd3yDVV+/4Fmyl1DD74/zbiQ==",
       "dev": true,
       "requires": {
-        "typescript": "3.9.6"
+        "typescript": "3.9.7"
       }
     },
     "@stencil/sass": {
@@ -23625,9 +23625,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "npm run copy-icons && stencil build",
+    "postbuild": "cpy dist/custom-elements/index.js dist/custom-elements/ --rename index.mjs",
     "copy-icons": "cpy ./node_modules/@esri/calcite-ui-icons/js/*.json ./src/components/calcite-icon/assets",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
     "start": "npm run copy-icons && stencil build --dev --watch --serve",
@@ -48,7 +49,7 @@
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "^2.1.0",
     "@esri/calcite-ui-icons": "^3.8.0",
-    "@stencil/core": "^1.16.3",
+    "@stencil/core": "^1.17.2",
     "@stencil/sass": "^1.3.2",
     "@stencil/state-tunnel": "^1.0.1",
     "@storybook/addon-a11y": "5.3.19",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -42,6 +42,7 @@ export const config: Config = {
   ],
   outputTargets: [
     { type: "dist-hydrate-script" },
+    { type: "dist-custom-elements-bundle" },
     { type: "dist" },
     { type: "docs-readme" },
     { type: "custom", name: "preact", generator: generatePreactTypes },


### PR DESCRIPTION
chore: update @stencil/core to v1.17.2

**Related Issue:** #485

## Summary

I've been working on how to use calcite-components in rollup, and I think I've got a solution. To make it work, this pr uses the `dist-custom-elements-bundle` output target to generate a tree-shakable bundle of our components. This can then be imported into a rollup file and only the components that are used will be bundled into your app. Once this is published on npm I'll open an pr onto [calcite-components-examples](https://github.com/arcgis/calcite-components-examples/) with a working rollup example. 

For some reason, rollup will choke on the custom elements bundle (thinking it's not ESM and trying to wrap it) unless it's file extension is `.mjs`. This is a problem we may want to request stencil update. For now I've added a postbuild command that saves a copy of the file to `index.mjs`. 

I've also updated @stencil/core as part of this change. 


