### PR TITLE
feat(color): allow color input nudging by using ⬆ ⬇ (+shift) keys

### DIFF
--- a/src/components/calcite-color-hex-input/calcite-color-hex-input.e2e.ts
+++ b/src/components/calcite-color-hex-input/calcite-color-hex-input.e2e.ts
@@ -169,5 +169,31 @@ describe("calcite-color-hex-input", () => {
       await assertTabAndEnterBehavior("aa", startingHex);
       await assertTabAndEnterBehavior("a", startingHex);
     });
+
+    it("allows nudging RGB channels with arrow keys (+/-1) and shift modifies amount (+/-10)", async () => {
+      const initialHex = "#000000";
+
+      await input.callMethod("setFocus");
+      await input.setProperty("value", initialHex);
+      await page.waitForChanges();
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("#010101");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe(initialHex);
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("ArrowUp");
+      await page.keyboard.up("Shift");
+      expect(await input.getProperty("value")).toBe("#0a0a0a");
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.up("Shift");
+      expect(await input.getProperty("value")).toBe(initialHex);
+    });
   });
 });

--- a/src/components/calcite-color-hex-input/calcite-color-hex-input.tsx
+++ b/src/components/calcite-color-hex-input/calcite-color-hex-input.tsx
@@ -24,6 +24,7 @@ import { Scale, Theme } from "../../interfaces/common";
 import { RGB } from "../../interfaces/Color";
 import { focusElement, getElementDir } from "../../utils/dom";
 import { TEXT } from "../calcite-color/resources";
+import { getKey } from "../../utils/key";
 
 const DEFAULT_COLOR = Color();
 
@@ -137,7 +138,8 @@ export class CalciteColorHexInput {
   };
 
   private onInputKeyDown = (event: KeyboardEvent): void => {
-    const { key, altKey, ctrlKey, metaKey, shiftKey } = event;
+    const { altKey, ctrlKey, metaKey, shiftKey } = event;
+    const key = getKey(event.key);
 
     if (key === "ArrowDown" || key === "ArrowUp") {
       const direction = key === "ArrowUp" ? 1 : -1;
@@ -230,8 +232,6 @@ export class CalciteColorHexInput {
   }
 
   private nudgeRGBChannels(color: Color, amount: number): Color {
-    const [r, g, b] = color.array();
-
-    return Color.rgb(r + amount, g + amount, b + amount);
+    return Color.rgb(color.array().map((channel) => channel + amount));
   }
 }

--- a/src/components/calcite-color-hex-input/calcite-color-hex-input.tsx
+++ b/src/components/calcite-color-hex-input/calcite-color-hex-input.tsx
@@ -137,9 +137,19 @@ export class CalciteColorHexInput {
   };
 
   private onInputKeyDown = (event: KeyboardEvent): void => {
-    const { inputNode } = this;
-    const { key, altKey, ctrlKey, metaKey } = event;
+    const { key, altKey, ctrlKey, metaKey, shiftKey } = event;
 
+    if (key === "ArrowDown" || key === "ArrowUp") {
+      const direction = key === "ArrowUp" ? 1 : -1;
+      const bump = shiftKey ? 10 : 1;
+
+      this.value = normalizeHex(this.nudgeRGBChannels(this.internalColor, bump * direction).hex());
+
+      event.preventDefault();
+      return;
+    }
+
+    const { inputNode } = this;
     const withModifiers = altKey || ctrlKey || metaKey;
     const exceededHexLength = inputNode.value.length >= 6;
     const hasTextSelection = getSelection().type === "Range";
@@ -217,5 +227,11 @@ export class CalciteColorHexInput {
 
   private formatForInternalInput(hex: string): string {
     return hex.replace("#", "");
+  }
+
+  private nudgeRGBChannels(color: Color, amount: number): Color {
+    const [r, g, b] = color.array();
+
+    return Color.rgb(r + amount, g + amount, b + amount);
   }
 }

--- a/src/components/calcite-color/calcite-color.e2e.ts
+++ b/src/components/calcite-color/calcite-color.e2e.ts
@@ -267,6 +267,29 @@ describe("calcite-color", () => {
       await page.waitForChanges();
     };
 
+    const assertChannelValueNudge = async (page: E2EPage, inputOrHexInput: E2EElement): Promise<void> => {
+      await inputOrHexInput.callMethod("setFocus");
+      await page.waitForChanges();
+
+      const currentValue = await inputOrHexInput.getProperty("value");
+
+      await page.keyboard.press("ArrowUp");
+      expect(await inputOrHexInput.getProperty("value")).toBe(currentValue + 1);
+
+      await page.keyboard.press("ArrowDown");
+      expect(await inputOrHexInput.getProperty("value")).toBe(currentValue);
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("ArrowUp");
+      await page.keyboard.up("Shift");
+      expect(await inputOrHexInput.getProperty("value")).toBe(currentValue + 10);
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.up("Shift");
+      expect(await inputOrHexInput.getProperty("value")).toBe(currentValue);
+    };
+
     it("keeps value in same format when applying updates", async () => {
       const page = await newE2EPage({
         html: "<calcite-color></calcite-color>"
@@ -290,6 +313,10 @@ describe("calcite-color", () => {
         await clearAndEnterValue(page, gInput, "64");
         await clearAndEnterValue(page, bInput, "32");
 
+        await assertChannelValueNudge(page, rInput);
+        await assertChannelValueNudge(page, gInput);
+        await assertChannelValueNudge(page, bInput);
+
         assertColorUpdate(await picker.getProperty("value"));
 
         await hsvModeButton.click();
@@ -299,6 +326,10 @@ describe("calcite-color", () => {
         await clearAndEnterValue(page, hInput, "180");
         await clearAndEnterValue(page, sInput, "90");
         await clearAndEnterValue(page, vInput, "45");
+
+        await assertChannelValueNudge(page, hInput);
+        await assertChannelValueNudge(page, sInput);
+        await assertChannelValueNudge(page, vInput);
 
         assertColorUpdate(await picker.getProperty("value"));
       };

--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -26,6 +26,7 @@ import {
 import { focusElement, getElementDir } from "../../utils/dom";
 import { colorEqual, CSSColorMode, normalizeHex, parseMode, SupportedMode } from "./utils";
 import { throttle } from "lodash-es";
+import { getKey } from "../../utils/key";
 
 const throttleFor60FpsInMs = 16;
 const defaultColor = normalizeHex(DEFAULT_COLOR.hex());
@@ -285,6 +286,8 @@ export class CalciteColor {
   };
 
   private handleChannelKeyUpOrDown = ({ key, shiftKey }: KeyboardEvent): void => {
+    key = getKey(key);
+
     // this gets applied to the input's up/down arrow increment/decrement
     const complementaryBump = 9;
 

--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -219,6 +219,8 @@ export class CalciteColor {
 
   private mode: SupportedMode = CSSColorMode.HEX;
 
+  private shiftKeyChannelAdjustment = 0;
+
   private sliderThumbState: "idle" | "hover" | "drag" = "idle";
 
   @State() colorFieldAndSliderInteractive = false;
@@ -264,18 +266,34 @@ export class CalciteColor {
     this.internalColorSet(Color(swatch.color));
   };
 
-  private handleChannelInput = (event: KeyboardEvent): void => {
-    const input = event.target as HTMLInputElement;
-    const channelIndex = Number(input.getAttribute("data-channel-index"));
+  private handleChannelInput = (event: CustomEvent): void => {
+    const input = event.currentTarget as HTMLCalciteInputElement;
+    const internalInput = event.target as HTMLInputElement;
+    const channelIndex = Number(internalInput.getAttribute("data-channel-index"));
 
     const limit =
       this.channelMode === "rgb"
         ? RGB_LIMITS[Object.keys(RGB_LIMITS)[channelIndex]]
         : HSV_LIMITS[Object.keys(HSV_LIMITS)[channelIndex]];
 
-    const clamped = Math.max(0, Math.min(Number(input.value), limit));
+    const value = Number(internalInput.value) + this.shiftKeyChannelAdjustment;
+    const clamped = Math.max(0, Math.min(value, limit));
 
+    // need to update both calcite-input and its internal input to keep them in sync
     input.value = `${clamped}`;
+    internalInput.value = `${clamped}`;
+  };
+
+  private handleChannelKeyUpOrDown = ({ key, shiftKey }: KeyboardEvent): void => {
+    // this gets applied to the input's up/down arrow increment/decrement
+    const complementaryBump = 9;
+
+    this.shiftKeyChannelAdjustment =
+      key === "ArrowUp" && shiftKey
+        ? complementaryBump
+        : key === "ArrowDown" && shiftKey
+        ? -complementaryBump
+        : 0;
   };
 
   private handleChannelChange = (event: KeyboardEvent): void => {
@@ -536,6 +554,8 @@ export class CalciteColor {
       numberButtonType="none"
       onChange={this.handleChannelChange}
       onInput={this.handleChannelInput}
+      onKeyDown={this.handleChannelKeyUpOrDown}
+      onKeyUp={this.handleChannelKeyUpOrDown}
       prefixText={label}
       scale="s"
       type="number"

--- a/src/demos/calcite-color-hex-input.html
+++ b/src/demos/calcite-color-hex-input.html
@@ -25,16 +25,16 @@
 
   <h3 class="leader-1">Default</h3>
 
-  <calcite-hex-input></calcite-hex-input>
+  <calcite-color-hex-input value="#beefee"></calcite-color-hex-input>
 
   <h3 class="leader-1">Accepts shorthand and longhand hex</h3>
 
-  <calcite-hex-input value="#F0F"></calcite-hex-input>
-  <calcite-hex-input value="#ff00ff"></calcite-hex-input>
+  <calcite-color-hex-input value="#F0F"></calcite-color-hex-input>
+  <calcite-color-hex-input value="#ff00ff"></calcite-color-hex-input>
 
   <h3 class="leader-1">RTL</h3>
 
-  <calcite-hex-input dir="rtl"></calcite-hex-input>
+  <calcite-color-hex-input dir="rtl"></calcite-color-hex-input>
 </body>
 
 </html>


### PR DESCRIPTION
**Related Issue:** #866 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This enhances `calcite-color` and `calcite-color-hex-input` to allow nudging values when using the arrow keys. Values are nudged by 1 or by 10 if the shift key is pressed alongside an arrow key.

Note that for the hex input, each channel value will be nudged. This is follows how Figma's hex input works, which is referenced in the related issue.