### PR TITLE
fix(tree): change tabindex to 0 to prevent forced first tab stop on page

### DIFF
--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -55,7 +55,7 @@ export class CalciteTree {
   render() {
     return (
       <Host
-        tabindex={this.root ? "1" : undefined}
+        tabindex={this.root ? "0" : undefined}
         aria-role={this.root ? "tree" : undefined}
         aria-multiselectable={
           this.selectionMode === TreeSelectionMode.Multi ||


### PR DESCRIPTION
**Related Issue:** #634
