### PR TITLE
fix(pagination): prevent page one rendering twice when total is smaller than num

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- `calcite-pagination` - fixed bug with single page result sets
+
 ### Added
 
 - `calcite-tab-title` - now supports icons: `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.

--- a/src/components/calcite-pagination/calcite-pagination.e2e.ts
+++ b/src/components/calcite-pagination/calcite-pagination.e2e.ts
@@ -8,6 +8,15 @@ describe("calcite-pagination", () => {
 
   it("is accessible", async () => accessible(`<calcite-pagination></calcite-pagination>`));
 
+  describe("page links", () => {
+    it("should render only one page when total is less than num", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-pagination total="10" num="11"></calcite-pagination>`);
+      const links = await page.findAll(`calcite-pagination >>> .${CSS.page}`);
+      expect(links.length).toBe(1);
+    });
+  });
+
   describe("ellipsis rendering", () => {
     it("should not render either ellipsis when total pages is less than or equal to 5", async () => {
       const page = await newE2EPage();

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -220,7 +220,7 @@ export class CalcitePagination {
         >
           <calcite-icon scale={iconScale} icon="chevronLeft" />
         </button>
-        {this.renderPage(1)}
+        {total > num ? this.renderPage(1) : null}
         {this.renderLeftEllipsis(iconScale)}
         {this.renderPages()}
         {this.renderRightEllipsis(iconScale)}

--- a/src/demos/calcite-pagination.html
+++ b/src/demos/calcite-pagination.html
@@ -30,6 +30,9 @@
   <div class="demo-spaced">
     <calcite-pagination total="46" num="10"></calcite-pagination>
   </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="8" num="10"></calcite-pagination>
+  </div>
 
   <div class="demo-background-dark">
     <h2>Dark Theme</h2>


### PR DESCRIPTION
## Summary

Current logic rendered page 1 link twice for single-page sets:

<img width="722" alt="Screen Shot 2020-08-10 at 10 01 35 AM" src="https://user-images.githubusercontent.com/1031758/89809558-8cf39000-daf0-11ea-8da8-740a2afe736f.png">

This fixes this edge case (and adds a test for it).
