### PR TITLE
fix(date): fix prev/next month buttons not rendering

### DIFF
--- a/src/components/calcite-date-month-header/calcite-date-month-header.e2e.ts
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.e2e.ts
@@ -1,0 +1,58 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+describe("calcite-date-month-header", () => {
+  const localeDataFixture = {
+    "default-calendar": "gregorian",
+    separator: "/",
+    unitOrder: "dd/MM/yy",
+    weekStart: 7,
+    placeholder: "dd/MM/yy",
+    days: {
+      narrow: ["D", "L", "M", "M", "J", "V", "S"]
+    },
+    numerals: "0123456789",
+    months: {
+      abbreviated: ["ene.", "feb.", "mar.", "abr.", "may.", "jun.", "jul.", "ago.", "sept.", "oct.", "nov.", "dic."],
+      narrow: ["E", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"],
+      wide: [
+        "enero",
+        "febrero",
+        "marzo",
+        "abril",
+        "mayo",
+        "junio",
+        "julio",
+        "agosto",
+        "septiembre",
+        "octubre",
+        "noviembre",
+        "diciembre"
+      ]
+    }
+  };
+
+  it("displays next/previous options", async () => {
+    const page = await newE2EPage({
+      // intentionally using calcite-date to wire up supporting components to be used in `evaluate` fn below
+      html: "<calcite-date></calcite-date>"
+    });
+    await page.waitForChanges();
+
+    await page.evaluate((localeData) => {
+      const dateMonthHeader = document.createElement("calcite-date-month-header") as HTMLCalciteDateMonthHeaderElement;
+      const now = new Date();
+      dateMonthHeader.activeDate = now;
+      dateMonthHeader.selectedDate = now;
+      dateMonthHeader.localeData = localeData;
+
+      document.body.innerHTML = "";
+      document.body.append(dateMonthHeader);
+    }, localeDataFixture);
+    await page.waitForChanges();
+
+    const [prev, next] = await page.findAll("calcite-date-month-header >>> .chevron");
+
+    expect(await prev.isVisible()).toBe(true);
+    expect(await next.isVisible()).toBe(true);
+  });
+});

--- a/src/components/calcite-date-month-header/calcite-date-month-header.scss
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.scss
@@ -67,7 +67,7 @@
     background-color: var(--calcite-ui-foreground-3);
   }
 
-  &[aria-disabled] {
+  &[aria-disabled="true"] {
     pointer-events: none;
     opacity: 0;
   }

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -92,4 +92,16 @@ describe("calcite-date", () => {
     await date.setProperty("value", "2001-10-28");
     expect(changedEvent).toHaveReceivedEventTimes(0);
   });
+
+  it("displays a calendar when clicked", async () => {
+    const page = await newE2EPage({
+      html: "<calcite-date value='2000-11-27'></calcite-date>"
+    });
+    const date = await page.find("calcite-date");
+
+    await date.click();
+    const calendar = await page.find("calcite-date >>> .calendar-picker-wrapper");
+
+    expect(await calendar.isVisible());
+  });
 });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

[This line](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-date-month-header/calcite-date-month-header.scss#L70) would always hide and prevent mouse interaction with date's next/prev month buttons.

cc @zaramatheson

*Note*: added simple `calcite-date` test to verify that calendar is displayed when clicked.