### PR TITLE
fix(calcite-radio-button): all children text nodes render inside a single calcite-label

### DIFF
--- a/src/components/calcite-radio-button/calcite-radio-button.e2e.ts
+++ b/src/components/calcite-radio-button/calcite-radio-button.e2e.ts
@@ -463,4 +463,41 @@ describe("calcite-radio-button", () => {
     expect(await unchecked.getProperty("checked")).toBe(false);
     expect(await checked.getProperty("checked")).toBe(true);
   });
+
+  it("renders all children text nodes concatenated together in a single calcite-label", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-radio-button>More<br> than<br> one<br> text<br> node</calcite-radio-button>
+    `);
+
+    const labels = await page.findAll("calcite-label");
+    expect(labels).toHaveLength(1);
+
+    const label = await page.find("calcite-label");
+    expect(label.textContent).toEqual("More than one text node");
+
+    const page2 = await newE2EPage();
+    await page2.setContent(`
+      <calcite-radio-button>More<br>than<br>one<br>text<br>node<p>Only plain text nodes allowed!</p></calcite-radio-button>
+    `);
+    const label2 = await page2.find("calcite-label");
+    expect(label2.textContent).toEqual("Morethanonetextnode");
+  });
+
+  it("only renders a label when text nodes are supplied", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-radio-button></calcite-radio-button>
+    `);
+    const labels = await page.findAll("calcite-label");
+    expect(labels).toHaveLength(0);
+
+    const page2 = await newE2EPage();
+    await page2.setContent(`
+      <calcite-radio-button><p>Only plain text nodes allowed!</p></calcite-radio-button>
+    `);
+
+    const labels2 = await page.findAll("calcite-label");
+    expect(labels2).toHaveLength(0);
+  });
 });

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -268,8 +268,8 @@ export class CalciteRadioButton {
   connectedCallback(): void {
     this.guid = this.el.id || `calcite-radio-button-${guid()}`;
     this.initialChecked = this.checked;
-    this.renderInput();
     this.renderLabel();
+    this.renderInput();
     this.setupTitleAttributeObserver();
     if (this.name) {
       this.checkLastRadioButton();
@@ -344,17 +344,20 @@ export class CalciteRadioButton {
 
   private renderLabel(): void {
     // Rendering a calcite-label outside of Shadow DOM for accessibility and form participation
-    this.el.childNodes.forEach((childNode) => {
-      if (childNode.nodeName === "#text" && childNode.textContent.trim().length > 0) {
-        this.label = document.createElement("calcite-label");
-        this.label.setAttribute("dir", getElementDir(this.el));
-        this.disabled && this.label.setAttribute("disabled", "");
-        this.label.setAttribute("disable-spacing", "");
-        this.label.setAttribute("scale", this.scale);
-        this.label.appendChild(document.createTextNode(childNode.textContent.trim()));
-        childNode.parentNode.replaceChild(this.label, childNode);
+    if (this.el.textContent) {
+      const textNodes = Array.from(this.el.childNodes).filter((childNode) => childNode.nodeName === "#text");
+      const labelText = textNodes.reduce((labelText, textNode) => labelText += textNode.textContent, "");
+      while (this.el.firstChild) {
+        this.el.removeChild(this.el.firstChild);
       }
-    });
+      this.label = document.createElement("calcite-label");
+      this.label.setAttribute("dir", getElementDir(this.el));
+      this.disabled && this.label.setAttribute("disabled", "");
+      this.label.setAttribute("disable-spacing", "");
+      this.label.setAttribute("scale", this.scale);
+      this.label.appendChild(document.createTextNode(labelText));
+      this.el.appendChild(this.label);
+    }
   }
 
   render(): VNode {

--- a/src/demos/calcite-radio-button.html
+++ b/src/demos/calcite-radio-button.html
@@ -92,6 +92,10 @@
                     </calcite-radio-button>
                   </calcite-label>
 
+                  <hr>
+
+                  <calcite-radio-button name="s-multiple-text-nodes" scale="s">More<br> than<br> one<br> text<br> node</calcite-radio-button>
+
                   <h3>Scale m (default)</h3>
                   <calcite-radio-button name="m" scale="m" value="stencil" checked>Stencil</calcite-radio-button>
                   <calcite-radio-button name="m" scale="m" value="react" checked>React</calcite-radio-button>
@@ -123,6 +127,10 @@
                     <calcite-radio-button name="m-label-wrapped" scale="m" value="angular">Angular
                     </calcite-radio-button>
                   </calcite-label>
+
+                  <hr>
+
+                  <calcite-radio-button name="m-multiple-text-nodes" scale="m">More<br> than<br> one<br> text<br> node</calcite-radio-button>
 
                   <h3>Scale l</h3>
                   <calcite-radio-button name="l" scale="l" value="stencil" checked>Stencil</calcite-radio-button>
@@ -158,6 +166,12 @@
                     <calcite-radio-button name="l-label-wrapped" scale="l" value="angular">Angular
                     </calcite-radio-button>
                   </calcite-label>
+
+                  <hr>
+
+                  <calcite-radio-button name="l-multiple-text-nodes" scale="l">More<br> than<br> one<br> text<br> node</calcite-radio-button>
+
+                  <hr>
 
                   <calcite-radio-button name="valueAsLabelDisabledSingle" value="1" checked>1</calcite-radio-button>
                   <calcite-radio-button name="valueAsLabelDisabledSingle" value="2" disabled>2</calcite-radio-button>


### PR DESCRIPTION
**Related Issue:** #1140 