### PR TITLE
fix(calcite-checkbox): resets to initial checked state when form reset event is triggered

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
@@ -175,4 +175,36 @@ describe("calcite-checkbox", () => {
     expect(element).toEqualText("test-label");
     expect(defaultSlot).toBeDefined();
   });
+
+  it("resets to initial value when form reset event is triggered", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <form>
+        <calcite-checkbox id="unchecked"></calcite-checkbox>
+        <calcite-checkbox id="checked" checked></calcite-checkbox>
+      </form>
+    `);
+
+    const unchecked = await page.find("#unchecked");
+    expect(await unchecked.getProperty("checked")).toBe(false);
+
+    await unchecked.click();
+    expect(await unchecked.getProperty("checked")).toBe(true);
+
+    const checked = await page.find("#checked");
+    expect(await checked.getProperty("checked")).toBe(true);
+
+    await checked.click();
+    expect(await checked.getProperty("checked")).toBe(false);
+
+    await page.evaluate(() => {
+      const form = document.querySelector("form");
+      form.reset();
+    });
+    await page.waitForChanges();
+
+    expect(await unchecked.getProperty("checked")).toBe(false);
+    expect(await checked.getProperty("checked")).toBe(true);
+
+  });
 });

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -100,6 +100,8 @@ export class CalciteCheckbox {
 
   private readonly indeterminatePath = "M4 7h8v2H4z";
 
+  private initialChecked: boolean;
+
   private input: HTMLInputElement;
 
   //--------------------------------------------------------------------------
@@ -167,6 +169,10 @@ export class CalciteCheckbox {
     this.hovered = false;
   }
 
+  formResetHandler = (): void => {
+    this.checked = this.initialChecked;
+  }
+
   private onInputBlur() {
     this.focused = false;
     this.calciteCheckboxFocusedChange.emit();
@@ -185,11 +191,20 @@ export class CalciteCheckbox {
 
   connectedCallback(): void {
     this.guid = this.el.id || `calcite-checkbox-${guid()}`;
+    this.initialChecked = this.checked;
     this.renderHiddenCheckboxInput();
+    const form = this.el.closest("form");
+    if (form) {
+      form.addEventListener("reset", this.formResetHandler);
+    }
   }
 
   disconnectedCallback(): void {
     this.input.parentNode.removeChild(this.input);
+    const form = this.el.closest("form");
+    if (form) {
+      form.removeEventListener("reset", this.formResetHandler);
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/src/demos/calcite-checkbox.html
+++ b/src/demos/calcite-checkbox.html
@@ -344,16 +344,15 @@
                       wrapped in calcite-label reversed
                       <calcite-checkbox name="dark-l-wrapped-reverse" scale="l"></calcite-checkbox>
                     </calcite-label>
-
                   </demo-spacer>
                 </div>
               </div>
               <calcite-button form="calcite-checkbox-demo-form" type="submit">Submit</calcite-button>
+              <calcite-button form="calcite-checkbox-demo-form" type="reset">Reset</calcite-button>
               <button type="submit" style="display: none">Submit</button>
             </demo-spacer>
           </form>
         </demo-form>
   </demo-spacer>
 </body>
-
 </html>


### PR DESCRIPTION
**Related Issue:** #943 