### PR TITLE
feat(switch): add disabled prop

### DIFF
--- a/src/components/calcite-card/readme.md
+++ b/src/components/calcite-card/readme.md
@@ -30,6 +30,7 @@
 graph TD;
   calcite-card --> calcite-loader
   calcite-card --> calcite-checkbox
+  calcite-checkbox --> calcite-label
   style calcite-card fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/calcite-checkbox/readme.md
+++ b/src/components/calcite-checkbox/readme.md
@@ -43,10 +43,15 @@ If you don't pass in an input, calcite-checkbox will act as the source of truth:
 
 - [calcite-card](../calcite-card)
 
+### Depends on
+
+- [calcite-label](../calcite-label)
+
 ### Graph
 
 ```mermaid
 graph TD;
+  calcite-checkbox --> calcite-label
   calcite-card --> calcite-checkbox
   style calcite-checkbox fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/calcite-label/readme.md
+++ b/src/components/calcite-label/readme.md
@@ -39,12 +39,14 @@ It allows consumers to set a `status` attribute that child `calcite-input` and `
 
 ### Used by
 
+- [calcite-checkbox](../calcite-checkbox)
 - [calcite-radio-button](../calcite-radio-button)
 
 ### Graph
 
 ```mermaid
 graph TD;
+  calcite-checkbox --> calcite-label
   calcite-radio-button --> calcite-label
   style calcite-label fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -81,6 +81,17 @@ describe("calcite-switch", () => {
     expect(changeEvent).toHaveFirstReceivedEventDetail({ switched: true });
   });
 
+  it("does not toggle when disabled", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-switch disabled></calcite-switch>`);
+    const calciteSwitch = await page.find("calcite-switch");
+    const changeEvent = await calciteSwitch.spyOnEvent("calciteSwitchChange");
+    expect(changeEvent).toHaveReceivedEventTimes(0);
+    await calciteSwitch.click();
+    expect(changeEvent).toHaveReceivedEventTimes(0);
+    expect(calciteSwitch).not.toHaveAttribute("switched");
+  });
+
   // Not sure why this is failing
   it("toggles the switched and checked attributes when the checkbox is toggled", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -92,7 +92,6 @@ describe("calcite-switch", () => {
     expect(calciteSwitch).not.toHaveAttribute("switched");
   });
 
-  // Not sure why this is failing
   it("toggles the switched and checked attributes when the checkbox is toggled", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -57,6 +57,11 @@
   tap-highlight-color: transparent;
 }
 
+:host([disabled]) {
+  opacity: 0.4;
+  pointer-events: none;
+  cursor: default;
+}
 // focus styles
 :host {
   @include focus-style-base();

--- a/src/components/calcite-switch/calcite-switch.stories.ts
+++ b/src/components/calcite-switch/calcite-switch.stories.ts
@@ -13,6 +13,7 @@ storiesOf("components|Switch", module)
         name="setting"
         value="enabled"
         ${boolean("switched", true)}
+        ${boolean("disabled", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
         color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
@@ -31,6 +32,7 @@ storiesOf("components|Switch", module)
         name="setting"
         value="enabled"
         ${boolean("switched", true)}
+        ${boolean("disabled", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
         color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
@@ -51,6 +53,7 @@ storiesOf("components|Switch", module)
         name="setting"
         value="enabled"
         ${boolean("switched", true)}
+        ${boolean("disabled", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
         color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -36,6 +36,9 @@ export class CalciteSwitch {
   /** The scale of the switch */
   @Prop({ reflect: true, mutable: true }) scale: "s" | "m" | "l" = "m";
 
+  /** True if the checkbox is disabled */
+  @Prop({ reflect: true }) disabled?: boolean = false;
+
   /** The component's theme. */
   @Prop({ reflect: true }) theme: "light" | "dark";
 
@@ -44,7 +47,11 @@ export class CalciteSwitch {
   private observer: MutationObserver;
 
   @Listen("calciteLabelFocus", { target: "window" }) handleLabelFocus(e) {
-    if (!this.el.contains(e.detail.interactedEl) && hasLabel(e.detail.labelEl, this.el)) {
+    if (
+      !this.disabled &&
+      !this.el.contains(e.detail.interactedEl) &&
+      hasLabel(e.detail.labelEl, this.el)
+    ) {
       this.updateSwitch(event);
       this.el.focus();
     } else return;
@@ -54,7 +61,7 @@ export class CalciteSwitch {
     // prevent duplicate click events that occur
     // when the component is wrapped in a label and checkbox is clicked
     if (
-      (this.el.closest("label") && e.target === this.inputProxy) ||
+      (!this.disabled && this.el.closest("label") && e.target === this.inputProxy) ||
       (!this.el.closest("label") && e.target === this.el)
     ) {
       this.updateSwitch(e);
@@ -63,7 +70,7 @@ export class CalciteSwitch {
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent) {
     const key = getKey(e.key);
-    if (key === " " || key === "Enter") {
+    if (!this.disabled && (key === " " || key === "Enter")) {
       this.updateSwitch(e);
     }
   }
@@ -78,7 +85,6 @@ export class CalciteSwitch {
 
   connectedCallback() {
     // prop validations
-
     const color = ["blue", "red"];
     if (!color.includes(this.color)) this.color = "blue";
 
@@ -103,7 +109,7 @@ export class CalciteSwitch {
         dir={dir}
         role="checkbox"
         aria-checked={this.switched.toString()}
-        tabIndex={this.tabIndex}
+        tabIndex={this.disabled ? -1 : this.tabIndex}
       >
         <div class="track">
           <div class="handle" />
@@ -130,6 +136,7 @@ export class CalciteSwitch {
     if (!this.inputProxy) {
       this.inputProxy = document.createElement("input");
       this.inputProxy.type = "checkbox";
+      this.inputProxy.disabled = this.disabled;
       this.syncProxyInputToThis();
       this.el.appendChild(this.inputProxy);
     }

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -36,7 +36,7 @@ export class CalciteSwitch {
   /** The scale of the switch */
   @Prop({ reflect: true, mutable: true }) scale: "s" | "m" | "l" = "m";
 
-  /** True if the checkbox is disabled */
+  /** True if the switch is disabled */
   @Prop({ reflect: true }) disabled?: boolean = false;
 
   /** The component's theme. */

--- a/src/components/calcite-switch/readme.md
+++ b/src/components/calcite-switch/readme.md
@@ -21,6 +21,7 @@ If you don't pass in an input, calcite-switch will act as the source of truth:
 | Property   | Attribute  | Description                        | Type                | Default     |
 | ---------- | ---------- | ---------------------------------- | ------------------- | ----------- |
 | `color`    | `color`    | What color the switch should be    | `"blue" \| "red"`   | `"blue"`    |
+| `disabled` | `disabled` | True if the checkbox is disabled   | `boolean`           | `false`     |
 | `name`     | `name`     | The name of the checkbox input     | `string`            | `""`        |
 | `scale`    | `scale`    | The scale of the switch            | `"l" \| "m" \| "s"` | `"m"`       |
 | `switched` | `switched` | True if the switch is initially on | `boolean`           | `false`     |

--- a/src/demos/calcite-switch.html
+++ b/src/demos/calcite-switch.html
@@ -22,23 +22,23 @@
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Switch</h1>
-    <calcite-label layout="inline">
-      <calcite-switch id="basicSwitch" switched="true"></calcite-switch>
+  <calcite-label layout="inline">
+    <calcite-switch id="basicSwitch" switched="true"></calcite-switch>
 
-      Without a proxy <code>input</code> element and listening for "change"
-    </calcite-label>
-    <script>
-      var basicSwitch = document.getElementById("basicSwitch");
+    Without a proxy <code>input</code> element and listening for "change"
+  </calcite-label>
+  <script>
+    var basicSwitch = document.getElementById("basicSwitch");
 
-      basicSwitch.addEventListener("change", function (
-        e
-      ) {
-        console.log(
-          "Basic switch changed by <calcite-switch>",
-          e.target.switched
-        );
-      });
-    </script>
+    basicSwitch.addEventListener("change", function (
+      e
+    ) {
+      console.log(
+        "Basic switch changed by <calcite-switch>",
+        e.target.switched
+      );
+    });
+  </script>
   <br />
   <div>
     <calcite-label layout="inline">
@@ -49,18 +49,38 @@
         With a proxy <code>input</code> element and changes on click.
       </span>
     </calcite-label>
-    <script>
-      var proxySwitchSpan = document.getElementById(
-        "proxySwitchSpan"
-      );
-      var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
+    <div>
 
-      proxySwitchSpan.addEventListener('click', function () {
-        proxySwitchCheckbox.hasAttribute('checked') ?
-          proxySwitchCheckbox.removeAttribute('checked') :
-          proxySwitchCheckbox.setAttribute('checked', '')
-      })
-    </script>
+      <script>
+        var proxySwitchSpan = document.getElementById(
+          "proxySwitchSpan"
+        );
+        var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
+
+        proxySwitchSpan.addEventListener('click', function () {
+          proxySwitchCheckbox.hasAttribute('checked') ?
+            proxySwitchCheckbox.removeAttribute('checked') :
+            proxySwitchCheckbox.setAttribute('checked', '')
+        })
+      </script>
+    </div>
+    <h4>Disabled with proxy input</h4>
+      <calcite-switch disabled>
+        <input id="proxySwitchCheckbox" type="checkbox" />
+      </calcite-switch>
+  </div>
+  <div>
+    <calcite-label layout="inline">
+      <calcite-switch color="red" disabled> </calcite-switch>
+      Disabled red switch
+    </calcite-label>
+  </div>
+  <br />
+  <div>
+    <calcite-label layout="inline">
+      <calcite-switch switched="true" disabled> </calcite-switch>
+      Disabled switch
+    </calcite-label>
   </div>
   <br />
   <div>
@@ -107,9 +127,9 @@
     <br />
     <div>
       <calcite-switch theme="dark">
-        <input id="proxySwitchCheckbox" type="checkbox" />
+        <input type="checkbox" />
       </calcite-switch>
-      <span id='proxySwitchSpan'>
+      <span>
         With a proxy <code>input</code> element and changes on click.
       </span>
       <script>
@@ -132,6 +152,7 @@
         Red switch
       </calcite-label>
     </div>
+
     <br />
     <div>
       <calcite-switch theme="dark"></calcite-switch>


### PR DESCRIPTION
**Related Issue:** Resolves #851  cc @rslibed

## Summary
Adds `disabled` prop to `calcite-switch`

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
