### PR TITLE
fix(select): Fix overlapping text with long options

### DIFF
--- a/src/components/calcite-select/calcite-select.scss
+++ b/src/components/calcite-select/calcite-select.scss
@@ -3,6 +3,7 @@
   display: flex;
   position: relative;
   width: var(--select-width);
+  --calcite-select-spacing-end: 2rem;
 }
 
 :host([scale="s"]) {
@@ -44,6 +45,7 @@
   font-size: var(--calcite-select-font-size);
   margin: 0;
   padding: var(--calcite-select-spacing);
+  padding-right: var(--calcite-select-spacing-end);
   width: 100%;
 
   @include focus-style-base();
@@ -57,18 +59,16 @@
   }
 }
 
-.select:focus ~ .icon-container {
-  background-color: transparent;
-  border-color: transparent;
-}
-
-:host(:hover) .icon-container {
-  background-color: transparent;
+:host([dir="rtl"]) .select {
+  padding-left: var(--calcite-select-spacing-end);
+  padding-right: var(--calcite-select-spacing);
+  border-right: solid 1px var(--calcite-ui-border-1);
+  border-left: none;
 }
 
 .icon-container {
   align-items: center;
-  background-color: var(--calcite-ui-foreground-1);
+  background-color: transparent;
   border: solid 1px var(--calcite-ui-border-1);
   border-left: none;
   color: var(--calcite-ui-text-2);
@@ -81,14 +81,13 @@
   top: 0;
 }
 
-.select.calcite--rtl {
-  border-right: solid 1px var(--calcite-ui-border-1);
-  border-left: none;
-}
-
-.icon-container.calcite--rtl {
+:host([dir="rtl"]) .icon-container {
   border-left: solid 1px var(--calcite-ui-border-1);
   border-right: none;
   right: unset;
   left: 0;
+}
+
+.select:focus ~ .icon-container {
+  border-color: transparent;
 }

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -13,7 +13,6 @@ import {
 import { focusElement, getElementDir } from "../../utils/dom";
 import { Scale, Theme } from "../../interfaces/common";
 import { CSS } from "./resources";
-import { CSS_UTILITY } from "../../utils/resources";
 import { FocusRequest } from "../../interfaces/Label";
 
 type CalciteOptionOrGroup = HTMLCalciteOptionElement | HTMLCalciteOptionGroupElement;
@@ -283,23 +282,21 @@ export class CalciteSelect {
   //--------------------------------------------------------------------------
 
   renderChevron(): VNode {
-    const rtl = getElementDir(this.el) === "rtl";
-
     return (
-      <div class={{ [CSS.iconContainer]: true, [CSS_UTILITY.rtl]: rtl }}>
+      <div class={{ [CSS.iconContainer]: true }}>
         <calcite-icon class={CSS.icon} icon="chevron-down" scale="s" />
       </div>
     );
   }
 
   render(): VNode {
-    const rtl = getElementDir(this.el) === "rtl";
+    const dir = getElementDir(this.el);
 
     return (
-      <Host>
+      <Host dir={dir}>
         <select
           aria-label={this.label}
-          class={{ [CSS.select]: true, [CSS_UTILITY.rtl]: rtl }}
+          class={{ [CSS.select]: true }}
           disabled={this.disabled}
           onChange={this.handleInternalSelectChange}
           ref={this.storeSelectRef}

--- a/src/demos/calcite-select.html
+++ b/src/demos/calcite-select.html
@@ -30,7 +30,7 @@
     <calcite-select scale="s">
       <calcite-option>uno</calcite-option>
       <calcite-option>dos</calcite-option>
-      <calcite-option>tres</calcite-option>
+      <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
     </calcite-select>
 
     <h3>Basic medium (default)</h3>
@@ -38,7 +38,7 @@
     <calcite-select scale="m">
       <calcite-option>uno</calcite-option>
       <calcite-option>dos</calcite-option>
-      <calcite-option>tres</calcite-option>
+      <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
     </calcite-select>
 
     <h3>Basic large</h3>
@@ -46,7 +46,7 @@
     <calcite-select scale="l">
       <calcite-option>uno</calcite-option>
       <calcite-option>dos</calcite-option>
-      <calcite-option>tres</calcite-option>
+      <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
     </calcite-select>
 
     <h3>Grouped</h3>
@@ -77,7 +77,7 @@
       <calcite-select width="half" label="half width">
         <calcite-option>☕️</calcite-option>
         <calcite-option>🌮</calcite-option>
-        <calcite-option>🍔</calcite-option>
+        <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
       </calcite-select>
       <calcite-select width="half" label="half width">
         <calcite-option>☕️</calcite-option>
@@ -107,7 +107,7 @@
         <calcite-option-group label="números">
           <calcite-option label="uno">1</calcite-option>
           <calcite-option label="dos" selected>2</calcite-option>
-          <calcite-option label="tres">3</calcite-option>
+          <calcite-option label="Some long content that will probably be enough to extend past the end">3</calcite-option>
         </calcite-option-group>
       </calcite-select>
     </div>


### PR DESCRIPTION
**Related Issue:** Resolves #1238 cc @AdelheidF 

Updates styling a bit to prevent text overlaps by adding padding to the select div.

<img width="317" alt="Screen Shot 2020-11-09 at 9 06 14 AM" src="https://user-images.githubusercontent.com/4733155/98573229-7681df80-226b-11eb-97de-f8a0dc28ca8b.png">

@jcfranco I moved styling to a dir tag on host instead of css utility, let me know if that was set up in that way for a reason I didn't catch.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
