### PR TITLE
fix(label): only render id on parent calcite-label

### DIFF
--- a/src/components/calcite-label/calcite-label.e2e.ts
+++ b/src/components/calcite-label/calcite-label.e2e.ts
@@ -38,6 +38,24 @@ describe("calcite-label", () => {
     expect(element).toEqualAttribute("layout", "inline-space-between");
   });
 
+  it("does not pass id to child label element", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-label id="dont-duplicate-me" status="invalid" theme="dark" layout="inline-space-between">
+    Label text
+    <calcite-input></calcite-input>
+    </calcite-label>
+    `);
+
+    const element = await page.find("calcite-label");
+    const childElement = await page.find("calcite-label label");
+    expect(element).toEqualAttribute("id", "dont-duplicate-me");
+    expect(childElement).not.toHaveAttribute("id");
+    expect(element).toEqualAttribute("status", "invalid");
+    expect(element).toEqualAttribute("theme", "dark");
+    expect(element).toEqualAttribute("layout", "inline-space-between");
+  });
+
   it("focuses a requested, non-wrapped input", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -93,7 +93,7 @@ export class CalciteLabel {
 
   private getAttributes(): Record<string, any> {
     // spread attributes from the component to rendered child, filtering out props
-    const props = ["layout", "theme", "scale", "status", "disabled"];
+    const props = ["disabled", "id", "layout", "scale", "status", "theme"];
     return Array.from(this.el.attributes)
       .filter((a) => a && !props.includes(a.name))
       .reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {});

--- a/src/demos/calcite-label.html
+++ b/src/demos/calcite-label.html
@@ -82,6 +82,13 @@
         <calcite-input></calcite-input>
       </calcite-label>
 
+      <h3>only render id on parent calcite-label</h3>
+      <calcite-label scale="m" id="dont-duplicate-me-please">
+        layout="default" scale="m" status="idle"
+        <calcite-input></calcite-input>
+      </calcite-label>
+
+
       <h3>medium wrapping calcite-input</h3>
 
       <calcite-label scale="m">

--- a/src/demos/calcite-label.html
+++ b/src/demos/calcite-label.html
@@ -82,13 +82,6 @@
         <calcite-input></calcite-input>
       </calcite-label>
 
-      <h3>only render id on parent calcite-label</h3>
-      <calcite-label scale="m" id="dont-duplicate-me-please">
-        layout="default" scale="m" status="idle"
-        <calcite-input></calcite-input>
-      </calcite-label>
-
-
       <h3>medium wrapping calcite-input</h3>
 
       <calcite-label scale="m">


### PR DESCRIPTION
Exclude id from attributes spread to child label
Add demo
Adds test

**Related Issue:** Resolves #1106 cc @jcfranco 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
