### PR TITLE
chore: update issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.md
+++ b/.github/ISSUE_TEMPLATE/accessibility.md
@@ -2,7 +2,7 @@
 name: Accessibility
 about: Report an accessibility issue in a component.
 title: "A11y: "
-labels: a11y, bug 🐞, 0 - new, p - high :point_up_2:
+labels: a11y, bug, 0 - new, p - high
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug
 about: Report a bug in a component.
 title: "Bug: "
-labels: bug 🐞, 0 - new
+labels: bug, 0 - new
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation
 about: Report issues with documentation.
 title: "Docs: "
-labels: docs 📓, 0 - new
+labels: docs, 0 - new
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -2,7 +2,7 @@
 name: Enhancement
 about: Request for a feature to be added to an existing component.
 title: "Enhancement: "
-labels: enhancement ✨, 0 - new
+labels: enhancement, 0 - new
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-component.md
+++ b/.github/ISSUE_TEMPLATE/new-component.md
@@ -2,7 +2,7 @@
 name: New Component
 about: Request for a new component to be added.
 title: "New Component: "
-labels: new component 🆕, 0 - new
+labels: new component, 0 - new
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question
 about: Request for information - not code changes.
 title: "Question: "
-labels: question❔, 0 - new
+labels: question, 0 - new
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -2,7 +2,7 @@
 name: Research
 about: Request an investigation into a specific topic.
 title: "Research: "
-labels: 0 - new, research 🔬
+labels: 0 - new, research
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/tooling.md
+++ b/.github/ISSUE_TEMPLATE/tooling.md
@@ -2,7 +2,7 @@
 name: Tooling
 about: Request improvements to our component workflow.
 title: "Tooling: "
-labels: tooling 🛠️, 0 - new
+labels: tooling, 0 - new
 assignees: ""
 ---
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Label emoji have been dropped, so this updates our GH issue templates to match.