### PR TITLE
fix(select): ensure select change event fires after render update

### DIFF
--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -300,4 +300,37 @@ describe("calcite-select", () => {
       expect(await internalSelect.findAll("optgroup")).toHaveLength(2);
     });
   });
+
+  it("item is selected before change event", async () => {
+    const page = await newE2EPage({
+      html: dedent`
+          <calcite-select>
+            <calcite-option id="1">uno</calcite-option>
+            <calcite-option id="2">dos</calcite-option>
+            <calcite-option id="3">tres</calcite-option>
+          </calcite-select>
+        `
+    });
+
+    type TestWindow = typeof window & { selectedOptionId: string };
+
+    await page.evaluate(() => {
+      document.querySelector("calcite-select").addEventListener("calciteSelectChange", (event) => {
+        (window as TestWindow).selectedOptionId = (event.target as HTMLElement).querySelector(
+          "calcite-option[selected]"
+        ).id;
+      });
+    });
+
+    const internalSelect = await page.evaluateHandle(() =>
+      document.querySelector("calcite-select").shadowRoot.querySelector("select")
+    );
+
+    await internalSelect.asElement().select("dos");
+    await page.waitForChanges();
+
+    const selectedOptionId = await page.evaluate(() => (window as TestWindow).selectedOptionId);
+
+    expect(selectedOptionId).toBe("2");
+  });
 });

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -138,7 +138,7 @@ export class CalciteSelect {
 
   private handleInternalSelectChange = (): void => {
     this.selectFromNativeOption(this.selectEl.selectedOptions[0]);
-    this.calciteSelectChange.emit();
+    requestAnimationFrame(this.emitChangeEvent);
   };
 
   @Listen("calciteOptionChange")
@@ -274,6 +274,10 @@ export class CalciteSelect {
       option.selected = false;
     });
   }
+
+  private emitChangeEvent = (): void => {
+    this.calciteSelectChange.emit();
+  };
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #1262 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates `calcite-select` to emit its change event after children have been updated in the DOM. This is needed to ensure correct results when querying the DOM for the selected option after the event.