### PR TITLE
feat(tile-select): add width prop to tiles for full width option

### DIFF
--- a/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
@@ -12,6 +12,7 @@ describe("calcite-tile-select", () => {
       { propertyName: "disabled", defaultValue: false },
       { propertyName: "focused", defaultValue: false },
       { propertyName: "hidden", defaultValue: false },
+      { propertyName: "width", defaultValue: "auto" },
       { propertyName: "theme", defaultValue: "light" }
     ]));
 
@@ -32,6 +33,7 @@ describe("calcite-tile-select", () => {
       { propertyName: "theme", value: "dark" },
       { propertyName: "type", value: "radio" },
       { propertyName: "type", value: "checkbox" },
+      { propertyName: "width", value: "auto" },
       { propertyName: "value", value: "option one" }
     ]));
 

--- a/src/components/calcite-tile-select/calcite-tile-select.scss
+++ b/src/components/calcite-tile-select/calcite-tile-select.scss
@@ -26,6 +26,11 @@ $spacing: $baseline/2;
   z-index: 2;
 }
 
+:host([width="full"]) {
+  max-width: none;
+  display: block;
+}
+
 :host([show-input="none"]) {
   box-shadow: 0 0 0 2px var(--calcite-ui-foreground-1), 0 0 0 3px var(--calcite-ui-border-2);
   margin-right: 1px;

--- a/src/components/calcite-tile-select/calcite-tile-select.tsx
+++ b/src/components/calcite-tile-select/calcite-tile-select.tsx
@@ -56,6 +56,9 @@ export class CalciteTileSelect {
   /** The value of the tile select.  This value will appear in form submissions when this tile select is checked. */
   @Prop({ reflect: true }) value?: string;
 
+  /** specify the width of the tile, defaults to auto */
+  @Prop({ reflect: true }) width: "auto" | "full" = "auto";
+
   //--------------------------------------------------------------------------
   //
   //  Private Properties

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -319,6 +319,34 @@
                       </calcite-tile-select>
                     </div>
 
+                    <h3>Full Width</h3>
+                    <div>
+                      <calcite-tile-select checked width="full" name="basic-heading-only-radio" value="one" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select width="full" name="basic-heading-only-radio" value="two" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select width="full" name="basic-heading-only-radio" value="three" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select width="full" name="basic-heading-only-radio" value="four" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select checked width="full" name="basic-heading-only-radio" value="five" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select width="full" name="basic-heading-only-radio" value="six" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select width="full" name="basic-heading-only-radio" value="seven" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                      <calcite-tile-select width="full" name="basic-heading-only-radio" value="eight" show-input="none"
+                        heading="Tile title lorem ipsum">
+                      </calcite-tile-select>
+                    </div>
+
                     <h3>Left Checkbox</h3>
                     <div>
                       <calcite-tile-select checked icon="layers" name="left-checkbox-one" type="checkbox"


### PR DESCRIPTION
**Related Issue:** #1021

## Summary

We're seeing UI designs with full width tile select UI's quite frequently across the platform. One is referenced in #1021 .

I've added a `width` property (which we've used on other components). Default is `auto` (current behavior of tiles), with new option `full` which will set the tile to fill its parent. This should allow us to keep these UI's consistent with tiles as currently they're implemented as their own special components in all the apps themselves.