### PR TITLE
chore: update changelog scripts

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,6 +1,6 @@
 {
   "header": "# Changelog\n\nThis document maintains a list of released versions and changes introduced by them.\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)\n",
-  "releaseCommitMessageFormat": "{{currentTag}}",
+  "releaseCommitMessageFormat": "{{currentTag}} [skip ci]",
   "skip": {
     "bump": true,
     "changelog": false,

--- a/support/ensureNonPrereleaseChangelog.ts
+++ b/support/ensureNonPrereleaseChangelog.ts
@@ -6,12 +6,11 @@ const childProcess = require("child_process");
   // this command will pass through standard-version args
   const standardVersionOverrides = process.argv.slice(2).join(" ");
 
-  const includePrereleaseChanges = true; // skipping until v1.0.0 is released
   const previousReleasedTag = childProcess.execSync("git describe --abbrev=0 --tags", { encoding: "utf-8" }).trim();
-  const prereleaseVersionPattern = /-beta\.\d+$/;
+  const prereleaseVersionPattern = /-next\.\d+$/;
   const previousReleaseIsPrerelease = prereleaseVersionPattern.test(previousReleasedTag);
 
-  if (!previousReleaseIsPrerelease || includePrereleaseChanges) {
+  if (!previousReleaseIsPrerelease) {
     // using process to generate changelog (auto loads .versionrc.json)
     childProcess.execSync(`npx standard-version --prerelease ${standardVersionOverrides}`, { stdio: "inherit" });
     process.exit();

--- a/support/ensureNonPrereleaseChangelog.ts
+++ b/support/ensureNonPrereleaseChangelog.ts
@@ -36,7 +36,10 @@ const childProcess = require("child_process");
     }
 
     // using process to generate changelog (auto loads .versionrc.json)
-    childProcess.execSync(`npx standard-version ${standardVersionOverrides}`, { stdio: "inherit" });
+    childProcess.execSync(
+      `npx standard-version ${standardVersionOverrides} --releaseCommitMessageFormat "{{currentTag}} [skip ci]"`,
+      { stdio: "inherit" }
+    );
   } catch (error) {
     console.log("an error occurred when generating the changelog:", error);
   }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Updates a changelog generation helper to work with the latest [@next deployment changes](https://github.com/Esri/calcite-components/pull/985). 

This also updates the release commit message to skip builds for (pre)release commits.