### PR TITLE
build: restore ES5 output for production builds

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -5,6 +5,7 @@ import autoprefixer from "autoprefixer";
 import { generatePreactTypes } from "./support/preact";
 
 export const create: () => Config = () => ({
+  buildEs5: "prod",
   namespace: "calcite",
   bundles: [
     { components: ["calcite-accordion", "calcite-accordion-item"] },


### PR DESCRIPTION
**Related Issue:** #935

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Stencil 2 [dropped the default ES5 build for production builds](https://github.com/ionic-team/stencil/commit/fa67d97d043d12e0a3af0d868fa1746eb9e3badf). This opts-in to ES5 builds to keep the same dist output before the version jump.
