### PR TITLE
fix(pagination): fix next button when last page has 1 element (#1180)

### DIFF
--- a/src/components/calcite-pagination/calcite-pagination.e2e.ts
+++ b/src/components/calcite-pagination/calcite-pagination.e2e.ts
@@ -91,6 +91,19 @@ describe("calcite-pagination", () => {
 
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
+    it("next button should be enabled if last page has only 1 result", async () => {
+      await pagination.setAttribute("total", "11");
+      await pagination.setAttribute("num", "10");
+      await pagination.setAttribute("start", "1");
+      await page.waitForChanges();
+
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const nextButton = await page.find(`calcite-pagination >>> .${CSS.next}`);
+      await nextButton.click();
+      await page.waitForChanges();
+
+      expect(toggleSpy).toHaveReceivedEventTimes(1);
+    });
   });
   describe("page buttons", () => {
     it("should switch selected page to the page that's clicked", async () => {

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -206,7 +206,7 @@ export class CalcitePagination {
     const { total, num, start } = this;
     const iconScale = this.scale === "l" ? "m" : "s";
     const prevDisabled = num === 1 ? start <= num : start < num;
-    const nextDisabled = num === 1 ? start + num > total : start + num >= total;
+    const nextDisabled = num === 1 ? start + num > total : start + num > total;
     return (
       <Host>
         <button


### PR DESCRIPTION
**Related Issue:** #1180

## Summary

next button was disabled in cases where the last page had only 1 result.