### PR TITLE
feat(dropdown): Update styling of dropdown groups

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -27,3 +27,11 @@
   cursor: default;
   @include font-size(-2);
 }
+
+:host .dropdown-separator {
+  display: block;
+  margin: 0;
+  height: 1px;
+  top: 1px;
+  background-color: var(--calcite-ui-border-3);
+}

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -67,8 +67,12 @@ export class CalciteDropdownGroup {
       </span>
     ) : null;
 
+    const dropdownseparator =
+      this.groupPosition !== 0 ? <div class="dropdown-separator" role="separator" /> : null;
+
     return (
       <Host>
+        {dropdownseparator}
         {groupTitle}
         <slot />
       </Host>

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -284,10 +284,11 @@ export class CalciteDropdown {
   @Listen("calciteDropdownGroupRegister")
   registerCalciteDropdownGroup(e: CustomEvent<GroupRegistration>): void {
     const {
-      detail: { items, position, titleEl }
+      detail: { group, items, position, titleEl }
     } = e;
 
     this.items.push({
+      group,
       items,
       position,
       titleEl
@@ -432,17 +433,24 @@ export class CalciteDropdown {
     const { maxItems } = this;
     let itemsToProcess = 0;
     let maxScrollerHeight = 0;
+    let borderHeight = 0;
 
     groups.forEach((group) => {
       if (maxItems > 0 && itemsToProcess < maxItems) {
-        maxScrollerHeight += group?.titleEl?.offsetHeight || 0;
-
         group.items.forEach((item) => {
           if (itemsToProcess < maxItems) {
             maxScrollerHeight += item.offsetHeight;
             itemsToProcess += 1;
           }
         });
+
+        const separatorEl = group?.group?.shadowRoot.querySelector(
+          ".dropdown-separator"
+        ) as HTMLElement;
+
+        borderHeight = group?.position !== 0 ? separatorEl?.offsetHeight : 0;
+        maxScrollerHeight += group?.titleEl?.offsetHeight || 0;
+        maxScrollerHeight = maxScrollerHeight + borderHeight;
       }
     });
 


### PR DESCRIPTION
**Related Issue:** Resolves #1022 cc @TheBlueDog 

@jcfranco I had to make some changes so the test for scrolling height would pass, basically adding the height of the divider to the max height, can you 👀 at that... seems like a lot but 🤷‍♂️ 

## Summary
Adds a full-width border between calcite-dropdown-groups. Keeps the indentation for groups with titles to better associate with the dropdown items beneath.

Some examples:
<img width="200" alt="Screen Shot 2020-09-22 at 8 23 38 PM" src="https://user-images.githubusercontent.com/4733155/93963766-e87d8400-fd12-11ea-97c1-ab740b8f78d4.png">
<img width="200" alt="Screen Shot 2020-09-22 at 8 23 10 PM" src="https://user-images.githubusercontent.com/4733155/93963768-e9161a80-fd12-11ea-8b25-cf364a6eeb12.png">
<img width="200" alt="Screen Shot 2020-09-22 at 8 21 42 PM" src="https://user-images.githubusercontent.com/4733155/93963770-e9aeb100-fd12-11ea-9e90-eb92bafca7fc.png">



<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
