### PR TITLE
fix(color): initial user-defined value (prop) gets set properly

### DIFF
--- a/src/components/calcite-color/calcite-color.e2e.ts
+++ b/src/components/calcite-color/calcite-color.e2e.ts
@@ -214,6 +214,40 @@ describe("calcite-color", () => {
     expect(await picker.getProperty("color")).toBeTruthy();
   });
 
+  describe.only("initial value used to initialize internal color", () => {
+    const initialColor = "#c0ff33";
+
+    async function getInternalColorAsHex(page: E2EPage): Promise<string> {
+      return page.$eval("calcite-color", (picker: HTMLCalciteColorElement) => picker.color.hex().toLowerCase());
+    }
+
+    it("value as attribute", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-color value="${initialColor}"></calcite-color>`
+      });
+
+      expect(await getInternalColorAsHex(page)).toBe(initialColor);
+    });
+
+    it("value as property", async () => {
+      // initialize page with calcite-color to make it available in the evaluate callback below
+      const page = await newE2EPage({
+        html: "<calcite-color></calcite-color>"
+      });
+      await page.setContent("");
+
+      await page.evaluate(async (color) => {
+        const picker = document.createElement<HTMLCalciteColorElement>("calcite-color");
+        picker.value = color;
+        document.body.append(picker);
+
+        await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      }, initialColor);
+
+      expect(await getInternalColorAsHex(page)).toBe(initialColor);
+    });
+  });
+
   // skipping until https://github.com/Esri/calcite-components/issues/928 is addressed
   describe.skip("color inputs", () => {
     // tests for all individual inputs takes longer than the default

--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -28,6 +28,7 @@ import { colorEqual, CSSColorMode, normalizeHex, parseMode, SupportedMode } from
 import { throttle } from "lodash-es";
 
 const throttleFor60FpsInMs = 16;
+const defaultColor = normalizeHex(DEFAULT_COLOR.hex());
 
 @Component({
   tag: "calcite-color",
@@ -174,7 +175,7 @@ export class CalciteColor {
   @Prop({
     mutable: true
   })
-  value: ColorValue = normalizeHex(DEFAULT_COLOR.hex());
+  value: ColorValue = defaultColor;
 
   @Watch("value")
   handleValueChange(value: ColorValue, oldValue: ColorValue): void {
@@ -333,11 +334,7 @@ export class CalciteColor {
       this.savedColors = JSON.parse(localStorage.getItem(storageKey));
     }
 
-    const valueAttr = this.el.getAttribute("value");
-    if (valueAttr) {
-      this.handleValueChange(valueAttr, this.value);
-    }
-
+    this.handleValueChange(this.value, defaultColor);
     this.updateDimensions(this.scale);
   }
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

The current initialization logic for `calcite-color` ignores the initial color value when set as a property. This is very noticeable whenever the component is initialized by a VDOM library that relies on props and not attributes (e.g., Stencil, maquette).