### PR TITLE
fix(button): Fix loading style in transparent button

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -537,6 +537,9 @@
   &:active {
     background-color: var(--calcite-button-transparent-press);
   }
+  & calcite-loader {
+    color: $color;
+  }
 }
 
 :host([appearance="transparent"][color="blue"]) {

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -46,6 +46,8 @@
   </calcite-button>
   <calcite-button icon-start="layer" icon-end="chevron-down" loading>Loading
   </calcite-button>
+  <calcite-button icon-start="layer" icon-end="chevron-down" appearance="transparent" color="dark" loading>Loading
+  </calcite-button>
   <calcite-button icon-start="layer" icon-end="chevron-down"></calcite-button>
   <calcite-button icon-start="layer" icon-end="chevron-down" loading></calcite-button>
   <calcite-button dir="rtl" icon-start="plus" icon-end="plus"></calcite-button>


### PR DESCRIPTION
## Summary
Fixes "loading" loader not appearing when using "transparent" appearance type cc @TheBlueDog

Also adds example to dev demo:
![Screen Shot 2020-11-10 at 12 43 45 PM](https://user-images.githubusercontent.com/4733155/98731582-c7203800-2352-11eb-8f77-53a302394e02.png)


<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
