### PR TITLE
fix(select): keep internal native elements in sync with calcite option and option groups

### DIFF
--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, focusable, reflects, renders } from "../../tests/commonTests";
 import dedent from "dedent";
+import { CSS } from "./resources";
 
 describe("calcite-select", () => {
   const simpleTestMarkup = dedent`
@@ -91,6 +92,38 @@ describe("calcite-select", () => {
 
       expect(selected).toHaveLength(1);
       expect(selected[0].innerText).toBe("uno");
+    });
+
+    it("internally maps children to native elements", async () => {
+      const page = await newE2EPage({
+        html: dedent`
+          <calcite-select>
+            <calcite-option>uno</calcite-option>
+            <calcite-option>dos</calcite-option>
+            <calcite-option>tres</calcite-option>
+          </calcite-select>
+        `
+      });
+      const internalSelect = await page.find(`calcite-select >>> .${CSS.select}`);
+
+      expect(await internalSelect.findAll("option")).toHaveLength(3);
+
+      const options = await page.findAll("calcite-option");
+
+      for (let i = 0; i < options.length; i++) {
+        await options[i].callMethod("remove");
+      }
+
+      expect(await internalSelect.findAll("option")).toHaveLength(0);
+
+      await page.$eval("calcite-select", (select) => {
+        const number = document.createElement("calcite-option");
+        number.innerHTML = "cuatro";
+
+        select.append(number);
+      });
+
+      expect(await internalSelect.findAll("option")).toHaveLength(1);
     });
   });
 
@@ -217,6 +250,54 @@ describe("calcite-select", () => {
 
         expect(await page.evaluate(() => document.activeElement.tagName)).toEqual("CALCITE-SELECT");
       });
+    });
+
+    it("internally maps children to native elements", async () => {
+      const page = await newE2EPage({
+        html: dedent`
+          <calcite-select>
+            <calcite-option-group label="letters">
+              <calcite-option>a</calcite-option>
+              <calcite-option>b</calcite-option>
+            </calcite-option-group>
+            <calcite-option-group label="numbers">
+              <calcite-option label="one">1</calcite-option>
+            </calcite-option-group>
+            <calcite-option-group label="empty"></calcite-option-group>
+          </calcite-select>
+        `
+      });
+      const internalSelect = await page.find(`calcite-select >>> .${CSS.select}`);
+
+      expect(await internalSelect.findAll("option")).toHaveLength(3);
+      expect(await internalSelect.findAll("optgroup")).toHaveLength(3);
+
+      const optionsAndGroups = await page.findAll("calcite-option, calcite-option-group");
+
+      for (let i = 0; i < optionsAndGroups.length; i++) {
+        await optionsAndGroups[i].callMethod("remove");
+      }
+
+      expect(await internalSelect.findAll("option, optgroup")).toHaveLength(0);
+
+      await page.$eval("calcite-select", (select) => {
+        const letters = document.createElement("calcite-option-group");
+        const numbers = document.createElement("calcite-option-group");
+
+        const letter = document.createElement("calcite-option");
+        letter.innerHTML = "c";
+
+        const number = document.createElement("calcite-option");
+        numbers.innerHTML = "2";
+
+        letters.append(letter);
+        numbers.append(number);
+
+        select.append(letters, numbers);
+      });
+
+      expect(await internalSelect.findAll("option")).toHaveLength(2);
+      expect(await internalSelect.findAll("optgroup")).toHaveLength(2);
     });
   });
 });

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -195,18 +195,16 @@ export class CalciteSelect {
   private populateInternalSelect = (): void => {
     const optionsAndGroups = Array.from(this.el.children as HTMLCollectionOf<CalciteOptionOrGroup>);
 
-    this.removeFromInternalSelect(optionsAndGroups);
+    this.clearInternalSelect();
 
-    optionsAndGroups.forEach((optionOrGroup) => {
-      this.selectEl.append(this.toNativeElement(optionOrGroup));
-    });
+    optionsAndGroups.forEach((optionOrGroup) =>
+      this.selectEl.append(this.toNativeElement(optionOrGroup))
+    );
   };
 
-  private removeFromInternalSelect(optionsAndGroups: CalciteOptionOrGroup[]): void {
-    optionsAndGroups.forEach((optionOrGroup) => {
-      this.componentToNativeEl.clear();
-      this.componentToNativeEl.get(optionOrGroup)?.remove();
-    });
+  private clearInternalSelect(): void {
+    this.componentToNativeEl.forEach((value) => value.remove());
+    this.componentToNativeEl.clear();
   }
 
   private storeSelectRef = (node: HTMLSelectElement): void => {


### PR DESCRIPTION
**Related Issue:** #1226 

## Summary

This fixes an issue where updating the option/option-group children caused duplicate items to be added. 

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

cc @priya4991