### PR TITLE
test(tooltip): Add unit test for triggering tooltip from combinations of hover/focus #1006

### DIFF
--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -240,4 +240,41 @@ describe("calcite-tooltip-manager", () => {
 
     expect(await tooltip.getProperty("open")).toBe(false);
   });
+
+  it("should honor hovered + focused tooltip closing with ESC key", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `
+      <calcite-tooltip-manager>
+        <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
+        <button id="ref">Button</button>
+      <calcite-tooltip-manager>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const tooltip = await page.find("calcite-tooltip");
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+
+    await referenceElement.focus();
+
+    await referenceElement.hover();
+
+    await page.waitFor(TOOLTIP_DELAY_MS);
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(true);
+
+    await page.keyboard.press("Escape");
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+  });
 });

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -91,7 +91,89 @@ describe("calcite-tooltip-manager", () => {
     expect(await tooltip.getProperty("open")).toBe(false);
   });
 
-  it("should honor tooltips closing with ESC key", async () => {
+  it("tooltip should remain open after hover + focus, then only focus", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `
+      <button id="test">test</button>
+      <calcite-tooltip-manager>
+        <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
+        <button id="ref">Button</button>
+      <calcite-tooltip-manager>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const tooltip = await page.find("calcite-tooltip");
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+
+    await referenceElement.hover();
+
+    await page.waitFor(TOOLTIP_DELAY_MS);
+
+    await referenceElement.focus();
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(true);
+
+    const testElement = await page.find("#test");
+
+    await testElement.hover();
+
+    await page.waitFor(TOOLTIP_DELAY_MS);
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(true);
+  });
+
+  it("tooltip should remain open after hover + focus, then only hover", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `
+      <button id="test">test</button>
+      <calcite-tooltip-manager>
+        <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
+        <button id="ref">Button</button>
+      <calcite-tooltip-manager>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const tooltip = await page.find("calcite-tooltip");
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+
+    await referenceElement.hover();
+
+    await page.waitFor(TOOLTIP_DELAY_MS);
+
+    await referenceElement.focus();
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(true);
+
+    const testElement = await page.find("#test");
+
+    await testElement.focus();
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(true);
+  });
+
+  it("should honor focused tooltip closing with ESC key", async () => {
     const page = await newE2EPage();
 
     await page.setContent(
@@ -118,6 +200,43 @@ describe("calcite-tooltip-manager", () => {
     expect(await tooltip.getProperty("open")).toBe(true);
 
     await referenceElement.press("Escape");
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+  });
+
+  it("should honor hovered tooltip closing with ESC key", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `
+      <calcite-tooltip-manager>
+        <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
+        <button id="ref">Button</button>
+      <calcite-tooltip-manager>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const tooltip = await page.find("calcite-tooltip");
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+
+    await referenceElement.hover();
+
+    await page.waitFor(TOOLTIP_DELAY_MS);
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(true);
+
+    await page.keyboard.press("Escape");
+
+    await page.waitForChanges();
 
     expect(await tooltip.getProperty("open")).toBe(false);
   });

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -61,14 +61,16 @@ export class CalciteTooltipManager {
     tooltip: HTMLCalciteTooltipElement;
     value: boolean;
   }): void => {
+    this.focusedReferenceEl = value ? referenceEl : null;
+
     if (tooltip === this.hoveredTooltipEl) {
       this.hoveredTooltipEl = null;
       this.clearTooltipTimeout(tooltip);
+      this.toggleFocusedTooltip(tooltip, value);
+      return;
     }
 
     const { hoveredTooltipEl, hoveredReferenceEl } = this;
-
-    this.focusedReferenceEl = value ? referenceEl : null;
 
     if (referenceEl === hoveredReferenceEl || tooltip === hoveredTooltipEl) {
       return;

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -61,14 +61,12 @@ export class CalciteTooltipManager {
     tooltip: HTMLCalciteTooltipElement;
     value: boolean;
   }): void => {
-    const { hoveredTooltipEl, hoveredReferenceEl } = this;
-
-    if (tooltip === hoveredTooltipEl) {
-      this.clearTooltipTimeout(hoveredTooltipEl);
+    if (tooltip === this.hoveredTooltipEl) {
       this.hoveredTooltipEl = null;
-      this.hoveredReferenceEl = null;
-      this.focusedTooltipEl = tooltip;
+      this.clearTooltipTimeout(tooltip);
     }
+
+    const { hoveredTooltipEl, hoveredReferenceEl } = this;
 
     this.focusedReferenceEl = value ? referenceEl : null;
 

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -63,9 +63,11 @@ export class CalciteTooltipManager {
   }): void => {
     const { hoveredTooltipEl, hoveredReferenceEl } = this;
 
-    if (tooltip === this.hoveredTooltipEl) {
+    if (tooltip === hoveredTooltipEl) {
+      this.clearTooltipTimeout(hoveredTooltipEl);
       this.hoveredTooltipEl = null;
-      this.clearTooltipTimeout(tooltip);
+      this.hoveredReferenceEl = null;
+      this.focusedTooltipEl = tooltip;
     }
 
     this.focusedReferenceEl = value ? referenceEl : null;
@@ -181,6 +183,7 @@ export class CalciteTooltipManager {
       this.focusedReferenceEl = null;
 
       if (hoveredTooltipEl) {
+        this.clearTooltipTimeout(hoveredTooltipEl);
         this.toggleHoveredTooltip(hoveredTooltipEl, false);
       }
 


### PR DESCRIPTION
**Related Issue:** #1006

## Summary

chore(tooltip): Add unit test for triggering tooltip from combinations of hover/focus #1006

- Also fixes minor issue when pressing escape while having a reference element hovered and focused the tooltip remains open.
