### PR TITLE
ci(travis): wire up auto @next deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 branches:
   only:
     - master
+deploy:
+  on:
+    branch: master
+    condition: $NEXT_RELEASE_ENABLED
+  provider: script
+  script: bash support/deployNextFromTravisBuild.sh
+  skip_cleanup: true
 language: node_js
 node_js:
   - lts/*


### PR DESCRIPTION
#  Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates the Travis CI configuration to automatically deploy @next releases. Any `feat`, `fix` install will trigger an automatic deployment to NPM. Users would get the latest by installing `@esri/calcite-components@next`. 

I also added a script `release:next` that does a clean install, test, build and deploys to `@next`, if needed.

Worth noting that this depends on a few custom environment variables defined on the Travis build environment. 

**Note:** This won't be enabled until the recent NPM script changes are completely stable (https://github.com/Esri/calcite-components/pull/899).