### PR TITLE
fix(calcite-radio-button): fixing issue where input isn't properly initialized in some cases

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -180,10 +180,6 @@ export class CalciteCheckbox {
     if (!scale.includes(this.scale)) this.scale = "m";
   }
 
-  disconnectedCallback() {
-    this.input.parentNode.removeChild(this.input);
-  }
-
   // --------------------------------------------------------------------------
   //
   //  Render Methods

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -180,6 +180,10 @@ export class CalciteCheckbox {
     if (!scale.includes(this.scale)) this.scale = "m";
   }
 
+  disconnectedCallback() {
+    this.input.parentNode.removeChild(this.input);
+  }
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -243,8 +243,8 @@ export class CalciteRadioButton {
   }
 
   disconnectedCallback(): void {
-    this.titleAttributeObserver.disconnect();
     this.input.parentNode.removeChild(this.input);
+    this.titleAttributeObserver.disconnect();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -243,7 +243,6 @@ export class CalciteRadioButton {
   }
 
   disconnectedCallback(): void {
-    this.input.parentNode.removeChild(this.input);
     this.titleAttributeObserver.disconnect();
   }
 
@@ -256,7 +255,7 @@ export class CalciteRadioButton {
   private renderInput() {
     // Rendering a hidden radio input outside Shadow DOM so it can participate in form submissions
     // @link https://www.hjorthhansen.dev/shadow-dom-form-participation/
-    this.input = this.el.ownerDocument.createElement("input");
+    this.input = document.createElement("input");
     this.input.setAttribute("aria-label", this.value || this.guid);
     this.input.checked = this.checked;
     this.input.disabled = this.disabled;
@@ -297,13 +296,13 @@ export class CalciteRadioButton {
     // Rendering a calcite-label outside of Shadow DOM for accessibility and form participation
     this.el.childNodes.forEach((childNode) => {
       if (childNode.nodeName === "#text" && childNode.textContent.trim().length > 0) {
-        this.label = this.el.ownerDocument.createElement("calcite-label");
+        this.label = document.createElement("calcite-label");
         this.label.setAttribute("dir", getElementDir(this.el));
         this.disabled && this.label.setAttribute("disabled", "");
         this.label.setAttribute("for", `${this.guid}-input`);
         this.label.setAttribute("disable-spacing", "");
         this.label.setAttribute("scale", this.scale);
-        this.label.appendChild(this.el.ownerDocument.createTextNode(childNode.textContent.trim()));
+        this.label.appendChild(document.createTextNode(childNode.textContent.trim()));
         childNode.parentNode.replaceChild(this.label, childNode);
       }
     });

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -244,6 +244,7 @@ export class CalciteRadioButton {
 
   disconnectedCallback(): void {
     this.titleAttributeObserver.disconnect();
+    this.input.parentNode.removeChild(this.input);
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-tile-select/calcite-tile-select.tsx
+++ b/src/components/calcite-tile-select/calcite-tile-select.tsx
@@ -151,7 +151,7 @@ export class CalciteTileSelect {
   // --------------------------------------------------------------------------
 
   private renderInput() {
-    this.input = this.el.ownerDocument.createElement(
+    this.input = document.createElement(
       this.type === "radio" ? "calcite-radio-button" : "calcite-checkbox"
     );
     this.input.checked = this.checked;


### PR DESCRIPTION
**Related Issue:** #977

I tested this on a local running instance of `arcgis-webviewer-app` without the workarounds that @kevindoshier was using as a temporary fix and I could not reproduce the bug, which consisted of unrendered input tags that correspond to each radio the second (and all subsequent) time(s) that the Map properties time slider options panel was opened.

Kevin wasn't able to verify these fixes on his local copy, but despite that these fixes make sense to commit anyway because it makes radio and checkbox more consistent with how all other calcite components create input elements.  We'll see once this makes it into a release and the webviewer can update calcite to see if this truly fixes the problem.