### PR TITLE
build: adding build:watch-dev command to enable source maps and useful dev features while debugging calcite in external apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "npm run util:copy-icons && stencil build && npm run util:add-custom-elements-index-mjs",
-    "build:watch": "npm run util:copy-icons && stencil build --watch && npm run util:add-custom-elements-index-mjs",
+    "build:watch": "npm run util:copy-icons && stencil build --dev --watch && npm run util:add-custom-elements-index-mjs",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
     "docs": "concurrently --kill-others --raw \"npm:util:build-docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\"  \"ts-node ./support/tempDocDirCleaner.ts\"",
     "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/tempDocDirCleaner.ts\"",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "npm run util:copy-icons && stencil build && npm run util:add-custom-elements-index-mjs",
-    "build:watch": "npm run util:copy-icons && stencil build --dev --watch && npm run util:add-custom-elements-index-mjs",
+    "build:watch": "npm run util:copy-icons && stencil build --watch && npm run util:add-custom-elements-index-mjs",
+    "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch && npm run util:add-custom-elements-index-mjs",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
     "docs": "concurrently --kill-others --raw \"npm:util:build-docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\"  \"ts-node ./support/tempDocDirCleaner.ts\"",
     "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/tempDocDirCleaner.ts\"",


### PR DESCRIPTION
**Related Issue:** n/a

Discovered that by adding the `--dev` option along with `--watch` you can get source maps enabled when debugging the build inside of `arcgis-webviewer-app` and the code is easier to read as well for debugging and breakpoints.

![image](https://user-images.githubusercontent.com/821864/101227082-8367d800-364b-11eb-9529-d68554ce4abb.png)
![image](https://user-images.githubusercontent.com/821864/101227094-911d5d80-364b-11eb-9119-8e3d41c88476.png)
