### PR TITLE
refactor: use different selector to hide components that should not be visible on first render

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -46,7 +46,7 @@
   overflow: hidden;
 }
 
-[calcite-hydrated][aria-hidden="true"] {
+[calcite-hydrated-hidden] {
   visibility: hidden;
   pointer-events: none;
 }

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -5,16 +5,16 @@ import {
   EventEmitter,
   h,
   Host,
-  Method,
   Listen,
+  Method,
   Prop,
   State,
-  Watch,
-  VNode
+  VNode,
+  Watch
 } from "@stencil/core";
 import { getElementDir, setRequestedIcon } from "../../utils/dom";
 import { DURATIONS, TEXT } from "./calcite-alert.resources";
-import { CalciteStatusColor, CalciteScale, CalciteTheme } from "../interfaces";
+import { CalciteScale, CalciteStatusColor, CalciteTheme } from "../interfaces";
 import { StatusIcons } from "../../interfaces/StatusIcons";
 
 /** Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
@@ -128,15 +128,18 @@ export class CalciteAlert {
         +{this.queueLength > 2 ? this.queueLength - 1 : 1}
       </div>
     );
+
+    const { active } = this;
     const progress = <div class="alert-dismiss-progress" />;
     const role = this.autoDismiss ? "alert" : "alertdialog";
-    const hidden = this.active ? "false" : "true";
+    const hidden = !active;
 
     return (
       <Host
-        active={this.active}
-        aria-hidden={hidden}
+        active={active}
+        aria-hidden={hidden.toString()}
         aria-label={this.label}
+        calcite-hydrated-hidden={hidden}
         dir={dir}
         queued={this.queued}
         role={role}

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -6,7 +6,10 @@ import { CSS, POPOVER_REFERENCE } from "./resources";
 
 describe("calcite-popover", () => {
   it("renders", async () =>
-    renders(`<calcite-popover label="test" open reference-element="ref"></calcite-popover><div id="ref">😄</div>`));
+    Promise.all([
+      renders("calcite-popover", false),
+      renders(`<calcite-popover label="test" open reference-element="ref"></calcite-popover><div id="ref">😄</div>`)
+    ]));
 
   it("is accessible when closed", async () =>
     accessible(`<calcite-popover label="test" reference-element="ref"></calcite-popover><div id="ref">😄</div>`));

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -367,14 +367,16 @@ export class CalcitePopover {
   render(): VNode {
     const { _referenceElement, label, open, disablePointer } = this;
     const displayed = _referenceElement && open;
+    const hidden = !displayed;
     const arrowNode = !disablePointer ? (
       <div class={CSS.arrow} ref={(arrowEl) => (this.arrowEl = arrowEl)} />
     ) : null;
 
     return (
       <Host
-        aria-hidden={(!displayed).toString()}
+        aria-hidden={hidden.toString()}
         aria-label={label}
+        calcite-hydrated-hidden={hidden}
         id={this.getId()}
         role="dialog"
       >

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -4,7 +4,10 @@ import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tooltip", () => {
   it("renders", async () =>
-    renders(`<calcite-tooltip open reference-element="ref"></calcite-tooltip><div id="ref">😄</div>`));
+    Promise.all([
+      renders(`calcite-tooltip`, false),
+      renders(`<calcite-tooltip open reference-element="ref"></calcite-tooltip><div id="ref">😄</div>`)
+    ]));
 
   it("is accessible when closed", async () =>
     accessible(`<calcite-tooltip label="test" reference-element="ref"></calcite-tooltip><div id="ref">😄</div>`));

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -241,11 +241,13 @@ export class CalciteTooltip {
   render(): VNode {
     const { _referenceElement, label, open } = this;
     const displayed = _referenceElement && open;
+    const hidden = !displayed;
 
     return (
       <Host
-        aria-hidden={(!displayed).toString()}
+        aria-hidden={hidden.toString()}
         aria-label={label}
+        calcite-hydrated-hidden={hidden}
         id={this.getId()}
         role="tooltip"
       >

--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -1,14 +1,8 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 
 describe("calcite-tree-item", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent("<calcite-tree-item></calcite-tree-item>");
-    const element = await page.find("calcite-tree-item");
-    expect(element).toHaveAttribute(HYDRATED_ATTR);
-  });
+  it("renders", async () => renders("calcite-tree-item", false));
 
   it("is accessible", async () => accessible(`<calcite-tree-item></calcite-tree-item>`));
 

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -97,10 +97,12 @@ export class CalciteTreeItem {
       />
     ) : null;
 
+    const hidden = !(this.parentExpanded || this.depth === 1);
+
     return (
       <Host
         aria-expanded={this.hasChildren ? this.expanded.toString() : undefined}
-        aria-hidden={this.parentExpanded || this.depth === 1 ? undefined : "true"}
+        aria-hidden={hidden.toString()}
         aria-selected={
           this.selected
             ? "true"
@@ -109,6 +111,7 @@ export class CalciteTreeItem {
             ? "false"
             : undefined
         }
+        calcite-hydrated-hidden={hidden}
         role="treeitem"
         tabindex={this.parentExpanded || this.depth === 1 ? "0" : "-1"}
       >


### PR DESCRIPTION
**Related Issue:** #1374 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This introduces a special attribute (`calcite-hydrated-hidden`) to hide hydrated components. This support boolean attribute would help prevent the default styling applied by `calcite-hydrated`, which makes any host component visible. This is undesired for a few components (`calcite-alert`, `calcite-popover`, `calcite-tooltip` and `calcite-tree-item`).