### PR TITLE
feat(tabs): Add support for content positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `calcite-tab-title` - now supports icons: `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
+- `calcite-tabs` - tabs can now be positioned `above` (default) or `below` the tab content with the `position` prop
 
 ### Updated
 

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -42,9 +42,15 @@ $tab-margin: 1.25rem;
   }
 }
 
+// positioning
+:host([position="below"]) a {
+  border-bottom: 0;
+  border-top: 3px solid transparent;
+}
+
 :host([active]) a {
   color: var(--calcite-ui-text-1);
-  border-bottom-color: var(--calcite-ui-blue-1);
+  border-color: var(--calcite-ui-blue-1);
   font-weight: 500;
 }
 

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -53,6 +53,10 @@ export class CalciteTabTitle {
 
   /** @internal Parent tabs component layout value */
   @Prop({ reflect: true, mutable: true }) layout: "center" | "inline";
+
+  /** @internal Parent tabs component position value */
+  @Prop({ reflect: true, mutable: true }) position: "above" | "below";
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -80,6 +84,7 @@ export class CalciteTabTitle {
 
   componentWillRender() {
     this.layout = this.el.closest("calcite-tabs")?.layout;
+    this.position = this.el.closest("calcite-tabs")?.position;
   }
 
   render() {

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -7,9 +7,19 @@
   flex-direction: column;
 }
 
+:host([position="below"]) {
+  flex-direction: column-reverse;
+}
+
 section {
   display: flex;
   flex-grow: 1;
   overflow: hidden;
   border-top: 1px solid var(--calcite-ui-border-1);
+}
+
+:host([position="below"]) section {
+  flex-direction: column-reverse;
+  border-top: 0;
+  border-bottom: 1px solid var(--calcite-ui-border-1);
 }

--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -19,7 +19,8 @@ storiesOf("components|Tabs", module)
     "Simple",
     () => `
     <calcite-tabs
-      layout="${select("layout", ["inline", "center"])}"
+      layout="${select("layout", ["inline", "center"], "inline")}"
+      position="${select("position", ["above", "below"], "above")}"
     >
       <calcite-tab-nav slot="tab-nav">
         <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
@@ -40,7 +41,8 @@ storiesOf("components|Tabs", module)
     "With icons",
     () => `
     <calcite-tabs
-      layout="${select("layout", ["inline", "center"])}"
+      layout="${select("layout", ["inline", "center"], "inline")}"
+      position="${select("position", ["above", "below"], "above")}"
     >
       <calcite-tab-nav
       slot="tab-nav">
@@ -70,7 +72,8 @@ storiesOf("components|Tabs", module)
     "Dark mode",
     () => `
     <calcite-tabs theme="dark"
-    layout="${select("layout", ["inline", "center"])}"
+    layout="${select("layout", ["inline", "center"], "inline")}"
+    position="${select("position", ["above", "below"], "above")}"
     >
       <calcite-tab-nav slot="tab-nav">
         <calcite-tab-title active>Icon 1</calcite-tab-title>

--- a/src/components/calcite-tabs/calcite-tabs.tsx
+++ b/src/components/calcite-tabs/calcite-tabs.tsx
@@ -36,6 +36,14 @@ export class CalciteTabs {
   })
   layout: "center" | "inline" = "inline";
 
+  /**
+   * Display the tabs above (default) or below the tab content
+   */
+  @Prop({
+    reflect: true
+  })
+  position: "above" | "below" = "above";
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle

--- a/src/components/calcite-tabs/readme.md
+++ b/src/components/calcite-tabs/readme.md
@@ -18,10 +18,11 @@ calcite-tabs uses several sub-components ([calcite-tab-nav](../calcite-tab-nav),
 
 ## Properties
 
-| Property | Attribute | Description                                                                      | Type                   | Default     |
-| -------- | --------- | -------------------------------------------------------------------------------- | ---------------------- | ----------- |
-| `layout` | `layout`  | Align tab titles to the edge or fully justify them across the tab nav ("center") | `"center" \| "inline"` | `"inline"`  |
-| `theme`  | `theme`   | Select theme (light or dark)                                                     | `"dark" \| "light"`    | `undefined` |
+| Property   | Attribute  | Description                                                                      | Type                   | Default     |
+| ---------- | ---------- | -------------------------------------------------------------------------------- | ---------------------- | ----------- |
+| `layout`   | `layout`   | Align tab titles to the edge or fully justify them across the tab nav ("center") | `"center" \| "inline"` | `"inline"`  |
+| `position` | `position` | Display the tabs above (default) or below the tab content                        | `"above" \| "below"`   | `"above"`   |
+| `theme`    | `theme`    | Select theme (light or dark)                                                     | `"dark" \| "light"`    | `undefined` |
 
 ## Dependencies
 

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -45,6 +45,50 @@
     <calcite-tab>Tab 3 Content</calcite-tab>
     <calcite-tab>Tab 4 Content</calcite-tab>
   </calcite-tabs>
+  <h3>Content position: above (default)</h3>
+
+  <calcite-tabs active position="above">
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 12 Title</calcite-tab-title>
+    </calcite-tab-nav>
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+  </calcite-tabs>
+
+  <h3>Content position: below</h3>
+  <calcite-tabs active position="below">
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 12 Title</calcite-tab-title>
+    </calcite-tab-nav>
+    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
+    <calcite-tab>Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
+  </calcite-tabs>
   <h2>
     Icons
   </h2>


### PR DESCRIPTION
**Related Issue:** Resolves #399 cc @jwasilgeo

## Summary
Adds a position prop to allow content to be positioned above or below the tab nav
Update dev demo, storybook, changelog
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
