### PR TITLE
 fix(calcite-checkbox): visibility of hidden input controlled by inline styles to prevent outside CSS from affecting its display

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -13,11 +13,6 @@
 :host([scale="l"]) {
   --calcite-checkbox-size: 20px;
 }
-::slotted(input) {
-  opacity: 0;
-  position: absolute;
-  z-index: -1;
-}
 :host {
   display: inline-flex;
   cursor: pointer;

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -198,6 +198,9 @@ export class CalciteCheckbox {
     this.input.name = this.name;
     this.input.onblur = () => (this.focused = false);
     this.input.onfocus = () => (this.focused = true);
+    this.input.style.opacity = "0";
+    this.input.style.position = "absolute";
+    this.input.style.zIndex = "-1";
     this.input.type = "checkbox";
     if (this.value) {
       this.input.value = this.value;


### PR DESCRIPTION
**Related Issue:** #996
