### PR TITLE
refactor: swap focus-trap module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@a11y/focus-trap": {
-      "version": "git+https://github.com/patrickarlt/focus-trap.git#de1fcb4d86a766515a7389603f04071e09703435",
-      "from": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build"
-    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -13616,6 +13612,15 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-trap": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.1.4.tgz",
+      "integrity": "sha512-jgNc+O8UkGsUpdhNXkyonwlw4i707+ESAWv1vCbyd8+29db5/Wv1BkJImDczfEWMu9O635FvM5ABOjeyqNQpEQ==",
+      "dev": true,
+      "requires": {
+        "tabbable": "^5.1.3"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -25575,6 +25580,12 @@
           }
         }
       }
+    },
+    "tabbable": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.3.tgz",
+      "integrity": "sha512-jqR3rOgeyNlYWDWoyjNTWuHk3+FObu3Fw4e0zjeOLBicI74TT/wGrvSbJUaFVs7FMfiY0Ee8CKM7QaJwVMT4YA==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "url": "git+https://github.com/Esri/calcite-components.git"
   },
   "dependencies": {
-    "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",
     "@popperjs/core": "2.5.3",
     "@types/color": "3.0.1",
     "sortablejs": "1.12.0"
@@ -102,6 +101,7 @@
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-react": "7.21.5",
+    "focus-trap": "6.1.4",
     "gh-release": "4.0.3",
     "git-semver-tags": "4.1.0",
     "husky": "4.3.0",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

NOT for merge. 

This attempts to use https://www.npmjs.com/package/focus-trap because it has more usage, longevity, slightly smaller, is actively maintained and its dist includes ESM and UMD modules.

There's one showstopper before we can switch over: it does not find focusable elements across shadow DOM trees.