### PR TITLE
fix(loader): ensure fallback id for loaders is generated properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `calcite-pagination` - fixed bug with single page result sets
+- `calcite-loader` - fix fallback id value
 
 ### Added
 

--- a/src/components/calcite-loader/calcite-loader.e2e.ts
+++ b/src/components/calcite-loader/calcite-loader.e2e.ts
@@ -56,6 +56,14 @@ describe("calcite-loader", () => {
     expect(rect).toEqualAttribute("r", "7.2");
   });
 
+  it("sets a default id when none is provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-loader active></calcite-loader>`);
+    const loader = await page.find("calcite-loader");
+    expect(loader).toHaveAttribute("id");
+    expect(loader.getAttribute("id").length).toEqual(36);
+  });
+
   it("validates scale and type properties", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-loader scale="bleep" type="bloop"></calcite-loader>`);

--- a/src/components/calcite-loader/calcite-loader.tsx
+++ b/src/components/calcite-loader/calcite-loader.tsx
@@ -59,7 +59,7 @@ export class CalciteLoader {
   render() {
     const { el, inline, scale, text, type, value } = this;
 
-    const id = el.id || guid;
+    const id = el.id || guid();
     const radiusRatio = 0.45;
     const size = inline ? this.getInlineSize(scale) : this.getSize(scale);
     const radius = size * radiusRatio;


### PR DESCRIPTION
**Related Issue:** #811

## Summary

Fixed this prior to seeing the issue as I was using loader, but it solves the issue 811 describes

<img width="633" alt="Screen Shot 2020-08-10 at 10 51 24 AM" src="https://user-images.githubusercontent.com/1031758/89815099-0d1df380-daf9-11ea-8b75-e047017204a4.png">



<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
