### PR TITLE
test(color): skip color input tests until they no longer time out

### DIFF
--- a/src/components/calcite-color/calcite-color.e2e.ts
+++ b/src/components/calcite-color/calcite-color.e2e.ts
@@ -214,7 +214,8 @@ describe("calcite-color", () => {
     expect(await picker.getProperty("color")).toBeTruthy();
   });
 
-  describe("color inputs", () => {
+  // skipping until https://github.com/Esri/calcite-components/issues/928 is addressed
+  describe.skip("color inputs", () => {
     // tests for all individual inputs takes longer than the default
     const timeoutOverrideInMs = 240000;
 

--- a/src/components/calcite-color/calcite-color.e2e.ts
+++ b/src/components/calcite-color/calcite-color.e2e.ts
@@ -216,7 +216,7 @@ describe("calcite-color", () => {
 
   describe("color inputs", () => {
     // tests for all individual inputs takes longer than the default
-    const timeoutOverrideInMs = 120000;
+    const timeoutOverrideInMs = 240000;
 
     const clearAndEnterValue = async (page: E2EPage, inputOrHexInput: E2EElement, value: string): Promise<void> => {
       await inputOrHexInput.callMethod("setFocus");


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Skips the 'color inputs' test suite since they are timing out sporadically. https://github.com/Esri/calcite-components/issues/928 will explore rewriting these tests to avoid using a custom timeout.