### PR TITLE
docs: correct knob name to match property name

### DIFF
--- a/src/components/calcite-icon/calcite-icon.stories.ts
+++ b/src/components/calcite-icon/calcite-icon.stories.ts
@@ -13,7 +13,7 @@ export default {
 export const simple = () => `
   <calcite-icon
     icon="${select("icon", iconNames, iconNames[0])}"
-    scale="${select("size", ["s", "m", "l"], "m")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("filled", false)}
   ></calcite-icon>
 `;


### PR DESCRIPTION
**Related Issue:** #

## Summary

It is confusing that the knob name for the icon `scale` property is `size`.

![image](https://user-images.githubusercontent.com/8754/89948576-37e07880-dbdb-11ea-8456-0f544ea5f9c9.png)

![image](https://user-images.githubusercontent.com/8754/89948624-4af34880-dbdb-11ea-80dc-1fa7533754b8.png)

