### PR TITLE
fix(block-section): use expand/collapse tooltips as a section's native tooltip

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -119,6 +119,7 @@ export class CalciteBlockSection {
           id={labelId}
           onKeyDown={this.handleHeaderLabelKeyDown}
           tabIndex={0}
+          title={toggleLabel}
         >
           {text}
           <calcite-switch
@@ -138,6 +139,7 @@ export class CalciteBlockSection {
           onClick={this.toggleSection}
           text={text}
           textEnabled={true}
+          title={toggleLabel}
         />
       );
 


### PR DESCRIPTION
**Related Issue:** #1074

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This uses `intlExpand`/`intlCollapse` for native tooltips on a block section. These were previously only used to set `aria-label`.

I don't know if there's a way to test for this without screenshots, which is still pending (https://github.com/Esri/calcite-components/issues/577).