### PR TITLE
fix(date): allow 3 digit years in input #905

### DIFF
--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -8,7 +8,6 @@ describe("calcite-date", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-date></calcite-date>");
     const input = await page.find("calcite-date >>> calcite-input");
-    await page.waitForChanges();
     const changedEvent = await page.spyOnEvent("calciteDateChange");
     await input.callMethod("setFocus");
     // have to wait for transition
@@ -21,10 +20,12 @@ describe("calcite-date", () => {
     await input.press("7");
     await input.press("/");
     await input.press("2");
-    await input.press("0");
-    await input.press("2");
-    await input.press("0");
-    await page.waitForChanges();
     expect(changedEvent).toHaveReceivedEventTimes(1);
+    await input.press("0");
+    expect(changedEvent).toHaveReceivedEventTimes(2);
+    await input.press("2");
+    expect(changedEvent).toHaveReceivedEventTimes(3);
+    await input.press("0");
+    expect(changedEvent).toHaveReceivedEventTimes(4);
   });
 });

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -332,9 +332,10 @@ export class CalciteDate {
     const validDay = day > 0;
     const validMonth = month > -1;
     const date = new Date(year, month, day);
+    date.setFullYear(year);
     const validDate = !isNaN(date.getTime());
     const validLength = value.split(separator).filter((c) => c).length > 2;
-    const validYear = year.toString().length > 3;
+    const validYear = year.toString().length > 0;
     if (
       validDay &&
       validMonth &&


### PR DESCRIPTION
**Related Issue:** #905

## Summary

Due to peculiarities in how the `new Date()` function works, two digit dates are turned into four digits with `19` preceding the date you entered. This caused issues where you'd start typing a year and the input would change what you were typing to `1920`. To get around this, we were only allowing years with 4 digits. 

I've found a better way to ensure the year is correct and not converted to 19XX, so I'm removing the 4 digit requirement. 