### PR TITLE
feat(inline-editable-input): add support for inline editable inputs and textareas

### DIFF
--- a/src/assets/demo/validateInput.js
+++ b/src/assets/demo/validateInput.js
@@ -134,3 +134,26 @@ function logNativeFocusIn(event) {
 function logNativeFocusOut(event) {
   console.log("native focusout", event.target.id);
 }
+
+function enableEditingForInput(id) {
+  const input = document.querySelector(id);
+  input.addEventListener('calciteInputEnableEditing', () => input.editingEnabled = true)
+}
+
+function saveChangesForInput(id, isSuccess = true) {
+  const input = document.querySelector(id)
+  const action = input.querySelector('[slot="input-action"]');
+  const label = document.querySelector(`${id}-status`);
+  action.addEventListener('click', () => {
+    action.loading = true
+    action.disabled = true
+    input.loading = true
+    window.setTimeout(() => {
+      input.loading = false
+      action.disabled = false
+      action.loading = false
+      if (isSuccess) return input.setAttribute('editing-enabled', false)
+      label.status = 'invalid'
+    }, 1500)
+  })
+}

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -13,12 +13,17 @@
   }
   & .calcite-input-number-button-wrapper,
   & .calcite-input-action-wrapper calcite-button,
-  & .calcite-input-action-wrapper calcite-button button {
+  & .calcite-input-action-wrapper calcite-button button,
+  & .calcite-input-inline-editable-label-wrapper {
     height: 32px;
   }
   & textarea,
   & input[type="file"] {
     height: auto;
+  }
+  & .calcite-input-clear-button {
+    min-height: 32px;
+    min-width: 32px;
   }
 }
 
@@ -36,12 +41,17 @@
   }
   & .calcite-input-number-button-wrapper,
   & .calcite-input-action-wrapper calcite-button,
-  & .calcite-input-action-wrapper calcite-button button {
+  & .calcite-input-action-wrapper calcite-button button,
+  & .calcite-input-inline-editable-label-wrapper {
     height: 44px;
   }
   & textarea,
   & input[type="file"] {
     height: auto;
+  }
+  & .calcite-input-clear-button {
+    min-height: 44px;
+    min-width: 44px;
   }
 }
 
@@ -59,12 +69,17 @@
   }
   & .calcite-input-number-button-wrapper,
   & .calcite-input-action-wrapper calcite-button,
-  & .calcite-input-action-wrapper calcite-button button {
+  & .calcite-input-action-wrapper calcite-button button,
+  & .calcite-input-inline-editable-label-wrapper {
     height: 56px;
   }
   & textarea,
   & input[type="file"] {
     height: auto;
+  }
+  & .calcite-input-clear-button {
+    min-height: 56px;
+    min-width: 56px;
   }
 }
 
@@ -177,11 +192,14 @@
 }
 //positioning wrapper for icon and loader
 .calcite-input-element-wrapper {
-  display: inline-flex;
+  display: none;
   flex: 1;
   min-width: 20%;
   position: relative;
   order: 3;
+  &.is-visible {
+    display: inline-flex;
+  }
 }
 
 .calcite-input-icon {
@@ -229,10 +247,10 @@ input[type="time"]::-webkit-clear-button {
   display: flex;
   align-self: stretch;
   align-items: center;
+  justify-content: center;
   box-sizing: border-box;
   cursor: pointer;
   min-height: 100%;
-  padding: 0 $baseline/2;
   border: 1px solid var(--calcite-ui-border-1);
   transition: $transition;
   pointer-events: initial;
@@ -245,6 +263,16 @@ input[type="time"]::-webkit-clear-button {
   }
   &:active {
     background-color: var(--calcite-ui-foreground-3);
+  }
+  &:disabled {
+    opacity: 0.4;
+  }
+}
+
+:host([dir="rtl"]) {
+  .calcite-input-clear-button {
+    border-left: 1px solid var(--calcite-ui-border-1);
+    border-right: none;
   }
 }
 
@@ -267,8 +295,11 @@ input[type="time"]::-webkit-clear-button {
 
 // slotted action
 .calcite-input-action-wrapper {
-  display: flex;
-  order: 7;
+  display: none;
+  &.is-visible {
+    order: 7;
+    display: flex;
+  }
 }
 
 // prefix and suffix
@@ -542,5 +573,90 @@ $inputStatusColors: "invalid" var(--calcite-ui-red-1), "valid" var(--calcite-ui-
 
   :host([status="#{$name}"]) .calcite-input-icon {
     color: $color;
+  }
+}
+
+.calcite-input-buttons-wrapper {
+  display: flex;
+  flex-direction: row;
+  order: 7;
+}
+
+.calcite-input-inline-editable-label-wrapper {
+  align-items: center;
+  display: none;
+  justify-content: space-between;
+  width: 100%;
+  &.is-visible {
+    display: flex;
+  }
+  &:hover {
+    background-color: var(--calcite-ui-foreground-2);
+  }
+  .calcite-input-inline-editable-label {
+    flex: 1;
+    height: 100%;
+    justify-content: center;
+    &.with-placeholder {
+      color: var(--calcite-ui-text-3);
+    }
+  }
+}
+
+:host([type="textarea"]) {
+  &[scale="s"] {
+    .calcite-input-inline-editable-label-wrapper {
+      min-height: 46px;
+      padding: 8px 0;
+      &.has-action {
+        min-height: 64px;
+      }
+    }
+    .calcite-input-clear-button {
+      width: 100%;
+    }
+  }
+  &[scale="m"] {
+    .calcite-input-inline-editable-label-wrapper {
+      min-height: 64px;
+      padding: 12px 0;
+      &.has-action {
+        min-height: 88px;
+      }
+    }
+  }
+  &[scale="l"] {
+    .calcite-input-inline-editable-label-wrapper {
+      min-height: 82px;
+      padding: 16px 0;
+      &.has-action {
+        min-height: 112px;
+      }
+    }
+  }
+  .calcite-input-buttons-wrapper {
+    flex-direction: column;
+  }
+  .calcite-input-clear-button {
+    align-self: flex-start;
+    order: 1;
+  }
+  .calcite-input-inline-editable-label-wrapper {
+    align-items: flex-start;
+    box-sizing: border-box;
+    .calcite-input-inline-editable-label {
+      justify-content: flex-start;
+    }
+  }
+  .calcite-input-enable-editing-button {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+  &[dir="rtl"] {
+    .calcite-input-enable-editing-button {
+      left: 0;
+      right: unset;
+    }
   }
 }

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -192,14 +192,11 @@
 }
 //positioning wrapper for icon and loader
 .calcite-input-element-wrapper {
-  display: none;
+  display: inline-flex;
   flex: 1;
   min-width: 20%;
   position: relative;
   order: 3;
-  &.is-visible {
-    display: inline-flex;
-  }
 }
 
 .calcite-input-icon {
@@ -295,11 +292,8 @@ input[type="time"]::-webkit-clear-button {
 
 // slotted action
 .calcite-input-action-wrapper {
-  display: none;
-  &.is-visible {
-    order: 7;
-    display: flex;
-  }
+  display: flex;
+  order: 7;
 }
 
 // prefix and suffix
@@ -398,7 +392,10 @@ input[type="time"]::-webkit-clear-button {
 
 :host([number-button-type="vertical"]) .calcite-input-wrapper {
   flex-direction: row;
-  display: flex;
+  display: none;
+  &.is-visible {
+    display: flex;
+  }
 }
 
 :host([number-button-type="vertical"]) {
@@ -487,9 +484,12 @@ input[type="time"]::-webkit-clear-button {
 }
 
 .calcite-input-wrapper {
-  display: flex;
+  display: none;
   flex-direction: row;
   position: relative;
+  &.is-visible {
+    display: flex;
+  }
 }
 
 // hide the default date picker
@@ -584,12 +584,9 @@ $inputStatusColors: "invalid" var(--calcite-ui-red-1), "valid" var(--calcite-ui-
 
 .calcite-input-inline-editable-label-wrapper {
   align-items: center;
-  display: none;
+  display: flex;
   justify-content: space-between;
   width: 100%;
-  &.is-visible {
-    display: flex;
-  }
   &:hover {
     background-color: var(--calcite-ui-foreground-2);
   }
@@ -644,6 +641,7 @@ $inputStatusColors: "invalid" var(--calcite-ui-red-1), "valid" var(--calcite-ui-
   .calcite-input-inline-editable-label-wrapper {
     align-items: flex-start;
     box-sizing: border-box;
+    position: relative;
     .calcite-input-inline-editable-label {
       justify-content: flex-start;
     }

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -11,9 +11,9 @@ import {
   State,
   VNode,
   Watch
-  } from '@stencil/core'
-import { getElementDir, getElementProp } from '../../utils/dom'
-import { getKey } from '../../utils/key'
+} from "@stencil/core";
+import { getElementDir, getElementProp } from "../../utils/dom";
+import { getKey } from "../../utils/key";
 
 @Component({
   tag: "calcite-input",
@@ -60,10 +60,13 @@ export class CalciteInput {
   /** flip the icon in rtl */
   @Prop({ reflect: true }) iconFlipRtl?: boolean;
 
+  /** Allow toggling between read only / editable state */
   @Prop() inlineEditable?: boolean = false;
 
+  /** Enable editing mode for inline-editable inputs */
   @Prop({ mutable: true, reflect: true }) editingEnabled?: boolean = false;
 
+  /** Flag used to disable input controls while an async/longer-running task is in progress. */
   @Prop() isActionInProgress?: boolean = false;
 
   /** specify if the input is in loading state */

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -1,3 +1,5 @@
+import { getElementDir, getElementProp } from "../../utils/dom";
+import { getKey } from "../../utils/key";
 import {
   Component,
   Element,
@@ -8,12 +10,10 @@ import {
   Listen,
   Method,
   Prop,
-  State,
+  // State,
   VNode,
   Watch
 } from "@stencil/core";
-import { getElementDir, getElementProp } from "../../utils/dom";
-import { getKey } from "../../utils/key";
 
 @Component({
   tag: "calcite-input",
@@ -61,13 +61,10 @@ export class CalciteInput {
   @Prop({ reflect: true }) iconFlipRtl?: boolean;
 
   /** Allow toggling between read only / editable state */
-  @Prop() inlineEditable?: boolean = false;
+  @Prop({ reflect: true }) inlineEditable?: boolean = false;
 
   /** Enable editing mode for inline-editable inputs */
   @Prop({ mutable: true, reflect: true }) editingEnabled?: boolean = false;
-
-  /** Flag used to disable input controls while an async/longer-running task is in progress. */
-  @Prop() isActionInProgress?: boolean = false;
 
   /** specify if the input is in loading state */
   @Prop({ reflect: true }) loading = false;
@@ -177,12 +174,12 @@ export class CalciteInput {
     this.stepString = this.step?.toString();
     this.slottedActionEl = this.el.querySelector("[slot=input-action]");
     if (this.disabled) this.setDisabledAction();
-    if (this.type === "textarea") this.value = this.slotValue;
+    if (this.type === "textarea") setTimeout(() => (this.value = this.slotValue));
   }
 
-  componentDidRender(): void {
-    this.labelValue = this.value || this.placeholder;
-  }
+  // componentDidRender(): void {
+  //   this.labelValue = this.value || this.placeholder;
+  // }
 
   componentWillLoad(): void {
     this.childElType = this.type === "textarea" ? "textarea" : "input";
@@ -201,10 +198,6 @@ export class CalciteInput {
     this.shouldSetFocus = false;
   }
 
-  get shouldShowAction(): boolean {
-    return this.inlineEditable ? this.hasAction && this.editingEnabled : this.hasAction;
-  }
-
   get shouldShowLoadingIndicator(): boolean {
     return this.loading && !this.inlineEditable;
   }
@@ -219,6 +212,10 @@ export class CalciteInput {
 
   get slotValue(): string | undefined {
     return this.slotRef?.innerText.trim();
+  }
+
+  get labelValue(): string {
+    return this.value || this.placeholder;
   }
 
   get isClearable(): boolean {
@@ -326,9 +323,7 @@ export class CalciteInput {
 
     const labelEl = (
       <div
-        class={`calcite-input-inline-editable-label-wrapper ${
-          this.shouldShowInputControls ? "" : "is-visible"
-        } ${this.hasAction ? "has-action" : ""}`}
+        class={`calcite-input-inline-editable-label-wrapper ${this.hasAction ? "has-action" : ""}`}
       >
         <calcite-label
           class={`calcite-input-inline-editable-label ${!this.value ? "with-placeholder" : ""}`}
@@ -357,45 +352,33 @@ export class CalciteInput {
         <div ref={(el) => (this.slotRef = el)} style={{ display: "none" }}>
           <slot />
         </div>
-        <div class="calcite-input-wrapper">
-          {this.type === "number" &&
-          this.numberButtonType === "horizontal" &&
-          this.shouldShowInputControls ? (
+        {!this.shouldShowInputControls ? labelEl : <div />}
+        <div class={`calcite-input-wrapper ${this.shouldShowInputControls ? "is-visible" : ""}`}>
+          {this.type === "number" && this.numberButtonType === "horizontal" ? (
             numberButtonsHorizontalDown
           ) : (
             <div />
           )}
-          {this.prefixText && this.shouldShowInputControls ? prefixText : <div />}
-          {labelEl}
-          <div
-            class={`calcite-input-element-wrapper ${
-              this.shouldShowInputControls ? "is-visible" : ""
-            }`}
-          >
+          {this.prefixText ? prefixText : <div />}
+          <div class="calcite-input-element-wrapper">
             {childEl}
             {this.isClearable && !this.inlineEditable ? inputClearButton : <div />}
-            {this.icon && this.shouldShowInputControls ? iconEl : <div />}
+            {this.icon ? iconEl : <div />}
             {this.shouldShowLoadingIndicator ? loader : <div />}
           </div>
           <div class="calcite-input-buttons-wrapper">
             {this.isClearable && this.inlineEditable ? inputClearButton : <div />}
-            <div
-              class={`calcite-input-action-wrapper ${this.shouldShowAction ? "is-visible" : ""}`}
-            >
+            <div class="calcite-input-action-wrapper">
               <slot name="input-action" />
             </div>
           </div>
-          {this.type === "number" &&
-          this.numberButtonType === "vertical" &&
-          this.shouldShowInputControls ? (
+          {this.type === "number" && this.numberButtonType === "vertical" ? (
             numberButtonsVertical
           ) : (
             <div />
           )}
-          {this.suffixText && this.shouldShowInputControls ? suffixText : <div />}
-          {this.type === "number" &&
-          this.numberButtonType === "horizontal" &&
-          this.shouldShowInputControls ? (
+          {this.suffixText ? suffixText : <div />}
+          {this.type === "number" && this.numberButtonType === "horizontal" ? (
             numberButtonsHorizontalUp
           ) : (
             <div />
@@ -468,7 +451,7 @@ export class CalciteInput {
   /** textarea types set their value via a slot. this ref provides access to it */
   private slotRef?: HTMLElement;
 
-  @State() private labelValue?: string;
+  // @State() private labelValue?: string;
 
   private shouldSetFocus = false;
 

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -517,6 +517,156 @@
             </calcite-label>
           </calcite-accordion-item>
         </calcite-accordion>
+
+        <h3>Inline Editable Text Input</h3>
+        <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
+          <calcite-accordion-item item-title="Scales" active>
+            <div>
+              S
+              <calcite-input id='monday-s' inline-editable value="Monday" placeholder="Day of the week" scale='s'/>
+              <script>enableEditingForInput('#monday-s')</script>
+            </div>
+
+            <div>
+              M
+              <calcite-input id='monday-m' inline-editable value="Monday" placeholder="Day of the week" scale='m'/>
+              <script>enableEditingForInput('#monday-m')</script>
+            </div>
+
+            <div>
+              L
+              <calcite-input id='monday-l' inline-editable value="Monday" placeholder="Day of the week" scale='l'/>
+              <script>enableEditingForInput('#monday-l')</script>
+            </div>
+          </calcite-accordion-item>
+
+          <calcite-accordion-item item-title="Scales: With Action">
+            <div>
+              S
+              <calcite-input id='tuesday-s' inline-editable value="Tuesday" placeholder="Day of the week" scale='s'>
+                <calcite-button slot="input-action" icon-start="check" scale='s'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#tuesday-s')</script>
+              <script>saveChangesForInput('#tuesday-s')</script>
+            </div>
+
+            <div>
+              M
+              <calcite-input id='tuesday-m' inline-editable value="Tuesday" placeholder="Day of the week" scale='m'>
+                <calcite-button slot="input-action" icon-start="check" scale='m'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#tuesday-m')</script>
+              <script>saveChangesForInput('#tuesday-m')</script>
+            </div>
+
+            <div>
+              L
+              <calcite-input id='tuesday-l' inline-editable value="Tuesday" placeholder="Day of the week" scale='l'>
+                <calcite-button slot="input-action" icon-start="check" scale='l'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#tuesday-l')</script>
+              <script>saveChangesForInput('#tuesday-l')</script>
+            </div>
+          </calcite-accordion-item>
+
+          <calcite-accordion-item item-title="Input Types">
+            <div>
+              <calcite-input id="inline-editable-kitchen" inline-editable prefix-text="pre" suffix-text="suf" clearable type="number" placeholder="How many apples?">
+                <calcite-button slot="input-action" icon-start="check"></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#inline-editable-kitchen')</script>
+              <script>saveChangesForInput('#inline-editable-kitchen')</script>
+            </div>
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="RTL">
+            <div>
+              <calcite-input id='inline-editable-rtl' inline-editable placeholder="Day of the week" scale='l' dir="rtl">
+                Wednesday
+                <calcite-button slot="input-action" icon-start="check" scale='l'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#inline-editable-rtl')</script>
+              <script>saveChangesForInput('#inline-editable-rtl')</script>
+            </div>
+            <div>
+              <calcite-input id="inline-editable-kitchen-rtl" inline-editable prefix-text="pre" suffix-text="suf" clearable type="number" placeholder="How many apples?" dir="rtl">
+                <calcite-button slot="input-action" icon-start="check"></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#inline-editable-kitchen-rtl')</script>
+              <script>saveChangesForInput('#inline-editable-kitchen-rtl')</script>
+            </div>
+          </calcite-accordion-item>
+        </calcite-accordion>
+
+        <h3>Inline Editable Textarea</h3>
+        <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
+          <calcite-accordion-item item-title="Scales" active>
+            <div>
+              S
+              <calcite-input id='monday-ta-s' inline-editable placeholder="Day of the week" scale='s' type='textarea' editing-enabled/>
+                Monday
+              </calcite-input>
+              <script>enableEditingForInput('#monday-ta-s')</script>
+            </div>
+
+            <div>
+              M
+              <calcite-input id='monday-ta-m' inline-editable placeholder="Day of the week" scale='m' type='textarea'>
+                Monday
+              </calcite-input>
+              <script>enableEditingForInput('#monday-ta-m')</script>
+            </div>
+
+            <div>
+              L
+              <calcite-input id='monday-ta-l' inline-editable placeholder="Day of the week" scale='l' type='textarea'>
+                Monday
+              </calcite-input>
+              <script>enableEditingForInput('#monday-ta-l')</script>
+            </div>
+          </calcite-accordion-item>
+
+          <calcite-accordion-item item-title="Scales: With Action">
+            <div>
+              S
+              <calcite-input id='tuesday-ta-s' inline-editable placeholder="Day of the week" scale='s' type='textarea'>
+                Tuesday
+                <calcite-button slot="input-action" icon-start="check" scale='s'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#tuesday-ta-s')</script>
+              <script>saveChangesForInput('#tuesday-ta-s')</script>
+            </div>
+
+            <div>
+              M
+              <calcite-input id='tuesday-ta-m' inline-editable placeholder="Day of the week" scale='m' type='textarea'>
+                Tuesday
+                <calcite-button slot="input-action" icon-start="check" scale='m'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#tuesday-ta-m')</script>
+              <script>saveChangesForInput('#tuesday-ta-m')</script>
+            </div>
+
+            <div>
+              L
+              <calcite-input id='tuesday-ta-l' inline-editable placeholder="Day of the week" scale='l' type='textarea'>
+                Tuesday
+                <calcite-button slot="input-action" icon-start="check" scale='l'></calcite-button>
+              </calcite-input>
+              <script>enableEditingForInput('#tuesday-ta-l')</script>
+              <script>saveChangesForInput('#tuesday-ta-l')</script>
+            </div>
+          </calcite-accordion-item>
+
+          <calcite-accordion-item item-title="RTL">
+            <calcite-input id='ta-rtl' inline-editable placeholder="Day of the week" scale='l' type='textarea' dir="rtl">
+              Wednesday
+              <calcite-button slot="input-action" icon-start="check" scale='l'></calcite-button>
+            </calcite-input>
+            <script>enableEditingForInput('#ta-rtl')</script>
+            <script>saveChangesForInput('#ta-rtl')</script>
+          </calcite-accordion-item>
+        </calcite-accordion>
+
         <h3>Disabled</h3>
         <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
           <calcite-accordion-item item-title="Scales" active>
@@ -532,6 +682,18 @@
               <calcite-input value="My great value" prefix-text="pre" icon="banana" suffix-text="suf"> </calcite-input>
               <calcite-input-message icon active>Some information about the input</calcite-input-message>
             </calcite-label>
+
+            <div>
+              Inline Editable Text Input
+              <calcite-input id='disabled-inline' inline-editable placeholder="Day of the week" scale='m' disabled>
+                Pi Day
+              </calcite-input>
+            </div>
+
+            <div>
+              Inline Editable Textarea
+              <calcite-input id='disabled-inline-ta' inline-editable placeholder="Day of the week" scale='m' type='textarea' value="Friday" disabled/>
+            </div>
 
             <calcite-label disabled scale="l">
               Scale l
@@ -1003,6 +1165,25 @@
               }
               validateInputWithNativeEvents("#validate-input-example-native-function-password");
             </script>
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Inline Editable Text Input" active>
+            <calcite-label id='black-friday-status'>
+              Success
+              <calcite-input id='black-friday' inline-editable value="Friday" placeholder="Day of the week" theme="dark">
+                <calcite-button slot="input-action" icon-start="check" theme="dark"/>
+              </calcite-input>
+              <script>enableEditingForInput('#black-friday')</script>
+              <script>saveChangesForInput('#black-friday')</script>
+            </calcite-label>
+
+            <calcite-label id='black-friday-error-status'>
+              Error
+              <calcite-input id='black-friday-error' inline-editable value="Friday" placeholder="Day of the week" theme="dark">
+                <calcite-button slot="input-action" icon-start="check" theme="dark"/>
+              </calcite-input>
+              <script>enableEditingForInput('#black-friday-error')</script>
+              <script>saveChangesForInput('#black-friday-error', false)</script>
+            </calcite-label>
           </calcite-accordion-item>
         </calcite-accordion>
       </div>


### PR DESCRIPTION
**Related Issue:** #819 

## Summary

Add support for inline editable inputs.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
