### PR TITLE
feat(inline editable inputs): support inline editable text inputs.

### DIFF
--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -1,0 +1,509 @@
+import { newE2EPage } from "@stencil/core/testing";
+import { HYDRATED_ATTR } from "../../tests/commonTests";
+
+describe("calcite-input", () => {
+  it("renders", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-input></calcite-input>");
+    const input = await page.find("calcite-input");
+    expect(input).toHaveAttribute(HYDRATED_ATTR);
+  });
+
+  it("renders default props when none are provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input></calcite-input>
+    `);
+    await page.waitForChanges();
+
+    const element = await page.find("calcite-input");
+    expect(element).toEqualAttribute("status", "idle");
+    expect(element).toEqualAttribute("alignment", "start");
+    expect(element).toEqualAttribute("number-button-type", "vertical");
+    expect(element).toEqualAttribute("type", "text");
+    expect(element).toEqualAttribute("scale", "m");
+  });
+
+  it("renders requested props when valid props are provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input status="invalid" theme="dark" alignment="end" number-button-type="none" type="number" scale="s"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    expect(element).toEqualAttribute("status", "invalid");
+    expect(element).toEqualAttribute("theme", "dark");
+    expect(element).toEqualAttribute("alignment", "end");
+    expect(element).toEqualAttribute("number-button-type", "none");
+    expect(element).toEqualAttribute("type", "number");
+    expect(element).toEqualAttribute("scale", "s");
+  });
+
+  it("inherits requested props when from wrapping calcite-label when props are provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-label status="invalid" theme="dark" scale="s">
+    Label text
+    <calcite-input></calcite-input>
+    </calcite-label>
+    `);
+
+    const element = await page.find("calcite-input");
+    expect(element).toEqualAttribute("status", "invalid");
+    expect(element).toEqualAttribute("scale", "s");
+  });
+
+  it("renders an icon when explicit Calcite UI is requested, and is a type without a default icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input icon="key" type="number"></calcite-input>
+    `);
+
+    const icon = await page.find("calcite-input .calcite-input-icon");
+    expect(icon).not.toBeNull();
+  });
+
+  it("renders an icon when explicit Calcite UI is requested, and is a type with a default icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input icon="key" type="date"></calcite-input>
+    `);
+
+    const icon = await page.find("calcite-input .calcite-input-icon");
+    expect(icon).not.toBeNull();
+  });
+
+  it("renders an icon when requested without an explicit Calcite UI, and is a type with a default icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input icon type="date"></calcite-input>
+    `);
+
+    const icon = await page.find("calcite-input .calcite-input-icon");
+    expect(icon).not.toBeNull();
+  });
+
+  it("does not render an icon when requested without an explicit Calcite UI, and is a type without a default icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input icon type="number"></calcite-input>
+    `);
+
+    const icon = await page.find("calcite-input .calcite-input-icon");
+    expect(icon).toBeNull();
+  });
+
+  it("renders number buttons in default vertical alignment when type=number", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number"></calcite-input>
+    `);
+
+    const numberVerticalWrapper = await page.find("calcite-input .calcite-input-number-button-wrapper");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .number-button-item-horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .number-button-item-horizontal[data-adjustment='up']"
+    );
+
+    expect(numberVerticalWrapper).not.toBeNull();
+    expect(numberHorizontalItemDown).toBeNull();
+    expect(numberHorizontalItemUp).toBeNull();
+  });
+
+  it("renders number buttons in horizontal vertical alignment when type=number and number button type is horizontal", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" number-button-type="horizontal"></calcite-input>
+    `);
+
+    const numberVerticalWrapper = await page.find("calcite-input .calcite-input-number-button-wrapper");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .number-button-item-horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .number-button-item-horizontal[data-adjustment='up']"
+    );
+
+    expect(numberVerticalWrapper).toBeNull();
+    expect(numberHorizontalItemDown).not.toBeNull();
+    expect(numberHorizontalItemUp).not.toBeNull();
+  });
+
+  it("renders no buttons in type=number and number button type is none", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" number-button-type="none"></calcite-input>
+    `);
+
+    const numberVerticalWrapper = await page.find("calcite-input .calcite-input-number-button-wrapper");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .number-button-item-horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .number-button-item-horizontal[data-adjustment='up']"
+    );
+
+    expect(numberVerticalWrapper).toBeNull();
+    expect(numberHorizontalItemDown).toBeNull();
+    expect(numberHorizontalItemUp).toBeNull();
+  });
+
+  it("focuses child input when setFocus method is called", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-label>
+    Label text
+    <calcite-input></calcite-input>
+    </calcite-label>
+    `);
+
+    const element = await page.find("calcite-input");
+    await element.callMethod("setFocus");
+    await page.waitForChanges();
+    const activeEl = await page.evaluate(() => document.activeElement["s-hn"]);
+    expect(activeEl).toEqual(element.nodeName);
+  });
+
+  it("correctly increments and decrements value when number buttons are clicked", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" value="3"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(element.getAttribute("value")).toBe("3");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("2");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("3");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("4");
+  });
+
+  it("correctly increments and decrements value when number buttons are clicked and step is set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" step="10" value="15"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(element.getAttribute("value")).toBe("15");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("5");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("15");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("25");
+  });
+
+  it("correctly stops decrementing value when min is set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" min="10" value="12"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    expect(element.getAttribute("value")).toBe("12");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("11");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+  });
+  it("correctly stops incrementing value when max is set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" max="10" value="8"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(element.getAttribute("value")).toBe("8");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("9");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("10");
+  });
+  it("correctly stops decrementing value when min is 0", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" min="0" value="2"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    expect(element.getAttribute("value")).toBe("2");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("1");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+  });
+
+  it("correctly stops incrementing value when max is 0", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" max="0" value="-2"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(element.getAttribute("value")).toBe("-2");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("-1");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("0");
+  });
+
+  it("when value is added, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await page.keyboard.press("a");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("a");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("when value changes, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await page.keyboard.press("e");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("John Doee");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("renders clear button when clearable is requested and value is populated at load", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+    const clearButton = await page.find("calcite-input .calcite-input-clear-button");
+    expect(clearButton).not.toBe(null);
+  });
+
+  it("does not render clear button when clearable is requested and value is not populated", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable></calcite-input>
+    `);
+
+    const clearButton = await page.find("calcite-input .calcite-input-clear-button");
+    expect(clearButton).toBe(null);
+  });
+
+  it("does not render clear button when clearable is not requested", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input></calcite-input>
+    `);
+
+    const clearButton = await page.find("calcite-input .calcite-input-clear-button");
+    expect(clearButton).toBe(null);
+  });
+
+  it("when clearable is requested, value is cleared on escape key press", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+  });
+
+  it("when clearable is requested, value is cleared on clear button click", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const clearButton = await page.find(".calcite-input-clear-button");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    clearButton.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+  });
+
+  it("when clearable is requested and clear button is clicked, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    const clearButton = await page.find(".calcite-input-clear-button");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    clearButton.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("when clearable is requested and input is cleared via escape key, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input clearable value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("when type is search and clear button is clicked, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="search" value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    const clearButton = await page.find(".calcite-input-clear-button");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    clearButton.click();
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("when type is search and input is cleared via escape key, event is received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="search" value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("");
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("when clearable is not requested and input is cleared via escape key, event is not received", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input value="John Doe"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+    const element = await page.find("calcite-input");
+    expect(element.getAttribute("value")).toBe("John Doe");
+    await element.callMethod("setFocus");
+    expect(calciteInputInput).not.toHaveReceivedEvent();
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(element.getAttribute("value")).toBe("John Doe");
+    expect(calciteInputInput).not.toHaveReceivedEvent();
+  });
+
+  it("should emit event when up or down clicked on input", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input type="number" max="0" value="-2"></calcite-input>
+    `);
+
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+    );
+    expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+    );
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(calciteInputInput).toHaveReceivedEventTimes(2);
+
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(calciteInputInput).toHaveReceivedEventTimes(3);
+  });
+});

--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -22,7 +22,6 @@ describe("calcite-inline-editable", () => {
     it("renders default props when none are provided", async () => {
       const element = await page.find("calcite-inline-editable");
       await page.waitForChanges();
-      expect(element).toEqualAttribute("scale", "m");
       expect(element).not.toHaveAttribute("has-controls");
       expect(element).not.toHaveAttribute("editing-enabled");
       expect(element).not.toHaveAttribute("loading");

--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -21,6 +21,7 @@ describe("calcite-inline-editable", () => {
 
     it("renders default props when none are provided", async () => {
       const element = await page.find("calcite-inline-editable");
+      await page.waitForChanges();
       expect(element).toEqualAttribute("scale", "m");
       expect(element).not.toHaveAttribute("has-controls");
       expect(element).not.toHaveAttribute("editing-enabled");

--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -22,7 +22,7 @@ describe("calcite-inline-editable", () => {
     it("renders default props when none are provided", async () => {
       const element = await page.find("calcite-inline-editable");
       await page.waitForChanges();
-      expect(element).not.toHaveAttribute("has-controls");
+      expect(element).not.toHaveAttribute("controls");
       expect(element).not.toHaveAttribute("editing-enabled");
       expect(element).not.toHaveAttribute("loading");
     });
@@ -60,7 +60,7 @@ describe("calcite-inline-editable", () => {
     it("renders requested props when valid props are provided", async () => {
       page = await newE2EPage();
       await page.setContent(`
-      <calcite-inline-editable has-controls editing-enabled loading disabled scale="l" theme="dark">
+      <calcite-inline-editable controls editing-enabled loading disabled scale="l" theme="dark">
         <calcite-input/>
       </calcite-inline-editable>
       `);
@@ -68,7 +68,7 @@ describe("calcite-inline-editable", () => {
       const element = await page.find("calcite-inline-editable");
       expect(element).toEqualAttribute("scale", "l");
       expect(element).toEqualAttribute("theme", "dark");
-      expect(element).toHaveAttribute("has-controls");
+      expect(element).toHaveAttribute("controls");
       expect(element).toHaveAttribute("editing-enabled");
       expect(element).toHaveAttribute("loading");
       expect(element).toHaveAttribute("disabled");
@@ -170,7 +170,7 @@ describe("calcite-inline-editable", () => {
     beforeEach(async () => {
       page = await newE2EPage();
       await page.setContent(`
-      <calcite-inline-editable has-controls>
+      <calcite-inline-editable controls>
         <calcite-input value="John Doe"/>
       </calcite-inline-editable>
       `);
@@ -296,7 +296,7 @@ describe("calcite-inline-editable", () => {
     describe("accessibility", () => {
       it("is accessible", async () =>
         accessible(`
-        <calcite-label has-controls>
+        <calcite-label controls>
           Label
           <calcite-inline-editable>
             <calcite-input value="John Doe"/>
@@ -306,7 +306,7 @@ describe("calcite-inline-editable", () => {
 
       it("is accessible when editing is enabled", async () =>
         accessible(`
-        <calcite-label has-controls editing-enabled>
+        <calcite-label controls editing-enabled>
           Label
           <calcite-inline-editable editing-enabled>
             <calcite-input value="John Doe"/>
@@ -321,7 +321,7 @@ describe("calcite-inline-editable", () => {
         await page.setContent(`
         <calcite-label>
           <span>Hello</span>
-          <calcite-inline-editable has-controls>
+          <calcite-inline-editable controls>
             <calcite-input value="John Doe"/>
           </calcite-inline-editable>
         </calcite-label>

--- a/src/components/calcite-inline-editable/calcite-inline-editable.scss
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.scss
@@ -46,6 +46,12 @@
   border-right: none;
 }
 
+:host([disabled]) {
+  .calcite-inline-editable-cancel-editing-button-wrapper {
+    border-color: var(--calcite-ui-border-2);
+  }
+}
+
 :host {
   &::slotted(*) {
     .calcite-input-element-wrapper {

--- a/src/components/calcite-inline-editable/calcite-inline-editable.scss
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.scss
@@ -109,3 +109,19 @@
     }
   }
 }
+
+[dir="rtl"] {
+  :host {
+    &:not([editing-enabled]) {
+      &::slotted(*) {
+        .calcite-input-element-wrapper {
+          textarea,
+          input {
+            padding-right: 0;
+            padding-left: unset;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/calcite-inline-editable/calcite-inline-editable.scss
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.scss
@@ -1,0 +1,111 @@
+:host([scale="s"]) {
+  .calcite-inline-editable-controls-wrapper {
+    height: 32px;
+  }
+}
+
+:host([scale="m"]) {
+  .calcite-inline-editable-controls-wrapper {
+    height: 44px;
+  }
+}
+
+:host([scale="l"]) {
+  .calcite-inline-editable-controls-wrapper {
+    height: 56px;
+  }
+}
+
+:host(:not([editing-enabled])) {
+  .calcite-inline-editable-wrapper {
+    &:hover {
+      background: var(--calcite-ui-foreground-2);
+    }
+  }
+}
+
+.calcite-inline-editable-wrapper {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  transition: $transition;
+  background: var(--calcite-ui-foreground-1);
+
+  .calcite-inline-editable-input-wrapper {
+    flex: 1;
+  }
+}
+
+.calcite-inline-editable-controls-wrapper {
+  display: flex;
+}
+
+.calcite-inline-editable-cancel-editing-button-wrapper {
+  border: 1px solid var(--calcite-ui-border-1);
+  border-left: none;
+  border-right: none;
+}
+
+:host {
+  &::slotted(*) {
+    .calcite-input-element-wrapper {
+      textarea,
+      input {
+        transition: $transition;
+      }
+    }
+  }
+}
+
+:host(:not([editing-enabled])) {
+  &:not([theme="dark"]) {
+    &::slotted(*) {
+      .calcite-input-element-wrapper {
+        background: transparent;
+      }
+    }
+  }
+}
+
+:host(:not([editing-enabled])) {
+  &::slotted(*) {
+    .sc-calcite-input {
+      display: none;
+    }
+
+    .calcite-input-element-wrapper {
+      display: flex;
+      cursor: pointer;
+      textarea,
+      input {
+        border-color: transparent;
+        padding-left: 0;
+        cursor: pointer;
+        display: flex;
+      }
+    }
+  }
+
+  &:hover {
+    &::slotted(*) {
+      textarea,
+      input {
+        background: var(--calcite-ui-foreground-2);
+      }
+    }
+  }
+}
+
+:host([dir="rtl"]) {
+  &:not([editing-enabled]) {
+    &::slotted(*) {
+      .calcite-input-element-wrapper {
+        textarea,
+        input {
+          padding-right: 0;
+          padding-left: unset;
+        }
+      }
+    }
+  }
+}

--- a/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
@@ -18,6 +18,7 @@ storiesOf("Components/Inline Editable", module)
           ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
           ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
           ${boolean("loading", false, "InlineEditable") && "loading"}
+          ${boolean("disabled", false, "InlineEditable") && "disabled"}
           intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
           intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
           intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
@@ -46,6 +47,7 @@ storiesOf("Components/Inline Editable", module)
           ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
           ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
           ${boolean("loading", false, "InlineEditable") && "loading"}
+          ${boolean("disabled", false, "InlineEditable") && "disabled"}
           intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
           intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
           intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
@@ -71,6 +73,7 @@ storiesOf("Components/Inline Editable", module)
           ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
           ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
           ${boolean("loading", false, "InlineEditable") && "loading"}
+          ${boolean("disabled", false, "InlineEditable") && "disabled"}
           intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
           intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
           intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">

--- a/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
@@ -15,7 +15,7 @@ storiesOf("Components/Inline Editable", module)
         layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}">
       ${text("label text", "My great label", "Label")}
       <calcite-inline-editable
-          ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
+          ${boolean("controls", false, "InlineEditable") && "controls"}
           ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
           ${boolean("loading", false, "InlineEditable") && "loading"}
           ${boolean("disabled", false, "InlineEditable") && "disabled"}
@@ -44,7 +44,7 @@ storiesOf("Components/Inline Editable", module)
     <div style="width:300px;max-width:100%;">
       <calcite-inline-editable
           scale="${select("scale", ["s", "m", "l"], "m", "InlineEditable")}"
-          ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
+          ${boolean("controls", false, "InlineEditable") && "controls"}
           ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
           ${boolean("loading", false, "InlineEditable") && "loading"}
           ${boolean("disabled", false, "InlineEditable") && "disabled"}
@@ -70,7 +70,7 @@ storiesOf("Components/Inline Editable", module)
         layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}">
       ${text("label text", "My great label", "Label")}
       <calcite-inline-editable
-          ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
+          ${boolean("controls", false, "InlineEditable") && "controls"}
           ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
           ${boolean("loading", false, "InlineEditable") && "loading"}
           ${boolean("disabled", false, "InlineEditable") && "disabled"}

--- a/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
@@ -1,86 +1,38 @@
-import { storiesOf } from "@storybook/html";
-import { select, text } from "@storybook/addon-knobs";
-import { boolean } from "../../../.storybook/helpers";
-import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { boolean, select, text } from "@storybook/addon-knobs";
+import { darkBackground } from "../../../.storybook/utils";
+import { storiesOf } from "@storybook/html";
 
-storiesOf("Components/Input", module)
+storiesOf("Components/Inline Editable", module)
   .addParameters({ notes: readme })
   .add(
-    "With Label",
+    "With label",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    >
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${text("min", "")}"
-      max="${text("max", "")}"
-      step="${text("step", "")}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
-    </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "With Label and Input Message",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+    <div style="width:300px;max-width:100%;">
     <calcite-label
-    status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
-    scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
-    layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
-    >
-    ${text("label text", "My great label", "Label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text",
-        "Input"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
-      alignment="${select("alignment", ["start", "end"], "start", "Input")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
-      min="${text("min", "", "Input")}"
-      max="${text("max", "", "Input")}"
-      step="${text("step", "", "Input")}"
-      prefix-text="${text("prefix-text", "", "Input")}"
-      suffix-text="${text("suffix-text", "", "Input")}"
-      ${boolean("loading", false, "Input")}
-      ${boolean("autofocus", false, "Input")}
-      ${boolean("required", false, "Input")}
-      value="${text("value", "", "Input")}"
-      placeholder="${text("placeholder", "Placeholder text", "Input")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("active", true, "Input Message")}
-    ${boolean("icon", true, "Input Message")}
-    type="${select("type", ["default", "floating"], "default", "Input Message")}"
-   >${text("input message text", "My great input message", "Input Message")}</calcite-input-message>
+        status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+        scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+        layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}">
+      ${text("label text", "My great label", "Label")}
+      <calcite-inline-editable
+          ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
+          ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
+          ${boolean("loading", false, "InlineEditable") && "loading"}
+          intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
+          intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
+          intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
+        <calcite-input
+            alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+            placeholder="${text("placeholder", "Placeholder text", "Input")}">
+        </calcite-input>
+      </calcite-inline-editable>
+      <calcite-input-message
+          ${boolean("active", false, "InputMessage") && "active"}
+          ${boolean("icon", false, "InputMessage") && "icon"}
+          type="${select("type", ["default", "floating"], "default", "InputMessage")}"
+          status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}">
+        ${text("text", "My great input message", "InputMessage")}
+      </calcite-input-message>
     </calcite-label>
     </div>
   `
@@ -88,131 +40,52 @@ storiesOf("Components/Input", module)
   .add(
     "Without Label",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-input
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${text("min", "")}"
-      max="${text("max", "")}"
-      step="${text("step", "")}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
+    <div style="width:300px;max-width:100%;">
+      <calcite-inline-editable
+          scale="${select("scale", ["s", "m", "l"], "m", "InlineEditable")}"
+          ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
+          ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
+          ${boolean("loading", false, "InlineEditable") && "loading"}
+          intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
+          intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
+          intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
+        <calcite-input
+            alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+            placeholder="${text("placeholder", "Placeholder text", "Input")}">
+        </calcite-input>
+      </calcite-inline-editable>
     </div>
   `
   )
   .add(
-    "With Slotted Action",
+    "Dark mode",
     (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    >
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${text("min", "")}"
-      max="${text("max", "")}"
-      step="${text("step", "")}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-      <calcite-button slot="input-action">${text("action button text", "Go")}</calcite-button>
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
-    </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "Textarea",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}">
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="textarea"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
-    </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "Simple - Dark mode",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-label theme="dark" status="${select("status", ["idle", "valid", "invalid"], "idle")}">
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${text("min", "")}"
-      max="${text("max", "")}"
-      step="${text("step", "")}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("calcite-input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
+    <div style="width:300px;max-width:100%;">
+    <calcite-label
+        theme="dark"
+        status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+        scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+        layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}">
+      ${text("label text", "My great label", "Label")}
+      <calcite-inline-editable
+          ${boolean("has-controls", false, "InlineEditable") && "has-controls"}
+          ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
+          ${boolean("loading", false, "InlineEditable") && "loading"}
+          intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
+          intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
+          intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
+        <calcite-input
+            alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+            placeholder="${text("placeholder", "Placeholder text", "Input")}">
+        </calcite-input>
+      </calcite-inline-editable>
+      <calcite-input-message
+          ${boolean("active", false, "InputMessage") && "active"}
+          ${boolean("icon", false, "InputMessage") && "icon"}
+          type="${select("type", ["default", "floating"], "default", "InputMessage")}"
+          status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}">
+        ${text("text", "My great input message", "InputMessage")}
+      </calcite-input-message>
     </calcite-label>
     </div>
   `,

--- a/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
@@ -1,0 +1,220 @@
+import { storiesOf } from "@storybook/html";
+import { select, text } from "@storybook/addon-knobs";
+import { boolean } from "../../../.storybook/helpers";
+import { darkBackground } from "../../../.storybook/utils";
+import readme from "./readme.md";
+
+storiesOf("Components/Input", module)
+  .addParameters({ notes: readme })
+  .add(
+    "With Label",
+    (): string => `
+    <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    >
+    ${text("label text", "My great label")}
+    <calcite-input
+      type="${select(
+        "type",
+        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+        "text"
+      )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+      alignment="${select("alignment", ["start", "end"], "start")}"
+      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
+      prefix-text="${text("prefix-text", "")}"
+      suffix-text="${text("suffix-text", "")}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
+      value="${text("value", "")}"
+      placeholder="${text("placeholder", "Placeholder text")}">
+    </calcite-input>
+    <calcite-input-message
+    ${boolean("input-message-active", false)}
+    type="${select("input message type", ["default", "floating"], "default")}"
+    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
+      "input message text",
+      "My great input message"
+    )}</calcite-input-message>
+    </calcite-label>
+    </div>
+  `
+  )
+  .add(
+    "With Label and Input Message",
+    (): string => `
+    <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+    status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+    scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+    layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+    >
+    ${text("label text", "My great label", "Label")}
+    <calcite-input
+      type="${select(
+        "type",
+        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+        "text",
+        "Input"
+      )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
+      alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
+      min="${text("min", "", "Input")}"
+      max="${text("max", "", "Input")}"
+      step="${text("step", "", "Input")}"
+      prefix-text="${text("prefix-text", "", "Input")}"
+      suffix-text="${text("suffix-text", "", "Input")}"
+      ${boolean("loading", false, "Input")}
+      ${boolean("autofocus", false, "Input")}
+      ${boolean("required", false, "Input")}
+      value="${text("value", "", "Input")}"
+      placeholder="${text("placeholder", "Placeholder text", "Input")}">
+    </calcite-input>
+    <calcite-input-message
+    ${boolean("active", true, "Input Message")}
+    ${boolean("icon", true, "Input Message")}
+    type="${select("type", ["default", "floating"], "default", "Input Message")}"
+   >${text("input message text", "My great input message", "Input Message")}</calcite-input-message>
+    </calcite-label>
+    </div>
+  `
+  )
+  .add(
+    "Without Label",
+    (): string => `
+    <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-input
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      type="${select(
+        "type",
+        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+        "text"
+      )}"
+
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+      alignment="${select("alignment", ["start", "end"], "start")}"
+      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
+      prefix-text="${text("prefix-text", "")}"
+      suffix-text="${text("suffix-text", "")}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
+      value="${text("value", "")}"
+      placeholder="${text("placeholder", "Placeholder text")}">
+    </calcite-input>
+    </div>
+  `
+  )
+  .add(
+    "With Slotted Action",
+    (): string => `
+    <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    >
+    ${text("label text", "My great label")}
+    <calcite-input
+      type="${select(
+        "type",
+        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+        "text"
+      )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+      alignment="${select("alignment", ["start", "end"], "start")}"
+      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
+      prefix-text="${text("prefix-text", "")}"
+      suffix-text="${text("suffix-text", "")}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
+      value="${text("value", "")}"
+      placeholder="${text("placeholder", "Placeholder text")}">
+      <calcite-button slot="input-action">${text("action button text", "Go")}</calcite-button>
+    </calcite-input>
+    <calcite-input-message
+    ${boolean("input-message-active", false)}
+    type="${select("input message type", ["default", "floating"], "default")}"
+    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
+      "input message text",
+      "My great input message"
+    )}</calcite-input-message>
+    </calcite-label>
+    </div>
+  `
+  )
+  .add(
+    "Textarea",
+    (): string => `
+    <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}">
+    ${text("label text", "My great label")}
+    <calcite-input
+      type="textarea"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
+      value="${text("value", "")}"
+      placeholder="${text("placeholder", "Placeholder text")}">
+    </calcite-input>
+    <calcite-input-message
+    ${boolean("input-message-active", false)}
+    type="${select("input message type", ["default", "floating"], "default")}"
+    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
+      "input message text",
+      "My great input message"
+    )}</calcite-input-message>
+    </calcite-label>
+    </div>
+  `
+  )
+  .add(
+    "Simple - Dark mode",
+    (): string => `
+    <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label theme="dark" status="${select("status", ["idle", "valid", "invalid"], "idle")}">
+    ${text("label text", "My great label")}
+    <calcite-input
+      type="${select(
+        "type",
+        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+        "text"
+      )}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+      alignment="${select("alignment", ["start", "end"], "start")}"
+      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+      min="${text("min", "")}"
+      max="${text("max", "")}"
+      step="${text("step", "")}"
+      prefix-text="${text("prefix-text", "")}"
+      suffix-text="${text("suffix-text", "")}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
+      value="${text("value", "")}"
+      placeholder="${text("placeholder", "Placeholder text")}">
+    </calcite-input>
+    <calcite-input-message
+    ${boolean("calcite-input-message-active", false)}
+    type="${select("input message type", ["default", "floating"], "default")}"
+    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
+      "input message text",
+      "My great input message"
+    )}</calcite-input-message>
+    </calcite-label>
+    </div>
+  `,
+    { backgrounds: darkBackground }
+  );

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -48,7 +48,7 @@ export class CalciteInlineEditable {
   @Prop({ mutable: true, reflect: true }) loading = false;
 
   /** specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false */
-  @Prop({ reflect: true }) hasControls = false;
+  @Prop({ reflect: true }) controls = false;
 
   /** specify text to be user for the enable editing button's aria-label, defaults to `Click to edit` */
   @Prop({ reflect: true }) intlEnableEditing = TEXT.intlEnablingEditing;
@@ -65,18 +65,8 @@ export class CalciteInlineEditable {
   /** specify the theme of the inline-editable component, defaults to the theme of the wrapped calcite-input or the theme of the closest wrapping component with a set theme */
   @Prop({ reflect: true }) theme?: "light" | "dark";
 
-  /** when has-controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically. */
-  @Prop() afterConfirm?: () => Promise<any>;
-
-  //--------------------------------------------------------------------------
-  //
-  //  Getters/Setters
-  //
-  //--------------------------------------------------------------------------
-
-  get shouldShowControls(): boolean {
-    return this.editingEnabled && this.hasControls;
-  }
+  /** when controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically. */
+  @Prop() afterConfirm?: () => Promise<void>;
 
   //--------------------------------------------------------------------------
   //
@@ -177,7 +167,7 @@ export class CalciteInlineEditable {
 
   @Listen("calciteInputBlur")
   blurHandler(): void {
-    if (!this.hasControls) this.disableEditing();
+    if (!this.controls) this.disableEditing();
   }
 
   @Listen("click", { target: "window" })
@@ -219,6 +209,10 @@ export class CalciteInlineEditable {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private get shouldShowControls(): boolean {
+    return this.editingEnabled && this.controls;
+  }
 
   private enableEditing = () => {
     this.htmlInput.tabIndex = undefined;

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -1,0 +1,254 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+  VNode
+} from "@stencil/core";
+import { getElementProp } from "../../utils/dom";
+import { TEXT } from "./resources";
+
+@Component({
+  tag: "calcite-inline-editable",
+  scoped: true,
+  styleUrl: "calcite-inline-editable.scss"
+})
+export class CalciteInlineEditable {
+  //--------------------------------------------------------------------------
+  //
+  //  Element
+  //
+  //--------------------------------------------------------------------------
+
+  @Element() el!: HTMLCalciteInlineEditableElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Props
+  //
+  //--------------------------------------------------------------------------
+
+  /** specify whether the wrapped input element is editable, defaults to false */
+  @Prop({ mutable: true, reflect: true }) editingEnabled = false;
+
+  /** specify whether the confirm button should display a loading state, defaults to false */
+  @Prop({ mutable: true, reflect: true }) loading = false;
+
+  /** specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false */
+  @Prop({ reflect: true }) hasControls = false;
+
+  /** specify text to be user for the enable editing button's aria-label, defaults to `Click to edit` */
+  @Prop({ reflect: true }) intlEnableEditing = TEXT.intlEnablingEditing;
+
+  /** specify text to be user for the cancel editing button's aria-label, defaults to `Cancel` */
+  @Prop({ reflect: true }) intlCancelEditing = TEXT.intlCancelEditing;
+
+  /** specify text to be user for the confirm changes button's aria-label, defaults to `Save` */
+  @Prop({ reflect: true }) intlConfirmChanges = TEXT.intlConfirmChanges;
+
+  /** specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the scale of the closest wrapping component with a set scale */
+  @Prop({ reflect: true }) scale?: "s" | "m" | "l";
+
+  /** specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the theme of the closest wrapping component with a set theme */
+  @Prop({ reflect: true }) theme?: "light" | "dark";
+
+  @Prop() onConfirmChanges: () => Promise<any>;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Getters/Setters
+  //
+  //--------------------------------------------------------------------------
+
+  get shouldShowControls(): boolean {
+    return this.editingEnabled && this.hasControls;
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  componentWillLoad() {
+    this.inputElement = this.el.querySelector("calcite-input") as HTMLCalciteInputElement;
+    this.inputElement.tabIndex = -1;
+    this.scale =
+      this.scale || this.inputElement.scale || getElementProp(this.el, "scale", undefined);
+    this.theme =
+      this.theme || this.inputElement.theme || getElementProp(this.el, "theme", undefined);
+  }
+
+  componentDidLoad() {
+    this.htmlInput = this.inputElement.querySelector("input");
+    if (!this.editingEnabled) this.htmlInput.tabIndex = -1;
+  }
+
+  render(): VNode {
+    return (
+      <Host>
+        <div
+          class="calcite-inline-editable-wrapper"
+          onClick={this.enableEditingHandler}
+          onKeyDown={this.escapeKeyHandler}
+        >
+          <div class="calcite-inline-editable-input-wrapper">
+            <slot />
+          </div>
+          <div class="calcite-inline-editable-controls-wrapper">
+            {!this.editingEnabled && (
+              <calcite-button
+                appearance="transparent"
+                aria-label={this.intlEnableEditing}
+                class="calcite-input-enable-editing-button"
+                color="dark"
+                disabled={this.inputElement.disabled}
+                iconStart="pencil"
+                onClick={this.enableEditingHandler}
+                ref={(el) => (this.enableEditingButton = el)}
+                scale={this.scale}
+                theme={this.theme}
+              />
+            )}
+            {this.shouldShowControls && [
+              <div class="calcite-inline-editable-cancel-editing-button-wrapper">
+                <calcite-button
+                  appearance="transparent"
+                  aria-label={this.intlCancelEditing}
+                  class="calcite-inline-editable-cancel-editing-button"
+                  color="dark"
+                  disabled={this.inputElement.disabled}
+                  iconStart="x"
+                  onClick={this.cancelEditingHandler}
+                  scale={this.scale}
+                  theme={this.theme}
+                />
+              </div>,
+              <calcite-button
+                appearance="solid"
+                aria-label={this.intlConfirmChanges}
+                class="calcite-inline-editable-confirm-changes-button"
+                color="blue"
+                disabled={this.inputElement.disabled}
+                iconStart="check"
+                loading={this.loading}
+                onClick={this.confirmChangesChangesHandler}
+                scale={this.scale}
+                theme={this.theme}
+              />
+            ]}
+          </div>
+        </div>
+      </Host>
+    );
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  //--------------------------------------------------------------------------
+
+  @Event() calciteInlineEditableCancelEditing: EventEmitter;
+
+  @Event() calciteInlineEditableConfirmChanges: EventEmitter;
+
+  @Event() calciteInlineEditableEnableEditing: EventEmitter;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Event Listeners
+  //
+  //--------------------------------------------------------------------------
+
+  @Listen("calciteInputBlur")
+  blurHandler(): void {
+    if (!this.hasControls) this.disableEditing();
+  }
+
+  @Listen("click", { target: "window" })
+  handleLabelFocus(e: CustomEvent): void {
+    const HTMLTarget = e.target as HTMLElement;
+    if (!HTMLTarget.classList.contains("calcite-label-text")) return;
+    if (!HTMLTarget.parentElement.contains(this.el)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    this.enableEditingButton.setFocus();
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private State
+  //
+  //--------------------------------------------------------------------------
+
+  private inputElement: HTMLCalciteInputElement;
+
+  private htmlInput: HTMLInputElement;
+
+  private valuePriorToEditing: string;
+
+  private enableEditingButton: HTMLCalciteButtonElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  private enableEditing = () => {
+    this.htmlInput.tabIndex = undefined;
+    this.valuePriorToEditing = this.inputElement.value;
+    this.editingEnabled = true;
+    this.inputElement.setFocus();
+    this.calciteInlineEditableEnableEditing.emit();
+  };
+
+  private disableEditing = () => {
+    this.htmlInput.tabIndex = -1;
+    this.editingEnabled = false;
+  };
+
+  private cancelEditing = () => {
+    this.inputElement.value = this.valuePriorToEditing;
+    this.disableEditing();
+    setTimeout(() => this.enableEditingButton.setFocus(), 100);
+    this.calciteInlineEditableCancelEditing.emit();
+  };
+
+  private escapeKeyHandler = async (e: KeyboardEvent) => {
+    if (e.key !== "Escape") return;
+    this.cancelEditing();
+  };
+
+  private cancelEditingHandler = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.cancelEditing();
+  };
+
+  private enableEditingHandler = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!this.editingEnabled) this.enableEditing();
+  };
+
+  private confirmChangesChangesHandler = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      if (this.onConfirmChanges) {
+        this.loading = true;
+        await this.onConfirmChanges();
+        this.disableEditing();
+      }
+      this.calciteInlineEditableConfirmChanges.emit();
+    } finally {
+      this.loading = false;
+    }
+  };
+}

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -57,7 +57,7 @@ export class CalciteInlineEditable {
   @Prop({ reflect: true }) theme?: "light" | "dark";
 
   //** when has-controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically. */
-  @Prop() onConfirmChanges: () => Promise<any>; //eslint-disable-line
+  @Prop() onConfirmChanges: () => Promise<any>; // eslint-disable-line @stencil/decorators-style
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-inline-editable/readme.md
+++ b/src/components/calcite-inline-editable/readme.md
@@ -1,0 +1,103 @@
+# calcite-inline-editable
+
+### Attributes
+
+#### Custom attributes
+
+#### Native attributes
+
+### Slots
+
+- there is a single slot for rendering a `<calcite-input>`
+
+### Events
+
+#### Custom events
+
+You can listen for the following custom events from emitted `<calcite-inline-editable>`:
+
+The events don't have a custom payload. In most cases, listening for these events should not be necessary if an `onConfirmChanges` method is used in combination with `has-controls`.
+
+```
+  input.addEventListener("calciteInlineEditableEnableEditing", doSomething);
+  input.addEventListener("calciteInlineEditableCancelEditing", doSomething);
+  input.addEventListener("calciteInlineEditableConfirmChanges", doSomething);
+
+```
+
+### Usage
+
+There is no need to set a theme or scale on the `<calcite-inline-editable>` component, as it inherits these values from the wrapped `<calcite-input>`, or the closest parent component where these props are set.
+
+#### Structure
+
+##### Basic (disables editing on blur)
+
+```
+<calcite-inline-editable>
+  <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+</calcite-inline-editable>
+```
+
+##### With explicit save/cancel controls
+
+```
+<calcite-inline-editable has-controls>
+  <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+</calcite-inline-editable>
+```
+
+##### With a label
+
+```
+<calcite-label>
+    My great label
+    <calcite-inline-editable has-controls>
+      <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+    </calcite-inline-editable>
+</calcite-label>
+```
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property             | Attribute              | Description                                                                                                                                                            | Type                 | Default                    |
+| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------------- |
+| `editingEnabled`     | `editing-enabled`      | specify whether the wrapped input element is editable, defaults to false                                                                                               | `boolean`            | `false`                    |
+| `hasControls`        | `has-controls`         | specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false                                                                | `boolean`            | `false`                    |
+| `intlCancelEditing`  | `intl-cancel-editing`  | specify text to be user for the cancel editing button's aria-label, defaults to `Cancel`                                                                               | `string`             | `TEXT.intlCancelEditing`   |
+| `intlConfirmChanges` | `intl-confirm-changes` | specify text to be user for the confirm changes button's aria-label, defaults to `Save`                                                                                | `string`             | `TEXT.intlConfirmChanges`  |
+| `intlEnableEditing`  | `intl-enable-editing`  | specify text to be user for the enable editing button's aria-label, defaults to `Click to edit`                                                                        | `string`             | `TEXT.intlEnablingEditing` |
+| `loading`            | `loading`              | specify whether the confirm button should display a loading state, defaults to false                                                                                   | `boolean`            | `false`                    |
+| `onConfirmChanges`   | --                     | specify method to be called upon clicking the confirm changes button                                                                                                   | `() => Promise<any>` | `undefined`                |
+| `scale`              | `scale`                | specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the scale of the closest wrapping component with a set scale | `"l" \| "m" \| "s"`  | `undefined`                |
+| `theme`              | `theme`                | specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the theme of the closest wrapping component with a set theme | `"dark" \| "light"`  | `undefined`                |
+
+## Events
+
+| Event                                 | Description | Type               |
+| ------------------------------------- | ----------- | ------------------ |
+| `calciteInlineEditableCancelEditing`  |             | `CustomEvent<any>` |
+| `calciteInlineEditableConfirmChanges` |             | `CustomEvent<any>` |
+| `calciteInlineEditableEnableEditing`  |             | `CustomEvent<any>` |
+
+## Dependencies
+
+### Depends on
+
+- [calcite-button](../calcite-button)
+
+### Graph
+
+```mermaid
+graph TD;
+  calcite-inline-editable --> calcite-button
+  calcite-button --> calcite-loader
+  calcite-button --> calcite-icon
+  style calcite-inline-editable fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-inline-editable/readme.md
+++ b/src/components/calcite-inline-editable/readme.md
@@ -16,12 +16,12 @@
 
 You can listen for the following custom events from emitted `<calcite-inline-editable>`:
 
-The events don't have a custom payload. In most cases, listening for these events should not be necessary if an `onConfirmChanges` method is used in combination with `has-controls`.
+The events don't have a custom payload. In most cases, listening for these events should not be necessary if an `afterConfirm` method is used in combination with `has-controls`.
 
 ```
-  input.addEventListener("calciteInlineEditableEnableEditing", doSomething);
-  input.addEventListener("calciteInlineEditableCancelEditing", doSomething);
-  input.addEventListener("calciteInlineEditableConfirmChanges", doSomething);
+  input.addEventListener("calciteInlineEditableEnableEditingChange", doSomething);
+  input.addEventListener("calciteInlineEditableEditingCancel", doSomething);
+  input.addEventListener("calciteInlineEditableChangesConfirm", doSomething);
 
 ```
 
@@ -64,23 +64,24 @@ There is no need to set a theme or scale on the `<calcite-inline-editable>` comp
 
 | Property             | Attribute              | Description                                                                                                                                                            | Type                 | Default                    |
 | -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------------- |
+| `afterConfirm`       | --                     | when has-controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically.                           | `() => Promise<any>` | `undefined`                |
+| `disabled`           | `disabled`             | specify whether editing can be enabled                                                                                                                                 | `boolean`            | `false`                    |
 | `editingEnabled`     | `editing-enabled`      | specify whether the wrapped input element is editable, defaults to false                                                                                               | `boolean`            | `false`                    |
 | `hasControls`        | `has-controls`         | specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false                                                                | `boolean`            | `false`                    |
 | `intlCancelEditing`  | `intl-cancel-editing`  | specify text to be user for the cancel editing button's aria-label, defaults to `Cancel`                                                                               | `string`             | `TEXT.intlCancelEditing`   |
 | `intlConfirmChanges` | `intl-confirm-changes` | specify text to be user for the confirm changes button's aria-label, defaults to `Save`                                                                                | `string`             | `TEXT.intlConfirmChanges`  |
 | `intlEnableEditing`  | `intl-enable-editing`  | specify text to be user for the enable editing button's aria-label, defaults to `Click to edit`                                                                        | `string`             | `TEXT.intlEnablingEditing` |
 | `loading`            | `loading`              | specify whether the confirm button should display a loading state, defaults to false                                                                                   | `boolean`            | `false`                    |
-| `onConfirmChanges`   | --                     | specify method to be called upon clicking the confirm changes button                                                                                                   | `() => Promise<any>` | `undefined`                |
 | `scale`              | `scale`                | specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the scale of the closest wrapping component with a set scale | `"l" \| "m" \| "s"`  | `undefined`                |
-| `theme`              | `theme`                | specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the theme of the closest wrapping component with a set theme | `"dark" \| "light"`  | `undefined`                |
+| `theme`              | `theme`                | specify the theme of the inline-editable component, defaults to the theme of the wrapped calcite-input or the theme of the closest wrapping component with a set theme | `"dark" \| "light"`  | `undefined`                |
 
 ## Events
 
-| Event                                 | Description | Type               |
-| ------------------------------------- | ----------- | ------------------ |
-| `calciteInlineEditableCancelEditing`  |             | `CustomEvent<any>` |
-| `calciteInlineEditableConfirmChanges` |             | `CustomEvent<any>` |
-| `calciteInlineEditableEnableEditing`  |             | `CustomEvent<any>` |
+| Event                                      | Description | Type               |
+| ------------------------------------------ | ----------- | ------------------ |
+| `calciteInlineEditableChangesConfirm`      |             | `CustomEvent<any>` |
+| `calciteInlineEditableEditingCancel`       |             | `CustomEvent<any>` |
+| `calciteInlineEditableEnableEditingChange` |             | `CustomEvent<any>` |
 
 ## Dependencies
 

--- a/src/components/calcite-inline-editable/readme.md
+++ b/src/components/calcite-inline-editable/readme.md
@@ -16,7 +16,7 @@
 
 You can listen for the following custom events from emitted `<calcite-inline-editable>`:
 
-The events don't have a custom payload. In most cases, listening for these events should not be necessary if an `afterConfirm` method is used in combination with `has-controls`.
+The events don't have a custom payload. In most cases, listening for these events should not be necessary if an `afterConfirm` method is used in combination with `controls`.
 
 ```
   input.addEventListener("calciteInlineEditableEnableEditingChange", doSomething);
@@ -42,7 +42,7 @@ There is no need to set a theme or scale on the `<calcite-inline-editable>` comp
 ##### With explicit save/cancel controls
 
 ```
-<calcite-inline-editable has-controls>
+<calcite-inline-editable controls>
   <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
 </calcite-inline-editable>
 ```
@@ -52,7 +52,7 @@ There is no need to set a theme or scale on the `<calcite-inline-editable>` comp
 ```
 <calcite-label>
     My great label
-    <calcite-inline-editable has-controls>
+    <calcite-inline-editable controls>
       <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
     </calcite-inline-editable>
 </calcite-label>
@@ -62,18 +62,18 @@ There is no need to set a theme or scale on the `<calcite-inline-editable>` comp
 
 ## Properties
 
-| Property             | Attribute              | Description                                                                                                                                                            | Type                 | Default                    |
-| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------------- |
-| `afterConfirm`       | --                     | when has-controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically.                           | `() => Promise<any>` | `undefined`                |
-| `disabled`           | `disabled`             | specify whether editing can be enabled                                                                                                                                 | `boolean`            | `false`                    |
-| `editingEnabled`     | `editing-enabled`      | specify whether the wrapped input element is editable, defaults to false                                                                                               | `boolean`            | `false`                    |
-| `hasControls`        | `has-controls`         | specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false                                                                | `boolean`            | `false`                    |
-| `intlCancelEditing`  | `intl-cancel-editing`  | specify text to be user for the cancel editing button's aria-label, defaults to `Cancel`                                                                               | `string`             | `TEXT.intlCancelEditing`   |
-| `intlConfirmChanges` | `intl-confirm-changes` | specify text to be user for the confirm changes button's aria-label, defaults to `Save`                                                                                | `string`             | `TEXT.intlConfirmChanges`  |
-| `intlEnableEditing`  | `intl-enable-editing`  | specify text to be user for the enable editing button's aria-label, defaults to `Click to edit`                                                                        | `string`             | `TEXT.intlEnablingEditing` |
-| `loading`            | `loading`              | specify whether the confirm button should display a loading state, defaults to false                                                                                   | `boolean`            | `false`                    |
-| `scale`              | `scale`                | specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the scale of the closest wrapping component with a set scale | `"l" \| "m" \| "s"`  | `undefined`                |
-| `theme`              | `theme`                | specify the theme of the inline-editable component, defaults to the theme of the wrapped calcite-input or the theme of the closest wrapping component with a set theme | `"dark" \| "light"`  | `undefined`                |
+| Property             | Attribute              | Description                                                                                                                                                            | Type                  | Default                    |
+| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------------------------- |
+| `afterConfirm`       | --                     | when controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically.                               | `() => Promise<void>` | `undefined`                |
+| `controls`           | `controls`             | specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false                                                                | `boolean`             | `false`                    |
+| `disabled`           | `disabled`             | specify whether editing can be enabled                                                                                                                                 | `boolean`             | `false`                    |
+| `editingEnabled`     | `editing-enabled`      | specify whether the wrapped input element is editable, defaults to false                                                                                               | `boolean`             | `false`                    |
+| `intlCancelEditing`  | `intl-cancel-editing`  | specify text to be user for the cancel editing button's aria-label, defaults to `Cancel`                                                                               | `string`              | `TEXT.intlCancelEditing`   |
+| `intlConfirmChanges` | `intl-confirm-changes` | specify text to be user for the confirm changes button's aria-label, defaults to `Save`                                                                                | `string`              | `TEXT.intlConfirmChanges`  |
+| `intlEnableEditing`  | `intl-enable-editing`  | specify text to be user for the enable editing button's aria-label, defaults to `Click to edit`                                                                        | `string`              | `TEXT.intlEnablingEditing` |
+| `loading`            | `loading`              | specify whether the confirm button should display a loading state, defaults to false                                                                                   | `boolean`             | `false`                    |
+| `scale`              | `scale`                | specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the scale of the closest wrapping component with a set scale | `"l" \| "m" \| "s"`   | `undefined`                |
+| `theme`              | `theme`                | specify the theme of the inline-editable component, defaults to the theme of the wrapped calcite-input or the theme of the closest wrapping component with a set theme | `"dark" \| "light"`   | `undefined`                |
 
 ## Events
 

--- a/src/components/calcite-inline-editable/resources.ts
+++ b/src/components/calcite-inline-editable/resources.ts
@@ -1,0 +1,5 @@
+export const TEXT = {
+  intlEnablingEditing: "Click to edit",
+  intlCancelEditing: "Cancel",
+  intlConfirmChanges: "Save"
+};

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -18,6 +18,10 @@
   & input[type="file"] {
     @apply h-auto;
   }
+  & .calcite-input-clear-button {
+    min-height: 32px;
+    min-width: 32px;
+  }
 }
 
 :host([scale="m"]) {
@@ -40,6 +44,10 @@
   & input[type="file"] {
     @apply h-auto;
   }
+  & .calcite-input-clear-button {
+    min-height: 44px;
+    min-width: 44px;
+  }
 }
 
 :host([scale="l"]) {
@@ -61,6 +69,10 @@
   & textarea,
   & input[type="file"] {
     height: auto;
+  }
+  & .calcite-input-clear-button {
+    min-height: 56px;
+    min-width: 56px;
   }
 }
 
@@ -225,10 +237,10 @@ input[type="time"]::-webkit-clear-button {
   display: flex;
   align-self: stretch;
   align-items: center;
+  justify-content: center;
   box-sizing: border-box;
   cursor: pointer;
   min-height: 100%;
-  padding: 0 $baseline/2;
   border: 1px solid var(--calcite-ui-border-1);
   transition: $transition;
   pointer-events: initial;
@@ -241,6 +253,16 @@ input[type="time"]::-webkit-clear-button {
   }
   &:active {
     background-color: var(--calcite-ui-foreground-3);
+  }
+  &:disabled {
+    opacity: 0.4;
+  }
+}
+
+:host([dir="rtl"]) {
+  .calcite-input-clear-button {
+    border-left: 1px solid var(--calcite-ui-border-1);
+    border-right: none;
   }
 }
 

--- a/src/demos/calcite-inline-editable.html
+++ b/src/demos/calcite-inline-editable.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Calcite Inline Editable</title>
+  <style>
+    .demo-background-dark {
+      background: #202020;
+      color: white;
+      padding: 1rem;
+    }
+  </style>
+  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
+  <link rel="stylesheet" href="../build/calcite.css" />
+  <script type="module" src="../build/calcite.esm.js"></script>
+  <script nomodule src="../build/calcite.js"></script>
+  <script>
+    const handleChangesFoInput = (id, isSuccess = true) => {
+      const onConfirmChanges = () => new Promise((resolve, reject) => {
+        if (isSuccess) return setTimeout(resolve, 1500)
+        setTimeout(reject, 1500)
+      })
+      document.querySelector(id).onConfirmChanges = onConfirmChanges
+    }
+  </script>
+</head>
+<body>
+  <calcite-button href="/">Home</calcite-button>
+  <h1>Calcite Inline Editable</h1>
+
+  <h3>Inline Editable Input</h3>
+
+  <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
+    <calcite-accordion-item item-title="Scales" active>
+      <calcite-label>
+        S
+        <calcite-inline-editable>
+          <calcite-input value="Monday" placeholder="Day of the week" scale="s"/>
+        </calcite-inline-editable>
+      </calcite-label>
+      <calcite-label>
+        M
+        <calcite-inline-editable>
+          <calcite-input value="Tuesday" placeholder="Day of the week" scale="m"/>
+        </calcite-inline-editable>
+      </calcite-label>
+      <calcite-label>
+        L
+        <calcite-inline-editable>
+          <calcite-input placeholder="Day of the week" scale="l"/>
+        </calcite-inline-editable>
+      </calcite-label>
+    </calcite-accordion-item>
+
+    <calcite-accordion-item item-title="Other Input Types">
+
+      <calcite-inline-editable>
+        <calcite-input prefix-text="pre" suffix-text="suf" type="number" placeholder="How many apples?"/>
+      </calcite-inline-editable>
+    </calcite-accordion-item>
+
+
+    <calcite-accordion-item item-title="RTL">
+      <div>
+        <calcite-label>
+          S
+          <calcite-inline-editable dir="rtl">
+            <calcite-input placeholder="Day of the week" scale="s" theme="dark" />
+          </calcite-inline-editable>
+        </calcite-label>
+        <calcite-label>
+          M
+          <calcite-inline-editable>
+            <calcite-input placeholder="Day of the week" scale="m"/>
+          </calcite-inline-editable>
+        </calcite-label>
+        <calcite-label>
+          L
+          <calcite-inline-editable>
+            <calcite-input placeholder="Day of the week" scale="l"/>
+          </calcite-inline-editable>
+        </calcite-label>
+      </div>
+    </calcite-accordion-item>
+  </calcite-accordion>
+
+
+  <h3>Inline Editable Input with Controls</h3>
+
+  <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
+    <calcite-accordion-item item-title="Scales" active>
+      <calcite-label>
+        S
+        <calcite-inline-editable id="example1" has-controls>
+          <calcite-input placeholder="Day of the week" scale="s"/>
+        </calcite-inline-editable>
+        <script>
+          handleChangesFoInput("#example1")
+        </script>
+      </calcite-label>
+      <calcite-label>
+        M
+        <calcite-inline-editable id="example2" has-controls>
+          <calcite-input placeholder="Day of the week" scale="m"/>
+        </calcite-inline-editable>
+        <script>
+          handleChangesFoInput("#example2")
+        </script>
+      </calcite-label>
+      <calcite-label>
+        L
+        <calcite-inline-editable id="example3" has-controls>
+          <calcite-input placeholder="Day of the week" scale="l"/>
+        </calcite-inline-editable>
+        <script>
+          handleChangesFoInput("#example3")
+        </script>
+      </calcite-label>
+    </calcite-accordion-item>
+    <calcite-accordion-item item-title="RTL">
+      <div dir="rtl">
+        <calcite-label>
+          S
+          <calcite-inline-editable id="example4"has-controls >
+            <calcite-input placeholder="Day of the week" scale="s"/>
+          </calcite-inline-editable>
+          <script>
+            handleChangesFoInput("#example4")
+          </script>
+        </calcite-label>
+        <calcite-label>
+          M
+          <calcite-inline-editable id="example5" has-controls>
+            <calcite-input placeholder="Day of the week" scale="m"/>
+          </calcite-inline-editable>
+          <script>
+            handleChangesFoInput("#example5")
+          </script>
+        </calcite-label>
+        <calcite-label>
+          L
+          <calcite-inline-editable id="example6" has-controls>
+            <calcite-input placeholder="Day of the week" scale="l"/>
+          </calcite-inline-editable>
+          <script>
+            handleChangesFoInput("#example6")
+          </script>
+        </calcite-label>
+      </div>
+    </calcite-accordion-item>
+  </calcite-accordion>
+</body>
+
+</html>

--- a/src/demos/calcite-inline-editable.html
+++ b/src/demos/calcite-inline-editable.html
@@ -39,22 +39,22 @@
   <h3>Inline Editable Input</h3>
   <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
     <calcite-accordion-item item-title="Scales" active>
-      <calcite-label>
+      <calcite-label scale="s">
         S
         <calcite-inline-editable>
-          <calcite-input value="Monday" placeholder="Day of the week" scale="s"/>
+          <calcite-input value="Monday" placeholder="Day of the week"/>
         </calcite-inline-editable>
       </calcite-label>
-      <calcite-label>
+      <calcite-label scale="m">
         M
         <calcite-inline-editable>
-          <calcite-input value="Tuesday" placeholder="Day of the week" scale="m"/>
+          <calcite-input value="Tuesday" placeholder="Day of the week"/>
         </calcite-inline-editable>
       </calcite-label>
-      <calcite-label>
+      <calcite-label scale="l">
         L
         <calcite-inline-editable>
-          <calcite-input placeholder="Day of the week" scale="l"/>
+          <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
       </calcite-label>
     </calcite-accordion-item>
@@ -77,22 +77,22 @@
 
     <calcite-accordion-item item-title="RTL">
       <div dir="rtl">
-        <calcite-label>
+        <calcite-label scale="s">
           S
           <calcite-inline-editable>
-            <calcite-input placeholder="Day of the week" scale="s" />
+            <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
         </calcite-label>
-        <calcite-label>
+        <calcite-label scale="m">
           M
           <calcite-inline-editable>
-            <calcite-input placeholder="Day of the week" scale="m"/>
+            <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
         </calcite-label>
-        <calcite-label>
+        <calcite-label scale="l">
           L
           <calcite-inline-editable>
-            <calcite-input placeholder="Day of the week" scale="l"/>
+            <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
         </calcite-label>
       </div>
@@ -104,28 +104,28 @@
 
   <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
     <calcite-accordion-item item-title="Scales" active>
-      <calcite-label>
+      <calcite-label scale="s">
         S
         <calcite-inline-editable id="example1" has-controls>
-          <calcite-input placeholder="Day of the week" scale="s"/>
+          <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
         <script>
           handleChangesFoInput("#example1")
         </script>
       </calcite-label>
-      <calcite-label>
+      <calcite-label scale="m">
         M
         <calcite-inline-editable id="example2" has-controls>
-          <calcite-input placeholder="Day of the week" scale="m"/>
+          <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
         <script>
           handleChangesFoInput("#example2")
         </script>
       </calcite-label>
-      <calcite-label>
+      <calcite-label scale="l">
         L
         <calcite-inline-editable id="example3" has-controls>
-          <calcite-input placeholder="Day of the week" scale="l"/>
+          <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
         <script>
           handleChangesFoInput("#example3")
@@ -142,28 +142,28 @@
   </calcite-accordion-item>
     <calcite-accordion-item item-title="RTL">
       <div dir="rtl">
-        <calcite-label>
+        <calcite-label scale="s">
           S
           <calcite-inline-editable id="example4"has-controls >
-            <calcite-input placeholder="Day of the week" scale="s"/>
+            <calcite-input placeholder="Day of the week" />
           </calcite-inline-editable>
           <script>
             handleChangesFoInput("#example4")
           </script>
         </calcite-label>
-        <calcite-label>
+        <calcite-label scale="m">
           M
           <calcite-inline-editable id="example5" has-controls>
-            <calcite-input placeholder="Day of the week" scale="m"/>
+            <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
           <script>
             handleChangesFoInput("#example5")
           </script>
         </calcite-label>
-        <calcite-label>
+        <calcite-label scale="l">
           L
           <calcite-inline-editable id="example6" has-controls>
-            <calcite-input placeholder="Day of the week" scale="l"/>
+            <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
           <script>
             handleChangesFoInput("#example6")

--- a/src/demos/calcite-inline-editable.html
+++ b/src/demos/calcite-inline-editable.html
@@ -106,7 +106,7 @@
     <calcite-accordion-item item-title="Scales" active>
       <calcite-label scale="s">
         S
-        <calcite-inline-editable id="example1" has-controls>
+        <calcite-inline-editable id="example1" controls>
           <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
         <script>
@@ -115,7 +115,7 @@
       </calcite-label>
       <calcite-label scale="m">
         M
-        <calcite-inline-editable id="example2" has-controls>
+        <calcite-inline-editable id="example2" controls>
           <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
         <script>
@@ -124,7 +124,7 @@
       </calcite-label>
       <calcite-label scale="l">
         L
-        <calcite-inline-editable id="example3" has-controls>
+        <calcite-inline-editable id="example3" controls>
           <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
         <script>
@@ -135,7 +135,7 @@
     <calcite-accordion-item item-title="Disabled">
       <calcite-label>
         Access denied
-        <calcite-inline-editable has-controls disabled>
+        <calcite-inline-editable controls disabled>
           <calcite-input placeholder="Day of the week"/>
         </calcite-inline-editable>
       </calcite-label>
@@ -144,7 +144,7 @@
       <div dir="rtl">
         <calcite-label scale="s">
           S
-          <calcite-inline-editable id="example4"has-controls >
+          <calcite-inline-editable id="example4"controls >
             <calcite-input placeholder="Day of the week" />
           </calcite-inline-editable>
           <script>
@@ -153,7 +153,7 @@
         </calcite-label>
         <calcite-label scale="m">
           M
-          <calcite-inline-editable id="example5" has-controls>
+          <calcite-inline-editable id="example5" controls>
             <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
           <script>
@@ -162,7 +162,7 @@
         </calcite-label>
         <calcite-label scale="l">
           L
-          <calcite-inline-editable id="example6" has-controls>
+          <calcite-inline-editable id="example6" controls>
             <calcite-input placeholder="Day of the week"/>
           </calcite-inline-editable>
           <script>

--- a/src/demos/calcite-inline-editable.html
+++ b/src/demos/calcite-inline-editable.html
@@ -13,11 +13,11 @@
   <script>
     let isDarkTheme = false;
     const handleChangesFoInput = (id, isSuccess = true) => {
-      const onConfirmChanges = () => new Promise((resolve, reject) => {
+      const afterConfirm = () => new Promise((resolve, reject) => {
         if (isSuccess) return setTimeout(resolve, 1500)
         setTimeout(reject, 1500)
       })
-      document.querySelector(id).onConfirmChanges = onConfirmChanges
+      document.querySelector(id).afterConfirm = afterConfirm
     }
   </script>
 </head>
@@ -66,6 +66,14 @@
       </calcite-inline-editable>
     </calcite-accordion-item>
 
+    <calcite-accordion-item item-title="Disabled">
+        <calcite-label>
+          Access denied
+          <calcite-inline-editable disabled>
+            <calcite-input placeholder="Day of the week"/>
+          </calcite-inline-editable>
+        </calcite-label>
+    </calcite-accordion-item>
 
     <calcite-accordion-item item-title="RTL">
       <div dir="rtl">
@@ -124,6 +132,14 @@
         </script>
       </calcite-label>
     </calcite-accordion-item>
+    <calcite-accordion-item item-title="Disabled">
+      <calcite-label>
+        Access denied
+        <calcite-inline-editable has-controls disabled>
+          <calcite-input placeholder="Day of the week"/>
+        </calcite-inline-editable>
+      </calcite-label>
+  </calcite-accordion-item>
     <calcite-accordion-item item-title="RTL">
       <div dir="rtl">
         <calcite-label>

--- a/src/demos/calcite-inline-editable.html
+++ b/src/demos/calcite-inline-editable.html
@@ -6,18 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Calcite Inline Editable</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
   <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="../build/calcite.css" />
   <script type="module" src="../build/calcite.esm.js"></script>
   <script nomodule src="../build/calcite.js"></script>
   <script>
+    let isDarkTheme = false;
     const handleChangesFoInput = (id, isSuccess = true) => {
       const onConfirmChanges = () => new Promise((resolve, reject) => {
         if (isSuccess) return setTimeout(resolve, 1500)
@@ -30,9 +24,19 @@
 <body>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Inline Editable</h1>
-
+  <calcite-label layout="inline">
+    Dark Mode
+    <calcite-switch id="themeSwitch"></calcite-switch>
+  </calcite-label>
+  <script>
+    document.querySelector("#themeSwitch").addEventListener("calciteSwitchChange", () => {
+      isDarkTheme = !isDarkTheme;
+      document.querySelectorAll("calcite-accordion").forEach(accordion => {
+        accordion.setAttribute("theme", isDarkTheme ? "dark" : "light");
+      });
+    });
+  </script>
   <h3>Inline Editable Input</h3>
-
   <calcite-accordion scale="m" icon-position="start" selection-mode="multi">
     <calcite-accordion-item item-title="Scales" active>
       <calcite-label>
@@ -64,11 +68,11 @@
 
 
     <calcite-accordion-item item-title="RTL">
-      <div>
+      <div dir="rtl">
         <calcite-label>
           S
-          <calcite-inline-editable dir="rtl">
-            <calcite-input placeholder="Day of the week" scale="s" theme="dark" />
+          <calcite-inline-editable>
+            <calcite-input placeholder="Day of the week" scale="s" />
           </calcite-inline-editable>
         </calcite-label>
         <calcite-label>

--- a/src/index.html
+++ b/src/index.html
@@ -82,6 +82,9 @@
           <calcite-link href="/demos/calcite-icon.html">calcite-icon</calcite-link>
         </li>
         <li>
+          <calcite-link href="/demos/calcite-inline-editable.html">calcite-inline-editable</calcite-link>
+        </li>
+        <li>
           <calcite-link href="/demos/calcite-input.html">calcite-input</calcite-link>
         </li>
         <li>


### PR DESCRIPTION
`textarea`s will be handled in a separate PR.

**Related Issue:** #819 

## Summary

Provides inline editing capabilities for calcite-inputs via compositional/wrapping component. 

```
<calcite-inline-editable>
  <calcite-input placeholder="Hooray"/>
</calcite-inline-editable>
```

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
