### PR TITLE
chore(github): update actions-milestone-sync

### DIFF
--- a/.github/workflows/milestone-mover.yml
+++ b/.github/workflows/milestone-mover.yml
@@ -1,4 +1,4 @@
-name: "main"
+name: "Move issues/PRs to next milestone"
 on:
   release:
     types: [released]
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: move to next milestone
-        uses: jcfranco/actions-milestone-sync@1e6c074cad4d8d627128f25a46d72eced6f5da45
+        uses: jcfranco/actions-milestone-sync@45fb8180b4ec0f176a26379ae7528b3fffdccf09
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Renamed and updated GH action to latest.