### PR TITLE
ci(github): enable milestone-updating GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: "main"
+on:
+  release:
+    types: [released]
+jobs:
+  move_to_next_milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: move to next milestone
+        uses: jcfranco/actions-milestone-sync@b228ad2d9631d8a84fed3cd8d67e58c5fc9cf6db
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This adds a custom workflow for updating issues/PRs after a release. It references a custom action (see https://github.com/jcfranco/actions-milestone-sync) that will:

1. create a new beta milestone
2. update all open PRs/issues to ☝
3. close the milestone associated with the release

**Note**: all milestones were renamed from `🔨 v1-beta.<x>`/`📦 v1-beta.<x>` to `v1.0.0-beta.<x>` to make labels easier to work with in Scriptland (the scriptiest place on Earth™).



