### PR TITLE
fix(tab-nav, tab-title): fix tab icons and active tab highlight in rtl

### DIFF
--- a/src/components/calcite-tab-nav/calcite-tab-nav.e2e.ts
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.e2e.ts
@@ -9,4 +9,34 @@ describe("calcite-tab-nav", () => {
     const element = await page.find("calcite-tab-nav");
     expect(element).toHaveAttribute(HYDRATED_ATTR);
   });
+
+  it("has its active indicator positioned from left if LTR", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-tab-nav>
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>`);
+    const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
+    const style = await element.getComputedStyle();
+    expect(style["left"]).toBe("0px");
+    expect(style["right"]).not.toBe("0px");
+  });
+
+  it("has its active indicator positioned from right if RTL", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-tab-nav dir='rtl'>
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>`);
+    const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
+    const style = await element.getComputedStyle();
+    expect(style["right"]).toBe("0px");
+    expect(style["left"]).not.toBe("0px");
+  });
 });

--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -256,8 +256,6 @@ export class CalciteTabNav {
 
   private animationActiveDuration = 0.3;
 
-  private dir: "ltr" | "rtl";
-
   //--------------------------------------------------------------------------
   //
   //  Private Methods
@@ -271,8 +269,9 @@ export class CalciteTabNav {
   };
 
   private updateOffsetPosition(): void {
+    const dir = getElementDir(this.el);
     this.indicatorOffset =
-      this.dir !== "rtl"
+      dir !== "rtl"
         ? this.selectedTabEl?.offsetLeft - this.tabNavEl?.scrollLeft
         : this.tabNavEl?.offsetWidth - this.selectedTabEl.getBoundingClientRect().right;
   }

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -129,6 +129,7 @@ export class CalciteTabTitle {
       <Host
         aria-controls={this.controls}
         aria-expanded={this.active.toString()}
+        dir={dir}
         hasText={this.hasText}
         id={id}
         role="tab"

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -383,9 +383,9 @@
 
   <calcite-tabs dir="rtl">
     <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
 


### PR DESCRIPTION
**Related Issue:** #1356

## Summary
Fixes the active tab highlight not being positioned correctly in RTL. While I was working on this, I noticed the icon margins for tabs in RTL were also messed up, so I fixed that as well. Sorry @caripizza if you were working on this one, I saw you were assigned to the issue. We ran into this bug in our RC testing, so I wanted to get a fix in as soon as I could.

(Redo of #1383)
Sorry for the duplicate PR here! My travis build for the last PR was failing due to attempting the PR from a fork, so I needed to make another attempt from a direct clone of the repo.