### PR TITLE
fix(input): No longer set clearable by default on type date or time

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -446,7 +446,7 @@ export class CalciteInput {
   private determineClearable() {
     this.isClearable =
       this.type !== "textarea" &&
-      (this.clearable || this.type === "search" || this.type === "time" || this.type === "date") &&
+      (this.clearable || this.type === "search") &&
       this.value.length > 0;
   }
 

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -313,15 +313,6 @@
             </calcite-input>
           </calcite-label>
 
-
-
-
-
-
-
-
-
-
           <calcite-label>
             Readonly with prefix
             <calcite-input readonly prefix-text="API Key" value="A123-S5DL-24FA">
@@ -340,7 +331,6 @@
             </calcite-input>
           </calcite-label>
 
-
           <calcite-label>
             File input
             <calcite-input type="file" placeholder="Drag 'em' here"></calcite-input>
@@ -350,6 +340,16 @@
             Loading input
             <calcite-input placeholder="john@doe.com" value="john@do" loading></calcite-input>
           </calcite-label>
+          <calcite-label>
+            Date input with clearable
+            <calcite-input icon="calendar" type="date" clearable></calcite-input>
+          </calcite-label>
+
+          <calcite-label>
+            Time input with clearable
+            <calcite-input icon type="time" clearable></calcite-input>
+          </calcite-label>
+
           <calcite-label>
             Date input with default icon
             <calcite-input icon="calendar" type="date"></calcite-input>


### PR DESCRIPTION
**Related Issue:** Resolves #892 cc @kevindoshier

## Summary
Clearable had been enabled by default within the `calcite-input` component for types `date`, `time`, and `search`... This PR removes that setting by default for `date` and `time`, since it is not consistently present across browers in native input elements. I opted to leave it on by default for `search`, since this is consistent across browsers.

For `date` and `time`, users can now just request the `clearable` prop to re-enable this previously default behavior.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
