### PR TITLE
test(dom): fix nesting

### DIFF
--- a/src/utils/dom.spec.ts
+++ b/src/utils/dom.spec.ts
@@ -246,12 +246,14 @@ describe("dom", () => {
         });
       });
     });
-    describe("set requested icon", () => {
-      it("returns the custom icon name if custom value is passed", () =>
-        expect(setRequestedIcon({ exampleValue: "exampleReturnedValue" }, "mycustomvalue", "exampleValue")).toBe(
-          "mycustomvalue"
-        ));
-    });
+  });
+
+  describe("setRequestedIcon()", () => {
+    it("returns the custom icon name if custom value is passed", () =>
+      expect(setRequestedIcon({ exampleValue: "exampleReturnedValue" }, "mycustomvalue", "exampleValue")).toBe(
+        "mycustomvalue"
+      ));
+
     it("returns the pre-defined icon name if custom value is not passed", () =>
       expect(setRequestedIcon({ exampleValue: "exampleReturnedValue" }, "", "exampleValue")).toBe(
         "exampleReturnedValue"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Fixed `setRequestedIcon` test block nesting.

🐦 :egg: 🌲  