### PR TITLE
fix(date): solve rerender issues in some timezones (#1111)

### DIFF
--- a/src/components/calcite-date-month-header/calcite-date-month-header.tsx
+++ b/src/components/calcite-date-month-header/calcite-date-month-header.tsx
@@ -66,7 +66,7 @@ export class CalciteDateMonthHeader {
   /**
    *  Changes to active date
    */
-  @Event() calciteActiveDateChange: EventEmitter<Date>;
+  @Event() calciteDateSelect: EventEmitter<Date>;
 
   //--------------------------------------------------------------------------
   //
@@ -183,7 +183,7 @@ export class CalciteDateMonthHeader {
   private handleArrowClick(e: Event, date: Date) {
     e?.preventDefault();
     e.stopPropagation();
-    this.calciteActiveDateChange.emit(date);
+    this.calciteDateSelect.emit(date);
   }
 
   /*
@@ -213,7 +213,7 @@ export class CalciteDateMonthHeader {
       const nextDate = new Date(activeDate);
       nextDate.setFullYear(year as number);
       const inRangeDate = dateFromRange(nextDate, min, max);
-      this.calciteActiveDateChange.emit(inRangeDate);
+      this.calciteDateSelect.emit(inRangeDate);
       yearInput.value = localizeNumber(inRangeDate.getFullYear(), localeData);
     } else {
       // leave the current active date and clean up garbage input

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -10,10 +10,6 @@
   @include calcite-theme-dark();
 }
 
-.slot {
-  display: none;
-}
-
 :host([scale="s"]) {
   max-width: 216px;
 }

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -46,7 +46,7 @@ export class CalciteDate {
   @Prop() value?: string;
 
   /** Selected date as full date object*/
-  @State() valueAsDate?: Date;
+  @Prop() valueAsDate?: Date;
 
   /** Earliest allowed date ("yyyy-mm-dd") */
   @Prop() min?: string;

--- a/src/components/calcite-date/calcite-date.tsx
+++ b/src/components/calcite-date/calcite-date.tsx
@@ -15,7 +15,7 @@ import {
 } from "@stencil/core";
 import { getLocaleData, DateLocaleData } from "./utils";
 import { getElementDir } from "../../utils/dom";
-import { dateFromRange, inRange, dateFromISO, dateToISO, parseDateString } from "../../utils/date";
+import { dateFromRange, inRange, dateFromISO, parseDateString, dateToISO } from "../../utils/date";
 import { getKey } from "../../utils/key";
 import { TEXT } from "./calcite-date-resources";
 import { createPopper, updatePopper, CSS as PopperCSS } from "../../utils/popper";
@@ -46,7 +46,7 @@ export class CalciteDate {
   @Prop() value?: string;
 
   /** Selected date as full date object*/
-  @Prop({ mutable: true }) valueAsDate?: Date;
+  @State() valueAsDate?: Date;
 
   /** Earliest allowed date ("yyyy-mm-dd") */
   @Prop() min?: string;
@@ -147,17 +147,12 @@ export class CalciteDate {
   //
   // --------------------------------------------------------------------------
   connectedCallback(): void {
-    this.setupProxyInput();
     this.loadLocaleData();
     if (this.value) {
-      this.setValueAsDate(this.value);
+      this.valueAsDate = dateFromISO(this.value);
     }
 
     this.createPopper();
-  }
-
-  componentWillRender(): void {
-    this.syncProxyInputToThis();
   }
 
   disconnectedCallback(): void {
@@ -174,9 +169,6 @@ export class CalciteDate {
 
     return (
       <Host dir={dir} role="application">
-        <div class="slot">
-          <slot />
-        </div>
         {!this.noCalendarInput && this.localeData && (
           <div aria-expanded={this.active.toString()} ref={this.setReferenceEl} role="application">
             <calcite-input
@@ -210,11 +202,7 @@ export class CalciteDate {
                 localeData={this.localeData}
                 max={max}
                 min={min}
-                onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
-                  this.setValue(new Date(e.detail));
-                  this.activeDate = new Date(e.detail);
-                  this.calciteDateChange.emit(new Date(e.detail));
-                }}
+                onCalciteDateSelect={this.updateSelectedDate}
                 scale={this.scale}
                 selectedDate={date || new Date()}
               />
@@ -224,15 +212,8 @@ export class CalciteDate {
                 localeData={this.localeData}
                 max={max}
                 min={min}
-                onCalciteActiveDateChange={(e: CustomEvent<Date>) => {
-                  this.activeDate = new Date(e.detail);
-                }}
-                onCalciteDateSelect={(e: CustomEvent<Date>) => {
-                  this.setValue(new Date(e.detail));
-                  this.activeDate = new Date(e.detail);
-                  this.calciteDateChange.emit(new Date(e.detail));
-                  this.reset();
-                }}
+                onCalciteActiveDateChange={this.updateActiveDate}
+                onCalciteDateSelect={this.updateSelectedDateAndClose}
                 scale={this.scale}
                 selectedDate={date}
               />
@@ -252,10 +233,6 @@ export class CalciteDate {
 
   private hasShadow: boolean = Build.isBrowser && !!document.head.attachShadow;
 
-  private inputProxy: HTMLInputElement;
-
-  private observer: MutationObserver;
-
   private popper: Popper;
 
   private menuEl: HTMLDivElement;
@@ -267,6 +244,22 @@ export class CalciteDate {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  updateActiveDate = (e: CustomEvent<Date>): void => {
+    this.activeDate = e.detail;
+  };
+
+  updateSelectedDate = (e: CustomEvent<Date>): void => {
+    this.value = dateToISO(e.detail);
+    this.valueAsDate = e.detail;
+    this.activeDate = e.detail;
+    this.calciteDateChange.emit(new Date(e.detail));
+  };
+
+  updateSelectedDateAndClose = (e: CustomEvent<Date>): void => {
+    this.updateSelectedDate(e);
+    this.reset();
+  };
 
   setMenuEl = (el: HTMLDivElement): void => {
     this.menuEl = el;
@@ -312,11 +305,6 @@ export class CalciteDate {
     this.popper = null;
   }
 
-  @Watch("value")
-  valueWatcher(value: string): void {
-    this.setValueAsDate(value);
-  }
-
   @Watch("locale")
   private async loadLocaleData(): Promise<void> {
     const { locale } = this;
@@ -324,84 +312,10 @@ export class CalciteDate {
   }
 
   /**
-   * Register slotted date input proxy, or create one if not provided
-   */
-  setupProxyInput(): void {
-    // check for a proxy input
-    this.inputProxy = this.el.querySelector("input");
-
-    // if the user didn't pass a proxy input create one for them
-    if (!this.inputProxy) {
-      this.inputProxy = document.createElement("input");
-      try {
-        this.inputProxy.type = "date";
-      } catch (e) {
-        this.inputProxy.type = "text";
-      }
-      this.syncProxyInputToThis();
-      this.el.appendChild(this.inputProxy);
-    }
-
-    this.syncThisToProxyInput();
-
-    if (Build.isBrowser) {
-      this.observer = new MutationObserver(this.syncThisToProxyInput);
-      this.observer.observe(this.inputProxy, { attributes: true });
-    }
-  }
-
-  /**
-   * Update component based on input proxy
-   */
-  syncThisToProxyInput = (): void => {
-    this.min = this.inputProxy.min;
-    this.max = this.inputProxy.max;
-    const min = dateFromISO(this.min);
-    const max = dateFromISO(this.max);
-    const date = dateFromISO(this.inputProxy.value);
-    this.value = dateToISO(dateFromRange(date, min, max));
-  };
-
-  /**
-   * Update input proxy
-   */
-  syncProxyInputToThis = (): void => {
-    if (this.inputProxy) {
-      this.inputProxy.value = this.value || "";
-      if (this.min) {
-        this.inputProxy.min = this.min;
-      }
-      if (this.max) {
-        this.inputProxy.max = this.max;
-      }
-    }
-  };
-
-  /**
-   * Set both iso value and date value and update proxy
-   */
-  private setValue(date: Date): void {
-    this.value = new Date(date).toISOString().split("T")[0];
-    this.syncProxyInputToThis();
-  }
-
-  /**
-   * Update date instance of value if valid
-   */
-  private setValueAsDate(value: string): void {
-    if (value) {
-      const date = dateFromISO(value);
-      if (date) {
-        this.valueAsDate = date as Date;
-      }
-    }
-  }
-
-  /**
    * Reset active date and close
    */
   private reset(): void {
-    if (this.valueAsDate) {
+    if (this.valueAsDate && this.valueAsDate?.getTime() !== this.activeDate?.getTime()) {
       this.activeDate = new Date(this.valueAsDate);
     }
     if (!this.noCalendarInput) {
@@ -415,8 +329,8 @@ export class CalciteDate {
   private input(value: string): void {
     const date = this.getDateFromInput(value);
     if (date) {
-      this.setValue(date);
-      this.activeDate = date as Date;
+      this.valueAsDate = date;
+      this.activeDate = date;
       this.calciteDateChange.emit(new Date(date));
     }
   }

--- a/src/demos/calcite-date.html
+++ b/src/demos/calcite-date.html
@@ -123,11 +123,6 @@
   <h2>Always open</h2>
   <calcite-date value="2000-11-27" no-calendar-input="true" active></calcite-date>
 
-  <h2>Input Proxy</h2>
-  <calcite-date>
-    <input type="date" value="2000-11-27" min="1999-12-02" max="2020-12-02">
-  </calcite-date>
-
   <h2>Set Value</h2>
   <calcite-button id="dynamic-button">Set value of date input</calcite-button>
   <calcite-date id="dynamic-value" value="2000-11-27"></calcite-date>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -34,7 +34,10 @@ export function dateFromRange(date?: any, min?: Date | string, max?: Date | stri
  * Parse an iso8601 string (YYYY-mm-dd) into a valid date.
  * TODO: handle time when time of day UI is added
  */
-export function dateFromISO(iso8601: string): Date | null {
+export function dateFromISO(iso8601: string | Date): Date | null {
+  if (iso8601 instanceof Date) {
+    return iso8601;
+  }
   if (!iso8601 || typeof iso8601 !== "string") {
     return null;
   }
@@ -50,7 +53,10 @@ export function dateFromISO(iso8601: string): Date | null {
 /**
  * Return first portion of ISO string (YYYY-mm-dd)
  */
-export function dateToISO(date?: Date): string {
+export function dateToISO(date?: Date | string): string {
+  if (typeof date === "string") {
+    return date;
+  }
   if (date instanceof Date) {
     return date.toISOString().split("T")[0];
   }


### PR DESCRIPTION
BREAKING CHANGE: date component no longer supports setting in input proxy

**Related Issue:** #1111

## Summary

Date component in certain timezone (basically anything past the international dateline) was getting stuck in a render loop. Delving into it there were actually quite a few multiple renders being fired. To solve, I've had to remove the proxy input support for the date component. I've also reworked some updates so that it's more efficient in how it renders. 

Other than the removal of proxy, the API/UX should remain the same.