### PR TITLE
fix(input): Accept strings for min, max, step

### DIFF
--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -9,7 +9,7 @@ storiesOf("Components/Input", module)
   .add(
     "With Label",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     >
@@ -48,7 +48,7 @@ storiesOf("Components/Input", module)
   .add(
     "With Label and Input Message",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-label
     status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
     scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
@@ -88,7 +88,7 @@ storiesOf("Components/Input", module)
   .add(
     "Without Label",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-input
       scale="${select("scale", ["s", "m", "l"], "m")}"
       status="${select("status", ["idle", "valid", "invalid"], "idle")}"
@@ -118,7 +118,7 @@ storiesOf("Components/Input", module)
   .add(
     "With Slotted Action",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     >
@@ -158,7 +158,7 @@ storiesOf("Components/Input", module)
   .add(
     "Textarea",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}">
     ${text("label text", "My great label")}
     <calcite-input
@@ -183,7 +183,7 @@ storiesOf("Components/Input", module)
   .add(
     "Simple - Dark mode",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-label theme="dark" status="${select("status", ["idle", "valid", "invalid"], "idle")}">
     ${text("label text", "My great label")}
     <calcite-input

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -60,7 +60,7 @@ export class CalciteInput {
   @Prop({ reflect: true }) loading = false;
 
   /** input max */
-  @Prop({ reflect: true }) max?: number;
+  @Prop({ reflect: true }) max?: number | string;
 
   /** watcher to update number-to-string for max */
   @Watch("max")
@@ -69,7 +69,7 @@ export class CalciteInput {
   }
 
   /** input min */
-  @Prop({ reflect: true }) min?: number;
+  @Prop({ reflect: true }) min?: number | string;
 
   /** watcher to update number-to-string for min */
   @Watch("min")
@@ -96,7 +96,7 @@ export class CalciteInput {
   @Prop({ reflect: true }) status: "invalid" | "valid" | "idle" = "idle";
 
   /** input step */
-  @Prop({ reflect: true }) step?: number;
+  @Prop({ reflect: true }) step?: number | string;
 
   @Watch("step")
   stepWatcher(): void {


### PR DESCRIPTION
This fixes the issue of the Storybook not loading this component, but I'm curious if this is a reasonable approach, it seems like it could benefit other implementation environments. Since we have watchers to convert these prop values to strings anyway, it seems like the initial value should be accepted as such as well?

The reason for not using "number" type of knob in Storybook is that it must have a value by default, so a Story with min / max / step set to 0 is a bit awkward. Thoughts on this @Esri/calcite-components 


Also updates a bit of formatting on input Storybook.
## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
