### PR TITLE
fix(tabs): ensure proper ARIA roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7750,9 +7750,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
+      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw==",
       "dev": true
     },
     "babel-code-frame": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "3.8.0",
     "autoprefixer": "9.8.6",
     "awesome-typescript-loader": "5.2.1",
-    "axe-core": "3.5.5",
+    "axe-core": "4.0.1",
     "babel-loader": "~8.1.0",
     "chalk": "4.1.0",
     "chokidar": "3.4.1",

--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -93,9 +93,9 @@ export class CalciteTabNav {
   render() {
     return (
       <Host role="tablist">
-        <nav class="tab-nav" ref={(el) => (this.tabNavEl = el as HTMLElement)}>
+        <div class="tab-nav" ref={(el) => (this.tabNavEl = el as HTMLElement)}>
           <slot />
-        </nav>
+        </div>
       </Host>
     );
   }

--- a/src/components/calcite-tabs/calcite-tabs.e2e.ts
+++ b/src/components/calcite-tabs/calcite-tabs.e2e.ts
@@ -1,7 +1,24 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { HYDRATED_ATTR } from "../../tests/commonTests";
+import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
 
 describe("calcite-tabs", () => {
+  it("is accessible", async () =>
+    accessible(
+      `<calcite-tabs>
+        <calcite-tab-nav slot="tab-nav">
+          <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        </calcite-tab-nav>
+
+        <calcite-tab active>Tab 1 Content</calcite-tab>
+        <calcite-tab>Tab 2 Content</calcite-tab>
+        <calcite-tab>Tab 3 Content</calcite-tab>
+        <calcite-tab>Tab 4 Content</calcite-tab>
+      </calcite-tabs>`
+    ));
+
   it("renders with a light theme", async () => {
     const page = await newE2EPage();
 


### PR DESCRIPTION
**Related Issue:** #831

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates the tag used within the tabs container to be presentational to conform to the expected child tab roles.

Also, this bumps axe-core to v4.x and adds a basic a11y test to `calcite-tabs`.