### PR TITLE
fix(dropdown): fix item selection when dropdown is in a shadow DOM context

### DIFF
--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -176,7 +176,9 @@ export class CalciteDropdownItem {
 
   @Listen("calciteDropdownItemChange", { target: "body" })
   updateActiveItemOnChange(event: CustomEvent) {
-    if (event.target === this.parentDropdownGroupEl) {
+    const parentEmittedChange = event.composedPath().includes(this.parentDropdownGroupEl);
+
+    if (parentEmittedChange) {
       this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
       this.requestedDropdownItem = event.detail.requestedDropdownItem;
       this.determineActiveItem();


### PR DESCRIPTION
**Related Issue:** #992 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates the logic that determines whether a dropdown item has been selected or not. The main issue is that when the dropdown is in the shadow DOM, the event target will be the wrapping component and not the dropdown, which breaks the current logic.