### PR TITLE
test: update path to prerender config

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -49,7 +49,7 @@ export const config: Config = {
     {
       type: "www",
       baseUrl: "https://stenciljs.com/",
-      prerenderConfig: "./prerender.config.js",
+      prerenderConfig: "./prerender.config.ts",
       copy: [{ src: "demos", dest: "demos" }],
       serviceWorker: {
         unregister: true


### PR DESCRIPTION
**Related Issue:** #781

## Summary

For some reason bumping `@stencil/core` exposed this bad link to the prerender config. Updating the path so it matches the actual prerender config file name fixes the issue.


<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
