### PR TITLE
fix(shell-panel): adds auto bottom margin to make height dynamic.

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -63,7 +63,8 @@
 .content--detached {
   border-radius: var(--calcite-border-radius);
   box-shadow: var(--calcite-shadow-0);
-  margin: var(--calcite-spacing-half) var(--calcite-spacing-half) 0;
+  height: auto;
+  margin: var(--calcite-spacing-half) var(--calcite-spacing-half) auto;
   max-height: var(--calcite-shell-panel-detached-max-height);
   overflow: hidden;
   ::slotted(calcite-panel),


### PR DESCRIPTION
## Summary
Minor tweak to make shell-panel content height dynamic when detached.

@driskull @macandcheese  Would like to get this into a release.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
