### PR TITLE
feat(switch)!: Remove red variant and color prop

### DIFF
--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -172,12 +172,11 @@ describe("calcite-switch", () => {
 
   it("renders requested props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-switch theme="dark" scale="l" color="red"></calcite-switch>`);
+    await page.setContent(`<calcite-switch theme="dark" scale="l" ></calcite-switch>`);
 
     const element = await page.find("calcite-switch");
     expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("scale", "l");
-    expect(element).toEqualAttribute("color", "red");
   });
 
   it("renders default props", async () => {
@@ -189,6 +188,5 @@ describe("calcite-switch", () => {
 
     const element = await page.find("calcite-switch");
     expect(element).toEqualAttribute("scale", "m");
-    expect(element).toEqualAttribute("color", "blue");
   });
 });

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -14,16 +14,6 @@
   --calcite-switch-switched-hover-handle-border: var(--calcite-ui-blue-3);
 }
 
-:host([color="red"]) {
-  --calcite-switch-switched-track-background: var(--calcite-ui-red-2);
-  --calcite-switch-switched-track-border: var(--calcite-ui-red-1);
-  --calcite-switch-hover-handle-border: var(--calcite-ui-red-2);
-  --calcite-switch-switched-handle-border: var(--calcite-ui-red-1);
-  --calcite-switch-switched-hover-track-background: var(--calcite-ui-red-1);
-  --calcite-switch-switched-hover-track-border: var(--calcite-ui-red-2);
-  --calcite-switch-switched-hover-handle-border: var(--calcite-ui-red-3);
-}
-
 // sizes
 :host([scale="s"]) {
   --calcite-switch-track-width: 28px;

--- a/src/components/calcite-switch/calcite-switch.stories.ts
+++ b/src/components/calcite-switch/calcite-switch.stories.ts
@@ -9,36 +9,42 @@ storiesOf("Components/Switch", module)
   .add(
     "Simple",
     (): string => `
-    <label>
       <calcite-switch
         name="setting"
         value="enabled"
         ${boolean("switched", true)}
         ${boolean("disabled", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
-        color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
+  `
+  )
+  .add(
+    "Wrapping calcite-label",
+    (): string => `
+      <calcite-label layout="${select("layout", ["inline", "inline-space-between", "default"], "inline")}"
+       ${boolean("disabled", false)}>
       Enable setting
-    </label>
+      <calcite-switch
+        name="setting"
+        value="enabled"
+        ${boolean("switched", true)}
+        ${boolean("disabled", false)}
+      ></calcite-switch>
+      </calcite-label>
   `
   )
   .add(
     "Dark mode",
     (): string => `
-    <div style="color:white">
-      <label>
       <calcite-switch
         theme="dark"
         name="setting"
         value="enabled"
         ${boolean("switched", true)}
-        ${boolean("disabled", false)}
+
         scale="${select("scale", ["s", "m", "l"], "m")}"
-        color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
-      Enable setting
-    </label>
-    </div>`,
+ `,
     {
       backgrounds: darkBackground
     }
@@ -46,16 +52,13 @@ storiesOf("Components/Switch", module)
   .add(
     "RTL",
     (): string => `
-      <label>
+      Enable setting
       <calcite-switch
         dir="rtl"
         name="setting"
         value="enabled"
         ${boolean("switched", true)}
-        ${boolean("disabled", false)}
         scale="${select("scale", ["s", "m", "l"], "m")}"
-        color="${select("color", ["blue", "red"], "blue")}"
       ></calcite-switch>
-      Enable setting
-    </label>`
+`
   );

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -25,9 +25,6 @@ export class CalciteSwitch {
   /** True if the switch is disabled */
   @Prop({ reflect: true }) disabled?: boolean = false;
 
-  /** What color the switch should be */
-  @Prop({ reflect: true }) color: "red" | "blue" = "blue";
-
   /** The name of the checkbox input */
   @Prop({ reflect: true, mutable: true }) name?: string = "";
 

--- a/src/components/calcite-switch/readme.md
+++ b/src/components/calcite-switch/readme.md
@@ -20,7 +20,6 @@ If you don't pass in an input, calcite-switch will act as the source of truth:
 
 | Property   | Attribute  | Description                        | Type                | Default     |
 | ---------- | ---------- | ---------------------------------- | ------------------- | ----------- |
-| `color`    | `color`    | What color the switch should be    | `"blue" \| "red"`   | `"blue"`    |
 | `disabled` | `disabled` | True if the switch is disabled     | `boolean`           | `false`     |
 | `name`     | `name`     | The name of the checkbox input     | `string`            | `""`        |
 | `scale`    | `scale`    | The scale of the switch            | `"l" \| "m" \| "s"` | `"m"`       |

--- a/src/demos/calcite-switch.html
+++ b/src/demos/calcite-switch.html
@@ -1,225 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Switch</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
+    <link rel="stylesheet" href="../build/calcite.css" />
+    <script type="module" src="../build/calcite.esm.js"></script>
+    <script nomodule src="../build/calcite.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Switch</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
-  <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
-  <link rel="stylesheet" href="../build/calcite.css" />
-  <script type="module" src="../build/calcite.esm.js"></script>
-  <script nomodule src="../build/calcite.js"></script>
-</head>
-
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Switch</h1>
-  <calcite-label layout="inline">
-    <calcite-switch id="basicSwitch" switched="true"></calcite-switch>
-
-    Without a proxy <code>input</code> element and listening for "change"
-  </calcite-label>
-  <script>
-    var basicSwitch = document.getElementById("basicSwitch");
-
-    basicSwitch.addEventListener("change", function (
-      e
-    ) {
-      console.log(
-        "Basic switch changed by <calcite-switch>",
-        e.target.switched
-      );
-    });
-  </script>
-  <br />
-  <div>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Switch</h1>
     <calcite-label layout="inline">
-      <calcite-switch>
-        <input id="proxySwitchCheckbox" type="checkbox" />
-      </calcite-switch>
-      <span id='proxySwitchSpan'>
-        With a proxy <code>input</code> element and changes on click.
-      </span>
+      <calcite-switch id="basicSwitch" switched="true"></calcite-switch>
+
+      Without a proxy <code>input</code> element and listening for "change"
     </calcite-label>
+    <script>
+      var basicSwitch = document.getElementById("basicSwitch");
+
+      basicSwitch.addEventListener("change", function (e) {
+        console.log("Basic switch changed by <calcite-switch>", e.target.switched);
+      });
+    </script>
+    <br />
     <div>
+      <calcite-label layout="inline">
+        <calcite-switch>
+          <input id="proxySwitchCheckbox" type="checkbox" />
+        </calcite-switch>
+        <span id="proxySwitchSpan"> With a proxy <code>input</code> element and changes on click. </span>
+      </calcite-label>
+      <div>
+        <script>
+          var proxySwitchSpan = document.getElementById("proxySwitchSpan");
+          var proxySwitchCheckbox = document.getElementById("proxySwitchCheckbox");
 
-      <script>
-        var proxySwitchSpan = document.getElementById(
-          "proxySwitchSpan"
-        );
-        var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
-
-        proxySwitchSpan.addEventListener('click', function () {
-          proxySwitchCheckbox.hasAttribute('checked') ?
-            proxySwitchCheckbox.removeAttribute('checked') :
-            proxySwitchCheckbox.setAttribute('checked', '')
-        })
-      </script>
-    </div>
-    <h4>Disabled with proxy input</h4>
+          proxySwitchSpan.addEventListener("click", function () {
+            proxySwitchCheckbox.hasAttribute("checked")
+              ? proxySwitchCheckbox.removeAttribute("checked")
+              : proxySwitchCheckbox.setAttribute("checked", "");
+          });
+        </script>
+      </div>
+      <h4>Disabled with proxy input</h4>
       <calcite-switch disabled>
         <input id="proxySwitchCheckbox" type="checkbox" />
       </calcite-switch>
-  </div>
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch color="red" disabled> </calcite-switch>
-      Disabled red switch
-    </calcite-label>
-  </div>
-  <br />
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch switched="true" disabled> </calcite-switch>
-      Disabled switch
-    </calcite-label>
-  </div>
-  <br />
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch scale="s" switched="true" color="red"> </calcite-switch>
-      Red switch scale small
-    </calcite-label>
-  </div>
-  <br />
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch scale="m" switched="true" color="red"> </calcite-switch>
-      Red switch scale medium
-    </calcite-label>
-  </div>
-  <br />
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch scale="l" switched="true" color="red"> </calcite-switch>
-      Red switch scale large
-    </calcite-label>
-  </div>
-  <br />
-  <br />
-  <div class="demo-background-dark">
+    </div>
     <div>
       <calcite-label layout="inline">
-        <calcite-switch theme="dark" id="basicSwitch2" switched="true"></calcite-switch>
-        Without a proxy <code>input</code> element and listening for "calciteSwitchChange".
-        <script>
-          var basicSwitch = document.getElementById("basicSwitch2");
-
-          basicSwitch.addEventListener("calciteSwitchChange", function (
-            e
-          ) {
-            console.log(
-              "Basic switch changed by <calcite-switch>",
-              e.target.switched
-            );
-          });
-        </script>
+        <calcite-switch switched="true" disabled> </calcite-switch>
+        Disabled switch
       </calcite-label>
-    </div>
-    <br />
-    <div>
-      <calcite-switch theme="dark">
-        <input type="checkbox" />
-      </calcite-switch>
-      <span>
-        With a proxy <code>input</code> element and changes on click.
-      </span>
-      <script>
-        var proxySwitchSpan = document.getElementById(
-          "proxySwitchSpan"
-        );
-        var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
-
-        proxySwitchSpan.addEventListener('click', function () {
-          proxySwitchCheckbox.hasAttribute('checked') ?
-            proxySwitchCheckbox.removeAttribute('checked') :
-            proxySwitchCheckbox.setAttribute('checked', '')
-        })
-      </script>
-    </div>
-    <br />
-    <div>
-      <calcite-label layout="inline">
-        <calcite-switch theme="dark" switched="true" color="red"> </calcite-switch>
-        Red switch
-      </calcite-label>
-    </div>
-
-    <br />
-    <div>
-      <calcite-switch theme="dark"></calcite-switch>
-      Switch with no wrapping <code>label</code>.
-    </div>
-  </div>
-  <h3>RTL Set Directly on Switch</h3>
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch dir="rtl"> </calcite-switch>
-      Example
-    </calcite-label>
-  </div>
-  <br />
-  <div>
-    <calcite-label layout="inline">
-      <calcite-switch switched="true" dir="rtl"> </calcite-switch>
-      Example
-    </calcite-label>
-  </div>
-  <div dir="rtl">
-    <h3>RTL Inherited from Container</h3>
-    <div>
-      <calcite-switch>
-        <input id="proxySwitchCheckbox" type="checkbox" />
-      </calcite-switch>
-      <span id='proxySwitchSpan'>
-        With a proxy <code>input</code> element and changes on click.
-      </span>
-      <script>
-        var proxySwitchSpan = document.getElementById(
-          "proxySwitchSpan"
-        );
-        var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
-
-        proxySwitchSpan.addEventListener('click', function () {
-          proxySwitchCheckbox.hasAttribute('checked') ?
-            proxySwitchCheckbox.removeAttribute('checked') :
-            proxySwitchCheckbox.setAttribute('checked', '')
-        })
-      </script>
-    </div>
-    <br />
-    <div>
-      <calcite-label layout="inline">
-        <calcite-switch scale="s" switched="true" color="red"> </calcite-switch>
-        Red switch scale small
-      </calcite-label>
-    </div>
-    <br />
-    <div>
-      <calcite-label layout="inline">
-        <calcite-switch scale="m" switched="true" color="red"> </calcite-switch>
-        Red switch scale medium
-      </calcite-label>
-    </div>
-    <br />
-    <div>
-      <calcite-label layout="inline">
-        <calcite-switch scale="l" switched="true" color="red"> </calcite-switch>
-        Red switch scale large
-      </calcite-label>
-    </div>
-    <br />
-    <div>
-      <calcite-switch></calcite-switch>
-      Switch with no wrapping <code>label</code>.
     </div>
     <br />
     <div class="demo-background-dark">
@@ -230,13 +73,8 @@
           <script>
             var basicSwitch = document.getElementById("basicSwitch2");
 
-            basicSwitch.addEventListener("calciteSwitchChange", function (
-              e
-            ) {
-              console.log(
-                "Basic switch changed by <calcite-switch>",
-                e.target.switched
-              );
+            basicSwitch.addEventListener("calciteSwitchChange", function (e) {
+              console.log("Basic switch changed by <calcite-switch>", e.target.switched);
             });
           </script>
         </calcite-label>
@@ -244,30 +82,19 @@
       <br />
       <div>
         <calcite-switch theme="dark">
-          <input id="proxySwitchCheckbox" type="checkbox" />
+          <input type="checkbox" />
         </calcite-switch>
-        <span id='proxySwitchSpan'>
-          With a proxy <code>input</code> element and changes on click.
-        </span>
+        <span> With a proxy <code>input</code> element and changes on click. </span>
         <script>
-          var proxySwitchSpan = document.getElementById(
-            "proxySwitchSpan"
-          );
-          var proxySwitchCheckbox = document.getElementById('proxySwitchCheckbox');
+          var proxySwitchSpan = document.getElementById("proxySwitchSpan");
+          var proxySwitchCheckbox = document.getElementById("proxySwitchCheckbox");
 
-          proxySwitchSpan.addEventListener('click', function () {
-            proxySwitchCheckbox.hasAttribute('checked') ?
-              proxySwitchCheckbox.removeAttribute('checked') :
-              proxySwitchCheckbox.setAttribute('checked', '')
-          })
+          proxySwitchSpan.addEventListener("click", function () {
+            proxySwitchCheckbox.hasAttribute("checked")
+              ? proxySwitchCheckbox.removeAttribute("checked")
+              : proxySwitchCheckbox.setAttribute("checked", "");
+          });
         </script>
-      </div>
-      <br />
-      <div>
-        <calcite-label layout="inline">
-          <calcite-switch theme="dark" switched="true" color="red"> </calcite-switch>
-          Red switch
-        </calcite-label>
       </div>
       <br />
       <div>
@@ -275,7 +102,88 @@
         Switch with no wrapping <code>label</code>.
       </div>
     </div>
-  </div>
-</body>
+    <h3>RTL Set Directly on Switch</h3>
+    <div>
+      <calcite-label layout="inline">
+        <calcite-switch dir="rtl"> </calcite-switch>
+        Example
+      </calcite-label>
+    </div>
+    <br />
+    <div>
+      <calcite-label layout="inline">
+        <calcite-switch switched="true" dir="rtl"> </calcite-switch>
+        Example
+      </calcite-label>
+    </div>
+    <div dir="rtl">
+      <h3>RTL Inherited from Container</h3>
+      <div>
+        <calcite-switch>
+          <input id="proxySwitchCheckbox" type="checkbox" />
+        </calcite-switch>
+        <span id="proxySwitchSpan"> With a proxy <code>input</code> element and changes on click. </span>
+        <script>
+          var proxySwitchSpan = document.getElementById("proxySwitchSpan");
+          var proxySwitchCheckbox = document.getElementById("proxySwitchCheckbox");
 
+          proxySwitchSpan.addEventListener("click", function () {
+            proxySwitchCheckbox.hasAttribute("checked")
+              ? proxySwitchCheckbox.removeAttribute("checked")
+              : proxySwitchCheckbox.setAttribute("checked", "");
+          });
+        </script>
+      </div>
+      <br />
+      <div>
+        <calcite-switch></calcite-switch>
+        Switch with no wrapping <code>label</code>.
+      </div>
+      <br />
+      <div class="demo-background-dark">
+        <div>
+          <calcite-label layout="inline">
+            <calcite-switch theme="dark" id="basicSwitch2" switched="true"></calcite-switch>
+            Without a proxy <code>input</code> element and listening for "calciteSwitchChange".
+            <script>
+              var basicSwitch = document.getElementById("basicSwitch2");
+
+              basicSwitch.addEventListener("calciteSwitchChange", function (e) {
+                console.log("Basic switch changed by <calcite-switch>", e.target.switched);
+              });
+            </script>
+          </calcite-label>
+        </div>
+        <br />
+        <div>
+          <calcite-switch theme="dark">
+            <input id="proxySwitchCheckbox" type="checkbox" />
+          </calcite-switch>
+          <span id="proxySwitchSpan"> With a proxy <code>input</code> element and changes on click. </span>
+          <script>
+            var proxySwitchSpan = document.getElementById("proxySwitchSpan");
+            var proxySwitchCheckbox = document.getElementById("proxySwitchCheckbox");
+
+            proxySwitchSpan.addEventListener("click", function () {
+              proxySwitchCheckbox.hasAttribute("checked")
+                ? proxySwitchCheckbox.removeAttribute("checked")
+                : proxySwitchCheckbox.setAttribute("checked", "");
+            });
+          </script>
+        </div>
+        <br />
+        <div>
+          <calcite-label layout="inline">
+            <calcite-switch theme="dark" switched="true"> </calcite-switch>
+            inline switch
+          </calcite-label>
+        </div>
+        <br />
+        <div>
+          <calcite-switch theme="dark"></calcite-switch>
+          Switch with no wrapping <code>label</code>.
+        </div>
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/1220

Beginning to remove instances of offering "red" versions of colors and associated color props. Link, Button, soon to come.

Users can STILL ACHIEVE these designs if absolutely necessary by overriding css vars for the particular component instance. But we want to remove them from the "off the shelf" options.

Also updates stories a bit to have examples without labels, and then an explicit story with a calcite-label.
## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
