### PR TITLE
chore: remove unregister events from tabs.

### DIFF
--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -78,7 +78,6 @@ export class CalciteTabTitle {
 
   disconnectedCallback(): void {
     this.observer.disconnect();
-    this.calciteTabTitleUnregister.emit();
   }
 
   componentWillLoad(): void {
@@ -215,11 +214,6 @@ export class CalciteTabTitle {
    * @internal
    */
   @Event() calciteTabTitleRegister: EventEmitter<TabID>;
-
-  /**
-   * @internal
-   */
-  @Event() calciteTabTitleUnregister: EventEmitter;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-tab/calcite-tab.tsx
+++ b/src/components/calcite-tab/calcite-tab.tsx
@@ -73,10 +73,6 @@ export class CalciteTab {
     this.calciteTabRegister.emit();
   }
 
-  disconnectedCallback(): void {
-    this.calciteTabUnregister.emit();
-  }
-
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -87,11 +83,6 @@ export class CalciteTab {
    * @internal
    */
   @Event() calciteTabRegister: EventEmitter;
-
-  /**
-   * @internal
-   */
-  @Event() calciteTabUnregister: EventEmitter;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-tabs/calcite-tabs.tsx
+++ b/src/components/calcite-tabs/calcite-tabs.tsx
@@ -79,26 +79,8 @@ export class CalciteTabs {
   /**
    * @internal
    */
-  @Listen("calciteTabTitleUnregister") calciteTabTitleUnregister(e: CustomEvent): void {
-    this.titles = this.titles.filter((el) => el !== e.target);
-    this.registryHandler();
-    e.stopPropagation();
-  }
-
-  /**
-   * @internal
-   */
   @Listen("calciteTabRegister") calciteTabRegister(e: CustomEvent): void {
     this.tabs = [...this.tabs, e.target as HTMLCalciteTabElement];
-    this.registryHandler();
-    e.stopPropagation();
-  }
-
-  /**
-   * @internal
-   */
-  @Listen("calciteTabUnregister") calciteTabUnregister(e: CustomEvent): void {
-    this.tabs = this.tabs.filter((el) => el !== e.target);
     this.registryHandler();
     e.stopPropagation();
   }


### PR DESCRIPTION
**Related Issue:** None

## Summary

chore: remove unregister events from tabs.

This gets rid of the console warnings during tests for the `calciteTabUnregister` events.

```
● Console
    console.warn
      STENCIL: The "calciteTabTitleUnregister" event was emitted, but the dispatcher node is no longer connected to the dom. 
      Location: http://localhost:3333/build/index-c14fe7c7.js:2699:70
      at t (node_modules/@stencil/core/testing/index.js:3685:67)
      at node_modules/@stencil/core/testing/index.js:3686:5
      at node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:62
          at Array.map (<anonymous>)
      at Object.emit (node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:43)
      at Page.emit (node_modules/puppeteer/lib/cjs/puppeteer/common/EventEmitter.js:72:22)
      at Page._addConsoleMessage (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:798:14)
      at Page._onConsoleAPI (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:741:14)
    console.warn
      STENCIL: The "calciteTabTitleUnregister" event was emitted, but the dispatcher node is no longer connected to the dom. 
      Location: http://localhost:3333/build/index-c14fe7c7.js:2699:70
      at t (node_modules/@stencil/core/testing/index.js:3685:67)
      at node_modules/@stencil/core/testing/index.js:3686:5
      at node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:62
          at Array.map (<anonymous>)
      at Object.emit (node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:43)
      at Page.emit (node_modules/puppeteer/lib/cjs/puppeteer/common/EventEmitter.js:72:22)
      at Page._addConsoleMessage (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:798:14)
      at Page._onConsoleAPI (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:741:14)
    console.warn
      STENCIL: The "calciteTabUnregister" event was emitted, but the dispatcher node is no longer connected to the dom. 
      Location: http://localhost:3333/build/index-c14fe7c7.js:2699:70
      at t (node_modules/@stencil/core/testing/index.js:3685:67)
      at node_modules/@stencil/core/testing/index.js:3686:5
      at node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:62
          at Array.map (<anonymous>)
      at Object.emit (node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:43)
      at Page.emit (node_modules/puppeteer/lib/cjs/puppeteer/common/EventEmitter.js:72:22)
      at Page._addConsoleMessage (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:798:14)
      at Page._onConsoleAPI (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:741:14)
    console.warn
      STENCIL: The "calciteTabUnregister" event was emitted, but the dispatcher node is no longer connected to the dom. 
      Location: http://localhost:3333/build/index-c14fe7c7.js:2699:70
      at t (node_modules/@stencil/core/testing/index.js:3685:67)
      at node_modules/@stencil/core/testing/index.js:3686:5
      at node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:62
          at Array.map (<anonymous>)
      at Object.emit (node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:43)
      at Page.emit (node_modules/puppeteer/lib/cjs/puppeteer/common/EventEmitter.js:72:22)
      at Page._addConsoleMessage (node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:798:14)
```

The unregister shouldn't have been doing anything since once the node is removed from the DOM the event can't bubble up to the tabs component. right?
