### PR TITLE
Document that you can pass additional attributes like target and type to <calcite-button>

### DIFF
--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -4,6 +4,11 @@ You can programmatically focus a `calcite-button` with the `setFocus()` method:
 
 `<div onclick=document.querySelector('#my-button').setFocus()>Focus!</div>`
 
+Any additional attributes set on `<calcite-button>` are passed to the internal `<a>` or `<button>` tag. For example:
+
+- `<calcite-button href="https://github.com/esri/calcite-components target="_blank">Calcite Components on GitHub</calcite-button>` would set `target="_blank` On the internal `<a>`.
+- `<calcite-button type="submit">Submit</calcite-button>` would set `type="submit"` On the internal `<button>`.
+
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -4,11 +4,6 @@ You can programmatically focus a `calcite-button` with the `setFocus()` method:
 
 `<div onclick=document.querySelector('#my-button').setFocus()>Focus!</div>`
 
-Any additional attributes set on `<calcite-button>` are passed to the internal `<a>` or `<button>` tag. For example:
-
-- `<calcite-button href="https://github.com/esri/calcite-components target="_blank">Calcite Components on GitHub</calcite-button>` would set `target="_blank` On the internal `<a>`.
-- `<calcite-button type="submit">Submit</calcite-button>` would set `type="submit"` On the internal `<button>`.
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-button/usage/internals.md
+++ b/src/components/calcite-button/usage/internals.md
@@ -1,0 +1,6 @@
+#### Passing attributes to internal components
+
+Any additional attributes set on `<calcite-button>` are passed to the internal `<a>` or `<button>` tag. For example:
+
+- `<calcite-button href="https://github.com/esri/calcite-components target="_blank">Calcite Components on GitHub</calcite-button>` would set `target="_blank` On the internal `<a>`.
+- `<calcite-button type="submit">Submit</calcite-button>` would set `type="submit"` On the internal `<button>`.


### PR DESCRIPTION
## Summary

This PR adds documentation that extra attributes passed to `<calcite-button>` are passed to the internal `<a>` or `<button>`. I had an entire PR ready to add support for `target` until I ran the tests and found out that it already does it.
