### PR TITLE
feat(input): Update default icon of input type email

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -414,7 +414,7 @@ export class CalciteInput {
   private iconTypeDefaults = {
     tel: "phone",
     password: "lock",
-    email: "send",
+    email: "email-address",
     date: "calendar",
     time: "clock",
     search: "search"

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -374,6 +374,11 @@
           </calcite-label>
 
           <calcite-label>
+            Email input with custom icon
+            <calcite-input icon="envelope" type="email" placeholder="john@doe.com"></calcite-input>
+          </calcite-label>
+
+          <calcite-label>
             Password input with default icon
             <calcite-input icon type="password" placeholder="•••••"></calcite-input>
           </calcite-label>


### PR DESCRIPTION
**Related Issue:** Resolves #864 cc @gpbmike 

## Summary
Updates the default icon for inputs of `type=email` from `send` to `email-address`

Note: input types that display a default icon with the `icon` attribute can still accept overrides by passing a Calcite UI Icon name to the attribute: `icon=banana`
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
