### PR TITLE
build: setting Screener's failureExitCode to 0 so that it doesn't break successful Travis builds

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -9,5 +9,6 @@ module.exports = {
     {
       browserName: 'chrome'
     }
-  ]
+  ],
+  failureExitCode: 0
 };


### PR DESCRIPTION
This setting change will prevent Travis from failing (when the rest of the build succeeds) when Screener detects visual regressions.  Merging continues to be blocked while Screener regressions are resolved.  Once Screener regressions are resolved, the Github PR's Screener status will update and greenlight the PR properly without having to re-run the Travis build again.

See setup steps here for more information: https://screener.io/v2/docs/github

**Related Issue:** n/a