### PR TITLE
chore(storybook): fix knob panel to the right

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -2,6 +2,6 @@ import { addons } from "@storybook/addons";
 import theme from "./theme";
 
 addons.setConfig({
-  panelPosition: "bottom",
+  panelPosition: "right",
   theme
 });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Per today's sync-up, this fixes the Storybook knob panel to the right.

<img width="1674" alt="Screen Shot 2020-10-08 at 6 02 26 PM" src="https://user-images.githubusercontent.com/197440/95529773-b0bc4080-0990-11eb-8234-667e4d148d75.png">
