### PR TITLE
refactor(dropdown): update calcite-dropdown to use Popper.js

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -1,10 +1,14 @@
+@mixin popperContainer {
+  display: block;
+  position: absolute;
+  z-index: 999;
+  top: -999999px;
+  left: -999999px;
+}
+
 @mixin popperHost {
   :host {
-    display: block;
-    position: absolute;
-    z-index: 999;
-    top: -999999px;
-    left: -999999px;
+    @include popperContainer();
   }
 
   :host([aria-hidden="false"]) {

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -3,6 +3,10 @@ $popper-transform-top: translateY(5px);
 $popper-transform-left: translateX(5px);
 $popper-transform-right: translateX(-5px);
 
+:root {
+  --calcite-popper-transition: #{$transition};
+}
+
 @mixin popperAnim {
   .calcite-popper-anim {
     position: relative;
@@ -24,8 +28,6 @@ $popper-transform-right: translateX(-5px);
 
 @mixin popperElemAnim($selector) {
   #{$selector} {
-    --calcite-popper-transition: #{$transition};
-
     @include popperAnim();
 
     &[data-popper-placement^="bottom"] .calcite-popper-anim {
@@ -51,10 +53,6 @@ $popper-transform-right: translateX(-5px);
 }
 
 @mixin popperHostAnim {
-  :host {
-    --calcite-popper-transition: #{$transition};
-  }
-
   @include popperAnim();
 
   :host([data-popper-placement^="bottom"]) .calcite-popper-anim {

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -1,3 +1,83 @@
+$popper-transform-bottom: translateY(-5px);
+$popper-transform-top: translateY(5px);
+$popper-transform-left: translateX(5px);
+$popper-transform-right: translateX(-5px);
+
+@mixin popperAnim {
+  .calcite-popper-anim {
+    position: relative;
+    z-index: 1;
+    transition: var(--calcite-popper-transition);
+    visibility: hidden;
+    transition-property: transform, visibility, opacity;
+    opacity: 0;
+    box-shadow: $shadow-2;
+    border-radius: var(--calcite-border-radius);
+  }
+}
+
+@mixin popperAnimActive {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(0);
+}
+
+@mixin popperElemAnim($selector) {
+  #{$selector} {
+    --calcite-popper-transition: #{$transition};
+
+    @include popperAnim();
+
+    &[data-popper-placement^="bottom"] .calcite-popper-anim {
+      transform: $popper-transform-bottom;
+    }
+
+    &[data-popper-placement^="top"] .calcite-popper-anim {
+      transform: $popper-transform-top;
+    }
+
+    &[data-popper-placement^="left"] .calcite-popper-anim {
+      transform: $popper-transform-left;
+    }
+
+    &[data-popper-placement^="right"] .calcite-popper-anim {
+      transform: $popper-transform-right;
+    }
+
+    &[data-popper-placement] .calcite-popper-anim--active {
+      @include popperAnimActive();
+    }
+  }
+}
+
+@mixin popperHostAnim {
+  :host {
+    --calcite-popper-transition: #{$transition};
+  }
+
+  @include popperAnim();
+
+  :host([data-popper-placement^="bottom"]) .calcite-popper-anim {
+    transform: $popper-transform-bottom;
+  }
+
+  :host([data-popper-placement^="top"]) .calcite-popper-anim {
+    transform: $popper-transform-top;
+  }
+
+  :host([data-popper-placement^="left"]) .calcite-popper-anim {
+    transform: $popper-transform-left;
+  }
+
+  :host([data-popper-placement^="right"]) .calcite-popper-anim {
+    transform: $popper-transform-right;
+  }
+
+  :host([data-popper-placement]) .calcite-popper-anim--active {
+    @include popperAnimActive();
+  }
+}
+
 @mixin popperContainer {
   display: block;
   position: absolute;
@@ -11,9 +91,7 @@
     @include popperContainer();
   }
 
-  :host([aria-hidden="false"]) {
-    box-shadow: $shadow-2;
-  }
+  @include popperHostAnim();
 }
 
 $pointer_size: 8px;
@@ -35,19 +113,19 @@ $pointer_offset: -$pointer_size/2;
     background: var(--calcite-ui-foreground-1);
   }
 
-  :host([data-popper-placement^="top"]) > .arrow {
+  :host([data-popper-placement^="top"]) .arrow {
     bottom: $pointer_offset;
   }
 
-  :host([data-popper-placement^="bottom"]) > .arrow {
+  :host([data-popper-placement^="bottom"]) .arrow {
     top: $pointer_offset;
   }
 
-  :host([data-popper-placement^="left"]) > .arrow {
+  :host([data-popper-placement^="left"]) .arrow {
     right: $pointer_offset;
   }
 
-  :host([data-popper-placement^="right"]) > .arrow {
+  :host([data-popper-placement^="right"]) .arrow {
     left: $pointer_offset;
   }
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -484,7 +484,7 @@ describe("calcite-dropdown", () => {
 
   it("should focus the first item on open when there is no active item", async () => {
     const page = await newE2EPage({
-      html: `<calcite-dropdown>
+      html: `<calcite-dropdown style="--calcite-popper-transition:none;">
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group>
       <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -503,7 +503,7 @@ describe("calcite-dropdown", () => {
 
   it("should focus the first active item on open", async () => {
     const page = await newE2EPage({
-      html: `<calcite-dropdown>
+      html: `<calcite-dropdown style="--calcite-popper-transition:none;">
         <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
         <calcite-dropdown-group>
           <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -523,7 +523,7 @@ describe("calcite-dropdown", () => {
 
   it("should focus the first active item on open", async () => {
     const page = await newE2EPage({
-      html: `<calcite-dropdown>
+      html: `<calcite-dropdown style="--calcite-popper-transition:none;">
         <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
         <calcite-dropdown-group selection-mode="multi">
           <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -545,7 +545,7 @@ describe("calcite-dropdown", () => {
     it("focused item should be in view when long", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-dropdown>
+      await page.setContent(`<calcite-dropdown style="--calcite-popper-transition:none;">
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group>
         <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -789,7 +789,7 @@ describe("calcite-dropdown", () => {
   it("focus is returned to trigger after close", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-dropdown>
+    <calcite-dropdown style="--calcite-popper-transition:none;">
     <calcite-button id="trigger" slot="dropdown-trigger">Open dropdown</calcite-button>
     <calcite-dropdown-group id="group-1" selection-mode="single">
     <calcite-dropdown-item id="item-1">

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,5 +1,6 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { HYDRATED_ATTR } from "../../tests/commonTests";
+const CSS_TRANSITION_DELAY = 400;
 
 describe("calcite-dropdown", () => {
   /**
@@ -498,6 +499,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
+    await page.waitFor(CSS_TRANSITION_DELAY);
     expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-1");
   });
 
@@ -517,7 +519,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-
+    await page.waitFor(CSS_TRANSITION_DELAY);
     expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-3");
   });
 
@@ -537,7 +539,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-
+    await page.waitFor(CSS_TRANSITION_DELAY);
     expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-2");
   });
 
@@ -595,7 +597,7 @@ describe("calcite-dropdown", () => {
       const element = await page.find("calcite-dropdown");
       await element.click();
       await page.waitForChanges();
-
+      await page.waitFor(CSS_TRANSITION_DELAY);
       expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-50");
 
       const item = await page.find("#item-50");

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,16 +1,6 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { HYDRATED_ATTR } from "../../tests/commonTests";
 
-const getActiveElementId = async (page: E2EPage): Promise<string> => {
-  return await page.evaluate(async () => {
-    const CSS_TRANSITION_DELAY = 500;
-
-    await new Promise((resolve) => setTimeout(resolve, CSS_TRANSITION_DELAY));
-
-    return document.activeElement.id;
-  });
-};
-
 describe("calcite-dropdown", () => {
   /**
    * Test helper for selected calcite-dropdown items. Expects items to have IDs to test against.
@@ -508,7 +498,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-    expect(await getActiveElementId(page)).toEqual("item-1");
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-1");
   });
 
   it("should focus the first active item on open", async () => {
@@ -527,7 +517,8 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-    expect(await getActiveElementId(page)).toEqual("item-3");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-3");
   });
 
   it("should focus the first active item on open", async () => {
@@ -546,7 +537,8 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-    expect(await getActiveElementId(page)).toEqual("item-2");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-2");
   });
 
   describe("scrolling", () => {
@@ -603,10 +595,12 @@ describe("calcite-dropdown", () => {
       const element = await page.find("calcite-dropdown");
       await element.click();
       await page.waitForChanges();
-      expect(await getActiveElementId(page)).toEqual("item-50");
 
-      // const item = await page.find("#item-50");
-      // expect(await item.isIntersectingViewport()).toBe(true);
+      expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-50");
+
+      const item = await page.find("#item-50");
+
+      expect(await item.isIntersectingViewport()).toBe(true);
     });
 
     it("control max items displayed", async () => {

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,6 +1,15 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { HYDRATED_ATTR } from "../../tests/commonTests";
-const CSS_TRANSITION_DELAY = 400;
+
+const getActiveElementId = async (page: E2EPage): Promise<string> => {
+  return await page.evaluate(async () => {
+    const CSS_TRANSITION_DELAY = 500;
+
+    await new Promise((resolve) => setTimeout(resolve, CSS_TRANSITION_DELAY));
+
+    return document.activeElement.id;
+  });
+};
 
 describe("calcite-dropdown", () => {
   /**
@@ -499,8 +508,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-    await page.waitFor(CSS_TRANSITION_DELAY);
-    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-1");
+    expect(await getActiveElementId(page)).toEqual("item-1");
   });
 
   it("should focus the first active item on open", async () => {
@@ -519,8 +527,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-    await page.waitFor(CSS_TRANSITION_DELAY);
-    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-3");
+    expect(await getActiveElementId(page)).toEqual("item-3");
   });
 
   it("should focus the first active item on open", async () => {
@@ -539,8 +546,7 @@ describe("calcite-dropdown", () => {
     const element = await page.find("calcite-dropdown");
     await element.click();
     await page.waitForChanges();
-    await page.waitFor(CSS_TRANSITION_DELAY);
-    expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-2");
+    expect(await getActiveElementId(page)).toEqual("item-2");
   });
 
   describe("scrolling", () => {
@@ -597,12 +603,10 @@ describe("calcite-dropdown", () => {
       const element = await page.find("calcite-dropdown");
       await element.click();
       await page.waitForChanges();
-      await page.waitFor(CSS_TRANSITION_DELAY);
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual("item-50");
+      expect(await getActiveElementId(page)).toEqual("item-50");
 
-      const item = await page.find("#item-50");
-
-      expect(await item.isIntersectingViewport()).toBe(true);
+      // const item = await page.find("#item-50");
+      // expect(await item.isIntersectingViewport()).toBe(true);
     });
 
     it("control max items displayed", async () => {

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -27,10 +27,15 @@
   pointer-events: none;
 }
 
-.dropdown-animation-wrapper {
+:host([active]) .calcite-dropdown-wrapper {
+  pointer-events: initial;
+  visibility: visible;
+}
+
+:host .dropdown-animation-wrapper {
   transition: $transition;
   transform-origin: top center;
-  transform: scaleY(0);
+  transform: scale(0);
 }
 
 :host [data-popper-placement^="top"] .dropdown-animation-wrapper {
@@ -38,7 +43,12 @@
 }
 
 :host([active]) .dropdown-animation-wrapper {
-  transform: scaleY(1);
+  transform: scale(1);
+}
+
+.calcite-dropdown-trigger-container {
+  position: relative;
+  display: inline-block;
 }
 
 // width
@@ -80,14 +90,4 @@
 
 :host([dir="rtl"][scale="l"]) {
   --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2 $baseline / 1.5};
-}
-
-.calcite-dropdown-trigger-container {
-  position: relative;
-  display: inline-block;
-}
-
-:host([active]) .calcite-dropdown-wrapper {
-  pointer-events: initial;
-  visibility: visible;
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -27,6 +27,20 @@
   pointer-events: none;
 }
 
+.dropdown-animation-wrapper {
+  transition: $transition;
+  transform-origin: top center;
+  transform: scaleY(0);
+}
+
+:host [data-popper-placement^="top"] .dropdown-animation-wrapper {
+  transform-origin: bottom center;
+}
+
+:host([active]) .dropdown-animation-wrapper {
+  transform: scaleY(1);
+}
+
 // width
 :host([width="s"]) {
   --calcite-dropdown-width: 12.5em;

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -17,9 +17,6 @@
 :host .calcite-dropdown-wrapper {
   @include popperContainer();
   visibility: hidden;
-  background: var(--calcite-ui-foreground-1);
-  border-radius: var(--calcite-border-radius);
-  box-shadow: $shadow-2;
   pointer-events: none;
 }
 
@@ -41,6 +38,8 @@
   overflow-y: auto;
   width: auto;
   width: var(--calcite-dropdown-width);
+  border-radius: var(--calcite-border-radius);
+  box-shadow: $shadow-2;
 }
 
 :host [data-popper-placement^="bottom"] .dropdown-animation-wrapper {

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,6 +1,7 @@
 :host {
   position: relative;
   display: inline-block;
+  --calcite-popper-transition: #{$transition};
 }
 
 // disabled styles
@@ -33,7 +34,7 @@
 }
 
 :host .dropdown-animation-wrapper {
-  transition: $transition;
+  transition: var(--calcite-popper-transition);
   transform-origin: top center;
   transform: scale(0);
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,5 +1,30 @@
+:host {
+  position: relative;
+  display: inline-block;
+}
+
+// disabled styles
+:host([disabled]) {
+  pointer-events: none;
+  opacity: 0.4;
+}
+
 :host-context([theme="dark"]) {
   @include calcite-theme-dark();
+}
+
+:host .calcite-dropdown-wrapper {
+  @include popperContainer();
+  visibility: hidden;
+  overflow: hidden;
+  max-height: 90vh;
+  overflow-y: auto;
+  width: auto;
+  width: var(--calcite-dropdown-width);
+  background: var(--calcite-ui-foreground-1);
+  border-radius: var(--calcite-border-radius);
+  box-shadow: $shadow-2;
+  pointer-events: none;
 }
 
 // width
@@ -43,76 +68,12 @@
   --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2 $baseline / 1.5};
 }
 
-:host {
+.calcite-dropdown-trigger-container {
   position: relative;
   display: inline-block;
 }
 
-// disabled styles
-:host([disabled]) {
-  pointer-events: none;
-  opacity: 0.4;
-}
-
 :host([active]) .calcite-dropdown-wrapper {
-  transform: translate3d(0, 0, 0);
-  opacity: 1;
-  max-height: 90vh;
-  overflow-y: auto;
-  visibility: visible;
   pointer-events: initial;
-}
-
-:host .calcite-dropdown-wrapper {
-  transform: translate3d(0, -$baseline, 0);
-  transition: all 0.15s ease-in-out, max-height 0.15s;
-  visibility: hidden;
-  opacity: 0;
-  display: block;
-  position: absolute;
-  left: 0;
-  z-index: 200;
-  overflow: hidden;
-  max-height: 0;
-  width: auto;
-  width: var(--calcite-dropdown-width);
-  background: var(--calcite-ui-foreground-1);
-  border-radius: var(--calcite-border-radius);
-  box-shadow: $shadow-2;
-  pointer-events: none;
-}
-
-:host([dir="rtl"]) .calcite-dropdown-wrapper {
-  right: 0;
-  left: unset;
-}
-
-:host([alignment="end"]) .calcite-dropdown-wrapper {
-  right: 0;
-  left: unset;
-}
-
-:host([dir="rtl"][alignment="end"]) .calcite-dropdown-wrapper {
-  right: unset;
-  left: 0;
-}
-
-:host([alignment="center"]) .calcite-dropdown-wrapper {
-  right: 0;
-  left: 50%;
-  transform: translate3d(0, -$baseline, 0) translateX(-50%);
-}
-
-:host([alignment="center"][active]) .calcite-dropdown-wrapper {
-  transform: translate3d(0, 0, 0) translateX(-50%);
-}
-
-:host([alignment="center"][dir="rtl"]) .calcite-dropdown-wrapper {
-  right: 50%;
-  left: 0;
-  transform: translate3d(0, -$baseline, 0) translateX(50%);
-}
-
-:host([alignment="center"][dir="rtl"][active]) .calcite-dropdown-wrapper {
-  transform: translate3d(0, 0, 0) translateX(50%);
+  visibility: visible;
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -17,11 +17,6 @@
 :host .calcite-dropdown-wrapper {
   @include popperContainer();
   visibility: hidden;
-  overflow: hidden;
-  max-height: 90vh;
-  overflow-y: auto;
-  width: auto;
-  width: var(--calcite-dropdown-width);
   background: var(--calcite-ui-foreground-1);
   border-radius: var(--calcite-border-radius);
   box-shadow: $shadow-2;
@@ -34,17 +29,40 @@
 }
 
 :host .dropdown-animation-wrapper {
+  position: relative;
+  z-index: 1;
+  background: var(--calcite-ui-foreground-1);
   transition: var(--calcite-popper-transition);
-  transform-origin: top center;
-  transform: scale(0);
+  visibility: hidden;
+  transition-property: transform, visibility, opacity;
+  opacity: 0;
+  max-height: 90vh;
+  overflow: hidden;
+  overflow-y: auto;
+  width: auto;
+  width: var(--calcite-dropdown-width);
+}
+
+:host [data-popper-placement^="bottom"] .dropdown-animation-wrapper {
+  transform: translateY(-5px);
 }
 
 :host [data-popper-placement^="top"] .dropdown-animation-wrapper {
-  transform-origin: bottom center;
+  transform: translateY(5px);
+}
+
+:host [data-popper-placement^="left"] .dropdown-animation-wrapper {
+  transform: translateX(5px);
+}
+
+:host [data-popper-placement^="right"] .dropdown-animation-wrapper {
+  transform: translateX(-5px);
 }
 
 :host([active]) .dropdown-animation-wrapper {
-  transform: scale(1);
+  opacity: 1;
+  visibility: visible;
+  transform: translate(0);
 }
 
 .calcite-dropdown-trigger-container {

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,7 +1,6 @@
 :host {
   position: relative;
   display: inline-block;
-  --calcite-popper-transition: #{$transition};
 }
 
 // disabled styles
@@ -20,48 +19,20 @@
   pointer-events: none;
 }
 
+@include popperElemAnim(".calcite-dropdown-wrapper");
+
 :host([active]) .calcite-dropdown-wrapper {
   pointer-events: initial;
   visibility: visible;
 }
 
-:host .dropdown-animation-wrapper {
-  position: relative;
-  z-index: 1;
+:host .calcite-dropdown-content {
   background: var(--calcite-ui-foreground-1);
-  transition: var(--calcite-popper-transition);
-  visibility: hidden;
-  transition-property: transform, visibility, opacity;
-  opacity: 0;
   max-height: 90vh;
   overflow: hidden;
   overflow-y: auto;
   width: auto;
   width: var(--calcite-dropdown-width);
-  border-radius: var(--calcite-border-radius);
-  box-shadow: $shadow-2;
-}
-
-:host [data-popper-placement^="bottom"] .dropdown-animation-wrapper {
-  transform: translateY(-5px);
-}
-
-:host [data-popper-placement^="top"] .dropdown-animation-wrapper {
-  transform: translateY(5px);
-}
-
-:host [data-popper-placement^="left"] .dropdown-animation-wrapper {
-  transform: translateX(5px);
-}
-
-:host [data-popper-placement^="right"] .dropdown-animation-wrapper {
-  transform: translateX(-5px);
-}
-
-:host([active]) .dropdown-animation-wrapper {
-  opacity: 1;
-  visibility: visible;
-  transform: translate(0);
 }
 
 .calcite-dropdown-trigger-container {

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -135,26 +135,22 @@ export class CalciteDropdown {
   }
 
   render(): VNode {
-    const { maxScrollerHeight } = this;
+    const { active, maxScrollerHeight } = this;
     const dir = getElementDir(this.el);
+
     return (
-      <Host dir={dir}>
+      <Host dir={dir} tabIndex={this.disabled ? -1 : null}>
         <div
           class="calcite-dropdown-trigger-container"
-          ref={(el) => (this.referenceEl = el)}
-          tabIndex={this.disabled ? -1 : null}
+          ref={this.setReferenceEl}
           onClick={this.openDropdown}
           onKeyDown={this.keyDownHandler}
         >
-          <slot
-            name="dropdown-trigger"
-            aria-haspopup="true"
-            aria-expanded={this.active.toString()}
-          />
+          <slot name="dropdown-trigger" aria-haspopup="true" aria-expanded={active.toString()} />
         </div>
         <div
-          aria-hidden={!this.active.toString()}
-          ref={(el) => (this.menuEl = el)}
+          aria-hidden={(!active).toString()}
+          ref={this.setMenuEl}
           class="calcite-dropdown-wrapper"
           role="menu"
           style={{
@@ -227,14 +223,14 @@ export class CalciteDropdown {
   }
 
   @Listen("mouseenter")
-  mouseoverHandler(): void {
+  mouseEnterHandler(): void {
     if (this.type === "hover") {
       this.openCalciteDropdown();
     }
   }
 
   @Listen("mouseleave")
-  mouseoffHandler(): void {
+  mouseLeaveHandler(): void {
     if (this.type === "hover") {
       this.closeCalciteDropdown();
     }
@@ -315,13 +311,10 @@ export class CalciteDropdown {
   /** trigger elements */
   private triggers: HTMLSlotElement[];
 
-  /** positions menu */
   private popper: Popper;
 
-  /** menu element */
   private menuEl: HTMLDivElement;
 
-  /** trigger reference element */
   private referenceEl: HTMLDivElement;
 
   //--------------------------------------------------------------------------
@@ -329,6 +322,14 @@ export class CalciteDropdown {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  setReferenceEl = (el: HTMLDivElement): void => {
+    this.referenceEl = el;
+  };
+
+  setMenuEl = (el: HTMLDivElement): void => {
+    this.menuEl = el;
+  };
 
   getModifiers(): Partial<StrictModifiers>[] {
     const flipModifier: Partial<StrictModifiers> = {

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -151,7 +151,11 @@ export class CalciteDropdown {
           role="menu"
         >
           <div
-            class="dropdown-animation-wrapper"
+            class={{
+              ["calcite-dropdown-content"]: true,
+              ["calcite-popper-anim"]: true,
+              ["calcite-popper-anim--active"]: active
+            }}
             style={{
               maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
             }}

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -40,12 +40,8 @@ export class CalciteDropdown {
   @Prop({ reflect: true, mutable: true }) active = false;
 
   @Watch("active")
-  activeHandler(active: boolean): void {
-    if (active) {
-      this.createPopper();
-    } else {
-      this.destroyPopper();
-    }
+  activeHandler(): void {
+    this.reposition();
   }
 
   /** specify the alignment of dropdown, defaults to start */
@@ -362,14 +358,13 @@ export class CalciteDropdown {
 
   createPopper(): void {
     this.destroyPopper();
-    const { active, menuEl, referenceEl } = this;
+    const { menuEl, referenceEl } = this;
     const modifiers = this.getModifiers();
     const placement = this.getPlacement();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      open: active,
       placement,
       referenceEl
     });

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -157,7 +157,9 @@ export class CalciteDropdown {
             maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
           }}
         >
-          <slot />
+          <div class="dropdown-animation-wrapper">
+            <slot />
+          </div>
         </div>
       </Host>
     );

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -149,11 +149,13 @@ export class CalciteDropdown {
           ref={this.setMenuEl}
           class="calcite-dropdown-wrapper"
           role="menu"
-          style={{
-            maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
-          }}
         >
-          <div class="dropdown-animation-wrapper">
+          <div
+            class="dropdown-animation-wrapper"
+            style={{
+              maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
+            }}
+          >
             <slot />
           </div>
         </div>

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -1,7 +1,21 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+  VNode,
+  Watch,
+  Method
+} from "@stencil/core";
 import { GroupRegistration, ItemKeyboardEvent } from "../../interfaces/Dropdown";
 import { getKey } from "../../utils/key";
 import { focusElement, getElementDir } from "../../utils/dom";
+import { createPopper, CalcitePlacement, updatePopper } from "../../utils/popper";
+import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 
 @Component({
   tag: "calcite-dropdown",
@@ -25,8 +39,22 @@ export class CalciteDropdown {
 
   @Prop({ reflect: true, mutable: true }) active = false;
 
+  @Watch("active")
+  activeHandler(active: boolean): void {
+    if (active) {
+      this.createPopper();
+    } else {
+      this.destroyPopper();
+    }
+  }
+
   /** specify the alignment of dropdown, defaults to start */
   @Prop({ mutable: true, reflect: true }) alignment: "start" | "center" | "end" = "start";
+
+  @Watch("alignment")
+  alignmentHandler(): void {
+    this.reposition();
+  }
 
   /** specify the max items to display before showing the scroller, must be greater than 0 **/
   @Prop() maxItems = 0;
@@ -65,7 +93,7 @@ export class CalciteDropdown {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback() {
+  connectedCallback(): void {
     // validate props
     const alignment = ["start", "center", "end"];
     if (!alignment.includes(this.alignment)) this.alignment = "start";
@@ -78,9 +106,16 @@ export class CalciteDropdown {
 
     const type = ["hover", "click"];
     if (!type.includes(this.type)) this.type = "hover";
+
+    this.createPopper();
   }
 
-  componentDidLoad() {
+  componentWillLoad(): void {
+    // get initially selected items
+    this.updateSelectedItems();
+  }
+
+  componentDidLoad(): void {
     this.triggers = Array.from(
       this.el.querySelectorAll("[slot=dropdown-trigger]")
     ) as HTMLSlotElement[];
@@ -95,18 +130,31 @@ export class CalciteDropdown {
     }
   }
 
-  componentWillLoad() {
-    // get initially selected items
-    this.updateSelectedItems();
+  disconnectedCallback(): void {
+    this.destroyPopper();
   }
 
-  render() {
+  render(): VNode {
     const { maxScrollerHeight } = this;
     const dir = getElementDir(this.el);
     return (
-      <Host dir={dir} tabIndex={this.disabled ? -1 : null}>
-        <slot name="dropdown-trigger" aria-haspopup="true" aria-expanded={this.active.toString()} />
+      <Host dir={dir}>
         <div
+          class="calcite-dropdown-trigger-container"
+          ref={(el) => (this.referenceEl = el)}
+          tabIndex={this.disabled ? -1 : null}
+          onClick={this.openDropdown}
+          onKeyDown={this.keyDownHandler}
+        >
+          <slot
+            name="dropdown-trigger"
+            aria-haspopup="true"
+            aria-expanded={this.active.toString()}
+          />
+        </div>
+        <div
+          aria-hidden={!this.active.toString()}
+          ref={(el) => (this.menuEl = el)}
           class="calcite-dropdown-wrapper"
           role="menu"
           style={{
@@ -117,6 +165,28 @@ export class CalciteDropdown {
         </div>
       </Host>
     );
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Public Methods
+  //
+  //--------------------------------------------------------------------------
+
+  @Method()
+  async reposition(): Promise<void> {
+    const { popper, menuEl } = this;
+    const modifiers = this.getModifiers();
+    const placement = this.getPlacement();
+
+    popper
+      ? updatePopper({
+          el: menuEl,
+          modifiers,
+          placement,
+          popper
+        })
+      : this.createPopper();
   }
 
   //--------------------------------------------------------------------------
@@ -134,73 +204,44 @@ export class CalciteDropdown {
   /** fires when a dropdown has been closed **/
   @Event() calciteDropdownClose: EventEmitter<void>;
 
-  @Listen("click") openDropdown(e) {
-    if (
-      this.triggers.includes(e.target) ||
-      this.triggers.some((trigger) => trigger.contains(e.target))
-    ) {
-      e.preventDefault();
-      e.stopPropagation();
-      this.openCalciteDropdown();
-    }
-  }
-
-  @Listen("click", { target: "window" }) closeCalciteDropdownOnClick(e) {
+  @Listen("click", { target: "window" })
+  closeCalciteDropdownOnClick(e: Event): void {
+    const target = e.target as HTMLElement;
     if (
       this.active &&
-      e.target.nodeName !== "CALCITE-DROPDOWN-ITEM" &&
-      e.target.nodeName !== "CALCITE-DROPDOWN-GROUP"
+      target.nodeName !== "CALCITE-DROPDOWN-ITEM" &&
+      target.nodeName !== "CALCITE-DROPDOWN-GROUP"
     ) {
       this.closeCalciteDropdown();
     }
   }
 
-  @Listen("calciteDropdownCloseRequest") closeCalciteDropdownOnEvent() {
+  @Listen("calciteDropdownCloseRequest")
+  closeCalciteDropdownOnEvent(): void {
     this.closeCalciteDropdown();
   }
 
   @Listen("calciteDropdownOpen", { target: "window" })
-  closeCalciteDropdownOnOpenEvent(e) {
+  closeCalciteDropdownOnOpenEvent(e: Event): void {
     if (e.target !== this.el) this.active = false;
   }
 
-  @Listen("keydown") keyDownHandler(e) {
-    const key = getKey(e.key);
-    if (
-      this.triggers.includes(e.target) ||
-      this.triggers.some((trigger) => trigger.contains(e.target))
-    ) {
-      if (e.target.nodeName !== "BUTTON" && e.target.nodeName !== "CALCITE-BUTTON") {
-        switch (key) {
-          case " ":
-          case "Enter":
-            this.openCalciteDropdown();
-            break;
-          case "Escape":
-            this.closeCalciteDropdown();
-            break;
-        }
-      } else if (key === "Escape" || (e.shiftKey && key === "Tab")) {
-        this.closeCalciteDropdown();
-      }
-    }
-  }
-
-  @Listen("mouseenter") mouseoverHandler() {
+  @Listen("mouseenter")
+  mouseoverHandler(): void {
     if (this.type === "hover") {
       this.openCalciteDropdown();
     }
   }
 
-  @Listen("mouseleave") mouseoffHandler() {
+  @Listen("mouseleave")
+  mouseoffHandler(): void {
     if (this.type === "hover") {
       this.closeCalciteDropdown();
     }
   }
 
-  @Listen("calciteDropdownItemKeyEvent") calciteDropdownItemKeyEvent(
-    e: CustomEvent<ItemKeyboardEvent>
-  ) {
+  @Listen("calciteDropdownItemKeyEvent")
+  calciteDropdownItemKeyEvent(e: CustomEvent<ItemKeyboardEvent>): void {
     const { keyboardEvent } = e.detail;
     // handle edge
     const target = keyboardEvent.target as HTMLCalciteDropdownItemElement;
@@ -231,7 +272,8 @@ export class CalciteDropdown {
     e.stopPropagation();
   }
 
-  @Listen("calciteDropdownItemSelect") handleItemSelect(event: CustomEvent): void {
+  @Listen("calciteDropdownItemSelect")
+  handleItemSelect(event: CustomEvent): void {
     this.updateSelectedItems();
     event.stopPropagation();
     this.calciteDropdownSelect.emit();
@@ -239,9 +281,8 @@ export class CalciteDropdown {
       this.closeCalciteDropdown();
   }
 
-  @Listen("calciteDropdownGroupRegister") registerCalciteDropdownGroup(
-    e: CustomEvent<GroupRegistration>
-  ) {
+  @Listen("calciteDropdownGroupRegister")
+  registerCalciteDropdownGroup(e: CustomEvent<GroupRegistration>): void {
     const {
       detail: { items, position, titleEl }
     } = e;
@@ -274,11 +315,107 @@ export class CalciteDropdown {
   /** trigger elements */
   private triggers: HTMLSlotElement[];
 
+  /** positions menu */
+  private popper: Popper;
+
+  /** menu element */
+  private menuEl: HTMLDivElement;
+
+  /** trigger reference element */
+  private referenceEl: HTMLDivElement;
+
   //--------------------------------------------------------------------------
   //
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  getModifiers(): Partial<StrictModifiers>[] {
+    const flipModifier: Partial<StrictModifiers> = {
+      name: "flip",
+      enabled: true
+    };
+
+    flipModifier.options = {
+      fallbackPlacements: ["top-start", "top", "top-end", "bottom-start", "bottom", "bottom-end"]
+    };
+
+    return [flipModifier];
+  }
+
+  getPlacement(): CalcitePlacement {
+    const { alignment } = this;
+
+    if (alignment === "center") {
+      return "bottom";
+    }
+
+    if (alignment === "end") {
+      return "bottom-end";
+    }
+
+    return "bottom-start";
+  }
+
+  createPopper(): void {
+    this.destroyPopper();
+    const { active, menuEl, referenceEl } = this;
+    const modifiers = this.getModifiers();
+    const placement = this.getPlacement();
+
+    this.popper = createPopper({
+      el: menuEl,
+      modifiers,
+      open: active,
+      placement,
+      referenceEl
+    });
+  }
+
+  destroyPopper(): void {
+    const { popper } = this;
+
+    if (popper) {
+      popper.destroy();
+    }
+
+    this.popper = null;
+  }
+
+  private openDropdown = (e: Event): void => {
+    const target = e.target as HTMLSlotElement;
+    if (
+      this.triggers.includes(target) ||
+      this.triggers.some((trigger) => trigger.contains(target))
+    ) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.openCalciteDropdown();
+    }
+  };
+
+  private keyDownHandler = (e: KeyboardEvent): void => {
+    const target = event.target as HTMLSlotElement;
+    const key = getKey(e.key);
+    if (
+      this.triggers.includes(target) ||
+      this.triggers.some((trigger) => trigger.contains(target))
+    ) {
+      if (target.nodeName !== "BUTTON" && target.nodeName !== "CALCITE-BUTTON") {
+        switch (key) {
+          case " ":
+          case "Enter":
+            this.openCalciteDropdown();
+            break;
+          case "Escape":
+            this.closeCalciteDropdown();
+            break;
+        }
+      } else if (key === "Escape" || (e.shiftKey && key === "Tab")) {
+        this.closeCalciteDropdown();
+      }
+    }
+  };
 
   private updateSelectedItems(): void {
     const items = Array.from(

--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -4,7 +4,6 @@ $image_max_height: 200px;
 @include popperArrow();
 
 .container {
-  border-radius: var(--calcite-border-radius);
   background: var(--calcite-ui-foreground-1);
   position: relative;
   display: flex;

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -86,11 +86,10 @@ export class CalcitePopover {
 
   @Watch("open")
   openHandler(open: boolean) {
+    this.reposition();
     if (open) {
-      this.createPopper();
       this.calcitePopoverOpen.emit();
     } else {
-      this.destroyPopper();
       this.calcitePopoverClose.emit();
     }
   }

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -355,12 +355,19 @@ export class CalcitePopover {
 
     return (
       <Host role="dialog" aria-hidden={!displayed ? "true" : "false"} id={this.getId()}>
-        {arrowNode}
-        <div class={CSS.container}>
-          {this.renderImage()}
-          <div class={CSS.content}>
-            <slot />
-            {this.renderCloseButton()}
+        <div
+          class={{
+            [CSS.anim]: true,
+            [CSS.animActive]: displayed
+          }}
+        >
+          {arrowNode}
+          <div class={CSS.container}>
+            {this.renderImage()}
+            <div class={CSS.content}>
+              <slot />
+              {this.renderCloseButton()}
+            </div>
           </div>
         </div>
       </Host>

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -292,13 +292,12 @@ export class CalcitePopover {
 
   createPopper(): void {
     this.destroyPopper();
-    const { el, open, placement, _referenceElement: referenceEl } = this;
+    const { el, placement, _referenceElement: referenceEl } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
-      open,
       placement,
       referenceEl
     });

--- a/src/components/calcite-popover/resources.ts
+++ b/src/components/calcite-popover/resources.ts
@@ -1,6 +1,8 @@
 export const CSS = {
   container: "container",
   arrow: "arrow",
+  anim: "calcite-popper-anim",
+  animActive: "calcite-popper-anim--active",
   imageContainer: "image-container",
   closeButton: "close-button",
   content: "content"

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -3,7 +3,6 @@
 
 .container {
   position: relative;
-  border-radius: var(--calcite-border-radius);
   background: var(--calcite-ui-foreground-1);
   max-width: 300px;
   max-height: 300px;

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -240,9 +240,16 @@ export class CalciteTooltip {
 
     return (
       <Host role="tooltip" aria-hidden={!displayed ? "true" : "false"} id={this.getId()}>
-        <div class={CSS.arrow} ref={(arrowEl) => (this.arrowEl = arrowEl)}></div>
-        <div class={CSS.container}>
-          <slot />
+        <div
+          class={{
+            [CSS.anim]: true,
+            [CSS.animActive]: displayed
+          }}
+        >
+          <div class={CSS.arrow} ref={(arrowEl) => (this.arrowEl = arrowEl)}></div>
+          <div class={CSS.container}>
+            <slot />
+          </div>
         </div>
       </Host>
     );

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -47,12 +47,8 @@ export class CalciteTooltip {
   @Prop({ reflect: true }) open = false;
 
   @Watch("open")
-  openHandler(open: boolean) {
-    if (open) {
-      this.createPopper();
-    } else {
-      this.destroyPopper();
-    }
+  openHandler() {
+    this.reposition();
   }
 
   /**

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -211,13 +211,12 @@ export class CalciteTooltip {
   createPopper(): void {
     this.destroyPopper();
 
-    const { el, open, placement, _referenceElement: referenceEl } = this;
+    const { el, placement, _referenceElement: referenceEl } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
-      open,
       placement,
       referenceEl
     });

--- a/src/components/calcite-tooltip/resources.ts
+++ b/src/components/calcite-tooltip/resources.ts
@@ -1,6 +1,8 @@
 export const CSS = {
   container: "container",
-  arrow: "arrow"
+  arrow: "arrow",
+  anim: "calcite-popper-anim",
+  animActive: "calcite-popper-anim--active"
 };
 
 export const TOOLTIP_REFERENCE = "data-calcite-tooltip-reference";

--- a/src/utils/popper.ts
+++ b/src/utils/popper.ts
@@ -18,17 +18,15 @@ export function getPlacement(el: HTMLElement, placement: CalcitePlacement): Plac
 export function createPopper({
   referenceEl,
   el,
-  open,
   placement,
   modifiers
 }: {
   el: HTMLElement;
   modifiers: Partial<StrictModifiers>[];
-  open: boolean;
   placement: CalcitePlacement;
   referenceEl: HTMLElement;
 }): Popper | null {
-  if (!referenceEl || !open) {
+  if (!referenceEl) {
     return null;
   }
 


### PR DESCRIPTION
**Related Issue:** #651

## Summary

Update calcite-dropdown to use Popper.js

@macandcheese this kills the animation of dropdown so we need to come up with another solution for animating.

Currently, animation is based off of the height of the menu changing. However, Popper needs to know the height before positioning so animating the height isn't a good idea. 

Is there something else we can animate?
