### PR TITLE
ci(github): update actions-milestone-sync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: move to next milestone
-        uses: jcfranco/actions-milestone-sync@b228ad2d9631d8a84fed3cd8d67e58c5fc9cf6db
+        uses: jcfranco/actions-milestone-sync@aaae6dbebbc68e210ba7cfe31aa588c2c56602bc
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates the milestone-mover GH action with the latest, which fixes an issue where dependencies weren't bundled (as https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-javascript-action#commit-and-push-your-action-to-github indicates).