### PR TITLE
chore(value-list): port dragging between same-group value lists

### DIFF
--- a/src/components/calcite-sortable-list/calcite-sortable-list.e2e.ts
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.e2e.ts
@@ -1,5 +1,6 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, hidden, renders } from "../../tests/commonTests";
+import { dragAndDrop } from "../../tests/utils";
 
 describe("calcite-sortable-list", () => {
   it("renders", async () => renders("calcite-sortable-list"));
@@ -11,37 +12,21 @@ describe("calcite-sortable-list", () => {
   describe("drag and drop", () => {
     let page: E2EPage;
     beforeEach(async () => {
-      page = await newE2EPage();
-      await page.setContent(`<calcite-sortable-list>
+      page = await newE2EPage({
+        html: `<calcite-sortable-list>
         <div id="one"><calcite-handle></calcite-handle>1</div>
         <div id="two"><calcite-handle></calcite-handle>2</div>
         <div id="three"><calcite-handle></calcite-handle>3</div>
-      </calcite-sortable-list>`);
+      </calcite-sortable-list>`
+      });
     });
-    it.skip("works using a mouse", async () => {
-      // TODO: remove skip once https://github.com/GoogleChrome/puppeteer/issues/1376 addressed
-      const itemBoundingBox = await page.evaluate(() => {
-        const { left, top, width, height } = document.querySelector(`#one`).getBoundingClientRect();
-        return { left, top, width, height };
-      });
-      const handleBoundingBox = await page.evaluate(() => {
-        const { left, top, width, height } = document
-          .querySelector(`#one calcite-handle`)
-          .shadowRoot.querySelector(`button`)
-          .getBoundingClientRect();
-        return { left, top, width, height };
-      });
-      const xCenter = handleBoundingBox.left + handleBoundingBox.width / 2;
-      const yCenter = handleBoundingBox.top + handleBoundingBox.height / 2;
-      await page.mouse.move(xCenter, yCenter);
-      await page.mouse.down();
-      await page.mouse.move(xCenter, yCenter + itemBoundingBox.height + 2);
-      await page.mouse.up();
 
-      // position in DOM of first and second item should be flipped
-      const itemsAfter = await page.findAll("div");
-      expect(await itemsAfter[0].getProperty("id")).toBe("two");
-      expect(await itemsAfter[1].getProperty("id")).toBe("one");
+    it("works using a mouse", async () => {
+      await dragAndDrop(page, `#one calcite-handle`, `#two calcite-handle`);
+
+      const [first, second] = await page.findAll("div");
+      expect(await first.getProperty("id")).toBe("two");
+      expect(await second.getProperty("id")).toBe("one");
     });
 
     it("works using a keyboard", async () => {

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -7,6 +7,7 @@ import {
   disabledStates,
   keyboardNavigation
 } from "../calcite-pick-list/shared-list-tests";
+import { dragAndDrop } from "../../tests/utils";
 
 describe("calcite-value-list", () => {
   it("renders", async () => renders("calcite-value-list"));
@@ -24,20 +25,22 @@ describe("calcite-value-list", () => {
 
   describe("icon logic", () => {
     it("should be 'grip' when in `configuration` mode drag and drop is enabled ", async () => {
-      const page = await newE2EPage();
-      await page.setContent(`<calcite-value-list drag-enabled>
+      const page = await newE2EPage({
+        html: `<calcite-value-list drag-enabled>
         <calcite-value-list-item value="one"></calcite-value-list-item>
-      </calcite-value-list>`);
+      </calcite-value-list>`
+      });
 
       const item = await page.find("calcite-value-list-item");
       const icon = await item.getProperty("icon");
       expect(icon).toBe(ICON_TYPES.grip);
     });
     it("should be null when drag and drop is disabled", async () => {
-      const page = await newE2EPage();
-      await page.setContent(`<calcite-value-list>
+      const page = await newE2EPage({
+        html: `<calcite-value-list>
         <calcite-value-list-item value="one"></calcite-value-list-item>
-      </calcite-value-list>`);
+      </calcite-value-list>`
+      });
 
       const item = await page.find("calcite-value-list-item");
       const icon = await item.getProperty("icon");
@@ -54,45 +57,39 @@ describe("calcite-value-list", () => {
   });
 
   describe("drag and drop", () => {
-    let page: E2EPage;
-    beforeEach(async () => {
-      page = await newE2EPage();
-      await page.setContent(`<calcite-value-list multiple drag-enabled>
+    async function createSimpleValueList(): Promise<E2EPage> {
+      return newE2EPage({
+        html: `<calcite-value-list drag-enabled>
         <calcite-value-list-item value="one" text-label="One"></calcite-value-list-item>
         <calcite-value-list-item value="two" text-label="Two"></calcite-value-list-item>
         <calcite-value-list-item value="three" text-label="Three"></calcite-value-list-item>
-      </calcite-value-list>`);
-    });
-    it.skip("works using a mouse", async () => {
-      // TODO: remove skip once https://github.com/GoogleChrome/puppeteer/issues/1376 addressed
-      const itemBoundingBox = await page.evaluate(() => {
-        const { left, top, width, height } = document
-          .querySelector(`calcite-value-list-item[value="one"]`)
-          .getBoundingClientRect();
-        return { left, top, width, height };
+      </calcite-value-list>`
       });
-      const handleBoundingBoxes = await page.evaluate((CSS) => {
-        const { left, top, width, height } = document
-          .querySelector(`calcite-value-list-item[value="one"]`)
-          .shadowRoot.querySelector(`calcite-pick-list-item`)
-          .shadowRoot.querySelector(`.${CSS.handle}`)
-          .getBoundingClientRect();
-        return { left, top, width, height };
-      }, CSS);
-      const xCenter = handleBoundingBoxes.left + handleBoundingBoxes.width / 2;
-      const yCenter = handleBoundingBoxes.top + handleBoundingBoxes.height / 2;
-      await page.mouse.move(xCenter, yCenter);
-      await page.mouse.down();
-      await page.mouse.move(xCenter, yCenter + itemBoundingBox.height + 2);
-      await page.mouse.up();
+    }
 
-      // position in DOM of first and second item should be flipped
-      const itemsAfter = await page.findAll("calcite-value-list-item");
-      expect(await itemsAfter[0].getProperty("value")).toBe("two");
-      expect(await itemsAfter[1].getProperty("value")).toBe("one");
+    it("works using a mouse", async () => {
+      const page = await createSimpleValueList();
+
+      await dragAndDrop(
+        page,
+        {
+          host: `calcite-value-list-item[value="one"]`,
+          shadow: `.${CSS.handle}`
+        },
+        {
+          host: `calcite-value-list-item[value="two"]`,
+          shadow: `.${CSS.handle}`
+        }
+      );
+
+      const [first, second] = await page.findAll("calcite-value-list-item");
+      expect(await first.getProperty("value")).toBe("two");
+      expect(await second.getProperty("value")).toBe("one");
     });
 
     it("works using a keyboard", async () => {
+      const page = await createSimpleValueList();
+
       await page.keyboard.press("Tab");
       await page.keyboard.press("Space");
       await page.waitForChanges();
@@ -115,6 +112,73 @@ describe("calcite-value-list", () => {
       await assertKeyboardMove("up", ["two", "three", "one"]);
       await assertKeyboardMove("up", ["two", "one", "three"]);
       await assertKeyboardMove("up", ["one", "two", "three"]);
+    });
+
+    it("supports dragging items between lists", async () => {
+      const page = await newE2EPage({
+        html: `
+        <calcite-value-list id="first-letters" drag-enabled group="letters">
+          <calcite-value-list-item value="a" text-label="A"></calcite-value-list-item>
+          <calcite-value-list-item value="b" text-label="B"></calcite-value-list-item>
+        </calcite-value-list>
+
+        <calcite-value-list id="numbers" drag-enabled group="numbers">
+          <calcite-value-list-item value="1" text-label="One"></calcite-value-list-item>
+          <calcite-value-list-item value="2" text-label="Two"></calcite-value-list-item>
+        </calcite-value-list>
+
+        <calcite-value-list id="no-group" drag-enabled>
+          <calcite-value-list-item value="no-group" text-label="No group"></calcite-value-list-item>
+        </calcite-value-list>
+
+        <calcite-value-list id="second-letters" drag-enabled group="letters">
+          <calcite-value-list-item value="c" text-label="C"></calcite-value-list-item>
+          <calcite-value-list-item value="d" text-label="D"></calcite-value-list-item>
+          <calcite-value-list-item value="e" text-label="E"></calcite-value-list-item>
+          <calcite-value-list-item value="f" text-label="F"></calcite-value-list-item>
+        </calcite-value-list>
+        `
+      });
+
+      await dragAndDrop(
+        page,
+        {
+          host: `calcite-value-list-item[value="d"]`,
+          shadow: `.${CSS.handle}`
+        },
+        `#first-letters`
+      );
+
+      await dragAndDrop(
+        page,
+        {
+          host: `calcite-value-list-item[value="e"]`,
+          shadow: `.${CSS.handle}`
+        },
+        `#numbers`
+      );
+
+      await dragAndDrop(
+        page,
+        {
+          host: `calcite-value-list-item[value="e"]`,
+          shadow: `.${CSS.handle}`
+        },
+        `#no-group`
+      );
+
+      const [first, second, third, fourth, fifth, sixth, seventh, eight, ninth] = await page.findAll(
+        "calcite-value-list-item"
+      );
+      expect(await first.getProperty("value")).toBe("a");
+      expect(await second.getProperty("value")).toBe("b");
+      expect(await third.getProperty("value")).toBe("d");
+      expect(await fourth.getProperty("value")).toBe("1");
+      expect(await fifth.getProperty("value")).toBe("2");
+      expect(await sixth.getProperty("value")).toBe("no-group");
+      expect(await seventh.getProperty("value")).toBe("c");
+      expect(await eight.getProperty("value")).toBe("e");
+      expect(await ninth.getProperty("value")).toBe("f");
     });
   });
 });

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -65,6 +65,11 @@ export class CalciteValueList<
   @Prop({ reflect: true }) filterEnabled = false;
 
   /**
+   * If this is set and drag is enabled, items can be dropped between lists of the same group.
+   */
+  @Prop() group: string;
+
+  /**
    * When true, content is waiting to be loaded. This state shows a busy indicator.
    */
   @Prop({ reflect: true }) loading = false;
@@ -182,7 +187,8 @@ export class CalciteValueList<
     this.sortable = Sortable.create(this.el, {
       handle: `.${CSS.handle}`,
       draggable: "calcite-value-list-item",
-      onUpdate: () => {
+      group: this.group,
+      onSort: () => {
         this.items = Array.from(this.el.querySelectorAll<ItemElement>("calcite-value-list-item"));
         const values = this.items.map((item) => item.value);
         this.calciteListOrderChange.emit(values);

--- a/src/demos/value-list/advanced.html
+++ b/src/demos/value-list/advanced.html
@@ -239,7 +239,7 @@
           valueList4.addEventListener("calciteListChange", (event) => {
             console.log(event.detail);
           });
-          valueList4.addEventListener("calciteValueListOrderChange", (event) => {
+          valueList4.addEventListener("calciteListOrderChange", (event) => {
             console.log("sort order changed");
             console.log(event.detail);
           });

--- a/src/demos/value-list/basic.html
+++ b/src/demos/value-list/basic.html
@@ -32,12 +32,6 @@
             </calcite-action>
           </calcite-value-list-item>
         </calcite-value-list>
-        <script>
-          const valueList = document.querySelector("#one");
-          valueList.addEventListener("calciteListChange", (event) => {
-            console.log(event.detail);
-          });
-        </script>
 
         <h2>ValueList - Multi-select w/ Filter</h2>
         <h3>Pick many</h3>
@@ -55,12 +49,6 @@
             </calcite-action>
           </calcite-value-list-item>
         </calcite-value-list>
-        <script>
-          const valueList2 = document.querySelector("#two");
-          valueList2.addEventListener("calciteListChange", (event) => {
-            console.log(event.detail);
-          });
-        </script>
 
         <h2>ValueList - drag and drop enabled</h2>
         <h3>Re-order by dragging the handle</h3>
@@ -73,17 +61,32 @@
           <calcite-value-list-item text-label="Entertainment" text-description="Toys and leisure" value="entertainment">
           </calcite-value-list-item>
         </calcite-value-list>
-        <script>
-          const valueList4 = document.querySelector("#four");
-          valueList4.addEventListener("calciteListChange", (event) => {
-            console.log(event.detail);
-          });
-          valueList4.addEventListener("calciteValueListOrderChange", (event) => {
-            console.log("sort order changed");
-            console.log(event.detail);
-          });
-        </script>
+
+        <h3>Drag and drop between different lists</h3>
+        <h4>List 1</h4>
+        <calcite-value-list id="five" drag-enabled group="draggable">
+          <calcite-value-list-item text-label="One" value="1"></calcite-value-list-item>
+          <calcite-value-list-item text-label="Two" value="2"></calcite-value-list-item>
+        </calcite-value-list>
+
+        <h4>List 2</h4>
+        <calcite-value-list id="six" drag-enabled group="draggable">
+          <calcite-value-list-item text-label="Three" value="3"></calcite-value-list-item>
+          <calcite-value-list-item text-label="Four" value="4"></calcite-value-list-item>
+        </calcite-value-list>
       </section>
+
+      <script>
+        function setUpValueListEventListeners(valueList) {
+          valueList.addEventListener("calciteListChange", (event) => console.log(event.detail));
+
+          if (valueList.hasAttribute("drag-enabled")) {
+            valueList.addEventListener("calciteListOrderChange", (event) => console.log("sort order changed", event.detail));
+          }
+        }
+
+        Array.from(document.getElementsByTagName("calcite-value-list")).forEach(valueList => setUpValueListEventListeners(valueList));
+      </script>
     </main>
   </body>
 </html>

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,0 +1,86 @@
+import { E2EPage } from "@stencil/core/testing";
+import { BoundingBox, JSONObject } from "puppeteer";
+
+type DragAndDropSelector = string | ShadowedSelectorOptions;
+
+interface ShadowedSelectorOptions extends JSONObject {
+  host: string;
+  shadow: string;
+}
+
+type MouseInitEvent = Pick<
+  MouseEvent,
+  "bubbles" | "cancelable" | "composed" | "screenX" | "screenY" | "clientX" | "clientY"
+>;
+
+/* based on https://github.com/puppeteer/puppeteer/issues/1366#issuecomment-615887204 */
+export async function dragAndDrop(
+  page: E2EPage,
+  dragStartSelector: DragAndDropSelector,
+  dragEndSelector: DragAndDropSelector
+): Promise<void> {
+  async function getBounds(selector: DragAndDropSelector): Promise<BoundingBox> {
+    const elementHandle =
+      typeof selector === "string"
+        ? await page.waitForSelector(selector)
+        : await page.evaluateHandle(
+            (selector) => document.querySelector(selector.host).shadowRoot.querySelector(selector.shadow),
+            selector
+          );
+
+    return elementHandle.asElement().boundingBox();
+  }
+
+  async function createEventInitializer(selector: DragAndDropSelector): Promise<MouseInitEvent> {
+    const { height, width, x, y } = await getBounds(selector);
+
+    const eventX = x + width / 2;
+    const eventY = y + height;
+
+    return {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      screenX: eventX,
+      screenY: eventY,
+      clientX: eventX,
+      clientY: eventY
+    };
+  }
+
+  async function browserContextFunction(
+    dragStartSelector: DragAndDropSelector,
+    dragEndSelector: DragAndDropSelector,
+    dragStartInitializer: MouseInitEvent,
+    dragEndInitializer: MouseInitEvent
+  ): Promise<void> {
+    const dragStart =
+      typeof dragStartSelector === "string"
+        ? document.querySelector(dragStartSelector)
+        : document.querySelector(dragStartSelector.host).shadowRoot.querySelector(dragStartSelector.shadow);
+
+    let dragEnd =
+      typeof dragEndSelector === "string"
+        ? document.querySelector(dragEndSelector)
+        : document.querySelector(dragEndSelector.host).shadowRoot.querySelector(dragEndSelector.shadow);
+
+    // if has child, put at the end.
+    dragEnd = dragEnd.lastElementChild || dragEnd;
+
+    dragStart.dispatchEvent(new PointerEvent("pointerdown", dragStartInitializer));
+    dragStart.dispatchEvent(new DragEvent("dragstart", dragStartInitializer));
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    dragEnd.dispatchEvent(new MouseEvent("dragenter", dragEndInitializer));
+    dragStart.dispatchEvent(new DragEvent("dragend", dragEndInitializer));
+  }
+
+  return page.evaluate(
+    browserContextFunction,
+    dragStartSelector,
+    dragEndSelector,
+    await createEventInitializer(dragStartSelector),
+    await createEventInitializer(dragEndSelector)
+  );
+}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Ports over changes from https://github.com/Esri/calcite-app-components/issues/1056.

This also adds a e2e utility to help test DnD interactions and unskips previous DnD tests. 🛠️
