### PR TITLE
fix(label): prevent calcite-input-message from always showing in disabled label

### DIFF
--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -110,7 +110,7 @@
   ::slotted(*[disabled] *) {
     opacity: 1;
   }
-  ::slotted(*[disabled] calcite-input-message:not([active])) {
+  ::slotted(calcite-input-message:not([active])) {
     opacity: 0;
   }
 }

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -110,6 +110,9 @@
   ::slotted(*[disabled] *) {
     opacity: 1;
   }
+  ::slotted(*[disabled] calcite-input-message:not([active])) {
+    opacity: 0;
+  }
 }
 
 // status

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -294,9 +294,8 @@
 
           <calcite-label disabled>
             Disabled with input message
-            <calcite-input disabled value="Readonly value">
-              <calcite-input-message>This text is not shown until active is set</calcite-input-message>
-            </calcite-input>
+            <calcite-input disabled value="Readonly value"></calcite-input>
+            <calcite-input-message>This text is not shown until active is set</calcite-input-message>
           </calcite-label>
 
           <calcite-label>

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -292,6 +292,13 @@
             </calcite-input>
           </calcite-label>
 
+          <calcite-label disabled>
+            Disabled with input message
+            <calcite-input disabled value="Readonly value">
+              <calcite-input-message>This text is not shown until active is set</calcite-input-message>
+            </calcite-input>
+          </calcite-label>
+
           <calcite-label>
             Disabled textarea
             <calcite-input disabled type="textarea">Disabled value


### PR DESCRIPTION
**Related Issue:** #1050

## Summary

Input message inside a disabled label was always showing (not respecting `active` prop)