### PR TITLE
fix(input): Prevent error when changing the 'step', 'min', or 'max'

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -206,6 +206,29 @@ describe("calcite-input", () => {
     expect(element.getAttribute("value")).toBe("25");
   });
 
+  it("should correctly handle property changes to 'min', 'max', and 'step'", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-input type="number" min="10" max="15" step="1" value="12"></calcite-input>`
+    });
+
+    const element = await page.find("calcite-input");
+
+    expect(await element.getProperty("value")).toBe("12");
+    expect(await element.getProperty("min")).toBe(10);
+    expect(await element.getProperty("max")).toBe(15);
+    expect(await element.getProperty("step")).toBe(1);
+
+    element.setProperty("min", null);
+    element.setProperty("max", null);
+    element.setProperty("step", null);
+
+    await page.waitForChanges();
+
+    expect(await element.getProperty("min")).toBe(null);
+    expect(await element.getProperty("max")).toBe(null);
+    expect(await element.getProperty("step")).toBe(null);
+  });
+
   it("correctly stops decrementing value when min is set", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -72,7 +72,7 @@ export class CalciteInput {
   /** watcher to update number-to-string for max */
   @Watch("max")
   maxWatcher(): void {
-    this.maxString = this.max.toString() || null;
+    this.maxString = this.max?.toString() || null;
   }
 
   /** input min */
@@ -81,7 +81,7 @@ export class CalciteInput {
   /** watcher to update number-to-string for min */
   @Watch("min")
   minWatcher(): void {
-    this.minString = this.min.toString() || null;
+    this.minString = this.min?.toString() || null;
   }
 
   /** specify the placement of the number buttons */
@@ -107,7 +107,7 @@ export class CalciteInput {
 
   @Watch("step")
   stepWatcher(): void {
-    this.maxString = this.max.toString() || null;
+    this.maxString = this.max?.toString() || null;
   }
 
   /** optionally add suffix  **/
@@ -328,11 +328,7 @@ export class CalciteInput {
 
   @Event() calciteInputBlur: EventEmitter;
 
-  @Event({
-    eventName: "calciteInputInput",
-    cancelable: true
-  })
-  calciteInputInput: EventEmitter;
+  @Event({ eventName: "calciteInputInput", cancelable: true }) calciteInputInput: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -446,6 +442,7 @@ export class CalciteInput {
             this.childEl.value = (inputVal -= inputStep).toString();
           break;
       }
+
       this.value = this.childEl.value.toString();
     }
   };


### PR DESCRIPTION
**Related Issue:** #1389

## Summary

fix(input): Prevent error when changing the 'step', 'min', or 'max' properties.
