### PR TITLE
fix(panel, block, block-section): updates font-sizes

### DIFF
--- a/src/assets/styles/_header.scss
+++ b/src/assets/styles/_header.scss
@@ -12,6 +12,7 @@
   padding: 0;
   margin: 0;
   font-weight: var(--calcite-ui-text-weight-demi);
+  line-height: 1.5;
 }
 
 .header .heading {
@@ -20,17 +21,17 @@
 }
 
 h1.heading {
-  @include font-size(0);
+  font-size: theme("fontSize.2");
 }
 
 h2.heading {
-  @include font-size(-1);
+  font-size: theme("fontSize.1");
 }
 
 h3.heading {
-  @include font-size(-2);
+  font-size: theme("fontSize.0");
 }
 h4.heading,
 h5.heading {
-  @include font-size(-4);
+  font-size: theme("fontSize.-1");
 }

--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -22,7 +22,7 @@
   cursor: pointer;
   text-align: unset;
   position: relative;
-  @include font-size(-4);
+  font-size: theme("fontSize.-2");
   @include focus-style-base();
   &:hover,
   &:focus {

--- a/src/components/calcite-block-section/calcite-block-section.e2e.ts
+++ b/src/components/calcite-block-section/calcite-block-section.e2e.ts
@@ -81,14 +81,6 @@ describe("calcite-block-section", () => {
       const page = await newE2EPage({ html: "<calcite-block-section></calcite-block-section>" });
       await assertToggleBehavior(page);
     });
-
-    it("renders section text", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-block-section text="test text" open="true"></calcite-block-section>`
-      });
-      const element = await page.find(`calcite-block-section >>> .${CSS.toggle}`);
-      expect(await element.getProperty("text")).toBe("test text");
-    });
   });
 
   async function assertContentIsDisplayedAndHidden(page: E2EPage): Promise<void> {

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -11,19 +11,30 @@
   border-bottom: none;
 }
 
-.toggle--switch {
+.toggle--switch,
+.section-header {
   align-items: center;
   cursor: pointer;
   display: flex;
-  justify-content: space-between;
   margin: var(--calcite-spacing-quarter) 0;
   padding: var(--calcite-spacing-half) 0;
   user-select: none;
-  @include font-size(-4);
+  font-size: theme("fontSize.-1");
   @include focus-style-base();
   &:focus {
     @include focus-style-outset();
   }
+  &:hover {
+    color: var(--calcite-ui-text-1);
+  }
+}
+
+.section-header__text {
+  margin: 0 var(--calcite-spacing-quarter);
+}
+
+.toggle--switch {
+  justify-content: space-between;
   calcite-switch {
     pointer-events: none;
     margin: 0 0 0 var(--calcite-spacing-half);

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -11,6 +11,15 @@
   border-bottom: none;
 }
 
+.toggle {
+  background-color: transparent;
+  border: none;
+  color: var(--calcite-ui-text-2);
+  font-family: theme("fontFamily.sans");
+  font-weight: theme("fontWeight.normal");
+  width: 100%;
+}
+
 .toggle--switch,
 .section-header {
   align-items: center;

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -131,18 +131,19 @@ export class CalciteBlockSection {
           />
         </label>
       ) : (
-        <label
+        <button
           aria-label={toggleLabel}
-          class={CSS.sectionHeader}
+          class={{
+            [CSS.sectionHeader]: true,
+            [CSS.toggle]: true
+          }}
+          name={toggleLabel}
           onClick={this.toggleSection}
           onKeyDown={this.handleHeaderLabelKeyDown}
-          role="button"
-          tabIndex={0}
-          title={toggleLabel}
         >
           <calcite-icon icon={arrowIcon} scale="s" />
           <span class={CSS.sectionHeaderText}>{text}</span>
-        </label>
+        </button>
       );
 
     return (

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -136,6 +136,7 @@ export class CalciteBlockSection {
           class={CSS.sectionHeader}
           onClick={this.toggleSection}
           onKeyDown={this.handleHeaderLabelKeyDown}
+          role="button"
           tabIndex={0}
           title={toggleLabel}
         >

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -131,16 +131,17 @@ export class CalciteBlockSection {
           />
         </label>
       ) : (
-        <calcite-action
+        <label
           aria-label={toggleLabel}
-          class={CSS.toggle}
-          compact
-          icon={arrowIcon}
+          class={CSS.sectionHeader}
           onClick={this.toggleSection}
-          text={text}
-          textEnabled={true}
+          onKeyDown={this.handleHeaderLabelKeyDown}
+          tabIndex={0}
           title={toggleLabel}
-        />
+        >
+          <calcite-icon icon={arrowIcon} scale="s" />
+          <span class={CSS.sectionHeaderText}>{text}</span>
+        </label>
       );
 
     return (

--- a/src/components/calcite-block-section/resources.ts
+++ b/src/components/calcite-block-section/resources.ts
@@ -1,7 +1,9 @@
 export const CSS = {
   content: "content",
   toggle: "toggle",
-  toggleSwitch: "toggle--switch"
+  toggleSwitch: "toggle--switch",
+  sectionHeader: "section-header",
+  sectionHeaderText: "section-header__text"
 };
 
 export const TEXT = {

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -71,13 +71,14 @@ calcite-handle {
   padding: 0;
   color: var(--calcite-ui-text-3);
   transition: color $transition;
+  font-size: theme("fontSize.-1");
   @include word-break();
 }
 
 .summary {
   color: var(--calcite-ui-text-3);
   padding: 0;
-  @include font-size(-5);
+  font-size: theme("fontSize.-2");
   @include word-break();
 }
 

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -108,14 +108,14 @@ calcite-scrim {
     color: var(--calcite-ui-text-3);
     font-weight: var(--calcite-ui-text-weight-demi);
     margin: 0 0 var(--calcite-spacing-quarter);
-    @include font-size(-2);
+    font-size: theme("fontSize.0");
     &:only-child {
       margin-bottom: 0;
     }
   }
   .summary {
     color: var(--calcite-ui-text-3);
-    @include font-size(-4);
+    font-size: theme("fontSize.-2");
   }
 }
 

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -324,7 +324,7 @@ export class CalcitePanel {
 
   renderHeaderContent(): VNode {
     const { heading, summary } = this;
-    const headingNode = heading ? <h4 class={CSS.heading}>{heading}</h4> : null;
+    const headingNode = heading ? <h3 class={CSS.heading}>{heading}</h3> : null;
     const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
 
     return headingNode || summaryNode ? (


### PR DESCRIPTION
**Related Issue:**  (#1131)

## Summary
Fixes incorrect font sizes for
- Panel heading
- Block heading
- Block summary

Sorry...I messed up the commit history on the previous branch.
This one is cleaner.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Note: the use of Tailwind themes in component stylesheets will be refactored in an upcoming PR.