### PR TITLE
fix(panel, block): updates font-sizes. uses tailwind theme

### DIFF
--- a/src/assets/styles/_header.scss
+++ b/src/assets/styles/_header.scss
@@ -12,6 +12,7 @@
   padding: 0;
   margin: 0;
   font-weight: var(--calcite-ui-text-weight-demi);
+  line-height: 1.5;
 }
 
 .header .heading {
@@ -20,17 +21,17 @@
 }
 
 h1.heading {
-  @include font-size(0);
+  font-size: theme("fontSize.2");
 }
 
 h2.heading {
-  @include font-size(-1);
+  font-size: theme("fontSize.1");
 }
 
 h3.heading {
-  @include font-size(-2);
+  font-size: theme("fontSize.0");
 }
 h4.heading,
 h5.heading {
-  @include font-size(-4);
+  font-size: theme("fontSize.-1");
 }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -71,13 +71,14 @@ calcite-handle {
   padding: 0;
   color: var(--calcite-ui-text-3);
   transition: color $transition;
+  font-size: theme("fontSize.-1");
   @include word-break();
 }
 
 .summary {
   color: var(--calcite-ui-text-3);
   padding: 0;
-  @include font-size(-5);
+  font-size: theme("fontSize.-2");
   @include word-break();
 }
 

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -108,14 +108,14 @@ calcite-scrim {
     color: var(--calcite-ui-text-3);
     font-weight: var(--calcite-ui-text-weight-demi);
     margin: 0 0 var(--calcite-spacing-quarter);
-    @include font-size(-2);
+    font-size: theme("fontSize.0");
     &:only-child {
       margin-bottom: 0;
     }
   }
   .summary {
     color: var(--calcite-ui-text-3);
-    @include font-size(-4);
+    font-size: theme("fontSize.-2");
   }
 }
 

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -324,7 +324,7 @@ export class CalcitePanel {
 
   renderHeaderContent(): VNode {
     const { heading, summary } = this;
-    const headingNode = heading ? <h4 class={CSS.heading}>{heading}</h4> : null;
+    const headingNode = heading ? <h3 class={CSS.heading}>{heading}</h3> : null;
     const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
 
     return headingNode || summaryNode ? (


### PR DESCRIPTION
**Related Issue:**  (#1126)

## Summary
Fixes incorrect font sizes for
- Block heading
- Block summary
- Panel heading

Updates header styles.
Note: header styles will be refactored with CSS vars in upcoming PR.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
