### PR TITLE
chore: remove unnecessary code from stepper resources

### DIFF
--- a/src/components/calcite-stepper/calcite-stepper.resources.ts
+++ b/src/components/calcite-stepper/calcite-stepper.resources.ts
@@ -10,7 +10,6 @@ const STYLES: CSS.Properties = {
 
 export const IESTYLES = JSON.stringify(STYLES)
   .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-  .replace(/:/g, ":")
   .replace(/[,]/g, ";")
   .replace(/["{}]/g, "")
   .toLowerCase();


### PR DESCRIPTION
chore: remove unnecessary code from stepper resources

---

Replacing a substring with itself has no effect and usually indicates a mistake, such as misspelling a backslash escape.

