### PR TITLE
chore: Storybook cleanup. Moves decorators to preview.ts and runs prettier

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,8 +1,12 @@
 import { addDecorator, addParameters } from "@storybook/html";
+import { withA11y } from "@storybook/addon-a11y";
+import { withKnobs } from "@storybook/addon-knobs";
 import centered from "@storybook/addon-centered/html";
 import theme from "./theme";
 import { titlelessDocsPage } from "./utils";
 
+addDecorator(withKnobs);
+addDecorator(withA11y);
 addDecorator(centered);
 addParameters({
   backgrounds: [{ name: "Light", value: "#f8f8f8", default: true }],

--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-accordion-item/readme.md";
@@ -9,7 +9,6 @@ const notes2 = parseReadme(readme2);
 const notes = notes1.concat(`\n${notes2}`);
 
 storiesOf("components|Accordion", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -9,7 +8,6 @@ import { TEXT } from "./resources";
 
 export default {
   title: "app components|calcite-action-bar",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -9,7 +8,6 @@ import { TEXT } from "./resources";
 
 export default {
   title: "app components|calcite-action-pad",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-action/calcite-action.stories.ts
+++ b/src/components/calcite-action/calcite-action.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -7,7 +6,6 @@ const { appearance, dir, scale, theme } = ATTRIBUTES;
 
 export default {
   title: "app components|calcite-action",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-alert/calcite-alert.stories.ts
+++ b/src/components/calcite-alert/calcite-alert.stories.ts
@@ -1,12 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean, select } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Alert", module)
-  .addDecorator(withKnobs)
-
   .add(
     "Alert - title, message, link",
     () => `

--- a/src/components/calcite-block/calcite-block.stories.ts
+++ b/src/components/calcite-block/calcite-block.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import {
   Attribute,
   Attributes,
@@ -14,7 +13,6 @@ import dedent from "dedent";
 
 export default {
   title: "app components|calcite-block",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: {

--- a/src/components/calcite-button/calcite-button.stories.ts
+++ b/src/components/calcite-button/calcite-button.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, text, select } from "@storybook/addon-knobs";
+import { text, select } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Button", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -1,8 +1,6 @@
 import { Component, Element, h, Host, Method, Prop, Build, State } from "@stencil/core";
 
 import { getElementDir } from "../../utils/dom";
-import { Components } from "../../components";
-import { CalciteIcon } from "../calcite-icon/calcite-icon";
 
 @Component({
   tag: "calcite-button",
@@ -62,7 +60,7 @@ export class CalciteButton {
   @Prop({ reflect: true }) href?: string;
 
   /** optionally pass an icon to display at the start of a button - accepts calcite ui icon names  */
-  @Prop({ reflect: true }) iconStart?: string | CalciteIcon;
+  @Prop({ reflect: true }) iconStart?: string;
 
   /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -1,6 +1,8 @@
 import { Component, Element, h, Host, Method, Prop, Build, State } from "@stencil/core";
 
 import { getElementDir } from "../../utils/dom";
+import { Components } from "../../components";
+import { CalciteIcon } from "../calcite-icon/calcite-icon";
 
 @Component({
   tag: "calcite-button",
@@ -60,7 +62,7 @@ export class CalciteButton {
   @Prop({ reflect: true }) href?: string;
 
   /** optionally pass an icon to display at the start of a button - accepts calcite ui icon names  */
-  @Prop({ reflect: true }) iconStart?: string;
+  @Prop({ reflect: true }) iconStart?: string | CalciteIcon;
 
   /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;

--- a/src/components/calcite-card/calcite-card.e2e.ts
+++ b/src/components/calcite-card/calcite-card.e2e.ts
@@ -41,9 +41,7 @@ describe("calcite-card", () => {
       </calcite-card>
     `);
 
-    const thumbContainer = await page.find(
-      `calcite-card >>> .${CSS.thumbnailWrapper}`
-    );
+    const thumbContainer = await page.find(`calcite-card >>> .${CSS.thumbnailWrapper}`);
 
     expect(thumbContainer).not.toBeNull();
   });
@@ -56,9 +54,7 @@ describe("calcite-card", () => {
       </calcite-card>
     `);
 
-    const thumbContainer = await page.find(
-      `calcite-card >>> .${CSS.checkboxWrapper}`
-    );
+    const thumbContainer = await page.find(`calcite-card >>> .${CSS.checkboxWrapper}`);
 
     expect(thumbContainer).not.toBeNull();
   });

--- a/src/components/calcite-card/calcite-card.scss
+++ b/src/components/calcite-card/calcite-card.scss
@@ -26,9 +26,7 @@
   }
 }
 
-:host([loading])
-  .calcite-card-container
-  *:not(calcite-loader):not(.calcite-card-loader-container) {
+:host([loading]) .calcite-card-container *:not(calcite-loader):not(.calcite-card-loader-container) {
   opacity: 0;
   pointer-events: none;
 }

--- a/src/components/calcite-card/calcite-card.stories.ts
+++ b/src/components/calcite-card/calcite-card.stories.ts
@@ -5,7 +5,6 @@ import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Card", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-checkbox/calcite-checkbox.stories.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Checkbox", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-chip/calcite-chip.e2e.ts
+++ b/src/components/calcite-chip/calcite-chip.e2e.ts
@@ -6,8 +6,7 @@ import { CSS } from "./resources";
 describe("calcite-chip", () => {
   it("renders", async () => renders("<calcite-chip>doritos</calcite-chip>"));
 
-  it("is accessible", async () =>
-    accessible(`<calcite-chip>doritos</calcite-chip>`));
+  it("is accessible", async () => accessible(`<calcite-chip>doritos</calcite-chip>`));
 
   it("should emit event after the close button is clicked", async () => {
     const page = await newE2EPage();
@@ -34,9 +33,7 @@ describe("calcite-chip", () => {
 
   it("renders default props when invalid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-chip appearance="zip" color="zat" scale="zop">Chip content</calcite-chip>`
-    );
+    await page.setContent(`<calcite-chip appearance="zip" color="zat" scale="zop">Chip content</calcite-chip>`);
 
     const element = await page.find("calcite-chip");
     expect(element).toEqualAttribute("appearance", "solid");
@@ -46,9 +43,7 @@ describe("calcite-chip", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-chip appearance="clear" color="blue" scale="l">Chip content</calcite-chip>`
-    );
+    await page.setContent(`<calcite-chip appearance="clear" color="blue" scale="l">Chip content</calcite-chip>`);
 
     const element = await page.find("calcite-chip");
     expect(element).toEqualAttribute("appearance", "clear");
@@ -58,9 +53,7 @@ describe("calcite-chip", () => {
 
   it("renders a close button when requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-chip dismissible>Chip content</calcite-chip>`
-    );
+    await page.setContent(`<calcite-chip dismissible>Chip content</calcite-chip>`);
 
     const close = await page.find("calcite-chip >>> button.close");
     expect(close).not.toBeNull();

--- a/src/components/calcite-chip/calcite-chip.scss
+++ b/src/components/calcite-chip/calcite-chip.scss
@@ -77,23 +77,23 @@
 }
 
 :host([dismissible]) span {
-  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s)
-    var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l);
+  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s)
+    var(--calcite-chip-spacing-unit-l);
 }
 
 :host([dir="rtl"][dismissible]) span {
-  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l)
-    var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s);
+  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s)
+    var(--calcite-chip-spacing-unit-s);
 }
 
 :host([icon]:not([dismissible])) span {
-  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l)
-    var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s);
+  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s)
+    var(--calcite-chip-spacing-unit-s);
 }
 
 :host([dir="rtl"][icon]:not([dismissible])) span {
-  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s)
-    var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l);
+  padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s)
+    var(--calcite-chip-spacing-unit-l);
 }
 
 :host button {
@@ -143,19 +143,16 @@
   margin: 0 var(--calcite-chip-spacing-unit-l) 0 0;
 }
 
-$chipColors: "blue" var(--calcite-ui-blue-1) var(--calcite-ui-blue-2)
-    var(--calcite-ui-blue-3) var(--calcite-ui-foreground-1)
-    var(--calcite-ui-blue-3),
-  "red" var(--calcite-ui-red-1) var(--calcite-ui-red-2) var(--calcite-ui-red-3)
-    var(--calcite-ui-foreground-1) var(--calcite-ui-red-3),
-  "yellow" var(--calcite-ui-yellow-1) var(--calcite-ui-yellow-2)
-    var(--calcite-ui-yellow-3) var(--calcite-ui-text-1)
+$chipColors: "blue" var(--calcite-ui-blue-1) var(--calcite-ui-blue-2) var(--calcite-ui-blue-3)
+    var(--calcite-ui-foreground-1) var(--calcite-ui-blue-3),
+  "red" var(--calcite-ui-red-1) var(--calcite-ui-red-2) var(--calcite-ui-red-3) var(--calcite-ui-foreground-1)
+    var(--calcite-ui-red-3),
+  "yellow" var(--calcite-ui-yellow-1) var(--calcite-ui-yellow-2) var(--calcite-ui-yellow-3) var(--calcite-ui-text-1)
     var(--calcite-ui-yellow-3),
-  "green" var(--calcite-ui-green-1) var(--calcite-ui-green-2)
-    var(--calcite-ui-green-3) var(--calcite-ui-text-1) var(--calcite-ui-green-3),
-  "grey" var(--calcite-ui-foreground-2) var(--calcite-ui-foreground-3)
-    var(--calcite-ui-foreground-3) var(--calcite-ui-text-1)
-    var(--calcite-ui-text-1);
+  "green" var(--calcite-ui-green-1) var(--calcite-ui-green-2) var(--calcite-ui-green-3) var(--calcite-ui-text-1)
+    var(--calcite-ui-green-3),
+  "grey" var(--calcite-ui-foreground-2) var(--calcite-ui-foreground-3) var(--calcite-ui-foreground-3)
+    var(--calcite-ui-text-1) var(--calcite-ui-text-1);
 
 @each $chipColor in $chipColors {
   $name: nth($chipColor, 1);
@@ -181,8 +178,7 @@ $chipColors: "blue" var(--calcite-ui-blue-1) var(--calcite-ui-blue-2)
 
   // handle dark theme text accessibility for solid
   :host([theme="dark"][color="#{$name}"][appearance="solid"]:not([color="grey"])),
-  :host([theme="dark"][color="#{$name}"][appearance="solid"]:not([color="grey"]))
-    button {
+  :host([theme="dark"][color="#{$name}"][appearance="solid"]:not([color="grey"])) button {
     color: var(--calcite-ui-background);
   }
 

--- a/src/components/calcite-chip/calcite-chip.stories.ts
+++ b/src/components/calcite-chip/calcite-chip.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Chip", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-color/calcite-color.stories.ts
+++ b/src/components/calcite-color/calcite-color.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground } from "../../../.storybook/helpers";
 import colorReadme from "./readme.md";
 import colorSwatchReadme from "../calcite-color-swatch/readme.md";
@@ -8,7 +8,6 @@ import hexInputReadme from "../calcite-color-hex-input/readme.md";
 const notes = [colorReadme, colorSwatchReadme, hexInputReadme].join("\n");
 
 storiesOf("components|Color", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -35,8 +35,7 @@ input {
   flex-grow: 1;
   font-size: inherit;
   font-family: inherit;
-  padding: var(--calcite-combobox-item-spacing-unit-s)
-    var(--calcite-combobox-item-spacing-unit-l);
+  padding: var(--calcite-combobox-item-spacing-unit-s) var(--calcite-combobox-item-spacing-unit-l);
   background-color: var(--calcite-ui-foreground-1);
   border: 1px solid var(--calcite-ui-border-1);
   color: 1px solid var(--calcite-ui-text-1);

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, boolean, select } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-combobox-item/readme.md";
@@ -9,7 +9,6 @@ const notes2 = parseReadme(readme2);
 const notes = notes1.concat(`\n${notes2}`);
 
 storiesOf("components|Combobox", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-date-day/calcite-date-day.scss
+++ b/src/components/calcite-date-day/calcite-date-day.scss
@@ -76,8 +76,7 @@
 }
 
 :host(:focus) .day {
-  box-shadow: 0 0 0 2px var(--calcite-ui-foreground-1),
-    0 0 0 4px var(--calcite-ui-blue-1);
+  box-shadow: 0 0 0 2px var(--calcite-ui-foreground-1), 0 0 0 4px var(--calcite-ui-blue-1);
 }
 
 :host([selected]) .day {

--- a/src/components/calcite-date/calcite-date.stories.ts
+++ b/src/components/calcite-date/calcite-date.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text, boolean } from "@storybook/addon-knobs";
+import { select, text, boolean } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -45,7 +45,6 @@ const locales = [
 ];
 
 storiesOf("components|Date", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -5,33 +5,27 @@
 
 // ie11
 :host-context([scale="s"]) {
-  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5
-    $baseline * 1.5};
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5 $baseline * 1.5};
 }
 
 :host-context([scale="m"]) {
-  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3
-    $baseline * 1.5};
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5};
 }
 
 :host-context([scale="l"]) {
-  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2
-    $baseline * 1.5};
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2 $baseline * 1.5};
 }
 
 :host-context([dir="rtl"][scale="s"]) {
-  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5
-    $baseline/1.5};
+  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5 $baseline/1.5};
 }
 
 :host-context([dir="rtl"][scale="m"]) {
-  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3
-    $baseline / 1.5};
+  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3 $baseline / 1.5};
 }
 
 :host-context([dir="rtl"][scale="l"]) {
-  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2
-    $baseline / 1.5};
+  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2 $baseline / 1.5};
 }
 
 @mixin itemStyling {

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, number, select } from "@storybook/addon-knobs";
+import { number, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-dropdown-group/readme.md";
@@ -11,7 +11,6 @@ const notes3 = parseReadme(readme3);
 const notes = notes1.concat(`\n${notes2}`).concat(`\n${notes3}`);
 
 storiesOf("components|Dropdown", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-fab/calcite-fab.stories.ts
+++ b/src/components/calcite-fab/calcite-fab.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import {
   Attributes,
   createComponentHTML as create,
@@ -14,7 +13,6 @@ const { appearance, dir, scale, theme } = ATTRIBUTES;
 
 export default {
   title: "app components|calcite-fab",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     docs: {

--- a/src/components/calcite-flow/calcite-flow.stories.ts
+++ b/src/components/calcite-flow/calcite-flow.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, theme } = ATTRIBUTES;
@@ -10,7 +9,6 @@ import dedent from "dedent";
 
 export default {
   title: "app components|calcite-flow",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: {

--- a/src/components/calcite-graph/util.ts
+++ b/src/components/calcite-graph/util.ts
@@ -1,11 +1,4 @@
-import {
-  Point,
-  DataSeries,
-  Graph,
-  TranslateOptions,
-  Translator,
-  Extent,
-} from "../../interfaces/Graph";
+import { Point, DataSeries, Graph, TranslateOptions, Translator, Extent } from "../../interfaces/Graph";
 
 /**
  * Math.sign not supported in IE
@@ -27,10 +20,7 @@ function slope(p0: Point, p1: Point, p2: Point): number {
   const m = dy / (dx || (dx1 < 0 && 0));
   const m1 = dy1 / (dx1 || (dx < 0 && 0));
   const p = (m * dx1 + m1 * dx) / (dx + dx1);
-  return (
-    (sign(m) + sign(m1)) *
-      Math.min(Math.abs(m), Math.abs(m1), 0.5 * Math.abs(p)) || 0
-  );
+  return (sign(m) + sign(m1)) * Math.min(Math.abs(m), Math.abs(m1), 0.5 * Math.abs(p)) || 0;
 }
 
 /**
@@ -49,13 +39,7 @@ function slopeSingle(p0: Point, p1: Point, m: number): number {
  * Translates Hermite Spline to Beziér curve:
  * stackoverflow.com/questions/42574940/
  */
-function bezier(
-  p0: Point,
-  p1: Point,
-  m0: number,
-  m1: number,
-  t: Translator
-): string {
+function bezier(p0: Point, p1: Point, m0: number, m1: number, t: Translator): string {
   const [x0, y0] = p0;
   const [x1, y1] = p1;
   const dx = (x1 - x0) / 3;
@@ -69,12 +53,7 @@ function bezier(
  * Generate a function which will translate a point
  * from the data coordinate space to svg viewbox oriented pixels
  */
-export function translate({
-  width,
-  height,
-  min,
-  max,
-}: TranslateOptions): Translator {
+export function translate({ width, height, min, max }: TranslateOptions): Translator {
   const rangeX = max[0] - min[0];
   const rangeY = max[1] - min[1];
   return (point) => {
@@ -94,7 +73,7 @@ export function range(data: DataSeries): Extent {
   return data.reduce(
     ({ min, max }, [x, y]) => ({
       min: [Math.min(min[0], x), Math.min(min[1], y)],
-      max: [Math.max(max[0], x), Math.max(max[1], y)],
+      max: [Math.max(max[0], x), Math.max(max[1], y)]
     }),
     { min, max }
   );

--- a/src/components/calcite-icon/calcite-icon.stories.ts
+++ b/src/components/calcite-icon/calcite-icon.stories.ts
@@ -1,4 +1,4 @@
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
@@ -6,7 +6,6 @@ const notes = parseReadme(readme);
 
 export default {
   title: "components|Icon",
-  decorators: [withKnobs],
   parameters: { notes }
 };
 

--- a/src/components/calcite-icon/utils.ts
+++ b/src/components/calcite-icon/utils.ts
@@ -24,13 +24,10 @@ export const requestCache: Record<string, Promise<CalciteIconPath>> = {};
 export const scaleToPx: Record<IconScale, number> = {
   s: 16,
   m: 24,
-  l: 32,
+  l: 32
 };
 
-export async function fetchIcon({
-  icon,
-  scale,
-}: FetchIconProps): Promise<CalciteIconPath> {
+export async function fetchIcon({ icon, scale }: FetchIconProps): Promise<CalciteIconPath> {
   const size = scaleToPx[scale];
   const name = normalizeIconName(icon);
   const filled = name.charAt(name.length - 1) === "F";

--- a/src/components/calcite-input-message/calcite-input-message.scss
+++ b/src/components/calcite-input-message/calcite-input-message.scss
@@ -19,10 +19,7 @@
 }
 
 :host([theme="dark"]) {
-  --calcite-input-message-floating-background: #{rgba(
-      $ui-foreground-1-dark,
-      0.96
-    )};
+  --calcite-input-message-floating-background: #{rgba($ui-foreground-1-dark, 0.96)};
 }
 
 :host {
@@ -83,10 +80,8 @@
 // status
 $inputStatusColors: "invalid" var(--calcite-ui-red-1) var(--calcite-ui-red-1)
     var(--calcite-input-status-invalid-focus-shadow-color),
-  "valid" var(--calcite-ui-green-1) var(--calcite-ui-green-1)
-    var(--calcite-input-status-valid-focus-shadow-color),
-  "idle" var(--calcite-ui-blue-1) var(--calcite-ui-blue-1)
-    var(--calcite-input-status-valid-focus-shadow-color);
+  "valid" var(--calcite-ui-green-1) var(--calcite-ui-green-1) var(--calcite-input-status-valid-focus-shadow-color),
+  "idle" var(--calcite-ui-blue-1) var(--calcite-ui-blue-1) var(--calcite-input-status-valid-focus-shadow-color);
 
 @each $statusColor in $inputStatusColors {
   $name: nth($statusColor, 1);

--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -1,12 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Input", module)
-  .addDecorator(withKnobs)
-
   .add(
     "With Label",
     () => `

--- a/src/components/calcite-label/calcite-label.stories.ts
+++ b/src/components/calcite-label/calcite-label.stories.ts
@@ -5,7 +5,6 @@ import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Label", module)
-  .addDecorator(withKnobs)
   .add(
     "Wrapping components other than input",
     () => `

--- a/src/components/calcite-link/calcite-link.stories.ts
+++ b/src/components/calcite-link/calcite-link.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, text, select } from "@storybook/addon-knobs";
+import { text, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import * as icons from "../../../node_modules/@esri/calcite-ui-icons";
 import readme from "./readme.md";
@@ -11,7 +11,6 @@ const iconNames = Object.keys(icons)
   .map((iconName) => iconName.replace("16", ""));
 
 storiesOf("components|Link", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-loader/calcite-loader.stories.ts
+++ b/src/components/calcite-loader/calcite-loader.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, number, color, select } from "@storybook/addon-knobs";
+import { number, color, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Loader", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-modal/calcite-modal.stories.ts
+++ b/src/components/calcite-modal/calcite-modal.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text, number } from "@storybook/addon-knobs";
+import { select, text, number } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Modal", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => {

--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -120,8 +120,7 @@
 
 @mixin notice-element-base() {
   box-sizing: border-box;
-  padding: var(--calcite-notice-spacing-token-small)
-    var(--calcite-notice-spacing-token-large);
+  padding: var(--calcite-notice-spacing-token-small) var(--calcite-notice-spacing-token-large);
   flex: 0 0 auto;
   transition: all 0.15s ease-in-out;
 }
@@ -133,30 +132,26 @@
   flex: 1 1 auto;
   min-width: 0;
   word-wrap: break-word;
-  padding: var(--calcite-notice-spacing-token-small)
-    var(--calcite-notice-spacing-token-small)
+  padding: var(--calcite-notice-spacing-token-small) var(--calcite-notice-spacing-token-small)
     var(--calcite-notice-spacing-token-small) 0;
 
   &:first-of-type:not(:only-child) {
     padding-left: var(--calcite-notice-spacing-token-large);
   }
   &:only-of-type {
-    padding: var(--calcite-notice-spacing-token-small)
-      var(--calcite-notice-spacing-token-large);
+    padding: var(--calcite-notice-spacing-token-small) var(--calcite-notice-spacing-token-large);
   }
 }
 
 :host([dir="rtl"]) .notice-content {
-  padding: var(--calcite-notice-spacing-token-small) 0
-    var(--calcite-notice-spacing-token-small)
+  padding: var(--calcite-notice-spacing-token-small) 0 var(--calcite-notice-spacing-token-small)
     var(--calcite-notice-spacing-token-small);
 
   &:first-of-type:not(:only-child) {
     padding-right: var(--calcite-notice-spacing-token-large);
   }
   &:only-of-type {
-    padding: var(--calcite-notice-spacing-token-small)
-      var(--calcite-notice-spacing-token-large);
+    padding: var(--calcite-notice-spacing-token-small) var(--calcite-notice-spacing-token-large);
   }
 }
 .notice-icon {
@@ -185,8 +180,8 @@
   }
 }
 
-$noticeColors: "blue" var(--calcite-ui-blue-1), "red" var(--calcite-ui-red-1),
-  "yellow" var(--calcite-ui-yellow-1), "green" var(--calcite-ui-green-1);
+$noticeColors: "blue" var(--calcite-ui-blue-1), "red" var(--calcite-ui-red-1), "yellow" var(--calcite-ui-yellow-1),
+  "green" var(--calcite-ui-green-1);
 
 @each $noticeColor in $noticeColors {
   $name: nth($noticeColor, 1);

--- a/src/components/calcite-notice/calcite-notice.stories.ts
+++ b/src/components/calcite-notice/calcite-notice.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Notice", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-pagination/calcite-pagination.stories.ts
+++ b/src/components/calcite-pagination/calcite-pagination.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, number, select } from "@storybook/addon-knobs";
+import { number, select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Pagination", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-pagination/resources.ts
+++ b/src/components/calcite-pagination/resources.ts
@@ -12,4 +12,4 @@ export const CSS = {
 export const TEXT = {
   nextLabel: "next",
   previousLabel: "previous"
-}
+};

--- a/src/components/calcite-panel/calcite-panel.stories.ts
+++ b/src/components/calcite-panel/calcite-panel.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, theme, scale } = ATTRIBUTES;
@@ -9,7 +8,6 @@ import dedent from "dedent";
 
 export default {
   title: "app components|calcite-panel",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -8,7 +7,6 @@ const { dir, theme } = ATTRIBUTES;
 
 export default {
   title: "app components|calcite-pick-list",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-popover/calcite-popover.stories.ts
+++ b/src/components/calcite-popover/calcite-popover.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, number, text } from "@storybook/addon-knobs";
+import { select, number, text } from "@storybook/addon-knobs";
 import { parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -38,7 +38,6 @@ const contentHTML = `
 const referenceElementHTML = `<calcite-popover-manager>Ut enim ad minim veniam, quis <calcite-button title="Reference Element" id="reference-element">nostrud exercitation</calcite-button> ullamco laboris nisi ut aliquip ex ea commodo consequat.</calcite-popover-manager>`;
 
 storiesOf("components|Popover", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => {

--- a/src/components/calcite-progress/calcite-progress.stories.ts
+++ b/src/components/calcite-progress/calcite-progress.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, number, text, boolean } from "@storybook/addon-knobs";
+import { select, number, text, boolean } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Progress", module)
-  .addDecorator(withKnobs)
   .add(
     "Determinate",
     () => `

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.ts
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.ts
@@ -1,12 +1,11 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
 const notes = parseReadme(readme);
 
 storiesOf("components|Radio Button Group", module)
-  .addDecorator(withKnobs)
   .add(
     "Light Theme",
     () => `

--- a/src/components/calcite-radio-button/calcite-radio-button.stories.ts
+++ b/src/components/calcite-radio-button/calcite-radio-button.stories.ts
@@ -1,12 +1,11 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
 const notes = parseReadme(readme);
 
 storiesOf("components|Radio Button", module)
-  .addDecorator(withKnobs)
   .add(
     "Light Theme",
     () => `

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.e2e.ts
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.e2e.ts
@@ -3,9 +3,7 @@ import { newE2EPage } from "@stencil/core/testing";
 describe("calcite-radio-group-item", () => {
   it("renders", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      "<calcite-radio-group-item></calcite-radio-group-item>"
-    );
+    await page.setContent("<calcite-radio-group-item></calcite-radio-group-item>");
     const element = await page.find("calcite-radio-group-item");
 
     expect(element).toBeDefined();
@@ -13,9 +11,7 @@ describe("calcite-radio-group-item", () => {
 
   it("is un-checked by default", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      "<calcite-radio-group-item value='test-value'></calcite-radio-group-item>"
-    );
+    await page.setContent("<calcite-radio-group-item value='test-value'></calcite-radio-group-item>");
     const element = await page.find("calcite-radio-group-item");
 
     const checked = await element.getProperty("checked");
@@ -24,9 +20,7 @@ describe("calcite-radio-group-item", () => {
 
   it("emits when checked", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      "<calcite-radio-group-item value='test-value'></calcite-radio-group-item>"
-    );
+    await page.setContent("<calcite-radio-group-item value='test-value'></calcite-radio-group-item>");
     const element = await page.find("calcite-radio-group-item");
     const spy = await element.spyOnEvent("calciteRadioGroupItemChange");
 
@@ -39,9 +33,7 @@ describe("calcite-radio-group-item", () => {
 
   it("supports value, label and checked", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      "<calcite-radio-group-item value='test-value' checked>test-label</calcite-radio-group-item>"
-    );
+    await page.setContent("<calcite-radio-group-item value='test-value' checked>test-label</calcite-radio-group-item>");
     const element = await page.find("calcite-radio-group-item");
 
     expect(element).toEqualText("test-label");
@@ -55,9 +47,7 @@ describe("calcite-radio-group-item", () => {
 
   it("uses value as fallback label", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      "<calcite-radio-group-item value='test-value' checked></calcite-radio-group-item>"
-    );
+    await page.setContent("<calcite-radio-group-item value='test-value' checked></calcite-radio-group-item>");
 
     const label = await page.find("calcite-radio-group-item >>> label");
     expect(label).toEqualText("test-value");
@@ -98,9 +88,7 @@ describe("calcite-radio-group-item", () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-radio-group-item icon="car">Content</calcite-accordion-item>`);
-    const icon = await page.find(
-      "calcite-radio-group-item >>> .radio-group-item-icon"
-    );
+    const icon = await page.find("calcite-radio-group-item >>> .radio-group-item-icon");
     expect(icon).not.toBe(null);
   });
 
@@ -108,18 +96,14 @@ describe("calcite-radio-group-item", () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-radio-group-item>Content</calcite-accordion-item>`);
-    const icon = await page.find(
-      "calcite-radio-group-item >>> .radio-group-item-icon"
-    );
+    const icon = await page.find("calcite-radio-group-item >>> .radio-group-item-icon");
     expect(icon).toBe(null);
   });
 
   describe("WAI-ARIA Roles, States, and Properties", () => {
     it(`has a role of 'radio'`, async () => {
       const page = await newE2EPage();
-      await page.setContent(
-        "<calcite-radio-group-item></calcite-radio-group-item>"
-      );
+      await page.setContent("<calcite-radio-group-item></calcite-radio-group-item>");
       const element = await page.find("calcite-radio-group-item");
 
       const role = await element.getAttribute("role");
@@ -129,9 +113,7 @@ describe("calcite-radio-group-item", () => {
 
     it(`updates 'aria-checked' based on 'checked' property`, async () => {
       const page = await newE2EPage();
-      await page.setContent(
-        "<calcite-radio-group-item></calcite-radio-group-item>"
-      );
+      await page.setContent("<calcite-radio-group-item></calcite-radio-group-item>");
       const element = await page.find("calcite-radio-group-item");
 
       let ariaChecked = await element.getAttribute("aria-checked");
@@ -155,12 +137,8 @@ describe("calcite-radio-group-item", () => {
 
     it("content/value is wrapped by label", async () => {
       const page = await newE2EPage();
-      await page.setContent(
-        "<calcite-radio-group-item></calcite-radio-group-item>"
-      );
-      const defaultSlot = await page.find(
-        "calcite-radio-group-item >>> label slot"
-      );
+      await page.setContent("<calcite-radio-group-item></calcite-radio-group-item>");
+      const defaultSlot = await page.find("calcite-radio-group-item >>> label slot");
 
       expect(defaultSlot).toBeDefined();
     });

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -38,9 +38,7 @@ describe("calcite-radio-group", () => {
     const selected = await element.getProperty("selectedItem");
     expect(selected).toBeDefined();
 
-    const selectedItems = await element.findAll(
-      "calcite-radio-group-item[checked]"
-    );
+    const selectedItems = await element.findAll("calcite-radio-group-item[checked]");
     expect(selectedItems).toHaveLength(1);
 
     const selectedValue = await selectedItems[0].getProperty("value");
@@ -60,9 +58,7 @@ describe("calcite-radio-group", () => {
       const element = await page.find("calcite-radio-group");
       const spy = await element.spyOnEvent("calciteRadioGroupChange");
 
-      const firstElement = await element.find(
-        "calcite-radio-group-item[checked]"
-      );
+      const firstElement = await element.find("calcite-radio-group-item[checked]");
       await firstElement.click();
       await element.press("ArrowRight");
       await page.waitForChanges();
@@ -109,9 +105,7 @@ describe("calcite-radio-group", () => {
         </calcite-radio-group>`
       );
 
-      const hiddenInput = await page.find(
-        `calcite-radio-group input[type="hidden"]`
-      );
+      const hiddenInput = await page.find(`calcite-radio-group input[type="hidden"]`);
       expect(hiddenInput).toBeDefined();
 
       const hiddenInputValue = await hiddenInput.getAttribute("value");
@@ -133,9 +127,7 @@ describe("calcite-radio-group", () => {
       const element = await page.find("calcite-radio-group");
       const spy = await element.spyOnEvent("calciteRadioGroupChange");
 
-      const firstElement = await element.find(
-        "calcite-radio-group-item[checked]"
-      );
+      const firstElement = await element.find("calcite-radio-group-item[checked]");
       await firstElement.click();
       await element.press("ArrowDown");
       let selected = await element.find("calcite-radio-group-item[checked]");
@@ -284,15 +276,13 @@ describe("calcite-radio-group", () => {
           <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
           <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
           <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
-        </calcite-radio-group>`,
+        </calcite-radio-group>`
       });
 
       const element = await page.find("calcite-radio-group");
       await element.callMethod("setFocus");
 
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual(
-        "child-1"
-      );
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-1");
     });
 
     it("focuses the selected item", async () => {
@@ -301,15 +291,13 @@ describe("calcite-radio-group", () => {
           <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
           <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
           <calcite-radio-group-item id="child-3" value="3" checked>three</calcite-radio-group-item>
-        </calcite-radio-group>`,
+        </calcite-radio-group>`
       });
 
       const element = await page.find("calcite-radio-group");
       await element.callMethod("setFocus");
 
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual(
-        "child-3"
-      );
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-3");
     });
   });
 });

--- a/src/components/calcite-radio-group/calcite-radio-group.stories.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-radio-group-item/readme.md";
@@ -9,7 +9,6 @@ const notes2 = parseReadme(readme2);
 const notes = notes1.concat(`\n${notes2}`);
 
 storiesOf("components|Radio Group", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-scrim/calcite-scrim.e2e.ts
+++ b/src/components/calcite-scrim/calcite-scrim.e2e.ts
@@ -10,8 +10,8 @@ describe("calcite-scrim", () => {
     defaults("calcite-scrim", [
       {
         propertyName: "loading",
-        defaultValue: false,
-      },
+        defaultValue: false
+      }
     ]));
 
   it("shows loading component", async () => {

--- a/src/components/calcite-scrim/calcite-scrim.stories.ts
+++ b/src/components/calcite-scrim/calcite-scrim.stories.ts
@@ -5,7 +5,6 @@ import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Scrim", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, position, scale, theme } = ATTRIBUTES;
@@ -9,7 +8,6 @@ import dedent from "dedent";
 
 export default {
   title: "app components|calcite-shell",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -101,8 +101,7 @@ $tick-height: 4px;
     border-radius: 100%;
     background-color: var(--calcite-ui-foreground-1);
     box-shadow: 0 0 0 2px var(--calcite-ui-text-3) inset;
-    transition: border 0.25s ease, background-color 0.25s ease,
-      box-shadow 0.25s ease;
+    transition: border 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
   }
 
   .handle-extension {

--- a/src/components/calcite-slider/calcite-slider.stories.ts
+++ b/src/components/calcite-slider/calcite-slider.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, text, number, array } from "@storybook/addon-knobs";
+import { text, number, array } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Slider", module)
-  .addDecorator(withKnobs)
   .add(
     "Single value",
     () => `

--- a/src/components/calcite-split-button/calcite-split-button.stories.ts
+++ b/src/components/calcite-split-button/calcite-split-button.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, text, select } from "@storybook/addon-knobs";
+import { text, select } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import * as icons from "../../../node_modules/@esri/calcite-ui-icons";
 import readme from "./readme.md";
@@ -7,7 +7,6 @@ import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Split Button", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-stepper-item/calcite-stepper-item.scss
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.scss
@@ -61,8 +61,7 @@
 
 :host .stepper-item-content,
 :host .stepper-item-header {
-  padding: var(--calcite-stepper-item-spacing-unit-l)
-    var(--calcite-stepper-item-spacing-unit-m);
+  padding: var(--calcite-stepper-item-spacing-unit-l) var(--calcite-stepper-item-spacing-unit-m);
   padding-left: 0;
   transition: $transition;
   text-align: left;

--- a/src/components/calcite-stepper/calcite-stepper.stories.ts
+++ b/src/components/calcite-stepper/calcite-stepper.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-stepper-item/readme.md";
@@ -9,7 +9,6 @@ const notes2 = parseReadme(readme2);
 const notes = notes1.concat(`\n${notes2}`);
 
 storiesOf("components|Stepper", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-switch/calcite-switch.stories.ts
+++ b/src/components/calcite-switch/calcite-switch.stories.ts
@@ -1,11 +1,10 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
 
 storiesOf("components|Switch", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme } from "../../../.storybook/helpers";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-tab/readme.md";
@@ -14,7 +14,6 @@ const notes4 = parseReadme(readme4);
 const notes = notes1.concat(`\n${notes2}`).concat(`\n${notes3}`).concat(`\n${notes4}`);
 
 storiesOf("components|Tabs", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
@@ -1,9 +1,8 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground } from "../../../.storybook/helpers";
 
 storiesOf("components|Tile Select Group", module)
-  .addDecorator(withKnobs)
   .add(
     "Light",
     () => `

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
@@ -3,7 +3,7 @@ import { Component, Host, h } from "@stencil/core";
 @Component({
   tag: "calcite-tile-select-group",
   styleUrl: "calcite-tile-select-group.scss",
-  shadow: true,
+  shadow: true
 })
 export class CalciteTileSelectGroup {
   render() {

--- a/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
@@ -1,17 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
-import {
-  accessible,
-  defaults,
-  hidden,
-  reflects,
-  renders,
-} from "../../tests/commonTests";
+import { accessible, defaults, hidden, reflects, renders } from "../../tests/commonTests";
 
 describe("calcite-tile-select", () => {
   it("renders", async () => renders("calcite-tile-select"));
 
-  it("is accessible", async () =>
-    accessible(`<calcite-tile-select></calcite-tile-select>`));
+  it("is accessible", async () => accessible(`<calcite-tile-select></calcite-tile-select>`));
 
   it("has defaults", async () =>
     defaults("calcite-tile-select", [
@@ -19,7 +12,7 @@ describe("calcite-tile-select", () => {
       { propertyName: "disabled", defaultValue: false },
       { propertyName: "focused", defaultValue: false },
       { propertyName: "hidden", defaultValue: false },
-      { propertyName: "theme", defaultValue: "light" },
+      { propertyName: "theme", defaultValue: "light" }
     ]));
 
   it("reflects", async () =>
@@ -39,7 +32,7 @@ describe("calcite-tile-select", () => {
       { propertyName: "theme", value: "dark" },
       { propertyName: "type", value: "radio" },
       { propertyName: "type", value: "checkbox" },
-      { propertyName: "value", value: "option one" },
+      { propertyName: "value", value: "option one" }
     ]));
 
   it("honors hidden attribute", async () => hidden("calcite-tile-select"));
@@ -54,9 +47,7 @@ describe("calcite-tile-select", () => {
 
   it("renders a calcite-radio-button when in radio mode", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      "<calcite-tile-select name='radio' value='one'></calcite-tile-select>"
-    );
+    await page.setContent("<calcite-tile-select name='radio' value='one'></calcite-tile-select>");
 
     const calciteRadio = await page.find("calcite-radio-button");
     const calciteCheckbox = await page.find("calcite-checkbox");

--- a/src/components/calcite-tile-select/calcite-tile-select.stories.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.stories.ts
@@ -1,12 +1,11 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
 const notes = parseReadme(readme);
 
 storiesOf("components|Tile Select", module)
-  .addDecorator(withKnobs)
   .add(
     "Light",
     () => `

--- a/src/components/calcite-tile/calcite-tile.stories.ts
+++ b/src/components/calcite-tile/calcite-tile.stories.ts
@@ -1,12 +1,11 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { darkBackground, iconNames, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 
 const notes = parseReadme(readme);
 
 storiesOf("components|Tile", module)
-  .addDecorator(withKnobs)
   .add(
     "Light",
     () => `

--- a/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { TEXT } from "./resources";
@@ -9,7 +8,6 @@ const { dir, theme } = ATTRIBUTES;
 
 export default {
   title: "app components|calcite-tip-manager",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-tip/calcite-tip.stories.ts
+++ b/src/components/calcite-tip/calcite-tip.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { TEXT } from "./resources";
@@ -7,7 +6,6 @@ import { ATTRIBUTES } from "../../../.storybook/resources";
 
 export default {
   title: "app components|calcite-tip",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/components/calcite-tooltip/calcite-tooltip.stories.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select, number } from "@storybook/addon-knobs";
+import { select, number } from "@storybook/addon-knobs";
 import { parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -32,7 +32,6 @@ const contentHTML = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, se
 const referenceElementHTML = `<calcite-tooltip-manager>Ut enim ad minim veniam, quis <calcite-button appearance="inline" title="Reference element" id="reference-element">nostrud exercitation</calcite-button> ullamco laboris nisi ut aliquip ex ea commodo consequat.</calcite-tooltip-manager>`;
 
 storiesOf("components|Tooltip", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => {

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -117,8 +117,7 @@
   transform: scaleY(0);
   opacity: 0;
   overflow: hidden;
-  transition: 0.15s $easing-function, opacity 0.15s $easing-function,
-    all 0.15s ease-in-out; // note that we're transitioning transform, not height!
+  transition: 0.15s $easing-function, opacity 0.15s $easing-function, all 0.15s ease-in-out; // note that we're transitioning transform, not height!
   height: 0;
   transform-origin: top; // keep the top of the element in the same place. this is optional.
 

--- a/src/components/calcite-tree/calcite-tree.stories.ts
+++ b/src/components/calcite-tree/calcite-tree.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { select } from "@storybook/addon-knobs";
 import { darkBackground, parseReadme, boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
 const notes = parseReadme(readme);
@@ -40,7 +40,6 @@ const treeItems = `
 `;
 
 storiesOf("components|Tree", module)
-  .addDecorator(withKnobs)
   .add(
     "Simple",
     () => `

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -1,5 +1,4 @@
-import { boolean, select, withKnobs } from "@storybook/addon-knobs";
-import { withA11y } from "@storybook/addon-a11y";
+import { boolean, select } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground, parseReadme } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -8,7 +7,6 @@ const { dir, theme } = ATTRIBUTES;
 
 export default {
   title: "app components|calcite-value-list",
-  decorators: [withKnobs, withA11y],
   parameters: {
     backgrounds: darkBackground,
     notes: parseReadme(readme)

--- a/src/interfaces/TreeSelect.ts
+++ b/src/interfaces/TreeSelect.ts
@@ -1,3 +1,3 @@
 export interface TreeSelectDetail {
-  selected: HTMLCalciteTreeItemElement[]
+  selected: HTMLCalciteTreeItemElement[];
 }


### PR DESCRIPTION
**Related Issue:** None

## Summary

Storybook cleanup

- Moves storybook decorators (Knobs/A11y) to preview.ts
- Run prettier