### PR TITLE
docs(alert): Update Storybook

### DIFF
--- a/src/components/calcite-alert/calcite-alert.stories.ts
+++ b/src/components/calcite-alert/calcite-alert.stories.ts
@@ -12,9 +12,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="light"
     ${boolean("icon", true)}
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
     <div slot="alert-title">Here's a general bit of information</div></div>
@@ -31,9 +31,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="light"
     ${boolean("icon", true)}
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
     <div slot="alert-title">Something failed</div>
@@ -49,9 +49,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="light"
     ${boolean("icon", true)}
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
     <div slot="alert-message">
@@ -67,9 +67,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="light"
     ${boolean("icon", true)}
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "yellow")}">
     <div slot="alert-message">
@@ -84,9 +84,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="light"
     icon="${select("icon", iconNames, iconNames[0])}"
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
     <div slot="alert-message">
@@ -152,9 +152,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="dark"
     ${boolean("icon", true)}
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
   auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
     <div slot="alert-title">Something failed</div>
@@ -222,9 +222,9 @@ storiesOf("Components/Alert", module)
     <calcite-alert
     theme="light"
     ${boolean("icon", true)}
-    auto-dismiss="${boolean("auto-dismiss", false)}"
+    ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    active="${boolean("active", true)}"
+    ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
     color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
     <div slot="alert-title">Something failed</div>


### PR DESCRIPTION
Uses the boolean helper to allow auto-dismiss to be false by default - this is a better "default" story and will also prevent Screener from taking snapshots at different dismiss progression percentages. 

**Related Issue:** #

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
