### PR TITLE
fix(storybook): fix stepper storybook

### DIFF
--- a/src/components/calcite-popover/readme.md
+++ b/src/components/calcite-popover/readme.md
@@ -65,10 +65,6 @@ Type: `Promise<void>`
 
 ## Dependencies
 
-### Used by
-
-- [calcite-flow-item](../calcite-flow-item)
-
 ### Depends on
 
 - [calcite-icon](../calcite-icon)
@@ -78,7 +74,6 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   calcite-popover --> calcite-icon
-  calcite-flow-item --> calcite-popover
   style calcite-popover fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/calcite-stepper/calcite-stepper.stories.ts
+++ b/src/components/calcite-stepper/calcite-stepper.stories.ts
@@ -18,7 +18,7 @@ storiesOf("components|Stepper", module)
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("numbered", true)}
-    ${boolean("icon", true)}"
+    ${boolean("icon", true)}">
     <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
       "item-1-subtitle",
       "Add members without sending invitations"
@@ -54,7 +54,7 @@ storiesOf("components|Stepper", module)
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("numbered", true)}
-    ${boolean("icon", true)}"
+    ${boolean("icon", true)}">
     <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
       "item-1-subtitle",
       "Add members without sending invitations"
@@ -88,7 +88,7 @@ storiesOf("components|Stepper", module)
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("numbered", true)}
-    ${boolean("icon", true)}"
+    ${boolean("icon", true)}">
     <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
       "item-1-subtitle",
       "Add members without sending invitations"
@@ -123,7 +123,7 @@ storiesOf("components|Stepper", module)
       <calcite-stepper
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       ${boolean("numbered", true)}
-      ${boolean("icon", true)}"
+      ${boolean("icon", true)}">
       <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
       "item-1-subtitle",
       "Add members without sending invitations"


### PR DESCRIPTION

**Related Issue:** # None

## Summary
The storybook for stepper had some wrongly placed closing tags.

This also commits an update to generated readme.
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
