### PR TITLE
fix(calcite-radio-button, calcite-checkbox): no longer fires custom change event when the checked attribute is controlled

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
@@ -61,6 +61,19 @@ describe("calcite-checkbox", () => {
     expect(changeEvent).toHaveReceivedEventTimes(1);
   });
 
+  it("doesn't emit when controlling checked attribute", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-checkbox value='test-value'></calcite-checkbox>");
+    const element = await page.find("calcite-checkbox");
+    const spy = await element.spyOnEvent("calciteCheckboxChange");
+
+    await element.setProperty("checked", true);
+    await page.waitForChanges();
+    await element.setProperty("checked", false);
+    await page.waitForChanges();
+    expect(spy).toHaveReceivedEventTimes(0);
+  });
+
   it("does not toggle when clicked if disabled", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-checkbox disabled></calcite-checkbox>");

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -38,7 +38,6 @@ export class CalciteCheckbox {
 
   @Watch("checked") checkedWatcher(newChecked: boolean) {
     newChecked ? this.input.setAttribute("checked", "") : this.input.removeAttribute("checked");
-    this.calciteCheckboxChange.emit();
   }
 
   /** The hovered state of the checkbox. */
@@ -53,7 +52,6 @@ export class CalciteCheckbox {
     } else {
       this.input.blur();
     }
-    this.calciteCheckboxFocusedChange.emit();
   }
 
   /** The id attribute of the checkbox.  When omitted, a globally unique identifier is used. */
@@ -117,6 +115,7 @@ export class CalciteCheckbox {
       this.checked = !this.checked;
       this.focused = true;
       this.indeterminate = false;
+      this.calciteCheckboxChange.emit();
     }
   };
 
@@ -167,6 +166,16 @@ export class CalciteCheckbox {
     this.hovered = false;
   }
 
+  private onInputBlur() {
+    this.focused = false;
+    this.calciteCheckboxFocusedChange.emit();
+  }
+
+  private onInputFocus() {
+    this.focused = true;
+    this.calciteCheckboxFocusedChange.emit();
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -196,8 +205,8 @@ export class CalciteCheckbox {
     this.input.disabled = this.disabled;
     this.input.id = `${this.guid}-input`;
     this.input.name = this.name;
-    this.input.onblur = () => (this.focused = false);
-    this.input.onfocus = () => (this.focused = true);
+    this.input.onblur = this.onInputBlur.bind(this);
+    this.input.onfocus = this.onInputFocus.bind(this);
     this.input.style.opacity = "0";
     this.input.style.position = "absolute";
     this.input.style.zIndex = "-1";

--- a/src/components/calcite-radio-button/calcite-radio-button.e2e.ts
+++ b/src/components/calcite-radio-button/calcite-radio-button.e2e.ts
@@ -300,7 +300,22 @@ describe("calcite-radio-button", () => {
     expect(checkedItems).toHaveLength(0);
   });
 
-  it("emits when checked", async () => {
+  it("appropriately triggers the custom change event", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-radio-button></calcite-radio-button>`);
+
+    const radio = await page.find("calcite-radio-button");
+
+    const changeEvent = await radio.spyOnEvent("calciteRadioButtonChange");
+
+    expect(changeEvent).toHaveReceivedEventTimes(0);
+
+    await radio.click();
+
+    expect(changeEvent).toHaveReceivedEventTimes(1);
+  });
+
+  it("doesn't emit when controlling checked attribute", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-radio-button value='test-value'></calcite-radio-button>");
     const element = await page.find("calcite-radio-button");
@@ -310,7 +325,7 @@ describe("calcite-radio-button", () => {
     await page.waitForChanges();
     await element.setProperty("checked", false);
     await page.waitForChanges();
-    expect(spy).toHaveReceivedEventTimes(2);
+    expect(spy).toHaveReceivedEventTimes(0);
   });
 
   it("is un-checked by default", async () => {

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -42,7 +42,6 @@ export class CalciteRadioButton {
       this.uncheckOtherRadioButtonsInGroup();
     }
     this.input.checked = newChecked;
-    this.calciteRadioButtonChange.emit();
   }
 
   /** The disabled state of the radio button. */
@@ -63,7 +62,6 @@ export class CalciteRadioButton {
     } else {
       this.input.blur();
     }
-    this.calciteRadioButtonFocusedChange.emit();
   }
 
   /** The id attribute of the radio button.  When omitted, a globally unique identifier is used. */
@@ -197,6 +195,7 @@ export class CalciteRadioButton {
       this.uncheckOtherRadioButtonsInGroup();
       this.checked = true;
       this.focused = true;
+      this.calciteRadioButtonChange.emit();
     }
   }
 
@@ -212,10 +211,12 @@ export class CalciteRadioButton {
 
   private onInputBlur() {
     this.focused = false;
+    this.calciteRadioButtonFocusedChange.emit();
   }
 
   private onInputFocus() {
     this.focused = true;
+    this.calciteRadioButtonFocusedChange.emit();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -81,6 +81,19 @@ describe("calcite-switch", () => {
     expect(changeEvent).toHaveFirstReceivedEventDetail({ switched: true });
   });
 
+  it("doesn't emit when controlling switched attribute", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-switch></calcite-switch>");
+    const element = await page.find("calcite-switch");
+    const spy = await element.spyOnEvent("calciteSwitchChange");
+
+    await element.setProperty("switched", true);
+    await page.waitForChanges();
+    await element.setProperty("switched", false);
+    await page.waitForChanges();
+    expect(spy).toHaveReceivedEventTimes(0);
+  });
+
   it("does not toggle when disabled", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-switch disabled></calcite-switch>`);


### PR DESCRIPTION
**Related Issue:** #975 

This change updates the custom change event behavior to match that of similar components like `calcite-switch` where the custom change event is only emitted when the component is "clicked" either programmatically (with `element.click()`) or actual user clicks from the mouse or keyboard.  When the `checked` attribute is controlled directly, this custom change event no longer fires because it was causing infinite loop issues.
