### PR TITLE
chore(linting): ensure all JSX props are sorted

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "lines-between-class-members": ["error", "always"],
     "no-multiple-empty-lines": ["error", { "max": 1 }],
+    "react/jsx-sort-props": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error"
   },

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -77,10 +77,10 @@ export class CalciteAccordionItem {
 
     return (
       <Host
-        tabindex="0"
         aria-expanded={this.active.toString()}
         dir={dir}
         icon-position={this.iconPosition}
+        tabindex="0"
       >
         <div class="accordion-item-header" onClick={this.itemHeaderClickHandler}>
           {this.icon ? iconEl : null}

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -157,10 +157,10 @@ export class CalciteActionBar {
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
-        expanded={expanded}
-        intlExpand={expandLabel}
-        intlCollapse={collapseLabel}
         el={el}
+        expanded={expanded}
+        intlCollapse={collapseLabel}
+        intlExpand={expandLabel}
         position={position}
         toggleExpand={toggleExpand}
         tooltipExpand={tooltipExpand}

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -151,10 +151,10 @@ export class CalciteActionPad {
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
-        expanded={expanded}
-        intlExpand={expandLabel}
-        intlCollapse={collapseLabel}
         el={el}
+        expanded={expanded}
+        intlCollapse={collapseLabel}
+        intlExpand={expandLabel}
         position={position}
         toggleExpand={toggleExpand}
         tooltipExpand={tooltipExpand}

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -133,7 +133,7 @@ export class CalciteAction {
     };
 
     return text ? (
-      <div key="text-container" class={textContainerClasses}>
+      <div class={textContainerClasses} key="text-container">
         {text}
       </div>
     ) : null;
@@ -159,7 +159,7 @@ export class CalciteAction {
     );
 
     return hasIconToDisplay ? (
-      <div key="icon-container" aria-hidden="true" class={CSS.iconContainer}>
+      <div aria-hidden="true" class={CSS.iconContainer} key="icon-container">
         {iconNode}
         {slotContainerNode}
       </div>
@@ -182,11 +182,11 @@ export class CalciteAction {
     return (
       <Host>
         <button
-          class={buttonClasses}
-          aria-label={ariaLabel}
-          disabled={disabled}
-          aria-disabled={disabled.toString()}
           aria-busy={loading.toString()}
+          aria-disabled={disabled.toString()}
+          aria-label={ariaLabel}
+          class={buttonClasses}
+          disabled={disabled}
           ref={(buttonEl): HTMLButtonElement => (this.buttonEl = buttonEl)}
         >
           {this.renderIconContainer()}

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -108,11 +108,11 @@ export class CalciteAlert {
     const dir = getElementDir(this.el);
     const closeButton = (
       <button
-        class="alert-close"
-        type="button"
         aria-label={this.intlClose}
+        class="alert-close"
         onClick={() => this.closeAlert()}
         ref={(el) => (this.closeButton = el)}
+        type="button"
       >
         <calcite-icon icon="x" scale="m"></calcite-icon>
       </button>
@@ -127,7 +127,7 @@ export class CalciteAlert {
     const hidden = this.active ? "false" : "true";
 
     return (
-      <Host active={this.active} queued={this.queued} role={role} dir={dir} aria-hidden={hidden}>
+      <Host active={this.active} aria-hidden={hidden} dir={dir} queued={this.queued} role={role}>
         {this.icon ? this.setIcon() : null}
         <div class="alert-content">
           <slot name="alert-title"></slot>

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -123,9 +123,9 @@ export class CalciteBlockSection {
           {text}
           <calcite-switch
             aria-labelledby={labelId}
-            switched={open}
             onCalciteSwitchChange={this.toggleSection}
             scale="s"
+            switched={open}
             tabIndex={-1}
           />
         </label>
@@ -133,11 +133,11 @@ export class CalciteBlockSection {
         <calcite-action
           aria-label={toggleLabel}
           class={CSS.toggle}
+          compact
+          icon={arrowIcon}
           onClick={this.toggleSection}
           text={text}
           textEnabled={true}
-          compact
-          icon={arrowIcon}
         />
       );
 

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -113,7 +113,7 @@ export class CalciteBlock {
     const defaultSlot = <slot />;
 
     return loading || disabled ? (
-      <calcite-scrim theme={getElementTheme(el)} loading={loading}>
+      <calcite-scrim loading={loading} theme={getElementTheme(el)}>
         {defaultSlot}
       </calcite-scrim>
     ) : (
@@ -183,8 +183,8 @@ export class CalciteBlock {
     return (
       <Host tabIndex={disabled ? -1 : null}>
         <article
-          aria-expanded={collapsible ? open.toString() : null}
           aria-busy={loading.toString()}
+          aria-expanded={collapsible ? open.toString() : null}
           class={{
             [CSS.article]: true,
             [CSS_UTILITY.rtl]: rtl

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -131,13 +131,13 @@ export class CalciteButton {
     );
 
     return (
-      <Host hasText={this.hasText} dir={dir}>
+      <Host dir={dir} hasText={this.hasText}>
         <Tag
           {...attributes}
-          onClick={(e) => this.handleClick(e)}
           disabled={this.disabled}
-          tabIndex={this.disabled ? -1 : null}
+          onClick={(e) => this.handleClick(e)}
           ref={(el) => (this.childEl = el)}
+          tabIndex={this.disabled ? -1 : null}
         >
           {this.loading ? loader : null}
           {this.iconStart ? iconStartEl : null}

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -73,7 +73,7 @@ export class CalciteCard {
               <calcite-loader active></calcite-loader>
             </div>
           ) : null}
-          <section class={{ [CSS.container]: true }} aria-busy={this.loading}>
+          <section aria-busy={this.loading} class={{ [CSS.container]: true }}>
             {this.selectable ? this.renderCheckbox() : null}
             {this.renderThumbnail()}
             {this.renderHeader()}
@@ -133,7 +133,7 @@ export class CalciteCard {
         onClick={() => this.cardSelectClick()}
         onKeyDown={(e) => this.cardSelectKeyDown(e)}
       >
-        <calcite-checkbox theme={this.theme} checked={this.selected}></calcite-checkbox>
+        <calcite-checkbox checked={this.selected} theme={this.theme}></calcite-checkbox>
       </div>
     );
   }

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -208,7 +208,7 @@ export class CalciteCheckbox {
   render() {
     if (this.el.textContent) {
       return (
-        <Host role="checkbox" aria-checked={this.checked.toString()}>
+        <Host aria-checked={this.checked.toString()} role="checkbox">
           <div class="hasLabel">
             <svg class="check-svg" viewBox="0 0 16 16">
               <path d={this.getPath()} />
@@ -221,7 +221,7 @@ export class CalciteCheckbox {
       );
     }
     return (
-      <Host role="checkbox" aria-checked={this.checked.toString()}>
+      <Host aria-checked={this.checked.toString()} role="checkbox">
         <svg class="check-svg" viewBox="0 0 16 16">
           <path d={this.getPath()} />
         </svg>

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -86,8 +86,8 @@ export class CalciteChip {
     const iconEl = <calcite-icon class="calcite-chip--icon" icon={this.icon} scale={iconScale} />;
 
     const closeButton = (
-      <button onClick={this.closeClickHandler} class={CSS.close} title={TEXT.close}>
-        <calcite-icon scale={iconScale} icon="x" />
+      <button class={CSS.close} onClick={this.closeClickHandler} title={TEXT.close}>
+        <calcite-icon icon="x" scale={iconScale} />
       </button>
     );
 

--- a/src/components/calcite-color-hex-input/calcite-color-hex-input.tsx
+++ b/src/components/calcite-color-hex-input/calcite-color-hex-input.tsx
@@ -184,15 +184,15 @@ export class CalciteColorHexInput {
           aria-label={intlHex}
           class={CSS.input}
           dir={elementDir}
-          onChange={this.onInputChange}
           onCalciteInputBlur={this.onCalciteInputBlur}
+          onChange={this.onInputChange}
           onKeyDown={this.onInputKeyDown}
           prefixText="#"
           ref={(node) => (this.inputNode = node)}
           scale="s"
           value={hexInputValue}
         />
-        <calcite-color-swatch active class={CSS.preview} scale="s" color={`#${hexInputValue}`} />
+        <calcite-color-swatch active class={CSS.preview} color={`#${hexInputValue}`} scale="s" />
       </div>
     );
   }

--- a/src/components/calcite-color-swatch/calcite-color-swatch.tsx
+++ b/src/components/calcite-color-swatch/calcite-color-swatch.tsx
@@ -85,7 +85,7 @@ export class CalciteColorSwatch {
     return (
       <Host aria-label={hex} title={hex}>
         <svg class={CSS.swatch} xmlns="http://www.w3.org/2000/svg">
-          <rect width="100%" height="100%" fill={hex} stroke={borderColor} rx={borderRadius} />
+          <rect fill={hex} height="100%" rx={borderRadius} stroke={borderColor} width="100%" />
         </svg>
       </Host>
     );

--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -394,12 +394,12 @@ export class CalciteColor {
                 </span>
                 <calcite-color-hex-input
                   class={CSS.control}
+                  dir={elementDir}
                   onCalciteColorHexInputChange={this.handleHexInputChange}
                   ref={(node) => (this.hexInputNode = node)}
                   scale={hexInputScale}
-                  value={selectedColorInHex}
                   theme={theme}
-                  dir={elementDir}
+                  value={selectedColorInHex}
                 />
               </div>
             )}
@@ -453,9 +453,9 @@ export class CalciteColor {
                 {[
                   ...savedColors.map((color) => (
                     <calcite-color-swatch
+                      active={selectedColorInHex === color}
                       class={CSS.savedColor}
                       color={color}
-                      active={selectedColorInHex === color}
                       key={color}
                       onClick={this.handleSavedColorSelect}
                       onKeyDown={this.handleSavedColorKeyDown}
@@ -537,8 +537,8 @@ export class CalciteColor {
       class={CSS.channel}
       data-channel-index={index}
       numberButtonType="none"
-      onInput={this.handleChannelInput}
       onChange={this.handleChannelChange}
+      onInput={this.handleChannelInput}
       prefixText={label}
       scale="s"
       type="number"

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -163,7 +163,7 @@ export class CalciteComboboxItem {
   renderIcon(scale): VNode {
     const iconScale = scale !== "l" ? "s" : "m";
     const iconPath = this.disabled ? "circle-disallowed" : "check";
-    return <calcite-icon class={CSS.icon} scale={iconScale} icon={iconPath} />;
+    return <calcite-icon class={CSS.icon} icon={iconPath} scale={iconScale} />;
   }
 
   renderChildren(): VNode {
@@ -189,11 +189,11 @@ export class CalciteComboboxItem {
 
     return (
       <Host
-        dir={dir}
-        scale={scale}
-        role="option"
         aria-selected={this.isSelected}
+        dir={dir}
         disabled={this.disabled}
+        role="option"
+        scale={scale}
         tabIndex={this.disabled ? null : 0}
       >
         <div

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -304,19 +304,19 @@ export class CalciteCombobox {
     return (
       <Host
         active={this.active}
+        dir={dir}
         onFocusin={this.comboboxFocusHandler}
         onFocusout={this.comboboxFocusHandler}
-        dir={dir}
       >
         <div class="selections">
           {this.selectedItems.map((item) => {
             return (
               <calcite-chip
+                dir={dir}
+                dismissible
                 key={item.value}
                 scale={this.scale}
                 value={item.value}
-                dir={dir}
-                dismissible
               >
                 {item.textLabel}
               </calcite-chip>
@@ -324,29 +324,29 @@ export class CalciteCombobox {
           })}
         </div>
         <div
-          role="combobox"
           aria-expanded={this.active.toString()}
-          aria-owns={listBoxId}
           aria-haspopup="listbox"
+          aria-owns={listBoxId}
+          role="combobox"
         >
           <input
-            type="text"
-            placeholder={this.placeholder}
-            aria-label={this.label}
             aria-autocomplete="list"
             aria-controls={listBoxId}
-            onInput={this.inputHandler}
+            aria-label={this.label}
             disabled={this.disabled}
+            onInput={this.inputHandler}
             onKeyDown={(e) => this.handleInputKeyDown(e)}
+            placeholder={this.placeholder}
             ref={(el) => (this.textInput = el as HTMLInputElement)}
+            type="text"
           />
         </div>
         <ul
-          id={listBoxId}
           aria-label={this.label}
-          role="listbox"
-          class={{ list: true }}
           aria-multiselectable="true"
+          class={{ list: true }}
+          id={listBoxId}
+          role="listbox"
         >
           <slot />
         </ul>

--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -74,14 +74,14 @@ export class CalciteDateMonthHeader {
     const prevMonthDate = dateFromRange(prevMonth(this.activeDate), this.min, this.max);
     return (
       <Host dir={dir}>
-        <div class="header" aria-hidden="true">
+        <div aria-hidden="true" class="header">
           <button
-            class="chevron"
             aria-label={this.intlPrevMonth}
+            class="chevron"
             disabled={prevMonthDate.getMonth() === activeMonth}
             onClick={() => this.calciteActiveDateChange.emit(prevMonthDate)}
           >
-            <calcite-icon icon="chevron-left" scale={iconScale} mirrored dir={dir} />
+            <calcite-icon dir={dir} icon="chevron-left" mirrored scale={iconScale} />
           </button>
           <div class="text">
             <span class="month" role="heading">
@@ -89,24 +89,24 @@ export class CalciteDateMonthHeader {
             </span>
             <input
               class="year"
-              type="text"
               inputmode="numeric"
               maxlength="4"
               minlength="4"
-              pattern="\d*"
-              value={`${localizedYear.slice(-4)}`}
-              onKeyDown={(event) => this.onYearKey(event)}
               onChange={(event) => this.setYear((event.target as HTMLInputElement).value)}
+              onKeyDown={(event) => this.onYearKey(event)}
+              pattern="\d*"
               ref={(el) => (this.yearInput = el)}
+              type="text"
+              value={`${localizedYear.slice(-4)}`}
             />
           </div>
           <button
-            class="chevron"
             aria-label={this.intlNextMonth}
+            class="chevron"
             disabled={nextMonthDate.getMonth() === activeMonth}
             onClick={() => this.calciteActiveDateChange.emit(nextMonthDate)}
           >
-            <calcite-icon icon="chevron-right" scale={iconScale} mirrored dir={dir} />
+            <calcite-icon dir={dir} icon="chevron-right" mirrored scale={iconScale} />
           </button>
         </div>
       </Host>

--- a/src/components/calcite-date-month/calcite-date-month.tsx
+++ b/src/components/calcite-date-month/calcite-date-month.tsx
@@ -138,12 +138,12 @@ export class CalciteDateMonth {
         const date = new Date(year, month - 1, day);
         return (
           <calcite-date-day
-            scale={this.scale}
             day={day}
             disabled={!inRange(date, this.min, this.max)}
-            selected={sameDate(date, this.selectedDate)}
-            onCalciteDaySelect={() => this.calciteDateSelect.emit(date)}
             locale={this.locale}
+            onCalciteDaySelect={() => this.calciteDateSelect.emit(date)}
+            scale={this.scale}
+            selected={sameDate(date, this.selectedDate)}
           />
         );
       }),
@@ -152,20 +152,20 @@ export class CalciteDateMonth {
         const active = sameDate(date, this.activeDate);
         return (
           <calcite-date-day
-            scale={this.scale}
+            active={active}
+            current-month
             day={day}
             disabled={!inRange(date, this.min, this.max)}
-            selected={sameDate(date, this.selectedDate)}
-            active={active}
-            onCalciteDaySelect={() => this.calciteDateSelect.emit(date)}
             locale={this.locale}
+            onCalciteDaySelect={() => this.calciteDateSelect.emit(date)}
             ref={(el) => {
               // when moving via keyboard, focus must be updated on active date
               if (active && this.activeFocus) {
                 el?.focus();
               }
             }}
-            current-month
+            scale={this.scale}
+            selected={sameDate(date, this.selectedDate)}
           />
         );
       }),
@@ -173,12 +173,12 @@ export class CalciteDateMonth {
         const date = new Date(year, month + 1, day);
         return (
           <calcite-date-day
-            scale={this.scale}
             day={day}
             disabled={!inRange(date, this.min, this.max)}
-            selected={sameDate(date, this.selectedDate)}
-            onCalciteDaySelect={() => this.calciteDateSelect.emit(date)}
             locale={this.locale}
+            onCalciteDaySelect={() => this.calciteDateSelect.emit(date)}
+            scale={this.scale}
+            selected={sameDate(date, this.selectedDate)}
           />
         );
       })

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -129,58 +129,58 @@ export class CalciteDate {
     const formattedDate = date ? date.toLocaleDateString(this.locale) : "";
     const dir = getElementDir(this.el);
     return (
-      <Host role="application" dir={dir}>
+      <Host dir={dir} role="application">
         <div class="slot">
           <slot></slot>
         </div>
         {!this.noCalendarInput && (
           <div role="application">
             <calcite-input
-              type="text"
-              value={formattedDate}
-              placeholder={this.localeData.placeholder}
+              class="input"
               icon="calendar"
+              number-button-type="none"
+              onCalciteInputBlur={(e) => this.blur(e.detail)}
               onCalciteInputFocus={() => (this.active = true)}
               onCalciteInputInput={(e) => this.input(e.detail.value)}
-              onCalciteInputBlur={(e) => this.blur(e.detail)}
+              placeholder={this.localeData.placeholder}
               scale={this.scale}
-              number-button-type="none"
-              class="input"
+              type="text"
+              value={formattedDate}
             />
           </div>
         )}
         <div class="calendar-picker-wrapper">
           <calcite-date-month-header
             activeDate={activeDate}
-            selectedDate={date || new Date()}
-            intlPrevMonth={this.intlPrevMonth}
+            dir={dir}
             intlNextMonth={this.intlNextMonth}
+            intlPrevMonth={this.intlPrevMonth}
             locale={this.locale}
-            min={min}
             max={max}
+            min={min}
             onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
               this.activeDate = new Date(e.detail);
             }}
-            dir={dir}
             scale={this.scale}
+            selectedDate={date || new Date()}
           />
           <calcite-date-month
-            min={min}
-            max={max}
-            selectedDate={date}
             activeDate={activeDate}
+            dir={dir}
             locale={this.locale}
+            max={max}
+            min={min}
+            onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
+              this.activeDate = new Date(e.detail);
+            }}
             onCalciteDateSelect={(e: CustomEvent<Date>) => {
               this.setValue(new Date(e.detail));
               this.activeDate = new Date(e.detail);
               this.calciteDateChange.emit(new Date(e.detail));
               this.reset();
             }}
-            onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
-              this.activeDate = new Date(e.detail);
-            }}
-            dir={dir}
             scale={this.scale}
+            selectedDate={date}
           />
         </div>
       </Host>

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -122,15 +122,15 @@ export class CalciteDropdownItem {
     );
     return (
       <Host
+        aria-selected={this.active.toString()}
         dir={dir}
-        tabindex="0"
+        isLink={this.href}
         role="menuitem"
         selection-mode={this.selectionMode}
-        aria-selected={this.active.toString()}
-        isLink={this.href}
+        tabindex="0"
       >
         {this.selectionMode === "multi" ? (
-          <calcite-icon class="dropdown-item-check-icon" scale="s" icon="check" />
+          <calcite-icon class="dropdown-item-check-icon" icon="check" scale="s" />
         ) : null}
         {contentEl}
       </Host>

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -138,16 +138,16 @@ export class CalciteDropdown {
       <Host dir={dir} tabIndex={this.disabled ? -1 : null}>
         <div
           class="calcite-dropdown-trigger-container"
-          ref={this.setReferenceEl}
           onClick={this.openDropdown}
           onKeyDown={this.keyDownHandler}
+          ref={this.setReferenceEl}
         >
-          <slot name="dropdown-trigger" aria-haspopup="true" aria-expanded={active.toString()} />
+          <slot aria-expanded={active.toString()} aria-haspopup="true" name="dropdown-trigger" />
         </div>
         <div
           aria-hidden={(!active).toString()}
-          ref={this.setMenuEl}
           class="calcite-dropdown-wrapper"
+          ref={this.setMenuEl}
           role="menu"
         >
           <div

--- a/src/components/calcite-fab/calcite-fab.tsx
+++ b/src/components/calcite-fab/calcite-fab.tsx
@@ -113,22 +113,22 @@ export class CalciteFab {
     return (
       <Host>
         <calcite-button
-          class={CSS.button}
-          loading={loading}
-          disabled={disabled}
-          title={title}
-          aria-label={label}
-          theme={theme}
-          dir={dir}
-          scale={scale}
-          iconStart={icon}
-          round={true}
-          width="auto"
           appearance={appearance}
+          aria-label={label}
+          class={CSS.button}
           color={color}
+          dir={dir}
+          disabled={disabled}
+          iconStart={icon}
+          loading={loading}
           ref={(buttonEl): void => {
             this.buttonEl = buttonEl;
           }}
+          round={true}
+          scale={scale}
+          theme={theme}
+          title={title}
+          width="auto"
         >
           {this.textEnabled ? this.text : null}
         </calcite-button>

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -134,24 +134,24 @@ export class CalciteFilter {
       <Host>
         <label class={rtl ? CSS_UTILITY.rtl : null}>
           <input
-            type="text"
-            value=""
-            placeholder={this.placeholder}
-            onInput={this.inputHandler}
             aria-label={this.intlLabel || TEXT.filterLabel}
+            onInput={this.inputHandler}
+            placeholder={this.placeholder}
             ref={(el): void => {
               this.textInput = el;
             }}
+            type="text"
+            value=""
           />
           <div class={CSS.searchIcon}>
-            <calcite-icon scale="s" icon={ICONS.search} />
+            <calcite-icon icon={ICONS.search} scale="s" />
           </div>
         </label>
         {!this.empty ? (
           <button
-            onClick={this.clear}
-            class={CSS.clearButton}
             aria-label={this.intlClear || TEXT.clear}
+            class={CSS.clearButton}
+            onClick={this.clear}
           >
             <calcite-icon icon={ICONS.close} />
           </button>

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -227,13 +227,13 @@ export class CalciteFlowItem {
 
     return showBackButton ? (
       <calcite-action
-        slot={PANEL_SLOTS.headerLeadingContent}
-        key="back-button"
         aria-label={label}
-        text={label}
         class={CSS.backButton}
-        onClick={backButtonClick}
         icon={icon}
+        key="back-button"
+        onClick={backButtonClick}
+        slot={PANEL_SLOTS.headerLeadingContent}
+        text={label}
       />
     ) : null;
   }
@@ -247,13 +247,13 @@ export class CalciteFlowItem {
 
     return (
       <calcite-action
-        class={CSS.menuButton}
         aria-label={menuLabel}
-        text={menuLabel}
-        ref={(menuButtonEl): HTMLCalciteActionElement => (this.menuButtonEl = menuButtonEl)}
+        class={CSS.menuButton}
+        icon={ICONS.menu}
         onClick={this.toggleMenuOpen}
         onKeyDown={this.menuButtonKeyDown}
-        icon={ICONS.menu}
+        ref={(menuButtonEl): HTMLCalciteActionElement => (this.menuButtonEl = menuButtonEl)}
+        text={menuLabel}
       />
     );
   }
@@ -263,14 +263,14 @@ export class CalciteFlowItem {
 
     return (
       <calcite-popover
+        disablePointer={true}
+        flipPlacements={["bottom-end", "top-end"]}
+        offsetDistance={0}
+        onKeyDown={this.menuActionsKeydown}
+        open={menuOpen}
+        placement="bottom-end"
         referenceElement={menuButtonEl}
         theme={getElementTheme(el)}
-        open={menuOpen}
-        offsetDistance={0}
-        disablePointer={true}
-        placement="bottom-end"
-        flipPlacements={["bottom-end", "top-end"]}
-        onKeyDown={this.menuActionsKeydown}
       >
         <div class={CSS.menu}>
           <slot name={SLOTS.menuActions} />
@@ -283,7 +283,7 @@ export class CalciteFlowItem {
     const hasFooterActions = !!getSlotted(this.el, SLOTS.footerActions);
 
     return hasFooterActions ? (
-      <div slot={PANEL_SLOTS.footer} class={CSS.footerActions}>
+      <div class={CSS.footerActions} slot={PANEL_SLOTS.footer}>
         <slot name={SLOTS.footerActions} />
       </div>
     ) : null;
@@ -309,7 +309,7 @@ export class CalciteFlowItem {
   renderHeaderLeadingContent(): VNode {
     const hasLeadingActions = getSlotted(this.el, SLOTS.leadingActions);
     return hasLeadingActions ? (
-      <div slot={PANEL_SLOTS.headerLeadingContent} class={CSS.leadingActions}>
+      <div class={CSS.leadingActions} slot={PANEL_SLOTS.headerLeadingContent}>
         <slot name={SLOTS.leadingActions}></slot>
       </div>
     ) : null;
@@ -327,7 +327,7 @@ export class CalciteFlowItem {
         : null;
 
     return menuActionsNodes ? (
-      <div slot={PANEL_SLOTS.headerTrailingContent} class={CSS.headerActions}>
+      <div class={CSS.headerActions} slot={PANEL_SLOTS.headerTrailingContent}>
         {menuActionsNodes}
       </div>
     ) : null;
@@ -377,11 +377,11 @@ export class CalciteFlowItem {
     return (
       <Host>
         <calcite-panel
-          loading={this.loading}
-          disabled={this.disabled}
-          theme={getElementTheme(el)}
-          height-scale={this.heightScale}
           dir={dir}
+          disabled={this.disabled}
+          height-scale={this.heightScale}
+          loading={this.loading}
+          theme={getElementTheme(el)}
         >
           {this.renderBackButton(dir === "rtl")}
           {this.renderHeaderLeadingContent()}

--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -157,7 +157,7 @@ export class CalciteFlow {
 
     return (
       <Host>
-        <div key={flowCount} class={frameDirectionClasses}>
+        <div class={frameDirectionClasses} key={flowCount}>
           <slot />
         </div>
       </Host>

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -54,11 +54,11 @@ export class CalciteGraph {
     if (!data || data.length === 0) {
       return (
         <svg
-          preserveAspectRatio="none"
           class="svg"
+          height={height}
+          preserveAspectRatio="none"
           viewBox={`0 0 ${width} ${height}`}
           width={width}
-          height={height}
         />
       );
     }
@@ -70,23 +70,22 @@ export class CalciteGraph {
     const areaPath = area({ data, min, max, t });
     return (
       <svg
-        preserveAspectRatio="none"
         class="svg"
+        height={height}
+        preserveAspectRatio="none"
         viewBox={`0 0 ${width} ${height}`}
         width={width}
-        height={height}
       >
         {highlightMin !== undefined ? (
           <svg
-            preserveAspectRatio="none"
             class="svg"
+            height={height}
+            preserveAspectRatio="none"
             viewBox={`0 0 ${width} ${height}`}
             width={width}
-            height={height}
           >
-            <mask id={`${id}1`} x="0%" y="0%" width="100%" height="100%">
+            <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
               <path
-                fill="white"
                 d={`
               M 0,0
               L ${hMinX - 1},0
@@ -94,12 +93,12 @@ export class CalciteGraph {
               L 0,${height}
               Z
             `}
+                fill="white"
               />
             </mask>
 
-            <mask id={`${id}2`} x="0%" y="0%" width="100%" height="100%">
+            <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
               <path
-                fill="white"
                 d={`
               M ${hMinX + 1},0
               L ${hMaxX - 1},0
@@ -107,12 +106,12 @@ export class CalciteGraph {
               L ${hMinX + 1}, ${height}
               Z
             `}
+                fill="white"
               />
             </mask>
 
-            <mask id={`${id}3`} x="0%" y="0%" width="100%" height="100%">
+            <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
               <path
-                fill="white"
                 d={`
                   M ${hMaxX + 1},0
                   L ${width},0
@@ -120,15 +119,16 @@ export class CalciteGraph {
                   L ${hMaxX + 1}, ${height}
                   Z
                 `}
+                fill="white"
               />
             </mask>
 
-            <path d={areaPath} class="graph-path" mask={`url(#${id}1)`} />
-            <path d={areaPath} class="graph-path--highlight" mask={`url(#${id}2)`} />
-            <path d={areaPath} class="graph-path" mask={`url(#${id}3)`} />
+            <path class="graph-path" d={areaPath} mask={`url(#${id}1)`} />
+            <path class="graph-path--highlight" d={areaPath} mask={`url(#${id}2)`} />
+            <path class="graph-path" d={areaPath} mask={`url(#${id}3)`} />
           </svg>
         ) : (
-          <path d={areaPath} class="graph-path" />
+          <path class="graph-path" d={areaPath} />
         )}
       </svg>
     );

--- a/src/components/calcite-handle/calcite-handle.tsx
+++ b/src/components/calcite-handle/calcite-handle.tsx
@@ -92,18 +92,18 @@ export class CalciteHandle {
     return (
       // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
       <span
-        role="button"
-        tabindex="0"
         aria-pressed={this.activated.toString()}
         class={{ [CSS.handle]: true, [CSS.handleActivated]: this.activated }}
-        onKeyDown={this.handleKeyDown}
         onBlur={this.handleBlur}
-        title={this.textTitle}
+        onKeyDown={this.handleKeyDown}
         ref={(el): void => {
           this.handleButton = el;
         }}
+        role="button"
+        tabindex="0"
+        title={this.textTitle}
       >
-        <calcite-icon scale="s" icon={ICONS.drag} />
+        <calcite-icon icon={ICONS.drag} scale="s" />
       </span>
     );
   }

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -105,11 +105,11 @@ export class CalciteIcon {
             [CSS.mirrored]: dir === "rtl" && mirrored,
             svg: true
           }}
-          xmlns="http://www.w3.org/2000/svg"
           fill="currentColor"
           height="100%"
-          width="100%"
           viewBox={`0 0 ${size} ${size}`}
+          width="100%"
+          xmlns="http://www.w3.org/2000/svg"
         >
           {paths.map((path: string | CalciteMultiPathEntry) =>
             typeof path === "string" ? (

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -65,7 +65,7 @@ export class CalciteInputMessage {
     const dir = getElementDir(this.el);
     this.iconEl = this.setIcon(this.iconDefaults[this.status]);
     return (
-      <Host theme={this.theme} dir={dir}>
+      <Host dir={dir} theme={this.theme}>
         {this.icon ? this.iconEl : null}
         <slot />
       </Host>
@@ -96,7 +96,7 @@ export class CalciteInputMessage {
 
   private setIcon(iconName) {
     return (
-      <calcite-icon class="calcite-input-message-icon" scale="s" icon={iconName}></calcite-icon>
+      <calcite-icon class="calcite-input-message-icon" icon={iconName} scale="s"></calcite-icon>
     );
   }
 }

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -219,15 +219,15 @@ export class CalciteInput {
 
     const inputClearButton = (
       <div class="calcite-input-clear-button" onClick={this.clearInputValue}>
-        <calcite-icon theme={this.theme} icon="x" scale={iconScale}></calcite-icon>
+        <calcite-icon icon="x" scale={iconScale} theme={this.theme}></calcite-icon>
       </div>
     );
     const iconEl = (
       <calcite-icon
         class="calcite-input-icon"
+        icon={this.icon as string}
         scale={iconScale}
         theme={this.theme}
-        icon={this.icon as string}
       ></calcite-icon>
     );
 
@@ -243,20 +243,20 @@ export class CalciteInput {
     const numberButtonsHorizontalUp = (
       <div
         class={`calcite-input-number-button-item ${numberButtonClassModifier}`}
-        onMouseDown={this.updateNumberValue}
         data-adjustment="up"
+        onMouseDown={this.updateNumberValue}
       >
-        <calcite-icon theme={this.theme} scale={iconScale} icon="chevron-up"></calcite-icon>
+        <calcite-icon icon="chevron-up" scale={iconScale} theme={this.theme}></calcite-icon>
       </div>
     );
 
     const numberButtonsHorizontalDown = (
       <div
         class={`calcite-input-number-button-item ${numberButtonClassModifier}`}
-        onMouseDown={this.updateNumberValue}
         data-adjustment="down"
+        onMouseDown={this.updateNumberValue}
       >
-        <calcite-icon theme={this.theme} scale={iconScale} icon="chevron-down"></calcite-icon>
+        <calcite-icon icon="chevron-down" scale={iconScale} theme={this.theme}></calcite-icon>
       </div>
     );
 
@@ -275,34 +275,34 @@ export class CalciteInput {
       this.childElType !== "textarea" ? (
         <input
           {...attributes}
+          autofocus={this.autofocus ? true : null}
+          disabled={this.disabled ? true : null}
+          max={this.maxString}
+          min={this.minString}
           onBlur={this.inputBlurHandler}
           onFocus={this.inputFocusHandler}
           onInput={this.inputInputHandler}
-          type={this.type}
-          min={this.minString}
-          max={this.maxString}
-          step={this.stepString}
-          value={this.value}
           placeholder={this.placeholder || ""}
-          required={this.required ? true : null}
-          autofocus={this.autofocus ? true : null}
-          disabled={this.disabled ? true : null}
-          tabIndex={this.disabled ? -1 : null}
           ref={(el) => (this.childEl = el)}
+          required={this.required ? true : null}
+          step={this.stepString}
+          tabIndex={this.disabled ? -1 : null}
+          type={this.type}
+          value={this.value}
         />
       ) : (
         [
           <textarea
             {...attributes}
+            autofocus={this.autofocus ? true : null}
+            disabled={this.disabled ? true : null}
             onBlur={this.inputBlurHandler}
             onFocus={this.inputFocusHandler}
             onInput={this.inputInputHandler}
-            required={this.required ? true : null}
             placeholder={this.placeholder || ""}
-            autofocus={this.autofocus ? true : null}
-            disabled={this.disabled ? true : null}
-            tabIndex={this.disabled ? -1 : null}
             ref={(el) => (this.childEl = el)}
+            required={this.required ? true : null}
+            tabIndex={this.disabled ? -1 : null}
           >
             <slot />
           </textarea>,

--- a/src/components/calcite-link/calcite-link.tsx
+++ b/src/components/calcite-link/calcite-link.tsx
@@ -83,9 +83,9 @@ export class CalciteLink {
         <Tag
           {...attributes}
           href={Tag === "a" && this.href}
+          ref={(el) => (this.childEl = el)}
           role={role}
           tabIndex={tabIndex}
-          ref={(el) => (this.childEl = el)}
         >
           {this.iconStart ? iconStartEl : null}
           <slot />

--- a/src/components/calcite-loader/calcite-loader.tsx
+++ b/src/components/calcite-loader/calcite-loader.tsx
@@ -80,15 +80,15 @@ export class CalciteLoader {
     return (
       <Host id={id} role="progressbar" {...(isDeterminate ? hostAttributes : {})}>
         <div class="loader__svgs">
-          <svg viewBox={viewbox} class="loader__svg loader__svg--1">
+          <svg class="loader__svg loader__svg--1" viewBox={viewbox}>
             <circle {...svgAttributes} />
           </svg>
-          <svg viewBox={viewbox} class="loader__svg loader__svg--2">
+          <svg class="loader__svg loader__svg--2" viewBox={viewbox}>
             <circle {...svgAttributes} />
           </svg>
           <svg
-            viewBox={viewbox}
             class="loader__svg loader__svg--3"
+            viewBox={viewbox}
             {...(isDeterminate ? { style: determinateStyle } : {})}
           >
             <circle {...svgAttributes} />

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -92,11 +92,11 @@ export class CalciteModal {
   render() {
     const dir = getElementDir(this.el);
     return (
-      <Host dir={dir} role="dialog" aria-modal="true" is-active={this.isActive}>
+      <Host aria-modal="true" dir={dir} is-active={this.isActive} role="dialog">
         <calcite-scrim class="scrim" theme="dark"></calcite-scrim>
         {this.renderStyle()}
         <div class="modal">
-          <div data-focus-fence="true" tabindex="0" onFocus={this.focusLastElement.bind(this)} />
+          <div data-focus-fence="true" onFocus={this.focusLastElement.bind(this)} tabindex="0" />
           <div class="modal__header">
             {this.renderCloseButton()}
             <header class="modal__title">
@@ -113,7 +113,7 @@ export class CalciteModal {
             <slot name="content" />
           </div>
           {this.renderFooter()}
-          <div data-focus-fence="true" tabindex="0" onFocus={this.focusFirstElement.bind(this)} />
+          <div data-focus-fence="true" onFocus={this.focusFirstElement.bind(this)} tabindex="0" />
         </div>
       </Host>
     );
@@ -138,11 +138,11 @@ export class CalciteModal {
   renderCloseButton(): VNode {
     return !this.disableCloseButton ? (
       <button
-        class="modal__close"
         aria-label={this.intlClose}
-        title={this.intlClose}
-        ref={(el) => (this.closeButtonEl = el)}
+        class="modal__close"
         onClick={() => this.close()}
+        ref={(el) => (this.closeButtonEl = el)}
+        title={this.intlClose}
       >
         <calcite-icon icon="x" scale="l"></calcite-icon>
       </button>

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -85,8 +85,8 @@ export class CalciteNotice {
     const dir = getElementDir(this.el);
     const closeButton = (
       <button
-        class="notice-close"
         aria-label={this.intlClose}
+        class="notice-close"
         onClick={() => this.close()}
         ref={() => this.closeButton}
       >

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -188,7 +188,7 @@ export class CalcitePagination {
     if (this.total / this.num > maxPagesDisplayed && this.showLeftEllipsis()) {
       return (
         <span class={`${CSS.ellipsis} ${CSS.ellipsisStart}`}>
-          <calcite-icon scale={iconScale} icon="ellipsis" />
+          <calcite-icon icon="ellipsis" scale={iconScale} />
         </span>
       );
     }
@@ -198,7 +198,7 @@ export class CalcitePagination {
     if (this.total / this.num > maxPagesDisplayed && this.showRightEllipsis()) {
       return (
         <span class={`${CSS.ellipsis} ${CSS.ellipsisEnd}`}>
-          <calcite-icon scale={iconScale} icon="ellipsis" />
+          <calcite-icon icon="ellipsis" scale={iconScale} />
         </span>
       );
     }
@@ -210,15 +210,15 @@ export class CalcitePagination {
     return (
       <Host>
         <button
+          aria-label={this.textLabelPrevious}
           class={{
             [CSS.previous]: true,
             [CSS.disabled]: start < num
           }}
-          aria-label={this.textLabelPrevious}
-          onClick={this.previousClicked}
           disabled={start < num}
+          onClick={this.previousClicked}
         >
-          <calcite-icon scale={iconScale} icon="chevronLeft" />
+          <calcite-icon icon="chevronLeft" scale={iconScale} />
         </button>
         {total > num ? this.renderPage(1) : null}
         {this.renderLeftEllipsis(iconScale)}
@@ -226,15 +226,15 @@ export class CalcitePagination {
         {this.renderRightEllipsis(iconScale)}
         {this.renderPage(this.getLastStart())}
         <button
+          aria-label={this.textLabelNext}
           class={{
             [CSS.next]: true,
             [CSS.disabled]: start + num >= total
           }}
-          aria-label={this.textLabelNext}
-          onClick={this.nextClicked}
           disabled={start + num >= total}
+          onClick={this.nextClicked}
         >
-          <calcite-icon scale={iconScale} icon="chevronRight" />
+          <calcite-icon icon="chevronRight" scale={iconScale} />
         </button>
       </Host>
     );

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -150,7 +150,7 @@ export class CalcitePanel {
   renderHeaderLeadingContent(): VNode {
     const hasLeadingContent = getSlotted(this.el, SLOTS.headerLeadingContent);
     return hasLeadingContent ? (
-      <div key="header-leading-content" class={CSS.headerLeadingContent}>
+      <div class={CSS.headerLeadingContent} key="header-leading-content">
         <slot name={SLOTS.headerLeadingContent} />
       </div>
     ) : null;
@@ -158,7 +158,7 @@ export class CalcitePanel {
 
   renderHeaderContent(): VNode {
     return (
-      <div key="header-content" class={CSS.headerContent}>
+      <div class={CSS.headerContent} key="header-content">
         <slot name={SLOTS.headerContent} />
       </div>
     );
@@ -170,20 +170,20 @@ export class CalcitePanel {
 
     const dismissibleNode = dismissible ? (
       <calcite-action
+        aria-label={text}
+        icon={ICONS.close}
+        onClick={dismiss}
         ref={(dismissButtonEl): HTMLCalciteActionElement =>
           (this.dismissButtonEl = dismissButtonEl)
         }
-        aria-label={text}
         text={text}
-        onClick={dismiss}
-        icon={ICONS.close}
       />
     ) : null;
 
     const slotNode = <slot name={SLOTS.headerTrailingContent} />;
 
     return (
-      <div key="header-trailing-content" class={CSS.headerTrailingContent}>
+      <div class={CSS.headerTrailingContent} key="header-trailing-content">
         {slotNode}
         {dismissibleNode}
       </div>
@@ -221,7 +221,7 @@ export class CalcitePanel {
 
   renderContent(): VNode {
     return (
-      <section tabIndex={0} class={CSS.contentContainer} onScroll={this.panelScrollHandler}>
+      <section class={CSS.contentContainer} onScroll={this.panelScrollHandler} tabIndex={0}>
         <slot />
         {this.renderFab()}
       </section>
@@ -246,14 +246,14 @@ export class CalcitePanel {
     const panelNode = (
       <article
         aria-busy={loading.toString()}
-        onKeyUp={panelKeyUpHandler}
-        tabIndex={dismissible ? 0 : -1}
-        hidden={dismissible && dismissed}
-        ref={(containerEl): HTMLElement => (this.containerEl = containerEl)}
         class={{
           [CSS.container]: true,
           [CSS_UTILITY.rtl]: rtl
         }}
+        hidden={dismissible && dismissed}
+        onKeyUp={panelKeyUpHandler}
+        ref={(containerEl): HTMLElement => (this.containerEl = containerEl)}
+        tabIndex={dismissible ? 0 : -1}
       >
         {this.renderHeader()}
         {this.renderContent()}
@@ -264,7 +264,7 @@ export class CalcitePanel {
     return (
       <Host>
         {loading || disabled ? (
-          <calcite-scrim theme={getElementTheme(el)} loading={loading}>
+          <calcite-scrim loading={loading} theme={getElementTheme(el)}>
             {panelNode}
           </calcite-scrim>
         ) : (

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -238,7 +238,7 @@ export class CalcitePickListItem {
         }}
       >
         {icon === ICON_TYPES.square ? (
-          <calcite-icon scale="s" icon={ICONS.checked}></calcite-icon>
+          <calcite-icon icon={ICONS.checked} scale="s"></calcite-icon>
         ) : null}
       </span>
     );
@@ -251,11 +251,11 @@ export class CalcitePickListItem {
 
     return (
       <calcite-action
-        scale="s"
         class={CSS.remove}
         icon={ICONS.remove}
-        text={this.textRemove}
         onClick={this.removeClickHandler}
+        scale="s"
+        text={this.textRemove}
       />
     );
   }
@@ -275,14 +275,14 @@ export class CalcitePickListItem {
     ) : null;
 
     return (
-      <Host role="menuitemcheckbox" aria-checked={this.selected.toString()}>
+      <Host aria-checked={this.selected.toString()} role="menuitemcheckbox">
         <label
+          aria-label={this.textLabel}
           class={CSS.label}
           onClick={this.pickListClickHandler}
           onKeyDown={this.pickListKeyDownHandler}
-          tabIndex={0}
           ref={(focusEl): HTMLLabelElement => (this.focusEl = focusEl)}
-          aria-label={this.textLabel}
+          tabIndex={0}
         >
           {this.renderIcon()}
           <div class={CSS.textContainer}>

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -191,6 +191,6 @@ export class CalcitePickList<
   }
 
   render(): VNode {
-    return <List props={this} onKeyDown={this.keyDownHandler} />;
+    return <List onKeyDown={this.keyDownHandler} props={this} />;
   }
 }

--- a/src/components/calcite-pick-list/shared-list-render.tsx
+++ b/src/components/calcite-pick-list/shared-list-render.tsx
@@ -16,22 +16,22 @@ export const List = ({ props, ...rest }): VNode => {
   const defaultSlot = <slot />;
 
   return (
-    <Host role="menu" aria-disabled={disabled.toString()} aria-busy={loading.toString()} {...rest}>
+    <Host aria-busy={loading.toString()} aria-disabled={disabled.toString()} role="menu" {...rest}>
       <section>
         <header class={{ [CSS.sticky]: true }}>
           {filterEnabled ? (
             <calcite-filter
+              aria-label={textFilterPlaceholder}
               data={dataForFilter}
               dir={getElementDir(el)}
-              placeholder={textFilterPlaceholder}
-              aria-label={textFilterPlaceholder}
               onCalciteFilterChange={handleFilter}
+              placeholder={textFilterPlaceholder}
             />
           ) : null}
           <slot name="menu-actions" />
         </header>
         {loading || disabled ? (
-          <calcite-scrim theme={getElementTheme(el)} loading={loading}>
+          <calcite-scrim loading={loading} theme={getElementTheme(el)}>
             {defaultSlot}
           </calcite-scrim>
         ) : (

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -335,11 +335,11 @@ export class CalcitePopover {
 
     return closeButton ? (
       <button
-        ref={(closeButtonEl) => (this.closeButtonEl = closeButtonEl)}
         aria-label={intlClose}
-        title={intlClose}
         class={{ [CSS.closeButton]: true }}
         onClick={this.hide}
+        ref={(closeButtonEl) => (this.closeButtonEl = closeButtonEl)}
+        title={intlClose}
       >
         <calcite-icon icon="x" scale="m"></calcite-icon>
       </button>
@@ -354,7 +354,7 @@ export class CalcitePopover {
     ) : null;
 
     return (
-      <Host role="dialog" aria-hidden={!displayed ? "true" : "false"} id={this.getId()}>
+      <Host aria-hidden={!displayed ? "true" : "false"} id={this.getId()} role="dialog">
         <div
           class={{
             [CSS.anim]: true,

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -99,11 +99,11 @@ export class CalciteRadioGroupItem {
 
     return (
       <Host
-        role="radio"
-        aria-checked={checked.toString()}
-        scale={scale}
         appearance={appearance}
+        aria-checked={checked.toString()}
         layout={layout}
+        role="radio"
+        scale={scale}
       >
         <label>
           {this.icon && this.iconPosition === "start" ? iconEl : null}

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -137,24 +137,24 @@ export class CalciteSlider {
 
     const handle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
         <div class="handle"></div>
       </button>
@@ -162,32 +162,32 @@ export class CalciteSlider {
 
     const labeledHandle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
-        <span class="handle__label handle__label--value" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value static">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value transformed">
           {value ? value.toLocaleString() : value}
         </span>
         <div class="handle"></div>
@@ -196,33 +196,33 @@ export class CalciteSlider {
 
     const histogramLabeledHandle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
         <div class="handle"></div>
-        <span class="handle__label handle__label--value" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value static">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value transformed">
           {value ? value.toLocaleString() : value}
         </span>
       </button>
@@ -230,25 +230,25 @@ export class CalciteSlider {
 
     const preciseHandle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
         <div class="handle"></div>
         <div class="handle-extension"></div>
@@ -257,25 +257,25 @@ export class CalciteSlider {
 
     const histogramPreciseHandle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
         <div class="handle-extension"></div>
         <div class="handle"></div>
@@ -284,33 +284,33 @@ export class CalciteSlider {
 
     const labeledPreciseHandle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
-        <span class="handle__label handle__label--value" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value static">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value transformed">
           {value ? value.toLocaleString() : value}
         </span>
         <div class="handle"></div>
@@ -320,35 +320,35 @@ export class CalciteSlider {
 
     const histogramLabeledPreciseHandle = (
       <button
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = maxProp)}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart(maxProp)}
-        onTouchStart={(e) => this.dragStart(maxProp, e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
-        aria-valuenow={value}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ right }}
+        aria-valuemin={this.min}
+        aria-valuenow={value}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = maxProp)}
+        onMouseDown={() => this.dragStart(maxProp)}
+        onTouchStart={(e) => this.dragStart(maxProp, e)}
+        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ right }}
       >
         <div class="handle-extension"></div>
         <div class="handle"></div>
-        <span class="handle__label handle__label--value" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value static">
           {value ? value.toLocaleString() : value}
         </span>
-        <span class="handle__label handle__label--value transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--value transformed">
           {value ? value.toLocaleString() : value}
         </span>
       </button>
@@ -356,24 +356,24 @@ export class CalciteSlider {
 
     const minHandle = (
       <button
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = "minValue")}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart("minValue")}
-        onTouchStart={(e) => this.dragStart("minValue", e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.minLabel}
-        aria-valuenow={this.minValue}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ left }}
+        aria-valuemin={this.min}
+        aria-valuenow={this.minValue}
         class={{
           thumb: true,
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue"
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ left }}
       >
         <div class="handle"></div>
       </button>
@@ -381,32 +381,32 @@ export class CalciteSlider {
 
     const minLabeledHandle = (
       <button
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = "minValue")}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart("minValue")}
-        onTouchStart={(e) => this.dragStart("minValue", e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.minLabel}
-        aria-valuenow={this.minValue}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ left }}
+        aria-valuemin={this.min}
+        aria-valuenow={this.minValue}
         class={{
           thumb: true,
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue"
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ left }}
       >
-        <span class="handle__label handle__label--minValue" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-        <span class="handle__label handle__label--minValue static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue static">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-        <span class="handle__label handle__label--minValue transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue transformed">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
         <div class="handle"></div>
@@ -415,33 +415,33 @@ export class CalciteSlider {
 
     const minHistogramLabeledHandle = (
       <button
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = "minValue")}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart("minValue")}
-        onTouchStart={(e) => this.dragStart("minValue", e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.minLabel}
-        aria-valuenow={this.minValue}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ left }}
+        aria-valuemin={this.min}
+        aria-valuenow={this.minValue}
         class={{
           thumb: true,
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue"
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ left }}
       >
         <div class="handle"></div>
-        <span class="handle__label handle__label--minValue" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-        <span class="handle__label handle__label--minValue static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue static">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-        <span class="handle__label handle__label--minValue transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue transformed">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
       </button>
@@ -449,25 +449,25 @@ export class CalciteSlider {
 
     const minPreciseHandle = (
       <button
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = "minValue")}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart("minValue")}
-        onTouchStart={(e) => this.dragStart("minValue", e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.minLabel}
-        aria-valuenow={this.minValue}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ left }}
+        aria-valuemin={this.min}
+        aria-valuenow={this.minValue}
         class={{
           thumb: true,
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue",
           "thumb--precise": true
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ left }}
       >
         <div class="handle-extension"></div>
         <div class="handle"></div>
@@ -476,35 +476,35 @@ export class CalciteSlider {
 
     const minLabeledPreciseHandle = (
       <button
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
-        onFocus={() => (this.activeProp = "minValue")}
-        onBlur={() => (this.activeProp = null)}
-        onMouseDown={() => this.dragStart("minValue")}
-        onTouchStart={(e) => this.dragStart("minValue", e)}
-        role="slider"
-        aria-orientation="horizontal"
         aria-label={this.minLabel}
-        aria-valuenow={this.minValue}
-        aria-valuemin={this.min}
+        aria-orientation="horizontal"
         aria-valuemax={this.max}
-        disabled={this.disabled}
-        style={{ left }}
+        aria-valuemin={this.min}
+        aria-valuenow={this.minValue}
         class={{
           thumb: true,
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue",
           "thumb--precise": true
         }}
+        disabled={this.disabled}
+        onBlur={() => (this.activeProp = null)}
+        onFocus={() => (this.activeProp = "minValue")}
+        onMouseDown={() => this.dragStart("minValue")}
+        onTouchStart={(e) => this.dragStart("minValue", e)}
+        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        role="slider"
+        style={{ left }}
       >
         <div class="handle-extension"></div>
         <div class="handle"></div>
-        <span class="handle__label handle__label--minValue" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-        <span class="handle__label handle__label--minValue static" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue static">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-        <span class="handle__label handle__label--minValue transformed" aria-hidden="true">
+        <span aria-hidden="true" class="handle__label handle__label--minValue transformed">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
       </button>
@@ -565,11 +565,11 @@ export class CalciteSlider {
     return this.histogram ? (
       <div class="graph">
         <calcite-graph
-          width={300}
-          height={48}
           data={this.histogram}
-          highlightMin={this.isRange ? this.minValue : this.min}
+          height={48}
           highlightMax={this.isRange ? this.maxValue : this.value}
+          highlightMin={this.isRange ? this.minValue : this.min}
+          width={300}
         />
       </div>
     ) : null;

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -90,16 +90,16 @@ export class CalciteSplitButton {
       <Host dir={dir}>
         <div class="split-button__container">
           <calcite-button
-            dir={dir}
             aria-label={this.primaryLabel}
             color={this.color}
-            scale={this.scale}
-            loading={this.loading}
-            icon-start={this.primaryIconStart ? this.primaryIconStart : null}
-            icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
+            dir={dir}
             disabled={this.disabled}
-            theme={this.theme}
+            icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
+            icon-start={this.primaryIconStart ? this.primaryIconStart : null}
+            loading={this.loading}
             onClick={this.calciteSplitButtonPrimaryClickHandler}
+            scale={this.scale}
+            theme={this.theme}
           >
             {this.primaryText}
           </calcite-button>
@@ -109,20 +109,20 @@ export class CalciteSplitButton {
           <calcite-dropdown
             alignment="end"
             dir={dir}
-            theme={this.theme}
-            scale={this.scale}
-            width={this.scale}
             onClick={this.calciteSplitButtonSecondaryClickHandler}
+            scale={this.scale}
+            theme={this.theme}
+            width={this.scale}
           >
             <calcite-button
-              dir={dir}
               aria-label={this.dropdownLabel}
-              slot="dropdown-trigger"
-              scale={this.scale}
               color={this.color}
+              dir={dir}
               disabled={this.disabled}
-              theme={this.theme}
               icon-start={this.dropdownIcon}
+              scale={this.scale}
+              slot="dropdown-trigger"
+              theme={this.theme}
             />
             <slot />
           </calcite-dropdown>

--- a/src/components/calcite-stepper-item/calcite-stepper-item.tsx
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.tsx
@@ -113,10 +113,10 @@ export class CalciteStepperItem {
     const dir = getElementDir(this.el);
     return (
       <Host
-        dir={dir}
-        tabindex={this.disabled ? null : 0}
         aria-expanded={this.active.toString()}
+        dir={dir}
         onClick={() => this.emitRequestedItem()}
+        tabindex={this.disabled ? null : 0}
       >
         <div class="stepper-item-header">
           {this.icon ? this.setIcon() : null}
@@ -202,7 +202,7 @@ export class CalciteStepperItem {
       ? "checkCircleF"
       : "circle";
 
-    return <calcite-icon icon={path} scale="s" class="stepper-item-icon" />;
+    return <calcite-icon class="stepper-item-icon" icon={path} scale="s" />;
   }
 
   private determineActiveItem() {

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -105,9 +105,9 @@ export class CalciteSwitch {
 
     return (
       <Host
+        aria-checked={this.switched.toString()}
         dir={dir}
         role="checkbox"
-        aria-checked={this.switched.toString()}
         tabIndex={this.disabled ? -1 : this.tabIndex}
       >
         <div class="track">

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -104,12 +104,12 @@ export class CalciteTabTitle {
 
     return (
       <Host
-        id={id}
         aria-controls={this.controls}
         aria-expanded={this.active.toString()}
+        hasText={this.hasText}
+        id={id}
         role="tab"
         tabindex={this.disabled ? "-1" : "0"}
-        hasText={this.hasText}
       >
         <Tag>
           {this.iconStart ? iconStartEl : null}

--- a/src/components/calcite-tab/calcite-tab.tsx
+++ b/src/components/calcite-tab/calcite-tab.tsx
@@ -56,9 +56,9 @@ export class CalciteTab {
 
     return (
       <Host
-        id={id}
-        aria-labelledby={this.labeledBy}
         aria-expanded={this.active.toString()}
+        aria-labelledby={this.labeledBy}
+        id={id}
         role="tabpanel"
       >
         <section>

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -241,17 +241,17 @@ export class CalciteTipManager {
     return tips.length > 1 ? (
       <footer class={CSS.pagination}>
         <calcite-action
-          text={previousLabel}
-          onClick={this.previousClicked}
           class={CSS.pagePrevious}
           icon={dir === "ltr" ? ICONS.chevronLeft : ICONS.chevronRight}
+          onClick={this.previousClicked}
+          text={previousLabel}
         />
         <span class={CSS.pagePosition}>{`${paginationLabel} ${selectedIndex + 1}/${total}`}</span>
         <calcite-action
-          text={nextLabel}
-          onClick={this.nextClicked}
           class={CSS.pageNext}
           icon={dir === "ltr" ? ICONS.chevronRight : ICONS.chevronLeft}
+          onClick={this.nextClicked}
+          text={nextLabel}
         />
       </footer>
     ) : null;
@@ -268,32 +268,32 @@ export class CalciteTipManager {
     return (
       <Host>
         <section
+          aria-hidden={closed.toString()}
           class={CSS.container}
           hidden={closed}
-          aria-hidden={closed.toString()}
-          tabIndex={0}
           onKeyUp={this.tipManagerKeyUpHandler}
           ref={this.storeContainerRef}
+          tabIndex={0}
         >
           <header class={CSS.header}>
-            <h2 key={selectedIndex} class={CSS.heading}>
+            <h2 class={CSS.heading} key={selectedIndex}>
               {groupTitle}
             </h2>
             <calcite-action
-              text={closeLabel}
-              onClick={this.hideTipManager}
               class={CSS.close}
               icon={ICONS.close}
+              onClick={this.hideTipManager}
+              text={closeLabel}
             />
           </header>
           <div
-            tabIndex={0}
             class={{
               [CSS.tipContainer]: true,
               [CSS.tipContainerAdvancing]: !closed && direction === "advancing",
               [CSS.tipContainerRetreating]: !closed && direction === "retreating"
             }}
             key={selectedIndex}
+            tabIndex={0}
           >
             <slot />
           </div>

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -102,11 +102,11 @@ export class CalciteTip {
 
     return !nonDismissible ? (
       <calcite-action
-        text={text}
-        onClick={hideTip}
-        scale="l"
         class={CSS.close}
         icon={ICONS.close}
+        onClick={hideTip}
+        scale="l"
+        text={text}
       />
     ) : null;
   }

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -239,7 +239,7 @@ export class CalciteTooltip {
     const displayed = _referenceElement && open;
 
     return (
-      <Host role="tooltip" aria-hidden={!displayed ? "true" : "false"} id={this.getId()}>
+      <Host aria-hidden={!displayed ? "true" : "false"} id={this.getId()} role="tooltip">
         <div
           class={{
             [CSS.anim]: true,

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -89,18 +89,18 @@ export class CalciteTreeItem {
     const icon = this.hasChildren ? (
       <calcite-icon
         class="calcite-tree-chevron"
-        icon="chevron-right"
-        scale="s"
-        onClick={this.iconClickHandler}
         data-test-id="icon"
+        icon="chevron-right"
+        onClick={this.iconClickHandler}
+        scale="s"
       ></calcite-icon>
     ) : null;
 
     return (
       <Host
-        tabindex={this.parentExpanded || this.depth === 1 ? "0" : "-1"}
-        aria-role="treeitem"
+        aria-expanded={this.hasChildren ? this.expanded.toString() : undefined}
         aria-hidden={this.parentExpanded || this.depth === 1 ? undefined : "true"}
+        aria-role="treeitem"
         aria-selected={
           this.selected
             ? "true"
@@ -109,7 +109,7 @@ export class CalciteTreeItem {
             ? "false"
             : undefined
         }
-        aria-expanded={this.hasChildren ? this.expanded.toString() : undefined}
+        tabindex={this.parentExpanded || this.depth === 1 ? "0" : "-1"}
       >
         <div class="calcite-tree-node" ref={(el) => (this.defaultSlotWrapper = el as HTMLElement)}>
           {icon}
@@ -118,9 +118,9 @@ export class CalciteTreeItem {
         <div
           class="calcite-tree-children"
           data-test-id="calcite-tree-children"
-          role={this.hasChildren ? "group" : undefined}
-          ref={(el) => (this.childrenSlotWrapper = el as HTMLElement)}
           onClick={this.childrenClickHandler}
+          ref={(el) => (this.childrenSlotWrapper = el as HTMLElement)}
+          role={this.hasChildren ? "group" : undefined}
         >
           <slot name="children"></slot>
         </div>

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -55,12 +55,12 @@ export class CalciteTree {
   render() {
     return (
       <Host
-        tabindex={this.root ? "0" : undefined}
-        aria-role={this.root ? "tree" : undefined}
         aria-multiselectable={
           this.selectionMode === TreeSelectionMode.Multi ||
           this.selectionMode === TreeSelectionMode.MultiChildren
         }
+        aria-role={this.root ? "tree" : undefined}
+        tabindex={this.root ? "0" : undefined}
       >
         <slot></slot>
       </Host>

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -142,18 +142,18 @@ export class CalciteValueListItem {
     if (icon === ICON_TYPES.grip) {
       return (
         <span
-          role="button"
+          aria-pressed={this.handleActivated.toString()}
           class={{
             [CSS.handle]: true,
             [CSS.handleActivated]: this.handleActivated
           }}
-          tabindex="0"
           data-js-handle="true"
-          aria-pressed={this.handleActivated.toString()}
-          onKeyDown={this.handleKeyDown}
           onBlur={this.handleBlur}
+          onKeyDown={this.handleKeyDown}
+          role="button"
+          tabindex="0"
         >
-          <calcite-icon scale="s" icon={ICONS.drag} />
+          <calcite-icon icon={ICONS.drag} scale="s" />
         </span>
       );
     }
@@ -164,15 +164,15 @@ export class CalciteValueListItem {
       <Host data-id={this.guid}>
         {this.renderHandle()}
         <calcite-pick-list-item
-          ref={this.getPickListRef}
-          disabled={this.disabled}
           disableDeselect={this.disableDeselect}
-          selected={this.selected}
+          disabled={this.disabled}
           metadata={this.metadata}
-          removable={this.removable}
-          textLabel={this.textLabel}
-          textDescription={this.textDescription}
           onCalciteListItemChange={this.handleSelectChange}
+          ref={this.getPickListRef}
+          removable={this.removable}
+          selected={this.selected}
+          textDescription={this.textDescription}
+          textLabel={this.textLabel}
           value={this.value}
         >
           <slot name="secondary-action" slot="secondary-action" />

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -285,6 +285,6 @@ export class CalciteValueList<
   }
 
   render(): VNode {
-    return <List props={this} onKeyDown={this.keyDownHandler} />;
+    return <List onKeyDown={this.keyDownHandler} props={this} />;
   }
 }

--- a/src/components/utils/CalciteExpandToggle.tsx
+++ b/src/components/utils/CalciteExpandToggle.tsx
@@ -67,13 +67,13 @@ export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> 
 
   const actionNode = (
     <calcite-action
+      icon={expanded ? expandIcon : collapseIcon}
+      onClick={toggleExpand}
       ref={(referenceElement): HTMLCalciteActionElement =>
         setTooltipReference(tooltipExpand, referenceElement, expanded)
       }
-      onClick={toggleExpand}
-      textEnabled={expanded}
       text={expandText}
-      icon={expanded ? expandIcon : collapseIcon}
+      textEnabled={expanded}
     />
   );
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Enables [`@react/jsx-sort-props`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md) (auto-fixable 🎉) for consistent JSX attributes.