### PR TITLE
fix(input): emit calcite input input on up and down click on number input #886

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1,6 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { HYDRATED_ATTR } from "../../tests/commonTests";
-import { CalciteInput } from "./calcite-input";
 
 describe("calcite-input", () => {
   it("renders", async () => {

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { HYDRATED_ATTR } from "../../tests/commonTests";
+import { CalciteInput } from "./calcite-input";
 
 describe("calcite-input", () => {
   it("renders", async () => {
@@ -370,5 +371,29 @@ describe("calcite-input", () => {
     clearButton.click();
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("");
+  });
+
+  it("should emit event when up or down clicked on input", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" max="0" value="-2"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+
+    expect(calciteInputInput).toHaveReceivedEvent();
+
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(calciteInputInput).toHaveReceivedEvent();
   });
 });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -505,6 +505,10 @@ export class CalciteInput {
           break;
       }
       this.value = this.childEl.value.toString();
+      this.calciteInputInput.emit({
+        element: this.childEl,
+        value: this.value
+      });
     }
   };
 }


### PR DESCRIPTION
**Related Issue:** #886 

## Summary

Added `CalciteInputInput` event on up and down click on number input.

- [x] feature or fix has a corresponding test
- [x] changes have been tested with demo page in Edge

