### PR TITLE
feat(combobox): add max-items prop for combobox

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -52,6 +52,41 @@ describe("calcite-combobox", () => {
     expect(item2Visible).toBe(false);
   });
 
+  it("should control max items displayed", async () => {
+    const page = await newE2EPage();
+
+    const maxItems = 7;
+
+    await page.setContent(`
+      <calcite-combobox max-items="${maxItems}">
+        <calcite-combobox-item id="item-0" value="item-0" text-label="item-0">
+          <calcite-combobox-item id="item-1" value="item-1" text-label="item-1"></calcite-combobox-item>
+          <calcite-combobox-item id="item-2" value="item-2" text-label="item-2"></calcite-combobox-item>
+          <calcite-combobox-item id="item-3" value="item-3" text-label="item-3"></calcite-combobox-item>
+          <calcite-combobox-item id="item-4" value="item-4" text-label="item-4"></calcite-combobox-item>
+          <calcite-combobox-item id="item-5" value="item-5" text-label="item-5"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item id="item-6" value="item-6" text-label="item-6">
+          <calcite-combobox-item id="item-7" value="item-7" text-label="item-7"></calcite-combobox-item>
+          <calcite-combobox-item id="item-8" value="item-8" text-label="item-8"></calcite-combobox-item>
+          <calcite-combobox-item id="item-9" value="item-9" text-label="item-9"></calcite-combobox-item>
+          <calcite-combobox-item id="item-10" value="item-10" text-label="item-10"></calcite-combobox-item>
+        </calcite-combobox-item>
+      </calcite-combobox>
+    `);
+    await page.waitForChanges();
+
+    const element = await page.find("calcite-combobox");
+    await element.click();
+    await page.waitForChanges();
+
+    const items = await page.findAll("calcite-combobox-item");
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].isIntersectingViewport()).toBe(i < maxItems);
+    }
+  });
+
   describe("item selection", () => {
     it("should add/remove item to the selected items when an item is clicked", async () => {
       const page = await newE2EPage();

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from "@storybook/html";
-import { select } from "@storybook/addon-knobs";
+import { select, number } from "@storybook/addon-knobs";
 
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
@@ -14,6 +14,7 @@ storiesOf("Components/Combobox", module)
     <calcite-combobox
       label="demo combobox"
       scale="${select("scale", ["s", "m", "l"], "m")}"
+      max-items="${number("max-items", 0)}"
       >
       <calcite-combobox-item value="Trees" text-label="Trees">
         <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
@@ -46,6 +47,7 @@ storiesOf("Components/Combobox", module)
     label="demo combobox"
     theme="dark"
     scale="${select("scale", ["s", "m", "l"], "m")}"
+    max-items="${number("max-items", 0)}"
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -54,6 +54,9 @@ export class CalciteCombobox {
 
   @Prop() placeholder?: string;
 
+  /** specify the maximum number lines to display before showing the scroller */
+  @Prop() maxItems = 0;
+
   /** specify the scale of the combobox, defaults to m */
   @Prop({ reflect: true }) scale: "s" | "m" | "l" = "m";
 
@@ -79,6 +82,9 @@ export class CalciteCombobox {
   data: ItemData[];
 
   observer: MutationObserver = null;
+
+  /** specifies the item wrapper height; it is updated when maxItems is > 0  **/
+  private maxScrollerHeight = 0;
 
   private popper: Popper;
 
@@ -106,6 +112,7 @@ export class CalciteCombobox {
 
   componentDidLoad(): void {
     this.observer?.observe(this.el, { childList: true, subtree: true });
+    this.maxScrollerHeight = this.getMaxScrollerHeight(this.items);
   }
 
   disconnectedCallback(): void {
@@ -225,6 +232,27 @@ export class CalciteCombobox {
     }
 
     this.popper = null;
+  }
+
+  private getMaxScrollerHeight(items: HTMLCalciteComboboxItemElement[]): number {
+    const { maxItems } = this;
+    let itemsToProcess = 0;
+    let maxScrollerHeight = 0;
+    items.forEach((item) => {
+      if (itemsToProcess < maxItems && maxItems > 0) {
+        maxScrollerHeight += item.offsetHeight;
+        itemsToProcess += 1;
+        // if item has children items, don't count their height twice
+        const children = item.querySelectorAll<HTMLCalciteComboboxItemElement>(
+          "calcite-combobox-item"
+        );
+        children.forEach((child) => {
+          maxScrollerHeight -= child.offsetHeight;
+        });
+      }
+    });
+
+    return maxScrollerHeight;
   }
 
   inputHandler = (event: Event): void => {
@@ -401,7 +429,16 @@ export class CalciteCombobox {
   //--------------------------------------------------------------------------
 
   render(): VNode {
-    const { active, disabled, el, label, placeholder, scale, selectedItems } = this;
+    const {
+      active,
+      disabled,
+      el,
+      label,
+      placeholder,
+      scale,
+      selectedItems,
+      maxScrollerHeight
+    } = this;
     const dir = getElementDir(el);
     const listBoxId = "listbox";
     return (
@@ -447,6 +484,9 @@ export class CalciteCombobox {
             }}
             id={listBoxId}
             role="listbox"
+            style={{
+              maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
+            }}
           >
             <slot />
           </ul>

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -54,7 +54,7 @@ export class CalciteCombobox {
 
   @Prop() placeholder?: string;
 
-  /** specify the maximum number lines to display before showing the scroller */
+  /** specify the maximum number of combobox items (including nested children) to display before showing the scroller */
   @Prop() maxItems = 0;
 
   /** specify the scale of the combobox, defaults to m */

--- a/src/components/calcite-combobox/readme.md
+++ b/src/components/calcite-combobox/readme.md
@@ -4,15 +4,15 @@
 
 ## Properties
 
-| Property             | Attribute     | Description                                                             | Type                | Default     |
-| -------------------- | ------------- | ----------------------------------------------------------------------- | ------------------- | ----------- |
-| `active`             | `active`      |                                                                         | `boolean`           | `false`     |
-| `disabled`           | `disabled`    |                                                                         | `boolean`           | `false`     |
-| `label` _(required)_ | `label`       |                                                                         | `string`            | `undefined` |
-| `maxItems`           | `max-items`   | specify the maximum number lines to display before showing the scroller | `number`            | `0`         |
-| `placeholder`        | `placeholder` |                                                                         | `string`            | `undefined` |
-| `scale`              | `scale`       | specify the scale of the combobox, defaults to m                        | `"l" \| "m" \| "s"` | `"m"`       |
-| `theme`              | `theme`       | Select theme (light or dark)                                            | `"dark" \| "light"` | `undefined` |
+| Property             | Attribute     | Description                                                                                                     | Type                | Default     |
+| -------------------- | ------------- | --------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `active`             | `active`      |                                                                                                                 | `boolean`           | `false`     |
+| `disabled`           | `disabled`    |                                                                                                                 | `boolean`           | `false`     |
+| `label` _(required)_ | `label`       |                                                                                                                 | `string`            | `undefined` |
+| `maxItems`           | `max-items`   | specify the maximum number of combobox items (including nested children) to display before showing the scroller | `number`            | `0`         |
+| `placeholder`        | `placeholder` |                                                                                                                 | `string`            | `undefined` |
+| `scale`              | `scale`       | specify the scale of the combobox, defaults to m                                                                | `"l" \| "m" \| "s"` | `"m"`       |
+| `theme`              | `theme`       | Select theme (light or dark)                                                                                    | `"dark" \| "light"` | `undefined` |
 
 ## Events
 

--- a/src/components/calcite-combobox/readme.md
+++ b/src/components/calcite-combobox/readme.md
@@ -4,14 +4,15 @@
 
 ## Properties
 
-| Property             | Attribute     | Description                                      | Type                | Default     |
-| -------------------- | ------------- | ------------------------------------------------ | ------------------- | ----------- |
-| `active`             | `active`      |                                                  | `boolean`           | `false`     |
-| `disabled`           | `disabled`    |                                                  | `boolean`           | `false`     |
-| `label` _(required)_ | `label`       |                                                  | `string`            | `undefined` |
-| `placeholder`        | `placeholder` |                                                  | `string`            | `undefined` |
-| `scale`              | `scale`       | specify the scale of the combobox, defaults to m | `"l" \| "m" \| "s"` | `"m"`       |
-| `theme`              | `theme`       | Select theme (light or dark)                     | `"dark" \| "light"` | `undefined` |
+| Property             | Attribute     | Description                                                             | Type                | Default     |
+| -------------------- | ------------- | ----------------------------------------------------------------------- | ------------------- | ----------- |
+| `active`             | `active`      |                                                                         | `boolean`           | `false`     |
+| `disabled`           | `disabled`    |                                                                         | `boolean`           | `false`     |
+| `label` _(required)_ | `label`       |                                                                         | `string`            | `undefined` |
+| `maxItems`           | `max-items`   | specify the maximum number lines to display before showing the scroller | `number`            | `0`         |
+| `placeholder`        | `placeholder` |                                                                         | `string`            | `undefined` |
+| `scale`              | `scale`       | specify the scale of the combobox, defaults to m                        | `"l" \| "m" \| "s"` | `"m"`       |
+| `theme`              | `theme`       | Select theme (light or dark)                                            | `"dark" \| "light"` | `undefined` |
 
 ## Events
 

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -12,6 +12,9 @@
       color: white;
       padding: 1rem;
     }
+    calcite-combobox {
+      max-width: 480px;
+    }
   </style>
   <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
   <link rel="stylesheet" href="../build/calcite.css" />
@@ -24,7 +27,7 @@
   <h1>Calcite Combobox</h1>
   <h2>Scale M</h2>
 
-  <calcite-combobox label="test">
+  <calcite-combobox label="test" max-items="4">
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
       <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>

--- a/src/index.html
+++ b/src/index.html
@@ -71,6 +71,8 @@
         <li>
           <calcite-link href="/demos/calcite-color.html">calcite-color</calcite-link>
         </li>
+        <li>
+          <calcite-link href="/demos/calcite-combobox.html">calcite-combobox</calcite-link>
         </li>
         <li>
           <calcite-link href="/demos/calcite-date.html">calcite-date</calcite-link>


### PR DESCRIPTION
## Summary

This is the first of several prs updating the combobox. Adds `max-items` property which behaves in exactly the same way the prop does on the dropdown component. Essentially, cap the height of the popover content to a particular number of items. 

Added a link to the combobox demo from the index as well.