### PR TITLE
feat(chip): allow passing avatar as chip image

### DIFF
--- a/src/components/calcite-avatar/calcite-avatar.e2e.ts
+++ b/src/components/calcite-avatar/calcite-avatar.e2e.ts
@@ -39,7 +39,7 @@ describe("calcite-avatar", () => {
       const background = document.querySelector("calcite-avatar").shadowRoot.querySelector(".background");
       return background.getAttribute("style");
     });
-    expect(style).toEqual("background-color: rgb(222, 236, 247);");
+    expect(style).toEqual("background-color: rgb(214, 232, 245);");
   });
 
   it("computes a background fill if id is not a valid hex", async () => {
@@ -51,7 +51,7 @@ describe("calcite-avatar", () => {
       const background = document.querySelector("calcite-avatar").shadowRoot.querySelector(".background");
       return background.getAttribute("style");
     });
-    expect(style).toEqual("background-color: rgb(247, 226, 222);");
+    expect(style).toEqual("background-color: rgb(245, 219, 214);");
   });
 
   it("renders default icon when no information is passed", async () => {

--- a/src/components/calcite-avatar/calcite-avatar.scss
+++ b/src/components/calcite-avatar/calcite-avatar.scss
@@ -12,11 +12,11 @@
 }
 
 :host([scale="m"]) {
-  @apply w-8 h-8 text--1;
+  @apply w-8 h-8 text--2;
 }
 
 :host([scale="l"]) {
-  @apply w-10 h-10 text-1;
+  @apply w-10 h-10 text--1;
 }
 
 .icon {
@@ -24,7 +24,7 @@
 }
 
 .background {
-  @apply w-full h-full flex items-center justify-center;
+  @apply w-full h-full flex items-center justify-center rounded-half;
 }
 
 .initials {

--- a/src/components/calcite-avatar/calcite-avatar.tsx
+++ b/src/components/calcite-avatar/calcite-avatar.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Host, Prop, State } from "@stencil/core";
-import { getElementDir } from "../../utils/dom";
+import { getElementDir, getElementTheme } from "../../utils/dom";
 import { isValidHex } from "../calcite-color/utils";
 import { hexToHue, stringToHex } from "./utils";
 
@@ -24,7 +24,7 @@ export class CalciteAvatar {
   //--------------------------------------------------------------------------
 
   /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: "light" | "dark" = "light";
+  @Prop({ reflect: true }) theme: "light" | "dark";
 
   /** specify the scale of the avatar, defaults to m */
   @Prop({ mutable: true, reflect: true }) scale: "s" | "m" | "l" = "m";
@@ -51,9 +51,6 @@ export class CalciteAvatar {
     // prop validations
     const scale = ["s", "m", "l"];
     if (!scale.includes(this.scale)) this.scale = "m";
-
-    const theme = ["dark", "light"];
-    if (!theme.includes(this.theme)) this.theme = "light";
   }
 
   render() {
@@ -102,7 +99,8 @@ export class CalciteAvatar {
    * Generate a valid background color that is consistent and unique to this user
    */
   private generateFillColor() {
-    const { userId, username, fullName, theme } = this;
+    const { userId, username, fullName } = this;
+    const theme = getElementTheme(this.el);
     const id = userId && `#${userId.substr(userId.length - 6)}`;
     const name = username || fullName || "";
     const hex = id && isValidHex(id) ? id : stringToHex(name);
@@ -111,7 +109,7 @@ export class CalciteAvatar {
       return `var(--calcite-ui-foreground-2)`;
     }
     const hue = hexToHue(hex);
-    const l = theme === "dark" ? 15 : 92;
+    const l = theme === "dark" ? 20 : 90;
     return `hsl(${hue}, 60%, ${l}%)`;
   }
 

--- a/src/components/calcite-chip/calcite-chip.scss
+++ b/src/components/calcite-chip/calcite-chip.scss
@@ -19,32 +19,37 @@
 // scale
 // todo update when new spacing modifiers are introduced to calcite-base
 :host([scale="s"]) {
-  font-size: 10px;
-  height: 22px;
+  @apply h-5 text--3;
   --calcite-chip-spacing-unit-l: theme("spacing.2");
   --calcite-chip-spacing-unit-s: theme("spacing.1");
   & slot[name="chip-image"]::slotted(*) {
-    max-height: theme("spacing.4");
+    @apply h-5 w-5;
   }
 }
 :host([scale="m"]) {
-  font-size: 12px;
-  height: 28px;
+  @apply h-8 text--2;
   --calcite-chip-spacing-unit-l: theme("spacing.3");
   --calcite-chip-spacing-unit-s: 6px;
   & slot[name="chip-image"]::slotted(*) {
-    max-height: 22px;
+    @apply h-6 w-6 pl-1;
   }
 }
 
 :host([scale="l"]) {
-  font-size: 14px;
-  height: 40px;
+  @apply h-10 text--1;
   --calcite-chip-spacing-unit-l: theme("spacing.4");
   --calcite-chip-spacing-unit-s: theme("spacing.2");
   & slot[name="chip-image"]::slotted(*) {
-    max-height: 30px;
+    @apply h-8 w-8 pl-1;
   }
+}
+
+:host([dir="rtl"][scale="m"]) slot[name="chip-image"]::slotted(*) {
+  @apply pl-0 pr-1;
+}
+
+:host([dir="rtl"][scale="l"]) slot[name="chip-image"]::slotted(*) {
+  @apply pl-0 pr-1;
 }
 
 :host {
@@ -97,18 +102,13 @@
 }
 
 :host button {
-  display: inline-flex;
-  align-self: stretch;
+  @apply m-0 p-0 inline-flex self-stretch items-center border-none cursor-pointer;
   -webkit-appearance: none;
   background-color: transparent;
-  margin: 0;
-  padding: 0;
   border-radius: var(--calcite-chip-button-border-radius);
-  border: none;
   transition: $transition;
   padding: var(--calcite-chip-spacing-unit-s);
   cursor: pointer;
-
   color: var(--calcite-ui-text-1);
   &:hover,
   &:focus {
@@ -121,19 +121,14 @@
 }
 
 //slotted image
-:host slot[name="chip-image"] {
-  display: inline-flex;
-}
 :host slot[name="chip-image"]::slotted(*) {
-  border-radius: 50%;
-  height: 100%;
-  padding: calc(var(--calcite-chip-spacing-unit-l) / 3);
+  @apply rounded-half overflow-hidden inline-flex;
 }
 
 //icon
 .calcite-chip--icon {
-  display: inline-flex;
-  position: relative;
+  @apply inline-flex relative;
+
   margin: 0 0 0 var(--calcite-chip-spacing-unit-l);
   transition: $transition;
   border-radius: var(--calcite-chip-button-border-radius);

--- a/src/components/calcite-chip/calcite-chip.stories.ts
+++ b/src/components/calcite-chip/calcite-chip.stories.ts
@@ -49,6 +49,22 @@ storiesOf("Components/Chip", module)
     </div>
   `
   )
+  .add("With Avatar", (): string => {
+    const scale = select("scale", ["s", "m", "l"], "m");
+    return `
+      <div style="background-color:white;padding:100px">
+        <calcite-chip
+          scale="${scale}"
+          appearance="${select("appearance", ["solid", "clear"], "solid")}"
+          color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+          ${boolean("dismissible", false)}
+        >
+          <calcite-avatar slot="chip-image" scale="${scale}" user-id="25684463a00c449585dbb32a065f6b74" full-name="user name"></calcite-avatar>
+          User Name
+        </calcite-chip>
+      </div>
+    `;
+  })
   .add(
     "Dark theme",
     (): string => `

--- a/src/demos/calcite-chip.html
+++ b/src/demos/calcite-chip.html
@@ -39,6 +39,16 @@
     <img slot="chip-image" src="https://placekitten.com/50/50" />
     Siamese Cat
   </calcite-chip>
+  <h2>Slotted avatar</h2>
+  <calcite-chip active scale="s">
+    <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
+  </calcite-chip>
+  <calcite-chip active scale="m">
+    <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
+  </calcite-chip>
+  <calcite-chip active scale="l">
+    <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
+  </calcite-chip>
   <h2>With icon attribute</h2>
   <calcite-chip icon="check-circle">
     Siamese Cat
@@ -172,7 +182,7 @@
   </calcite-chip>
   <br />
   <br />
-  <div class="demo-background-dark">
+  <div class="demo-background-dark" theme="dark">
     <h2>Basic</h2>
     <calcite-chip theme="dark" id="one">Apple</calcite-chip>
     <h2>Slotted "chip-image"</h2>
@@ -300,11 +310,30 @@
     <calcite-chip theme="dark" dismissible icon="camera-flash-on" appearance="clear" color="blue">
       Blue
     </calcite-chip>
+    <h2>Slotted avatar</h2>
+    <calcite-chip active scale="s">
+      <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
+    </calcite-chip>
+    <calcite-chip active scale="m">
+      <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
+    </calcite-chip>
+    <calcite-chip active scale="l">
+      <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
+    </calcite-chip>
     <h2>RTL</h2>
     <calcite-chip theme="dark" dir="rtl">Apple</calcite-chip>
     <calcite-chip theme="dark" dir="rtl">
       <img slot="chip-image" src="https://placekitten.com/50/50" />
       Siamese Cat
+    </calcite-chip>
+    <calcite-chip active scale="s" dir="rtl">
+      <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
+    </calcite-chip>
+    <calcite-chip active scale="m" dir="rtl">
+      <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
+    </calcite-chip>
+    <calcite-chip active scale="l" dir="rtl">
+      <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
     </calcite-chip>
     <calcite-chip theme="dark" icon="camera-flash-on" dir="rtl">
       Camera Flash On


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

This allows passing an avatar to a chip as per discussion yesterday. 

```html
<calcite-chip>
    <calcite-avatar slot="chip-image" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw" />
    Carol Whitten
</calcite-chip>
```

@bstifle on the gray of the chip, the backgrounds were really hard to distinguish, so I lowered the lightness a bit. Had to tweak the initials font sizes a little as well so they wouldn't get cramped in this slightly smaller container. Take a 👀  and we can tweak as needed.