### PR TITLE
test(date): attempt to make date tests more consistent on travis

### DIFF
--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -31,11 +31,9 @@ describe("calcite-date", () => {
 
   it("fires a calciteDateChange event when changing year in header", async () => {
     const page = await newE2EPage();
-    await page.setContent("<calcite-date value='2000-11-27'></calcite-date>");
+    await page.setContent("<calcite-date value='2000-11-27' no-calendar-input active></calcite-date>");
     const date = await page.find("calcite-date");
-    const input = await page.find("calcite-date >>> calcite-input");
     const changedEvent = await page.spyOnEvent("calciteDateChange");
-    await input.callMethod("setFocus");
     // have to wait for transition
     await new Promise((res) => setTimeout(() => res(true), 200));
     // can't find this input as it's deeply nested in shadow dom, so just tab to it


### PR DESCRIPTION
## Summary

Seems like there may be a problem in travis using the shadow-piercing selector to get an interactive element.