### PR TITLE
feat(split): separate primary + secondary disabled

### DIFF
--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -59,6 +59,27 @@ describe("calcite-split-button", () => {
     expect(dropdownButton).toEqualAttribute("aria-label", "more actions");
   });
 
+  it("can separately disable the primary secondary buttons", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-split-button
+        primary-disabled=true
+        primary-text="primary action"
+        primary-icon-start="save"
+        dropdown-icon-type="caret">
+      </calcite-split-button>`);
+    const element = await page.find("calcite-split-button");
+    const primaryButton = await page.find("calcite-split-button >>> calcite-button");
+    const dropdownButton = await page.find("calcite-split-button >>> calcite-dropdown calcite-button");
+    expect(primaryButton).toHaveAttribute("disabled");
+    expect(dropdownButton).not.toHaveAttribute("disabled");
+    element.removeAttribute("primary-disabled");
+    element.setAttribute("secondary-disabled", true);
+    await page.waitForChanges();
+    expect(primaryButton).not.toHaveAttribute("disabled");
+    expect(dropdownButton).toHaveAttribute("disabled");
+  });
+
   it("renders primaryText without icons as inner content of primary button", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-split-button/calcite-split-button.stories.ts
+++ b/src/components/calcite-split-button/calcite-split-button.stories.ts
@@ -16,6 +16,8 @@ storiesOf("components|Split Button", module)
         scale="${select("size", ["s", "m", "l"], "m")}"
         ${boolean("loading", false)}
         ${boolean("disabled", false)}
+        ${boolean("primary-disabled", false)}
+        ${boolean("secondary-disabled", false)}
         primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
         primary-text="${text("primary-text", "Primary Option")}"
         primary-label="${text("primary-label", "Primary Option")}"

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -44,8 +44,14 @@ export class CalciteSplitButton {
     disabling interaction. with the primary button */
   @Prop({ reflect: true }) loading?: boolean = false;
 
-  /** is the control disabled  */
+  /** is the entire control disabled  */
   @Prop({ reflect: true }) disabled?: boolean;
+
+  /** is the primary control disabled  */
+  @Prop({ reflect: true }) primaryDisabled?: boolean;
+
+  /** is the secondar dropdown control disabled  */
+  @Prop({ reflect: true }) secondaryDisabled?: boolean;
 
   /** fired when the primary button is clicked */
   @Event() calciteSplitButtonPrimaryClick: EventEmitter;
@@ -94,7 +100,7 @@ export class CalciteSplitButton {
             loading={this.loading}
             icon-start={this.primaryIconStart ? this.primaryIconStart : null}
             icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
-            disabled={this.disabled}
+            disabled={this.disabled || this.primaryDisabled}
             theme={this.theme}
             onClick={this.calciteSplitButtonPrimaryClickHandler}
           >
@@ -116,7 +122,7 @@ export class CalciteSplitButton {
               slot="dropdown-trigger"
               scale={this.scale}
               color={this.color}
-              disabled={this.disabled}
+              disabled={this.disabled || this.secondaryDisabled}
               theme={this.theme}
               icon-start={this.dropdownIcon}
             />

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -98,7 +98,30 @@
     </div>
 
     <h3>Disabled</h3>
-    <calcite-split-button disabled=true primary-text="Primary Option"></calcite-split-button>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button disabled=true primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button primary-disabled=true secondary-disabled=false primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button primary-disabled=false secondary-disabled=true primary-text="Primary Option">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+
+    </div>
 
     <h3>Loading</h3>
     <calcite-split-button loading=true primary-text="Primary Option"></calcite-split-button>


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/652

## Summary

This allows distinct disabled states for a `calcite-split-button`'s primary and secondary buttons. The existing `disabled` attribute exists as a backward-compatible way to handle the state of the entire component.

It occurs to me that there may be a slick way of dynamically accepting primary and secondary variations of any attribute one might want to apply to a button (like `appearance`, as in the linked issue), but that could get a bit complex and maybe it makes sense to constrain some aspects of customizability. Let me know if another approach is preferred!

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
