### PR TITLE
refactor(input): rename resource const

### DIFF
--- a/src/components/calcite-input/calcite-input.resources.ts
+++ b/src/components/calcite-input/calcite-input.resources.ts
@@ -1,4 +1,4 @@
-export const INPUTTYPEICONS = {
+export const INPUT_TYPE_ICONS = {
   tel: "phone",
   password: "lock",
   email: "email-address",

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -14,7 +14,7 @@ import {
 } from "@stencil/core";
 import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-import { INPUTTYPEICONS } from "./calcite-input.resources";
+import { INPUT_TYPE_ICONS } from "./calcite-input.resources";
 
 @Component({
   tag: "calcite-input",
@@ -149,7 +149,7 @@ export class CalciteInput {
   @Watch("icon")
   @Watch("type")
   updateRequestedIcon(): void {
-    this.requestedIcon = setRequestedIcon(INPUTTYPEICONS, this.icon, this.type);
+    this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
   }
 
   //--------------------------------------------------------------------------
@@ -165,7 +165,7 @@ export class CalciteInput {
 
   componentWillLoad(): void {
     this.childElType = this.type === "textarea" ? "textarea" : "input";
-    this.requestedIcon = setRequestedIcon(INPUTTYPEICONS, this.icon, this.type);
+    this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
   }
 
   componentDidLoad(): void {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Renamed input const to include word separators.