### PR TITLE
fix(dropdown): Emit close event on trigger click

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -403,7 +403,7 @@ export class CalciteDropdown {
             this.closeCalciteDropdown();
             break;
         }
-      } else if (key === "Escape" || (e.shiftKey && key === "Tab")) {
+      } else if (this.active && (key === "Escape" || (e.shiftKey && key === "Tab"))) {
         this.closeCalciteDropdown();
       }
     }
@@ -493,6 +493,8 @@ export class CalciteDropdown {
 
     if (this.active) {
       setTimeout(() => this.focusOnFirstActiveOrFirstItem(), animationDelayInMs);
+    } else {
+      this.calciteDropdownClose.emit();
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** Resolves #1003 cc @joeyHarig 

## Summary
Ensures the close event is fired when a user clicks on a dropdown-trigger of an open dropdown.
Also adds a check to prevent the close function from running when "shift tabbing" backwards through triggers with closed dropdowns.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
