### PR TITLE
chore(storybook): rename app component story titles for consistency

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -7,7 +7,7 @@ const { dir, position, theme } = ATTRIBUTES;
 import { TEXT } from "./resources";
 
 export default {
-  title: "App Components/calcite-action-bar",
+  title: "App Components/Action Bar",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -7,7 +7,7 @@ const { dir, position, theme } = ATTRIBUTES;
 import { TEXT } from "./resources";
 
 export default {
-  title: "App Components/calcite-action-pad",
+  title: "App Components/Action Pad",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-action/calcite-action.stories.ts
+++ b/src/components/calcite-action/calcite-action.stories.ts
@@ -5,7 +5,7 @@ import { ATTRIBUTES } from "../../../.storybook/resources";
 const { appearance, dir, scale, theme } = ATTRIBUTES;
 
 export default {
-  title: "App Components/calcite-action",
+  title: "App Components/Action",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-block/calcite-block.stories.ts
+++ b/src/components/calcite-block/calcite-block.stories.ts
@@ -6,7 +6,7 @@ import { ATTRIBUTES } from "../../../.storybook/resources";
 import dedent from "dedent";
 
 export default {
-  title: "App Components/calcite-block",
+  title: "App Components/Block",
   parameters: {
     backgrounds: darkBackground,
     notes: {

--- a/src/components/calcite-fab/calcite-fab.stories.ts
+++ b/src/components/calcite-fab/calcite-fab.stories.ts
@@ -6,7 +6,7 @@ import { ICONS } from "./resources";
 const { appearance, dir, scale, theme } = ATTRIBUTES;
 
 export default {
-  title: "App Components/calcite-fab",
+  title: "App Components/FAB",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-flow/calcite-flow.stories.ts
+++ b/src/components/calcite-flow/calcite-flow.stories.ts
@@ -8,7 +8,7 @@ import { SLOTS, TEXT } from "../calcite-panel/resources";
 import dedent from "dedent";
 
 export default {
-  title: "App Components/calcite-flow",
+  title: "App Components/Flow",
   parameters: {
     backgrounds: darkBackground,
     notes: {

--- a/src/components/calcite-panel/calcite-panel.stories.ts
+++ b/src/components/calcite-panel/calcite-panel.stories.ts
@@ -7,7 +7,7 @@ import { SLOTS, TEXT } from "./resources";
 import dedent from "dedent";
 
 export default {
-  title: "App Components/calcite-panel",
+  title: "App Components/Panel",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -6,7 +6,7 @@ import dedent from "dedent";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
-  title: "App Components/calcite-pick-list",
+  title: "App Components/Pick List",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -7,7 +7,7 @@ import panelReadme from "../calcite-shell-panel/readme.md";
 import dedent from "dedent";
 
 export default {
-  title: "App Components/calcite-shell",
+  title: "App Components/Shell",
   parameters: {
     backgrounds: darkBackground,
     notes: {

--- a/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
@@ -7,7 +7,7 @@ import dedent from "dedent";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
-  title: "App Components/calcite-tip-manager",
+  title: "App Components/Tip Manager",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-tip/calcite-tip.stories.ts
+++ b/src/components/calcite-tip/calcite-tip.stories.ts
@@ -5,7 +5,7 @@ import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 
 export default {
-  title: "App Components/calcite-tip",
+  title: "App Components/Tip",
   parameters: {
     backgrounds: darkBackground,
     notes: readme

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -6,7 +6,7 @@ import dedent from "dedent";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
-  title: "App Components/calcite-value-list",
+  title: "App Components/Value List",
   parameters: {
     backgrounds: darkBackground,
     notes: readme


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Consistent story titles FTW! 🏆