### PR TITLE
docs: fix boolean attribute generation in story util

### DIFF
--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -62,7 +62,15 @@ export type Attribute = KnobbedAttribute | SimpleAttribute;
 export type Attributes = Attribute[];
 
 export const createComponentHTML = (tagName: string, attributes: Attributes, contentHTML: string = ""): string =>
-  `<${tagName} ${attributes.map(({ name, value }) => `${name}="${value}"`).join(" ")}>${contentHTML}</${tagName}>`;
+  `<${tagName} ${attributes
+    .map(({ name, value }) => {
+      const booleanAttr = typeof value === "boolean";
+      if (booleanAttr) {
+        return value ? name : "";
+      }
+      return `${name}="${value}"`;
+    })
+    .join(" ")}>${contentHTML}</${tagName}>`;
 
 export const titlelessDocsPage: typeof DocsPage = () =>
   DocsPage({


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates the component HTML util to handle boolean attributes correctly.

**Note**: this is a port of https://github.com/Esri/calcite-app-components/pull/1053