### PR TITLE
feat(tile-select): Add disabled styling for tile select, updates hover and focus style

### DIFF
--- a/src/components/calcite-tile-select/calcite-tile-select.scss
+++ b/src/components/calcite-tile-select/calcite-tile-select.scss
@@ -34,7 +34,7 @@ $spacing: $baseline/2;
 }
 :host([show-input="none"][focused]) {
   box-shadow: 0 0 0 1px var(--calcite-ui-blue-1), inset 0 0 0 2px var(--calcite-ui-foreground-1),
-    inset 0 0 0 4px var(--calcite-ui-blue-1);
+    inset 0 0 0 5px var(--calcite-ui-blue-1);
 }
 
 :host([width="full"]) {

--- a/src/components/calcite-tile-select/calcite-tile-select.scss
+++ b/src/components/calcite-tile-select/calcite-tile-select.scss
@@ -6,6 +6,7 @@ $spacing: $baseline/2;
 :host {
   background-color: var(--calcite-ui-foreground-1);
   box-shadow: 0 0 0 1px var(--calcite-ui-border-2);
+  border: 1px solid transparent;
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
@@ -14,48 +15,40 @@ $spacing: $baseline/2;
   position: relative;
   transition: $transition;
   vertical-align: top;
+  @apply z-10;
+}
+
+:host(:hover) {
+  @apply z-20;
+  box-shadow: 0 0 0 1px var(--calcite-ui-border-1);
 }
 :host([checked]) {
+  @apply z-30;
   box-shadow: 0 0 0 1px var(--calcite-ui-blue-1);
-  z-index: 1;
 }
-:host([checked]:focus),
-:host([checked][focused]) {
-  z-index: 2;
+:host([focused]) {
+  @apply z-30;
+}
+
+:host([show-input="none"]:hover) {
+  box-shadow: 0 0 0 1px var(--calcite-ui-blue-1);
+}
+
+:host([show-input="none"][focused]) {
+  box-shadow: 0 0 0 1px var(--calcite-ui-blue-1), inset 0 0 0 1px var(--calcite-ui-foreground-1),
+    inset 0 0 0 4px var(--calcite-ui-blue-1);
 }
 
 :host([width="full"]) {
   max-width: none;
   display: block;
 }
-
 :host([show-input="none"]) {
-  box-shadow: 0 0 0 2px var(--calcite-ui-foreground-1), 0 0 0 3px var(--calcite-ui-border-2);
-  margin-right: 1px;
-  margin-bottom: 5px;
   ::slotted(calcite-checkbox),
   ::slotted(calcite-radio-button) {
     opacity: 0;
     position: absolute;
   }
-}
-:host([show-input="none"]:hover) {
-  box-shadow: 0 0 0 2px var(--calcite-ui-foreground-1), 0 0 0 4px var(--calcite-ui-blue-1);
-  z-index: 3;
-}
-:host([show-input="none"][checked]) {
-  box-shadow: 0 0 0 1px var(--calcite-ui-foreground-1), 0 0 0 4px var(--calcite-ui-blue-1);
-}
-:host([show-input="none"]:focus),
-:host([show-input="none"][focused]) {
-  box-shadow: 0 0 0 2px var(--calcite-ui-foreground-1), 0 0 0 4px var(--calcite-ui-blue-1),
-    0 0 0 6px var(--calcite-ui-foreground-1), 0 0 0 9px var(--calcite-ui-blue-1);
-  z-index: 2;
-}
-:host([show-input="none"][checked]:focus),
-:host([show-input="none"][checked][focused]) {
-  box-shadow: 0 0 0 1px var(--calcite-ui-foreground-1), 0 0 0 4px var(--calcite-ui-blue-1),
-    0 0 0 6px var(--calcite-ui-foreground-1), 0 0 0 9px var(--calcite-ui-blue-1);
 }
 
 :host([heading]:not([icon]):not([description])) {
@@ -103,4 +96,9 @@ $spacing: $baseline/2;
 
 :host([hidden]) {
   display: none;
+}
+
+:host([disabled]) {
+  opacity: var(--calcite-ui-opacity-disabled);
+  pointer-events: none;
 }

--- a/src/components/calcite-tile-select/calcite-tile-select.scss
+++ b/src/components/calcite-tile-select/calcite-tile-select.scss
@@ -6,7 +6,6 @@ $spacing: $baseline/2;
 :host {
   background-color: var(--calcite-ui-foreground-1);
   box-shadow: 0 0 0 1px var(--calcite-ui-border-2);
-  border: 1px solid transparent;
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
@@ -33,9 +32,8 @@ $spacing: $baseline/2;
 :host([show-input="none"]:hover) {
   box-shadow: 0 0 0 1px var(--calcite-ui-blue-1);
 }
-
 :host([show-input="none"][focused]) {
-  box-shadow: 0 0 0 1px var(--calcite-ui-blue-1), inset 0 0 0 1px var(--calcite-ui-foreground-1),
+  box-shadow: 0 0 0 1px var(--calcite-ui-blue-1), inset 0 0 0 2px var(--calcite-ui-foreground-1),
     inset 0 0 0 4px var(--calcite-ui-blue-1);
 }
 

--- a/src/components/calcite-tile/calcite-tile.scss
+++ b/src/components/calcite-tile/calcite-tile.scss
@@ -30,11 +30,13 @@ $spacing: $baseline/2;
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: $spacing;
+  pointer-events: none;
 }
 .heading {
   @include font-size(0);
-  color: var(--calcite-ui-text-1);
+  color: var(--calcite-ui-text-2);
   font-weight: 500;
+  pointer-events: none;
 }
 .large-visual {
   justify-items: center;
@@ -48,5 +50,15 @@ $spacing: $baseline/2;
 }
 .description {
   @include font-size(-1);
-  color: var(--calcite-ui-text-2);
+  color: var(--calcite-ui-text-3);
+  pointer-events: none;
+}
+
+:host([active]) {
+  .heading {
+    color: var(--calcite-ui-text-1);
+  }
+  .description {
+    color: var(--calcite-ui-text-2);
+  }
 }

--- a/src/components/calcite-tile/calcite-tile.scss
+++ b/src/components/calcite-tile/calcite-tile.scss
@@ -35,6 +35,7 @@ $spacing: $baseline/2;
 .heading {
   @include font-size(0);
   color: var(--calcite-ui-text-2);
+  transition: $transition;
   font-weight: 500;
   pointer-events: none;
 }
@@ -51,9 +52,11 @@ $spacing: $baseline/2;
 .description {
   @include font-size(-1);
   color: var(--calcite-ui-text-3);
+  transition: $transition;
   pointer-events: none;
 }
 
+:host(:hover),
 :host([active]) {
   .heading {
     color: var(--calcite-ui-text-1);

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -65,7 +65,7 @@
                         heading="Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="left-radio" value="four" heading="Tile title lorem ipsum"
+                      <calcite-tile-select disabled icon="layers" name="left-radio" value="four" heading="Disabled - Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
                       <calcite-tile-select icon="layers" name="left-radio" value="five" heading="Tile title lorem ipsum"
@@ -74,8 +74,8 @@
                       <calcite-tile-select icon="layers" name="left-radio" value="six" heading="Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="left-radio" value="seven"
-                        heading="Tile title lorem ipsum"
+                      <calcite-tile-select disabled icon="layers" name="left-radio" value="seven"
+                        heading="Disabled - Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
                       <calcite-tile-select icon="layers" name="left-radio" value="eight"
@@ -243,16 +243,16 @@
                         heading="Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="four" show-input="none"
-                        heading="Tile title lorem ipsum"
+                      <calcite-tile-select disabled icon="layers" name="basic-radio" value="four" show-input="none"
+                        heading="Disabled - Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
                       <calcite-tile-select checked icon="layers" name="basic-radio" value="five" show-input="none"
                         heading="Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="six" show-input="none"
-                        heading="Tile title lorem ipsum"
+                      <calcite-tile-select disabled icon="layers" name="basic-radio" value="six" show-input="none"
+                        heading="Disabled - Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
                       <calcite-tile-select icon="layers" name="basic-radio" value="seven" show-input="none"


### PR DESCRIPTION
**Related Issue:** 

Resolves #1063 cc @noahmulfinger 
Resolves #1098 cc @eriklharper @bstifle 

Adds disabled styling:

![Screen Shot 2020-11-04 at 10 58 48 AM](https://user-images.githubusercontent.com/4733155/98156563-d43db280-1e8c-11eb-900a-c85ec26cbe2c.png)


While adding the disabled styling, I ran into the issues described in #1098, so I tried to alleviate that as much as possible by simplifying the styling. I tried the "outset" focus as @bstifle suggested but it was ultimately unreliable with similar weirdness.

For tile-select items that SHOW a radio or checkbox, the focus state is applied to that input within the tile. Hover state for these configurations is a darker border.

For tile-select items that DO NOT SHOW a radio or checkbox, we apply an inset focus style. Hover state for these configurations is a blue border.

Additionally I've lightened the text for header and description by one step when a wrapped calcite-tile is NOT active, so that on hover, focus, or active, the text for header and description can darken by one step as a better indicator. This also helps the "focusing over a checkbox without a radio or checkbox but it's not selected" visual. That's still a weak point IMO but, not sure what else we can do there.

| Current | This PR |
| --- | --- |
|![Screencast 2020-11-04 at 9 43 41 AM (1)](https://user-images.githubusercontent.com/4733155/98156617-e6b7ec00-1e8c-11eb-83e6-ac2c12bbc9c7.gif) | ![Screencast 2020-11-04 at 10 44 03 AM](https://user-images.githubusercontent.com/4733155/98156657-f2a3ae00-1e8c-11eb-92b4-b36fa6435c84.gif) |

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
