### PR TITLE
docs(contributing): add note on doc-updating script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,11 @@ To release a new version of Calcite Components you must:
 - Push the release tag to the repo
 - Publish to NPM
 - Publish to GitHub (including source and package)
+
+1. Lastly, run `npm run release:docs` to update the docs. This script will:
+
+- Create the component doc
+- Create the storybook build
+- Push all doc content to the `gh-pages` branch
+
+  **Note**: this script can be run anytime the docs need to be updated


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

The doc-updating script was missing since it was disconnected from the `release:publish` script.