### PR TITLE
feat(tooltip, popover): Make Tooltip ❤️  Popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "release:publish": "npm run util:push-tags && npm publish && ts-node ./support/releaseToGitHub.ts",
     "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm:build --dev --watch --serve\"",
     "test": "npm run util:run-tests && npm run test:prerender",
+    "test2": "npm run util:copy-icons && stencil test --no-docs --spec --e2e calcite-tooltip",
     "test:prerender": "stencil build --no-docs --prerender",
     "test:storybook": "concurrently --raw \"npm:util:build-docs && screener-storybook --conf screener.config.js\"",
     "test:watch": "npm run util:run-tests -- --watchAll",

--- a/src/components/calcite-popover-manager/calcite-popover-manager.tsx
+++ b/src/components/calcite-popover-manager/calcite-popover-manager.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, h, Listen, Prop, VNode } from "@stencil/core";
 import { POPOVER_REFERENCE } from "../calcite-popover/resources";
-import { getElementByAttributeName } from "../../utils/dom";
+import { getElementByAttributeId } from "../../utils/dom";
 
 @Component({
   tag: "calcite-popover-manager"
@@ -46,8 +46,8 @@ export class CalcitePopoverManager {
   //
   //--------------------------------------------------------------------------
 
-  queryPopover = (el: HTMLElement): HTMLCalcitePopoverElement => {
-    return getElementByAttributeName(
+  getRelatedPopover = (el: HTMLElement): HTMLCalcitePopoverElement => {
+    return getElementByAttributeId(
       el.closest(this.selector),
       POPOVER_REFERENCE
     ) as HTMLCalcitePopoverElement;
@@ -65,18 +65,18 @@ export class CalcitePopoverManager {
     const { autoClose, el } = this;
     const popoverSelector = "calcite-popover";
     const isTargetInsidePopover = target.closest(popoverSelector);
-    const popoverResult = this.queryPopover(target);
+    const relatedPopover = this.getRelatedPopover(target);
 
     if (autoClose && !isTargetInsidePopover) {
       Array.from(document.body.querySelectorAll(popoverSelector))
-        .filter((popover) => popover.open && popover !== popoverResult)
+        .filter((popover) => popover.open && popover !== relatedPopover)
         .forEach((popover) => popover.toggle(false));
     }
 
-    if (!el.contains(target) || !popoverResult) {
+    if (!el.contains(target) || !relatedPopover) {
       return;
     }
 
-    popoverResult.toggle();
+    relatedPopover.toggle();
   }
 }

--- a/src/components/calcite-popover-manager/calcite-popover-manager.tsx
+++ b/src/components/calcite-popover-manager/calcite-popover-manager.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, h, Listen, Prop, VNode } from "@stencil/core";
 import { POPOVER_REFERENCE } from "../calcite-popover/resources";
-import { getDescribedByElement } from "../../utils/dom";
+import { getElementByAttributeName } from "../../utils/dom";
 
 @Component({
   tag: "calcite-popover-manager"
@@ -42,6 +42,19 @@ export class CalcitePopoverManager {
 
   //--------------------------------------------------------------------------
   //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  queryPopover = (el: HTMLElement): HTMLCalcitePopoverElement => {
+    return getElementByAttributeName(
+      el.closest(this.selector),
+      POPOVER_REFERENCE
+    ) as HTMLCalcitePopoverElement;
+  };
+
+  //--------------------------------------------------------------------------
+  //
   //  Event Listeners
   //
   //--------------------------------------------------------------------------
@@ -49,23 +62,23 @@ export class CalcitePopoverManager {
   @Listen("click", { target: "window", capture: true })
   closeOpenPopovers(event: Event): void {
     const target = event.target as HTMLElement;
-    const { autoClose, el, selector } = this;
+    const { autoClose, el } = this;
     const popoverSelector = "calcite-popover";
     const isTargetInsidePopover = target.closest(popoverSelector);
-    const describedByElement = getDescribedByElement(target.closest(selector));
+    const popover = this.queryPopover(target);
 
     if (autoClose && !isTargetInsidePopover) {
       Array.from(document.body.querySelectorAll(popoverSelector))
-        .filter((popover) => popover.open && popover !== describedByElement)
-        .forEach((popover) => popover.toggle(false));
+        .filter((p) => p.open && p !== popover)
+        .forEach((p) => p.toggle(false));
     }
 
     if (!el.contains(target)) {
       return;
     }
 
-    if (describedByElement) {
-      (describedByElement as HTMLCalcitePopoverElement).toggle();
+    if (popover) {
+      popover.toggle();
     }
   }
 }

--- a/src/components/calcite-popover-manager/calcite-popover-manager.tsx
+++ b/src/components/calcite-popover-manager/calcite-popover-manager.tsx
@@ -65,20 +65,18 @@ export class CalcitePopoverManager {
     const { autoClose, el } = this;
     const popoverSelector = "calcite-popover";
     const isTargetInsidePopover = target.closest(popoverSelector);
-    const popover = this.queryPopover(target);
+    const popoverResult = this.queryPopover(target);
 
     if (autoClose && !isTargetInsidePopover) {
       Array.from(document.body.querySelectorAll(popoverSelector))
-        .filter((p) => p.open && p !== popover)
-        .forEach((p) => p.toggle(false));
+        .filter((popover) => popover.open && popover !== popoverResult)
+        .forEach((popover) => popover.toggle(false));
     }
 
-    if (!el.contains(target)) {
+    if (!el.contains(target) || !popoverResult) {
       return;
     }
 
-    if (popover) {
-      popover.toggle();
-    }
+    popoverResult.toggle();
   }
 }

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -2,7 +2,7 @@ import { newE2EPage } from "@stencil/core/testing";
 
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 
-import { CSS } from "./resources";
+import { CSS, POPOVER_REFERENCE } from "./resources";
 
 describe("calcite-popover", () => {
   it("renders", async () =>
@@ -230,7 +230,7 @@ describe("calcite-popover", () => {
     expect(event).toHaveReceivedEventTimes(1);
   });
 
-  it("guid id should match referenceElement's aria-describedby", async () => {
+  it("guid id should match referenceElement's referenceId", async () => {
     const page = await newE2EPage();
 
     await page.setContent(`<calcite-popover open></calcite-popover>`);
@@ -250,12 +250,12 @@ describe("calcite-popover", () => {
     const referenceElement = await page.find("div");
 
     const id = element.getAttribute("id");
-    const describedby = referenceElement.getAttribute("aria-describedby");
+    const referenceId = referenceElement.getAttribute(POPOVER_REFERENCE);
 
-    expect(id).toEqual(describedby);
+    expect(id).toEqual(referenceId);
   });
 
-  it("user defined id should match referenceElement's aria-describedby", async () => {
+  it("user defined id should match referenceElement's referenceId", async () => {
     const page = await newE2EPage();
 
     const userDefinedId = "user-defined-id";
@@ -277,9 +277,9 @@ describe("calcite-popover", () => {
     const referenceElement = await page.find("div");
 
     const id = element.getAttribute("id");
-    const describedby = referenceElement.getAttribute("aria-describedby");
+    const referenceId = referenceElement.getAttribute(POPOVER_REFERENCE);
 
     expect(id).toEqual(userDefinedId);
-    expect(describedby).toEqual(userDefinedId);
+    expect(referenceId).toEqual(userDefinedId);
   });
 });

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -11,7 +11,7 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CSS, ARIA_DESCRIBED_BY, POPOVER_REFERENCE, TEXT } from "./resources";
+import { CSS, ARIA_CONTROLS, ARIA_EXPANDED, POPOVER_REFERENCE, TEXT } from "./resources";
 import {
   CalcitePlacement,
   defaultOffsetDistance,
@@ -91,6 +91,7 @@ export class CalcitePopover {
   @Watch("open")
   openHandler(open: boolean): void {
     this.reposition();
+    this.setExpandedAttr();
     if (open) {
       this.calcitePopoverOpen.emit();
     } else {
@@ -218,6 +219,16 @@ export class CalcitePopover {
     return this.el.id || this.guid;
   };
 
+  setExpandedAttr = (): void => {
+    const { _referenceElement, open } = this;
+
+    if (!_referenceElement) {
+      return;
+    }
+
+    _referenceElement.setAttribute(ARIA_EXPANDED, open.toString());
+  };
+
   addReferences = (): void => {
     const { _referenceElement } = this;
 
@@ -225,11 +236,11 @@ export class CalcitePopover {
       return;
     }
 
-    _referenceElement.setAttribute(POPOVER_REFERENCE, "");
+    const id = this.getId();
 
-    if (!_referenceElement.hasAttribute(ARIA_DESCRIBED_BY)) {
-      _referenceElement.setAttribute(ARIA_DESCRIBED_BY, this.getId());
-    }
+    _referenceElement.setAttribute(POPOVER_REFERENCE, id);
+    _referenceElement.setAttribute(ARIA_CONTROLS, id);
+    this.setExpandedAttr();
   };
 
   removeReferences = (): void => {
@@ -239,8 +250,9 @@ export class CalcitePopover {
       return;
     }
 
-    _referenceElement.removeAttribute(ARIA_DESCRIBED_BY);
     _referenceElement.removeAttribute(POPOVER_REFERENCE);
+    _referenceElement.removeAttribute(ARIA_CONTROLS);
+    _referenceElement.removeAttribute(ARIA_EXPANDED);
   };
 
   getReferenceElement(): HTMLElement {
@@ -361,7 +373,7 @@ export class CalcitePopover {
 
     return (
       <Host
-        aria-hidden={!displayed ? "true" : "false"}
+        aria-hidden={(!displayed).toString()}
         aria-label={label}
         id={this.getId()}
         role="dialog"

--- a/src/components/calcite-popover/resources.ts
+++ b/src/components/calcite-popover/resources.ts
@@ -11,5 +11,5 @@ export const TEXT = {
 };
 
 export const POPOVER_REFERENCE = "data-calcite-popover-reference";
-
-export const ARIA_DESCRIBED_BY = "aria-describedby";
+export const ARIA_CONTROLS = "aria-controls";
+export const ARIA_EXPANDED = "aria-expanded";

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Listen, Prop, VNode } from "@stencil/core";
 import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
-import { getElementByAttributeName } from "../../utils/dom";
+import { getElementByAttributeId } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 
 @Component({
@@ -35,7 +35,7 @@ export class CalciteTooltipManager {
   // --------------------------------------------------------------------------
 
   queryTooltip = (el: HTMLElement): HTMLCalciteTooltipElement => {
-    return getElementByAttributeName(
+    return getElementByAttributeId(
       el.closest(this.selector),
       TOOLTIP_REFERENCE
     ) as HTMLCalciteTooltipElement;

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Listen, Prop, VNode } from "@stencil/core";
 import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
-import { getDescribedByElement } from "../../utils/dom";
+import { getElementByAttributeName } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 
 @Component({
@@ -35,7 +35,10 @@ export class CalciteTooltipManager {
   // --------------------------------------------------------------------------
 
   queryTooltip = (el: HTMLElement): HTMLCalciteTooltipElement => {
-    return getDescribedByElement(el.closest(this.selector)) as HTMLCalciteTooltipElement;
+    return getElementByAttributeName(
+      el.closest(this.selector),
+      TOOLTIP_REFERENCE
+    ) as HTMLCalciteTooltipElement;
   };
 
   clearHoverTimeout = (tooltip: HTMLCalciteTooltipElement): void => {

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
+import { TOOLTIP_DELAY_MS, TOOLTIP_REFERENCE } from "../calcite-tooltip/resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tooltip", () => {
@@ -166,7 +166,7 @@ describe("calcite-tooltip", () => {
     expect(content.textContent).toBe("hi");
   });
 
-  it("guid id should match referenceElement's aria-describedby", async () => {
+  it("guid id should match referenceElement's referenceId", async () => {
     const page = await newE2EPage();
 
     await page.setContent(`<calcite-tooltip open></calcite-tooltip>`);
@@ -186,12 +186,12 @@ describe("calcite-tooltip", () => {
     const referenceElement = await page.find("div");
 
     const id = element.getAttribute("id");
-    const describedby = referenceElement.getAttribute("aria-describedby");
+    const referenceId = referenceElement.getAttribute(TOOLTIP_REFERENCE);
 
-    expect(id).toEqual(describedby);
+    expect(id).toEqual(referenceId);
   });
 
-  it("user defined id should match referenceElement's aria-describedby", async () => {
+  it("user defined id should match referenceElement's referenceId", async () => {
     const page = await newE2EPage();
 
     const userDefinedId = "user-defined-id";
@@ -213,9 +213,9 @@ describe("calcite-tooltip", () => {
     const referenceElement = await page.find("div");
 
     const id = element.getAttribute("id");
-    const describedby = referenceElement.getAttribute("aria-describedby");
+    const referenceId = referenceElement.getAttribute(TOOLTIP_REFERENCE);
 
     expect(id).toEqual(userDefinedId);
-    expect(describedby).toEqual(userDefinedId);
+    expect(referenceId).toEqual(userDefinedId);
   });
 });

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -151,11 +151,10 @@ export class CalciteTooltip {
       return;
     }
 
-    _referenceElement.setAttribute(TOOLTIP_REFERENCE, "");
+    const id = this.getId();
 
-    if (!_referenceElement.hasAttribute(ARIA_DESCRIBED_BY)) {
-      _referenceElement.setAttribute(ARIA_DESCRIBED_BY, this.getId());
-    }
+    _referenceElement.setAttribute(TOOLTIP_REFERENCE, id);
+    _referenceElement.setAttribute(ARIA_DESCRIBED_BY, id);
   };
 
   removeReferences = (): void => {
@@ -165,8 +164,8 @@ export class CalciteTooltip {
       return;
     }
 
-    _referenceElement.removeAttribute(ARIA_DESCRIBED_BY);
     _referenceElement.removeAttribute(TOOLTIP_REFERENCE);
+    _referenceElement.removeAttribute(ARIA_DESCRIBED_BY);
   };
 
   show = (): void => {
@@ -245,7 +244,7 @@ export class CalciteTooltip {
 
     return (
       <Host
-        aria-hidden={!displayed ? "true" : "false"}
+        aria-hidden={(!displayed).toString()}
         aria-label={label}
         id={this.getId()}
         role="tooltip"

--- a/src/components/calcite-tooltip/resources.ts
+++ b/src/components/calcite-tooltip/resources.ts
@@ -3,8 +3,7 @@ export const CSS = {
   arrow: "arrow"
 };
 
-export const TOOLTIP_REFERENCE = "data-calcite-tooltip-reference";
-
-export const ARIA_DESCRIBED_BY = "aria-describedby";
-
 export const TOOLTIP_DELAY_MS = 500;
+
+export const TOOLTIP_REFERENCE = "data-calcite-tooltip-reference";
+export const ARIA_DESCRIBED_BY = "aria-describedby";

--- a/src/demos/calcite-popover.html
+++ b/src/demos/calcite-popover.html
@@ -82,6 +82,14 @@
     <div style="padding:12px 16px">I am a popover with a close button!</div>
   </calcite-popover>
 
+  <calcite-popover reference-element="tooltip-and-popover" placement="top" theme="dark" >
+    <div style="padding:12px 16px">Hello! I am some popover content!</div>
+  </calcite-popover>
+
+  <calcite-tooltip reference-element="tooltip-and-popover" placement="bottom">Lorem Ipsum is simply of the printing and typesetting industry. Lorem
+    Ipsum has been the industry's standard printer of type and scrambled it
+    to make a type specimen book.</calcite-tooltip>
+
   <style>
     .popover-list {
       list-style: none;
@@ -115,6 +123,11 @@
     <li>
       <calcite-button id="popover-button-three" icon="plus">
         Title, content & CTA</calcite-button>
+    </li>
+    <li>
+      <calcite-tooltip-manager>
+        <calcite-button id="tooltip-and-popover">Tooltip and popover test</calcite-button>
+    </calcite-tooltip-manager>
     </li>
   </ul>
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -109,10 +109,7 @@ export function filterDirectChildren<T extends Element>(el: Element, selector: s
   return Array.from(el.children).filter((child): child is T => child.matches(selector));
 }
 
-export function getElementByAttributeName<T extends Element>(
-  element: Element,
-  attrName: string
-): T | HTMLElement | null {
+export function getElementByAttributeId<T extends Element>(element: Element, attrName: string): T | HTMLElement | null {
   const id = element?.getAttribute(attrName);
 
   return (id && document.getElementById(id)) || null;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -109,8 +109,11 @@ export function filterDirectChildren<T extends Element>(el: Element, selector: s
   return Array.from(el.children).filter((child): child is T => child.matches(selector));
 }
 
-export function getDescribedByElement<T extends Element>(element: Element): T | HTMLElement | null {
-  const id = element?.getAttribute("aria-describedby");
+export function getElementByAttributeName<T extends Element>(
+  element: Element,
+  attrName: string
+): T | HTMLElement | null {
+  const id = element?.getAttribute(attrName);
 
   return (id && document.getElementById(id)) || null;
 }


### PR DESCRIPTION
**Related Issue:** #548

## Summary

fix(popover, tooltip): Allow both tooltip and popover to share the same referenceElement.

- Uses data-attribute for referenceElement ID instead of aria-describedby.
- Adds aria-expanded and aria-controls to popover for added a11y.
- No longer sets aria-describedby on popover referenceElement.
- Cleanup.