### PR TITLE
ci: tweak next release tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "util:clean-tested-build": "npm ci && npm test && npm run build",
     "util:copy-icons": "cpy ./node_modules/@esri/calcite-ui-icons/js/*.json ./src/components/calcite-icon/assets",
     "util:deploy-next-from-existing-build": "npm run util:prep-next-from-existing-build && npm run util:push-tags && npm run util:publish-next",
-    "util:prep-next-from-existing-build": "standard-version --no-skip.bump --no-skip.commit --no-skip.tag --skip.changelog --prerelease beta",
+    "util:prep-next-from-existing-build": "standard-version --no-skip.bump --no-skip.commit --no-skip.tag --skip.changelog --prerelease next",
     "util:publish-next": "npm publish --tag next",
     "util:push-tags": "git push --follow-tags",
     "util:run-tests": "npm run util:copy-icons && stencil test --no-docs --spec --e2e",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Updates `next` release tag to avoid updating the beta one.

`@next` versions will be labeled as `1.0.0-next.<num>`. After we're officially on 1.0.0, we'll have better labels following the semver based on the current changelog: `<upcoming-semver>-next.<num>`