### PR TITLE
fix(calcite-input): fix setting value for textarea

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -395,4 +395,18 @@ describe("calcite-input", () => {
     await page.waitForChanges();
     expect(calciteInputInput).toHaveReceivedEvent();
   });
+
+  it("renders the provided value for a textarea", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="textarea" value="Prefilled text."></calcite-input>
+    `);
+
+    await page.waitForChanges();
+
+    const element = await page.$("textarea");
+    const text = await page.evaluate((element) => element.value, element as any);
+
+    expect(text).toEqual("Prefilled text.");
+  });
 });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -303,9 +303,8 @@ export class CalciteInput {
             ref={(el) => (this.childEl = el)}
             required={this.required ? true : null}
             tabIndex={this.disabled ? -1 : null}
-          >
-            <slot />
-          </textarea>,
+            value={this.value}
+          />,
           <div class="calcite-input-resize-icon-wrapper">
             <calcite-icon icon="chevron-down" scale="s"></calcite-icon>
           </div>

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -158,7 +158,7 @@
 
           <calcite-label>
             Textarea full input
-            <calcite-input type="textarea" placeholder="How was your day?">Here I am with some text</calcite-input>
+            <calcite-input type="textarea" placeholder="How was your day?" value="Here I am with some text"></calcite-input>
           </calcite-label>
           <calcite-label>
             Number input - default type vertical
@@ -294,7 +294,7 @@
 
           <calcite-label>
             Disabled textarea
-            <calcite-input disabled type="textarea">Disabled value
+            <calcite-input disabled type="textarea" value="Disabled value">
             </calcite-input>
           </calcite-label>
 
@@ -303,7 +303,7 @@
           <calcite-input disabled value="Disabled value">
           </calcite-input>
           <br />
-          <calcite-input disabled type="textarea" value="Disabled value">Disabled value
+          <calcite-input disabled type="textarea" value="Disabled value" value="Disabled value">
           </calcite-input>
 
           <h4>Readonly</h4>
@@ -327,7 +327,7 @@
           </calcite-label>
           <calcite-label>
             Textarea Readonly
-            <calcite-input readonly type="textarea" placeholder="How was your day?">Here I am with some text
+            <calcite-input readonly type="textarea" placeholder="How was your day?" value="Here I am with some text">
             </calcite-input>
           </calcite-label>
 
@@ -616,7 +616,7 @@
 
           <calcite-label disabled>
             Textarea full input
-            <calcite-input type="textarea" placeholder="How was your day?">Here I am with some text</calcite-input>
+            <calcite-input type="textarea" placeholder="How was your day?" value="Here I am with some text"></calcite-input>
           </calcite-label>
           <calcite-label disabled>
             Number input - default type vertical
@@ -753,7 +753,7 @@
 
           <calcite-label disabled>
             Disabled textarea
-            <calcite-input disabled type="textarea">Disabled value
+            <calcite-input disabled type="textarea" value="Disabled value">
             </calcite-input>
           </calcite-label>
 
@@ -762,7 +762,7 @@
           <calcite-input disabled value="Disabled value">
           </calcite-input>
           <br />
-          <calcite-input disabled type="textarea" value="Disabled value">Disabled value
+          <calcite-input disabled type="textarea" value="Disabled value" value="Disabled value">
           </calcite-input>
 
           <h4>Readonly</h4>
@@ -786,7 +786,7 @@
           </calcite-label>
           <calcite-label disabled>
             Textarea Readonly
-            <calcite-input readonly type="textarea" placeholder="How was your day?">Here I am with some text
+            <calcite-input readonly type="textarea" placeholder="How was your day?" value="Here I am with some text">
             </calcite-input>
           </calcite-label>
 


### PR DESCRIPTION
## Summary

This PR fixes the ability to pass a  default value to `<calcite-input type="textarea">`. The currently documented way to do this is to pass things to the nested `<slot />` which doesn't work. You can look at the current demos to see it not working or read https://github.com/Polymer/lit-element/issues/954 to learn more.

You can now do this:

```
<calcite-input type="textarea" value="Existing value...">
```
