### PR TITLE
build: adding a build watch command for debugging with npm link in external apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "npm run util:copy-icons && stencil build && npm run util:add-custom-elements-index-mjs",
+    "build:watch": "npm run util:copy-icons && stencil build --watch && npm run util:add-custom-elements-index-mjs",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
     "docs": "concurrently --kill-others --raw \"npm:util:build-docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\"  \"ts-node ./support/tempDocDirCleaner.ts\"",
     "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/tempDocDirCleaner.ts\"",


### PR DESCRIPTION
**Related Issue:** n/a

This new command is useful for debugging calcite in say the WebViewer App when using `npm link` to symlink the calcite repo.  `npm start` works for the initial build, but fails to update after changes are made, but this new watch script, which just calls `stencil build --watch` works much more consistently.

After merging this, will update https://devtopia.esri.com/WebGIS/arcgis-webviewer-app/wiki/How-to-live-debug-calcite-components-and-arcgis-components-in-arcgis-webviewer-app to use this new `npm run build:watch` command instead of `npm start`.