### PR TITLE
feat: updates a shortlist of components with new font-sizes for each scale

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -8,21 +8,21 @@
   --calcite-accordion-item-spacing-unit: #{$baseline/3};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  font-size: theme("fontSize.-2");
+  @apply text--2;
 }
 
 :host-context([scale="m"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline/2};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  font-size: theme("fontSize.-1");
+  @apply text--1;
 }
 
 :host-context([scale="l"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  font-size: theme("fontSize.1");
+  @apply text-1;
 }
 
 // icon position variants for child

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -8,21 +8,21 @@
   --calcite-accordion-item-spacing-unit: #{$baseline/3};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  @include font-size(-3);
+  font-size: theme("fontSize.-2");
 }
 
 :host-context([scale="m"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline/2};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  @include font-size(-2);
+  font-size: theme("fontSize.-1");
 }
 
 :host-context([scale="l"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  @include font-size(-1);
+  font-size: theme("fontSize.1");
 }
 
 // icon position variants for child

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -7,21 +7,21 @@
   --calcite-accordion-item-spacing-unit: #{$baseline/3};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  font-size: theme("fontSize.-2");
+  @apply text--2;
 }
 
 :host([scale="m"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline/2};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  font-size: theme("fontSize.-1");
+  @apply text--1;
 }
 
 :host([scale="l"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  font-size: theme("fontSize.1");
+  @apply text-1;
 }
 
 :host {

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -7,21 +7,21 @@
   --calcite-accordion-item-spacing-unit: #{$baseline/3};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  @include font-size(-3);
+  font-size: theme("fontSize.-2");
 }
 
 :host([scale="m"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline/2};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  @include font-size(-2);
+  font-size: theme("fontSize.-1");
 }
 
 :host([scale="l"]) {
   --calcite-accordion-item-spacing-unit: #{$baseline};
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit)
     var(--calcite-accordion-item-spacing-unit);
-  @include font-size(-1);
+  font-size: theme("fontSize.1");
 }
 
 :host {
@@ -30,6 +30,7 @@
   max-width: 100%;
   border: 1px solid var(--calcite-ui-border-2);
   border-bottom: none;
+  line-height: 1.5;
   --calcite-accordion-item-border: var(--calcite-ui-border-2);
   --calcite-accordion-item-background: var(--calcite-ui-foreground-1);
 }

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -566,7 +566,7 @@
 }
 
 // generate button scales
-$btnScales: "s" 12px 16px 7px 12px, "m" 16px 16px 13px 20px, "l" 20px 24px 15px 24px;
+$btnScales: "s" 12px 1.33 7px 12px, "m" 14px 1.15 13px 20px, "l" 18px 1.2 15px 24px;
 @each $btnScale in $btnScales {
   $name: nth($btnScale, 1);
   $font-size: nth($btnScale, 2);
@@ -587,7 +587,7 @@ $btnScales: "s" 12px 16px 7px 12px, "m" 16px 16px 13px 20px, "l" 20px 24px 15px 
 }
 
 // generate fab scales
-$btnScales2: "s" 12px 32px, "m" 16px 44px, "l" 20px 56px;
+$btnScales2: "s" 12px 32px, "m" 14px 44px, "l" 18px 56px;
 
 @each $btnScale in $btnScales2 {
   $name: nth($btnScale, 1);
@@ -601,7 +601,7 @@ $btnScales2: "s" 12px 32px, "m" 16px 44px, "l" 20px 56px;
 }
 
 // generate fab scales
-$btnScales3: "s" 12px 32px, "m" 16px 44px, "l" 20px 56px;
+$btnScales3: "s" 12px 32px, "m" 14px 44px, "l" 18px 56px;
 
 @each $btnScale in $btnScales3 {
   $name: nth($btnScale, 1);

--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -5,13 +5,16 @@
   @include calcite-theme-dark();
 }
 :host([scale="s"]) {
-  --calcite-checkbox-size: theme("spacing.3");
+  --calcite-checkbox-size: theme("fontSize.-2");
+  --calcite-checkbox-grid-gap: theme("spacing.2");
 }
 :host([scale="m"]) {
-  --calcite-checkbox-size: theme("spacing.4");
+  --calcite-checkbox-size: theme("fontSize.-1");
+  --calcite-checkbox-grid-gap: theme("spacing.2");
 }
 :host([scale="l"]) {
-  --calcite-checkbox-size: theme("spacing.5");
+  --calcite-checkbox-size: theme("fontSize.1");
+  --calcite-checkbox-grid-gap: theme("spacing.3");
 }
 :host {
   @apply inline-flex
@@ -33,7 +36,7 @@
   }
   .hasLabel {
     display: grid;
-    grid-gap: 12px;
+    grid-gap: var(--calcite-checkbox-grid-gap);
     align-items: center;
     --calcite-label-margin-bottom: 0;
   }

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -5,14 +5,17 @@
 
 // ie11
 :host-context([scale="s"]) {
+  @apply text--2;
   --calcite-dropdown-group-padding: #{$baseline/3 0};
 }
 
 :host-context([scale="m"]) {
+  @apply text--1;
   --calcite-dropdown-group-padding: #{$baseline/2 0};
 }
 
 :host-context([scale="l"]) {
+  @apply text-1;
   --calcite-dropdown-group-padding: #{$baseline/1.5 0};
 }
 
@@ -25,7 +28,6 @@
   font-weight: 600;
   word-wrap: break-word;
   cursor: default;
-  @include font-size(-2);
 }
 
 .dropdown-separator {

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -52,6 +52,15 @@
   @include itemStyling;
 }
 
+.dropdown-item-content {
+  @apply mr-auto;
+}
+
+:host([dir="rtl"]) .dropdown-item-content {
+  margin-right: unset;
+  @apply ml-auto;
+}
+
 //focus
 :host,
 :host([islink]) a {

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -6,17 +6,17 @@
 // ie11
 :host-context([scale="s"]) {
   --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5 $baseline * 1.5};
-  font-size: theme("fontSize.-2");
+  @apply text--2;
 }
 
 :host-context([scale="m"]) {
   --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5};
-  font-size: theme("fontSize.-1");
+  @apply text--1;
 }
 
 :host-context([scale="l"]) {
   --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2 $baseline * 1.5};
-  font-size: theme("fontSize.1");
+  @apply text-1;
 }
 
 :host-context([dir="rtl"][scale="s"]) {
@@ -35,7 +35,7 @@
   display: flex;
   flex-grow: 1;
   align-items: center;
-  font-size: theme("fontSize.-1");
+  @apply text--1;
   color: var(--calcite-ui-text-3);
   transition: $transition;
   padding: var(--calcite-dropdown-item-padding);

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -16,16 +16,17 @@
   @apply text-1 pr-5 pl-10 py-4;
 }
 
+// RTL
 :host-context([dir="rtl"][scale="s"]) {
-  @apply text--2 pr-6 pl-3 py-2;
+  @apply pr-6 pl-3;
 }
 
 :host-context([dir="rtl"][scale="m"]) {
-  @apply text--1 pr-8 pl-4 py-3;
+  @apply pr-8 pl-4;
 }
 
 :host-context([dir="rtl"][scale="l"]) {
-  @apply text-1 pr-10 pl-5 py-4;
+  @apply pr-10 pl-5;
 }
 
 @mixin itemStyling {

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -5,30 +5,27 @@
 
 // ie11
 :host-context([scale="s"]) {
-  --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5 $baseline * 1.5};
-  @apply text--2;
+  @apply text--2 pr-3 pl-6 py-2;
 }
 
 :host-context([scale="m"]) {
-  --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5};
-  @apply text--1;
+  @apply text--1 pr-4 pl-8 py-3;
 }
 
 :host-context([scale="l"]) {
-  --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2 $baseline * 1.5};
-  @apply text-1;
+  @apply text-1 pr-5 pl-10 py-4;
 }
 
 :host-context([dir="rtl"][scale="s"]) {
-  --calcite-dropdown-item-padding: #{$baseline/5 $baseline * 1.5 $baseline/5 $baseline/1.5};
+  @apply text--2 pr-6 pl-3 py-2;
 }
 
 :host-context([dir="rtl"][scale="m"]) {
-  --calcite-dropdown-item-padding: #{$baseline/3 $baseline * 1.5 $baseline/3 $baseline / 1.5};
+  @apply text--1 pr-8 pl-4 py-3;
 }
 
 :host-context([dir="rtl"][scale="l"]) {
-  --calcite-dropdown-item-padding: #{$baseline/2 $baseline * 1.5 $baseline/2 $baseline / 1.5};
+  @apply text-1 pr-10 pl-5 py-4;
 }
 
 @mixin itemStyling {
@@ -38,7 +35,6 @@
   @apply text--1;
   color: var(--calcite-ui-text-3);
   transition: $transition;
-  padding: var(--calcite-dropdown-item-padding);
   cursor: pointer;
   text-decoration: none;
   outline: none;
@@ -46,7 +42,6 @@
   &:before {
     content: "\2022";
     position: absolute;
-    left: 1rem;
     opacity: 0;
     color: var(--calcite-ui-border-1);
     transition: $transition;
@@ -132,18 +127,68 @@
   padding-right: $baseline/1.5;
 }
 
+// single select "icon"
+:host-context([scale="s"]):before {
+  left: theme("spacing.2");
+}
+:host-context([scale="m"]):before {
+  left: theme("spacing.3");
+}
+:host-context([scale="l"]):before {
+  left: theme("spacing.4");
+}
+
+// single select "icon" RTL
+:host-context([dir="rtl"]):before {
+  left: unset;
+}
+
+:host-context([dir="rtl"][scale="s"]):before {
+  right: theme("spacing.2");
+}
+:host-context([dir="rtl"][scale="m"]):before {
+  right: theme("spacing.3");
+}
+:host-context([dir="rtl"][scale="l"]):before {
+  right: theme("spacing.4");
+}
+
 // multi select check icon
 :host .dropdown-item-check-icon {
   position: absolute;
-  left: $baseline / 1.75;
   opacity: 0;
   transform: scale(0.9);
   transition: $transition;
 }
 
-:host([dir="rtl"]) .dropdown-item-check-icon {
+:host-context([scale="s"]) .dropdown-item-check-icon {
+  left: theme("spacing.1");
+}
+
+:host-context([scale="m"]) .dropdown-item-check-icon {
+  left: theme("spacing.2");
+}
+
+:host-context([scale="l"]) .dropdown-item-check-icon {
+  left: theme("spacing.3");
+}
+
+// multi select check icon RTL
+:host-context([dir="rtl"]) .dropdown-item-check-icon {
   left: unset;
-  right: $baseline / 1.75;
+  @apply ml-0;
+}
+
+:host-context([dir="rtl"][scale="s"]) .dropdown-item-check-icon {
+  right: theme("spacing.1");
+}
+
+:host-context([dir="rtl"][scale="m"]) .dropdown-item-check-icon {
+  right: theme("spacing.2");
+}
+
+:host-context([dir="rtl"][scale="l"]) .dropdown-item-check-icon {
+  right: theme("spacing.3");
 }
 
 :host(:hover) .dropdown-item-check-icon {
@@ -156,27 +201,72 @@
   opacity: 1;
 }
 
-// icons
-:host .dropdown-item-icon-start {
-  margin-right: $baseline / 1.5;
+// icon start & end
+:host-context([scale="s"]) {
+  .dropdown-item-icon-start {
+    @apply mr-2;
+  }
+  .dropdown-item-icon-end {
+    @apply ml-2;
+  }
 }
-:host .dropdown-item-icon-end {
-  margin-left: auto;
-  padding-left: $baseline / 1.5;
+
+:host-context([scale="m"]) {
+  .dropdown-item-icon-start {
+    @apply mr-3;
+  }
+  .dropdown-item-icon-end {
+    @apply ml-3;
+  }
+}
+
+:host-context([scale="l"]) {
+  .dropdown-item-icon-start {
+    @apply mr-4;
+  }
+  .dropdown-item-icon-end {
+    @apply ml-4;
+  }
+}
+
+// icon start & end RTL
+:host-context([dir="rtl"]) {
+  .dropdown-item-icon-start {
+    @apply mr-0;
+  }
+  .dropdown-item-icon-end {
+    @apply ml-0;
+  }
+}
+
+:host-context([dir="rtl"][scale="s"]) {
+  .dropdown-item-icon-start {
+    @apply ml-2;
+  }
+  .dropdown-item-icon-end {
+    @apply mr-2;
+  }
+}
+
+:host-context([dir="rtl"][scale="m"]) {
+  .dropdown-item-icon-start {
+    @apply ml-3;
+  }
+  .dropdown-item-icon-end {
+    @apply mr-3;
+  }
+}
+
+:host-context([dir="rtl"][scale="l"]) {
+  .dropdown-item-icon-start {
+    @apply ml-4;
+  }
+  .dropdown-item-icon-end {
+    @apply mr-4;
+  }
 }
 
 :host([dir="rtl"]) calcite-icon {
   margin-right: 0;
   margin-left: $baseline / 1.5;
-}
-
-:host([dir="rtl"]) .dropdown-item-icon-start {
-  margin-left: $baseline / 1.5;
-  margin-right: 0;
-}
-:host([dir="rtl"]) .dropdown-item-icon-end {
-  margin-right: auto;
-  padding-right: $baseline / 1.5;
-  margin-left: 0;
-  padding-left: 0;
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -6,14 +6,17 @@
 // ie11
 :host-context([scale="s"]) {
   --calcite-dropdown-item-padding: #{$baseline/5 $baseline/1.5 $baseline/5 $baseline * 1.5};
+  font-size: theme("fontSize.-2");
 }
 
 :host-context([scale="m"]) {
   --calcite-dropdown-item-padding: #{$baseline/3 $baseline/1.5 $baseline/3 $baseline * 1.5};
+  font-size: theme("fontSize.-1");
 }
 
 :host-context([scale="l"]) {
   --calcite-dropdown-item-padding: #{$baseline/2 $baseline/1.5 $baseline/2 $baseline * 1.5};
+  font-size: theme("fontSize.1");
 }
 
 :host-context([dir="rtl"][scale="s"]) {
@@ -32,7 +35,7 @@
   display: flex;
   flex-grow: 1;
   align-items: center;
-  @include font-size(-2);
+  font-size: theme("fontSize.-1");
   color: var(--calcite-ui-text-3);
   transition: $transition;
   padding: var(--calcite-dropdown-item-padding);

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -108,6 +108,11 @@ export class CalciteDropdownItem {
         scale={iconScale}
       />
     );
+    const contentNode = (
+      <span class="dropdown-item-content">
+        <slot />
+      </span>
+    );
     const iconEndEl = (
       <calcite-icon
         class="dropdown-item-icon-end"
@@ -119,15 +124,13 @@ export class CalciteDropdownItem {
     );
 
     const slottedContent =
-      this.iconStart && this.iconEnd ? (
-        [iconStartEl, <slot />, iconEndEl]
-      ) : this.iconStart ? (
-        [iconStartEl, <slot />]
-      ) : this.iconEnd ? (
-        [<slot />, iconEndEl]
-      ) : (
-        <slot />
-      );
+      this.iconStart && this.iconEnd
+        ? [iconStartEl, contentNode, iconEndEl]
+        : this.iconStart
+        ? [iconStartEl, <slot />]
+        : this.iconEnd
+        ? [contentNode, iconEndEl]
+        : contentNode;
 
     const contentEl = !this.href ? (
       slottedContent

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -4,8 +4,7 @@
   & input,
   & .calcite-input-prefix,
   & .calcite-input-suffix {
-    @apply text--2 p-2;
-    height: 32px;
+    @apply text--2 p-2 h-8;
   }
   & textarea {
     min-height: 32px;
@@ -13,11 +12,11 @@
   & .calcite-input-number-button-wrapper,
   & .calcite-input-action-wrapper calcite-button,
   & .calcite-input-action-wrapper calcite-button button {
-    height: 32px;
+    @apply h-8;
   }
   & textarea,
   & input[type="file"] {
-    height: auto;
+    @apply h-auto;
   }
 }
 
@@ -39,7 +38,7 @@
   }
   & textarea,
   & input[type="file"] {
-    height: auto;
+    @apply h-auto;
   }
 }
 

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -5,7 +5,7 @@
   & .calcite-input-prefix,
   & .calcite-input-suffix {
     padding: 8px;
-    font-size: theme("fontSize.-2");
+    @apply text--2;
     height: 32px;
   }
   & textarea {
@@ -28,7 +28,7 @@
   & .calcite-input-prefix,
   & .calcite-input-suffix {
     padding: 12px;
-    font-size: theme("fontSize.-1");
+    @apply text--1;
     height: 44px;
   }
   & textarea {
@@ -51,7 +51,7 @@
   & .calcite-input-prefix,
   & .calcite-input-suffix {
     padding: 16px;
-    font-size: theme("fontSize.1");
+    @apply text-1;
     height: 56px;
   }
   & textarea {

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -5,7 +5,7 @@
   & .calcite-input-prefix,
   & .calcite-input-suffix {
     padding: 8px;
-    font-size: 12px;
+    font-size: theme("fontSize.-2");
     height: 32px;
   }
   & textarea {
@@ -28,7 +28,7 @@
   & .calcite-input-prefix,
   & .calcite-input-suffix {
     padding: 12px;
-    font-size: 16px;
+    font-size: theme("fontSize.-1");
     height: 44px;
   }
   & textarea {
@@ -51,7 +51,7 @@
   & .calcite-input-prefix,
   & .calcite-input-suffix {
     padding: 16px;
-    font-size: 20px;
+    font-size: theme("fontSize.1");
     height: 56px;
   }
   & textarea {

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -4,8 +4,7 @@
   & input,
   & .calcite-input-prefix,
   & .calcite-input-suffix {
-    padding: 8px;
-    @apply text--2;
+    @apply text--2 p-2;
     height: 32px;
   }
   & textarea {
@@ -27,8 +26,7 @@
   & input,
   & .calcite-input-prefix,
   & .calcite-input-suffix {
-    padding: 12px;
-    @apply text--1;
+    @apply text--1 p-3;
     height: 44px;
   }
   & textarea {
@@ -50,8 +48,7 @@
   & input,
   & .calcite-input-prefix,
   & .calcite-input-suffix {
-    padding: 16px;
-    @apply text-1;
+    @apply text-1 p-4;
     height: 56px;
   }
   & textarea {

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -24,15 +24,15 @@
 }
 
 :host([scale="s"]) label {
-  font-size: theme("fontSize.-2");
+  @apply text--2;
 }
 
 :host([scale="m"]) label {
-  font-size: theme("fontSize.-1");
+  @apply text--1;
 }
 
 :host([scale="l"]) label {
-  font-size: theme("fontSize.1");
+  @apply text-1;
 }
 
 :host([layout="default"]) {

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -10,10 +10,10 @@
   --calcite-label-margin-bottom: 12px;
 }
 :host([scale="m"]) {
-  --calcite-label-margin-bottom: 16px;
+  --calcite-label-margin-bottom: 14px;
 }
 :host([scale="l"]) {
-  --calcite-label-margin-bottom: 20px;
+  --calcite-label-margin-bottom: 18px;
 }
 
 :host label {
@@ -24,18 +24,15 @@
 }
 
 :host([scale="s"]) label {
-  font-size: var(--calcite-label-font-size, 12px);
-  --calcite-label-spacing-value: 8px;
+  font-size: theme("fontSize.-2");
 }
 
 :host([scale="m"]) label {
-  font-size: var(--calcite-label-font-size, 16px);
-  --calcite-label-spacing-value: 12px;
+  font-size: theme("fontSize.-1");
 }
 
 :host([scale="l"]) label {
-  font-size: var(--calcite-label-font-size, 20px);
-  --calcite-label-spacing-value: 16px;
+  font-size: theme("fontSize.1");
 }
 
 :host([layout="default"]) {

--- a/src/components/calcite-radio-button/calcite-radio-button.scss
+++ b/src/components/calcite-radio-button/calcite-radio-button.scss
@@ -52,6 +52,7 @@
   margin-right: 12px;
   @supports not (display: grid) {
     .radio {
+      height: 12px;
       margin-right: 8px;
     }
   }

--- a/src/components/calcite-radio-button/calcite-radio-button.scss
+++ b/src/components/calcite-radio-button/calcite-radio-button.scss
@@ -47,7 +47,7 @@
   }
 }
 :host([scale="s"][labeled]) {
-  line-height: 12px;
+  line-height: 1.33;
   margin-bottom: 8px;
   margin-right: 12px;
   @supports not (display: grid) {
@@ -71,14 +71,14 @@
 
 :host([scale="m"]) {
   .radio {
-    height: 16px;
-    min-width: 16px;
-    max-width: 16px;
+    height: 14px;
+    min-width: 14px;
+    max-width: 14px;
   }
 }
 :host([scale="m"][labeled]) {
-  line-height: 16px;
-  margin-bottom: 10px;
+  line-height: 1.15;
+  margin-bottom: 8px;
   margin-right: 16px;
   @supports not (display: grid) {
     .radio {
@@ -108,7 +108,7 @@
 }
 :host([scale="l"][labeled]) {
   gap: 12px;
-  line-height: 20px;
+  line-height: 1.2;
   margin-bottom: 10px;
   margin-right: 20px;
   @supports not (display: grid) {

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -36,17 +36,17 @@
 }
 
 :host([scale="s"]) label {
-  font-size: theme("fontSize.-2");
+  @apply text--2;
   padding: 0.25rem 0.75rem;
 }
 
 :host([scale="m"]) label {
-  font-size: theme("fontSize.-1");
+  @apply text--1;
   padding: 0.4rem 1rem;
 }
 
 :host([scale="l"]) label {
-  font-size: theme("fontSize.1");
+  @apply text-1;
   padding: 0.5rem 1.5rem;
 }
 

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -7,7 +7,7 @@
   display: flex;
   align-self: stretch;
   cursor: pointer;
-  transition: background 0.1s ease-in-out, border-color 0.1s ease-in-out;
+  transition: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out;
 }
 
 :host label {
@@ -17,7 +17,7 @@
   border: 1px solid transparent;
   margin: 4px;
   box-sizing: border-box;
-  transition: background 0.1s ease-in-out, border-color 0.1s ease-in-out;
+  transition: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out;
   pointer-events: none;
   display: flex;
   align-items: center;
@@ -36,17 +36,17 @@
 }
 
 :host([scale="s"]) label {
-  @include font-size(-3);
+  font-size: theme("fontSize.-2");
   padding: 0.25rem 0.75rem;
 }
 
 :host([scale="m"]) label {
-  @include font-size(-1);
+  font-size: theme("fontSize.-1");
   padding: 0.4rem 1rem;
 }
 
 :host([scale="l"]) label {
-  @include font-size(0);
+  font-size: theme("fontSize.1");
   padding: 0.5rem 1.5rem;
 }
 

--- a/src/components/calcite-select/calcite-select.scss
+++ b/src/components/calcite-select/calcite-select.scss
@@ -6,17 +6,17 @@
 }
 
 :host([scale="s"]) {
-  --calcite-select-font-size: 0.75rem;
+  --calcite-select-font-size: theme("fontSize.-2");
   --calcite-select-spacing: 0.5rem;
 }
 
 :host([scale="m"]) {
-  --calcite-select-font-size: 1rem;
+  --calcite-select-font-size: theme("fontSize.-1");
   --calcite-select-spacing: 0.75rem;
 }
 
 :host([scale="l"]) {
-  --calcite-select-font-size: 1.25rem;
+  --calcite-select-font-size: theme("fontSize.1");
   --calcite-select-spacing: 1rem;
 }
 

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -55,7 +55,7 @@
     </calcite-dropdown>
     <br />
     <br />
-    <h3> Dropdown scales</h3>
+    <h3> Dropdown scales + Icon start</h3>
 
     <calcite-dropdown scale="s">
       <calcite-button scale="s" slot="dropdown-trigger">Scale S small</calcite-button>
@@ -81,6 +81,34 @@
         <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
         <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
         <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+
+    <h3>Dropdown scales + Icon end</h3>
+    <calcite-dropdown scale="s" selection-mode="multi">
+      <calcite-button scale="s" slot="dropdown-trigger">Scale S small</calcite-button>
+      <calcite-dropdown-group group-title="View" selction-mode="multi">
+        <calcite-dropdown-item icon-end="list-bullet" icon-start="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+
+    <calcite-dropdown scale="m" selection-mode="multi">
+      <calcite-button scale="m" slot="dropdown-trigger">Scale M medium</calcite-button>
+      <calcite-dropdown-group group-title="View" selction-mode="multi">
+        <calcite-dropdown-item icon-end="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+
+    <calcite-dropdown scale="l" selection-mode="multi">
+      <calcite-button color="dark" scale="l" slot="dropdown-trigger">Scale L large</calcite-button>
+      <calcite-dropdown-group group-title="View" selction-mode="multi">
+        <calcite-dropdown-item icon-end="list-bullet" active>List</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="grid">Grid</calcite-dropdown-item>
+        <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
     <br />


### PR DESCRIPTION
**Related Issue:** #1186 #1137

## Summary
This is an interim update to font sizes.
Note: this uses the `theme` utility, and that will be refactored with `@apply` in a future PR.

This is aimed at UI alignment with newly ported components.

This does not include any new line-height patterns.
The few line-height changes are intended to approximate previously defined line-heights relative to the new font-sizes..

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
