### PR TITLE
feat(split-button): add secondary click event

### DIFF
--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -50,6 +50,9 @@ export class CalciteSplitButton {
   /** fired when the primary button is clicked */
   @Event() calciteSplitButtonPrimaryClick: EventEmitter;
 
+  /** fired when the secondary button is clicked */
+  @Event() calciteSplitButtonSecondaryClick: EventEmitter;
+
   @Watch("color")
   validateColor() {
     const color = ["blue", "red", "dark", "light"];
@@ -109,6 +112,7 @@ export class CalciteSplitButton {
             theme={this.theme}
             scale={this.scale}
             width={this.scale}
+            onClick={this.calciteSplitButtonSecondaryClickHandler}
           >
             <calcite-button
               dir={dir}
@@ -129,6 +133,9 @@ export class CalciteSplitButton {
 
   private calciteSplitButtonPrimaryClickHandler = (e: MouseEvent) =>
     this.calciteSplitButtonPrimaryClick.emit(e);
+
+  private calciteSplitButtonSecondaryClickHandler = (e: MouseEvent) =>
+    this.calciteSplitButtonSecondaryClick.emit(e);
 
   private get dropdownIcon() {
     return this.dropdownIconType === "chevron"

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -128,6 +128,7 @@
       </calcite-split-button>
       <script>
         document.addEventListener('calciteSplitButtonPrimaryClick', () => alert('primary action'))
+        document.addEventListener('calciteSplitButtonSecondaryClick', () => alert('secondary action'))
       </script>
     </div>
 


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/652

## Summary
Extends access to a click handler on the secondary button/dropdown trigger in a `calcite-split-button`. It seems like nesting components like this one does introduce a number of challenges when trying to interface with children from elsewhere in an app. Since the primary click handler was already in place, I figured it made sense to follow that pattern, but I'm open to hearing other suggestions for how to go about achieving this behavior.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
