### PR TITLE
fix(date): use correct props for next/previous month labels (#1122)

### DIFF
--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -91,7 +91,7 @@ export class CalciteDateMonthHeader {
         <div aria-hidden="true" class="header">
           <a
             aria-disabled={nextMonthDate.getMonth() === activeMonth}
-            aria-label={this.intlNextMonth}
+            aria-label={this.intlPrevMonth}
             class="chevron"
             href="#"
             onClick={(e) => this.handleArrowClick(e, prevMonthDate)}

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -1,8 +1,35 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { renders } from "../../tests/commonTests";
+import { renders, defaults, hidden } from "../../tests/commonTests";
+import { TEXT } from "./calcite-date-resources";
 
 describe("calcite-date", () => {
   it("renders", async () => renders("calcite-date"));
+
+  it("honors hidden attribute", async () => hidden("calcite-date"));
+
+  it("has property defaults", async () =>
+    defaults("calcite-date", [
+      {
+        propertyName: "intlPrevMonth",
+        defaultValue: TEXT.prevMonth
+      },
+      {
+        propertyName: "intlNextMonth",
+        defaultValue: TEXT.nextMonth
+      },
+      {
+        propertyName: "active",
+        defaultValue: false
+      },
+      {
+        propertyName: "noCalendarInput",
+        defaultValue: false
+      },
+      {
+        propertyName: "scale",
+        defaultValue: "m"
+      }
+    ]));
 
   it("fires a calciteDateChange event on change", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-date/calcite-date.stories.ts
+++ b/src/components/calcite-date/calcite-date.stories.ts
@@ -67,8 +67,8 @@ storiesOf("Components/Date", module)
       min="${text("min", "2016-08-09")}"
       max="${text("max", "2023-12-18")}"
       locale="${select("locale", locales, "en-US")}"
-      next-month-label="${text("next-month-label", "Next month")}"
-      prev-month-label="${text("prev-month-label", "Previous month")}"
+      intl-next-month="${text("intl-next-month", "Next month")}"
+      intl-prev-month="${text("intl-prev-month", "Previous month")}"
     ></calcite-date>
     </div>
   `
@@ -85,8 +85,8 @@ storiesOf("Components/Date", module)
       locale="${select("locale", locales, "en-US")}"
       active
       no-calendar-input
-      next-month-label="${text("next-month-label", "Next month")}"
-      prev-month-label="${text("prev-month-label", "Previous month")}"
+      intl-next-month="${text("intl-next-month", "Next month")}"
+      intl-prev-month="${text("intl-prev-month", "Previous month")}"
     ></calcite-date>
     </div>
   `
@@ -102,8 +102,8 @@ storiesOf("Components/Date", module)
       min="${text("min", "2016-08-09")}"
       max="${text("max", "2023-12-18")}"
       locale="${select("locale", locales, "en-US")}"
-      next-month-label="${text("next-month-label", "Next month")}"
-      prev-month-label="${text("prev-month-label", "Previous month")}"
+      intl-next-month="${text("intl-next-month", "Next month")}"
+      intl-prev-month="${text("intl-prev-month", "Previous month")}"
     ></calcite-date>
     </div>
 `,

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -52,10 +52,10 @@ export class CalciteDate {
   /** Expand or collapse when calendar does not have input */
   @Prop({ reflect: true }) active = false;
 
-  /** Localized string for "previous month" */
+  /** Localized string for "previous month" (used for aria label) */
   @Prop() intlPrevMonth?: string = TEXT.prevMonth;
 
-  /** Localized string for "next month" */
+  /** Localized string for "next month" (used for aria label) */
   @Prop() intlNextMonth?: string = TEXT.nextMonth;
 
   /** BCP 47 language tag for desired language and country format */


### PR DESCRIPTION
**Related Issue:** #1122 

## Summary

We were always using the "next month" string for both next and previous aria labels. This fixes that and also updates the storybook example to use the correct props as well.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
