### PR TITLE
docs: fix storybook config

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -35,6 +35,5 @@ const stories = glob
 
 module.exports = {
   addons: ["@storybook/addon-docs", "@storybook/addon-backgrounds", "@storybook/addon-knobs", "@storybook/addon-a11y"],
-  presets: ["@storybook/addon-knobs/preset"],
   stories
 };


### PR DESCRIPTION
This fixes the following issue when running the storybook preview:

```
info => Loading custom manager config.
WARN Unable to close preview build!
ERR! WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
ERR!  - configuration.entry should not contain the item '/.../calcite-components/node_modules/@storybook/addon-knobs/dist/register.js' twice.
ERR!    -> A non-empty array of non-empty strings
ERR!     at webpack (/.../calcite-components/node_modules/webpack/lib/webpack.js:31:9)
ERR!     at /.../calcite-components/node_modules/@storybook/core/dist/server/dev-server.js:69:48
ERR!  WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
ERR!  - configuration.entry should not contain the item '/.../calcite-components/node_modules/@storybook/addon-knobs/dist/register.js' twice.
ERR!    -> A non-empty array of non-empty strings
ERR!     at webpack (/.../calcite-components/node_modules/webpack/lib/webpack.js:31:9)
ERR!     at /.../calcite-components/node_modules/@storybook/core/dist/server/dev-server.js:69:48```