### PR TITLE
feat(tabs): Add support for icons in tab-title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- `calcite-tab-title` - now supports icons: `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
+
 ### Updated
 
 - `calcite-radio-group` styling has been updated

--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -6,6 +6,17 @@ You can programmatically focus a `calcite-button` with the `setFocus()` method:
 
 <!-- Auto Generated Below -->
 
+## Usage
+
+### Internals
+
+#### Passing attributes to internal components
+
+Any additional attributes set on `<calcite-button>` are passed to the internal `<a>` or `<button>` tag. For example:
+
+- `<calcite-button href="https://github.com/esri/calcite-components target="_blank">Calcite Components on GitHub</calcite-button>` would set `target="_blank` On the internal `<a>`.
+- `<calcite-button type="submit">Submit</calcite-button>` would set `type="submit"` On the internal `<button>`.
+
 ## Properties
 
 | Property     | Attribute    | Description                                                                                        | Type                                               | Default     |

--- a/src/components/calcite-checkbox/readme.md
+++ b/src/components/calcite-checkbox/readme.md
@@ -28,13 +28,14 @@ If you don't pass in an input, calcite-checkbox will act as the source of truth:
 | `name`          | `name`          | The name of the checkbox input                                                                                                                | `string`            | `""`        |
 | `scale`         | `scale`         | specify the scale of the checkbox, defaults to m                                                                                              | `"l" \| "m" \| "s"` | `"m"`       |
 | `theme`         | `theme`         | Determines what theme to use                                                                                                                  | `"dark" \| "light"` | `undefined` |
-| `value`         | `value`         | The value of the checkbox input                                                                                                               | `string`            | `""`        |
+| `value`         | `value`         | The value of the checkbox input                                                                                                               | `string`            | `undefined` |
 
 ## Events
 
-| Event                   | Description                                      | Type               |
-| ----------------------- | ------------------------------------------------ | ------------------ |
-| `calciteCheckboxChange` | Emitted when the checkbox checked status changes | `CustomEvent<any>` |
+| Event                          | Description                                      | Type               |
+| ------------------------------ | ------------------------------------------------ | ------------------ |
+| `calciteCheckboxChange`        | Emitted when the checkbox checked status changes | `CustomEvent<any>` |
+| `calciteCheckboxFocusedChange` | Emitted when the checkbox focused state changes  | `CustomEvent<any>` |
 
 ## Dependencies
 

--- a/src/components/calcite-color/readme.md
+++ b/src/components/calcite-color/readme.md
@@ -71,6 +71,7 @@ graph TD;
   calcite-color --> calcite-tab-nav
   calcite-color --> calcite-button
   calcite-color --> calcite-color-swatch
+  calcite-tab-title --> calcite-icon
   calcite-input --> calcite-icon
   calcite-input --> calcite-progress
   calcite-color-hex-input --> calcite-input

--- a/src/components/calcite-icon/readme.md
+++ b/src/components/calcite-icon/readme.md
@@ -44,6 +44,7 @@ To use a custom color for the icon fill, you can add a class to the `calcite-ico
 - [calcite-popover](../calcite-popover)
 - [calcite-radio-group-item](../calcite-radio-group-item)
 - [calcite-stepper-item](../calcite-stepper-item)
+- [calcite-tab-title](../calcite-tab-title)
 - [calcite-tile](../calcite-tile)
 - [calcite-tree-item](../calcite-tree-item)
 
@@ -67,6 +68,7 @@ graph TD;
   calcite-popover --> calcite-icon
   calcite-radio-group-item --> calcite-icon
   calcite-stepper-item --> calcite-icon
+  calcite-tab-title --> calcite-icon
   calcite-tile --> calcite-icon
   calcite-tree-item --> calcite-icon
   style calcite-icon fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/components/calcite-link/readme.md
+++ b/src/components/calcite-link/readme.md
@@ -8,14 +8,15 @@ You can programmatically focus a `calcite-link` with the `setFocus()` method:
 
 ## Properties
 
-| Property    | Attribute    | Description                                                                                      | Type                                   | Default     |
-| ----------- | ------------ | ------------------------------------------------------------------------------------------------ | -------------------------------------- | ----------- |
-| `color`     | `color`      | specify the color of the link, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"` | `"blue"`    |
-| `disabled`  | `disabled`   | is the link disabled                                                                             | `boolean`                              | `undefined` |
-| `href`      | `href`       | optionally pass a href - used to determine if the component should render as a link or an anchor | `string`                               | `undefined` |
-| `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of a button - accepts calcite ui icon names        | `string`                               | `undefined` |
-| `iconStart` | `icon-start` | optionally pass an icon to display at the start of a button - accepts calcite ui icon names      | `string`                               | `undefined` |
-| `theme`     | `theme`      | Select theme (light or dark)                                                                     | `"dark" \| "light"`                    | `undefined` |
+| Property     | Attribute     | Description                                                                                      | Type                                   | Default     |
+| ------------ | ------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------- | ----------- |
+| `color`      | `color`       | specify the color of the link, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"` | `"blue"`    |
+| `disabled`   | `disabled`    | is the link disabled                                                                             | `boolean`                              | `undefined` |
+| `href`       | `href`        | optionally pass a href - used to determine if the component should render as a link or an anchor | `string`                               | `undefined` |
+| `iconEnd`    | `icon-end`    | optionally pass an icon to display at the end of a button - accepts calcite ui icon names        | `string`                               | `undefined` |
+| `iconStart`  | `icon-start`  | optionally pass an icon to display at the start of a button - accepts calcite ui icon names      | `string`                               | `undefined` |
+| `theme`      | `theme`       | Select theme (light or dark)                                                                     | `"dark" \| "light"`                    | `undefined` |
+| `userSelect` | `user-select` | Allows the text to be selectable                                                                 | `boolean`                              | `true`      |
 
 ## Methods
 

--- a/src/components/calcite-tab-title/calcite-tab-title.e2e.ts
+++ b/src/components/calcite-tab-title/calcite-tab-title.e2e.ts
@@ -9,4 +9,36 @@ describe("calcite-tab-title", () => {
     const element = await page.find("calcite-tab-title");
     expect(element).toHaveAttribute(HYDRATED_ATTR);
   });
+  it("renders with an icon-start", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-tab-title icon-start='plus'>Text</calcite-tab-title>`);
+    const element = await page.find("calcite-tab-title");
+    const iconStart = await page.find("calcite-tab-title >>> .calcite-tab-title--icon.icon-start");
+    const iconEnd = await page.find("calcite-tab-title >>> .calcite-tab-title--icon.icon-end");
+    expect(element).toHaveAttribute(HYDRATED_ATTR);
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).toBeNull();
+  });
+
+  it("renders with an icon-end", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-tab-title icon-end='plus'>Text</calcite-tab-title>`);
+    const element = await page.find("calcite-tab-title");
+    const iconStart = await page.find("calcite-tab-title >>> .calcite-tab-title--icon.icon-start");
+    const iconEnd = await page.find("calcite-tab-title >>> .calcite-tab-title--icon.icon-end");
+    expect(element).toHaveAttribute(HYDRATED_ATTR);
+    expect(iconStart).toBeNull();
+    expect(iconEnd).not.toBeNull();
+  });
+
+  it("renders with an icon-start and icon-end", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-tab-title icon-start='plus' icon-end='plus'>Text</calcite-tab-title>`);
+    const element = await page.find("calcite-tab-title");
+    const iconStart = await page.find("calcite-tab-title >>> .calcite-tab-title--icon.icon-start");
+    const iconEnd = await page.find("calcite-tab-title >>> .calcite-tab-title--icon.icon-end");
+    expect(element).toHaveAttribute(HYDRATED_ATTR);
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).not.toBeNull();
+  });
 });

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -57,9 +57,55 @@ a {
   text-overflow: ellipsis;
   border-bottom: 3px solid transparent;
   cursor: pointer;
-  transition: all 0.15s ease-in-out;
+  transition: $transition;
   color: var(--calcite-ui-text-3);
   outline: none;
   width: 100%;
-  display: block;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+// icon positioning and styles
+.calcite-tab-title--icon {
+  display: inline-flex;
+  position: relative;
+  margin: 0;
+  line-height: inherit;
+  align-self: center;
+  & svg {
+    transition: $transition;
+  }
+}
+
+:host([hastext]) .calcite-tab-title--icon.icon-start {
+  margin-right: $baseline/3;
+}
+
+:host([hastext][dir="rtl"]) .calcite-tab-title--icon.icon-start {
+  margin-right: 0;
+  margin-left: $baseline/3;
+}
+
+:host([hastext]) .calcite-tab-title--icon.icon-end {
+  margin-left: $baseline/3;
+}
+
+:host([hastext][dir="rtl"]) .calcite-tab-title--icon.icon-end {
+  margin-left: 0;
+  margin-right: $baseline/3;
+}
+
+// compensate for spacing when no hastext and two icons
+:host([icon-start][icon-end]) {
+  .calcite-tab-title--icon:first-child {
+    margin-right: $baseline/3;
+  }
+}
+
+:host([icon-start][icon-end][dir="rtl"]) {
+  .calcite-tab-title--icon:first-child {
+    margin-right: 0;
+    margin-left: $baseline/3;
+  }
 }

--- a/src/components/calcite-tab-title/readme.md
+++ b/src/components/calcite-tab-title/readme.md
@@ -6,10 +6,12 @@ The tab-title is the link that switches between panes in [calcite-tabs](../calci
 
 ## Properties
 
-| Property | Attribute | Description                                                                                              | Type      | Default     |
-| -------- | --------- | -------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `active` | `active`  | Show this tab title as selected                                                                          | `boolean` | `false`     |
-| `tab`    | `tab`     | Optionally include a unique name for the tab title, be sure to also set this name on the associated tab. | `string`  | `undefined` |
+| Property    | Attribute    | Description                                                                                              | Type      | Default     |
+| ----------- | ------------ | -------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `active`    | `active`     | Show this tab title as selected                                                                          | `boolean` | `false`     |
+| `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of a tab title - accepts calcite ui icon names             | `string`  | `undefined` |
+| `iconStart` | `icon-start` | optionally pass an icon to display at the start of a tab title - accepts calcite ui icon names           | `string`  | `undefined` |
+| `tab`       | `tab`        | Optionally include a unique name for the tab title, be sure to also set this name on the associated tab. | `string`  | `undefined` |
 
 ## Events
 
@@ -33,10 +35,15 @@ Type: `Promise<number>`
 
 - [calcite-color](../calcite-color)
 
+### Depends on
+
+- [calcite-icon](../calcite-icon)
+
 ### Graph
 
 ```mermaid
 graph TD;
+  calcite-tab-title --> calcite-icon
   calcite-color --> calcite-tab-title
   style calcite-tab-title fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
 import { withKnobs, select } from "@storybook/addon-knobs";
-import { darkBackground, parseReadme } from "../../../.storybook/helpers";
+import { darkBackground, iconNames, parseReadme } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-tab/readme.md";
 import readme3 from "../calcite-tab-nav/readme.md";
@@ -19,7 +19,7 @@ storiesOf("components|Tabs", module)
     "Simple",
     () => `
     <calcite-tabs
-      layout="${select("layout", { inline: "inline", center: "center" })}"
+      layout="${select("layout", ["inline", "center"])}"
     >
       <calcite-tab-nav slot="tab-nav">
         <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
@@ -37,11 +37,43 @@ storiesOf("components|Tabs", module)
     { notes }
   )
   .add(
+    "With icons",
+    () => `
+    <calcite-tabs
+      layout="${select("layout", ["inline", "center"])}"
+    >
+      <calcite-tab-nav
+      slot="tab-nav">
+        <calcite-tab-title active
+        icon-start="${select("tab 1 icon-start", iconNames, iconNames[0])}"
+        >Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title
+        icon-end="${select("tab 2 icon-end", iconNames, iconNames[0])}"
+        >Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title
+        icon-start="${select("tab 3 icon-start", iconNames, iconNames[0])}"
+        icon-end="${select("tab 3 icon-end", iconNames, iconNames[0])}"
+        >Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title
+        icon-start="${select("tab 4 icon-start", iconNames, iconNames[0])}"></calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+      <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+      <calcite-tab><p>Tab 3 Content</p></calcite-tab>
+      <calcite-tab><p>Tab 4 Content</p></calcite-tab>
+    </calcite-tabs>
+  `,
+    { notes }
+  )
+  .add(
     "Dark mode",
     () => `
-    <calcite-tabs theme="dark">
+    <calcite-tabs theme="dark"
+    layout="${select("layout", ["inline", "center"])}"
+    >
       <calcite-tab-nav slot="tab-nav">
-        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title active>Icon 1</calcite-tab-title>
         <calcite-tab-title>Tab 2 Title</calcite-tab-title>
         <calcite-tab-title>Tab 3 Title</calcite-tab-title>
         <calcite-tab-title>Tab 4 Title</calcite-tab-title>

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -45,6 +45,66 @@
     <calcite-tab>Tab 3 Content</calcite-tab>
     <calcite-tab>Tab 4 Content</calcite-tab>
   </calcite-tabs>
+  <h2>
+    Icons
+  </h2>
+  <h3>Icon start</h3>
+  <calcite-tabs active>
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active icon-start="layer">Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="layer">Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="layer">Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="layer">Tab 4 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+  </calcite-tabs>
+  <h3>Icon end</h3>
+  <calcite-tabs active>
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active icon-end="layer">Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-end="layer">Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title icon-end="layer">Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title icon-end="layer">Tab 4 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+  </calcite-tabs>
+
+  <h3>Icon start and end</h3>
+  <calcite-tabs active>
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active icon-start="layer" icon-end="layer">Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="layer" icon-end="layer">Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="layer" icon-end="layer">Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="layer" icon-end="layer">Tab 4 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+  </calcite-tabs>
+  <h3>Icon no text</h3>
+  <calcite-tabs active>
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active icon-start="layer"></calcite-tab-title>
+      <calcite-tab-title icon-start="layer"></calcite-tab-title>
+      <calcite-tab-title icon-start="layer"></calcite-tab-title>
+      <calcite-tab-title icon-start="layer"></calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+  </calcite-tabs>
 
   <h2>Just tab-nav</h2>
   <calcite-tab-nav>
@@ -77,6 +137,19 @@
         <calcite-tab-title>Tab 2 Title</calcite-tab-title>
         <calcite-tab-title>Tab 3 Title</calcite-tab-title>
         <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+    <calcite-tabs active theme="dark">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active icon-start="layer" icon-end="layer">Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="layer" icon-end="layer">Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="layer" icon-end="layer">Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="layer" icon-end="layer">Tab 4 Title</calcite-tab-title>
       </calcite-tab-nav>
 
       <calcite-tab active>Tab 1 Content</calcite-tab>
@@ -218,6 +291,24 @@
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
       <calcite-tab-title>Tab 5 Title</calcite-tab-title>
       <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+    <calcite-tab>Tab 5 Content</calcite-tab>
+    <calcite-tab>Tab 6 Content</calcite-tab>
+  </calcite-tabs>
+
+  <calcite-tabs layout="center">
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="plus">Tab 4 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="plus"></calcite-tab-title>
+      <calcite-tab-title icon-end="plus">Tab 6 Title</calcite-tab-title>
     </calcite-tab-nav>
 
     <calcite-tab active>Tab 1 Content</calcite-tab>


### PR DESCRIPTION
**Related Issue:** Resolves #672 

## Summary
Adds icon-start and icon-end props to tab-title component
Adds hasText watcher to tab-title component to properly space icons in tabs when no text is present
Update dev demo, storybook, tests, changelog

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
