### PR TITLE
feat(value-list-item): add event emitter to value-list-item

### DIFF
--- a/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
@@ -1,6 +1,6 @@
 import { CSS as PICK_LIST_ITEM_CSS } from "../calcite-pick-list-item/resources";
 import { accessible, focusable, renders } from "../../tests/commonTests";
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import dedent from "dedent";
 
 describe("calcite-value-list-item", () => {
@@ -75,6 +75,23 @@ describe("calcite-value-list-item", () => {
     expect(await item.getProperty("selected")).toBe(true);
   });
 
+  function queryWrappedPickListPart(page: E2EPage, partSelector: string, partMethodToInvoke?: string): Promise<void> {
+    return page.$eval(
+      "calcite-value-list-item",
+      (item: HTMLCalciteValueListItemElement, selector, partMethod?: string) => {
+        const part = item.shadowRoot
+          .querySelector("calcite-pick-list-item")
+          .shadowRoot.querySelector<HTMLElement>(selector);
+
+        if (partMethod) {
+          part[partMethod]();
+        }
+      },
+      partSelector,
+      partMethodToInvoke
+    );
+  }
+
   it("allows for easy removal", async () => {
     const page = await newE2EPage({
       html: `<calcite-value-list-item label="test" value="example" removable></calcite-value-list-item>`
@@ -83,12 +100,7 @@ describe("calcite-value-list-item", () => {
     const item = await page.find("calcite-value-list-item");
     const removeEventSpy = await item.spyOnEvent("calciteListItemRemove");
 
-    await page.$eval(
-      "calcite-value-list-item",
-      (item: HTMLCalciteValueListItemElement, selector) =>
-        item.shadowRoot.querySelector("calcite-pick-list-item").shadowRoot.querySelector<HTMLElement>(selector).click(),
-      `.${PICK_LIST_ITEM_CSS.remove}`
-    );
+    await queryWrappedPickListPart(page, `.${PICK_LIST_ITEM_CSS.remove}`, "click");
 
     expect(removeEventSpy).toHaveReceivedEventTimes(1);
   });
@@ -101,12 +113,7 @@ describe("calcite-value-list-item", () => {
       </calcite-value-list-item>`
     });
 
-    const actionsNodeStart = await page.$eval(
-      "calcite-value-list-item",
-      (item: HTMLCalciteValueListItemElement, selector) =>
-        item.shadowRoot.querySelector("calcite-pick-list-item").shadowRoot.querySelector(selector),
-      `.${PICK_LIST_ITEM_CSS.actionsStart}`
-    );
+    const actionsNodeStart = await queryWrappedPickListPart(page, `.${PICK_LIST_ITEM_CSS.actionsStart}`);
 
     expect(actionsNodeStart).not.toBeNull();
   });
@@ -119,12 +126,7 @@ describe("calcite-value-list-item", () => {
       </calcite-value-list-item>`
     });
 
-    const actionsNodeEnd = await page.$eval(
-      "calcite-value-list-item",
-      (item: HTMLCalciteValueListItemElement, selector) =>
-        item.shadowRoot.querySelector("calcite-pick-list-item").shadowRoot.querySelector(selector),
-      `.${PICK_LIST_ITEM_CSS.actionsEnd}`
-    );
+    const actionsNodeEnd = await queryWrappedPickListPart(page, `.${PICK_LIST_ITEM_CSS.actionsEnd}`);
 
     expect(actionsNodeEnd).not.toBeNull();
   });

--- a/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
@@ -1,0 +1,131 @@
+import { CSS as PICK_LIST_ITEM_CSS } from "../calcite-pick-list-item/resources";
+import { accessible, focusable, renders } from "../../tests/commonTests";
+import { newE2EPage } from "@stencil/core/testing";
+import dedent from "dedent";
+
+describe("calcite-value-list-item", () => {
+  it("renders", async () => renders("calcite-value-list-item"));
+
+  it("is accessible", async () =>
+    Promise.all([
+      accessible(dedent`
+        <calcite-value-list>
+          <calcite-value-list-item label="test" description="a number" value="one"></calcite-value-list-item>
+        </calcite-value-list>
+      `),
+
+      accessible(dedent`
+        <calcite-value-list>
+          <calcite-value-list-item label="test" description="a number" value="one" selected></calcite-value-list-item>
+        </calcite-value-list>
+      `),
+
+      accessible(dedent`
+        <calcite-value-list>
+          <calcite-value-list-item label="test" description="a number" value="one" removable></calcite-value-list-item>
+        </calcite-value-list>
+      `)
+    ]));
+
+  it("is focusable", async () => focusable("calcite-value-list-item"));
+
+  it("should toggle selected attribute when clicked", async () => {
+    const page = await newE2EPage({ html: `<calcite-value-list-item label="test"></calcite-value-list-item>` });
+
+    const item = await page.find("calcite-value-list-item");
+    expect(await item.getProperty("selected")).toBe(false);
+
+    await item.click();
+    expect(await item.getProperty("selected")).toBe(true);
+
+    await item.click();
+    expect(await item.getProperty("selected")).toBe(false);
+  });
+
+  it("should fire event calciteListItemChange when item is clicked", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-value-list-item label="test" value="example"></calcite-value-list-item>`
+    });
+    const item = await page.find("calcite-value-list-item");
+    await page.evaluate(() =>
+      document.addEventListener("calciteListItemChange", (event: CustomEvent): void => {
+        (window as any).eventDetail = event.detail;
+      })
+    );
+
+    await item.click();
+
+    const eventDetail: any = await page.evaluateHandle(() => (window as any).eventDetail);
+    const properties = await eventDetail.getProperties();
+
+    expect(properties.get("item")).toBeDefined();
+    expect(properties.get("value")._remoteObject.value).toBe("example");
+    expect(properties.get("selected")._remoteObject.value).toBe(true);
+    expect(properties.get("shiftPressed")._remoteObject.value).toBe(false);
+  });
+
+  it("prevents deselection when disableDeselect is true", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-value-list-item label="test" value="example" disable-deselect selected></calcite-value-list-item>`
+    });
+    const item = await page.find("calcite-value-list-item");
+
+    await item.click();
+
+    expect(await item.getProperty("selected")).toBe(true);
+  });
+
+  it("allows for easy removal", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-value-list-item label="test" value="example" removable></calcite-value-list-item>`
+    });
+
+    const item = await page.find("calcite-value-list-item");
+    const removeEventSpy = await item.spyOnEvent("calciteListItemRemove");
+
+    await page.$eval(
+      "calcite-value-list-item",
+      (item: HTMLCalciteValueListItemElement, selector) =>
+        item.shadowRoot.querySelector("calcite-pick-list-item").shadowRoot.querySelector<HTMLElement>(selector).click(),
+      `.${PICK_LIST_ITEM_CSS.remove}`
+    );
+
+    expect(removeEventSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it("supports adding start-actions", async () => {
+    const page = await newE2EPage({
+      html: `
+      <calcite-value-list-item label="test" description="example">
+        <calcite-action text="test" slot="actions-start"></calcite-action>
+      </calcite-value-list-item>`
+    });
+
+    const actionsNodeStart = await page.$eval(
+      "calcite-value-list-item",
+      (item: HTMLCalciteValueListItemElement, selector) =>
+        item.shadowRoot.querySelector("calcite-pick-list-item").shadowRoot.querySelector(selector),
+      `.${PICK_LIST_ITEM_CSS.actionsStart}`
+    );
+
+    expect(actionsNodeStart).not.toBeNull();
+  });
+
+  it("supports adding end-actions", async () => {
+    const page = await newE2EPage({
+      html: `
+      <calcite-value-list-item label="test" description="example">
+        <calcite-action text="test" slot="actions-end"></calcite-action>
+      </calcite-value-list-item>`
+    });
+
+    const actionsNodeEnd = await page.$eval(
+      "calcite-value-list-item",
+      (item: HTMLCalciteValueListItemElement, selector) =>
+        item.shadowRoot.querySelector("calcite-pick-list-item").shadowRoot.querySelector(selector),
+      `.${PICK_LIST_ITEM_CSS.actionsEnd}`
+    );
+
+    expect(actionsNodeEnd).not.toBeNull();
+  });
+});

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -1,4 +1,15 @@
-import { Component, Element, h, Host, Listen, Method, Prop, VNode } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Method,
+  Prop,
+  VNode
+} from "@stencil/core";
 import { ICON_TYPES } from "../calcite-pick-list/resources";
 import { guid } from "../../utils/guid";
 import { CSS } from "../calcite-pick-list-item/resources";
@@ -105,6 +116,12 @@ export class CalciteValueListItem {
   //  Events
   //
   // --------------------------------------------------------------------------
+
+  /**
+   * Emitted whenever the remove button is pressed.
+   * @event calciteListItemRemove
+   */
+  @Event() calciteListItemRemove: EventEmitter<void>; // wrapped pick-list-item emits this
 
   @Listen("calciteListItemChange")
   calciteListItemChangeHandler(event: CustomEvent): void {


### PR DESCRIPTION
**Related Issue:** #1306

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This adds an event emitter to `calcite-value-list-item` to have the event listener show up in the types. The `calciteListItemRemove` event is emitted by the wrapped `calcite-pick-list-item` component.

cc @pemberdom

~Note that this adds a test suite (based on `calcite-pick-list-item`) since it was never added. 😱~ moved over to #1313