### PR TITLE
fix(icon): Explicitly set dir on components with pass-through flip-rtl

### DIFF
--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -106,6 +106,7 @@ export class CalciteButton {
     const iconStartEl = (
       <calcite-icon
         class="calcite-button--icon icon-start"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "start" || this.iconFlipRtl === "both"}
         icon={this.iconStart}
         scale={iconScale}
@@ -115,6 +116,7 @@ export class CalciteButton {
     const iconEndEl = (
       <calcite-icon
         class="calcite-button--icon icon-end"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "end" || this.iconFlipRtl === "both"}
         icon={this.iconEnd}
         scale={iconScale}

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -78,6 +78,7 @@ export class CalciteChip {
     const iconEl = (
       <calcite-icon
         class="calcite-chip--icon"
+        dir={dir}
         flipRtl={this.iconFlipRtl}
         icon={this.icon}
         scale={iconScale}

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -102,6 +102,7 @@ export class CalciteDropdownItem {
     const iconStartEl = (
       <calcite-icon
         class="dropdown-item-icon-start"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "start" || this.iconFlipRtl === "both"}
         icon={this.iconStart}
         scale={iconScale}
@@ -110,6 +111,7 @@ export class CalciteDropdownItem {
     const iconEndEl = (
       <calcite-icon
         class="dropdown-item-icon-end"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "end" || this.iconFlipRtl === "both"}
         icon={this.iconEnd}
         scale={iconScale}

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -200,6 +200,7 @@ export class CalciteInput {
     const iconEl = (
       <calcite-icon
         class="calcite-input-icon"
+        dir={dir}
         flipRtl={this.iconFlipRtl}
         icon={this.icon as string}
         scale={iconScale}

--- a/src/components/calcite-link/calcite-link.tsx
+++ b/src/components/calcite-link/calcite-link.tsx
@@ -71,6 +71,7 @@ export class CalciteLink {
     const iconStartEl = (
       <calcite-icon
         class="calcite-link--icon icon-start"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "start" || this.iconFlipRtl === "both"}
         icon={this.iconStart}
         scale="s"
@@ -80,6 +81,7 @@ export class CalciteLink {
     const iconEndEl = (
       <calcite-icon
         class="calcite-link--icon icon-end"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "end" || this.iconFlipRtl === "both"}
         icon={this.iconEnd}
         scale="s"

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -11,7 +11,7 @@ import {
   State,
   VNode
 } from "@stencil/core";
-import { getElementProp } from "../../utils/dom";
+import { getElementDir, getElementProp } from "../../utils/dom";
 @Component({
   tag: "calcite-radio-group-item",
   styleUrl: "calcite-radio-group-item.scss",
@@ -90,6 +90,7 @@ export class CalciteRadioGroupItem {
 
   render(): VNode {
     const { checked, useFallback, value } = this;
+    const dir = getElementDir(this.el);
     const scale = getElementProp(this.el, "scale", "m");
     const appearance = getElementProp(this.el, "appearance", "solid");
     const layout = getElementProp(this.el, "layout", "horizontal");
@@ -97,6 +98,7 @@ export class CalciteRadioGroupItem {
     const iconEl = (
       <calcite-icon
         class="radio-group-item-icon"
+        dir={dir}
         flipRtl={this.iconFlipRtl}
         icon={this.icon}
         scale="s"

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -96,12 +96,14 @@ export class CalciteTabTitle {
   }
 
   render(): VNode {
+    const dir = getElementDir(this.el);
     const id = this.el.id || this.guid;
     const Tag = this.disabled ? "span" : "a";
 
     const iconStartEl = (
       <calcite-icon
         class="calcite-tab-title--icon icon-start"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "start" || this.iconFlipRtl === "both"}
         icon={this.iconStart}
         scale="s"
@@ -111,6 +113,7 @@ export class CalciteTabTitle {
     const iconEndEl = (
       <calcite-icon
         class="calcite-tab-title--icon icon-end"
+        dir={dir}
         flipRtl={this.iconFlipRtl === "end" || this.iconFlipRtl === "both"}
         icon={this.iconEnd}
         scale="s"


### PR DESCRIPTION
**Related Issue:** #

## Summary
The pass through props weren't adhering to RTL set on the components, so this passes that down to the icon to correctly use `flip-rtl` at the `calcite-icon` level
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
