### PR TITLE
build: move non-dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,10 @@
   "requires": true,
   "dependencies": {
     "@a11y/focus-trap": {
-      "version": "git+https://github.com/patrickarlt/focus-trap.git#de1fcb4d86a766515a7389603f04071e09703435",
-      "from": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
+      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -24389,7 +24391,8 @@
     "sortablejs": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.12.0.tgz",
-      "integrity": "sha512-bPn57rCjBRlt2sC24RBsu40wZsmLkSo2XeqG8k6DC1zru5eObQUIPPZAQG7W2SJ8FZQYq+BEJmvuw1Zxb3chqg=="
+      "integrity": "sha512-bPn57rCjBRlt2sC24RBsu40wZsmLkSo2XeqG8k6DC1zru5eObQUIPPZAQG7W2SJ8FZQYq+BEJmvuw1Zxb3chqg==",
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -52,12 +52,11 @@
     "url": "git+https://github.com/Esri/calcite-components.git"
   },
   "dependencies": {
-    "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",
     "@popperjs/core": "2.5.3",
-    "@types/color": "3.0.1",
-    "sortablejs": "1.12.0"
+    "@types/color": "3.0.1"
   },
   "devDependencies": {
+    "@a11y/focus-trap": "1.0.5",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "5.0.0",
     "@esri/calcite-ui-icons": "3.13.0",
@@ -116,6 +115,7 @@
     "puppeteer": "5.3.1",
     "rimraf": "3.0.2",
     "semver": "7.3.2",
+    "sortablejs": "1.12.0",
     "standard-version": "9.0.0",
     "storybook": "6.0.27",
     "stylelint": "13.7.2",

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -12,7 +12,8 @@ import {
   Watch,
   VNode
 } from "@stencil/core";
-import { queryShadowRoot, isHidden, isFocusable } from "@a11y/focus-trap";
+import { isHidden, isFocusable } from "@a11y/focus-trap/focusable";
+import { queryShadowRoot } from "@a11y/focus-trap/shadow";
 import { getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This moves dependencies that get bundled into the distributable to dev dependencies. `@popperjs/core` is still kept as a dep for the types referenced in the component types.

This also changes `@a11y/focus-trap` to point to the NPM package instead of a personal fork. Additionally, this decreases modal's bundle size because the utils are tree-shaken.