### PR TITLE
feat(calcite-shell-panel): adds detached-height-scale property

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -23,10 +23,23 @@
   transition: max-height $transition, max-width $transition;
 }
 
+:host([detached-height-scale="s"]) .content--detached {
+  --calcite-shell-panel-detached-max-height: 40vh;
+}
+
+:host([detached-height-scale="m"]) .content--detached {
+  --calcite-shell-panel-detached-max-height: 60vh;
+}
+
+:host([detached-height-scale="l"]) .content--detached {
+  --calcite-shell-panel-detached-max-height: 80vh;
+}
+
 .content--detached {
   border-radius: var(--calcite-border-radius);
   box-shadow: var(--calcite-shadow-0);
   margin: var(--calcite-spacing-half) var(--calcite-spacing-half) auto;
+  max-height: var(--calcite-shell-panel-detached-max-height);
   overflow: hidden;
   ::slotted(calcite-panel),
   ::slotted(calcite-flow) {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -4,6 +4,8 @@
   align-items: stretch;
   background-color: transparent;
   pointer-events: none;
+
+  --calcite-shell-panel-detached-max-height: unset;
 }
 
 ::slotted(calcite-panel),

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -1,6 +1,6 @@
 import { Component, Event, EventEmitter, Host, Prop, Watch, h, VNode } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
-import { CalcitePosition } from "../interfaces";
+import { CalcitePosition, CalciteScale } from "../interfaces";
 
 /**
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
@@ -32,6 +32,11 @@ export class CalciteShellPanel {
    * This property makes the content area appear like a "floating" panel.
    */
   @Prop({ reflect: true }) detached = false;
+
+  /**
+   * Specifies the maxiumum height of the contents when detached.
+   */
+  @Prop({ reflect: true }) detachedHeightScale: CalciteScale = "l";
 
   /**
    * Arranges the component depending on the elements 'dir' property.

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -118,13 +118,12 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow id="flow">
-              <calcite-panel heading="cool" summary="Popular Demographics in the United States (Beta) - County" width-scale="m" height-scale="l">
+              <calcite-panel heading="cool" summary="Popular Demographics in the United States (Beta) - County" width-scale="m">
                 I'm this panel's content.
               </calcite-panel>
               <calcite-panel
                 heading="Configure popup"
                 summary="Popular Demographics in the United States (Beta) - County"
-                height-scale="l"
                 width-scale="m"
               >
                 <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>


### PR DESCRIPTION
**Related Issue:** #1029 

## Summary
Adds `detached-height-scale` to ShellPanel.

cc @jcfranco 

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
