### PR TITLE
fix(calcite-checkbox): cleaning up hidden input when checkbox is unmo…

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
@@ -112,4 +112,44 @@ describe("calcite-checkbox", () => {
     expect(calciteCheckbox).toHaveAttribute("checked");
     expect(input).toHaveAttribute("checked");
   });
+
+  it("removing a checkbox also removes the hidden <input type=checkbox> element", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-checkbox name="checky" id="first" value="one"></calcite-checkbox>
+    `);
+
+    let input = await page.find("input");
+    expect(input).toBeTruthy();
+
+    await page.evaluate(() => {
+      const checkbox = document.querySelector("calcite-checkbox");
+      checkbox.parentNode.removeChild(checkbox);
+    });
+    await page.waitForChanges();
+
+    input = await page.find("input");
+
+    expect(input).toBeFalsy();
+  });
+
+  it("behaves as expected when wrapped in a calcite-label with inline layout mode", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-label layout="inline"><calcite-checkbox></calcite-checkbox>Label</calcite-label>
+    `);
+
+    const inputs = await page.findAll("calcite-label >>> input");
+    expect(inputs.length).toEqual(1);
+  });
+
+  it("behaves as expected when wrapped in a calcite-label with inline-space-between layout mode", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-label layout="inline-space-between"><calcite-checkbox></calcite-checkbox>Label</calcite-label>
+    `);
+
+    const inputs = await page.findAll("calcite-label >>> input");
+    expect(inputs.length).toEqual(1);
+  });
 });

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -172,6 +172,10 @@ export class CalciteCheckbox {
     if (!scale.includes(this.scale)) this.scale = "m";
   }
 
+  disconnectedCallback() {
+    this.input.parentNode.removeChild(this.input);
+  }
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods


### PR DESCRIPTION
…unted to prevent the extra input from being created the next time it mounts because calcite-label reconstructs its children whenever a layout other than default is used.

**Related Issue:** #810

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
