### PR TITLE
fix(date): fire date change on interactions with calcite-date-month-header element

### DIFF
--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -109,7 +109,7 @@ export class CalciteDateMonthHeader {
                 }}
                 inputmode="numeric"
                 maxlength="4"
-                minlength="4"
+                minlength="1"
                 onChange={(event) => this.setYear((event.target as HTMLInputElement).value)}
                 onKeyDown={(event) => this.onYearKey(event)}
                 pattern="\d*"
@@ -181,7 +181,7 @@ export class CalciteDateMonthHeader {
     const inRange =
       year && (!min || min.getFullYear() <= year) && (!max || max.getFullYear() >= year);
     // if you've supplied a year and it's in range, update active date
-    if (year && inRange && length === localizedYear.length && length > 3) {
+    if (year && inRange && length === localizedYear.length) {
       const nextDate = new Date(activeDate);
       nextDate.setFullYear(year as number);
       const inRangeDate = dateFromRange(nextDate, min, max);

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -28,4 +28,26 @@ describe("calcite-date", () => {
     await input.press("0");
     expect(changedEvent).toHaveReceivedEventTimes(4);
   });
+
+  it("fires a calciteDateChange event when changing year in header", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-date value='2000-11-27'></calcite-date>");
+    const date = await page.find("calcite-date");
+    const input = await page.find("calcite-date >>> calcite-input");
+    const changedEvent = await page.spyOnEvent("calciteDateChange");
+    await input.callMethod("setFocus");
+    // have to wait for transition
+    await new Promise((res) => setTimeout(() => res(true), 200));
+    // can't find this input as it's deeply nested in shadow dom, so just tab to it
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("ArrowUp");
+    expect(changedEvent).toHaveReceivedEventTimes(1);
+    const value = await date.getProperty("value");
+    expect(value).toEqual("2001-11-27");
+    await page.keyboard.press("ArrowDown");
+    const value2 = await date.getProperty("value");
+    expect(value2).toEqual("2000-11-27");
+    expect(changedEvent).toHaveReceivedEventTimes(2);
+  });
 });

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -161,7 +161,9 @@ export class CalciteDate {
               max={max}
               min={min}
               onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
+                this.setValue(new Date(e.detail));
                 this.activeDate = new Date(e.detail);
+                this.calciteDateChange.emit(new Date(e.detail));
               }}
               scale={this.scale}
               selectedDate={date || new Date()}


### PR DESCRIPTION
**Related Issue:** #1017

## Summary

Firing calcite date change event when year and month left/right buttons are interacted with. Also allowing shorter years now as we're handling them elsewhere.