### PR TITLE
fix(tooltip): Keep tooltip visible if focus occurs after hover #938

### DIFF
--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -63,6 +63,11 @@ export class CalciteTooltipManager {
   }): void => {
     const { hoveredTooltipEl, hoveredReferenceEl } = this;
 
+    if (tooltip === this.hoveredTooltipEl) {
+      this.hoveredTooltipEl = null;
+      this.clearTooltipTimeout(tooltip);
+    }
+
     this.focusedReferenceEl = value ? referenceEl : null;
 
     if (referenceEl === hoveredReferenceEl || tooltip === hoveredTooltipEl) {


### PR DESCRIPTION
**Related Issue:** #938

## Summary

fix(tooltip): Keep tooltip visible if focus occurs after hover #938