### PR TITLE
feat(shell-panel)!: add width-scale property

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -13,6 +13,14 @@ describe("calcite-shell-panel", () => {
       {
         propertyName: "collapsed",
         defaultValue: false
+      },
+      {
+        propertyName: "height-scale",
+        defaultValue: "m"
+      },
+      {
+        propertyName: "width-scale",
+        defaultValue: "m"
       }
     ]));
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -42,21 +42,26 @@
   min-height: var(--calcite-app-shell-panel-min-height);
   padding: 0;
   pointer-events: auto;
+  transition: max-height var(--calcite-app-animation-time) var(--calcite-app-easing-function),
+    max-width var(--calcite-app-animation-time) var(--calcite-app-easing-function);
 }
 
 .content--detached {
   border-radius: var(--calcite-app-border-radius);
   box-shadow: var(--calcite-app-shadow-0);
   margin: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half) auto;
-  max-height: var(--calcite-app-shell-panel-max-height-medium);
   overflow: auto;
 }
 
-:host([detached-scale="s"]) .content--detached {
+:host([height-scale="s"]) .content--detached {
   max-height: var(--calcite-app-shell-panel-max-height-small);
 }
 
-:host([detached-scale="l"]) .content--detached {
+:host([height-scale="m"]) .content--detached {
+  max-height: var(--calcite-app-shell-panel-max-height-medium);
+}
+
+:host([height-scale="l"]) .content--detached {
   max-height: var(--calcite-app-shell-panel-max-height-large);
 }
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -5,9 +5,7 @@
   background-color: var(--calcite-app-background-transparent);
   pointer-events: none;
 
-  --calcite-app-shell-panel-width: 20vw;
   --calcite-app-shell-panel-min-width: 240px;
-  --calcite-app-shell-panel-max-width: 360px;
   --calcite-app-shell-panel-min-height: 4rem;
   --calcite-app-shell-panel-max-height-small: 35vh;
   --calcite-app-shell-panel-max-height-medium: 55vh;
@@ -15,6 +13,22 @@
 }
 
 @import "../../scss/includes/_component";
+
+:host([width-scale="s"]) {
+  --calcite-app-shell-panel-width: 12vw;
+  --calcite-app-shell-panel-min-width: 150px;
+  --calcite-app-shell-panel-max-width: 300px;
+}
+
+:host([width-scale="m"]) {
+  --calcite-app-shell-panel-width: 20vw;
+  --calcite-app-shell-panel-max-width: 420px;
+}
+
+:host([width-scale="l"]) {
+  --calcite-app-shell-panel-width: 45vw;
+  --calcite-app-shell-panel-max-width: 680px;
+}
 
 .content {
   align-items: stretch;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -36,7 +36,7 @@ export class CalciteShellPanel {
   /**
    * This sets limits the height of the content area. It only applies when detached is true.
    */
-  @Prop({ reflect: true }) detachedScale: CalciteScale = "m";
+  @Prop({ reflect: true }) heightScale: CalciteScale = "m";
 
   /**
    * This sets width and max-width of the content area.

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -36,7 +36,12 @@ export class CalciteShellPanel {
   /**
    * This sets limits the height of the content area. It only applies when detached is true.
    */
-  @Prop({ reflect: false }) detachedScale: CalciteScale = "m";
+  @Prop({ reflect: true }) detachedScale: CalciteScale = "m";
+
+  /**
+   * This sets width and max-width of the content area.
+   */
+  @Prop({ reflect: true }) widthScale: CalciteScale = "m";
 
   /**
    * Arranges the component depending on the elements 'dir' property.

--- a/src/components/calcite-shell-panel/readme.md
+++ b/src/components/calcite-shell-panel/readme.md
@@ -4,6 +4,7 @@ The `calcite-shell-panel` is a child component of `calcite-shell` used as a cont
 
 <!-- Auto Generated Below -->
 
+
 ## Usage
 
 ### Basic
@@ -32,20 +33,25 @@ Renders a panel with an action bar.
 </calcite-shell-panel>
 ```
 
+
+
 ## Properties
 
-| Property        | Attribute        | Description                                                                             | Type                | Default     |
-| --------------- | ---------------- | --------------------------------------------------------------------------------------- | ------------------- | ----------- |
-| `collapsed`     | `collapsed`      | Hide the content panel.                                                                 | `boolean`           | `false`     |
-| `detached`      | `detached`       | This property makes the content area appear like a "floating" panel.                    | `boolean`           | `false`     |
-| `detachedScale` | `detached-scale` | This sets limits the height of the content area. It only applies when detached is true. | `"l" \| "m" \| "s"` | `"m"`       |
-| `position`      | `position`       | Arranges the component depending on the elements 'dir' property.                        | `"end" \| "start"`  | `undefined` |
+| Property      | Attribute      | Description                                                                             | Type                | Default     |
+| ------------- | -------------- | --------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `collapsed`   | `collapsed`    | Hide the content panel.                                                                 | `boolean`           | `false`     |
+| `detached`    | `detached`     | This property makes the content area appear like a "floating" panel.                    | `boolean`           | `false`     |
+| `heightScale` | `height-scale` | This sets limits the height of the content area. It only applies when detached is true. | `"l" \| "m" \| "s"` | `"m"`       |
+| `position`    | `position`     | Arranges the component depending on the elements 'dir' property.                        | `"end" \| "start"`  | `undefined` |
+| `widthScale`  | `width-scale`  | This sets width and max-width of the content area.                                      | `"l" \| "m" \| "s"` | `"m"`       |
+
 
 ## Events
 
 | Event                     | Description                             | Type               |
 | ------------------------- | --------------------------------------- | ------------------ |
 | `calciteShellPanelToggle` | Emitted when collapse has been toggled. | `CustomEvent<any>` |
+
 
 ## Slots
 
@@ -54,6 +60,7 @@ Renders a panel with an action bar.
 |                | A slot for adding content to the shell panel.          |
 | `"action-bar"` | A slot for adding a `calcite-action-bar` to the panel. |
 
----
 
-_Built with [StencilJS](https://stenciljs.com/)_
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -47,8 +47,12 @@ const createShellPanelAttributes: (group: "Leading Panel" | "Trailing Panel") =>
       value: boolean("detached", false, group)
     },
     {
-      name: "detached-scale",
-      value: select("detachedScale", scale.values, scale.defaultValue, group)
+      name: "height-scale",
+      value: select("heightScale", scale.values, scale.defaultValue, group)
+    },
+    {
+      name: "width-scale",
+      value: select("widthScale", scale.values, scale.defaultValue, group)
     },
     {
       name: "position",

--- a/src/components/calcite-shell/readme.md
+++ b/src/components/calcite-shell/readme.md
@@ -42,7 +42,7 @@ Renders a shell with leading and trailing floating panels, action bar/pad, block
     </calcite-block>
   </calcite-shell-panel>
 
-   <calcite-shell-panel slot="contextual-panel" position="end" detached detached-scale="l">
+   <calcite-shell-panel slot="contextual-panel" position="end" detached height-scale="l">
       <calcite-action-bar slot="action-bar">
         <calcite-action-group>
           <calcite-action text="Add" active icon="plus"></calcite-action>

--- a/src/components/calcite-shell/usage/advanced.md
+++ b/src/components/calcite-shell/usage/advanced.md
@@ -30,7 +30,7 @@ Renders a shell with leading and trailing floating panels, action bar/pad, block
     </calcite-block>
   </calcite-shell-panel>
 
-   <calcite-shell-panel slot="contextual-panel" position="end" detached detached-scale="l">
+   <calcite-shell-panel slot="contextual-panel" position="end" detached height-scale="l">
       <calcite-action-bar slot="action-bar">
         <calcite-action-group>
           <calcite-action text="Add" active icon="plus"></calcite-action>

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -63,7 +63,7 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached detached-scale="l">
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached height-scale="l">
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>

--- a/src/demos/shell/demo-app-advanced-center-row.html
+++ b/src/demos/shell/demo-app-advanced-center-row.html
@@ -57,7 +57,7 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached-scale="l">
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" height-scale="l">
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
@@ -89,7 +89,7 @@
             </calcite-flow>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" position="end" detached-scale="l">
+          <calcite-shell-panel slot="contextual-panel" position="end" height-scale="l">
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>

--- a/src/demos/shell/demo-app-advanced.html
+++ b/src/demos/shell/demo-app-advanced.html
@@ -64,7 +64,7 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached detached-scale="l">
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached height-scale="l">
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator>

--- a/src/demos/shell/demo-app-center-row-action-bar.html
+++ b/src/demos/shell/demo-app-center-row-action-bar.html
@@ -57,7 +57,7 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached-scale="l" detached>
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" height-scale="l" detached>
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
@@ -91,7 +91,7 @@
             </calcite-flow>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" position="end" detached-scale="l" collapsed>
+          <calcite-shell-panel slot="contextual-panel" position="end" height-scale="l" collapsed>
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -143,7 +143,7 @@
             </calcite-block>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" position="start" detached detached-scale="l">
+          <calcite-shell-panel slot="contextual-panel" position="start" detached height-scale="l">
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Add" active icon="plus"> </calcite-action>


### PR DESCRIPTION
**Related Issue:** #815

## Summary
Add a property to set the dynamic width of a ShellPanel's content area.

Should we also rename the `detached-scale` property to be explicitly about height?

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
