### PR TITLE
fix(calcite-dropdown): calcite-dropdown-item uses unsupported ARIA attribute

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -86,7 +86,7 @@ export class CalciteDropdownGroup {
     const dir = getElementDir(this.el);
     const scale = getElementProp(this.el, "scale", "m");
     const groupTitle = this.groupTitle ? (
-      <span class="dropdown-title" ref={this.setDropdownTitleRef}>
+      <span aria-hidden="true" class="dropdown-title" ref={this.setDropdownTitleRef}>
         {this.groupTitle}
       </span>
     ) : null;
@@ -97,7 +97,7 @@ export class CalciteDropdownGroup {
       ) : null;
 
     return (
-      <Host dir={dir} scale={scale}>
+      <Host dir={dir} role="menu" scale={scale} title={this.groupTitle}>
         {dropdownSeparator}
         {groupTitle}
         <slot />

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -139,12 +139,23 @@ export class CalciteDropdownItem {
         {slottedContent}
       </a>
     );
+
+    const itemRole = this.href
+      ? null
+      : this.selectionMode === "single"
+      ? "menuitemradio"
+      : this.selectionMode === "multi"
+      ? "menuitemcheckbox"
+      : "menuitem";
+
+    const itemAria = this.selectionMode !== "none" ? this.active.toString() : null;
+
     return (
       <Host
-        aria-checked={this.active.toString()}
+        aria-checked={itemAria}
         dir={dir}
         isLink={this.href}
-        role="menuitem"
+        role={itemRole}
         scale={scale}
         selection-mode={this.selectionMode}
         tabindex="0"

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -140,7 +140,7 @@ export class CalciteDropdownItem {
       </a>
     );
 
-    const itemRole = this.href
+    const itemRole = this.href // https://www.levelaccess.com/how-not-to-misuse-aria-states-properties-and-roles/
       ? null
       : this.selectionMode === "single"
       ? "menuitemradio"

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -857,6 +857,78 @@ describe("calcite-dropdown", () => {
     expect(await dropdownWrapper.isVisible()).toBe(false);
   });
 
+  it("correct role and aria properties are applied based on selection type", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-dropdown>
+    <calcite-button slot="dropdown-trigger" id="trigger">Open dropdown</calcite-button>
+    <calcite-dropdown-group id="group-1" selection-mode="multi">
+    <calcite-dropdown-item id="item-1">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-2" active>
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-3" active>
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group id="group-2" selection-mode="single">
+    <calcite-dropdown-item id="item-4">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-5" active>
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group id="group-3" selection-mode="none">
+    <calcite-dropdown-item id="item-6">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-7" href="google.com">
+    Dropdown Item Content
+    </calcite-dropdown-item>
+    </calcite-dropdown-group>
+    </calcite-dropdown>`);
+
+    const element = await page.find("calcite-dropdown");
+    const group1 = await element.find("calcite-dropdown-group[id='group-1']");
+    const group2 = await element.find("calcite-dropdown-group[id='group-2']");
+    const group3 = await element.find("calcite-dropdown-group[id='group-3']");
+    const item1 = await element.find("calcite-dropdown-item[id='item-1']");
+    const item2 = await element.find("calcite-dropdown-item[id='item-2']");
+    const item3 = await element.find("calcite-dropdown-item[id='item-3']");
+    const item4 = await element.find("calcite-dropdown-item[id='item-4']");
+    const item5 = await element.find("calcite-dropdown-item[id='item-5']");
+    const item6 = await element.find("calcite-dropdown-item[id='item-6']");
+    const item7 = await element.find("calcite-dropdown-item[id='item-7']");
+
+    expect(group1).toEqualAttribute("role", "menu");
+    expect(group2).toEqualAttribute("role", "menu");
+    expect(group3).toEqualAttribute("role", "menu");
+
+    expect(item1).toEqualAttribute("role", "menuitemcheckbox");
+    expect(item1).toEqualAttribute("aria-checked", "false");
+
+    expect(item2).toEqualAttribute("role", "menuitemcheckbox");
+    expect(item2).toEqualAttribute("aria-checked", "true");
+
+    expect(item3).toEqualAttribute("role", "menuitemcheckbox");
+    expect(item3).toEqualAttribute("aria-checked", "true");
+
+    expect(item4).toEqualAttribute("role", "menuitemradio");
+    expect(item4).toEqualAttribute("aria-checked", "false");
+
+    expect(item5).toEqualAttribute("role", "menuitemradio");
+    expect(item5).toEqualAttribute("aria-checked", "true");
+
+    expect(item6).toEqualAttribute("role", "menuitem");
+    expect(item6).not.toHaveAttribute("aria-checked");
+
+    expect(item7).not.toHaveAttribute("role");
+    expect(item7).not.toHaveAttribute("aria-checked");
+  });
+
   it("item selection should work when placed inside shadow DOM (#992)", async () => {
     const wrappedDropdownTemplateHTML = `
      <calcite-dropdown disable-close-on-select>

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -138,7 +138,7 @@ export class CalciteDropdown {
           aria-hidden={(!active).toString()}
           class="calcite-dropdown-wrapper"
           ref={this.setMenuEl}
-          role="menu"
+          tabIndex={-1}
         >
           <div
             class={{


### PR DESCRIPTION
**Related Issue:** #675

## Summary
Added changes from [macandcheese](https://github.com/macandcheese/calcite-components/commit/77ae6f2ab1d56c95c8393125db966ce0f4bc7e6d#diff-8f6e4c214e58e59f3253d9f369db62edcd3ae99a530d26a19e42f5802c96f77bR81) to fix a11y attributes

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [x] feature or fix has a corresponding test
- [x] changes have been tested with demo page in Edge

-->
