### PR TITLE
docs: create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities. 
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities using the [security concern](https://trust.arcgis.com/en/security-concern/) form. If the issue is confirmed, we will release a patch as soon as possible depending on complexity.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ We release patches for security vulnerabilities.
 
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities using the [security concern](https://trust.arcgis.com/en/security-concern/) form. If the issue is confirmed, we will release a patch as soon as possible depending on complexity.
+Please report (suspected) security vulnerabilities using the [security concern form](https://trust.arcgis.com/en/security-concern/). If the issue is confirmed, we will release a patch as soon as possible depending on complexity.


### PR DESCRIPTION
Took a stab at it.

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

## Summary

Creates a security markdown for users to report security concerns. I don't think we have an email alias to use but if we did that might be better than the ArcGIS trust form?