### PR TITLE
fix(date): don't fire event on outside value update (#722)

### DIFF
--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -50,4 +50,13 @@ describe("calcite-date", () => {
     expect(value2).toEqual("2000-11-27");
     expect(changedEvent).toHaveReceivedEventTimes(2);
   });
+
+  it("doesn't fire calciteDateChange on outside changes to value", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-date value='2000-11-27'></calcite-date>");
+    const date = await page.find("calcite-date");
+    const changedEvent = await page.spyOnEvent("calciteDateChange");
+    await date.setProperty("value", "2001-10-28");
+    expect(changedEvent).toHaveReceivedEventTimes(0);
+  });
 });

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -115,6 +115,9 @@ export class CalciteDate {
   connectedCallback(): void {
     this.setupProxyInput();
     this.loadLocaleData();
+    if (this.value) {
+      this.setValueAsDate(this.value);
+    }
   }
 
   componentWillRender(): void {
@@ -210,6 +213,10 @@ export class CalciteDate {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+  @Watch("value") validateValue(value: string): void {
+    this.setValueAsDate(value);
+  }
+
   @Watch("locale")
   private async loadLocaleData(): Promise<void> {
     const { locale } = this;
@@ -252,8 +259,7 @@ export class CalciteDate {
     const min = dateFromISO(this.min);
     const max = dateFromISO(this.max);
     const date = dateFromISO(this.inputProxy.value);
-    this.valueAsDate = dateFromRange(date, min, max);
-    this.value = dateToISO(this.valueAsDate);
+    this.value = dateToISO(dateFromRange(date, min, max));
   };
 
   /**
@@ -275,9 +281,20 @@ export class CalciteDate {
    * Set both iso value and date value and update proxy
    */
   private setValue(date: Date): void {
-    this.valueAsDate = new Date(date);
-    this.value = date.toISOString().split("T")[0];
+    this.value = new Date(date).toISOString().split("T")[0];
     this.syncProxyInputToThis();
+  }
+
+  /**
+   * Update date instance of value if valid
+   */
+  private setValueAsDate(value: string): void {
+    if (value) {
+      const date = dateFromISO(value);
+      if (date) {
+        this.valueAsDate = date as Date;
+      }
+    }
   }
 
   /**

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -213,7 +213,7 @@ export class CalciteDate {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
-  @Watch("value") validateValue(value: string): void {
+  @Watch("value") valueWatcher(value: string): void {
     this.setValueAsDate(value);
   }
 

--- a/src/demos/calcite-date.html
+++ b/src/demos/calcite-date.html
@@ -128,6 +128,17 @@
     <input type="date" value="2000-11-27" min="1999-12-02" max="2020-12-02">
   </calcite-date>
 
+  <h2>Set Value</h2>
+  <calcite-button id="dynamic-button">Set value of date input</calcite-button>
+  <calcite-date id="dynamic-value" value="2000-11-27"></calcite-date>
+  <script>
+    var dynamicDate = document.getElementById("dynamic-value");
+    document.getElementById("dynamic-button").addEventListener("click", function () {
+      console.log("setting value");
+      document.getElementById("dynamic-value").value = "2020-10-02";
+    });
+  </script>
+
   <h2>Events</h2>
   <calcite-date id="dateSample"></calcite-date>
   <p>Date selected: <pre><code id="dateDisplay">n/a</code></pre></p>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -40,6 +40,7 @@ export function dateFromISO(iso8601: string): Date | null {
   }
   const d = iso8601.split(/[: T-]/).map(parseFloat);
   const date = new Date(d[0], (d[1] || 1) - 1, d[2] || 1);
+  date.setFullYear(d[0]);
   if (isNaN(date.getTime())) {
     throw new Error(`Invalid ISO 8601 date: "${iso8601}"`);
   }


### PR DESCRIPTION
**Related Issue:** #722

## Summary

When updating the value of the `calcite-date` element, we were always firing the `calciteDateChange` event. This led to devs having to handle infinite loops of `event => app state => value => event`.