### PR TITLE
feat(card): Adds checkbox label props for selectable cards

### DIFF
--- a/src/components/calcite-card/calcite-card.e2e.ts
+++ b/src/components/calcite-card/calcite-card.e2e.ts
@@ -1,15 +1,23 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { renders } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-card", () => {
   it("renders", async () => renders("calcite-card"));
 
+  it("is accessible", async () => accessible("calcite-card"));
+
+  it("is accessible when selectable", async () =>
+    accessible(`
+      <calcite-card selectable>
+        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
+      </calcite-card>`));
+
   it("renders with default props if none are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" />
+        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
       </calcite-card>`);
 
     const element = await page.find("calcite-card");
@@ -23,7 +31,7 @@ describe("calcite-card", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card loading selectable selected disabled>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" />
+        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
       </calcite-card>`);
 
     const element = await page.find("calcite-card");
@@ -37,7 +45,7 @@ describe("calcite-card", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" />
+        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
       </calcite-card>
     `);
 
@@ -50,7 +58,7 @@ describe("calcite-card", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card selectable>
-      <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" />
+      <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
       </calcite-card>
     `);
 

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Host, Prop, VNode } from "@stencil/core";
-import { CSS, SLOTS } from "./resources";
+import { CSS, SLOTS, TEXT } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 
@@ -47,6 +47,12 @@ export class CalciteCard {
 
   /**  The theme of the card.*/
   @Prop({ reflect: true }) theme: "light" | "dark";
+
+  /** string to override English select text for checkbox when selectable is true */
+  @Prop({ reflect: false }) intlSelect: string = TEXT.select;
+
+  /** string to override English deselect text for checkbox when selectable is true */
+  @Prop({ reflect: false }) intlDeselect: string = TEXT.deselect;
 
   //--------------------------------------------------------------------------
   //
@@ -127,14 +133,19 @@ export class CalciteCard {
   }
 
   private renderCheckbox(): VNode {
+    const checkboxLabel = this.selected ? this.intlDeselect : this.intlSelect;
+    console.log(checkboxLabel);
+
     return (
-      <div
+      <label
+        aria-label={checkboxLabel}
         class={CSS.checkboxWrapper}
         onClick={() => this.cardSelectClick()}
         onKeyDown={(e) => this.cardSelectKeyDown(e)}
+        title={checkboxLabel}
       >
         <calcite-checkbox checked={this.selected} theme={this.theme} />
-      </div>
+      </label>
     );
   }
 

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -134,7 +134,6 @@ export class CalciteCard {
 
   private renderCheckbox(): VNode {
     const checkboxLabel = this.selected ? this.intlDeselect : this.intlSelect;
-    console.log(checkboxLabel);
 
     return (
       <label

--- a/src/components/calcite-card/resources.ts
+++ b/src/components/calcite-card/resources.ts
@@ -15,3 +15,8 @@ export const SLOTS = {
   footerLeading: "footer-leading",
   footerTrailing: "footer-trailing"
 };
+
+export const TEXT = {
+  select: "Select",
+  deselect: "Deselect"
+};

--- a/src/demos/calcite-card.html
+++ b/src/demos/calcite-card.html
@@ -61,7 +61,7 @@
     </div>
     <div class="example-grid-item">
       <calcite-card>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
         <h3 slot="title">Portland Businesses</h3>
         <span slot="subtitle">by
           <calcite-link href="">example_user</calcite-link>
@@ -98,7 +98,7 @@
     <div class="example-grid-item">
 
       <calcite-card>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
         <h3 slot="title">My great Workforce project that might wrap two lines</h3>
         <span slot="subtitle">Johnathan Smith</span>
         <span slot="footer-leading">Nov 25, 2018</span>
@@ -119,9 +119,23 @@
 
 
       <calcite-card selected selectable>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
 
         <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+        <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
+          overly verbose.</span>
+        <calcite-link slot="footer-leading">Lead füt</calcite-link>
+        <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+      </calcite-card>
+    </div>
+
+    <div class="example-grid-item">
+
+
+      <calcite-card selected selectable intl-select="translated select" intl-deselect="translated deselect">
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+
+        <h3 slot="title">Translated select and deselect example</h3>
         <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
           overly verbose.</span>
         <calcite-link slot="footer-leading">Lead füt</calcite-link>
@@ -132,7 +146,7 @@
 
 
       <calcite-card loading>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
 
         <h3 slot="title">Loading example</h3>
         <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -145,7 +159,7 @@
     <div class="example-grid-item">
 
       <calcite-card selectable>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
         <h3 slot="title">Untitled experience</h3>
         <span slot="subtitle">Subtext</span>
         <calcite-button slot="footer-leading" width="full">Go</calcite-button>
@@ -165,7 +179,7 @@
     <h2>Same height</h2>
     <div class="block-group">
       <calcite-card selected selectable>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
 
         <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
         <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -174,7 +188,7 @@
         <calcite-link slot="footer-trailing">Trail füt</calcite-link>
       </calcite-card>
       <calcite-card loading>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
 
         <h3 slot="title">Loading example</h3>
         <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
@@ -183,7 +197,7 @@
         <calcite-link slot="footer-trailing">Trail füt</calcite-link>
       </calcite-card>
       <calcite-card selectable>
-        <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
         <h3 slot="title">Untitled experience</h3>
         <span slot="subtitle">Subtext</span>
         <calcite-button slot="footer-leading" width="full">Go</calcite-button>
@@ -202,7 +216,7 @@
     <div class="example-grid">
       <div class="example-grid-item">
         <calcite-card theme="dark">
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
           <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
           <calcite-link theme="dark" slot="footer-leading">Lead füt</calcite-link>
           <calcite-link theme="dark" slot="footer-trailing">Trail füt</calcite-link>
@@ -211,7 +225,7 @@
       <div class="example-grid-item">
 
         <calcite-card theme="dark">
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
           <h3 slot="title">ArcGIS Pro Editing Workflows</h3>
           <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
             overly verbose.</span>
@@ -223,7 +237,7 @@
 
 
         <calcite-card theme="dark">
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
           <h3 slot="title">Portland Businesses</h3>
           <span slot="subtitle">by
             <calcite-link theme="dark" href="">example_user</calcite-link>
@@ -261,7 +275,7 @@
       <div class="example-grid-item">
 
         <calcite-card theme="dark" selected>
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
           <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
 
           <calcite-link theme="dark" slot="footer-leading">Lead füt</calcite-link>
@@ -271,7 +285,7 @@
       <div class="example-grid-item">
 
         <calcite-card theme="dark" selected selectable>
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
           <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
           <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
             overly verbose.</span>


### PR DESCRIPTION
**Related Issue:** #1159 

## Summary
Caught one! While adding accessible tests to cards, I found that our rendered checkbox in the "selectable" card was not accessible. This PR adds two `intl-*` strings to the card component with English fallbacks to "Select" and "Deselect", updates the wrapping element around the checkbox to be a label, and sets aria-label and title. 

I opted to use title to display the "Select" and "Deselect" promps, I suppose this could also be a tooltip... 

Thoughts there on UI - tooltip is certainly nicer looking than a title but may not always be wanted... @mitc7862 @bstifle @asangma ?

Thoughts on UX of chosen text strings @capeoples - they could always be overridden with another English word as well if Select and Deselect are not desired by an app for whatever reason.

@jcfranco I did lump the tests in with this PR... let me know if I should remove and do a follow-up PR with those.


Adds intl-select and intl-deselect props along with English fallbacks
Adds accessible tests, adds alt text to slotted content in tests and examples
Updates dev demo
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
