### PR TITLE
docs(calcite-alert, calcite-combobox-item, calcite-date-day, calcite-date-month): fix invalid JSDoc

### DIFF
--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -142,12 +142,18 @@ export class CalciteAlert {
   /** Fired when an alert is opened */
   @Event() calciteAlertOpen: EventEmitter;
 
-  /** Fired to sync queue when opened or closed */
-  /* @internal */
+  /**
+   * Fired to sync queue when opened or closed
+   *
+   * @internal
+   */
   @Event() calciteAlertSync: EventEmitter;
 
-  /** Fired when an alert is added to dom - used to receive initial queue */
-  /* @internal */
+  /**
+   * Fired when an alert is added to dom - used to receive initial queue
+   *
+   * @internal
+   */
   @Event() calciteAlertRegister: EventEmitter;
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -28,23 +28,23 @@ export class CalciteComboboxItem {
   //
   // --------------------------------------------------------------------------
 
-  /* When true, the item cannot be clicked and is visually muted. */
+  /** When true, the item cannot be clicked and is visually muted. */
   @Prop({ reflect: true }) disabled = false;
 
-  /* The parent combobox item element */
+  /** The parent combobox item element */
   @Prop() parentItem?: HTMLCalciteComboboxItemElement;
 
-  /* Set this to true to pre-select an item. Toggles when an item is checked/unchecked. */
+  /** Set this to true to pre-select an item. Toggles when an item is checked/unchecked. */
   @Prop({ reflect: true }) selected = false;
 
   @Watch("selected") selectedWatchHandler(newValue: boolean): void {
     this.isSelected = newValue;
   }
 
-  /* The main label for this item. */
+  /** The main label for this item. */
   @Prop({ reflect: true }) textLabel!: string;
 
-  /* A unique value used to identify this item - similar to the value attribute on an <input>. */
+  /** A unique value used to identify this item - similar to the value attribute on an <input>. */
   @Prop({ reflect: true }) value!: string;
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-date-day/calcite-date-day.tsx
+++ b/src/components/calcite-date-day/calcite-date-day.tsx
@@ -47,8 +47,11 @@ export class CalciteDateDay {
   /** Date is actively in focus for keyboard navigation */
   @Prop({ reflect: true }) active = false;
 
-  /** CLDR data for current locale */
-  /* @internal */
+  /**
+   * CLDR data for current locale
+   *
+   * @internal
+   */
   @Prop() localeData: DateLocaleData;
 
   /** specify the scale of the date picker */

--- a/src/components/calcite-date-month/calcite-date-month.tsx
+++ b/src/components/calcite-date-month/calcite-date-month.tsx
@@ -48,8 +48,11 @@ export class CalciteDateMonth {
   /** specify the scale of the date picker */
   @Prop({ reflect: true }) scale: "s" | "m" | "l";
 
-  /** CLDR locale data for current locale */
-  /* @internal */
+  /**
+   * CLDR locale data for current locale
+   *
+   * @internal
+   */
   @Prop() localeData: DateLocaleData;
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

🧹📄 