### PR TITLE
build: restore legacy polyfills

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -112,6 +112,10 @@ export const create: () => Config = () => ({
   },
   extras: {
     appendChildSlotFix: true,
+    cssVarsShim: true,
+    dynamicImportShim: true,
+    safari10: true,
+    shadowDomShim: true,
     slotChildNodesFix: true
   }
 });

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -115,6 +115,7 @@ export const create: () => Config = () => ({
     cssVarsShim: true,
     dynamicImportShim: true,
     safari10: true,
+    scriptDataOpts: true,
     shadowDomShim: true,
     slotChildNodesFix: true
   }


### PR DESCRIPTION
**Related Issue:** #935 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Adds missing extras to restore legacy polyfills (see https://github.com/ionic-team/stencil/blob/master/CHANGELOG.md#opt-in-for-ie11-edge-16-18-and-safari-10-builds). 
