### PR TITLE
feat(popover): adds flex-direction and slotted styles for panel and flow

### DIFF
--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -8,7 +8,7 @@ $image_max_height: 200px;
   position: relative;
   display: flex;
   overflow: hidden;
-  flex-direction: column;
+  flex-direction: column nowrap;
   color: var(--calcite-ui-text-1);
 }
 
@@ -63,4 +63,9 @@ slot[name="image"]::slotted(img) {
   max-height: $image_max_height;
   object-position: 50% 50%;
   object-fit: cover;
+}
+
+::slotted(calcite-panel),
+::slotted(calcite-flow) {
+  height: 100%;
 }


### PR DESCRIPTION
Post refactor, Panel and Flow in Popover were not doing scrolling correctly.
This fixes that.



## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
