### PR TITLE
feat(tabs): add tab-title disabled state

### DIFF
--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -125,10 +125,14 @@ export class CalciteTabNav {
    * @internal
    */
   @Listen("calciteTabsFocusPrevious") focusPreviousTabHandler(e: CustomEvent) {
-    const currentIndex = this.getIndexOfTabTitle(e.target as HTMLCalciteTabTitleElement);
+    const currentIndex = this.getIndexOfTabTitle(
+      e.target as HTMLCalciteTabTitleElement,
+      this.enabledTabTitles
+    );
 
     const previousTab =
-      this.tabTitles[currentIndex - 1] || this.tabTitles[this.tabTitles.length - 1];
+      this.enabledTabTitles[currentIndex - 1] ||
+      this.enabledTabTitles[this.enabledTabTitles.length - 1];
 
     previousTab.focus();
 
@@ -140,9 +144,12 @@ export class CalciteTabNav {
    * @internal
    */
   @Listen("calciteTabsFocusNext") focusNextTabHandler(e: CustomEvent) {
-    const currentIndex = this.getIndexOfTabTitle(e.target as HTMLCalciteTabTitleElement);
+    const currentIndex = this.getIndexOfTabTitle(
+      e.target as HTMLCalciteTabTitleElement,
+      this.enabledTabTitles
+    );
 
-    const nextTab = this.tabTitles[currentIndex + 1] || this.tabTitles[0];
+    const nextTab = this.enabledTabTitles[currentIndex + 1] || this.enabledTabTitles[0];
 
     nextTab.focus();
 
@@ -211,11 +218,20 @@ export class CalciteTabNav {
   //
   //--------------------------------------------------------------------------
 
-  private getIndexOfTabTitle(el: HTMLCalciteTabTitleElement) {
-    return this.tabTitles.indexOf(el);
+  private getIndexOfTabTitle(el: HTMLCalciteTabTitleElement, tabTitles = this.tabTitles) {
+    // In most cases, since these indexes correlate with tab contents, we want to consider all tab titles.
+    // However, when doing relative index operations, it makes sense to pass in this.enabledTabTitles as the 2nd arg.
+    return tabTitles.indexOf(el);
   }
 
   private get tabTitles(): HTMLCalciteTabTitleElement[] {
+    if (this.tabNavEl) {
+      return getSlottedElements<HTMLCalciteTabTitleElement>(this.tabNavEl, "calcite-tab-title");
+    }
+    return [];
+  }
+
+  private get enabledTabTitles(): HTMLCalciteTabTitleElement[] {
     if (this.tabNavEl) {
       return getSlottedElements<HTMLCalciteTabTitleElement>(
         this.tabNavEl,

--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -217,7 +217,10 @@ export class CalciteTabNav {
 
   private get tabTitles(): HTMLCalciteTabTitleElement[] {
     if (this.tabNavEl) {
-      return getSlottedElements<HTMLCalciteTabTitleElement>(this.tabNavEl, "calcite-tab-title");
+      return getSlottedElements<HTMLCalciteTabTitleElement>(
+        this.tabNavEl,
+        "calcite-tab-title:not([disabled])"
+      );
     }
     return [];
   }

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -54,6 +54,16 @@ $tab-margin: 1.25rem;
   font-weight: 500;
 }
 
+// disabled styles
+:host([disabled]) {
+  pointer-events: none;
+  span,
+  a {
+    pointer-events: none;
+    opacity: 0.4;
+  }
+}
+
 a,
 span {
   box-sizing: border-box;

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -25,17 +25,17 @@ $tab-margin: 1.25rem;
 }
 
 // focus styles
-:host {
+:host a {
   @include focus-style-base();
 }
-:host(:focus) {
+:host(:focus) a {
   @include focus-style-outset();
 }
+
 :host(:active),
 :host(:focus),
 :host(:hover) {
   a {
-    outline: none;
     text-decoration: none;
     color: var(--calcite-ui-text-1);
     border-bottom-color: var(--calcite-ui-border-2);
@@ -54,7 +54,8 @@ $tab-margin: 1.25rem;
   font-weight: 500;
 }
 
-a {
+a,
+span {
   box-sizing: border-box;
   @include font-size(-2);
   padding: $baseline/2 0;
@@ -62,14 +63,18 @@ a {
   overflow: hidden;
   text-overflow: ellipsis;
   border-bottom: 3px solid transparent;
+  -webkit-appearance: none;
   cursor: pointer;
   transition: $transition;
   color: var(--calcite-ui-text-3);
-  outline: none;
   width: 100%;
   height: 100%;
   display: flex;
   justify-content: center;
+}
+
+span {
+  cursor: default;
 }
 
 // icon positioning and styles

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -45,6 +45,9 @@ export class CalciteTabTitle {
   /** Show this tab title as selected */
   @Prop({ reflect: true, mutable: true }) active = false;
 
+  /** Disable this tab title  */
+  @Prop({ reflect: true }) disabled = false;
+
   /** optionally pass an icon to display at the start of a tab title - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconStart?: string;
 
@@ -77,9 +80,7 @@ export class CalciteTabTitle {
       this.updateHasText();
     }
     if (this.tab && this.active) {
-      this.calciteTabsActivate.emit({
-        tab: this.tab
-      });
+      this.emitActiveTab();
     }
   }
 
@@ -90,6 +91,7 @@ export class CalciteTabTitle {
 
   render() {
     const id = this.el.id || this.guid;
+    const Tag = this.disabled ? "span" : "a";
 
     const iconStartEl = (
       <calcite-icon class="calcite-tab-title--icon icon-start" icon={this.iconStart} scale="s" />
@@ -105,14 +107,14 @@ export class CalciteTabTitle {
         aria-controls={this.controls}
         aria-expanded={this.active.toString()}
         role="tab"
-        tabindex="0"
+        tabindex={this.disabled ? "-1" : "0"}
         hasText={this.hasText}
       >
-        <a>
+        <Tag>
           {this.iconStart ? iconStartEl : null}
           <slot />
           {this.iconEnd ? iconEndEl : null}
-        </a>
+        </Tag>
       </Host>
     );
   }
@@ -140,18 +142,14 @@ export class CalciteTabTitle {
   }
 
   @Listen("click") onClick() {
-    this.calciteTabsActivate.emit({
-      tab: this.tab
-    });
+    this.emitActiveTab();
   }
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent) {
     switch (getKey(e.key)) {
       case " ":
       case "Enter":
-        this.calciteTabsActivate.emit({
-          tab: this.tab
-        });
+        this.emitActiveTab();
         e.preventDefault();
         break;
       case "ArrowRight":
@@ -261,6 +259,14 @@ export class CalciteTabTitle {
         this.updateHasText();
       });
       this.observer.observe(this.el, { childList: true, subtree: true });
+    }
+  }
+
+  private emitActiveTab() {
+    if (!this.disabled) {
+      this.calciteTabsActivate.emit({
+        tab: this.tab
+      });
     }
   }
 

--- a/src/components/calcite-tabs/calcite-tabs.e2e.ts
+++ b/src/components/calcite-tabs/calcite-tabs.e2e.ts
@@ -155,4 +155,28 @@ describe("calcite-tabs", () => {
 
     expect(results).toMatchScreenshot({ allowableMismatchedPixels: 100 });
   });
+
+  it("disallows selection of a disabled tab", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <calcite-tabs>
+        <calcite-tab-nav slot="tab-nav">
+          <calcite-tab-title id="title-1" active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title disabled id="title-2" >Tab 2 Title</calcite-tab-title>
+        </calcite-tab-nav>
+
+        <calcite-tab id="tab-1" active>Tab 1 Content</calcite-tab>
+        <calcite-tab id="tab-2">Tab 2 Content</calcite-tab>
+      </calcite-tabs>
+    `);
+
+    await page.waitForChanges();
+
+    const [, tab2] = await page.findAll("calcite-tab");
+    const [, tabTitle2] = await page.findAll("calcite-tab-title");
+
+    await tabTitle2.click();
+    expect(tab2).not.toHaveAttribute("active");
+  });
 });

--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { select } from "@storybook/addon-knobs";
+import { select, optionsKnob } from "@storybook/addon-knobs";
 import { iconNames } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
@@ -76,4 +76,32 @@ storiesOf("Components/Tabs", module)
     </calcite-tabs>
   `,
     { backgrounds: darkBackground }
+  ).add(
+    "Disabled tabs",
+    () => {
+      const disabledLabel = "Disabled Tabs";
+      const disabledValuesObj = {
+        Tab1: "tab1",
+        Tab2: "tab2",
+        Tab3: "tab3",
+      };
+      const defaultValue = "tab2";
+      const optionsKnobSelections = optionsKnob(disabledLabel, disabledValuesObj, defaultValue, { display: "multi-select" }, "DISABLED-TABS");
+      const tab1disabled = optionsKnobSelections.includes(disabledValuesObj.Tab1);
+      const tab2disabled = optionsKnobSelections.includes(disabledValuesObj.Tab2);
+      const tab3disabled = optionsKnobSelections.includes(disabledValuesObj.Tab3);
+
+      return `
+      <calcite-tabs>
+        <calcite-tab-nav slot="tab-nav">
+          <calcite-tab-title active ${tab1disabled ? "disabled" : ""}>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title ${tab2disabled ? "disabled" : ""}>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title ${tab3disabled ? "disabled" : ""}>Tab 3 Title</calcite-tab-title>
+        </calcite-tab-nav>
+
+        <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+        <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+        <calcite-tab><p>Tab 3 Content</p></calcite-tab>
+      </calcite-tabs>
+    `}
   );

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -219,6 +219,18 @@
     <calcite-tab>Tab 4 Content</calcite-tab>
   </calcite-tabs>
 
+  <h1 class="leader-1">Disabled Tab</h1>
+
+  <calcite-tabs>
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title disabled>Tab 2 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab>Tab 1 Content</calcite-tab>
+    <calcite-tab>Inaccessible</calcite-tab>
+  </calcite-tabs>
+
   <h1 class="leader-1">Named Tabs</h1>
   <calcite-tabs>
     <calcite-tab-nav slot="tab-nav">

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -224,10 +224,12 @@
   <calcite-tabs>
     <calcite-tab-nav slot="tab-nav">
       <calcite-tab-title>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title disabled>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title disabled>Tab 3 Title (disabled)</calcite-tab-title>
     </calcite-tab-nav>
 
     <calcite-tab>Tab 1 Content</calcite-tab>
+    <calcite-tab>Tab 2 Content</calcite-tab>
     <calcite-tab>Inaccessible</calcite-tab>
   </calcite-tabs>
 

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -226,11 +226,13 @@
       <calcite-tab-title>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title disabled>Tab 3 Title (disabled)</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
 
     <calcite-tab>Tab 1 Content</calcite-tab>
     <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Inaccessible</calcite-tab>
+    <calcite-tab>Inaccessible Tab 3 Content</calcite-tab>
+    <calcite-tab>Tab 4 Content</calcite-tab>
   </calcite-tabs>
 
   <h1 class="leader-1">Named Tabs</h1>


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/640

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This adds a `disabled` state to `<calcite-tab-title>`, following `link`'s pattern of using a `<span>` element. In order to remove focus state on a non-actionable tab title, I had to move the focus styles off of `:host` and into the child anchor element.
