### PR TITLE
feat(calcite-label): adds no-margin property. also updates label-text spacing

### DIFF
--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -14,7 +14,7 @@
   margin: 0 0 var(--calcite-label-margin-bottom, $baseline) 0;
 }
 
-:host([no-margin]) label {
+:host([disable-spacing]) label {
   margin: 0;
 }
 

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -14,24 +14,31 @@
   margin: 0 0 var(--calcite-label-margin-bottom, $baseline) 0;
 }
 
+:host([no-margin]) label {
+  margin: 0;
+}
+
 :host([scale="s"]) label {
   font-size: var(--calcite-label-font-size, 12px);
   --calcite-label-spacing-value: 8px;
+  --calcite-label-text-spacing-value: 4px;
 }
 
 :host([scale="m"]) label {
   font-size: var(--calcite-label-font-size, 16px);
   --calcite-label-spacing-value: 12px;
+  --calcite-label-text-spacing-value: 6px;
 }
 
 :host([scale="l"]) label {
   font-size: var(--calcite-label-font-size, 20px);
   --calcite-label-spacing-value: 16px;
+  --calcite-label-text-spacing-value: 8px;
 }
 
 :host([layout="default"]) {
   ::slotted(.calcite-label-text) {
-    margin-bottom: 8px;
+    margin-bottom: var(--calcite-label-text-spacing-value);
   }
 }
 

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -34,6 +34,9 @@ export class CalciteLabel {
   @Prop({ mutable: true, reflect: true }) layout: "inline" | "inline-space-between" | "default" =
     "default";
 
+  /** Turn off margin around the label */
+  @Prop() noMargin?: boolean;
+
   //--------------------------------------------------------------------------
   //
   //  Events

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -34,8 +34,8 @@ export class CalciteLabel {
   @Prop({ mutable: true, reflect: true }) layout: "inline" | "inline-space-between" | "default" =
     "default";
 
-  /** Turn off margin around the label */
-  @Prop() noMargin?: boolean;
+  /** Turn off spacing around the label */
+  @Prop() disableSpacing?: boolean;
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #916

## Summary
* Adds no-margin property
* Updates label-text spacing.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
