### PR TITLE
docs(scrim): Correct text to match example for loading state

### DIFF
--- a/src/components/calcite-scrim/readme.md
+++ b/src/components/calcite-scrim/readme.md
@@ -26,7 +26,7 @@
 ```html
 <div style="position: relative; width: 200px; height: 200px; overflow: auto;">
   <calcite-scrim loading>
-    <p>I'm a panel that is not loading.</p>
+    <p>I'm a panel that is loading.</p>
     <p>I have a loading spinner over my content.</p>
     <p>.</p>
     <p>.</p>


### PR DESCRIPTION
**Related Issue:** #

## Summary

The example is a loading scrim. The text should reflect that.
