### PR TITLE
refactor: enhance focusable test helper to support more use cases

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
+import dedent from "dedent";
 
 describe("calcite-action-bar", () => {
   it("renders", async () => renders("calcite-action-bar"));
@@ -152,22 +153,18 @@ describe("calcite-action-bar", () => {
     </calcite-action-bar>
     `));
 
-  it("should focus on toggle button", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-bar>
-      <calcite-action-group>
-        <calcite-action text="Add" icon="plus"></calcite-action>
-      </calcite-action-group>
-    </calcite-action-bar>`
-    });
-
-    const tagName = await page.evaluate(async () => {
-      const actionBar = document.querySelector("calcite-action-bar");
-      await actionBar.setFocus("expand-toggle");
-      const activeElement = actionBar.shadowRoot.activeElement;
-      return activeElement.tagName;
-    });
-
-    expect(tagName).toBe("CALCITE-ACTION");
-  });
+  it("should focus on toggle button", async () =>
+    focusable(
+      dedent`
+        <calcite-action-bar>
+          <calcite-action-group>
+            <calcite-action text="Add" icon="plus"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      `,
+      {
+        focusId: "expand-toggle",
+        focusTargetSelector: "calcite-action-bar"
+      }
+    ));
 });

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -136,7 +136,7 @@ export class CalciteActionBar {
   @Method()
   async setFocus(focusId?: "expand-toggle"): Promise<void> {
     if (focusId === "expand-toggle") {
-      await focusElement(this.expandToggleEl);
+      focusElement(this.expandToggleEl);
       return;
     }
 

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -136,7 +136,7 @@ export class CalciteActionBar {
   @Method()
   async setFocus(focusId?: "expand-toggle"): Promise<void> {
     if (focusId === "expand-toggle") {
-      focusElement(this.expandToggleEl);
+      await focusElement(this.expandToggleEl);
       return;
     }
 

--- a/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
+import dedent from "dedent";
 
 describe("calcite-action-pad", () => {
   it("renders", async () => renders("calcite-action-pad"));
@@ -131,22 +132,18 @@ describe("calcite-action-pad", () => {
     </calcite-action-pad>
     `));
 
-  it("should focus on toggle button", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-pad>
-        <calcite-action-group>
-          <calcite-action text="Add" icon="plus"></calcite-action>
-        </calcite-action-group>
-      </calcite-action-pad>`
-    });
-
-    const tagName = await page.evaluate(async () => {
-      const actionPad = document.querySelector("calcite-action-pad");
-      await actionPad.setFocus("expand-toggle");
-      const activeElement = actionPad.shadowRoot.activeElement;
-      return activeElement.tagName;
-    });
-
-    expect(tagName).toBe("CALCITE-ACTION");
-  });
+  it("should focus on toggle button", async () =>
+    focusable(
+      dedent`
+        <calcite-action-pad>
+          <calcite-action-group>
+            <calcite-action text="Add" icon="plus"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-pad>
+      `,
+      {
+        focusId: "expand-toggle",
+        focusTargetSelector: "calcite-action-pad"
+      }
+    ));
 });

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.e2e.ts
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.e2e.ts
@@ -1,17 +1,7 @@
-import { newE2EPage } from "@stencil/core/testing";
-import { renders } from "../../tests/commonTests";
+import { focusable, renders } from "../../tests/commonTests";
 
 describe("calcite-dropdown-item", () => {
   it("renders", () => renders("calcite-dropdown-item"));
 
-  it("can be focused", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-dropdown-item></calcite-dropdown-item>"
-    });
-    const element = await page.find("calcite-dropdown-item");
-
-    await element.callMethod("setFocus");
-
-    expect(await page.evaluate(() => document.activeElement.tagName)).toEqual("CALCITE-DROPDOWN-ITEM");
-  });
+  it("can be focused", async () => focusable(`calcite-dropdown-item`));
 });

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { HYDRATED_ATTR } from "../../tests/commonTests";
+import { focusable, HYDRATED_ATTR } from "../../tests/commonTests";
 
 describe("calcite-input", () => {
   it("renders", async () => {
@@ -150,21 +150,10 @@ describe("calcite-input", () => {
     expect(numberHorizontalItemUp).toBeNull();
   });
 
-  it("focuses child input when setFocus method is called", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-label>
-    Label text
-    <calcite-input></calcite-input>
-    </calcite-label>
-    `);
-
-    const element = await page.find("calcite-input");
-    await element.callMethod("setFocus");
-    await page.waitForChanges();
-    const activeEl = await page.evaluate(() => document.activeElement["s-hn"]);
-    expect(activeEl).toEqual(element.nodeName);
-  });
+  it("focuses child input when setFocus method is called", async () =>
+    focusable(`calcite-input`, {
+      focusTargetSelector: "input"
+    }));
 
   it("correctly increments and decrements value when number buttons are clicked", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, renders } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-panel", () => {
@@ -59,44 +59,22 @@ describe("calcite-panel", () => {
     </calcite-panel>
     `));
 
-  it("should focus on close button", async () => {
-    const page = await newE2EPage({ html: "<calcite-panel dismissible>test</calcite-panel>" });
+  it("should focus on close button", async () =>
+    focusable(`<calcite-panel dismissible>test</calcite-panel>`, {
+      focusId: "dismiss-button",
+      shadowFocusTargetSelector: "calcite-action"
+    }));
 
-    const tagName = await page.evaluate(async () => {
-      const calcitePanel = document.querySelector("calcite-panel");
-      await calcitePanel.setFocus("dismiss-button");
-      const activeElement = calcitePanel.shadowRoot.activeElement;
-      return activeElement.tagName;
-    });
+  it("should focus on back button", async () =>
+    focusable(`<calcite-panel show-back-button>test</calcite-panel>`, {
+      focusId: "back-button",
+      shadowFocusTargetSelector: "calcite-action"
+    }));
 
-    expect(tagName).toBe("CALCITE-ACTION");
-  });
-
-  it("should focus on back button", async () => {
-    const page = await newE2EPage({ html: "<calcite-panel show-back-button>test</calcite-panel>" });
-
-    const tagName = await page.evaluate(async () => {
-      const calcitePanel = document.querySelector("calcite-panel");
-      await calcitePanel.setFocus("back-button");
-      const activeElement = calcitePanel.shadowRoot.activeElement;
-      return activeElement.tagName;
-    });
-
-    expect(tagName).toBe("CALCITE-ACTION");
-  });
-
-  it("should focus on container", async () => {
-    const page = await newE2EPage({ html: "<calcite-panel dismissible>test</calcite-panel>" });
-
-    const tagName = await page.evaluate(async () => {
-      const calcitePanel = document.querySelector("calcite-panel");
-      await calcitePanel.setFocus();
-      const activeElement = calcitePanel.shadowRoot.activeElement;
-      return activeElement.tagName;
-    });
-
-    expect(tagName).toBe("ARTICLE");
-  });
+  it("should focus on container", async () =>
+    focusable(`<calcite-panel dismissible>test</calcite-panel>`, {
+      shadowFocusTargetSelector: "article"
+    }));
 
   it("honors calcitePanelScroll event", async () => {
     const page = await newE2EPage({
@@ -141,7 +119,7 @@ describe("calcite-panel", () => {
   it("should not render a header if there are no actions or content", async () => {
     const page = await newE2EPage();
 
-    await page.setContent("<calcite-panel>test</<calcite-panel>");
+    await page.setContent("<calcite-panel>test</calcite-panel>");
 
     const header = await page.find(`calcite-panel >>> .${CSS.header}`);
 
@@ -314,7 +292,7 @@ describe("calcite-panel", () => {
   it("should not render footer node if there are no actions or content", async () => {
     const page = await newE2EPage();
 
-    await page.setContent("<calcite-panel>test</<calcite-panel>");
+    await page.setContent("<calcite-panel>test</calcite-panel>");
 
     const footer = await page.find(`calcite-panel >>> .${CSS.footer}`);
 

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -1,4 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { focusable } from "../../tests/commonTests";
+import dedent from "dedent";
 
 describe("calcite-radio-group", () => {
   it("renders", async () => {
@@ -237,34 +239,32 @@ describe("calcite-radio-group", () => {
   });
 
   describe("setFocus()", () => {
-    it("focuses the first item if there is no selection", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-radio-group>
-          <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
-          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
-          <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
-        </calcite-radio-group>`
-      });
+    it("focuses the first item if there is no selection", async () =>
+      focusable(
+        dedent`
+          <calcite-radio-group>
+            <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+          </calcite-radio-group>
+        `,
+        {
+          focusTargetSelector: "#child-1"
+        }
+      ));
 
-      const element = await page.find("calcite-radio-group");
-      await element.callMethod("setFocus");
-
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-1");
-    });
-
-    it("focuses the selected item", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-radio-group>
-          <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
-          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
-          <calcite-radio-group-item id="child-3" value="3" checked>three</calcite-radio-group-item>
-        </calcite-radio-group>`
-      });
-
-      const element = await page.find("calcite-radio-group");
-      await element.callMethod("setFocus");
-
-      expect(await page.evaluate(() => document.activeElement.id)).toEqual("child-3");
-    });
+    it("focuses the selected item", async () =>
+      focusable(
+        dedent`
+          <calcite-radio-group>
+            <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-3" value="3" checked>three</calcite-radio-group-item>
+          </calcite-radio-group>
+        `,
+        {
+          focusTargetSelector: "#child-3"
+        }
+      ));
   });
 });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Stems from https://github.com/Esri/calcite-components/pull/1309#discussion_r534349890

This adds the following improvements to the `focusable` test helper:

* `focusId` can now be specified to be passed into `setFocus()` (if the component supports focusing different parts)
* uses a selector to match focused element instead of an element's tag
* can specify a selector to match the focusable element on the light and shadow DOM. The shadow DOM use case is used to assert the actual elements focused inside a component's shadow tree.