### PR TITLE
refactor(flow-item, panel): moves header props, slots, and styles into panel

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -15,7 +15,7 @@ calcite-panel {
   display: flex;
 }
 
-.header-content {
+.header-content { // moving to Panel
   display: block;
   .heading,
   .summary {

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -15,32 +15,6 @@ calcite-panel {
   display: flex;
 }
 
-.header-content { // moving to Panel
-  display: block;
-  .heading,
-  .summary {
-    padding: 0;
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    width: 100%;
-  }
-  .heading {
-    color: var(--calcite-ui-text-3);
-    font-weight: var(--calcite-ui-text-weight-demi);
-    margin: 0 0 var(--calcite-spacing-quarter);
-    @include font-size(-2);
-    &:only-child {
-      margin-bottom: 0;
-    }
-  }
-  .summary {
-    color: var(--calcite-ui-text-3);
-    @include font-size(-4);
-  }
-}
-
 .menu-button {
   align-self: stretch;
   flex: 0 1 auto;

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -11,7 +11,7 @@ calcite-panel {
   height: 100%;
 }
 
-.leading-actions {
+.header-leading-actions {
   display: flex;
 }
 
@@ -22,8 +22,8 @@ calcite-panel {
   position: relative;
 }
 
-.header-actions,
-.single-action-container {
+.header-trailing-actions,
+.header-single-action-container {
   display: flex;
 }
 

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -47,6 +47,11 @@ export class CalciteFlowItem {
   @Prop() heading: string;
 
   /**
+   * Displays a close button in the trailing side of the header.
+   */
+  @Prop({ reflect: true }) dismissible = false;
+
+  /**
    * When true, content is waiting to be loaded. This state shows a busy indicator.
    */
   @Prop({ reflect: true }) loading = false;
@@ -227,7 +232,7 @@ export class CalciteFlowItem {
 
     return showBackButton ? (
       <calcite-action
-        slot={PANEL_SLOTS.headerLeadingContent}
+        slot={SLOTS.leadingActions}
         key="back-button"
         aria-label={label}
         text={label}
@@ -306,15 +311,6 @@ export class CalciteFlowItem {
     );
   }
 
-  renderHeaderLeadingContent(): VNode {
-    const hasLeadingActions = getSlotted(this.el, SLOTS.leadingActions);
-    return hasLeadingActions ? (
-      <div slot={PANEL_SLOTS.headerLeadingContent} class={CSS.leadingActions}>
-        <slot name={SLOTS.leadingActions}></slot>
-      </div>
-    ) : null;
-  }
-
   renderHeaderActions(): VNode {
     const menuActions = getSlotted(this.el, SLOTS.menuActions, { all: true });
     const actionCount = menuActions.length;
@@ -333,34 +329,6 @@ export class CalciteFlowItem {
     ) : null;
   }
 
-  renderHeading(): VNode {
-    const { heading } = this;
-
-    return heading ? (
-      <h2 class={CSS.heading} slot={PANEL_SLOTS.headerContent}>
-        {heading}
-      </h2>
-    ) : null;
-  }
-
-  renderSummary(): VNode {
-    const { summary } = this;
-
-    return summary ? <span class={CSS.summary}>{summary}</span> : null;
-  }
-
-  renderHeader(): VNode {
-    const headingNode = this.renderHeading();
-    const summaryNode = this.renderSummary();
-
-    return headingNode || summaryNode ? (
-      <div class={CSS.header} slot={PANEL_SLOTS.headerContent}>
-        {headingNode}
-        {summaryNode}
-      </div>
-    ) : null;
-  }
-
   renderFab(): VNode {
     const hasFab = getSlotted(this.el, SLOTS.fab);
     return hasFab ? (
@@ -371,21 +339,23 @@ export class CalciteFlowItem {
   }
 
   render(): VNode {
-    const { el } = this;
+    const { disabled, dismissible, el, heading, heightScale, loading, summary } = this;
     const dir = getElementDir(el);
 
     return (
       <Host>
         <calcite-panel
-          loading={this.loading}
-          disabled={this.disabled}
+          dismissible={dismissible}
+          heading={heading}
+          summary={summary}
+          loading={loading}
+          disabled={disabled}
           theme={getElementTheme(el)}
-          height-scale={this.heightScale}
+          height-scale={heightScale}
           dir={dir}
         >
           {this.renderBackButton(dir === "rtl")}
-          {this.renderHeaderLeadingContent()}
-          {this.renderHeader()}
+          <slot slot={SLOTS.leadingActions} name={SLOTS.leadingActions}></slot>
           {this.renderHeaderActions()}
           <slot />
           {this.renderFooterActions()}

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -132,7 +132,7 @@ export class CalciteFlowItem {
   }
 
   queryActions(): HTMLCalciteActionElement[] {
-    return getSlotted<HTMLCalciteActionElement>(this.el, SLOTS.menuActions, {
+    return getSlotted<HTMLCalciteActionElement>(this.el, SLOTS.headerTrailingActions, {
       all: true
     });
   }
@@ -232,7 +232,7 @@ export class CalciteFlowItem {
 
     return showBackButton ? (
       <calcite-action
-        slot={SLOTS.leadingActions}
+        slot={PANEL_SLOTS.headerLeadingActions}
         key="back-button"
         aria-label={label}
         text={label}
@@ -278,7 +278,7 @@ export class CalciteFlowItem {
         onKeyDown={this.menuActionsKeydown}
       >
         <div class={CSS.menu}>
-          <slot name={SLOTS.menuActions} />
+          <slot name={SLOTS.headerTrailingActions} />
         </div>
       </calcite-popover>
     );
@@ -296,8 +296,8 @@ export class CalciteFlowItem {
 
   renderSingleActionContainer(): VNode {
     return (
-      <div class={CSS.singleActionContainer}>
-        <slot name={SLOTS.menuActions} />
+      <div class={CSS.headerSingleActionContainer}>
+        <slot name={SLOTS.headerTrailingActions} />
       </div>
     );
   }
@@ -312,7 +312,7 @@ export class CalciteFlowItem {
   }
 
   renderHeaderActions(): VNode {
-    const menuActions = getSlotted(this.el, SLOTS.menuActions, { all: true });
+    const menuActions = getSlotted(this.el, SLOTS.headerTrailingActions, { all: true });
     const actionCount = menuActions.length;
 
     const menuActionsNodes =
@@ -323,17 +323,8 @@ export class CalciteFlowItem {
         : null;
 
     return menuActionsNodes ? (
-      <div slot={PANEL_SLOTS.headerTrailingContent} class={CSS.headerActions}>
+      <div slot={PANEL_SLOTS.headerTrailingActions} class={CSS.headerLeadingActions}>
         {menuActionsNodes}
-      </div>
-    ) : null;
-  }
-
-  renderFab(): VNode {
-    const hasFab = getSlotted(this.el, SLOTS.fab);
-    return hasFab ? (
-      <div class={CSS.fabContainer} slot={PANEL_SLOTS.fab}>
-        <slot name={SLOTS.fab} />
       </div>
     ) : null;
   }
@@ -355,11 +346,11 @@ export class CalciteFlowItem {
           dir={dir}
         >
           {this.renderBackButton(dir === "rtl")}
-          <slot slot={SLOTS.leadingActions} name={SLOTS.leadingActions}></slot>
+          <slot slot={SLOTS.headerLeadingActions} name={PANEL_SLOTS.headerLeadingActions}></slot>
           {this.renderHeaderActions()}
           <slot />
           {this.renderFooterActions()}
-          {this.renderFab()}
+          <slot slot={SLOTS.fab} name={PANEL_SLOTS.fab}></slot>
         </calcite-panel>
       </Host>
     );

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -1,12 +1,10 @@
 export const CSS = {
   header: "header-content",
-  heading: "heading",
-  summary: "summary",
   backButton: "back-button",
   footerActions: "footer-actions",
-  headerActions: "header-actions",
-  leadingActions: "leading-actions",
-  singleActionContainer: "single-action-container",
+  headerTrailingActions: "header-trailing-actions",
+  headerLeadingActions: "header-leading-actions",
+  headerSingleActionContainer: "header-single-action-container",
   menuContainer: "menu-container",
   menuButton: "menu-button",
   menu: "menu",
@@ -15,8 +13,8 @@ export const CSS = {
 };
 
 export const SLOTS = {
-  leadingActions: "leading-actions",
-  menuActions: "menu-actions",
+  headerLeadingActions: "header-leading-actions",
+  headerTrailingActions: "header-trailing-actions",
   fab: "fab",
   footerActions: "footer-actions"
 };

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -93,18 +93,25 @@ calcite-scrim {
 }
 
 .header-leading-content,
-.header-trailing-content {
+.header-trailing-actions {
   align-items: stretch;
   display: flex;
   flex-flow: row nowrap;
 }
 
-.header-trailing-content {
+.header-trailing-actions {
   margin-left: auto;
 }
 
-.header-leading-content + .header-content {
-  padding-left: var(--calcite-spacing-half);
+.menu-button {
+  align-self: stretch;
+  flex: 0 1 auto;
+  height: 100%;
+  position: relative;
+}
+.menu {
+  min-width: var(--calcite-menu-min-width);
+  flex-flow: column nowrap;
 }
 
 .content-container {
@@ -129,7 +136,7 @@ calcite-scrim {
   .header-leading-content + .header-content {
     padding-right: var(--calcite-spacing-half);
   }
-  .header-trailing-content {
+  .header-trailing-actions {
     margin-left: 0;
     margin-right: auto;
   }

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -64,9 +64,35 @@ calcite-scrim {
   width: 100%;
 }
 
+// .header-content {
+// }
+
 .header-content {
+  display: block;
   overflow: hidden;
   padding: var(--calcite-spacing) var(--calcite-spacing);
+  .heading,
+  .summary {
+    padding: 0;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+  }
+  .heading {
+    color: var(--calcite-ui-text-3);
+    font-weight: var(--calcite-ui-text-weight-demi);
+    margin: 0 0 var(--calcite-spacing-quarter);
+    @include font-size(-2);
+    &:only-child {
+      margin-bottom: 0;
+    }
+  }
+  .summary {
+    color: var(--calcite-ui-text-3);
+    @include font-size(-4);
+  }
 }
 
 .header-leading-content,

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -64,9 +64,6 @@ calcite-scrim {
   width: 100%;
 }
 
-// .header-content {
-// }
-
 .header-content {
   display: block;
   overflow: hidden;

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -208,14 +208,14 @@ export class CalcitePanel {
   }
 
   renderHeaderNode(): VNode {
-    const hasHeaderContent = getSlotted(this.el, SLOTS.headerContent);
-    const headerContentNode = hasHeaderContent ? this.renderHeaderSlottedContent() : this.renderHeaderContent();
+    const hasHeaderSlotContent = getSlotted(this.el, SLOTS.headerContent);
+    const hasHeaderLeadingActoins = getSlotted(this.el, SLOTS.headerLeadingActions);
+    const headerContentNode = hasHeaderSlotContent
+      ? this.renderHeaderSlottedContent()
+      : this.renderHeaderContent();
     const headerTrailingActionsNode = this.renderHeaderTrailingContent();
 
-    const canDisplayHeader =
-      headerContentNode || headerTrailingActionsNode;
-
-    return canDisplayHeader ? (
+    return hasHeaderLeadingActoins || headerContentNode || headerTrailingActionsNode ? (
       <header class={CSS.header}>
         <slot name={SLOTS.headerLeadingActions} />
         {headerContentNode}

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -79,7 +79,7 @@ export class CalcitePanel {
    * Heading text.
    */
 
-  @Prop() heading: string;
+  @Prop() heading?: string;
   /**
    * Summary text. A description displayed underneath the heading.
    */
@@ -157,34 +157,23 @@ export class CalcitePanel {
   //
   // --------------------------------------------------------------------------
 
-  renderHeaderLeadingContent(): VNode {
-    const hasLeadingContent = getSlotted(this.el, SLOTS.headerLeadingContent);
-    return hasLeadingContent ? (
-      <div key="header-leading-content" class={CSS.headerLeadingContent}>
-        <slot name={SLOTS.headerLeadingContent} />
-      </div>
-    ) : null;
-  }
-
-
-  renderSummary(): VNode {
-    const { summary } = this;
-
-    return summary ? <span class={CSS.summary}>{summary}</span> : null;
-  }
-
-  renderHeader(): VNode {
-    const { heading } = this;
+  renderHeaderContent(): VNode {
+    const { heading, summary } = this;
+    const headingNode = heading ? <h4 class={CSS.heading}>{heading}</h4> : null;
+    const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
 
     return (
       <div key="header-content" class={CSS.headerContent}>
-        <h3 class={CSS.heading}>{heading}</h3>
-        {this.renderSummary()}
+        {headingNode}
+        {summaryNode}
       </div>
     );
   }
 
-  renderHeaderContent(): VNode {
+  /**
+   * Allows user to override the entire header-content node.
+   */
+  renderHeaderSlottedContent(): VNode {
     return (
       <div key="header-content" class={CSS.headerContent}>
         <slot name={SLOTS.headerContent} />
@@ -219,17 +208,16 @@ export class CalcitePanel {
   }
 
   renderHeaderNode(): VNode {
-    const hasHeaderSlot = getSlotted(this.el, SLOTS.headerContent);
-    const headerLeadingContentNode = this.renderHeaderLeadingContent();
-    const headerContentNode = hasHeaderSlot ? this.renderHeaderContent() : this.renderHeader();
+    const hasHeaderContent = getSlotted(this.el, SLOTS.headerContent);
+    const headerContentNode = hasHeaderContent ? this.renderHeaderSlottedContent() : this.renderHeaderContent();
     const headerTrailingContentNode = this.renderHeaderTrailingContent();
 
     const canDisplayHeader =
-      headerContentNode || headerLeadingContentNode || headerTrailingContentNode;
+      headerContentNode || headerTrailingContentNode;
 
     return canDisplayHeader ? (
       <header class={CSS.header}>
-        {headerLeadingContentNode}
+        <slot name={SLOTS.leadingActions} />
         {headerContentNode}
         {headerTrailingContentNode}
       </header>

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -197,10 +197,10 @@ export class CalcitePanel {
       />
     ) : null;
 
-    const slotNode = <slot name={SLOTS.headerTrailingContent} />;
+    const slotNode = <slot name={SLOTS.headerTrailingActions} />;
 
     return (
-      <div key="header-trailing-content" class={CSS.headerTrailingContent}>
+      <div key="header-trailing-content" class={CSS.headerTrailingActions}>
         {slotNode}
         {dismissibleNode}
       </div>
@@ -210,16 +210,16 @@ export class CalcitePanel {
   renderHeaderNode(): VNode {
     const hasHeaderContent = getSlotted(this.el, SLOTS.headerContent);
     const headerContentNode = hasHeaderContent ? this.renderHeaderSlottedContent() : this.renderHeaderContent();
-    const headerTrailingContentNode = this.renderHeaderTrailingContent();
+    const headerTrailingActionsNode = this.renderHeaderTrailingContent();
 
     const canDisplayHeader =
-      headerContentNode || headerTrailingContentNode;
+      headerContentNode || headerTrailingActionsNode;
 
     return canDisplayHeader ? (
       <header class={CSS.header}>
-        <slot name={SLOTS.leadingActions} />
+        <slot name={SLOTS.headerLeadingActions} />
         {headerContentNode}
-        {headerTrailingContentNode}
+        {headerTrailingActionsNode}
       </header>
     ) : null;
   }

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -73,7 +73,17 @@ export class CalcitePanel {
   /**
    * Used to set the component's color scheme.
    */
+
   @Prop({ reflect: true }) theme: CalciteTheme;
+  /**
+   * Heading text.
+   */
+
+  @Prop() heading: string;
+  /**
+   * Summary text. A description displayed underneath the heading.
+   */
+  @Prop() summary?: string;
 
   // --------------------------------------------------------------------------
   //
@@ -156,6 +166,24 @@ export class CalcitePanel {
     ) : null;
   }
 
+
+  renderSummary(): VNode {
+    const { summary } = this;
+
+    return summary ? <span class={CSS.summary}>{summary}</span> : null;
+  }
+
+  renderHeader(): VNode {
+    const { heading } = this;
+
+    return (
+      <div key="header-content" class={CSS.headerContent}>
+        <h3 class={CSS.heading}>{heading}</h3>
+        {this.renderSummary()}
+      </div>
+    );
+  }
+
   renderHeaderContent(): VNode {
     return (
       <div key="header-content" class={CSS.headerContent}>
@@ -190,9 +218,10 @@ export class CalcitePanel {
     );
   }
 
-  renderHeader(): VNode {
+  renderHeaderNode(): VNode {
+    const hasHeaderSlot = getSlotted(this.el, SLOTS.headerContent);
     const headerLeadingContentNode = this.renderHeaderLeadingContent();
-    const headerContentNode = this.renderHeaderContent();
+    const headerContentNode = hasHeaderSlot ? this.renderHeaderContent() : this.renderHeader();
     const headerTrailingContentNode = this.renderHeaderTrailingContent();
 
     const canDisplayHeader =
@@ -255,7 +284,7 @@ export class CalcitePanel {
           [CSS_UTILITY.rtl]: rtl
         }}
       >
-        {this.renderHeader()}
+        {this.renderHeaderNode()}
         {this.renderContent()}
         {this.renderFooter()}
       </article>

--- a/src/components/calcite-panel/resources.ts
+++ b/src/components/calcite-panel/resources.ts
@@ -1,6 +1,8 @@
 export const CSS = {
   container: "container",
   header: "header",
+  heading: "heading",
+  summary: "summary",
   headerLeadingContent: "header-leading-content",
   headerContent: "header-content",
   headerTrailingContent: "header-trailing-content",
@@ -14,6 +16,8 @@ export const ICONS = {
 };
 
 export const SLOTS = {
+  leadingActions: "leading-actions",
+  menuActions: "menu-actions",
   headerContent: "header-content",
   headerLeadingContent: "header-leading-content",
   headerTrailingContent: "header-trailing-content",

--- a/src/components/calcite-panel/resources.ts
+++ b/src/components/calcite-panel/resources.ts
@@ -3,28 +3,27 @@ export const CSS = {
   header: "header",
   heading: "heading",
   summary: "summary",
-  headerLeadingContent: "header-leading-content",
   headerContent: "header-content",
-  headerTrailingContent: "header-trailing-content",
+  headerTrailingActions: "header-trailing-actions",
   contentContainer: "content-container",
   fabContainer: "fab-container",
   footer: "footer"
 };
 
 export const ICONS = {
-  close: "x"
+  close: "x",
+  menu: "ellipsis"
 };
 
 export const SLOTS = {
-  leadingActions: "leading-actions",
-  menuActions: "menu-actions",
+  headerLeadingActions: "header-leading-actions",
+  headerTrailingActions: "header-trailing-actions",
   headerContent: "header-content",
-  headerLeadingContent: "header-leading-content",
-  headerTrailingContent: "header-trailing-content",
   fab: "fab",
   footer: "footer"
 };
 
 export const TEXT = {
-  close: "Close"
+  close: "Close",
+  open: "Open"
 };

--- a/src/demos/flow/basic.html
+++ b/src/demos/flow/basic.html
@@ -18,22 +18,31 @@
         <h2>Basic</h2>
         <calcite-flow>
           <calcite-flow-item heading="Item One">
-            <calcite-action icon="caret-down" slot="leading-actions"></calcite-action>
-            <button slot="menu-actions">Reset</button>
-            <button slot="menu-actions">Rename</button>
-            <img src="https://via.placeholder.com/300x200" alt="placeholder" />
+            <calcite-action icon="caret-down" slot="header-trailing-actions"></calcite-action>
+            <!-- <button slot="header-trailing-actions">Reset</button>
+            <button slot="header-trailing-actions">Rename</button> -->
+            <p>
+              <img src="https://via.placeholder.com/300x200" alt="placeholder" />
+            </p>
           </calcite-flow-item>
           <calcite-flow-item heading="Item Two">
-            <img src="http://www.fillmurray.com/100/100" height="40" slot="leading-actions" />
-            <button slot="menu-actions">Reset</button>
-            <button slot="menu-actions">Rename</button>
-            <img src="https://via.placeholder.com/400x300" alt="placeholder" />
+            <img src="http://www.fillmurray.com/100/100" height="40" slot="header-leading-actions" />
+            <button slot="header-trailing-actions">Reset</button>
+            <button slot="header-trailing-actions">Rename</button>
+            <p>
+              <img src="https://via.placeholder.com/400x300" alt="placeholder" />
+            </p>
             <calcite-fab slot="fab"></calcite-fab>
           </calcite-flow-item>
-          <calcite-flow-item heading="Item Three">
-            <button slot="menu-actions">Reset</button>
-            <button slot="menu-actions">Rename</button>
-            <img src="https://via.placeholder.com/400x300" alt="placeholder" />
+          <calcite-flow-item heading="Item Three" summary="I'm a summary.">
+            <calcite-action icon="caret-down" slot="header-leading-actions"></calcite-action>
+            <button slot="header-trailing-actions">Reset</button>
+            <button slot="header-trailing-actions">Rename</button>
+            <p>
+              <img src="https://via.placeholder.com/400x300" alt="placeholder" />
+            </p>
+            <calcite-button slot="footer-actions" >Save</calcite-button>
+            <calcite-button slot="footer-actions" appearance="outline">Cancel</calcite-button>
             <calcite-fab slot="fab"></calcite-fab>
           </calcite-flow-item>
         </calcite-flow>
@@ -41,10 +50,10 @@
         <h2>Menu-actions and Footer-actions</h2>
         <calcite-flow>
           <calcite-flow-item heading="What are the most popular commute alternatives?">
-            <button slot="menu-actions">Reset</button>
-            <button slot="menu-actions">Rename</button>
-            <button slot="footer-actions" class="btn">Save</button>
-            <button slot="footer-actions" class="btn btn-secondary">Cancel</button>
+            <calcite-action icon="banana" slot="header-trailing-actions"></calcite-action>
+            <!-- <button slot="header-trailing-actions">Rename</button> -->
+            <calcite-button slot="footer-actions" >Save</calcite-button>
+            <calcite-button slot="footer-actions" appearance="outline">Cancel</calcite-button>
             <p><img src="https://via.placeholder.com/300x200" alt="placeholder" /></p>
             <p><img src="https://via.placeholder.com/300x200" alt="placeholder" /></p>
           </calcite-flow-item>
@@ -55,21 +64,23 @@
           <h3>Basic</h3>
           <calcite-flow>
             <calcite-flow-item heading="Item One">
-              <calcite-action icon="caret-down" slot="leading-actions"></calcite-action>
-              <button slot="menu-actions">Reset</button>
-              <button slot="menu-actions">Rename</button>
+              <calcite-action icon="caret-down" slot="header-leading-actions"></calcite-action>
+              <button slot="header-trailing-actions">Reset</button>
+              <button slot="header-trailing-actions">Rename</button>
               <img src="https://via.placeholder.com/300x200" alt="placeholder" />
             </calcite-flow-item>
             <calcite-flow-item heading="Item Two">
-              <img src="http://www.fillmurray.com/100/100" height="40" slot="leading-actions" />
-              <button slot="menu-actions">Reset</button>
-              <button slot="menu-actions">Rename</button>
+              <p>
+                <img src="http://www.fillmurray.com/100/100" height="40" slot="header-leading-actions" />
+              </p>
+              <button slot="header-trailing-actions">Reset</button>
+              <button slot="header-trailing-actions">Rename</button>
               <img src="https://via.placeholder.com/400x300" alt="placeholder" />
               <calcite-fab slot="fab"></calcite-fab>
             </calcite-flow-item>
             <calcite-flow-item heading="Item Three">
-              <button slot="menu-actions">Reset</button>
-              <button slot="menu-actions">Rename</button>
+              <button slot="header-trailing-actions">Reset</button>
+              <button slot="header-trailing-actions">Rename</button>
               <img src="https://via.placeholder.com/400x300" alt="placeholder" />
               <calcite-fab slot="fab"></calcite-fab>
             </calcite-flow-item>
@@ -78,8 +89,8 @@
           <h3>Menu-actions and Footer-actions</h3>
           <calcite-flow>
             <calcite-flow-item heading="What are the most popular commute alternatives?">
-              <button slot="menu-actions">Reset</button>
-              <button slot="menu-actions">Rename</button>
+              <button slot="header-trailing-actions">Reset</button>
+              <button slot="header-trailing-actions">Rename</button>
               <button slot="footer-actions" class="btn">Save</button>
               <button slot="footer-actions" class="btn btn-secondary">Cancel</button>
               <p><img src="https://via.placeholder.com/300x200" alt="placeholder" /></p>

--- a/src/demos/panel/basic.html
+++ b/src/demos/panel/basic.html
@@ -21,18 +21,30 @@
           <p>Slotted content</p>
         </calcite-panel>
 
-        <h2>With Footer</h2>
-        <calcite-panel>
-          <div slot="header-content">panel 2 header</div>
-          <p>I have a footer.</p>
-          <div slot="footer">panel Footer</div>
+        <h2>Header properties</h2>
+        <calcite-panel heading="I'm using heading" summary="I'm using summary">
+          <!-- <div slot="menu-actions" style="display: flex;"> -->
+          <calcite-action icon="banana" slot="header-trailing-actions"></calcite-action>
+          <calcite-action icon="banana" slot="header-trailing-actions"></calcite-action>
+          <calcite-action icon="banana" slot="header-leading-actions"></calcite-action>
+        <!-- </div> -->
+          <p>I'm using the properties.</p>
+          <img src="https://via.placeholder.com/300x400" alt="placeholder" />
+          <calcite-fab slot="fab"></calcite-fab>
         </calcite-panel>
 
-        <h2>With Header Actions</h2>
+        <!-- <h2>With Footer</h2>
         <calcite-panel>
-          <div slot="header-leading-content"><button onclick="console.log('left clicked');">L</button></div>
+          <div slot="header-content">header-content slot</div>
+          <p>I have a footer.</p>
+          <div slot="footer">panel Footer</div>
+        </calcite-panel> -->
+
+        <!-- <h2>With Header Actions</h2>
+        <calcite-panel>
+          <div slot="header-leading-actions"><button onclick="console.log('left clicked');">L</button></div>
           <div slot="header-content">panel 3 header</div>
-          <div slot="header-trailing-content"><button onclick="console.log('right clicked');">R</button></div>
+          <div slot="header-trailing-actions"><button onclick="console.log('right clicked');">R</button></div>
           <p>Buttons in the top left and right. Mainly for calcite-actions and not plain buttons.</p>
         </calcite-panel>
 
@@ -40,9 +52,9 @@
         <calcite-panel dismissible id="dismissible-panel">
           <div slot="header-content">Dismissible panel header</div>
           <p>Click the X and I go away</p>
-        </calcite-panel>
+        </calcite-panel> -->
 
-        <script>
+        <!-- <script>
           const dismissiblePanel = document.getElementById("dismissible-panel");
           dismissiblePanel.addEventListener("calcitePanelDismissedChange", function () {
             console.log("calcitePanelDismiss event");
@@ -50,9 +62,9 @@
           setTimeout(function () {
             dismissiblePanel.setFocus("dismiss-button");
           }, 3000);
-        </script>
+        </script> -->
 
-        <h2>Scrolling Panel</h2>
+        <!-- <h2>Scrolling Panel</h2>
         <calcite-panel style="height: 500px;" id="panel">
           <div slot="header-content">panel header</div>
           <p>Slotted content</p>
@@ -132,36 +144,40 @@
           <p>Slotted content</p>
           <p>Slotted content</p>
           <calcite-fab slot="fab" text-enabled text="Add" label="Add"></calcite-fab>
-        </calcite-panel>
-        <script>
+        </calcite-panel> -->
+        <!-- <script>
           const panel = document.getElementById("panel");
           panel.addEventListener("calcitePanelScroll", function (event) {
             console.log("scrolled", event);
           });
-        </script>
+        </script> -->
 
         <div class="panel-container" dir="rtl">
           <h2>RTL</h2>
 
-          <h3>Basic Panel</h3>
+          <h3>Header slot</h3>
           <calcite-panel>
-            <div slot="header-content">panel header</div>
+            <div slot="header-content">I'm using the header-content slot</div>
             <p>Slotted content</p>
           </calcite-panel>
 
-          <h3>With Header Actions</h3>
-          <calcite-panel>
-            <div slot="header-leading-content"><button onclick="console.log('left clicked');">L</button></div>
+          <h3>With Header props</h3>
+          <calcite-panel heading="I'm using heading" summary="I'm using summary">
+            <p>I'm using the properties.</p>
+          </calcite-panel>
+          
+          <!-- <calcite-panel>
+            <div slot="header-leading-actions"><button onclick="console.log('left clicked');">L</button></div>
             <div slot="header-content">panel 3 header</div>
             <div slot="header-trailing-content"><button onclick="console.log('right clicked');">R</button></div>
             <p>Button positions are reversed!</p>
-          </calcite-panel>
+          </calcite-panel> -->
 
-          <h3>Dismissible Panel</h3>
+          <!-- <h3>Dismissible Panel</h3>
           <calcite-panel dismissible>
-            <div slot="header-content">Dismissible panel header</div>
-            <p>X position reversed!</p>
-          </calcite-panel>
+            <div slot="header-content">I'm using header-content slot.</div>
+            <p>I'm the content.</p>
+          </calcite-panel> -->
         </div>
       </section>
     </main>


### PR DESCRIPTION
**Related Issue:** #891

I would appreciate feedback on whether this seems to be the correct direction.
I am keeping things like intelligently making a `...` overflow menu in FlowItem since that lends itself nicely to drill-in panels.

Users can still override the entire header node by using the `header-content` slot.

Currently `footer-actions` are still in FlowItem, but I'm considering moving `footer-actions` slot into Panel and, like with the header node, allowing users to override by using the `footer` slot.

## Summary
* retains the ability to completely override the header node of the Panel
* makes heading and summary part of Panel
* replaces header "content" slots with "action" slots
* redundancy and duplication is purposeful so that when we deprecate and remove FlowItem, refactoring apps will be easier

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

note: still working on this and doing cleanup.