### PR TITLE
fix(modal): Allow re-opening of modal when close button is clicked

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -191,7 +191,7 @@ describe("calcite-modal accessibility checks", () => {
     expect(modal).toHaveAttribute("is-active");
   });
 
-  it("closes when Close button  is clicked", async () => {
+  it("closes when Close button is clicked", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
     const modal = await page.find("calcite-modal");

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -176,6 +176,50 @@ describe("calcite-modal accessibility checks", () => {
     expect(modal).not.toHaveAttribute("is-active");
   });
 
+  it("closes and allows re-opening when Escape key is pressed", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    expect(modal).toHaveAttribute("is-active");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(modal).not.toHaveAttribute("is-active");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    expect(modal).toHaveAttribute("is-active");
+  });
+
+  it("closes when Close button  is clicked", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    const button = await page.find("calcite-modal >>> .modal__close");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    expect(modal).toHaveAttribute("is-active");
+    await button.click();
+    await page.waitForChanges();
+    expect(modal).not.toHaveAttribute("is-active");
+  });
+
+  it("closes and allows re-opening when Close button  is clicked", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    const button = await page.find("calcite-modal >>> .modal__close");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    expect(modal).toHaveAttribute("is-active");
+    await button.click();
+    await page.waitForChanges();
+    expect(modal).not.toHaveAttribute("is-active");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    expect(modal).toHaveAttribute("is-active");
+  });
+
   it("does not close when Escape is pressed and disable-escape is set", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal disable-escape></calcite-modal>`);

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -187,9 +187,7 @@ export class CalciteModal {
   //--------------------------------------------------------------------------
   @Listen("keyup", { target: "window" }) handleEscape(e: KeyboardEvent): void {
     if (this.active && !this.disableEscape && getKey(e.key) === "Escape") {
-      this.beforeClose(this.el).then(() => {
-        this.active = false;
-      });
+      this.close();
     }
   }
 
@@ -244,10 +242,8 @@ export class CalciteModal {
     if (value !== oldValue) {
       if (value) {
         this.open();
-        this.isActive = true;
       } else if (!value) {
         this.close();
-        this.isActive = false;
       }
     }
   }
@@ -268,6 +264,7 @@ export class CalciteModal {
   private close() {
     return this.beforeClose(this.el).then(() => {
       this.active = false;
+      this.isActive = false;
       this.previousActiveElement?.focus();
       document.documentElement.classList.remove("overflow-hidden");
       setTimeout(() => this.calciteModalClose.emit(), 300);

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -244,8 +244,10 @@ export class CalciteModal {
     if (value !== oldValue) {
       if (value) {
         this.open();
+        this.isActive = true;
       } else if (!value) {
         this.close();
+        this.isActive = false;
       }
     }
   }
@@ -265,7 +267,7 @@ export class CalciteModal {
   /** Close the modal, first running the `beforeClose` method */
   private close() {
     return this.beforeClose(this.el).then(() => {
-      this.isActive = false;
+      this.active = false;
       this.previousActiveElement?.focus();
       document.documentElement.classList.remove("overflow-hidden");
       setTimeout(() => this.calciteModalClose.emit(), 300);


### PR DESCRIPTION

**Related Issue:** #918 cc @noahmulfinger

## Summary
There was a discrepancy between how the modal functioned when clicking close vs. closing via Escape key. This adds a watcher to the "active" prop to sync it with the "is-active" state.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
