### PR TITLE
test: add more a11y tests

### DIFF
--- a/src/components/calcite-color-hex-input/calcite-color-hex-input.e2e.ts
+++ b/src/components/calcite-color-hex-input/calcite-color-hex-input.e2e.ts
@@ -1,9 +1,11 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
-import { defaults, focusable, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, focusable, reflects, renders } from "../../tests/commonTests";
 import { isValidHex, normalizeHex } from "../calcite-color/utils";
 
 describe("calcite-color-hex-input", () => {
   it("renders", () => renders("calcite-color-hex-input"));
+
+  it("is accessible", () => accessible("calcite-color-hex-input"));
 
   it("has defaults", () =>
     defaults("calcite-color-hex-input", [

--- a/src/components/calcite-color-swatch/calcite-color-swatch.e2e.ts
+++ b/src/components/calcite-color-swatch/calcite-color-swatch.e2e.ts
@@ -1,9 +1,15 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS } from "./resources";
-import { defaults, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, reflects, renders } from "../../tests/commonTests";
 
 describe("calcite-color-swatch", () => {
   it("renders", () => renders("calcite-color-swatch"));
+
+  it("is accessible", () =>
+    Promise.all([
+      accessible(`<calcite-color-swatch color='#c0ffee'></calcite-color-swatch>`),
+      accessible(`<calcite-color-swatch active color='#c0ffee'></calcite-color-swatch>`)
+    ]));
 
   it("has defaults", () =>
     defaults("calcite-color-swatch", [

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
@@ -1,8 +1,15 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS } from "./resources";
 import { accessible } from "../../tests/commonTests";
+import dedent from "dedent";
 
 describe("calcite-pick-list-group", () => {
+  it("is accessible", () =>
+    Promise.all([
+      accessible("<calcite-pick-list-group></calcite-pick-list-group>"),
+      accessible(`<calcite-pick-list-group group-title="awesome title, bruh"></calcite-pick-list-group>`)
+    ]));
+
   it("should render", async () => {
     const page = await newE2EPage();
 
@@ -14,9 +21,13 @@ describe("calcite-pick-list-group", () => {
   });
 
   it("is accessible", async () =>
-    accessible(
-      `<calcite-pick-list><calcite-pick-list-group><calcite-pick-list-item label="Sample" value="one"></calcite-pick-list-item></calcite-pick-list-group></calcite-pick-list>`
-    ));
+    accessible(dedent`
+      <calcite-pick-list>
+        <calcite-pick-list-group>
+          <calcite-pick-list-item label="Sample" value="one"></calcite-pick-list-item>
+        </calcite-pick-list-group>
+      </calcite-pick-list>
+    `));
 
   it("should render a header if one is provided", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
@@ -1,9 +1,31 @@
 import { CSS } from "./resources";
-import { renders } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 import { newE2EPage } from "@stencil/core/testing";
+import dedent from "dedent";
 
 describe("calcite-pick-list-item", () => {
   it("renders", async () => renders("calcite-pick-list-item"));
+
+  it("is accessible", async () =>
+    Promise.all([
+      accessible(dedent`
+        <calcite-pick-list>
+          <calcite-pick-list-item label="test" description="a number" value="one"></calcite-pick-list-item>
+        </calcite-pick-list>
+      `),
+
+      accessible(dedent`
+        <calcite-pick-list>
+          <calcite-pick-list-item label="test" description="a number" value="one" selected></calcite-pick-list-item>
+        </calcite-pick-list>
+      `),
+
+      accessible(dedent`
+        <calcite-pick-list>
+          <calcite-pick-list-item label="test" description="a number" value="one" removable></calcite-pick-list-item>
+        </calcite-pick-list>
+      `)
+    ]));
 
   it("should toggle selected attribute when clicked", async () => {
     const page = await newE2EPage({ html: `<calcite-pick-list-item label="test"></calcite-pick-list-item>` });

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -2,6 +2,7 @@ import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { ICON_TYPES } from "./resources";
 import { accessible, hidden, renders } from "../../tests/commonTests";
 import { selectionAndDeselection, filterBehavior, disabledStates, keyboardNavigation } from "./shared-list-tests";
+import dedent from "dedent";
 
 describe("calcite-pick-list", () => {
   it("renders", async () => renders("calcite-pick-list"));
@@ -9,9 +10,11 @@ describe("calcite-pick-list", () => {
   it("honors hidden attribute", async () => hidden("calcite-pick-list"));
 
   it("is accessible", async () =>
-    accessible(
-      `<calcite-pick-list><calcite-pick-list-item label="Sample" value="one"></calcite-pick-list-item></calcite-pick-list>`
-    ));
+    accessible(dedent`
+      <calcite-pick-list>
+        <calcite-pick-list-item label="Sample" value="one"></calcite-pick-list-item>
+      </calcite-pick-list>
+    `));
 
   describe("Selection and Deselection", () => selectionAndDeselection("pick"));
 

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -1,5 +1,6 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { JSEvalable } from "puppeteer";
+import dedent from "dedent";
 
 type ListType = "pick" | "value";
 type ListElement = HTMLCalcitePickListElement | HTMLCalciteValueListElement;
@@ -401,10 +402,13 @@ export function filterBehavior(listType: ListType): void {
 
 export function disabledStates(listType: ListType): void {
   it("disabled", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<calcite-${listType}-list disabled>
-        <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
-      </calcite-${listType}-list>`);
+    const page = await newE2EPage({
+      html: dedent`
+        <calcite-${listType}-list disabled>
+          <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>
+      `
+    });
 
     const list = await page.find(`calcite-${listType}-list`);
     const item1 = await list.find("[value=one]");

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -8,14 +8,19 @@ import {
   keyboardNavigation
 } from "../calcite-pick-list/shared-list-tests";
 import { dragAndDrop } from "../../tests/utils";
+import dedent from "dedent";
 
 describe("calcite-value-list", () => {
-  it("renders", async () => renders("calcite-value-list"));
+  it("renders", () => renders("calcite-value-list"));
+
   it("honors hidden attribute", async () => hidden("calcite-value-list"));
-  it("is accessible", async () =>
-    accessible(
-      `<calcite-value-list><calcite-value-list-item label="Sample" value="one"></calcite-value-list-item></calcite-value-list>`
-    ));
+
+  it("is accessible", () =>
+    accessible(dedent`
+      <calcite-value-list>
+        <calcite-value-list-item label="Sample" value="one"></calcite-value-list-item>
+      </calcite-value-list>
+    `));
 
   describe("Selection and Deselection", () => {
     selectionAndDeselection("value");


### PR DESCRIPTION
**Related Issue:** #1159 

## Summary

This adds a11y tests to the following components:

* `calcite-color-hex-input`
* `calcite-color-swatch`
* `calcite-pick-list-group`
* `calcite-pick-list-item`
* `calcite-pick-list`
* `calcite-value-list`

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
