### PR TITLE
feat(split-button): Add support for appearance

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -512,6 +512,20 @@
   }
 }
 
+:host([dir="ltr"][appearance="outline"][split-child="primary"]:not([floating])) button,
+:host([dir="rtl"][appearance="outline"][split-child="secondary"]:not([floating])) button,
+:host([dir="ltr"][appearance="clear"][split-child="primary"]:not([floating])) button,
+:host([dir="rtl"][appearance="clear"][split-child="secondary"]:not([floating])) button {
+  border-right: 0;
+}
+
+:host([dir="ltr"][appearance="outline"][split-child="secondary"]:not([floating])) button,
+:host([dir="rtl"][appearance="outline"][split-child="primary"]:not([floating])) button,
+:host([dir="ltr"][appearance="clear"][split-child="secondary"]:not([floating])) button,
+:host([dir="rtl"][appearance="clear"][split-child="primary"]:not([floating])) button {
+  border-left: 0;
+}
+
 // transparent
 @mixin btn-transparent($color) {
   color: $color;

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -197,7 +197,7 @@ export class CalciteButton {
       "icon-start",
       "icon-end",
       "id",
-      "isSplitPrimary",
+      "splitChild",
       "loading",
       "scale",
       "slot",

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -61,6 +61,9 @@ export class CalciteButton {
   /** specify the scale of the button, defaults to m */
   @Prop({ reflect: true }) scale: "s" | "m" | "l" = "m";
 
+  /** is the button a child of a calcite-split-button */
+  @Prop({ reflect: true }) splitChild?: "primary" | "secondary" | false = false;
+
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: "light" | "dark";
 
@@ -194,6 +197,7 @@ export class CalciteButton {
       "icon-start",
       "icon-end",
       "id",
+      "isSplitPrimary",
       "loading",
       "scale",
       "slot",

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -120,4 +120,15 @@ describe("calcite-split-button", () => {
       expect(primaryButton).toEqualAttribute("scale", elementScaleToButtonScale[elementScale]);
     }
   });
+
+  it("adds split-child attributes to child button components ", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-split-button>
+      </calcite-split-button>`);
+    const primaryButton = await page.find("calcite-split-button >>> calcite-button");
+    const dropdownButton = await page.find("calcite-split-button >>> calcite-dropdown calcite-button");
+    expect(primaryButton).toEqualAttribute("split-child", "primary");
+    expect(dropdownButton).toEqualAttribute("split-child", "secondary");
+  });
 });

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -88,6 +88,15 @@
     &:host(:hover) .split-button__divider-container {
       background-color: var(--calcite-button-light);
     }
+    &:host([theme="dark"]) {
+      .split-button__divider {
+        background-color: var(--calcite-ui-text-1);
+      }
+      .split-button__divider-container {
+        background-color: var(--calcite-ui-foreground-1);
+        border-color: var(--calcite-ui-foreground-1);
+      }
+    }
   }
   &:host([appearance="clear"]) {
     .split-button__divider-container {
@@ -97,14 +106,34 @@
     &:host(:hover) .split-button__divider-container {
       background-color: var(--calcite-button-light);
     }
+    &:host([theme="dark"]) {
+      .split-button__divider,
+      &:host(:hover) .split-button__divider-container {
+        background-color: var(--calcite-button-dark);
+      }
+      .split-button__divider-container {
+        background-color: transparent;
+        border-color: var(--calcite-button-dark);
+      }
+    }
   }
   &:host([theme="dark"]) {
     .split-button__divider-container {
       background-color: var(--calcite-button-dark);
     }
   }
-  &:host([appearance="transparent"]) .split-button__divider {
-    background-color: var(--calcite-button-light);
+  &:host([appearance="transparent"]) {
+    .split-button__divider {
+      background-color: var(--calcite-button-light);
+    }
+    &:host([theme="dark"]) {
+      .split-button__divider-container {
+        background-color: transparent;
+      }
+      .split-button__divider {
+        background-color: var(--calcite-ui-foreground-1);
+      }
+    }
   }
 
   .split-button__divider {

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -23,7 +23,7 @@
   &:host([appearance="outline"]),
   &:host([appearance="clear"]) {
     .split-button__divider-container {
-      border-color: var(--calcite-ui-blue-1);
+      border-color: var(--calcite-ui-blue-3);
     }
     .split-button__divider,
     &:host(:hover) .split-button__divider-container,
@@ -33,7 +33,7 @@
   }
   &:host([appearance="transparent"]) {
     .split-button__divider {
-      background-color: var(--calcite-ui-blue-1);
+      background-color: var(--calcite-ui-blue-3);
     }
     &:host([appearance="transparent"]) .split-button__divider {
       background-color: var(--calcite-ui-blue-3);

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -17,6 +17,18 @@
   .split-button__divider-container {
     background-color: var(--calcite-ui-blue-1);
   }
+  &:host([appearance="outline"]),
+  &:host([appearance="clear"]) {
+    .split-button__divider-container {
+      border-color: var(--calcite-ui-blue-1);
+    }
+    .split-button__divider {
+      background-color: var(--calcite-ui-blue-1);
+    }
+  }
+  &:host([appearance="transparent"]) .split-button__divider {
+    background-color: var(--calcite-ui-blue-1);
+  }
   &:host([theme="dark"]) {
     .split-button__divider {
       background-color: var(--calcite-button-dark-text);
@@ -26,6 +38,18 @@
 
 :host([color="red"]) {
   .split-button__divider-container {
+    background-color: var(--calcite-ui-red-1);
+  }
+  &:host([appearance="outline"]),
+  &:host([appearance="clear"]) {
+    .split-button__divider-container {
+      border-color: var(--calcite-ui-red-1);
+    }
+    .split-button__divider {
+      background-color: var(--calcite-ui-red-1);
+    }
+  }
+  &:host([appearance="transparent"]) .split-button__divider {
     background-color: var(--calcite-ui-red-1);
   }
   &:host([theme="dark"]) {
@@ -39,6 +63,18 @@
   .split-button__divider-container {
     background-color: var(--calcite-button-light);
   }
+  &:host([appearance="outline"]),
+  &:host([appearance="clear"]) {
+    .split-button__divider-container {
+      border-color: var(--calcite-button-light);
+    }
+    .split-button__divider {
+      background-color: var(--calcite-button-light);
+    }
+  }
+  &:host([appearance="transparent"]) .split-button__divider {
+    background-color: var(--calcite-button-light);
+  }
 
   .split-button__divider {
     background-color: var(--calcite-button-light-text);
@@ -47,6 +83,18 @@
 
 :host([color="dark"]) {
   .split-button__divider-container {
+    background-color: var(--calcite-button-dark);
+  }
+  &:host([appearance="outline"]),
+  &:host([appearance="clear"]) {
+    .split-button__divider-container {
+      border-color: var(--calcite-button-dark);
+    }
+    .split-button__divider {
+      background-color: var(--calcite-button-dark);
+    }
+  }
+  &:host([appearance="transparent"]) .split-button__divider {
     background-color: var(--calcite-button-dark);
   }
 }
@@ -73,4 +121,18 @@
   height: 66.666%;
   display: inline-block;
   background-color: white;
+}
+
+:host([appearance="outline"]) .split-button__divider-container,
+:host([appearance="clear"]) .split-button__divider-container {
+  background-color: transparent;
+  border-width: 1px;
+  border-left: 0;
+  border-right: 0;
+  border-style: solid;
+}
+
+:host([appearance="transparent"]) .split-button__divider-container {
+  background-color: transparent;
+  border-width: 0;
 }

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -6,171 +6,6 @@
       height: 100%;
     }
   }
-
-  --calcite-button-light: #{$blk-020};
-  --calcite-button-light-text: #{$blk-220};
-  --calcite-button-dark: #{$blk-180};
-  --calcite-button-dark-text: #{$blk-230};
-}
-
-:host([color="blue"]) {
-  .split-button__divider-container {
-    background-color: var(--calcite-ui-blue-1);
-  }
-  &:host([appearance="outline"]) .split-button__divider-container {
-    background-color: var(--calcite-ui-foreground-1);
-  }
-  &:host([appearance="outline"]),
-  &:host([appearance="clear"]) {
-    .split-button__divider-container {
-      border-color: var(--calcite-ui-blue-3);
-    }
-    .split-button__divider,
-    &:host(:hover) .split-button__divider-container,
-    &:host([theme="dark"]) .split-button__divider {
-      background-color: var(--calcite-ui-blue-3);
-    }
-  }
-  &:host([appearance="transparent"]) {
-    .split-button__divider {
-      background-color: var(--calcite-ui-blue-3);
-    }
-    &:host([appearance="transparent"]) .split-button__divider {
-      background-color: var(--calcite-ui-blue-3);
-    }
-  }
-  &:host([theme="dark"]) {
-    .split-button__divider {
-      background-color: var(--calcite-button-dark-text);
-    }
-  }
-}
-
-:host([color="red"]) {
-  .split-button__divider-container {
-    background-color: var(--calcite-ui-red-1);
-  }
-  &:host([appearance="outline"]) .split-button__divider-container {
-    background-color: var(--calcite-ui-foreground-1);
-  }
-  &:host([appearance="outline"]),
-  &:host([appearance="clear"]) {
-    .split-button__divider-container {
-      border-color: var(--calcite-ui-red-3);
-    }
-    .split-button__divider,
-    &:host(:hover) .split-button__divider-container {
-      background-color: var(--calcite-ui-red-3);
-    }
-  }
-  &:host([appearance="transparent"]) .split-button__divider {
-    background-color: var(--calcite-ui-red-3);
-  }
-  &:host([theme="dark"]) {
-    .split-button__divider {
-      background-color: var(--calcite-button-dark-text);
-    }
-  }
-}
-
-:host([color="light"]) {
-  .split-button__divider-container {
-    background-color: var(--calcite-button-light);
-  }
-  &:host([appearance="outline"]) {
-    .split-button__divider {
-      background-color: var(--calcite-button-light-text);
-    }
-    .split-button__divider-container {
-      background-color: var(--calcite-ui-foreground-1);
-      border-color: var(--calcite-button-light);
-    }
-    &:host(:hover) .split-button__divider-container {
-      background-color: var(--calcite-button-light);
-    }
-    &:host([theme="dark"]) {
-      .split-button__divider {
-        background-color: var(--calcite-ui-text-1);
-      }
-      .split-button__divider-container {
-        background-color: var(--calcite-ui-foreground-1);
-        border-color: var(--calcite-ui-foreground-1);
-      }
-    }
-  }
-  &:host([appearance="clear"]) {
-    .split-button__divider-container {
-      border-color: var(--calcite-button-light);
-    }
-    .split-button__divider,
-    &:host(:hover) .split-button__divider-container {
-      background-color: var(--calcite-button-light);
-    }
-    &:host([theme="dark"]) {
-      .split-button__divider,
-      &:host(:hover) .split-button__divider-container {
-        background-color: var(--calcite-button-dark);
-      }
-      .split-button__divider-container {
-        background-color: transparent;
-        border-color: var(--calcite-button-dark);
-      }
-    }
-  }
-  &:host([theme="dark"]) {
-    .split-button__divider-container {
-      background-color: var(--calcite-button-dark);
-    }
-  }
-  &:host([appearance="transparent"]) {
-    .split-button__divider {
-      background-color: var(--calcite-button-light);
-    }
-    &:host([theme="dark"]) {
-      .split-button__divider-container {
-        background-color: transparent;
-      }
-      .split-button__divider {
-        background-color: var(--calcite-ui-foreground-1);
-      }
-    }
-  }
-
-  .split-button__divider {
-    background-color: var(--calcite-button-light-text);
-  }
-}
-
-:host([color="dark"]) {
-  .split-button__divider-container {
-    background-color: var(--calcite-button-dark);
-  }
-  &:host([appearance="outline"]) .split-button__divider-container {
-    background-color: var(--calcite-ui-foreground-1);
-  }
-  &:host([appearance="outline"]),
-  &:host([appearance="clear"]) {
-    .split-button__divider-container {
-      border-color: var(--calcite-button-dark);
-    }
-    .split-button__divider,
-    &:host(:hover) .split-button__divider-container {
-      background-color: var(--calcite-button-dark);
-    }
-  }
-  &:host([appearance="transparent"]) .split-button__divider {
-    background-color: var(--calcite-button-dark);
-  }
-}
-
-:host([disabled]) {
-  .split-button__divider-container {
-    opacity: 0.4;
-  }
-
-  calcite-dropdown > calcite-button {
-    pointer-events: none;
-  }
 }
 
 .split-button__divider-container {
@@ -184,7 +19,98 @@
   width: 1px;
   height: 66.666%;
   display: inline-block;
-  background-color: white;
+}
+
+:host-context([theme="dark"]) {
+  @include calcite-theme-dark();
+}
+
+:host([disabled]) {
+  .split-button__divider-container {
+    opacity: 0.4;
+  }
+
+  calcite-dropdown > calcite-button {
+    pointer-events: none;
+  }
+}
+
+:host([appearance="solid"]) {
+  --border-color: transparent;
+  --seperator-color: var(--calcite-ui-foreground-1);
+
+  &:host([color="blue"]) {
+    --bg-color: var(--calcite-ui-blue-1);
+  }
+
+  &:host([color="red"]) {
+    --bg-color: var(--calcite-ui-red-1);
+  }
+
+  &:host([color="light"]) {
+    --bg-color: var(--calcite-ui-foreground-3);
+    --seperator-color: var(--calcite-ui-text-1);
+  }
+
+  &:host([color="dark"]) {
+    --bg-color: #{$blk-180};
+    --seperator-color: #{$blk-000};
+  }
+}
+
+:host([appearance="outline"]),
+:host([appearance="clear"]),
+:host([appearance="transparent"]) {
+  --bg-color: var(--calcite-ui-foreground-1);
+
+  &:host([color="blue"]) {
+    --border-color: var(--calcite-ui-blue-3);
+    --seperator-color: var(--calcite-ui-blue-3);
+  }
+
+  &:host([color="red"]) {
+    --border-color: var(--calcite-ui-red-3);
+    --seperator-color: var(--calcite-ui-red-3);
+  }
+
+  &:host([color="light"]) {
+    --border-color: var(--calcite-ui-foreground-3);
+    --seperator-color: var(--calcite-ui-text-1);
+  }
+
+  &:host([color="dark"]) {
+    --border-color: #{$blk-180};
+    --seperator-color: var(--calcite-ui-text-1);
+  }
+}
+
+:host([appearance="clear"]),
+:host([appearance="transparent"]) {
+  --bg-color: transparent;
+
+  &:host([color="light"]) {
+    --seperator-color: var(--calcite-ui-background);
+  }
+
+  &:host([color="dark"]) {
+    --seperator-color: #{$blk-220};
+  }
+}
+
+:host([appearance="transparent"]) {
+  --border-color: transparent;
+}
+
+.split-button__divider-container {
+  background-color: var(--bg-color);
+  border-color: var(--border-color);
+}
+.split-button__divider {
+  background-color: var(--seperator-color);
+}
+:host(:hover[appearance="outline"]) .split-button__divider-container,
+:host(:hover[appearance="clear"]) .split-button__divider-container {
+  background-color: var(--border-color);
 }
 
 :host([appearance="outline"]) .split-button__divider-container,
@@ -195,11 +121,6 @@
   border-style: solid;
 }
 
-:host([appearance="clear"]) .split-button__divider-container {
-  background-color: transparent;
-}
-
 :host([appearance="transparent"]) .split-button__divider-container {
-  background-color: transparent;
   border-width: 0;
 }

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -72,6 +72,11 @@
       background-color: var(--calcite-button-light);
     }
   }
+  &:host([theme="dark"]) {
+    .split-button__divider-container {
+      background-color: var(--calcite-button-dark);
+    }
+  }
   &:host([appearance="transparent"]) .split-button__divider {
     background-color: var(--calcite-button-light);
   }

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -26,12 +26,18 @@
       border-color: var(--calcite-ui-blue-1);
     }
     .split-button__divider,
-    &:host(:hover) .split-button__divider-container {
-      background-color: var(--calcite-ui-blue-1);
+    &:host(:hover) .split-button__divider-container,
+    &:host([theme="dark"]) .split-button__divider {
+      background-color: var(--calcite-ui-blue-3);
     }
   }
-  &:host([appearance="transparent"]) .split-button__divider {
-    background-color: var(--calcite-ui-blue-1);
+  &:host([appearance="transparent"]) {
+    .split-button__divider {
+      background-color: var(--calcite-ui-blue-1);
+    }
+    &:host([appearance="transparent"]) .split-button__divider {
+      background-color: var(--calcite-ui-blue-3);
+    }
   }
   &:host([theme="dark"]) {
     .split-button__divider {
@@ -44,18 +50,21 @@
   .split-button__divider-container {
     background-color: var(--calcite-ui-red-1);
   }
+  &:host([appearance="outline"]) .split-button__divider-container {
+    background-color: var(--calcite-ui-foreground-1);
+  }
   &:host([appearance="outline"]),
   &:host([appearance="clear"]) {
     .split-button__divider-container {
-      border-color: var(--calcite-ui-red-1);
+      border-color: var(--calcite-ui-red-3);
     }
     .split-button__divider,
     &:host(:hover) .split-button__divider-container {
-      background-color: var(--calcite-ui-red-1);
+      background-color: var(--calcite-ui-red-3);
     }
   }
   &:host([appearance="transparent"]) .split-button__divider {
-    background-color: var(--calcite-ui-red-1);
+    background-color: var(--calcite-ui-red-3);
   }
   &:host([theme="dark"]) {
     .split-button__divider {
@@ -68,7 +77,18 @@
   .split-button__divider-container {
     background-color: var(--calcite-button-light);
   }
-  &:host([appearance="outline"]),
+  &:host([appearance="outline"]) {
+    .split-button__divider {
+      background-color: var(--calcite-button-light-text);
+    }
+    .split-button__divider-container {
+      background-color: var(--calcite-ui-foreground-1);
+      border-color: var(--calcite-button-light);
+    }
+    &:host(:hover) .split-button__divider-container {
+      background-color: var(--calcite-button-light);
+    }
+  }
   &:host([appearance="clear"]) {
     .split-button__divider-container {
       border-color: var(--calcite-button-light);
@@ -95,6 +115,9 @@
 :host([color="dark"]) {
   .split-button__divider-container {
     background-color: var(--calcite-button-dark);
+  }
+  &:host([appearance="outline"]) .split-button__divider-container {
+    background-color: var(--calcite-ui-foreground-1);
   }
   &:host([appearance="outline"]),
   &:host([appearance="clear"]) {

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -17,6 +17,9 @@
   .split-button__divider-container {
     background-color: var(--calcite-ui-blue-1);
   }
+  &:host([appearance="outline"]) .split-button__divider-container {
+    background-color: var(--calcite-ui-foreground-1);
+  }
   &:host([appearance="outline"]),
   &:host([appearance="clear"]) {
     .split-button__divider-container {
@@ -134,11 +137,14 @@
 
 :host([appearance="outline"]) .split-button__divider-container,
 :host([appearance="clear"]) .split-button__divider-container {
-  background-color: transparent;
   border-width: 1px;
   border-left: 0;
   border-right: 0;
   border-style: solid;
+}
+
+:host([appearance="clear"]) .split-button__divider-container {
+  background-color: transparent;
 }
 
 :host([appearance="transparent"]) .split-button__divider-container {

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -22,7 +22,8 @@
     .split-button__divider-container {
       border-color: var(--calcite-ui-blue-1);
     }
-    .split-button__divider {
+    .split-button__divider,
+    &:host(:hover) .split-button__divider-container {
       background-color: var(--calcite-ui-blue-1);
     }
   }
@@ -45,7 +46,8 @@
     .split-button__divider-container {
       border-color: var(--calcite-ui-red-1);
     }
-    .split-button__divider {
+    .split-button__divider,
+    &:host(:hover) .split-button__divider-container {
       background-color: var(--calcite-ui-red-1);
     }
   }
@@ -68,7 +70,8 @@
     .split-button__divider-container {
       border-color: var(--calcite-button-light);
     }
-    .split-button__divider {
+    .split-button__divider,
+    &:host(:hover) .split-button__divider-container {
       background-color: var(--calcite-button-light);
     }
   }
@@ -95,7 +98,8 @@
     .split-button__divider-container {
       border-color: var(--calcite-button-dark);
     }
-    .split-button__divider {
+    .split-button__divider,
+    &:host(:hover) .split-button__divider-container {
       background-color: var(--calcite-button-dark);
     }
   }

--- a/src/components/calcite-split-button/calcite-split-button.stories.ts
+++ b/src/components/calcite-split-button/calcite-split-button.stories.ts
@@ -10,6 +10,7 @@ storiesOf("Components/Split Button", module)
     "Simple",
     (): string => `
     <calcite-split-button
+        appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
         color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
         scale="${select("size", ["s", "m", "l"], "m")}"
         ${boolean("loading", false)}

--- a/src/components/calcite-split-button/calcite-split-button.stories.ts
+++ b/src/components/calcite-split-button/calcite-split-button.stories.ts
@@ -76,6 +76,7 @@ storiesOf("Components/Split Button", module)
     (): string => `
     <div dir='rtl'>
       <calcite-split-button
+          appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
           color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
           scale="${select("size", ["s", "m", "l"], "m")}"
           ${boolean("loading", false)}
@@ -97,6 +98,7 @@ storiesOf("Components/Split Button", module)
     "Dark mode",
     (): string => `
     <calcite-split-button
+        appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
         color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
         scale="${select("size", ["s", "m", "l"], "m")}"
         ${boolean("loading", false)}

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -9,6 +9,9 @@ import { getElementDir } from "../../utils/dom";
 export class CalciteSplitButton {
   @Element() el: HTMLCalciteSplitButtonElement;
 
+  /** specify the appearance style of the button, defaults to solid. */
+  @Prop({ reflect: true }) appearance: "solid" | "outline" | "clear" | "transparent" = "solid";
+
   /** specify the color of the control, defaults to blue */
   @Prop({ reflect: true }) color: "blue" | "dark" | "light" | "red" = "blue";
 
@@ -59,6 +62,7 @@ export class CalciteSplitButton {
       <Host dir={dir}>
         <div class="split-button__container">
           <calcite-button
+            appearance={this.appearance}
             aria-label={this.primaryLabel}
             color={this.color}
             dir={dir}
@@ -69,6 +73,7 @@ export class CalciteSplitButton {
             loading={this.loading}
             onClick={this.calciteSplitButtonPrimaryClickHandler}
             scale={this.scale}
+            splitChild={"primary"}
             theme={this.theme}
           >
             {this.primaryText}
@@ -85,6 +90,7 @@ export class CalciteSplitButton {
             width={this.scale}
           >
             <calcite-button
+              appearance={this.appearance}
               aria-label={this.dropdownLabel}
               color={this.color}
               dir={dir}
@@ -92,6 +98,7 @@ export class CalciteSplitButton {
               icon-start={this.dropdownIcon}
               scale={this.scale}
               slot="dropdown-trigger"
+              splitChild={"secondary"}
               theme={this.theme}
             />
             <slot />

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -58,7 +58,7 @@
     </div>
 
     <h3>Appearance</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
       <calcite-split-button primary-text="Default/Solid Appearance">
         <calcite-dropdown-group selection-mode="none">
           <calcite-dropdown-item>Option 1</calcite-dropdown-item>

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -157,6 +157,18 @@
       </calcite-split-button>
     </div>
 
+    <h3>Appearance (Light Color, Dark Theme)</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
+      <calcite-split-button theme="dark" color="light" primary-text="Default/Solid Appearance">
+      </calcite-split-button>
+      <calcite-split-button theme="dark" color="light" appearance='outline' primary-text="Outline Appearance">
+      </calcite-split-button>
+      <calcite-split-button theme="dark" color="light" appearance='clear' primary-text="Clear Appearance">
+      </calcite-split-button>
+      <calcite-split-button theme="dark" color="light" appearance='transparent' primary-text="Transparent Appearance">
+      </calcite-split-button>
+    </div>
+
     <h3>Disabled</h3>
     <calcite-split-button disabled=true primary-text="Primary Option"></calcite-split-button>
 

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -57,6 +57,30 @@
       </calcite-split-button>
     </div>
 
+    <h3>Appearance</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between'>
+      <calcite-split-button primary-text="Default/Solid Appearance">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button appearance='outline' primary-text="Outline Appearance">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button appearance='clear' primary-text="Clear Appearance">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+      <calcite-split-button appearance='transparent' primary-text="Transparent Appearance">
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-split-button>
+    </div>
+
     <h3>Color</h3>
     <div style='display:flex;flex-direction:row;justify-content:space-between'>
       <calcite-split-button primary-text="Primary Option"></calcite-split-button>

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -57,30 +57,6 @@
       </calcite-split-button>
     </div>
 
-    <h3>Appearance</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
-      <calcite-split-button primary-text="Default/Solid Appearance">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button appearance='outline' primary-text="Outline Appearance">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button appearance='clear' primary-text="Clear Appearance">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button appearance='transparent' primary-text="Transparent Appearance">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 1</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-
     <h3>Color</h3>
     <div style='display:flex;flex-direction:row;justify-content:space-between'>
       <calcite-split-button primary-text="Primary Option"></calcite-split-button>
@@ -118,6 +94,66 @@
           <calcite-dropdown-item>Option 3</calcite-dropdown-item>
           <calcite-dropdown-item>Option 4</calcite-dropdown-item>
         </calcite-dropdown-group>
+      </calcite-split-button>
+    </div>
+
+    <h3>Appearance</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
+      <calcite-split-button primary-text="Default/Solid Appearance">
+      </calcite-split-button>
+      <calcite-split-button appearance='outline' primary-text="Outline Appearance">
+      </calcite-split-button>
+      <calcite-split-button appearance='clear' primary-text="Clear Appearance">
+      </calcite-split-button>
+      <calcite-split-button appearance='transparent' primary-text="Transparent Appearance">
+      </calcite-split-button>
+    </div>
+
+    <h3>Appearance (Red Color)</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
+      <calcite-split-button color="red" primary-text="Default/Solid Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="red" appearance='outline' primary-text="Outline Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="red" appearance='clear' primary-text="Clear Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="red" appearance='transparent' primary-text="Transparent Appearance">
+      </calcite-split-button>
+    </div>
+
+    <h3>Appearance (Light Color)</h3>
+    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between;'>
+      <calcite-split-button color="light" primary-text="Default/Solid Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="light" appearance='outline' primary-text="Outline Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="light" appearance='clear' primary-text="Clear Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="light" appearance='transparent' primary-text="Transparent Appearance">
+      </calcite-split-button>
+    </div>
+
+    <h3>Appearance (Dark Color)</h3>
+    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
+      <calcite-split-button color="dark" primary-text="Default/Solid Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="dark" appearance='outline' primary-text="Outline Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="dark" appearance='clear' primary-text="Clear Appearance">
+      </calcite-split-button>
+      <calcite-split-button color="dark" appearance='transparent' primary-text="Transparent Appearance">
+      </calcite-split-button>
+    </div>
+
+    <h3>Appearance (Dark Theme)</h3>
+    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;'>
+      <calcite-split-button theme="dark" primary-text="Default/Solid Appearance">
+      </calcite-split-button>
+      <calcite-split-button theme="dark" appearance='outline' primary-text="Outline Appearance">
+      </calcite-split-button>
+      <calcite-split-button theme="dark" appearance='clear' primary-text="Clear Appearance">
+      </calcite-split-button>
+      <calcite-split-button theme="dark" appearance='transparent' primary-text="Transparent Appearance">
       </calcite-split-button>
     </div>
 

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -122,7 +122,7 @@
     </div>
 
     <h3>Appearance (Light Color)</h3>
-    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between;'>
+    <div style='display:flex;flex-direction:row;justify-content:space-between;'>
       <calcite-split-button color="light" primary-text="Default/Solid Appearance">
       </calcite-split-button>
       <calcite-split-button color="light" appearance='outline' primary-text="Outline Appearance">
@@ -158,7 +158,7 @@
     </div>
 
     <h3>Appearance (Light Color, Dark Theme)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
+    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between;'>
       <calcite-split-button theme="dark" color="light" primary-text="Default/Solid Appearance">
       </calcite-split-button>
       <calcite-split-button theme="dark" color="light" appearance='outline' primary-text="Outline Appearance">


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/796

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Adds a passthrough `appearance` attribute to the `calcite-split-button` that lands on both the primary and secondary button elements, as well as a new `split-child` attribute on the `calcite-button` component to allow for styling specific to when they're inside split buttons!

![image](https://user-images.githubusercontent.com/1634397/96606790-a883cf80-12c5-11eb-9ea4-9a083016daf5.png)

