### PR TITLE
fix(rating): add props for accessible labels, structure as radio button

### DIFF
--- a/src/components/calcite-rating/calcite-rating-resources.ts
+++ b/src/components/calcite-rating/calcite-rating-resources.ts
@@ -1,0 +1,4 @@
+export const TEXT = {
+  rating: "Rating",
+  stars: "stars: ${num}"
+};

--- a/src/components/calcite-rating/calcite-rating.e2e.ts
+++ b/src/components/calcite-rating/calcite-rating.e2e.ts
@@ -8,176 +8,148 @@ describe("calcite-rating", () => {
     await accessible(`<calcite-rating></calcite-rating>`);
   });
 
-  it("renders default props and total number of rating items", async () => {
+  it("renders outlined star when no value or average is set", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
 
     expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star");
-    expect(ratingItem2).toEqualAttribute("icon", "star");
-    expect(ratingItem3).toEqualAttribute("icon", "star");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "false");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star");
+    expect(icons[1]).toEqualAttribute("icon", "star");
+    expect(icons[2]).toEqualAttribute("icon", "star");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).not.toHaveClass("selected");
+    expect(labels[1]).not.toHaveClass("selected");
+    expect(labels[2]).not.toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
   });
 
-  it("displays the value when no average is present and assigns correct data attributes and icon", async () => {
+  it("displays the correct stars as filled and selected when called with a value", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating value=3></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
 
     expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "true");
-    expect(ratingItem2).toEqualAttribute("data-selected", "true");
-    expect(ratingItem3).toEqualAttribute("data-selected", "true");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("selected");
+    expect(labels[1]).toHaveClass("selected");
+    expect(labels[2]).toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
   });
 
-  it("displays the average when value is not present and assigns correct data attributes and icon", async () => {
+  it("displays the average when value is not present", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating average=2></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
-
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
     expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "false");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-average", "true");
-    expect(ratingItem2).toEqualAttribute("data-average", "true");
-    expect(ratingItem3).toEqualAttribute("data-average", "false");
-    expect(ratingItem4).toEqualAttribute("data-average", "false");
-    expect(ratingItem5).toEqualAttribute("data-average", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).not.toHaveClass("selected");
+    expect(labels[1]).not.toHaveClass("selected");
+    expect(labels[2]).not.toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
+    expect(labels[0]).toHaveClass("average");
+    expect(labels[1]).toHaveClass("average");
+    expect(labels[2]).not.toHaveClass("average");
+    expect(labels[3]).not.toHaveClass("average");
+    expect(labels[4]).not.toHaveClass("average");
   });
-  it("displays the value when average and value are present and assigns correct data attributes and icon", async () => {
+
+  it("displays the value when average and value are present", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating average=3 value=1></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
-
-    expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star");
-    expect(ratingItem3).toEqualAttribute("icon", "star");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "true");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-average", "false");
-    expect(ratingItem2).toEqualAttribute("data-average", "false");
-    expect(ratingItem3).toEqualAttribute("data-average", "false");
-    expect(ratingItem4).toEqualAttribute("data-average", "false");
-    expect(ratingItem5).toEqualAttribute("data-average", "false");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star");
+    expect(icons[2]).toEqualAttribute("icon", "star");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("selected");
+    expect(labels[1]).not.toHaveClass("selected");
+    expect(labels[2]).not.toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
+    expect(labels[0]).not.toHaveClass("average");
+    expect(labels[1]).not.toHaveClass("average");
+    expect(labels[2]).not.toHaveClass("average");
+    expect(labels[3]).not.toHaveClass("average");
+    expect(labels[4]).not.toHaveClass("average");
   });
 
   it("displays a partial star when average is present and contains a partial value", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating average=3.45></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
-
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
     expect(partialStarContainer).not.toBeNull();
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "false");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-average", "true");
-    expect(ratingItem2).toEqualAttribute("data-average", "true");
-    expect(ratingItem3).toEqualAttribute("data-average", "true");
-    expect(ratingItem4).toEqualAttribute("data-average", "false");
-    expect(ratingItem5).toEqualAttribute("data-average", "false");
-    expect(ratingItem4).toEqualAttribute("data-partialparent", "true");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).not.toHaveClass("selected");
+    expect(labels[1]).not.toHaveClass("selected");
+    expect(labels[2]).not.toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
+    expect(labels[0]).toHaveClass("average");
+    expect(labels[1]).toHaveClass("average");
+    expect(labels[2]).toHaveClass("average");
+    expect(labels[3]).not.toHaveClass("average");
+    expect(labels[4]).not.toHaveClass("average");
   });
 
   it("clicking on an icon will correctly set the value", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating></calcite-rating>");
     const element = await page.find("calcite-rating");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
 
     expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star");
-    expect(ratingItem2).toEqualAttribute("icon", "star");
-    expect(ratingItem3).toEqualAttribute("icon", "star");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "false");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star");
+    expect(icons[1]).toEqualAttribute("icon", "star");
+    expect(icons[2]).toEqualAttribute("icon", "star");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).not.toHaveClass("selected");
+    expect(labels[1]).not.toHaveClass("selected");
+    expect(labels[2]).not.toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
     expect(element).toEqualAttribute("value", "0");
-    await ratingItem3.click();
+    await labels[2].click();
     await page.waitForChanges();
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "true");
-    expect(ratingItem2).toEqualAttribute("data-selected", "true");
-    expect(ratingItem3).toEqualAttribute("data-selected", "true");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("selected");
+    expect(labels[1]).toHaveClass("selected");
+    expect(labels[2]).toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
     expect(element).toEqualAttribute("value", "3");
   });
 
@@ -185,219 +157,167 @@ describe("calcite-rating", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating average=3.5></calcite-rating>");
     const element = await page.find("calcite-rating");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
+
     expect(partialStarContainer).not.toBeNull();
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "false");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(partialStarContainer).toEqualAttribute("data-partialhidden", "false");
-    expect(ratingItem1).toEqualAttribute("data-average", "true");
-    expect(ratingItem2).toEqualAttribute("data-average", "true");
-    expect(ratingItem3).toEqualAttribute("data-average", "true");
-    expect(ratingItem4).toEqualAttribute("data-average", "false");
-    expect(ratingItem5).toEqualAttribute("data-average", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("average");
+    expect(labels[1]).toHaveClass("average");
+    expect(labels[2]).toHaveClass("average");
+    expect(labels[3]).not.toHaveClass("average");
+    expect(labels[4]).not.toHaveClass("average");
     expect(element).toEqualAttribute("value", "0");
-    expect(ratingItem4).toEqualAttribute("data-partialparent", "true");
-    await ratingItem4.click();
+
+    await labels[3].click();
     await page.waitForChanges();
+
     expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star-f");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "true");
-    expect(ratingItem2).toEqualAttribute("data-selected", "true");
-    expect(ratingItem3).toEqualAttribute("data-selected", "true");
-    expect(ratingItem4).toEqualAttribute("data-selected", "true");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star-f");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("selected");
+    expect(labels[1]).toHaveClass("selected");
+    expect(labels[2]).toHaveClass("selected");
+    expect(labels[3]).toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
+    expect(labels[0]).not.toHaveClass("average");
+    expect(labels[1]).not.toHaveClass("average");
+    expect(labels[2]).not.toHaveClass("average");
+    expect(labels[3]).not.toHaveClass("average");
+    expect(labels[4]).not.toHaveClass("average");
     expect(element).toEqualAttribute("value", "4");
   });
 
   it("uses the correct data attributes while hovering over an unselected star with no value", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    expect(ratingItem1).toEqualAttribute("icon", "star");
-    expect(ratingItem2).toEqualAttribute("icon", "star");
-    expect(ratingItem3).toEqualAttribute("icon", "star");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "false");
-    await ratingItem4.hover();
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+
+    expect(icons[0]).toEqualAttribute("icon", "star");
+    expect(icons[1]).toEqualAttribute("icon", "star");
+    expect(icons[2]).toEqualAttribute("icon", "star");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).not.toHaveClass("hovered");
+    expect(labels[1]).not.toHaveClass("hovered");
+    expect(labels[2]).not.toHaveClass("hovered");
+    expect(labels[3]).not.toHaveClass("hovered");
+    expect(labels[4]).not.toHaveClass("hovered");
+
+    await labels[3].hover();
     await page.waitForChanges();
-    expect(ratingItem1).toEqualAttribute("icon", "star");
-    expect(ratingItem2).toEqualAttribute("icon", "star");
-    expect(ratingItem3).toEqualAttribute("icon", "star");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "false");
-  });
-  it("uses the correct data attributes while hovering over an unselected star with value", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-rating value=3></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "true");
-    expect(ratingItem2).toEqualAttribute("data-selected", "true");
-    expect(ratingItem3).toEqualAttribute("data-selected", "true");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "false");
-    await ratingItem4.hover();
-    await page.waitForChanges();
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "true");
-    expect(ratingItem2).toEqualAttribute("data-selected", "true");
-    expect(ratingItem3).toEqualAttribute("data-selected", "true");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "false");
-  });
-  it("uses the correct data attributes while hovering over an unselected star with average", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-rating average=4.2></calcite-rating>");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem2 = await page.find("calcite-rating >>> calcite-icon:nth-child(2)");
-    const ratingItem3 = await page.find("calcite-rating >>> calcite-icon:nth-child(3)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
-    const ratingItem5 = await page.find("calcite-rating >>> calcite-icon:nth-child(5)");
-    const partialStarContainer = await page.find("calcite-rating >>> .partial-rating-star-container");
-    expect(partialStarContainer).not.toBeNull();
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star-f");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-selected", "false");
-    expect(ratingItem2).toEqualAttribute("data-selected", "false");
-    expect(ratingItem3).toEqualAttribute("data-selected", "false");
-    expect(ratingItem4).toEqualAttribute("data-selected", "false");
-    expect(ratingItem5).toEqualAttribute("data-selected", "false");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "false");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "false");
-    expect(partialStarContainer).toEqualAttribute("data-partialhidden", "false");
-    await ratingItem5.hover();
-    await page.waitForChanges();
-    expect(partialStarContainer).toBeNull;
-    expect(ratingItem1).toEqualAttribute("icon", "star-f");
-    expect(ratingItem2).toEqualAttribute("icon", "star-f");
-    expect(ratingItem3).toEqualAttribute("icon", "star-f");
-    expect(ratingItem4).toEqualAttribute("icon", "star-f");
-    expect(ratingItem5).toEqualAttribute("icon", "star");
-    expect(ratingItem1).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem2).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem3).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem4).toEqualAttribute("data-hovered", "true");
-    expect(ratingItem5).toEqualAttribute("data-hovered", "true");
+    expect(icons[0]).toEqualAttribute("icon", "star");
+    expect(icons[1]).toEqualAttribute("icon", "star");
+    expect(icons[2]).toEqualAttribute("icon", "star");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("hovered");
+    expect(labels[1]).toHaveClass("hovered");
+    expect(labels[2]).toHaveClass("hovered");
+    expect(labels[3]).toHaveClass("hovered");
+    expect(labels[4]).not.toHaveClass("hovered");
   });
 
-  it("keyboard functionality works to navigate and select items", async () => {
+  it("correctly sets classes while hovering over an unselected star with value", async () => {
     const page = await newE2EPage();
-    await page.setContent("<calcite-rating></calcite-rating>");
-    const element = await page.find("calcite-rating");
-    expect(element).toEqualAttribute("value", "0");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Enter");
+    await page.setContent("<calcite-rating value=3></calcite-rating>");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("selected");
+    expect(labels[1]).toHaveClass("selected");
+    expect(labels[2]).toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
+    expect(labels[0]).not.toHaveClass("hovered");
+    expect(labels[1]).not.toHaveClass("hovered");
+    expect(labels[2]).not.toHaveClass("hovered");
+    expect(labels[3]).not.toHaveClass("hovered");
+    expect(labels[4]).not.toHaveClass("hovered");
+
+    await labels[3].hover();
     await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "1");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Space");
+
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+
+    expect(labels[0]).toHaveClass("hovered");
+    expect(labels[1]).toHaveClass("hovered");
+    expect(labels[2]).toHaveClass("hovered");
+    expect(labels[3]).toHaveClass("hovered");
+    expect(labels[4]).not.toHaveClass("hovered");
+  });
+
+  it("correctly sets classes while hovering over an unselected star with average", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-rating average=4.2></calcite-rating>");
+    const icons = await page.findAll("calcite-rating >>> .icon");
+    const labels = await page.findAll("calcite-rating >>> .star");
+    const partialStarContainer = await page.find("calcite-rating >>> .fraction");
+
+    expect(partialStarContainer).not.toBeNull();
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star-f");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).not.toHaveClass("selected");
+    expect(labels[1]).not.toHaveClass("selected");
+    expect(labels[2]).not.toHaveClass("selected");
+    expect(labels[3]).not.toHaveClass("selected");
+    expect(labels[4]).not.toHaveClass("selected");
+    expect(labels[0]).not.toHaveClass("hovered");
+    expect(labels[1]).not.toHaveClass("hovered");
+    expect(labels[2]).not.toHaveClass("hovered");
+    expect(labels[3]).not.toHaveClass("hovered");
+    expect(labels[4]).not.toHaveClass("hovered");
+    await labels[4].hover();
     await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "3");
-    await page.keyboard.press("ArrowLeft");
-    await page.keyboard.press("Space");
-    await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "2");
-    await page.keyboard.press("ArrowLeft");
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "1");
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "4");
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("ArrowRight");
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "1");
-    await page.keyboard.press("End");
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "5");
-    await page.keyboard.press("Home");
-    await page.keyboard.press("Space");
-    await page.waitForChanges();
-    expect(element).toEqualAttribute("value", "1");
+    expect(partialStarContainer).toBeNull;
+    expect(icons[0]).toEqualAttribute("icon", "star-f");
+    expect(icons[1]).toEqualAttribute("icon", "star-f");
+    expect(icons[2]).toEqualAttribute("icon", "star-f");
+    expect(icons[3]).toEqualAttribute("icon", "star-f");
+    expect(icons[4]).toEqualAttribute("icon", "star");
+    expect(labels[0]).toHaveClass("hovered");
+    expect(labels[1]).toHaveClass("hovered");
+    expect(labels[2]).toHaveClass("hovered");
+    expect(labels[3]).toHaveClass("hovered");
+    expect(labels[4]).toHaveClass("hovered");
   });
 
   it("emits expected event when user clicks to choose value", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating></calcite-rating>");
     const element = await page.find("calcite-rating");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
-    const ratingItem4 = await page.find("calcite-rating >>> calcite-icon:nth-child(4)");
+    const labels = await page.findAll("calcite-rating >>> .star");
 
     const changeEvent = await element.spyOnEvent("calciteRatingChange");
     expect(changeEvent).toHaveReceivedEventTimes(0);
-    await ratingItem1.click();
+    await labels[0].click();
     expect(element).toEqualAttribute("value", "1");
     expect(changeEvent).toHaveReceivedEventTimes(1);
     expect(changeEvent).toHaveReceivedEventDetail({
       value: 1
     });
-    await ratingItem4.click();
+    await labels[3].click();
     expect(element).toEqualAttribute("value", "4");
     expect(changeEvent).toHaveReceivedEventTimes(2);
     expect(changeEvent).toHaveReceivedEventDetail({
@@ -405,23 +325,37 @@ describe("calcite-rating", () => {
     });
   });
 
-  it("emits expected event when user uses enter or space key to choose value", async () => {
+  it("can be edited with keyboard like a set of radio inputs", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating></calcite-rating>");
     const element = await page.find("calcite-rating");
     const changeEvent = await element.spyOnEvent("calciteRatingChange");
     await page.keyboard.press("Tab");
     expect(changeEvent).toHaveReceivedEventTimes(0);
-    await page.keyboard.press("Enter");
+    await element.press(" ");
     expect(changeEvent).toHaveReceivedEventTimes(1);
     expect(changeEvent).toHaveReceivedEventDetail({
       value: 1
     });
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Space");
+    await page.keyboard.press("ArrowRight");
     expect(changeEvent).toHaveReceivedEventTimes(2);
     expect(changeEvent).toHaveReceivedEventDetail({
       value: 2
+    });
+    await page.keyboard.press("ArrowLeft");
+    expect(changeEvent).toHaveReceivedEventTimes(3);
+    expect(changeEvent).toHaveReceivedEventDetail({
+      value: 1
+    });
+    await page.keyboard.press("ArrowLeft");
+    expect(changeEvent).toHaveReceivedEventTimes(4);
+    expect(changeEvent).toHaveReceivedEventDetail({
+      value: 5
+    });
+    await page.keyboard.press("ArrowRight");
+    expect(changeEvent).toHaveReceivedEventTimes(5);
+    expect(changeEvent).toHaveReceivedEventDetail({
+      value: 1
     });
   });
 
@@ -429,16 +363,17 @@ describe("calcite-rating", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating value=4 read-only></calcite-rating>");
     const element = await page.find("calcite-rating");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
+    const ratingItem1 = await page.find("calcite-rating >>> .star");
     expect(element).toEqualAttribute("value", "4");
     await ratingItem1.click();
     expect(element).toEqualAttribute("value", "4");
   });
+
   it("disables click interaction when disabled is requested", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating disabled></calcite-rating>");
     const element = await page.find("calcite-rating");
-    const ratingItem1 = await page.find("calcite-rating >>> calcite-icon:nth-child(1)");
+    const ratingItem1 = await page.find("calcite-rating >>> .star");
     expect(element).toEqualAttribute("value", "0");
     await ratingItem1.click();
     expect(element).toEqualAttribute("value", "0");
@@ -455,28 +390,30 @@ describe("calcite-rating", () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating count=15></calcite-rating>");
     const calciteChip = await page.find("calcite-rating >>> calcite-chip");
-    const countSpan = await page.find("calcite-rating >>> calcite-chip >>> .calcite-rating-count");
-    const averageSpan = await page.find("calcite-rating >>> calcite-chip >>> .calcite-rating-average");
+    const countSpan = await page.find("calcite-rating >>> calcite-chip >>> .number--count");
+    const averageSpan = await page.find("calcite-rating >>> calcite-chip >>> .number--average");
     expect(calciteChip).not.toBeNull();
     expect(countSpan).not.toBeNull();
     expect(averageSpan).toBeNull;
   });
+
   it("renders the calcite chip and the average span when average is present and count is not", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating average=4.2></calcite-rating>");
     const calciteChip = await page.find("calcite-rating >>> calcite-chip");
-    const countSpan = await page.find("calcite-rating >>> calcite-chip >>> .calcite-rating-count");
-    const averageSpan = await page.find("calcite-rating >>> calcite-chip >>> .calcite-rating-average");
+    const countSpan = await page.find("calcite-rating >>> calcite-chip >>> .number---count");
+    const averageSpan = await page.find("calcite-rating >>> calcite-chip >>> .number--average");
     expect(calciteChip).not.toBeNull();
     expect(countSpan).toBeNull;
     expect(averageSpan).not.toBeNull();
   });
+
   it("renders the calcite chip and both the average and count spans when average and count are present", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating count=15 average=4.2></calcite-rating>");
     const calciteChip = await page.find("calcite-rating >>> calcite-chip");
-    const countSpan = await page.find("calcite-rating >>> calcite-chip >>> .calcite-rating-count");
-    const averageSpan = await page.find("calcite-rating >>> calcite-chip >>> .calcite-rating-average");
+    const countSpan = await page.find("calcite-rating >>> calcite-chip >>> .number---count");
+    const averageSpan = await page.find("calcite-rating >>> calcite-chip >>> .number--average");
     expect(calciteChip).not.toBeNull();
     expect(countSpan).not.toBeNull();
     expect(averageSpan).not.toBeNull();

--- a/src/components/calcite-rating/calcite-rating.scss
+++ b/src/components/calcite-rating/calcite-rating.scss
@@ -1,139 +1,98 @@
 :host([scale="s"]) {
-  --calcite-rating-spacing-unit: 4px;
-}
-
-:host,
-:host([scale="m"]) {
-  --calcite-rating-spacing-unit: 8px;
-}
-
-:host([scale="l"]) {
-  --calcite-rating-spacing-unit: 12px;
+  --calcite-rating-spacing-unit: theme("spacing.1");
 }
 
 :host {
-  display: flex;
-  align-items: center;
+  --calcite-rating-spacing-unit: theme("spacing.2");
+}
+
+:host([scale="l"]) {
+  --calcite-rating-spacing-unit: theme("spacing.3");
+}
+
+:host {
+  @apply flex items-center relative;
   width: fit-content;
-  position: relative;
 }
 
 :host([disabled]) {
-  opacity: 0.4;
-  pointer-events: none;
+  @apply pointer-events-none opacity-50;
 }
 
 :host([read-only]) {
-  pointer-events: none;
+  @apply pointer-events-none;
 }
 
-:host(:not([read-only])) calcite-icon {
+.fieldset {
+  @apply p-0 m-0 border-0 flex flex-no-wrap relative;
+}
+
+.wrapper {
+  margin-right: var(--calcite-rating-spacing-unit);
+}
+
+:host([dir="rtl"]) .wrapper {
+  margin-right: 0;
+  margin-left: var(--calcite-rating-spacing-unit);
+}
+
+.star {
+  @include focus-style-base();
+  @apply relative inline-block;
+  color: var(--calcite-ui-border-1);
   transition: $transition;
+  transform: scale(1);
   cursor: pointer;
   &:active {
     transform: scale(1.1);
   }
 }
 
-// container for icon items
-:host .calcite-rating-item-container {
-  display: flex;
-  flex-wrap: nowrap;
-  position: relative;
+.focused {
+  @include focus-style-outset();
 }
 
-// focus styles
-:host calcite-icon {
-  @include focus-style-base();
-
-  &:focus {
-    @include focus-style-outset();
-  }
-}
-
-:host calcite-icon {
-  pointer-events: default;
-  &:not(:last-of-type) {
-    margin-right: var(--calcite-rating-spacing-unit);
-  }
-}
-:host([dir="rtl"]) calcite-icon:not(:last-of-type) {
-  margin-right: 0;
-  margin-left: var(--calcite-rating-spacing-unit);
-}
-
-:host calcite-icon {
-  color: var(--calcite-ui-text-3);
-  box-sizing: border-box;
-}
-:host([read-only]) calcite-icon:not([data-selected="true"]) {
-  color: var(--calcite-ui-border-1);
-}
-
-:host calcite-icon[data-average="true"],
-:host calcite-icon[data-partial="true"],
-:host calcite-icon[data-average="true"][date-selected="false"] {
+.average,
+.partial {
   color: var(--calcite-ui-yellow-1);
 }
 
-:host calcite-icon[data-partial="true"] {
+.hovered,
+.selected,
+:host([read-only]) .average,
+:host([read-only]) .partial {
+  color: var(--calcite-ui-blue-1);
 }
 
-:host .partial-rating-star-container {
+.hovered:not(.selected) {
+  transform: scale(0.9);
+}
+
+:host .fraction {
   position: absolute;
   overflow: hidden;
   pointer-events: none;
   top: 0;
+  left: 0;
   transition: $transition;
-  &:hover {
-    transform: scale(0.9);
-  }
 }
 
-// handle hiding of our partial star
-:host
-  calcite-icon[data-partialparent="true"]:hover
-  ~ .partial-rating-star-container
-  :host
-  calcite-icon[data-partialparent="true"]:focus
-  ~ .partial-rating-star-container {
-  opacity: 0;
-}
-
-:host .partial-rating-star-container[data-partialhidden="true"] {
-  opacity: 0;
-}
-
-:host([read-only]) calcite-icon[data-average="true"],
-:host([disabled]) calcite-icon[data-average="true"],
-:host([read-only]) calcite-icon[data-partial="true"],
-:host([disabled]) calcite-icon[data-partial="true"],
-:host calcite-icon[data-selected="true"],
-:host calcite-icon[data-hovered="true"] {
-  color: var(--calcite-ui-blue-1);
-}
-
-:host calcite-icon[data-hovered="true"]:not([data-selected="true"]) {
-  transform: scale(0.9);
+:host([dir="rtl"]) .fraction {
+  right: 0;
+  left: unset;
 }
 
 // rating count
-:host calcite-chip {
-  margin-left: var(--calcite-rating-spacing-unit);
+calcite-chip {
   cursor: default;
   pointer-events: none;
 }
 
-:host([dir="rtl"]) calcite-chip {
-  margin-right: var(--calcite-rating-spacing-unit);
-  margin-left: 0;
-}
-
-:host .calcite-rating-average {
+.number--average {
   font-weight: 700;
 }
 
-:host .calcite-rating-count {
+.number--count {
   font-style: italic;
   color: var(--calcite-ui-text-2);
   &:not(:first-child) {
@@ -141,7 +100,11 @@
   }
 }
 
-:host([dir="rtl"]) .calcite-rating-count:not(:first-child) {
+:host([dir="rtl"]) .number--count:not(:first-child) {
   margin-right: var(--calcite-rating-spacing-unit);
   margin-left: 0;
+}
+
+.visually-hidden {
+  @apply sr-only;
 }

--- a/src/components/calcite-rating/calcite-rating.scss
+++ b/src/components/calcite-rating/calcite-rating.scss
@@ -53,14 +53,14 @@
 }
 
 .average,
-.partial {
+.fraction {
   color: var(--calcite-ui-yellow-1);
 }
 
 .hovered,
 .selected,
 :host([read-only]) .average,
-:host([read-only]) .partial {
+:host([read-only]) .fraction {
   color: var(--calcite-ui-blue-1);
 }
 

--- a/src/components/calcite-rating/calcite-rating.stories.ts
+++ b/src/components/calcite-rating/calcite-rating.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { number, select } from "@storybook/addon-knobs";
+import { number, select, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
@@ -16,6 +16,8 @@ storiesOf("Components/Rating", module)
     count="${number("count", 0)}"
     ${boolean("read-only", false)}
     ${boolean("disabled", false)}
+    intl-rating="${text("intl-rating", "Rating")}"
+    intl-stars="${text("intl-rating", "Stars: ${num}")}"
    ></calcite-rating>
   `
   )
@@ -30,6 +32,8 @@ storiesOf("Components/Rating", module)
       count="${number("count", 0)}"
       ${boolean("read-only", false)}
       ${boolean("disabled", false)}
+      intl-rating="${text("intl-rating", "Rating")}"
+      intl-stars="${text("intl-rating", "Stars: ${num}")}"
     ></calcite-rating>
   `,
     { backgrounds: darkBackground }
@@ -46,6 +50,8 @@ storiesOf("Components/Rating", module)
       count="${number("count", 0)}"
       ${boolean("read-only", false)}
       ${boolean("disabled", false)}
+      intl-rating="${text("intl-rating", "Rating")}"
+      intl-stars="${text("intl-rating", "Stars: ${num}")}"
     ></calcite-rating>
    </calcite-label>
   `
@@ -61,6 +67,8 @@ storiesOf("Components/Rating", module)
       count="${number("count", 0)}"
       ${boolean("read-only", false)}
       ${boolean("disabled", false)}
+      intl-rating="${text("intl-rating", "Rating")}"
+      intl-stars="${text("intl-rating", "Stars: ${num}")}"
     ></calcite-rating>
    </div>
   `

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -108,7 +108,7 @@ export class CalciteRating {
       const partial = !this.value && !hovered && fraction > 0 && fraction < 1;
       const focused = this.hasFocus && this.focusValue === i;
       return (
-        <span class="wrapper">
+        <span class={{ wrapper: true }}>
           <label
             class={{ star: true, focused, selected, average, hovered, partial }}
             htmlFor={`${this.guid}-${i}`}
@@ -119,7 +119,7 @@ export class CalciteRating {
             <calcite-icon
               aria-hidden="true"
               class="icon"
-              icon={selected || average || (this.readOnly && !partial) ? "star-f" : "star"}
+              icon={selected || average || this.readOnly ? "star-f" : "star"}
               scale={this.scale}
             />
             {partial && (
@@ -141,6 +141,7 @@ export class CalciteRating {
               this.focusValue = i;
             }}
             type="radio"
+            value={i}
           />
         </span>
       );

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -8,10 +8,12 @@ import {
   Listen,
   Method,
   Prop,
-  State
+  State,
+  VNode
 } from "@stencil/core";
-import { getKey } from "../../utils/key";
 import { getElementDir, hasLabel } from "../../utils/dom";
+import { guid } from "../../utils/guid";
+import { TEXT } from "./calcite-rating-resources";
 
 @Component({
   tag: "calcite-rating",
@@ -57,6 +59,12 @@ export class CalciteRating {
   /** optionally pass a cumulative average rating to display */
   @Prop({ reflect: true }) average?: number;
 
+  /** Localized string for "Rating" (used for aria label) */
+  @Prop() intlRating?: string = TEXT.rating;
+
+  /** Localized string for labelling each star, `${num}` in the string will be replaced by the number */
+  @Prop() intlStars?: string = TEXT.stars;
+
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -81,82 +89,86 @@ export class CalciteRating {
     }
   }
 
-  //--------------------------------------------------------------------------
-  //
-  //  Lifecycle
-  //
-  //--------------------------------------------------------------------------
-
-  componentDidLoad() {
-    this.determineInitialRating();
+  @Listen("blur") blurHandler(): void {
+    this.hasFocus = false;
   }
 
   // --------------------------------------------------------------------------
   //
-  //  Render Method
+  //  Render Methods
   //
   // --------------------------------------------------------------------------
 
-  render() {
-    this.dir = getElementDir(this.el);
-
-    const partialRatingStarContainer = (
-      <div
-        class="partial-rating-star-container"
-        data-partialhidden="false"
-        ref={(el) => (this.partialStarContainer = el)}
-      >
-        <calcite-icon
-          data-partial="true"
-          icon={this.selectedIconType}
-          ref={(el) => (this.partialStar = el)}
-          scale={this.scale}
-          theme={this.theme}
-        />
-      </div>
-    );
-
-    // ie11 safe version of array / spread / keys
-    const iconsToRender = [];
-    for (let i = 0; i < 5; i++) {
-      iconsToRender.push(
-        <calcite-icon
-          icon={this.iconType}
-          onClick={(e) => this.determineRatingPosition(e)}
-          onFocus={(e) => this.showSelectedIconOnHover(e)}
-          onKeyDown={(e) => this.handleKeyDown(e)}
-          onMouseEnter={(e) => this.showSelectedIconOnHover(e)}
-          onTouchStart={(e) => this.showSelectedIconOnHover(e)}
-          ref={(el) => this.ratingItems.set(i + 1, el)}
-          scale={this.scale}
-          tabindex={!this.readOnly && !this.disabled ? 0 : null}
-        />
+  renderStars(): VNode[] {
+    return [1, 2, 3, 4, 5].map((i) => {
+      const selected = this.value >= i;
+      const average = this.average && !this.value && i <= this.average;
+      const hovered = i <= this.hoverValue;
+      const fraction = this.average && this.average + 1 - i;
+      const partial = !this.value && !hovered && fraction > 0 && fraction < 1;
+      const focused = this.hasFocus && this.focusValue === i;
+      return (
+        <span class="wrapper">
+          <label
+            class={{ star: true, focused, selected, average, hovered, partial }}
+            htmlFor={`${this.guid}-${i}`}
+            onMouseOver={() => {
+              this.hoverValue = i;
+            }}
+          >
+            <calcite-icon
+              aria-hidden="true"
+              class="icon"
+              icon={selected || average || (this.readOnly && !partial) ? "star-f" : "star"}
+              scale={this.scale}
+            />
+            {partial && (
+              <div class="fraction" style={{ width: `${fraction * 100}%` }}>
+                <calcite-icon icon="star-f" scale={this.scale} theme={this.theme} />
+              </div>
+            )}
+            <span class="visually-hidden">{this.intlStars.replace("${num}", `${i}`)}</span>
+          </label>
+          <input
+            checked={i === this.value}
+            class="visually-hidden"
+            disabled={this.disabled || this.readOnly}
+            id={`${this.guid}-${i}`}
+            name={this.guid}
+            onChange={() => this.updateValue(i)}
+            onFocus={() => {
+              this.hasFocus = true;
+              this.focusValue = i;
+            }}
+            type="radio"
+          />
+        </span>
       );
-    }
+    });
+  }
+
+  render() {
+    const dir = getElementDir(this.el);
     return (
-      <Host dir={this.dir}>
-        <div
-          class="calcite-rating-item-container"
-          onBlur={() => this.resetHoverState()}
-          onMouseLeave={() => this.resetHoverState()}
-          onTouchEnd={() => this.resetHoverState()}
+      <Host dir={dir}>
+        <fieldset
+          class="fieldset"
+          onBlur={() => (this.hoverValue = null)}
+          onMouseLeave={() => (this.hoverValue = null)}
+          onTouchEnd={() => (this.hoverValue = null)}
         >
-          {iconsToRender}
-          {this.average && !this.value ? partialRatingStarContainer : null}
-        </div>
+          <legend class="visually-hidden">{this.intlRating}</legend>
+          {this.renderStars()}
+        </fieldset>
         {this.count || this.average ? (
           <calcite-chip
-            dir={this.dir}
+            dir={dir}
             scale={this.scale}
             theme={this.theme}
             value={this.count?.toString()}
           >
-            {this.average ? (
-              <span class="calcite-rating-average">{this.average.toString()}</span>
-            ) : null}
-            {this.count ? (
-              <span class="calcite-rating-count">({this.count?.toString()})</span>
-            ) : null}
+            {this.average && <span class="number--average">{this.average.toString()}</span>}
+            {this.count && <span class="number--count">({this.count?.toString()})</span>}
           </calcite-chip>
         ) : null}
       </Host>
@@ -168,166 +180,9 @@ export class CalciteRating {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
-
-  private handleKeyDown(e) {
-    if (!this.readOnly) {
-      const itemToFocus = e.target;
-      const isFirstItem = this.itemValue(itemToFocus) === 1;
-      const isLastItem = this.itemValue(itemToFocus) === this.ratingItems.size;
-      switch (getKey(e.key)) {
-        case " ":
-        case "Enter":
-          e.preventDefault();
-          this.determineRatingPosition(e);
-          break;
-        case "ArrowRight":
-          if (isLastItem) this.focusFirstItem();
-          else this.focusNextItem(itemToFocus);
-          break;
-        case "ArrowLeft":
-          if (isFirstItem) this.focusLastItem();
-          else this.focusPrevItem(itemToFocus);
-          break;
-        case "Home":
-          this.focusFirstItem();
-          e.preventDefault();
-          break;
-        case "End":
-          this.focusLastItem();
-          e.preventDefault();
-          break;
-        case "Tab":
-          if (isLastItem || (isFirstItem && e.shiftKey)) this.resetHoverState();
-          break;
-      }
-    }
-  }
-
-  private determineRatingPosition(e) {
-    if (!this.readOnly) {
-      const isEdgeOrIE =
-        window.navigator.userAgent.indexOf("Edge") > -1 ||
-        !!(navigator.userAgent.match(/Trident/) && !navigator.userAgent.match(/MSIE/));
-      const value = !isEdgeOrIE
-        ? this.itemValue(e.target)
-        : this.itemValue(e.target.closest("CALCITE-ICON"));
-
-      this.value = value;
-      this.emitRatingChange();
-      this.determineActiveItems();
-    }
-  }
-
-  private determineInitialRating() {
-    const valueToUse = this.value ? this.value : this.average;
-    this.ratingItems?.forEach((item, value) => {
-      item.dataset.hovered = "false";
-      item.dataset.average =
-        this.average && !this.value && value <= this.average ? "true" : "false";
-      item.dataset.selected =
-        item.dataset.average === "false" && value <= valueToUse ? "true" : "false";
-      item.icon = value <= valueToUse || this.readOnly ? this.selectedIconType : this.iconType;
-    });
-
-    if (this.average) {
-      this.determinePartialStar();
-    }
-  }
-
-  private determinePartialStar() {
-    // position an extra icon and fill to width of percentage
-    const rootVal = Math.floor(this.average);
-    const decimal = parseInt((this.average % 1).toFixed(2).split(".")[1]);
-
-    // track the closest full star to position the partial icon
-    this.ratingItems?.forEach((item, value) => {
-      if (this.average && !this.value && value === rootVal + 1) {
-        this.rootStar = item;
-        this.rootStar.dataset.partialparent = "true";
-      }
-    });
-    if (this.rootStar) {
-      this.partialStar.dataset.rootvalue = (rootVal + 1).toString();
-      // get margin from first star item in case partial is last and has none
-      const marginProp = this.dir === "rtl" ? "margin-left" : "margin-right";
-      const margin = window.getComputedStyle(this.ratingItems.get(1)).getPropertyValue(marginProp);
-      const offset = `calc((${this.rootStar.offsetWidth}px + ${margin}) * ${rootVal})`;
-
-      this.partialStarContainer.style.width = `${(decimal / 100) * this.rootStar.offsetWidth}px`;
-      this.partialStarContainer.style.height = `${this.rootStar.offsetHeight}px`;
-
-      this.dir === "rtl"
-        ? (this.partialStarContainer.style.right = offset)
-        : (this.partialStarContainer.style.left = offset);
-    }
-  }
-
-  private resetHoverState() {
-    if (this.partialStarContainer) this.partialStarContainer.dataset.partialhidden = "false";
-    this.ratingItems?.forEach((item) => {
-      item.dataset.hovered = "false";
-    });
-  }
-
-  private determineActiveItems() {
-    const valueToUse = this.value ? this.value : this.average;
-    this.ratingItems?.forEach((item, value) => {
-      item.dataset.hovered = "false";
-      item.dataset.average = "false";
-      item.dataset.selected = value <= valueToUse ? "true" : "false";
-      item.icon = this.readOnly || value <= this.value ? this.selectedIconType : this.iconType;
-    });
-  }
-
-  private showSelectedIconOnHover(e) {
-    if (!this.readOnly) {
-      const hoveredValue = this.itemValue(e.target);
-      if (this.partialStarContainer)
-        this.partialStarContainer.dataset.partialhidden =
-          parseInt(this.partialStar.dataset.rootvalue) <= hoveredValue ? "true" : "false";
-      this.ratingItems?.forEach((item, value) => {
-        item.dataset.hovered = hoveredValue >= value ? "true" : "false";
-      });
-    }
-  }
-
-  private emitRatingChange() {
-    this.calciteRatingChange.emit({
-      value: this.value
-    });
-  }
-
-  // focus helpers
-  private focusFirstItem() {
-    const firstItem = this.ratingItems.get(1);
-    this.focusElement(firstItem);
-  }
-
-  private focusLastItem() {
-    const lastItem = this.ratingItems.get(this.ratingItems.size);
-    this.focusElement(lastItem);
-  }
-
-  private focusNextItem(e) {
-    const position = this.itemValue(e);
-    const nextItem = this.ratingItems.get(position + 1) || this.ratingItems.get(1);
-    this.focusElement(nextItem);
-  }
-
-  private focusPrevItem(e) {
-    const position = this.itemValue(e);
-    const prevItem =
-      this.ratingItems.get(position - 1) || this.ratingItems.get(this.ratingItems.size);
-    this.focusElement(prevItem);
-  }
-
-  private itemValue(e) {
-    return Array.from(this.ratingItems.values()).indexOf(e) + 1;
-  }
-
-  private focusElement(item) {
-    const target = item as HTMLCalciteIconElement;
-    target.focus();
+  private updateValue(value: number) {
+    this.value = value;
+    this.calciteRatingChange.emit({ value });
   }
 
   //--------------------------------------------------------------------------
@@ -335,32 +190,23 @@ export class CalciteRating {
   //  Public Methods
   //
   //--------------------------------------------------------------------------
-
   @Method()
   async setFocus(): Promise<void> {
-    this.ratingItems.get(1).focus();
+    this.el.querySelector("input").focus();
+    this.hasFocus = true;
   }
 
   // --------------------------------------------------------------------------
   //
-  //  Private Properties
+  //  Private State / Properties
   //
   // --------------------------------------------------------------------------
 
-  /* @internal */
-  @State() ratingItems: Map<number, HTMLCalciteIconElement> = new Map();
+  @State() hoverValue: number;
 
-  private iconType = "star";
+  @State() focusValue: number;
 
-  private selectedIconType = "star-f";
+  @State() hasFocus: boolean;
 
-  private dir;
-
-  // the absolutely positioned star when an average rating has decimal
-  private partialStar: HTMLCalciteIconElement;
-
-  private partialStarContainer: HTMLDivElement;
-
-  // track the last full value star to position the partial star
-  private rootStar: HTMLCalciteIconElement;
+  private guid = `calcite-ratings-${guid()}`;
 }


### PR DESCRIPTION
## Summary

- Adds two additional props for configuring screen reader labels for the rating component. 
- Structures the rating like a radio-input group (left/right to change selection, etc)
- Updates styles to use tailwind

@macandcheese can you look at these styles and make sure it visually looks like it used to? 