### PR TITLE
fix(tooltip): Add a11y improvements for hovering over a tooltip

### DIFF
--- a/src/components/calcite-popover-manager/calcite-popover-manager.tsx
+++ b/src/components/calcite-popover-manager/calcite-popover-manager.tsx
@@ -36,7 +36,7 @@ export class CalcitePopoverManager {
   //
   // --------------------------------------------------------------------------
 
-  render() {
+  render(): void {
     return <Host />;
   }
 
@@ -46,7 +46,8 @@ export class CalcitePopoverManager {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("click", { target: "window", capture: true }) closeOpenPopovers(event: Event) {
+  @Listen("click", { target: "window", capture: true })
+  closeOpenPopovers(event: Event): void {
     const target = event.target as HTMLElement;
     const { autoClose, el, selector } = this;
     const popoverSelector = "calcite-popover";

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -66,7 +66,7 @@ export class CalcitePopover {
   @Prop({ reflect: true }) offsetDistance = defaultOffsetDistance;
 
   @Watch("offsetDistance")
-  offsetDistanceOffsetHandler() {
+  offsetDistanceOffsetHandler(): void {
     this.reposition();
   }
 
@@ -76,7 +76,7 @@ export class CalcitePopover {
   @Prop({ reflect: true }) offsetSkidding = 0;
 
   @Watch("offsetSkidding")
-  offsetSkiddingHandler() {
+  offsetSkiddingHandler(): void {
     this.reposition();
   }
 
@@ -86,7 +86,7 @@ export class CalcitePopover {
   @Prop({ reflect: true }) open = false;
 
   @Watch("open")
-  openHandler(open: boolean) {
+  openHandler(open: boolean): void {
     this.reposition();
     if (open) {
       this.calcitePopoverOpen.emit();
@@ -101,7 +101,7 @@ export class CalcitePopover {
   @Prop({ reflect: true }) placement: CalcitePlacement = "auto";
 
   @Watch("placement")
-  placementHandler() {
+  placementHandler(): void {
     this.reposition();
   }
 
@@ -111,7 +111,7 @@ export class CalcitePopover {
   @Prop() referenceElement!: HTMLElement | string;
 
   @Watch("referenceElement")
-  referenceElementHandler() {
+  referenceElementHandler(): void {
     this.removeReferences();
     this._referenceElement = this.getReferenceElement();
     this.addReferences();
@@ -175,7 +175,8 @@ export class CalcitePopover {
   //
   // --------------------------------------------------------------------------
 
-  @Method() async reposition(): Promise<void> {
+  @Method()
+  async reposition(): Promise<void> {
     const { popper, el, placement } = this;
     const modifiers = this.getModifiers();
 
@@ -190,7 +191,7 @@ export class CalcitePopover {
   }
 
   @Method()
-  async setFocus(focusId?: FocusId) {
+  async setFocus(focusId?: FocusId): Promise<void> {
     if (focusId === "close-button") {
       this.closeButtonEl?.focus();
       return;
@@ -199,7 +200,8 @@ export class CalcitePopover {
     this.el?.focus();
   }
 
-  @Method() async toggle(value = !this.open): Promise<void> {
+  @Method()
+  async toggle(value = !this.open): Promise<void> {
     this.open = value;
   }
 
@@ -347,7 +349,7 @@ export class CalcitePopover {
     ) : null;
   }
 
-  render() {
+  render(): VNode {
     const { _referenceElement, open, disablePointer } = this;
     const displayed = _referenceElement && open;
     const arrowNode = !disablePointer ? (

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { TOOLTIP_REFERENCE } from "../calcite-tooltip/resources";
+import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
 import { defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tooltip-manager", () => {
@@ -18,13 +18,10 @@ describe("calcite-tooltip-manager", () => {
   it("should honor tooltips on mouseover/mouseout", async () => {
     const page = await newE2EPage();
 
-    const openDelay = 500;
-    const closeDelay = 500;
-
     await page.setContent(
       `
       <button id="test">test</button>
-      <calcite-tooltip-manager open-delay="${openDelay}" close-delay="${closeDelay}">
+      <calcite-tooltip-manager>
         <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
         <button id="ref">Button</button>
       <calcite-tooltip-manager>
@@ -43,7 +40,7 @@ describe("calcite-tooltip-manager", () => {
 
     await page.waitForChanges();
 
-    await page.waitFor(openDelay);
+    await page.waitFor(TOOLTIP_DELAY_MS);
 
     expect(await tooltip.getProperty("open")).toBe(true);
 
@@ -53,7 +50,7 @@ describe("calcite-tooltip-manager", () => {
 
     await page.waitForChanges();
 
-    await page.waitFor(closeDelay);
+    await page.waitFor(TOOLTIP_DELAY_MS);
 
     expect(await tooltip.getProperty("open")).toBe(false);
   });

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -18,10 +18,13 @@ describe("calcite-tooltip-manager", () => {
   it("should honor tooltips on mouseover/mouseout", async () => {
     const page = await newE2EPage();
 
+    const openDelay = 500;
+    const closeDelay = 500;
+
     await page.setContent(
       `
       <button id="test">test</button>
-      <calcite-tooltip-manager>
+      <calcite-tooltip-manager open-delay="${openDelay}" close-delay="${closeDelay}">
         <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
         <button id="ref">Button</button>
       <calcite-tooltip-manager>
@@ -40,6 +43,8 @@ describe("calcite-tooltip-manager", () => {
 
     await page.waitForChanges();
 
+    await page.waitFor(openDelay);
+
     expect(await tooltip.getProperty("open")).toBe(true);
 
     const testElement = await page.find("#test");
@@ -47,6 +52,8 @@ describe("calcite-tooltip-manager", () => {
     await testElement.hover();
 
     await page.waitForChanges();
+
+    await page.waitFor(closeDelay);
 
     expect(await tooltip.getProperty("open")).toBe(false);
   });

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -29,7 +29,7 @@ export class CalciteTooltipManager {
   /**
    * Time to wait in milliseconds before opening the popup from mouse over.
    */
-  @Prop() openDelay = 0;
+  @Prop() openDelay = 500;
 
   /**
    * CSS Selector to match reference elements for tooltips.

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -1,9 +1,7 @@
 import { Component, Host, h, Listen, Prop, VNode } from "@stencil/core";
-import { TOOLTIP_REFERENCE } from "../calcite-tooltip/resources";
+import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
 import { getDescribedByElement } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-
-const TOOLTIP_DELAY_MS = 500;
 
 @Component({
   tag: "calcite-tooltip-manager"

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -82,7 +82,7 @@ export class CalciteTooltipManager {
       : this.delayedToggle(hoveredTooltipEl, false);
   };
 
-  hoverEvent = ({ event, value }: { event: MouseEvent; value: boolean }): void => {
+  hoverEvent = (event: MouseEvent, value: boolean): void => {
     this.activeTooltipHover(event);
 
     const referenceEl = event.target as HTMLElement;
@@ -102,7 +102,7 @@ export class CalciteTooltipManager {
     }
   };
 
-  focusEvent = ({ event, value }: { event: FocusEvent; value: boolean }): void => {
+  focusEvent = (event: FocusEvent, value: boolean): void => {
     const referenceEl = event.target as HTMLElement;
     const tooltip = this.queryTooltip(referenceEl);
 
@@ -151,21 +151,21 @@ export class CalciteTooltipManager {
 
   @Listen("mouseenter", { capture: true })
   mouseEnterShow(event: MouseEvent): void {
-    this.hoverEvent({ event, value: true });
+    this.hoverEvent(event, true);
   }
 
   @Listen("mouseleave", { capture: true })
   mouseLeaveHide(event: MouseEvent): void {
-    this.hoverEvent({ event, value: true });
+    this.hoverEvent(event, false);
   }
 
   @Listen("focus", { capture: true })
   focusShow(event: FocusEvent): void {
-    this.focusEvent({ event, value: true });
+    this.focusEvent(event, true);
   }
 
   @Listen("blur", { capture: true })
   blurHide(event: FocusEvent): void {
-    this.focusEvent({ event, value: false });
+    this.focusEvent(event, false);
   }
 }

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-
+import { TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
 import { defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tooltip", () => {
@@ -117,6 +117,8 @@ describe("calcite-tooltip", () => {
 
     await ref.hover();
 
+    await page.waitFor(TOOLTIP_DELAY_MS);
+
     expect(await tooltip.isVisible()).toBe(true);
   });
 
@@ -136,6 +138,8 @@ describe("calcite-tooltip", () => {
     const ref = await page.find("#ref span");
 
     await ref.hover();
+
+    await page.waitFor(TOOLTIP_DELAY_MS);
 
     expect(await tooltip.isVisible()).toBe(true);
   });

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, Method, Prop, State, Watch, h } from "@stencil/core";
+import { Component, Element, Host, Method, Prop, State, Watch, h, VNode } from "@stencil/core";
 import { CSS, TOOLTIP_REFERENCE, ARIA_DESCRIBED_BY } from "./resources";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
@@ -28,7 +28,7 @@ export class CalciteTooltip {
   @Prop({ reflect: true }) offsetDistance = defaultOffsetDistance;
 
   @Watch("offsetDistance")
-  offsetDistanceOffsetHandler() {
+  offsetDistanceOffsetHandler(): void {
     this.reposition();
   }
 
@@ -38,7 +38,7 @@ export class CalciteTooltip {
   @Prop({ reflect: true }) offsetSkidding = 0;
 
   @Watch("offsetSkidding")
-  offsetSkiddingHandler() {
+  offsetSkiddingHandler(): void {
     this.reposition();
   }
 
@@ -48,7 +48,7 @@ export class CalciteTooltip {
   @Prop({ reflect: true }) open = false;
 
   @Watch("open")
-  openHandler() {
+  openHandler(): void {
     this.reposition();
   }
 
@@ -58,7 +58,7 @@ export class CalciteTooltip {
   @Prop({ reflect: true }) placement: CalcitePlacement = "auto";
 
   @Watch("placement")
-  placementHandler() {
+  placementHandler(): void {
     this.reposition();
   }
 
@@ -68,7 +68,7 @@ export class CalciteTooltip {
   @Prop() referenceElement!: HTMLElement | string;
 
   @Watch("referenceElement")
-  referenceElementHandler() {
+  referenceElementHandler(): void {
     this.removeReferences();
     this._referenceElement = this.getReferenceElement();
     this.addReferences();
@@ -116,7 +116,8 @@ export class CalciteTooltip {
   //
   // --------------------------------------------------------------------------
 
-  @Method() async reposition(): Promise<void> {
+  @Method()
+  async reposition(): Promise<void> {
     const { popper, el, placement } = this;
     const modifiers = this.getModifiers();
 
@@ -235,7 +236,7 @@ export class CalciteTooltip {
   //
   // --------------------------------------------------------------------------
 
-  render() {
+  render(): VNode {
     const { _referenceElement, open } = this;
     const displayed = _referenceElement && open;
 

--- a/src/components/calcite-tooltip/resources.ts
+++ b/src/components/calcite-tooltip/resources.ts
@@ -6,3 +6,5 @@ export const CSS = {
 export const TOOLTIP_REFERENCE = "data-calcite-tooltip-reference";
 
 export const ARIA_DESCRIBED_BY = "aria-describedby";
+
+export const TOOLTIP_DELAY_MS = 500;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -103,17 +103,3 @@ export function getDescribedByElement<T extends Element>(element: Element): T | 
 export function hasLabel(labelEl: HTMLCalciteLabelElement, el: HTMLElement): boolean {
   return labelEl.contains(el);
 }
-
-export function once(
-  element: HTMLElement,
-  event: string,
-  callback: (evt?: Event) => void,
-  options?: boolean | AddEventListenerOptions
-): void {
-  const func = (evt?: Event) => {
-    element.removeEventListener(event, func, options);
-    callback(evt);
-  };
-
-  element.addEventListener(event, func, options);
-}

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -100,6 +100,20 @@ export function getDescribedByElement<T extends Element>(element: Element): T | 
   return (id && document.getElementById(id)) || null;
 }
 
-export function hasLabel(labelEl: HTMLCalciteLabelElement, el: HTMLElement) {
+export function hasLabel(labelEl: HTMLCalciteLabelElement, el: HTMLElement): boolean {
   return labelEl.contains(el);
+}
+
+export function addEventListenerOnce(
+  element: HTMLElement,
+  event: string,
+  fn: (evt?: Event) => void,
+  options?: boolean | AddEventListenerOptions
+): void {
+  const func = (evt?: Event) => {
+    element.removeEventListener(event, func, options);
+    fn(evt);
+  };
+
+  element.addEventListener(event, func, options);
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -107,12 +107,12 @@ export function hasLabel(labelEl: HTMLCalciteLabelElement, el: HTMLElement): boo
 export function addEventListenerOnce(
   element: HTMLElement,
   event: string,
-  fn: (evt?: Event) => void,
+  callback: (evt?: Event) => void,
   options?: boolean | AddEventListenerOptions
 ): void {
   const func = (evt?: Event) => {
     element.removeEventListener(event, func, options);
-    fn(evt);
+    callback(evt);
   };
 
   element.addEventListener(event, func, options);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -104,7 +104,7 @@ export function hasLabel(labelEl: HTMLCalciteLabelElement, el: HTMLElement): boo
   return labelEl.contains(el);
 }
 
-export function addEventListenerOnce(
+export function once(
   element: HTMLElement,
   event: string,
   callback: (evt?: Event) => void,


### PR DESCRIPTION
**Related Issue:** #938

## Summary

- Delays the closing/opening of a tooltip to allow a user to hover the tooltip with their mouse and keep it open. Defaults to 500ms and can't be changed for now.
- Once the tooltip is hovered, the timeout is cleared and started again on mouseout.
- Closes both hovered or focused tooltips on ESC key press (moved to document)
- Focus/Hover tooltips are opened/closed independent of each other
- Cleans up some linting on related files.
- Updates tests

## Questions

- What should the default timeout be for opening/closing a tooltip? 

## References

https://codepen.io/smhigley/pen/KjoerX?editors=0010

https://www.digitala11y.com/tooltip-role/
