### PR TITLE
fix(dropdown): Adjust display of slotted full width buttons

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -1,6 +1,7 @@
 :host {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  flex-grow: 1;
 }
 
 // disabled styles
@@ -37,7 +38,7 @@
 
 .calcite-dropdown-trigger-container {
   position: relative;
-  display: inline-block;
+  width: 100%;
 }
 
 // width

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -10,8 +10,20 @@
     .demo-background-dark {
       background: #202020;
       color: white;
+      display: flex;
       padding: 1rem;
     }
+
+    .test-width-container {
+      border: 1px dashed blue;
+      display: flex;
+      flex: 0;
+    }
+
+    .test-width-container calcite-dropdown {
+      border: 1px dashed red;
+    }
+
   </style>
   <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="../build/calcite.css" />
@@ -76,11 +88,11 @@
     <h3>Disabled dropdown</h3>
     <calcite-dropdown disabled>
       <calcite-button slot="dropdown-trigger">Disabled dropdown</calcite-button>
-        <calcite-dropdown-group group-title="View">
-          <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
-          <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
-          <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
-        </calcite-dropdown-group>
+      <calcite-dropdown-group group-title="View">
+        <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
     </calcite-dropdown>
     <br />
     <br />
@@ -410,6 +422,42 @@
         <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
+  </div>
+
+  <h3>Full width slotted button</h3>
+
+  <div class="test-width-container">
+    <calcite-dropdown>
+      <calcite-button width="full" slot="dropdown-trigger">Scale S small</calcite-button>
+      <calcite-dropdown-group group-title="View">
+        <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+  </div>
+
+  <div class="test-width-container">
+    <calcite-dropdown>
+      <calcite-button width="half" slot="dropdown-trigger">Scale S small</calcite-button>
+      <calcite-dropdown-group group-title="View">
+        <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+  </div>
+
+  <div class="test-width-container">
+    <calcite-dropdown>
+      <calcite-button slot="dropdown-trigger">Scale S small</calcite-button>
+      <calcite-dropdown-group group-title="View">
+        <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+    some text
   </div>
 </body>
 


### PR DESCRIPTION
**Related Issue:** Resolves https://github.com/Esri/calcite-components/issues/1012

## Summary
This should restore the functionality that was in the example in the linked issue above in v38. @asangma can you confirm this doesn't break anything layout-wise?


<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
