### PR TITLE
feat(tile-select-group): add layout prop for vertical tile select

### DIFF
--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.e2e.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.e2e.ts
@@ -1,0 +1,12 @@
+import { accessible, defaults, reflects, renders } from "../../tests/commonTests";
+
+describe("calcite-tile-select-group", () => {
+  it("renders", async () => renders("calcite-tile-select-group"));
+
+  it("is accessible", async () => accessible(`<calcite-tile-select-group></calcite-tile-select-group>`));
+
+  it("has defaults", async () =>
+    defaults("calcite-tile-select-group", [{ propertyName: "layout", defaultValue: "horizontal" }]));
+
+  it("reflects", async () => reflects("calcite-tile-select-group", [{ propertyName: "layout", value: "horizontal" }]));
+});

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.scss
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.scss
@@ -6,3 +6,7 @@
     margin-bottom: 1px;
   }
 }
+
+:host([layout="vertical"]) {
+  flex-direction: column;
+}

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, VNode } from "@stencil/core";
+import { Component, Host, h, VNode, Prop } from "@stencil/core";
 
 @Component({
   tag: "calcite-tile-select-group",
@@ -6,6 +6,14 @@ import { Component, Host, h, VNode } from "@stencil/core";
   shadow: true
 })
 export class CalciteTileSelectGroup {
+  //--------------------------------------------------------------------------
+  //
+  //  Properties
+  //
+  //--------------------------------------------------------------------------
+  /** Tiles by default move horizontally, stacking with each row, vertical allows single-column layouts */
+  @Prop({ reflect: true }) layout?: "vertical" | "horizontal" = "horizontal";
+
   render(): VNode {
     return (
       <Host>

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -636,6 +636,44 @@
                       </calcite-tile-select>
                     </div>
 
+                    <h3>Vertical Layout</h3>
+                    <div>
+                      <calcite-tile-select-group layout="vertical">
+                        <calcite-tile-select checked theme="dark" icon="layers" name="left-radio-dark" value="one"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="two"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="three"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="four"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="five"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="six"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="seven"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                        <calcite-tile-select theme="dark" icon="layers" name="left-radio-dark" value="eight"
+                          heading="Tile title lorem ipsum"
+                          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
+                        </calcite-tile-select>
+                      </calcite-tile-select-group>
+                    </div>
+
                     <h3>Left Radio Large Visual</h3>
                     <div>
                       <calcite-tile-select checked theme="dark" icon="layers" name="left-radio-large-visual-dark"


### PR DESCRIPTION
**Related Issue:** #1020

## Summary

Saw issue #1020 about documenting this behavior, but I don't think it was actually possible. I've also added a test suite for the group component as it now has a prop.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
