### PR TITLE
feat(icon): update handling of mirrored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `calcite-tab-title` - now supports icons: `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
-
 - `calcite-button` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
 - `calcite-split-button` now has a `primary-icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
 - `calcite-dropdown-item` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `calcite-tab-title` - now supports icons: `icon-start` and `icon-end` props have been added for explicit positioning of up to two icons.
 
+- `calcite-button` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
+- `calcite-split-button` now has a `primary-icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
+- `calcite-dropdown-item` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
+- `calcite-tab-title` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
+
 ### Updated
 
 - `calcite-radio-group` styling has been updated
+- `calcite-icon` - the `mirrored` prop will now be applied in both `dir=rtl` and `dir=ltr` - previously it would only apply if `dir=rtl`
 
 ## [v1.0.0-beta.36]
 

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -65,6 +65,9 @@ export class CalciteButton {
   /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;
 
+  /** mirror the icon  */
+  @Prop({ reflect: true }) iconMirrored?: "both" | "start" | "end";
+
   /** is the button disabled  */
   @Prop({ reflect: true }) disabled?: boolean;
 
@@ -123,11 +126,17 @@ export class CalciteButton {
         class="calcite-button--icon icon-start"
         icon={this.iconStart}
         scale={iconScale}
+        mirrored={this.iconMirrored === "start" || this.iconMirrored === "both"}
       />
     );
 
     const iconEndEl = (
-      <calcite-icon class="calcite-button--icon icon-end" icon={this.iconEnd} scale={iconScale} />
+      <calcite-icon
+        class="calcite-button--icon icon-end"
+        icon={this.iconEnd}
+        scale={iconScale}
+        mirrored={this.iconMirrored === "end" || this.iconMirrored === "both"}
+      />
     );
 
     return (

--- a/src/components/calcite-button/readme.md
+++ b/src/components/calcite-button/readme.md
@@ -19,20 +19,21 @@ Any additional attributes set on `<calcite-button>` are passed to the internal `
 
 ## Properties
 
-| Property     | Attribute    | Description                                                                                        | Type                                               | Default     |
-| ------------ | ------------ | -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
-| `appearance` | `appearance` | specify the appearance style of the button, defaults to solid.                                     | `"clear" \| "outline" \| "solid" \| "transparent"` | `"solid"`   |
-| `color`      | `color`      | specify the color of the button, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
-| `disabled`   | `disabled`   | is the button disabled                                                                             | `boolean`                                          | `undefined` |
-| `floating`   | `floating`   | optionally add a floating style to the button - this should be positioned fixed or sticky          | `boolean`                                          | `false`     |
-| `href`       | `href`       | optionally pass a href - used to determine if the component should render as a button or an anchor | `string`                                           | `undefined` |
-| `iconEnd`    | `icon-end`   | optionally pass an icon to display at the end of a button - accepts calcite ui icon names          | `string`                                           | `undefined` |
-| `iconStart`  | `icon-start` | optionally pass an icon to display at the start of a button - accepts calcite ui icon names        | `string`                                           | `undefined` |
-| `loading`    | `loading`    | optionally add a calcite-loader component to the button, disabling interaction.                    | `boolean`                                          | `false`     |
-| `round`      | `round`      | optionally add a round style to the button                                                         | `boolean`                                          | `false`     |
-| `scale`      | `scale`      | specify the scale of the button, defaults to m                                                     | `"l" \| "m" \| "s"`                                | `"m"`       |
-| `theme`      | `theme`      | Select theme (light or dark)                                                                       | `"dark" \| "light"`                                | `undefined` |
-| `width`      | `width`      | specify the width of the button, defaults to auto                                                  | `"auto" \| "full" \| "half"`                       | `"auto"`    |
+| Property       | Attribute       | Description                                                                                        | Type                                               | Default     |
+| -------------- | --------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `appearance`   | `appearance`    | specify the appearance style of the button, defaults to solid.                                     | `"clear" \| "outline" \| "solid" \| "transparent"` | `"solid"`   |
+| `color`        | `color`         | specify the color of the button, defaults to blue                                                  | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
+| `disabled`     | `disabled`      | is the button disabled                                                                             | `boolean`                                          | `undefined` |
+| `floating`     | `floating`      | optionally add a floating style to the button - this should be positioned fixed or sticky          | `boolean`                                          | `false`     |
+| `href`         | `href`          | optionally pass a href - used to determine if the component should render as a button or an anchor | `string`                                           | `undefined` |
+| `iconEnd`      | `icon-end`      | optionally pass an icon to display at the end of a button - accepts calcite ui icon names          | `string`                                           | `undefined` |
+| `iconMirrored` | `icon-mirrored` | mirror the icon                                                                                    | `"both" \| "end" \| "start"`                       | `undefined` |
+| `iconStart`    | `icon-start`    | optionally pass an icon to display at the start of a button - accepts calcite ui icon names        | `string`                                           | `undefined` |
+| `loading`      | `loading`       | optionally add a calcite-loader component to the button, disabling interaction.                    | `boolean`                                          | `false`     |
+| `round`        | `round`         | optionally add a round style to the button                                                         | `boolean`                                          | `false`     |
+| `scale`        | `scale`         | specify the scale of the button, defaults to m                                                     | `"l" \| "m" \| "s"`                                | `"m"`       |
+| `theme`        | `theme`         | Select theme (light or dark)                                                                       | `"dark" \| "light"`                                | `undefined` |
+| `width`        | `width`         | specify the width of the button, defaults to auto                                                  | `"auto" \| "full" \| "half"`                       | `"auto"`    |
 
 ## Methods
 

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -41,6 +41,9 @@ export class CalciteDropdownItem {
   /** optionally pass an icon to display at the end of an item - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;
 
+  /** mirror the icon  */
+  @Prop({ reflect: true }) iconMirrored?: "both" | "start" | "end";
+
   /** optionally pass a href - used to determine if the component should render as anchor */
   @Prop({ reflect: true }) href?: string;
   //--------------------------------------------------------------------------
@@ -90,10 +93,20 @@ export class CalciteDropdownItem {
     const scale = getElementProp(this.el, "scale", "m");
     const iconScale = scale === "s" || scale === "m" ? "s" : "m";
     const iconStartEl = (
-      <calcite-icon class="dropdown-item-icon-start" icon={this.iconStart} scale={iconScale} />
+      <calcite-icon
+        class="dropdown-item-icon-start"
+        icon={this.iconStart}
+        scale={iconScale}
+        mirrored={this.iconMirrored === "start" || this.iconMirrored === "both"}
+      />
     );
     const iconEndEl = (
-      <calcite-icon class="dropdown-item-icon-end" icon={this.iconEnd} scale={iconScale} />
+      <calcite-icon
+        class="dropdown-item-icon-end"
+        icon={this.iconEnd}
+        scale={iconScale}
+        mirrored={this.iconMirrored === "end" || this.iconMirrored === "both"}
+      />
     );
 
     const slottedContent =

--- a/src/components/calcite-dropdown-item/readme.md
+++ b/src/components/calcite-dropdown-item/readme.md
@@ -4,12 +4,13 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                                                                | Type      | Default     |
-| ----------- | ------------ | ------------------------------------------------------------------------------------------ | --------- | ----------- |
-| `active`    | `active`     |                                                                                            | `boolean` | `false`     |
-| `href`      | `href`       | optionally pass a href - used to determine if the component should render as anchor        | `string`  | `undefined` |
-| `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of an item - accepts calcite ui icon names   | `string`  | `undefined` |
-| `iconStart` | `icon-start` | optionally pass an icon to display at the start of an item - accepts calcite ui icon names | `string`  | `undefined` |
+| Property       | Attribute       | Description                                                                                | Type                         | Default     |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------ | ---------------------------- | ----------- |
+| `active`       | `active`        |                                                                                            | `boolean`                    | `false`     |
+| `href`         | `href`          | optionally pass a href - used to determine if the component should render as anchor        | `string`                     | `undefined` |
+| `iconEnd`      | `icon-end`      | optionally pass an icon to display at the end of an item - accepts calcite ui icon names   | `string`                     | `undefined` |
+| `iconMirrored` | `icon-mirrored` | mirror the icon                                                                            | `"both" \| "end" \| "start"` | `undefined` |
+| `iconStart`    | `icon-start`    | optionally pass an icon to display at the start of an item - accepts calcite ui icon names | `string`                     | `undefined` |
 
 ## Events
 

--- a/src/components/calcite-icon/calcite-icon.stories.ts
+++ b/src/components/calcite-icon/calcite-icon.stories.ts
@@ -1,41 +1,32 @@
+import { storiesOf } from "@storybook/html";
 import { withKnobs, select } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
 const notes = parseReadme(readme);
 
-export default {
-  title: "components|Icon",
-  decorators: [withKnobs],
-  parameters: { notes }
-};
-
-export const simple = () => `
-  <calcite-icon
+storiesOf("components|Icon", module)
+  .addDecorator(withKnobs)
+  .add(
+    "Simple",
+    () => `
+    <calcite-icon
     icon="${select("icon", iconNames, iconNames[0])}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    ${boolean("filled", false)}
-  ></calcite-icon>
-`;
-
-export const RTL = () => `
-  <calcite-icon
-    dir="rtl"
-    icon="arrowBoldLeft"
-    ${boolean("mirror", false)}
-  ></calcite-icon>
-`;
-
-export const darkMode = () => `
-  <calcite-icon
-    dir="rtl"
-    icon="${select("icon", iconNames, iconNames[0])}"
+    ${boolean("mirrored", false)}
+    />
+  `,
+    { notes }
+  )
+  .add(
+    "Dark theme",
+    () => `
+    <calcite-icon
     theme="dark"
-  ></calcite-icon>
-`;
-
-darkMode.story = {
-  parameters: {
-    backgrounds: darkBackground
-  }
-};
+    icon="${select("icon", iconNames, iconNames[0])}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("mirrored", false)}
+    />
+  `,
+    { notes, backgrounds: darkBackground }
+  );

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -1,6 +1,5 @@
 import { Build, Component, Element, h, Host, Prop, State, Watch } from "@stencil/core";
 import { CSS } from "./resources";
-import { getElementDir } from "../../utils/dom";
 import { fetchIcon, scaleToPx } from "./utils";
 import { IconScale } from "../../interfaces/Icon";
 import { Theme } from "../../interfaces/common";
@@ -37,7 +36,7 @@ export class CalciteIcon {
   icon: string = null;
 
   /**
-   * When true, the icon will be mirrored when the element direction is 'rtl'.
+   * When true, the icon will be mirrored.
    */
   @Prop({
     reflect: true
@@ -93,8 +92,7 @@ export class CalciteIcon {
   }
 
   render() {
-    const { el, mirrored, pathData, scale, textLabel } = this;
-    const dir = getElementDir(el);
+    const { mirrored, pathData, scale, textLabel } = this;
     const size = scaleToPx[scale];
     const semantic = !!textLabel;
     const paths = [].concat(pathData || "");
@@ -102,7 +100,7 @@ export class CalciteIcon {
       <Host aria-label={semantic ? textLabel : null} role={semantic ? "img" : null}>
         <svg
           class={{
-            [CSS.mirrored]: dir === "rtl" && mirrored,
+            [CSS.mirrored]: mirrored,
             svg: true
           }}
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/calcite-icon/readme.md
+++ b/src/components/calcite-icon/readme.md
@@ -19,7 +19,7 @@ To use a custom color for the icon fill, you can add a class to the `calcite-ico
 | Property    | Attribute    | Description                                                                                                                         | Type                | Default     |
 | ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
 | `icon`      | `icon`       | The name of the icon to display. The value of this property must match the icon name from https://esri.github.io/calcite-ui-icons/. | `string`            | `null`      |
-| `mirrored`  | `mirrored`   | When true, the icon will be mirrored when the element direction is 'rtl'.                                                           | `boolean`           | `false`     |
+| `mirrored`  | `mirrored`   | When true, the icon will be mirrored.                                                                                               | `boolean`           | `false`     |
 | `scale`     | `scale`      | Icon scale. Can be "s" \| "m" \| "l".                                                                                               | `"l" \| "m" \| "s"` | `"m"`       |
 | `textLabel` | `text-label` | The icon label. It is recommended to set this value if your icon is semantic.                                                       | `string`            | `undefined` |
 | `theme`     | `theme`      | Icon theme. Can be "light" or "dark".                                                                                               | `"dark" \| "light"` | `undefined` |

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -35,7 +35,7 @@ export class CalciteSplitButton {
   @Prop({ reflect: true }) primaryIconEnd?: string;
 
   /** mirror the icon for the primary button  */
-  @Prop({ reflect: true }) primaryiconMirrored?: "both" | "start" | "end";
+  @Prop({ reflect: true }) primaryIconMirrored?: "both" | "start" | "end";
 
   /** optionally pass an aria-label for the primary button */
   @Prop({ reflect: true }) primaryLabel?: string;
@@ -97,7 +97,7 @@ export class CalciteSplitButton {
             loading={this.loading}
             icon-start={this.primaryIconStart ? this.primaryIconStart : null}
             icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
-            icon-mirrored={this.primaryiconMirrored ? this.primaryiconMirrored : null}
+            icon-mirrored={this.primaryIconMirrored ? this.primaryIconMirrored : null}
             disabled={this.disabled}
             theme={this.theme}
             onClick={this.calciteSplitButtonPrimaryClickHandler}

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -34,6 +34,9 @@ export class CalciteSplitButton {
   /** optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names  */
   @Prop({ reflect: true }) primaryIconEnd?: string;
 
+  /** mirror the icon for the primary button  */
+  @Prop({ reflect: true }) primaryiconMirrored?: "both" | "start" | "end";
+
   /** optionally pass an aria-label for the primary button */
   @Prop({ reflect: true }) primaryLabel?: string;
 
@@ -94,6 +97,7 @@ export class CalciteSplitButton {
             loading={this.loading}
             icon-start={this.primaryIconStart ? this.primaryIconStart : null}
             icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
+            icon-mirrored={this.primaryiconMirrored ? this.primaryiconMirrored : null}
             disabled={this.disabled}
             theme={this.theme}
             onClick={this.calciteSplitButtonPrimaryClickHandler}

--- a/src/components/calcite-split-button/readme.md
+++ b/src/components/calcite-split-button/readme.md
@@ -18,20 +18,20 @@ Basic Usage:
 
 ## Properties
 
-| Property              | Attribute              | Description                                                                                              | Type                                               | Default     |
-| --------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
-| `color`               | `color`                | specify the color of the control, defaults to blue                                                       | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
-| `disabled`            | `disabled`             | is the control disabled                                                                                  | `boolean`                                          | `undefined` |
-| `dropdownIconType`    | `dropdown-icon-type`   | specify the icon used for the dropdown menu, defaults to chevron                                         | `"caret" \| "chevron" \| "ellipsis" \| "overflow"` | `"chevron"` |
-| `dropdownLabel`       | `dropdown-label`       | aria label for overflow button                                                                           | `string`                                           | `undefined` |
-| `loading`             | `loading`              | optionally add a calcite-loader component to the control, disabling interaction. with the primary button | `boolean`                                          | `false`     |
-| `primaryIconEnd`      | `primary-icon-end`     | optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names      | `string`                                           | `undefined` |
-| `primaryIconStart`    | `primary-icon-start`   | optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names    | `string`                                           | `undefined` |
-| `primaryLabel`        | `primary-label`        | optionally pass an aria-label for the primary button                                                     | `string`                                           | `undefined` |
-| `primaryText`         | `primary-text`         | text for primary action button                                                                           | `string`                                           | `undefined` |
-| `primaryiconMirrored` | `primaryicon-mirrored` | mirror the icon for the primary button                                                                   | `"both" \| "end" \| "start"`                       | `undefined` |
-| `scale`               | `scale`                | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                                | `"m"`       |
-| `theme`               | `theme`                | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                                | `undefined` |
+| Property              | Attribute               | Description                                                                                              | Type                                               | Default     |
+| --------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `color`               | `color`                 | specify the color of the control, defaults to blue                                                       | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
+| `disabled`            | `disabled`              | is the control disabled                                                                                  | `boolean`                                          | `undefined` |
+| `dropdownIconType`    | `dropdown-icon-type`    | specify the icon used for the dropdown menu, defaults to chevron                                         | `"caret" \| "chevron" \| "ellipsis" \| "overflow"` | `"chevron"` |
+| `dropdownLabel`       | `dropdown-label`        | aria label for overflow button                                                                           | `string`                                           | `undefined` |
+| `loading`             | `loading`               | optionally add a calcite-loader component to the control, disabling interaction. with the primary button | `boolean`                                          | `false`     |
+| `primaryIconEnd`      | `primary-icon-end`      | optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names      | `string`                                           | `undefined` |
+| `primaryIconMirrored` | `primary-icon-mirrored` | mirror the icon for the primary button                                                                   | `"both" \| "end" \| "start"`                       | `undefined` |
+| `primaryIconStart`    | `primary-icon-start`    | optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names    | `string`                                           | `undefined` |
+| `primaryLabel`        | `primary-label`         | optionally pass an aria-label for the primary button                                                     | `string`                                           | `undefined` |
+| `primaryText`         | `primary-text`          | text for primary action button                                                                           | `string`                                           | `undefined` |
+| `scale`               | `scale`                 | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                                | `"m"`       |
+| `theme`               | `theme`                 | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                                | `undefined` |
 
 ## Events
 

--- a/src/components/calcite-split-button/readme.md
+++ b/src/components/calcite-split-button/readme.md
@@ -18,19 +18,20 @@ Basic Usage:
 
 ## Properties
 
-| Property           | Attribute            | Description                                                                                              | Type                                               | Default     |
-| ------------------ | -------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
-| `color`            | `color`              | specify the color of the control, defaults to blue                                                       | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
-| `disabled`         | `disabled`           | is the control disabled                                                                                  | `boolean`                                          | `undefined` |
-| `dropdownIconType` | `dropdown-icon-type` | specify the icon used for the dropdown menu, defaults to chevron                                         | `"caret" \| "chevron" \| "ellipsis" \| "overflow"` | `"chevron"` |
-| `dropdownLabel`    | `dropdown-label`     | aria label for overflow button                                                                           | `string`                                           | `undefined` |
-| `loading`          | `loading`            | optionally add a calcite-loader component to the control, disabling interaction. with the primary button | `boolean`                                          | `false`     |
-| `primaryIconEnd`   | `primary-icon-end`   | optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names      | `string`                                           | `undefined` |
-| `primaryIconStart` | `primary-icon-start` | optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names    | `string`                                           | `undefined` |
-| `primaryLabel`     | `primary-label`      | optionally pass an aria-label for the primary button                                                     | `string`                                           | `undefined` |
-| `primaryText`      | `primary-text`       | text for primary action button                                                                           | `string`                                           | `undefined` |
-| `scale`            | `scale`              | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                                | `"m"`       |
-| `theme`            | `theme`              | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                                | `undefined` |
+| Property              | Attribute              | Description                                                                                              | Type                                               | Default     |
+| --------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `color`               | `color`                | specify the color of the control, defaults to blue                                                       | `"blue" \| "dark" \| "light" \| "red"`             | `"blue"`    |
+| `disabled`            | `disabled`             | is the control disabled                                                                                  | `boolean`                                          | `undefined` |
+| `dropdownIconType`    | `dropdown-icon-type`   | specify the icon used for the dropdown menu, defaults to chevron                                         | `"caret" \| "chevron" \| "ellipsis" \| "overflow"` | `"chevron"` |
+| `dropdownLabel`       | `dropdown-label`       | aria label for overflow button                                                                           | `string`                                           | `undefined` |
+| `loading`             | `loading`              | optionally add a calcite-loader component to the control, disabling interaction. with the primary button | `boolean`                                          | `false`     |
+| `primaryIconEnd`      | `primary-icon-end`     | optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names      | `string`                                           | `undefined` |
+| `primaryIconStart`    | `primary-icon-start`   | optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names    | `string`                                           | `undefined` |
+| `primaryLabel`        | `primary-label`        | optionally pass an aria-label for the primary button                                                     | `string`                                           | `undefined` |
+| `primaryText`         | `primary-text`         | text for primary action button                                                                           | `string`                                           | `undefined` |
+| `primaryiconMirrored` | `primaryicon-mirrored` | mirror the icon for the primary button                                                                   | `"both" \| "end" \| "start"`                       | `undefined` |
+| `scale`               | `scale`                | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                                | `"m"`       |
+| `theme`               | `theme`                | select theme (light or dark), defaults to light                                                          | `"dark" \| "light"`                                | `undefined` |
 
 ## Events
 

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -51,6 +51,9 @@ export class CalciteTabTitle {
   /** optionally pass an icon to display at the end of a tab title - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;
 
+  /** mirror the icon  */
+  @Prop({ reflect: true }) iconMirrored?: "both" | "start" | "end";
+
   /** @internal Parent tabs component layout value */
   @Prop({ reflect: true, mutable: true }) layout: "center" | "inline";
   //--------------------------------------------------------------------------
@@ -86,11 +89,19 @@ export class CalciteTabTitle {
     const id = this.el.id || this.guid;
 
     const iconStartEl = (
-      <calcite-icon class="calcite-tab-title--icon icon-start" icon={this.iconStart} scale="s" />
+      <calcite-icon
+        class="calcite-tab-title--icon icon-start"
+        icon={this.iconStart}
+        mirrored={this.iconMirrored === "start" || this.iconMirrored === "both"}
+      />
     );
 
     const iconEndEl = (
-      <calcite-icon class="calcite-tab-title--icon icon-end" icon={this.iconEnd} scale="s" />
+      <calcite-icon
+        class="calcite-tab-title--icon icon-end"
+        icon={this.iconEnd}
+        mirrored={this.iconMirrored === "end" || this.iconMirrored === "both"}
+      />
     );
 
     return (

--- a/src/components/calcite-tab-title/readme.md
+++ b/src/components/calcite-tab-title/readme.md
@@ -6,12 +6,13 @@ The tab-title is the link that switches between panes in [calcite-tabs](../calci
 
 ## Properties
 
-| Property    | Attribute    | Description                                                                                              | Type      | Default     |
-| ----------- | ------------ | -------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `active`    | `active`     | Show this tab title as selected                                                                          | `boolean` | `false`     |
-| `iconEnd`   | `icon-end`   | optionally pass an icon to display at the end of a tab title - accepts calcite ui icon names             | `string`  | `undefined` |
-| `iconStart` | `icon-start` | optionally pass an icon to display at the start of a tab title - accepts calcite ui icon names           | `string`  | `undefined` |
-| `tab`       | `tab`        | Optionally include a unique name for the tab title, be sure to also set this name on the associated tab. | `string`  | `undefined` |
+| Property       | Attribute       | Description                                                                                              | Type                         | Default     |
+| -------------- | --------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------- |
+| `active`       | `active`        | Show this tab title as selected                                                                          | `boolean`                    | `false`     |
+| `iconEnd`      | `icon-end`      | optionally pass an icon to display at the end of a tab title - accepts calcite ui icon names             | `string`                     | `undefined` |
+| `iconMirrored` | `icon-mirrored` | mirror the icon                                                                                          | `"both" \| "end" \| "start"` | `undefined` |
+| `iconStart`    | `icon-start`    | optionally pass an icon to display at the start of a tab title - accepts calcite ui icon names           | `string`                     | `undefined` |
+| `tab`          | `tab`           | Optionally include a unique name for the tab title, be sure to also set this name on the associated tab. | `string`                     | `undefined` |
 
 ## Events
 

--- a/src/demos/calcite-icon.html
+++ b/src/demos/calcite-icon.html
@@ -61,12 +61,10 @@
     <calcite-icon icon="camera" theme="dark"></calcite-icon>
   </div>
 
-  <h2>Flips icon in RTL when mirrored</h2>
-  <div dir="rtl">
-    <calcite-icon icon="aZ" mirror></calcite-icon>
-    <calcite-icon icon="basemap" mirror></calcite-icon>
-    <calcite-icon icon="camera" mirror></calcite-icon>
-  </div>
+  <h2>Flips with `mirrored`</h2>
+    <calcite-icon icon="aZ" mirrored></calcite-icon>
+    <calcite-icon icon="basemap" mirrored></calcite-icon>
+    <calcite-icon icon="camera" mirrored></calcite-icon>
 
 </body>
 


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/846 cc @gpbmike

## Summary

Previously, `mirrored` only worked when `calcite-icon` was set to `dir=rtl`. This PR allows `mirrored` to work regardless of `dir`. Additionally, it adds some pass-through props to components that render icons that users do not have direct access to set `mirrored` on.

**CHANGELOG:** 
- `calcite-icon` - the `mirrored` prop will now be applied in both `dir=rtl` and `dir=ltr` - previously it would only apply if `dir=rtl`
- `calcite-button` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
- `calcite-split-button` now has a `primary-icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
- `calcite-dropdown-item` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.
- `calcite-tab-title` now has an `icon-mirrored` prop that can be used with values `start`, `end`, or `both`, to mirror displayed icons.

Additionally updates the dev demo and storybook for `calcite-icon`.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
