### PR TITLE
feat(select): add selectedOption convenience prop

### DIFF
--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, focusable, reflects, renders } from "../../tests/commonTests";
 import dedent from "dedent";
 import { CSS } from "./resources";
@@ -34,6 +34,15 @@ describe("calcite-select", () => {
       }
     ]));
 
+  async function assertSelectedOption(page: E2EPage, selectedOption: E2EElement): void {
+    const selectedOptionValue = await page.$eval(
+      "calcite-select",
+      (select: HTMLCalciteSelectElement): string => select.selectedOption.value
+    );
+
+    expect(selectedOptionValue).toBe(await selectedOption.getProperty("value"));
+  }
+
   describe("flat options", () => {
     it("allows selecting items", async () => {
       const page = await newE2EPage({
@@ -57,6 +66,7 @@ describe("calcite-select", () => {
 
       const selected = await page.findAll("calcite-option[selected]");
 
+      await assertSelectedOption(page, selected[0]);
       expect(selected.length).toBe(1);
       expect(selected[0].innerText).toBe("dos");
       expect(spy).toHaveReceivedEventTimes(1);
@@ -74,6 +84,7 @@ describe("calcite-select", () => {
       });
       const selected = await page.findAll("calcite-option[selected]");
 
+      await assertSelectedOption(page, selected[0]);
       expect(selected).toHaveLength(1);
       expect(selected[0].innerText).toBe("tres");
     });
@@ -90,6 +101,7 @@ describe("calcite-select", () => {
       });
       const selected = await page.findAll("calcite-option[selected]");
 
+      await assertSelectedOption(page, selected[0]);
       expect(selected).toHaveLength(1);
       expect(selected[0].innerText).toBe("uno");
     });
@@ -158,6 +170,7 @@ describe("calcite-select", () => {
 
       const selected = await page.findAll("calcite-option[selected]");
 
+      await assertSelectedOption(page, selected[0]);
       expect(selected.length).toBe(1);
       expect(selected[0].innerText).toBe("c");
       expect(spy).toHaveReceivedEventTimes(1);
@@ -182,6 +195,7 @@ describe("calcite-select", () => {
       });
       const selected = await page.findAll("calcite-option[selected]");
 
+      await assertSelectedOption(page, selected[0]);
       expect(selected).toHaveLength(1);
       expect(selected[0].innerText).toBe("3");
     });
@@ -205,6 +219,7 @@ describe("calcite-select", () => {
       });
       const selected = await page.findAll("calcite-option[selected]");
 
+      await assertSelectedOption(page, selected[0]);
       expect(selected).toHaveLength(1);
       expect(selected[0].innerText).toBe("a");
     });

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -228,13 +228,19 @@ export class CalciteSelect {
       return;
     }
 
+    let futureSelected: HTMLCalciteOptionElement;
+
     this.componentToNativeEl.forEach((nativeOptionOrGroup, optionOrGroup) => {
       if (isOption(optionOrGroup) && nativeOptionOrGroup === nativeOption) {
         optionOrGroup.selected = true;
-        this.selectedOption = optionOrGroup;
+        futureSelected = optionOrGroup;
         this.deselectAllExcept(optionOrGroup as HTMLCalciteOptionElement);
       }
     });
+
+    if (futureSelected) {
+      requestAnimationFrame(() => (this.selectedOption = futureSelected));
+    }
   }
 
   private toNativeElement(

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -64,6 +64,14 @@ export class CalciteSelect {
   scale: Scale = "m";
 
   /**
+   * The currently selected option.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true })
+  selectedOption: HTMLCalciteOptionElement;
+
+  /**
    * The component theme.
    */
   @Prop({
@@ -137,8 +145,9 @@ export class CalciteSelect {
   calciteSelectChange: EventEmitter<void>;
 
   private handleInternalSelectChange = (): void => {
-    this.selectFromNativeOption(this.selectEl.selectedOptions[0]);
-    requestAnimationFrame(this.emitChangeEvent);
+    const selected = this.selectEl.selectedOptions[0];
+    this.selectFromNativeOption(selected);
+    requestAnimationFrame(() => this.emitChangeEvent());
   };
 
   @Listen("calciteOptionChange")
@@ -222,6 +231,7 @@ export class CalciteSelect {
     this.componentToNativeEl.forEach((nativeOptionOrGroup, optionOrGroup) => {
       if (isOption(optionOrGroup) && nativeOptionOrGroup === nativeOption) {
         optionOrGroup.selected = true;
+        this.selectedOption = optionOrGroup;
         this.deselectAllExcept(optionOrGroup as HTMLCalciteOptionElement);
       }
     });


### PR DESCRIPTION
**Related Issue:** #1250

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This enhances `calcite-select`'s API with a convenience prop for the currently selected option. 

Note that the prop technically be read-only, but at least it will be doc'd as such.