### PR TITLE
fix(modal)!: use a prop for modal title rather than a slot

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { HYDRATED_ATTR } from "../../tests/commonTests";
+import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
 
 describe("calcite-modal properties", () => {
   it("renders", async () => {
@@ -9,10 +9,14 @@ describe("calcite-modal properties", () => {
     expect(element).toHaveAttribute(HYDRATED_ATTR);
   });
 
+  it("should be accessible", async () => {
+    await accessible(`<calcite-modal title-text="Title"></calcite-modal>`);
+  });
+
   it("adds localized strings set via intl-* props", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal intl-close="test"></calcite-modal>`);
-    const button = await page.find("calcite-modal >>> .modal__close");
+    const button = await page.find("calcite-modal >>> .close");
     expect(button).toEqualAttribute("aria-label", "test");
   });
 
@@ -22,7 +26,7 @@ describe("calcite-modal properties", () => {
     const modal = await page.find("calcite-modal");
     modal.setProperty("disableCloseButton", true);
     await page.waitForChanges();
-    const closeButton = await page.find("calcite-modal >>> .modal__close");
+    const closeButton = await page.find("calcite-modal >>> .close");
     expect(closeButton).toBe(null);
   });
 
@@ -42,8 +46,7 @@ describe("calcite-modal properties", () => {
   it("focuses the firstFocus element on load", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-      <calcite-modal active>
-        <h3 slot="header">Title</h3>
+      <calcite-modal title-text="Title" active>
         <p slot="content">This is the content <button class="test">test</button></p>
       </calcite-modal>
     `);
@@ -122,7 +125,7 @@ describe("calcite-modal accessibility checks", () => {
     await page.$eval(".btn-1", (elm) => ($button1 = elm));
     await page.$eval(".btn-2", (elm) => ($button2 = elm));
     await page.$eval("calcite-modal", (elm) => {
-      $close = elm.shadowRoot.querySelector(".modal__close");
+      $close = elm.shadowRoot.querySelector(".close");
     });
     await modal.setProperty("active", true);
     await page.waitForChanges();
@@ -156,14 +159,6 @@ describe("calcite-modal accessibility checks", () => {
     expect(document.activeElement).toEqual($button);
   });
 
-  it("has correct aria role/attribute", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<calcite-modal></calcite-modal>`);
-    const modal = await page.find("calcite-modal");
-    expect(modal).toEqualAttribute("role", "dialog");
-    expect(modal).toEqualAttribute("aria-modal", "true");
-  });
-
   it("closes when Escape key is pressed", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
@@ -195,7 +190,7 @@ describe("calcite-modal accessibility checks", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
-    const button = await page.find("calcite-modal >>> .modal__close");
+    const button = await page.find("calcite-modal >>> .close");
     await modal.setProperty("active", true);
     await page.waitForChanges();
     expect(modal).toHaveAttribute("is-active");
@@ -208,7 +203,7 @@ describe("calcite-modal accessibility checks", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
-    const button = await page.find("calcite-modal >>> .modal__close");
+    const button = await page.find("calcite-modal >>> .close");
     await modal.setProperty("active", true);
     await page.waitForChanges();
     expect(modal).toHaveAttribute("is-active");

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -1,91 +1,73 @@
 :host {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow-y: hidden;
-  color: var(--calcite-ui-text-2);
-  opacity: 0;
+  @apply fixed inset-0 flex justify-center items-center overflow-y-hidden text-color-2 opacity-0;
   visibility: hidden !important;
   transition: visibility 0ms linear 300ms, opacity 300ms $easing-function;
   z-index: 101;
-  --calcite-modal-title-padding: 12px 16px;
-  --calcite-modal-title-text: 20px;
-  --calcite-modal-content-padding: 16px;
-  --calcite-modal-content-text: 16px;
-  --calcite-modal-close-padding: 12px;
-  --calcite-modal-footer-padding: 12px;
+  --calcite-modal-title-padding: theme("spacing.3") theme("spacing.4");
+  --calcite-modal-title-text: theme("spacing.5");
+  --calcite-modal-content-padding: theme("spacing.4");
+  --calcite-modal-content-text: theme("spacing.4");
+  --calcite-modal-close-padding: theme("spacing.3");
+  --calcite-modal-footer-padding: theme("spacing.3");
 }
 
 :host([scale="s"]) {
-  --calcite-modal-title-padding: 8px 12px;
-  --calcite-modal-title-text: 18px;
-  --calcite-modal-content-padding: 12px;
-  --calcite-modal-content-text: 14px;
-  --calcite-modal-close-padding: 8px;
-  --calcite-modal-footer-padding: 8px;
+  --calcite-modal-title-padding: theme("spacing.2") theme("spacing.3");
+  --calcite-modal-title-text: 1theme ("spacing.2");
+  --calcite-modal-content-padding: theme("spacing.3");
+  --calcite-modal-content-text: theme("fontSize.-1");
+  --calcite-modal-close-padding: theme("spacing.2");
+  --calcite-modal-footer-padding: theme("spacing.2");
 }
 
 :host([scale="l"]) {
-  --calcite-modal-title-padding: 16px 20px;
-  --calcite-modal-title-text: 26px;
-  --calcite-modal-content-padding: 20px;
-  --calcite-modal-content-text: 18px;
-  --calcite-modal-close-padding: 16px;
-  --calcite-modal-footer-padding: 16px;
+  --calcite-modal-title-padding: theme("spacing.4") theme("spacing.5");
+  --calcite-modal-title-text: theme("fontSize.3");
+  --calcite-modal-content-padding: theme("spacing.5");
+  --calcite-modal-content-text: theme("fontSize.1");
+  --calcite-modal-close-padding: theme("spacing.4");
+  --calcite-modal-footer-padding: theme("spacing.4");
 }
 
 .scrim {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  overflow-y: hidden;
+  @apply inset-0 fixed overflow-y-hidden;
 }
 
 .modal {
-  @apply shadow-2-sm;
-  box-sizing: border-box;
+  @apply shadow-2-sm
+  box-border
+  float-none
+  text-left
+  scrolling-touch
+  flex
+  flex-col
+  opacity-0
+  pointer-events-none
+  bg-foreground-1
+  rounded-1
+  m-6
+  w-full;
   z-index: 102;
-  float: none;
-  text-align: left;
-  -webkit-overflow-scrolling: touch;
-  display: flex;
-  flex-direction: column;
   flex-wrap: row-wrap;
-  opacity: 0;
   visibility: hidden;
-  pointer-events: none;
   transition: transform 300ms $easing-function, visibility 0ms linear 300ms, opacity 300ms $easing-function;
   transform: translate3d(0, 20px, 0);
-  background-color: var(--calcite-ui-foreground-1);
-  border-radius: var(--calcite-border-radius);
-  margin: $baseline;
-  width: 100%;
 }
 
 // focus styles
-.modal__close {
+.close {
   @include focus-style-base();
-  &.modal__close:focus {
+  &.close:focus {
     @include focus-style-inset();
   }
 }
 
 :host([is-active]) {
+  @apply opacity-100;
   visibility: visible !important;
-  opacity: 1;
   transition-delay: 0ms;
   .modal {
-    pointer-events: auto;
-    visibility: visible;
-    opacity: 1;
+    @apply pointer-events-auto visible opacity-100;
     transition-delay: 0ms;
     transform: translate3d(0, 0, 0);
     transition: transform 300ms $easing-function, visibility 0ms linear, opacity 300ms $easing-function,
@@ -94,87 +76,65 @@
 }
 
 :host([dir="rtl"]) .modal {
-  text-align: right;
+  @apply text-right;
 }
 
 /**
- * Header
+ * top
  */
-.modal__header {
-  background-color: var(--calcite-ui-foreground-1);
+.top {
+  @apply bg-foreground-1 flex max-w-full min-w-0;
   flex: 0 0 auto;
-  display: flex;
-  max-width: 100%;
-  min-width: 0;
   z-index: 2;
   border-bottom: 1px solid var(--calcite-ui-border-3);
   border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
 }
 
-.modal__close {
+.close {
+  @apply m-0 order-2 appearance-none border-none text-color-1 outline-none cursor-pointer;
   padding: var(--calcite-modal-close-padding);
-  margin: 0;
-  order: 2;
   flex: 0 0 auto;
   transition-delay: 300ms;
   transition: all 0.15s ease-in-out;
   background-color: transparent;
-  -webkit-appearance: none;
-  border: none;
-  color: var(--calcite-ui-text-1);
-  outline: none;
-  cursor: pointer;
   border-radius: 0 var(--calcite-border-radius) 0 0;
   calcite-icon {
-    pointer-events: none;
+    @apply pointer-events-none;
     vertical-align: -2px;
   }
   &:hover,
   &:focus {
-    background-color: var(--calcite-ui-foreground-2);
+    @apply bg-foreground-2;
   }
   &:active {
-    background-color: var(--calcite-ui-foreground-3);
+    @apply bg-foreground-3;
   }
 }
 
-:host([dir="rtl"]) .modal__close {
+:host([dir="rtl"]) .close {
   border-radius: var(--calcite-border-radius) 0 0 0;
 }
 
-.modal__title {
-  display: flex;
-  align-items: center;
+.header {
+  @apply flex items-center flex-auto order-1 min-w-0;
   padding: var(--calcite-modal-title-padding);
-  flex: 1 1 auto;
-  order: 1;
-  min-width: 0;
 }
 
-@include slotted("header", "*") {
-  margin: 0;
-  font-weight: 400;
+.title {
+  @apply m-0 font-normal text-color-1;
   font-size: var(--calcite-modal-title-text);
-  color: var(--calcite-ui-text-1);
 }
 
 /**
  * Content area
  */
-.modal__content {
-  position: relative;
-  padding: 0;
-  height: 100%;
-  overflow: auto;
-  max-height: calc(100vh - 12rem);
-  overflow-y: auto;
-  display: block;
-  background-color: var(--calcite-ui-foreground-1);
-  box-sizing: border-box;
+.content {
+  @apply relative p-0 h-full overflow-auto block bg-foreground-1 box-border;
+  max-height: calc(100vh - theme("spacing.48"));
   z-index: 1;
 }
 
-.modal__content--spaced {
+.content--spaced {
   padding: var(--calcite-modal-content-padding);
 }
 
@@ -184,50 +144,43 @@
 }
 
 :host([background-color="grey"]) {
-  .modal__content {
-    background-color: var(--calcite-ui-background);
+  .content {
+    @apply bg-background;
   }
 }
 
 /**
  * Footer
  */
-.modal__footer {
-  display: flex;
+.footer {
+  @apply flex justify-between mt-auto box-border w-full bg-foreground-1;
   flex: 0 0 auto;
-  justify-content: space-between;
   padding: var(--calcite-modal-footer-padding);
-  margin-top: auto;
-  box-sizing: border-box;
   border-radius: 0 0 var(--calcite-border-radius) var(--calcite-border-radius);
-  width: 100%;
-  background-color: var(--calcite-ui-foreground-1);
   border-top: 1px solid var(--calcite-ui-border-3);
   z-index: 2;
 }
 
-.modal__footer--hide-back .modal__back,
-.modal__footer--hide-secondary .modal__secondary {
-  display: none;
+.footer--hide-back .back,
+.footer--hide-secondary .secondary {
+  @apply hidden;
 }
 
-.modal__back {
-  display: block;
-  margin-right: auto;
+.back {
+  @apply block mr-auto;
 }
 
-:host([dir="rtl"]) .modal__back {
-  margin-left: auto;
+:host([dir="rtl"]) .back {
+  @apply ml-auto;
   margin-right: unset;
 }
 
-.modal__secondary {
-  display: block;
-  margin: 0 $baseline * 0.25;
+.secondary {
+  @apply block my-0 mx-1;
 }
 
 slot[name="primary"] {
-  display: block;
+  @apply block;
 }
 
 /**
@@ -242,30 +195,25 @@ slot[name="primary"] {
   @media screen and (max-width: $width + 2 * $baseline) {
     :host([width="#{$size}"]) {
       .modal {
-        height: 100%;
-        max-height: 100%;
-        width: 100%;
-        max-width: 100%;
-        margin: 0;
-        border-radius: 0;
+        @apply h-full max-h-full w-full max-w-full m-0 rounded-none;
       }
-      .modal__content {
-        flex: 1 1 auto;
+      .content {
+        @apply flex-auto;
         max-height: unset;
       }
-      .modal__header,
-      .modal__footer {
+      .top,
+      .footer {
         flex: inherit;
       }
     }
     :host([width="#{$size}"][docked]) {
-      align-items: flex-end;
+      @apply items-end;
     }
   }
 }
 
 :host([width="small"]) .modal {
-  width: auto;
+  @apply w-auto;
 }
 
 @include modal-size("s", 32rem);
@@ -278,19 +226,14 @@ slot[name="primary"] {
 :host([fullscreen]) {
   background-color: transparent;
   .modal {
+    @apply h-full max-h-full w-full max-w-full m-0;
     transform: translate3D(0, 20px, 0) scale(0.95);
-    height: 100%;
-    max-height: 100%;
-    width: 100%;
-    max-width: 100%;
-    margin: 0;
   }
-  .modal__content {
-    flex: 1 1 auto;
-    max-height: 100%;
+  .content {
+    @apply flex-auto max-h-full;
   }
-  .modal__header,
-  .modal__footer {
+  .top,
+  .footer {
     flex: inherit;
   }
 }
@@ -299,11 +242,11 @@ slot[name="primary"] {
   .modal {
     transform: translate3D(0, 0, 0) scale(1);
   }
-  .modal__header {
-    border-radius: 0;
+  .top {
+    @apply rounded-none;
   }
-  .modal__footer {
-    border-radius: 0;
+  .footer {
+    @apply rounded-none;
   }
 }
 
@@ -314,23 +257,22 @@ slot[name="primary"] {
   .modal {
     height: auto !important;
   }
-  .modal__content {
-    height: auto;
-    flex: 1 1 auto;
+  .content {
+    @apply h-auto flex-auto;
   }
   @media screen and (max-width: $viewport-medium) {
     .modal {
-      border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
+      @apply rounded-t-1 rounded-b-none;
     }
 
-    .modal__close {
+    .close {
       border-radius: 0 var(--calcite-border-radius) 0 0;
     }
   }
 }
 
 @media screen and (max-width: $viewport-medium) {
-  :host([docked][dir="rtl"]) .modal__close {
+  :host([docked][dir="rtl"]) .close {
     border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
   }
 }
@@ -352,8 +294,8 @@ slot[name="primary"] {
 
 :host([color="red"]),
 :host([color="blue"]) {
-  .modal__header {
-    border-radius: var(--calcite-border-radius);
+  .top {
+    @apply rounded-1;
   }
 }
 
@@ -361,21 +303,20 @@ slot[name="primary"] {
  * Tablet
  */
 @media screen and (max-width: $viewport-medium) {
-  @include slotted("header", "*") {
-    @include font-size(1);
+  .title {
+    @apply text-1;
   }
-  .modal__title {
-    padding: $baseline * 0.25 $baseline * 0.675;
+  .header {
+    @apply py-1 px-4;
   }
-  .modal__close {
-    padding: 0.75rem;
+  .close {
+    @apply p-3;
   }
-  .modal__content--spaced {
-    padding: $baseline * 0.675;
+  .content--spaced {
+    @apply p-4;
   }
-  .modal__footer {
-    position: sticky;
-    bottom: 0;
+  .footer {
+    @apply sticky bottom-0;
   }
 }
 
@@ -383,12 +324,11 @@ slot[name="primary"] {
  * Mobile
  */
 @media screen and (max-width: $viewport-small) {
-  .modal__footer {
-    flex-direction: column;
+  .footer {
+    @apply flex-col;
   }
-  .modal__back,
-  .modal__secondary {
-    margin: 0;
-    margin-bottom: $baseline * 0.25;
+  .back,
+  .secondary {
+    @apply m-0 mb-1;
   }
 }

--- a/src/components/calcite-modal/calcite-modal.stories.ts
+++ b/src/components/calcite-modal/calcite-modal.stories.ts
@@ -19,8 +19,8 @@ storiesOf("Components/Modal", module)
         ${boolean("disable-escape", false)}
         ${boolean("no-padding", false)}
         close-label="${text("close-label", "Close")}"
+        title-text="${text("title-text", "Modal Title")}"
       >
-        <h3 slot="header">Small Modal</h3>
         <div slot="content">
           <p>
             The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
@@ -37,8 +37,8 @@ storiesOf("Components/Modal", module)
       <calcite-modal
         active
         width="${number("width", 500)}"
+        title-text="Custom Size"
       >
-        <h3 slot="header">Custom Size</h3>
         <div slot="content">
           <p>
             By passing a number rather than "small", "medium", "large", or "fullscreen", you can set your own max width for the modal.
@@ -67,6 +67,7 @@ storiesOf("Components/Modal", module)
         ${boolean("disable-escape", false)}
         ${boolean("no-padding", false)}
         close-label="${text("close-label", "Close")}"
+        title-text="${text("title-text", "Modal Title")}"
       >
         <h3 slot="header">Small Modal</h3>
         <div slot="content">

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -59,6 +59,7 @@ modal.beforeClose = beforeClose;
 | `noPadding`          | `no-padding`           | Turn off spacing around the content area slot                                                               | `boolean`                            | `undefined`               |
 | `scale`              | `scale`                | specify the scale of modal, defaults to m                                                                   | `"l" \| "m" \| "s"`                  | `"m"`                     |
 | `theme`              | `theme`                | Select theme (light or dark)                                                                                | `"dark" \| "light"`                  | `undefined`               |
+| `title`              | `title`                | Title of the modal                                                                                          | `string`                             | `undefined`               |
 | `width`              | `width`                | Set the width of the modal. Can use stock sizes or pass a number (in pixels)                                | `"l" \| "m" \| "s" \| number`        | `"m"`                     |
 
 ## Events

--- a/src/demos/calcite-modal.html
+++ b/src/demos/calcite-modal.html
@@ -29,8 +29,7 @@
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Modal</h1>
 
-  <calcite-modal class="js-modal-1" width="s">
-    <h3 slot="header">Small Modal</h3>
+  <calcite-modal class="js-modal-1" width="s" title-text="Small Modal">
     <div slot="content">
       <p>
         The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
@@ -41,8 +40,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-2" width="m">
-    <h3 slot="header">Medium Modal</h3>
+  <calcite-modal class="js-modal-2" width="m" title-text="Medium Modal">
     <div slot="content">
       <table>
         <tbody>
@@ -64,8 +62,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-3" width="l">
-    <h3 slot="header">Large modal</h3>
+  <calcite-modal class="js-modal-3" width="l" title-text="Large modal">
     <div slot="content">
       <p>This modal will be fullscreen until it is as wide as the calcite-web grid's max-width. This enables you
         to use gridded
@@ -74,8 +71,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-4" fullscreen>
-    <h3 slot="header">Fullscreen modal</h3>
+  <calcite-modal class="js-modal-4" fullscreen title-text="Fullscreen modal">
     <div slot="content">
       <p>This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your
         modal
@@ -86,24 +82,21 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-5" color="red">
-    <h3 slot="header">Delete</h3>
+  <calcite-modal class="js-modal-5" color="red" title-text="Delete">
     <div slot="content">
       <p>This will delete things and perform some desctructive action, do you wish to continue?</p>
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline" color="red">Cancel</calcite-button>
     <calcite-button slot="primary" width="full" color="red">Delete</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-6" color="blue">
-    <h3 slot="header">Information</h3>
+  <calcite-modal class="js-modal-6" color="blue" title-text="Information">
     <div slot="content">
       <p>This dialog should be used when choosing two viable paths.</p>
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Start with no members</calcite-button>
     <calcite-button slot="primary" width="full">Add members now</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-7" status="info" docked>
-    <h3 slot="header">Docked</h3>
+  <calcite-modal class="js-modal-7" status="info" docked title-text="Docked">
     <div slot="content">
       <p>For devices smaller than a tablet this modal will "dock" to the bottom. This makes action selection more
         thumb-friendly.</p>
@@ -111,8 +104,7 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-8" status="info" docked>
-    <h3 slot="header">Tab Fencing</h3>
+  <calcite-modal class="js-modal-8" status="info" docked title-text="Tab Fencing">
     <div slot="content">
       <p>When you open a modal, the focus should be set to the first focusable element. <calcite-button>LIKE THIS
         </calcite-button>.</p>
@@ -122,37 +114,32 @@
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal theme="dark" class="js-modal-9">
-    <h3 slot="header">Dark Theme</h3>
+  <calcite-modal theme="dark" class="js-modal-9" title-text="Dark Theme">
     <div slot="content">
       <p>Example of a modal rendered in dark theme. The text will become light on dark, but notice box shadows are
         still dark.
     </div>
     <calcite-button theme="dark" slot="primary">OK</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-10" disable-escape>
-    <h3 slot="header">Modal title</h3>
+  <calcite-modal class="js-modal-10" disable-escape title-text="Modal title">
     <div slot="content">
       <p>This modal has <code>disable-escape</code> set, so pressing the escape key will not dismiss it.</p>
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-11" disable-close-button="true">
-    <h3 slot="header">Modal title</h3>
+  <calcite-modal class="js-modal-11" disable-close-button="true" title-text="Modal title">
     <div slot="content">
       <p>This modal has no close button.</p>
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-12" width="500">
-    <h3 slot="header">Modal title</h3>
+  <calcite-modal class="js-modal-12" width="500" title-text="Modal title">
     <div slot="content">
       <p>This modal will be 500 pixels wide on larger screens and become fullscreen below that.</p>
     </div>
     <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-13" width="s" scale="s">
-    <h3 slot="header">Small Scale</h3>
+  <calcite-modal class="js-modal-13" width="s" scale="s" title-text="Small Scale">
     <div slot="content">
       <p>
         This is the small scale modal. It is meant to work with other components at the small scale (like buttons, etc).
@@ -163,8 +150,7 @@
     <calcite-button scale="s" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button scale="s" slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-14" width="s" scale="m">
-    <h3 slot="header">Medium Scale</h3>
+  <calcite-modal class="js-modal-14" width="s" scale="m" title-text="Medium Scale">
     <div slot="content">
       <p>
         This is the medium scale modal. It is the default scale and is meant to work with other components at the medium scale.
@@ -175,8 +161,7 @@
     <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-15" width="s" scale="l">
-    <h3 slot="header">Large Scale</h3>
+  <calcite-modal class="js-modal-15" width="s" scale="l" title-text="Large Scale">
     <div slot="content">
       <p>
         This is the large scale modal. It is meant to work with other components at the large scale (like buttons, etc).
@@ -187,8 +172,7 @@
     <calcite-button scale="l" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button scale="l" slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-16" fullscreen background-color="grey">
-    <h3 slot="header">Grey Background</h3>
+  <calcite-modal class="js-modal-16" fullscreen background-color="grey" title-text="Grey Background">
     <div slot="content">
       <p>
         By using the backgroundColor attribute, you can create a modal with a light grey background rather than white.
@@ -230,8 +214,7 @@
     <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
-  <calcite-modal class="js-modal-17" width="s">
-    <h3 slot="header">Small Modal</h3>
+  <calcite-modal class="js-modal-17" width="s" title-text="Small Modal">
     <div slot="content">
       <calcite-loader active/>
     </div>


### PR DESCRIPTION
**Related Issue:**  #1023

## Summary

⚠️ This is a breaking change ⚠️ 

Fixes aria labelling of the modal. When the modal opens, previously the screen reader only read the buttons. "Dialog, back button". Which was not very helpful...

The fix is to properly label the dialog with `aria-labelledby` pointing to the title text and `aria-describedby` pointing to the body of the modal. _However_, I found out that aria labels can't pass through the shadow dom. So there was no way for us to label the slot and have it read by the screen reader. For this reason I've moved the title to a prop. This also has the benefit of allowing us to lock down the text styling of the modal title a lot more. 

Also updated some of the css to use the tailwind rules as I think our current rule is "if you touch it you must tailwind it".

@bstifle would be good to get your eyes on the various sizes for title text and make sure they are correct now that we can closely control them.