### PR TITLE
fix(input): Removed calciteInputInput event on componentWillUpdate

### DIFF
--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -13,9 +13,7 @@ describe("calcite-date", () => {
     await input.callMethod("setFocus");
     // have to wait for transition
     await new Promise((res) => setTimeout(() => res(true), 200));
-    const wrapper = await page.find(
-      "calcite-date >>> .calendar-picker-wrapper"
-    );
+    const wrapper = await page.find("calcite-date >>> .calendar-picker-wrapper");
     const visible = await wrapper.isVisible();
     expect(visible).toBe(true);
     await input.press("3");
@@ -27,6 +25,6 @@ describe("calcite-date", () => {
     await input.press("2");
     await input.press("0");
     await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(2);
+    expect(changedEvent).toHaveReceivedEventTimes(1);
   });
 });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -192,11 +192,6 @@ export class CalciteInput {
   }
 
   componentWillUpdate() {
-    this.calciteInputInput.emit({
-      element: this.childEl,
-      value: this.value
-    });
-
     this.determineClearable();
   }
 


### PR DESCRIPTION
**Related Issue:** #
https://github.com/Esri/calcite-components/issues/829

## Summary
Removed  emission of calciteInputInput event on componentWillUpdate
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
