### PR TITLE
fix(calcite-icon): Fixing issue where calcite-icon being rendered in …

### DIFF
--- a/src/components/calcite-icon/calcite-icon.scss
+++ b/src/components/calcite-icon/calcite-icon.scss
@@ -3,15 +3,21 @@
 }
 :host([scale="s"]) {
   height: 16px;
+  min-height: 16px;
   width: 16px;
+  min-width: 16px;
 }
 :host([scale="m"]) {
   height: 24px;
+  min-height: 24px;
   width: 24px;
+  min-width: 24px;
 }
 :host([scale="l"]) {
   height: 32px;
+  min-height: 32px;
   width: 32px;
+  min-width: 32px;
 }
 
 .mirrored {


### PR DESCRIPTION
…a flex container wasn't sizing properly or not appearing at all.

**Related Issue:** #804 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
