### PR TITLE
test(date): work around missing shadow piercing element in e2e test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ notifications:
 script:
   - npm test
 services: xvfb
+addons:
+  chrome: stable
+before_install:
+  - # start your web application and listen on `localhost`
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,3 @@ notifications:
 script:
   - npm test
 services: xvfb
-addons:
-  chrome: stable
-before_install:
-  - # start your web application and listen on `localhost`
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ deploy:
 language: node_js
 node_js:
   - lts/*
-before_install:
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 notifications:
   webhooks:
     secure: "NtIaVttZMs7AUSzJHGriM2fdQcdzpg65d7f/10Hdeu0wSjhmKiV/74QRcwc60MhNdWSxgq4ecdsR/n1Bhm4e5RvPTxLKBZrjeUn72UefZ/B7Kt4QMQWhBMp6AxShsPQNBkSSuk7jL/QrbGuaLBjmquzxJBHp3et9BKth+Ew+T4NQk7J9EqNtrWlipV1acobkQW8nJZEg3Y1bESaVY69ebozVYJMDDjk0SL2XYCUAz2w9aZ2x/sodzjLLxC01Ouxd7G1h/Zvuvvhjqh3UmgH15E1QUcFI7X/zU+bwIg+trndALQbuVBuzSVpWiIM3Pe5+uiBtkSQqQRHkZj91OHDSKjTLwAsWhHHw6d+/GYTaZ0ful2riwxMyXpNR4Zv65aEnYMftZ4hk7okrVwkIBtpiUwwIe/F1RF2h+X0I8ontDevNqd492ZyXFUOtebOiWYOmgJPOso1dAl+ADnkoyJNY14o6ouBl4TPji71T8jGzGVGz3Cn5/Ww8sE60cFgLoHacXxtoe43nsx384skBfGKPrxujj2GoVRRInJCd2jECpNDVTVlXwnojtOoR0LUboJYpVHA40QAcm88YiscY+PZbIreF/kCcxEAmFw95CY5p9op93bfUgbetp7bGkbtAptRtiDA4Wz5EqUSSh5POSKUhCAqMpYU1It1Th7LHqRgelcU="

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ deploy:
 language: node_js
 node_js:
   - lts/*
+before_install:
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 notifications:
   webhooks:
     secure: "NtIaVttZMs7AUSzJHGriM2fdQcdzpg65d7f/10Hdeu0wSjhmKiV/74QRcwc60MhNdWSxgq4ecdsR/n1Bhm4e5RvPTxLKBZrjeUn72UefZ/B7Kt4QMQWhBMp6AxShsPQNBkSSuk7jL/QrbGuaLBjmquzxJBHp3et9BKth+Ew+T4NQk7J9EqNtrWlipV1acobkQW8nJZEg3Y1bESaVY69ebozVYJMDDjk0SL2XYCUAz2w9aZ2x/sodzjLLxC01Ouxd7G1h/Zvuvvhjqh3UmgH15E1QUcFI7X/zU+bwIg+trndALQbuVBuzSVpWiIM3Pe5+uiBtkSQqQRHkZj91OHDSKjTLwAsWhHHw6d+/GYTaZ0ful2riwxMyXpNR4Zv65aEnYMftZ4hk7okrVwkIBtpiUwwIe/F1RF2h+X0I8ontDevNqd492ZyXFUOtebOiWYOmgJPOso1dAl+ADnkoyJNY14o6ouBl4TPji71T8jGzGVGz3Cn5/Ww8sE60cFgLoHacXxtoe43nsx384skBfGKPrxujj2GoVRRInJCd2jECpNDVTVlXwnojtOoR0LUboJYpVHA40QAcm88YiscY+PZbIreF/kCcxEAmFw95CY5p9op93bfUgbetp7bGkbtAptRtiDA4Wz5EqUSSh5POSKUhCAqMpYU1It1Th7LHqRgelcU="

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -11,9 +11,12 @@ describe("calcite-date", () => {
     const changedEvent = await page.spyOnEvent("calciteDateChange");
     // have to wait for transition
     await new Promise((res) => setTimeout(() => res(true), 200));
-    const wrapper = await page.find("calcite-date >>> .calendar-picker-wrapper");
-    const visible = await wrapper.isVisible();
-    expect(visible).toBe(true);
+    const wrapper = (
+      await page.waitForFunction(() =>
+        document.querySelector("calcite-date").shadowRoot.querySelector(".calendar-picker-wrapper")
+      )
+    ).asElement();
+    expect(await wrapper.isIntersectingViewport()).toBe(true);
     await page.keyboard.press("3");
     await page.keyboard.press("/");
     await page.keyboard.press("7");

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -22,12 +22,16 @@ describe("calcite-date", () => {
     await page.keyboard.press("7");
     await page.keyboard.press("/");
     await page.keyboard.press("2");
+    await page.waitForChanges();
     expect(changedEvent).toHaveReceivedEventTimes(1);
     await page.keyboard.press("0");
+    await page.waitForChanges();
     expect(changedEvent).toHaveReceivedEventTimes(2);
     await page.keyboard.press("2");
+    await page.waitForChanges();
     expect(changedEvent).toHaveReceivedEventTimes(3);
     await page.keyboard.press("0");
+    await page.waitForChanges();
     expect(changedEvent).toHaveReceivedEventTimes(4);
   });
 

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -7,25 +7,24 @@ describe("calcite-date", () => {
   it("fires a calciteDateChange event on change", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-date></calcite-date>");
-    const input = await page.find("calcite-date >>> calcite-input");
+    await page.keyboard.press("Tab");
     const changedEvent = await page.spyOnEvent("calciteDateChange");
-    await input.callMethod("setFocus");
     // have to wait for transition
     await new Promise((res) => setTimeout(() => res(true), 200));
     const wrapper = await page.find("calcite-date >>> .calendar-picker-wrapper");
     const visible = await wrapper.isVisible();
     expect(visible).toBe(true);
-    await input.press("3");
-    await input.press("/");
-    await input.press("7");
-    await input.press("/");
-    await input.press("2");
+    await page.keyboard.press("3");
+    await page.keyboard.press("/");
+    await page.keyboard.press("7");
+    await page.keyboard.press("/");
+    await page.keyboard.press("2");
     expect(changedEvent).toHaveReceivedEventTimes(1);
-    await input.press("0");
+    await page.keyboard.press("0");
     expect(changedEvent).toHaveReceivedEventTimes(2);
-    await input.press("2");
+    await page.keyboard.press("2");
     expect(changedEvent).toHaveReceivedEventTimes(3);
-    await input.press("0");
+    await page.keyboard.press("0");
     expect(changedEvent).toHaveReceivedEventTimes(4);
   });
 

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -7,7 +7,12 @@ describe("calcite-date", () => {
   it("fires a calciteDateChange event on change", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-date></calcite-date>");
-    await page.keyboard.press("Tab");
+    const input = (
+      await page.waitForFunction(() =>
+        document.querySelector("calcite-date").shadowRoot.querySelector("calcite-input input")
+      )
+    ).asElement();
+    await input.focus();
     const changedEvent = await page.spyOnEvent("calciteDateChange");
     // have to wait for transition
     await new Promise((res) => setTimeout(() => res(true), 200));
@@ -17,21 +22,18 @@ describe("calcite-date", () => {
       )
     ).asElement();
     expect(await wrapper.isIntersectingViewport()).toBe(true);
-    await page.keyboard.press("3");
-    await page.keyboard.press("/");
-    await page.keyboard.press("7");
-    await page.keyboard.press("/");
-    await page.keyboard.press("2");
-    await page.waitForChanges();
+
+    await input.press("3");
+    await input.press("/");
+    await input.press("7");
+    await input.press("/");
+    await input.press("2");
     expect(changedEvent).toHaveReceivedEventTimes(1);
-    await page.keyboard.press("0");
-    await page.waitForChanges();
+    await input.press("0");
     expect(changedEvent).toHaveReceivedEventTimes(2);
-    await page.keyboard.press("2");
-    await page.waitForChanges();
+    await input.press("2");
     expect(changedEvent).toHaveReceivedEventTimes(3);
-    await page.keyboard.press("0");
-    await page.waitForChanges();
+    await input.press("0");
     expect(changedEvent).toHaveReceivedEventTimes(4);
   });
 


### PR DESCRIPTION

## Summary

Tests _sometimes_ fail with missing element when you query for an element inside a shadow dom boundary. This only happens on travis. All other environments work fine. For now, I'm just tabbing to the input and executing keyboard commands on the page instead. 

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
