### PR TITLE
style(card): make card footers align for multiple cards in flex box row

### DIFF
--- a/src/components/calcite-card/calcite-card.scss
+++ b/src/components/calcite-card/calcite-card.scss
@@ -26,6 +26,12 @@
   }
 }
 
+.container {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
 :host([loading]) .calcite-card-container *:not(calcite-loader):not(.calcite-card-loader-container) {
   opacity: 0;
   pointer-events: none;
@@ -56,6 +62,7 @@
   flex-direction: row;
   align-content: space-between;
   justify-content: space-between;
+  margin-top: auto;
 }
 
 :host .card-content {

--- a/src/demos/calcite-card.html
+++ b/src/demos/calcite-card.html
@@ -27,6 +27,17 @@
       color: white;
       padding: 1rem;
     }
+
+    .block-group {
+      display: flex;
+      flex-wrap: wrap;
+      margin-bottom: 4rem;
+    }
+
+    .block-group > calcite-card {
+      flex-basis: 300px;
+      margin: 10px;
+    }
   </style>
   <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="/build/calcite.css" />
@@ -141,7 +152,42 @@
       </calcite-card>
     </div>
     <div class="example-grid-item">
+      <calcite-card selectable>
+        <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+        <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
+          overly verbose.</span>
+        <calcite-link slot="footer-leading">Lead füt</calcite-link>
+        <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+      </calcite-card>
+    </div>
+  </div>
+  <div >
+    <h2>Same height</h2>
+    <div class="block-group">
+      <calcite-card selected selectable>
+        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
 
+        <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+        <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
+          overly verbose.</span>
+        <calcite-link slot="footer-leading">Lead füt</calcite-link>
+        <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+      </calcite-card>
+      <calcite-card loading>
+        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+
+        <h3 slot="title">Loading example</h3>
+        <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
+          overly verbose.</span>
+        <calcite-link slot="footer-leading">Lead füt</calcite-link>
+        <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+      </calcite-card>
+      <calcite-card selectable>
+        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <h3 slot="title">Untitled experience</h3>
+        <span slot="subtitle">Subtext</span>
+        <calcite-button slot="footer-leading" width="full">Go</calcite-button>
+      </calcite-card>
       <calcite-card selectable>
         <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
         <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't


### PR DESCRIPTION


## Summary

When cards get put in a container using flexbox to make them all the same height, the actions on the bottom won't line up if cards have different content heights:

![Screen Shot 2020-10-14 at 12 38 26 PM](https://user-images.githubusercontent.com/1031758/96037193-58ff5880-0e1a-11eb-98c9-c843b2768dc5.png)


This pr places the footers at the bottom of the card:

![Screen Shot 2020-10-14 at 11 55 21 AM](https://user-images.githubusercontent.com/1031758/96037230-69afce80-0e1a-11eb-87ca-d5a53bde50cf.png)


This shouldn't impact any of the current card styles, and will only apply if the card has already been stretched vertically.