### PR TITLE
fix(rating): fix ratings appearing vertically in certain sites

### DIFF
--- a/src/components/calcite-rating/calcite-rating.scss
+++ b/src/components/calcite-rating/calcite-rating.scss
@@ -24,7 +24,7 @@
 }
 
 .fieldset {
-  @apply p-0 m-0 border-0 flex flex-no-wrap relative;
+  @apply p-0 m-0 border-0 inline-block;
 }
 
 .wrapper {


### PR DESCRIPTION


## Summary

Not 100% why, but rating stars display vertically now due to some weird interaction with `fieldset` and `display: flex`. Seems like `inline-block` solves it...