### PR TITLE
fix(input): Emit calciteInputInput on clear

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -391,6 +391,38 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEvent();
   });
 
+  it("when type is search and clear button is clicked, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="search" value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    const clearButton = await page.find(".calcite-input-clear-button");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    clearButton.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEvent();
+  });
+
+  it("when type is search and input is cleared via escape key, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="search" value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEvent();
+  });
+
   it("when clearable is not requested and input is cleared via escape key, event is not received", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -359,6 +359,54 @@ describe("calcite-input", () => {
     expect(element.getAttribute("value")).toBe("");
   });
 
+  it("when clearable is requested and clear button is clicked, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    const clearButton = await page.find(".calcite-input-clear-button");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    clearButton.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEvent();
+  });
+
+  it("when clearable is requested and input is cleared via escape key, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEvent();
+  });
+
+  it("when clearable is not requested and input is cleared via escape key, event is not received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("John Doe");
+    expect(calciteInputInput).not.toHaveReceivedEvent();
+  });
+
   it("should emit event when up or down clicked on input", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -280,6 +280,7 @@ describe("calcite-input", () => {
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("0");
   });
+
   it("correctly stops incrementing value when max is 0", async () => {
     const page = await newE2EPage();
     await page.setContent(`
@@ -300,6 +301,40 @@ describe("calcite-input", () => {
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("0");
+  });
+
+  it("when value is added, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await page.keyboard.press("a");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("a");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("when value changes, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await page.keyboard.press("e");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("John Doee");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
   it("renders clear button when clearable is requested and value is populated at load", async () => {
@@ -372,7 +407,7 @@ describe("calcite-input", () => {
     clearButton.click();
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("");
-    expect(calciteInputInput).toHaveReceivedEvent();
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
   it("when clearable is requested and input is cleared via escape key, event is received", async () => {
@@ -385,10 +420,11 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     expect(element.getAttribute("value")).toBe("John Doe");
     await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("");
-    expect(calciteInputInput).toHaveReceivedEvent();
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
   it("when type is search and clear button is clicked, event is received", async () => {
@@ -401,10 +437,11 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     const clearButton = await page.find(".calcite-input-clear-button");
     expect(element.getAttribute("value")).toBe("John Doe");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
     clearButton.click();
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("");
-    expect(calciteInputInput).toHaveReceivedEvent();
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
   it("when type is search and input is cleared via escape key, event is received", async () => {
@@ -417,10 +454,11 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     expect(element.getAttribute("value")).toBe("John Doe");
     await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("");
-    expect(calciteInputInput).toHaveReceivedEvent();
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
   it("when clearable is not requested and input is cleared via escape key, event is not received", async () => {
@@ -433,6 +471,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     expect(element.getAttribute("value")).toBe("John Doe");
     await element.callMethod("setFocus");
+    expect(calciteInputInput).not.toHaveReceivedEvent();
     await page.keyboard.press("Escape");
     await page.waitForChanges();
     expect(element.getAttribute("value")).toBe("John Doe");
@@ -450,16 +489,21 @@ describe("calcite-input", () => {
     const numberHorizontalItemUp = await page.find(
       "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
     );
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
 
-    expect(calciteInputInput).toHaveReceivedEvent();
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
 
     const numberHorizontalItemDown = await page.find(
       "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
     );
     await numberHorizontalItemDown.click();
     await page.waitForChanges();
-    expect(calciteInputInput).toHaveReceivedEvent();
+    expect(calciteInputInput).toHaveReceivedEventTimes(2);
+
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(calciteInputInput).toHaveReceivedEventTimes(3);
   });
 });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -386,12 +386,16 @@ export class CalciteInput {
     search: "search"
   };
 
-  private inputInputHandler = (e) => {
-    this.value = e.target.value;
+  private emitInputInput(): void {
     this.calciteInputInput.emit({
       element: this.childEl,
       value: this.value
     });
+  }
+
+  private inputInputHandler = (e) => {
+    this.value = e.target.value;
+    this.emitInputInput();
   };
 
   private inputBlurHandler = () => {
@@ -446,6 +450,7 @@ export class CalciteInput {
 
   private clearInputValue = () => {
     this.value = "";
+    this.emitInputInput();
   };
 
   private updateNumberValue = (e) => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -131,6 +131,13 @@ export class CalciteInput {
   /** input value */
   @Prop({ mutable: true, reflect: true }) value?: string = "";
 
+  @Watch("value") valueWatcher(): void {
+    this.calciteInputInput.emit({
+      element: this.childEl,
+      value: this.value
+    });
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -386,16 +393,8 @@ export class CalciteInput {
     search: "search"
   };
 
-  private emitInputInput(): void {
-    this.calciteInputInput.emit({
-      element: this.childEl,
-      value: this.value
-    });
-  }
-
   private inputInputHandler = (e) => {
     this.value = e.target.value;
-    this.emitInputInput();
   };
 
   private inputBlurHandler = () => {
@@ -450,7 +449,6 @@ export class CalciteInput {
 
   private clearInputValue = () => {
     this.value = "";
-    this.emitInputInput();
   };
 
   private updateNumberValue = (e) => {
@@ -474,10 +472,6 @@ export class CalciteInput {
           break;
       }
       this.value = this.childEl.value.toString();
-      this.calciteInputInput.emit({
-        element: this.childEl,
-        value: this.value
-      });
     }
   };
 }


### PR DESCRIPTION
Emits calciteInputInput on clear
Adds tests for clearing on key and clear button press

**Related Issue:**  Resolves #1065 cc @noahmulfinger

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
