### PR TITLE
test(modal): fix context type for exposed function

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -66,7 +66,7 @@ describe("calcite-modal properties", () => {
     `);
     const modal = await page.find("calcite-modal");
     await page.$eval("calcite-modal", (elm: any) => {
-      elm.beforeClose = this.beforeClose;
+      elm.beforeClose = (window as typeof window & { beforeClose: () => void }).beforeClose;
     });
     await page.waitForChanges();
     await modal.setProperty("active", true);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

`beforeClose` is exposed on `window` and not the test (context of `this`).