### PR TITLE
feat(label): Adds disabled prop to label, radio-group

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -109,6 +109,10 @@ export class CalciteInput {
   /** is the input disabled  */
   @Prop({ reflect: true }) disabled?: boolean;
 
+  @Watch("disabled") disabledWatcher() {
+    if (this.disabled) this.setDisabledAction();
+  }
+
   /** watcher to update number-to-string for min max */
   @Watch("min") minWatcher() {
     this.minString = this.min.toString() || null;
@@ -184,6 +188,7 @@ export class CalciteInput {
     this.maxString = this.max?.toString();
     this.stepString = this.step?.toString();
     this.slottedActionEl = this.el.querySelector("[slot=input-action]");
+    this.setDisabledAction();
   }
 
   componentWillLoad() {
@@ -438,6 +443,10 @@ export class CalciteInput {
       this.type !== "textarea" &&
       (this.clearable || this.type === "search") &&
       this.value.length > 0;
+  }
+
+  private setDisabledAction() {
+    if (this.slottedActionEl) (this.slottedActionEl as HTMLElement).setAttribute("disabled", "");
   }
 
   private getAttributes() {

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -88,6 +88,22 @@
   }
 }
 
+// disabled styles
+:host([disabled]) {
+  & > label {
+    pointer-events: none;
+    opacity: 0.4;
+  }
+  ::slotted(*) {
+    pointer-events: none;
+  }
+  // prevent opacity stacking with already disabled child elements
+  ::slotted(*[disabled]),
+  ::slotted(*[disabled] *) {
+    opacity: 1;
+  }
+}
+
 // status
 $inputStatusColors: "invalid" var(--calcite-ui-red-1), "valid" var(--calcite-ui-text-2), "idle" var(--calcite-ui-text-2);
 

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -1,4 +1,14 @@
-import { Component, Element, Event, Listen, Host, h, Prop, EventEmitter } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  Listen,
+  Host,
+  h,
+  Prop,
+  EventEmitter,
+  Watch
+} from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
 
 @Component({
@@ -34,6 +44,12 @@ export class CalciteLabel {
   @Prop({ mutable: true, reflect: true }) layout: "inline" | "inline-space-between" | "default" =
     "default";
 
+  /** is the label disabled  */
+  @Prop({ reflect: true }) disabled?: boolean;
+
+  @Watch("disabled") disabledWatcher() {
+    if (this.disabled) this.setDisabledControls();
+  }
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -68,7 +84,7 @@ export class CalciteLabel {
 
   private getAttributes() {
     // spread attributes from the component to rendered child, filtering out props
-    const props = ["layout", "theme", "scale", "status"];
+    const props = ["layout", "theme", "scale", "status", "disabled"];
     return Array.from(this.el.attributes)
       .filter((a) => a && !props.includes(a.name))
       .reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {});
@@ -102,6 +118,7 @@ export class CalciteLabel {
         childNode.parentNode.replaceChild(newChildNode, childNode);
       }
     });
+    if (this.disabled) this.setDisabledControls();
   }
 
   render() {
@@ -109,10 +126,32 @@ export class CalciteLabel {
     const dir = getElementDir(this.el);
     return (
       <Host dir={dir}>
-        <label {...attributes}>
+        <label {...attributes} ref={(el) => (this.childLabelEl = el)}>
           <slot />
         </label>
       </Host>
     );
+  }
+  //--------------------------------------------------------------------------
+  //
+  //  Private State/Props
+  //
+  //--------------------------------------------------------------------------
+
+  // the rendered wrapping label element
+  private childLabelEl: HTMLLabelElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  private setDisabledControls() {
+    this.childLabelEl?.childNodes.forEach((item) => {
+      if (item.nodeName.includes("CALCITE")) {
+        (item as HTMLElement).setAttribute("disabled", "");
+      }
+    });
   }
 }

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -28,3 +28,9 @@
 ::slotted(calcite-radio-group-item:focus) {
   z-index: 0;
 }
+
+// disabled styles
+:host([disabled]) {
+  opacity: 0.4;
+  pointer-events: none;
+}

--- a/src/components/calcite-radio-group/calcite-radio-group.stories.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
-
+import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-radio-group-item/readme.md";
@@ -15,6 +15,7 @@ storiesOf("Components/Radio Group", module)
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["auto", "full"], "auto")}"
+      ${boolean("disabled", false)}
     >
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
@@ -32,6 +33,7 @@ storiesOf("Components/Radio Group", module)
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       width="${select("width", ["auto", "full"], "auto")}"
+      ${boolean("disabled", false)}
     >
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
@@ -50,6 +52,7 @@ storiesOf("Components/Radio Group", module)
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       width="${select("width", ["auto", "full"], "auto")}"
+      ${boolean("disabled", false)}
     >
       <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
       <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
@@ -67,6 +70,7 @@ storiesOf("Components/Radio Group", module)
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       width="${select("width", ["auto", "full"], "auto")}"
+      ${boolean("disabled", false)}
     >
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
@@ -84,6 +88,7 @@ storiesOf("Components/Radio Group", module)
         layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
         appearance="${select("appearance", ["solid", "outline"], "solid")}"
         width="${select("width", ["auto", "full"], "full")}"
+        ${boolean("disabled", false)}
       >
         <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
         <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -88,6 +88,9 @@ export class CalciteRadioGroup {
 
   /** specify the width of the group, defaults to auto */
   @Prop({ mutable: true, reflect: true }) width: "auto" | "full" = "auto";
+
+  /** is the radio group disabled  */
+  @Prop({ reflect: true }) disabled?: boolean;
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -137,7 +140,7 @@ export class CalciteRadioGroup {
 
   render() {
     return (
-      <Host role="radiogroup">
+      <Host role="radiogroup" tabIndex={this.disabled ? -1 : null}>
         <slot />
       </Host>
     );

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -89,28 +89,6 @@
           </calcite-label>
 
           <calcite-label layout="inline">
-            <calcite-input placeholder="Enter something">
-              <calcite-button slot="input-action">Go</calcite-button>
-            </calcite-input>
-            Text trailing inline
-          </calcite-label>
-
-          <calcite-label layout="inline-space-between">
-            <calcite-input placeholder="Enter something">
-            </calcite-input>
-            trailing between
-          </calcite-label>
-
-          <calcite-label layout="inline">
-            Text leading inline
-            <calcite-input placeholder="Enter something"></calcite-input>
-          </calcite-label>
-
-          <calcite-label layout="inline-space-between">
-            Text leading inline space between
-            <calcite-input placeholder="Enter something"></calcite-input>
-          </calcite-label>
-          <calcite-label layout="inline">
             Off
             <calcite-switch></calcite-switch>
             On
@@ -508,26 +486,46 @@
 
         </calcite-accordion-item>
       </calcite-accordion>
-      <h4>RTL</h4>
-      <calcite-accordion dir="rtl">
+      <h3>Disabled</h3>
+      <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
+        <calcite-accordion-item item-title="Scales" active>
+
+          <calcite-label disabled scale="s">
+            Scale s
+            <calcite-input  disabled value="My great value" prefix-text="pre" icon="banana" suffix-text="suf">
+            </calcite-input>
+            <calcite-input-message icon active>Some information about the input</calcite-input-message>
+          </calcite-label>
+
+          <calcite-label disabled scale="m">
+            Scale m
+            <calcite-input value="My great value" prefix-text="pre" icon="banana" suffix-text="suf">
+            </calcite-input>
+            <calcite-input-message icon active>Some information about the input</calcite-input-message>
+          </calcite-label>
+
+          <calcite-label disabled scale="l">
+            Scale l
+            <calcite-input value="My great value" prefix-text="pre" icon="banana" suffix-text="suf">
+            </calcite-input>
+            <calcite-input-message icon active>Some information about the input</calcite-input-message>
+          </calcite-label>
+
+
+        </calcite-accordion-item>
         <calcite-accordion-item active item-title="With other components" item-subtitle="Handle wrapped components">
-          <calcite-label>
-            <calcite-input type="number"  number-button-type="horizontal"></calcite-input>
-          </calcite-label>
-          <calcite-label>
-            <calcite-input type="textarea"></calcite-input>
-          </calcite-label>
-          <calcite-label>
+
+          <calcite-label disabled>
             Default label wrapping a switch
             <calcite-switch></calcite-switch>
           </calcite-label>
 
-          <calcite-label>
+          <calcite-label disabled>
             Default label wrapping a checkbox
             <calcite-checkbox></calcite-checkbox>
           </calcite-label>
 
-          <calcite-label>
+          <calcite-label disabled>
             Default label wrapping a radio group
             <calcite-radio-group>
               <calcite-radio-group-item value="react">React</calcite-radio-group-item>
@@ -536,7 +534,7 @@
             </calcite-radio-group>
           </calcite-label>
 
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             Inline label wrapping a radio group
             <calcite-radio-group>
               <calcite-radio-group-item value="ember" checked>Ember</calcite-radio-group-item>
@@ -544,94 +542,326 @@
             </calcite-radio-group>
           </calcite-label>
 
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             Text leading inline
             <calcite-switch></calcite-switch>
           </calcite-label>
 
-          <calcite-label layout="inline">
-            <calcite-input placeholder="Enter something">
-              <calcite-button slot="input-action">Go</calcite-button>
-            </calcite-input>
-            Text trailing inline
-          </calcite-label>
-
-          <calcite-label layout="inline-space-between">
-            <calcite-input placeholder="Enter something">
-            </calcite-input>
-            trailing between
-          </calcite-label>
-
-          <calcite-label layout="inline">
-            Text leading inline
-            <calcite-input placeholder="Enter something"></calcite-input>
-          </calcite-label>
-
-          <calcite-label layout="inline-space-between">
-            Text leading inline space between
-            <calcite-input placeholder="Enter something"></calcite-input>
-          </calcite-label>
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             Off
             <calcite-switch></calcite-switch>
             On
           </calcite-label>
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             Off
             <calcite-switch></calcite-switch>
             On
           </calcite-label>
 
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             <calcite-switch></calcite-switch>
             Text trailing inline
           </calcite-label>
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             Text leading inline
             <calcite-checkbox></calcite-checkbox>
           </calcite-label>
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             Focus slider test
             <calcite-slider style="width:100%"></calcite-slider>
           </calcite-label>
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             Focus slider test
             <calcite-slider min-value="10" max-value="80" style="width:50%"></calcite-slider>
           </calcite-label>
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             Value
             <calcite-slider style="width:100%"></calcite-slider>
             Value
           </calcite-label>
-          <calcite-label>
+          <calcite-label disabled>
             Focus slider test
             <calcite-slider></calcite-slider>
           </calcite-label>
-          <calcite-label>
+          <calcite-label disabled>
             Focus slider test
             <calcite-slider min-value="10" max-value="80"></calcite-slider>
           </calcite-label>
-          <calcite-label layout="inline">
+          <calcite-label disabled layout="inline">
             <calcite-checkbox></calcite-checkbox>
             Text trailing inline
           </calcite-label>
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             Text leading inline-space-between
             <calcite-switch></calcite-switch>
           </calcite-label>
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             <calcite-switch></calcite-switch>
             Text trailing inline-space-between
           </calcite-label>
 
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             Text leading inline-space-between
             <calcite-checkbox></calcite-checkbox>
           </calcite-label>
-          <calcite-label layout="inline-space-between">
+          <calcite-label disabled layout="inline-space-between">
             <calcite-checkbox></calcite-checkbox>
             Text trailing inline-space-between
           </calcite-label>
+        </calcite-accordion-item>
+        <calcite-accordion-item item-title="Input types">
+          <calcite-label disabled>
+            Textarea empty input
+            <calcite-input type="textarea" placeholder="How was your day?"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Textarea full input
+            <calcite-input type="textarea" placeholder="How was your day?">Here I am with some text</calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Number input - default type vertical
+            <calcite-input type="number" placeholder="How many apples?"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Number input - button type horizontal
+            <calcite-input type="number" number-button-type="horizontal" placeholder="How many apples?">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Number input clearable horizontal
+            <calcite-input clearable type="number" number-button-type="horizontal" placeholder="How many apples?">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Number input clearable vertical
+            <calcite-input clearable type="number" placeholder="How many apples?">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Text input clearable
+            <calcite-input clearable placeholder="John Doe">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Text input clearable with value on load
+            <calcite-input clearable value="My great name" placeholder="John Doe">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Number input clearable kitchen sync
+            <calcite-input prefix-text="pre" suffix-text="suf" clearable type="number" placeholder="How many apples?">
+              <calcite-button slot="input-action">Go</calcite-button>
+
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Number input - button type none
+            <calcite-input type="number" number-button-type="none" placeholder="How many apples?">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with button auto
+            <calcite-input placeholder="Text">
+              <calcite-button slot="input-action">Go</calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with button
+            <calcite-input type="number" placeholder="0" value="0">
+              <calcite-button slot="input-action">Go</calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with max set to 0
+            <calcite-input max="0" step="10" value="-40" type="number" number-button-type="vertical" placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with min set to 0
+            <calcite-input min="0" max="100" step="10" value="40" type="number" number-button-type="horizontal"
+              placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with button and min max step set
+            <calcite-input min="-100" max="100" step="10" value="40" type="number" number-button-type="horizontal"
+              placeholder="0">
+              <calcite-button slot="input-action">Go or some long text</calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with button auto
+            <calcite-input placeholder="Text">
+              <calcite-button width="full" slot="input-action">Go</calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with button with icon
+            <calcite-input placeholder="Text">
+              <calcite-button slot="input-action" icon="plus">Add </calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            with button with icon
+            <calcite-input placeholder="Text">
+              <calcite-button width="full" slot="input-action" icon="plus"></calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            prefix
+            <calcite-input type="number" number-button-type="none" prefix-text="prefix" placeholder="How many apples?">
+            </calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Enter your organization's URL below
+            <calcite-input suffix-text=".maps.arcgis.com" placeholder="Email">
+            </calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            prefix and suffix w numbers
+            <calcite-input type="number" prefix-text="$" suffix-text=".00" placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            prefix and suffix w numbers horizontal alignment end
+            <calcite-input type="number" alignment="end" number-button-type="horizontal" prefix-text="$"
+              suffix-text=".00" placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            prefix and suffix w numbers vertical alignment end
+            <calcite-input type="number" alignment="end" prefix-text="$" suffix-text=".00" placeholder="0">
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            prefix and suffix w alignment end
+            <calcite-input type="number" alignment="end" number-button-type="horizontal" prefix-text="$ (USD)"
+              suffix-text="no cents here" placeholder="0">
+            </calcite-input>
+          </calcite-label>
+
+          <h4>Disabled - set on input with wrapping label</h4>
+
+          <calcite-label disabled>
+            Disabled
+            <calcite-input disabled value="Readonly value">
+            </calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Disabled textarea
+            <calcite-input disabled type="textarea">Disabled value
+            </calcite-input>
+          </calcite-label>
+
+          <h4>Disabled - set on input without wrapping label</h4>
+
+          <calcite-input disabled value="Disabled value">
+          </calcite-input>
+          <br />
+          <calcite-input disabled type="textarea" value="Disabled value">Disabled value
+          </calcite-input>
+
+          <h4>Readonly</h4>
+          <calcite-label disabled>
+            Readonly
+            <calcite-input readonly value="Readonly value">
+            </calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Readonly with prefix
+            <calcite-input readonly prefix-text="API Key" value="A123-S5DL-24FA">
+            </calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Readonly with prefix and button
+            <calcite-input readonly prefix-text="API Key" value="A123-S5DL-24FA">
+              <calcite-button slot="input-action" onclick="alert('copied')" icon="copy-to-clipboard"></calcite-button>
+            </calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Textarea Readonly
+            <calcite-input readonly type="textarea" placeholder="How was your day?">Here I am with some text
+            </calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            File input
+            <calcite-input type="file" placeholder="Drag 'em' here"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Loading input
+            <calcite-input placeholder="john@doe.com" value="john@do" loading></calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Date input with clearable
+            <calcite-input icon="calendar" type="date" clearable></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Time input with clearable
+            <calcite-input icon type="time" clearable></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Date input with default icon
+            <calcite-input icon="calendar" type="date"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Time input with default icon
+            <calcite-input icon type="time"></calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Time input with custom calcite icon
+            <calcite-input icon="clock-up" type="time"></calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Tel input with default icon
+            <calcite-input icon type="tel" placeholder="(123) 456-7890"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Email input with default icon
+            <calcite-input icon type="email" placeholder="john@doe.com"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Email input with custom icon
+            <calcite-input icon="envelope" type="email" placeholder="john@doe.com"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Password input with default icon
+            <calcite-input icon type="password" placeholder="•••••"></calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Password input with custom calcite icon
+            <calcite-input prefix-text="prefix" icon="key" type="password" placeholder="•••••"></calcite-input>
+          </calcite-label>
+          <calcite-label disabled>
+            Password input with no icon
+            <calcite-input prefix-text="prefix" type="password" placeholder="•••••"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Plain text with calcite icon
+            <calcite-input icon="lightbulb" placeholder="asdfasdfas"></calcite-input>
+          </calcite-label>
+
+          <calcite-label disabled>
+            Search with icon
+            <calcite-input icon type="search" placeholder="Filter your files"></calcite-input>
+          </calcite-label>
+
+
         </calcite-accordion-item>
       </calcite-accordion>
     </div>

--- a/src/demos/calcite-radio-group.html
+++ b/src/demos/calcite-radio-group.html
@@ -161,6 +161,13 @@
       <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
     </calcite-radio-group>
 
+    <h3 class="leader-1">Disabled</h3>
+
+    <calcite-radio-group disabled>
+      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+    </calcite-radio-group>
     <h3 class="leader-1">With labels</h3>
 
     <calcite-radio-group>


### PR DESCRIPTION
- Adds disabled prop to label
- Adds disabled prop to radio-group
- Updates demos and storybook

- Any calcite-* components contained within a disabled input will have disabled applied
- Handles "opacity stacking" of wrapped disabled inputs by setting contained elements opacity to 1 and only setting one level of opacity on the wrapping disabled label

**Related Issue:** Resolves #760 cc @joeyHarig

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
