### PR TITLE
fix(pagination): prev/next disabled, page 1 shown

### DIFF
--- a/src/components/calcite-pagination/calcite-pagination.e2e.ts
+++ b/src/components/calcite-pagination/calcite-pagination.e2e.ts
@@ -134,4 +134,36 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(2);
     });
   });
+  describe("showing one item at a time", () => {
+    let page: E2EPage;
+    let pagination: E2EElement;
+    beforeEach(async () => {
+      page = await newE2EPage();
+      await page.setContent(`<calcite-pagination start="1" total="5" num="1"></calcite-pagination>`);
+      pagination = await page.find("calcite-pagination");
+    });
+    it("should show the first page", async () => {
+      const selectedPage = await page.find(`calcite-pagination >>> .${CSS.page}.${CSS.selected}`);
+      expect(selectedPage.innerText).toBe("1");
+    });
+    it("previous button should be disabled when selected page equals the starting page", async () => {
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const previousButton = await page.find(`calcite-pagination >>> .${CSS.previous}`);
+      await previousButton.click();
+      await page.waitForChanges();
+
+      expect(toggleSpy).toHaveReceivedEventTimes(0);
+    });
+    it("next button should be disabled on last page", async () => {
+      await pagination.setAttribute("start", "5");
+      await page.waitForChanges();
+
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const nextButton = await page.find(`calcite-pagination >>> .${CSS.next}`);
+      await nextButton.click();
+      await page.waitForChanges();
+
+      expect(toggleSpy).toHaveReceivedEventTimes(0);
+    });
+  });
 });

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -165,7 +165,8 @@ export class CalcitePagination {
   }
 
   renderPage(start: number): VNode {
-    const page = Math.floor(start / this.num) + 1;
+    let page = Math.floor(start / this.num) + 1;
+    if (this.num === 1) page--;
     return (
       <button
         class={{
@@ -205,15 +206,17 @@ export class CalcitePagination {
   render(): VNode {
     const { total, num, start } = this;
     const iconScale = this.scale === "l" ? "m" : "s";
+    const prevDisabled = num === 1 ? start <= num : start < num;
+    const nextDisabled = num === 1 ? start + num > total : start + num >= total;
     return (
       <Host>
         <button
           aria-label={this.textLabelPrevious}
           class={{
             [CSS.previous]: true,
-            [CSS.disabled]: start < num
+            [CSS.disabled]: prevDisabled
           }}
-          disabled={start < num}
+          disabled={prevDisabled}
           onClick={this.previousClicked}
         >
           <calcite-icon icon="chevronLeft" scale={iconScale} />
@@ -227,9 +230,9 @@ export class CalcitePagination {
           aria-label={this.textLabelNext}
           class={{
             [CSS.next]: true,
-            [CSS.disabled]: start + num >= total
+            [CSS.disabled]: nextDisabled
           }}
-          disabled={start + num >= total}
+          disabled={nextDisabled}
           onClick={this.nextClicked}
         >
           <calcite-icon icon="chevronRight" scale={iconScale} />

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -165,8 +165,7 @@ export class CalcitePagination {
   }
 
   renderPage(start: number): VNode {
-    let page = Math.floor(start / this.num) + 1;
-    if (this.num === 1) page--;
+    const page = Math.floor(start / this.num) + (this.num === 1 ? 0 : 1);
     return (
       <button
         class={{

--- a/src/demos/calcite-pagination.html
+++ b/src/demos/calcite-pagination.html
@@ -77,6 +77,14 @@
     <calcite-pagination total="1200" num="100" start="1101"></calcite-pagination>
   </div>
 
+  <h2>One per page</h2>
+  <div class="demo-spaced">
+    <calcite-pagination total="5" num="1" start="1"></calcite-pagination>
+  </div>
+  <div class="demo-spaced">
+    <calcite-pagination total="15" num="1" start="1"></calcite-pagination>
+  </div>
+
   <h2>Scales</h2>
   <h3>S</h3>
   <div class="demo-spaced">


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/833

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
When `calcite-pagination`'s `num` attribute was set to `1`, the logic was off:
- for rendering the current page (showed `2` when `start=1`)
- which left the "previous" button visibly enabled but non-functional,
- and rendered one more page than necessary

<img width="469" alt="image" src="https://user-images.githubusercontent.com/1634397/94178312-ecbbb580-fe68-11ea-9877-60c87b27b799.png">

<img width="466" alt="image" src="https://user-images.githubusercontent.com/1634397/94178340-f80ee100-fe68-11ea-8a8b-1e3b4eaaf9cb.png">


This PR fixes that by specifically accounting for `num === 1`, and adds tests and demos. Let me know what I missed!