### PR TITLE
chore: add helper to enable auto-formatting of HTML template strings

### DIFF
--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -1,5 +1,5 @@
 import { Attribute, Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { iconNames } from "../../../.storybook/helpers";
 import { select, text } from "@storybook/addon-knobs";
@@ -120,44 +120,44 @@ export const basic = (): string =>
   create(
     "calcite-accordion",
     createAccordionAttributes(),
-    dedent`
-    ${create(
-      "calcite-accordion-item",
-      createAccordionItemAttributes({ group: "accordion-item-1" }),
-      accordionItemContent
-    )}
-    ${create(
-      "calcite-accordion-item",
-      createAccordionItemAttributes({ group: "accordion-item-2" }),
-      accordionItemContent
-    )}
-    ${create(
-      "calcite-accordion-item",
-      createAccordionItemAttributes({ group: "accordion-item-3" }),
-      accordionItemContent
-    )}
-  `
+    html`
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-1" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-2" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-3" }),
+        accordionItemContent
+      )}
+    `
   );
 
 export const icon = (): string =>
   create(
     "calcite-accordion",
     createAccordionAttributes(),
-    dedent`
-    ${create(
-      "calcite-accordion-item",
-      createAccordionItemAttributes({ icon: true, group: "accordion-item-1" }),
-      accordionItemContent
-    )}
-    ${create(
-      "calcite-accordion-item",
-      createAccordionItemAttributes({ icon: true, group: "accordion-item-2" }),
-      accordionItemContent
-    )}
-    ${create(
-      "calcite-accordion-item",
-      createAccordionItemAttributes({ icon: true, group: "accordion-item-3" }),
-      accordionItemContent
-    )}
-  `
+    html`
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ icon: true, group: "accordion-item-1" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ icon: true, group: "accordion-item-2" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ icon: true, group: "accordion-item-3" }),
+        accordionItemContent
+      )}
+    `
   );

--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-action-bar", () => {
   it("renders", async () => renders("calcite-action-bar"));
@@ -155,7 +155,7 @@ describe("calcite-action-bar", () => {
 
   it("should focus on toggle button", async () =>
     focusable(
-      dedent`
+      html`
         <calcite-action-bar>
           <calcite-action-group>
             <calcite-action text="Add" icon="plus"></calcite-action>

--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -2,7 +2,7 @@ import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 const { dir, position, theme } = ATTRIBUTES;
 import { TEXT } from "./resources";
 
@@ -49,15 +49,15 @@ export const basic = (): string =>
   create(
     "calcite-action-bar",
     createAttributes(),
-    dedent`
-    <calcite-action-group>
-      <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
-      <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
-    </calcite-action-group>
-    <calcite-action-group>
-      <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
-    </calcite-action-group>
-  `
+    html`
+      <calcite-action-group>
+        <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
+        <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
+      </calcite-action-group>
+    `
   );
 
 export const withTooltip = (): DocumentFragment => {

--- a/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-action-pad", () => {
   it("renders", async () => renders("calcite-action-pad"));
@@ -134,7 +134,7 @@ describe("calcite-action-pad", () => {
 
   it("should focus on toggle button", async () =>
     focusable(
-      dedent`
+      html`
         <calcite-action-pad>
           <calcite-action-group>
             <calcite-action text="Add" icon="plus"></calcite-action>

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -2,7 +2,7 @@ import { boolean, select, text } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 const { dir, position, theme } = ATTRIBUTES;
 import { TEXT } from "./resources";
 
@@ -49,15 +49,15 @@ export const basic = (): string =>
   create(
     "calcite-action-pad",
     createAttributes(),
-    dedent`
-    <calcite-action-group>
-      <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
-      <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
-    </calcite-action-group>
-    <calcite-action-group>
-      <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
-    </calcite-action-group>
-  `
+    html`
+      <calcite-action-group>
+        <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
+        <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
+      </calcite-action-group>
+    `
   );
 
 export const withTooltip = (): DocumentFragment => {

--- a/src/components/calcite-block/calcite-block.stories.ts
+++ b/src/components/calcite-block/calcite-block.stories.ts
@@ -3,7 +3,7 @@ import { Attribute, Attributes, createComponentHTML as create, darkBackground } 
 import blockReadme from "./readme.md";
 import sectionReadme from "../calcite-block-section/readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 export default {
   title: "App Components/Block",
@@ -143,17 +143,17 @@ export const basic = (): string =>
   create(
     "calcite-block",
     createBlockAttributes(),
-    dedent`
-    ${create(
-      "calcite-block-section",
-      createSectionAttributes(),
-      `<img alt="demo" src="https://placeimg.com/320/240/animals" />`
-    )}
+    html`
+      ${create(
+        "calcite-block-section",
+        createSectionAttributes(),
+        `<img alt="demo" src="https://placeimg.com/320/240/animals" />`
+      )}
 
-    <calcite-block-section text="Nature" open>
-      <img alt="demo" src="https://placeimg.com/320/240/nature" />
-    </calcite-block-section>
-  `
+      <calcite-block-section text="Nature" open>
+        <img alt="demo" src="https://placeimg.com/320/240/nature" />
+      </calcite-block-section>
+    `
   );
 
 export const withHeaderControl = (): string =>

--- a/src/components/calcite-flow/calcite-flow.stories.ts
+++ b/src/components/calcite-flow/calcite-flow.stories.ts
@@ -5,7 +5,7 @@ const { dir, theme } = ATTRIBUTES;
 import readme from "./readme.md";
 import itemReadme from "../calcite-panel/readme.md";
 import { SLOTS, TEXT } from "../calcite-panel/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 export default {
   title: "App Components/Flow",
@@ -70,13 +70,19 @@ const createFlowItemAttributes: (group: string) => Attributes = (group) => {
   ];
 };
 
-const menuActionsHTML = dedent`
+const menuActionsHTML = html`
   <calcite-action slot="${SLOTS.menuActions}" text-enabled text="Add" label="Add Item" icon="plus"></calcite-action>
   <calcite-action slot="${SLOTS.menuActions}" text-enabled text="Save" label="Save Item" icon="save"></calcite-action>
-  <calcite-action slot="${SLOTS.menuActions}" text-enabled text="Layers" label="View Layers" icon="layers"></calcite-action>
+  <calcite-action
+    slot="${SLOTS.menuActions}"
+    text-enabled
+    text="Layers"
+    label="View Layers"
+    icon="layers"
+  ></calcite-action>
 `;
 
-const footerActionsHTML = dedent`
+const footerActionsHTML = html`
   <calcite-button slot="${SLOTS.footerActions}" width="half">Save</calcite-button>
   <calcite-button slot="${SLOTS.footerActions}" width="half" appearance="clear">Cancel</button>
 `;
@@ -85,30 +91,63 @@ function createItemHTML(content: string): string {
   return `${menuActionsHTML}${content}${footerActionsHTML}`;
 }
 
-const item1HTML = dedent`
+const item1HTML = html`
   <p>
-  Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non. Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti consectetur. Non porttitor tempor orci dictumst magna porta vitae.
+    Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo
+    semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus
+    habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non.
+    Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti
+    consectetur. Non porttitor tempor orci dictumst magna porta vitae.
   </p>
   <p>
-  Ipsum nostra tempus etiam augue ullamcorper scelerisque sapien potenti erat nisi gravida. Vehicula sem tristique sed. Nullam, sociis imperdiet ullamcorper? Dapibus fames primis ridiculus vulputate, habitant inceptos! Nunc torquent lorem urna vehicula volutpat donec nec. Orci massa eu nec donec enim fames, faucibus quam aenean. Laoreet tellus tempor quisque ornare lobortis praesent erat senectus natoque consectetur donec imperdiet. Quis sem cum gravida dictumst a pretium purus aptent amet id. Orci habitasse, praesent facilisis condimentum. Nec elit turpis leo.
+    Ipsum nostra tempus etiam augue ullamcorper scelerisque sapien potenti erat nisi gravida. Vehicula sem tristique
+    sed. Nullam, sociis imperdiet ullamcorper? Dapibus fames primis ridiculus vulputate, habitant inceptos! Nunc
+    torquent lorem urna vehicula volutpat donec nec. Orci massa eu nec donec enim fames, faucibus quam aenean. Laoreet
+    tellus tempor quisque ornare lobortis praesent erat senectus natoque consectetur donec imperdiet. Quis sem cum
+    gravida dictumst a pretium purus aptent amet id. Orci habitasse, praesent facilisis condimentum. Nec elit turpis
+    leo.
   </p>
   <p>
-  Tempus per volutpat diam tempor mauris parturient vulputate leo id libero quisque. Mattis aliquam dictum venenatis fringilla. Taciti venenatis, ultrices sollicitudin consequat. Sapien fusce est iaculis potenti ut auctor potenti. Nisi malesuada feugiat vulputate vitae porttitor. Nullam nullam nullam accumsan quis magna in. Elementum, nascetur gravida cras scelerisque inceptos aenean inceptos potenti. Lobortis condimentum accumsan posuere curabitur fermentum diam, natoque quisque. Eget placerat sed aptent orci urna fusce magnis. Vel lacus magnis nunc.
+    Tempus per volutpat diam tempor mauris parturient vulputate leo id libero quisque. Mattis aliquam dictum venenatis
+    fringilla. Taciti venenatis, ultrices sollicitudin consequat. Sapien fusce est iaculis potenti ut auctor potenti.
+    Nisi malesuada feugiat vulputate vitae porttitor. Nullam nullam nullam accumsan quis magna in. Elementum, nascetur
+    gravida cras scelerisque inceptos aenean inceptos potenti. Lobortis condimentum accumsan posuere curabitur fermentum
+    diam, natoque quisque. Eget placerat sed aptent orci urna fusce magnis. Vel lacus magnis nunc.
   </p>
   <p>
-  Magna ligula neque phasellus. Velit duis auctor etiam nullam sociis nam neque quis. Donec fusce bibendum quam egestas sociosqu orci tempus vulputate egestas penatibus urna sociosqu. Nulla nam potenti diam egestas litora lobortis tristique maecenas pulvinar maecenas vitae tortor. Lacus purus facilisi est accumsan varius gravida facilisis rutrum tortor potenti rhoncus id. Ipsum praesent tristique blandit taciti morbi torquent pharetra fermentum aenean!
+    Magna ligula neque phasellus. Velit duis auctor etiam nullam sociis nam neque quis. Donec fusce bibendum quam
+    egestas sociosqu orci tempus vulputate egestas penatibus urna sociosqu. Nulla nam potenti diam egestas litora
+    lobortis tristique maecenas pulvinar maecenas vitae tortor. Lacus purus facilisi est accumsan varius gravida
+    facilisis rutrum tortor potenti rhoncus id. Ipsum praesent tristique blandit taciti morbi torquent pharetra
+    fermentum aenean!
   </p>
   <p>
-  Congue eu duis integer nisl molestie nostra dis auctor lobortis tellus parturient. Porttitor dis curae; maecenas quis praesent ridiculus posuere mus. Dictumst, vivamus fames semper congue fusce! Nunc placerat enim fermentum posuere magna justo habitasse. Tristique placerat mauris, per nulla gravida dui urna ut nec venenatis! Non lacus iaculis quisque, neque erat integer. Duis tortor ad habitant turpis dis eu mollis at facilisis. Tellus nisl amet morbi fringilla mus dui neque himenaeos maecenas platea venenatis. Tristique nisl quisque ad aliquam senectus pulvinar litora.
+    Congue eu duis integer nisl molestie nostra dis auctor lobortis tellus parturient. Porttitor dis curae; maecenas
+    quis praesent ridiculus posuere mus. Dictumst, vivamus fames semper congue fusce! Nunc placerat enim fermentum
+    posuere magna justo habitasse. Tristique placerat mauris, per nulla gravida dui urna ut nec venenatis! Non lacus
+    iaculis quisque, neque erat integer. Duis tortor ad habitant turpis dis eu mollis at facilisis. Tellus nisl amet
+    morbi fringilla mus dui neque himenaeos maecenas platea venenatis. Tristique nisl quisque ad aliquam senectus
+    pulvinar litora.
   </p>
 `;
 
-const item2HTML = dedent`
+const item2HTML = html`
   <ul>
-    <li>Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu. Cras consequat.</li>
-    <li>Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.</li>
-    <li>Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.</li>
-    <li>Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc.</li>
+    <li>
+      Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed
+      arcu. Cras consequat.
+    </li>
+    <li>
+      Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam
+      erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+    </li>
+    <li>
+      Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique cursus.
+      Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.
+    </li>
+    <li>
+      Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc.
+    </li>
   </ul>
 `;
 

--- a/src/components/calcite-panel/calcite-panel.stories.ts
+++ b/src/components/calcite-panel/calcite-panel.stories.ts
@@ -4,7 +4,7 @@ import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, theme, scale } = ATTRIBUTES;
 import readme from "./readme.md";
 import { SLOTS, TEXT } from "./resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 export default {
   title: "App Components/Panel",
@@ -51,20 +51,33 @@ const createAttributes: () => Attributes = () => [
 
 const headerHTML = `<h3 class="heading" slot="${SLOTS.headerContent}">Heading</h3>`;
 
-const contentHTML = dedent`
+const contentHTML = html`
   <p>
-  Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non. Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti consectetur. Non porttitor tempor orci dictumst magna porta vitae.
+    Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo
+    semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus
+    habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non.
+    Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti
+    consectetur. Non porttitor tempor orci dictumst magna porta vitae.
   </p>
   <p>
-  Ipsum nostra tempus etiam augue ullamcorper scelerisque sapien potenti erat nisi gravida. Vehicula sem tristique sed. Nullam, sociis imperdiet ullamcorper? Dapibus fames primis ridiculus vulputate, habitant inceptos! Nunc torquent lorem urna vehicula volutpat donec nec. Orci massa eu nec donec enim fames, faucibus quam aenean. Laoreet tellus tempor quisque ornare lobortis praesent erat senectus natoque consectetur donec imperdiet. Quis sem cum gravida dictumst a pretium purus aptent amet id. Orci habitasse, praesent facilisis condimentum. Nec elit turpis leo.
+    Ipsum nostra tempus etiam augue ullamcorper scelerisque sapien potenti erat nisi gravida. Vehicula sem tristique
+    sed. Nullam, sociis imperdiet ullamcorper? Dapibus fames primis ridiculus vulputate, habitant inceptos! Nunc
+    torquent lorem urna vehicula volutpat donec nec. Orci massa eu nec donec enim fames, faucibus quam aenean. Laoreet
+    tellus tempor quisque ornare lobortis praesent erat senectus natoque consectetur donec imperdiet. Quis sem cum
+    gravida dictumst a pretium purus aptent amet id. Orci habitasse, praesent facilisis condimentum. Nec elit turpis
+    leo.
   </p>
   <p>
-  Tempus per volutpat diam tempor mauris parturient vulputate leo id libero quisque. Mattis aliquam dictum venenatis fringilla. Taciti venenatis, ultrices sollicitudin consequat. Sapien fusce est iaculis potenti ut auctor potenti. Nisi malesuada feugiat vulputate vitae porttitor. Nullam nullam nullam accumsan quis magna in. Elementum, nascetur gravida cras scelerisque inceptos aenean inceptos potenti. Lobortis condimentum accumsan posuere curabitur fermentum diam, natoque quisque. Eget placerat sed aptent orci urna fusce magnis. Vel lacus magnis nunc.
+    Tempus per volutpat diam tempor mauris parturient vulputate leo id libero quisque. Mattis aliquam dictum venenatis
+    fringilla. Taciti venenatis, ultrices sollicitudin consequat. Sapien fusce est iaculis potenti ut auctor potenti.
+    Nisi malesuada feugiat vulputate vitae porttitor. Nullam nullam nullam accumsan quis magna in. Elementum, nascetur
+    gravida cras scelerisque inceptos aenean inceptos potenti. Lobortis condimentum accumsan posuere curabitur fermentum
+    diam, natoque quisque. Eget placerat sed aptent orci urna fusce magnis. Vel lacus magnis nunc.
   </p>
 `;
 
-const footerHTML = dedent`
-  <calcite-button slot="${SLOTS.footer}" width="half" >Yeah!</calcite-button>
+const footerHTML = html`
+  <calcite-button slot="${SLOTS.footer}" width="half">Yeah!</calcite-button>
   <calcite-button slot="${SLOTS.footer}" width="half" appearance="clear">Naw.</calcite-button>
 `;
 

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS } from "./resources";
 import { accessible } from "../../tests/commonTests";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-pick-list-group", () => {
   it("is accessible", () =>
@@ -21,7 +21,7 @@ describe("calcite-pick-list-group", () => {
   });
 
   it("is accessible", async () =>
-    accessible(dedent`
+    accessible(html`
       <calcite-pick-list>
         <calcite-pick-list-group>
           <calcite-pick-list-item label="Sample" value="one"></calcite-pick-list-item>

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
@@ -1,26 +1,26 @@
 import { CSS } from "./resources";
 import { accessible, renders } from "../../tests/commonTests";
 import { newE2EPage } from "@stencil/core/testing";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-pick-list-item", () => {
   it("renders", async () => renders("calcite-pick-list-item"));
 
   it("is accessible", async () =>
     Promise.all([
-      accessible(dedent`
+      accessible(html`
         <calcite-pick-list>
           <calcite-pick-list-item label="test" description="a number" value="one"></calcite-pick-list-item>
         </calcite-pick-list>
       `),
 
-      accessible(dedent`
+      accessible(html`
         <calcite-pick-list>
           <calcite-pick-list-item label="test" description="a number" value="one" selected></calcite-pick-list-item>
         </calcite-pick-list>
       `),
 
-      accessible(dedent`
+      accessible(html`
         <calcite-pick-list>
           <calcite-pick-list-item label="test" description="a number" value="one" removable></calcite-pick-list-item>
         </calcite-pick-list>

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -8,7 +8,7 @@ import {
   keyboardNavigation,
   itemRemoval
 } from "./shared-list-tests";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-pick-list", () => {
   it("renders", async () => renders("calcite-pick-list"));
@@ -16,7 +16,7 @@ describe("calcite-pick-list", () => {
   it("honors hidden attribute", async () => hidden("calcite-pick-list"));
 
   it("is accessible", async () =>
-    accessible(dedent`
+    accessible(html`
       <calcite-pick-list>
         <calcite-pick-list-item label="Sample" value="one"></calcite-pick-list-item>
       </calcite-pick-list>

--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -2,7 +2,7 @@ import { boolean, select } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
@@ -40,83 +40,76 @@ const createAttributes: () => Attributes = () => [
   }
 ];
 
-const action = dedent`
-  <calcite-action slot="actions-end" label="click-me" onClick="console.log('clicked');" appearance="clear" scale="s" icon="information"></calcite-action>
+const action = html`
+  <calcite-action
+    slot="actions-end"
+    label="click-me"
+    onClick="console.log('clicked');"
+    appearance="clear"
+    scale="s"
+    icon="information"
+  ></calcite-action>
 `;
 
 export const basic = (): string =>
   create(
     "calcite-pick-list",
     createAttributes(),
-    dedent`
-    <calcite-pick-list-item label="T. Rex" description="arm strength impaired" value="trex">
-      ${action}
-    </calcite-pick-list-item>
-    <calcite-pick-list-item label="Triceratops" description="3 horn" value="triceratops" selected>
-      ${action}
-    </calcite-pick-list-item>
-    <calcite-pick-list-item label="hi" description="there" value="helloWorld">
-      ${action}
-    </calcite-pick-list-item>
-  `
+    html`
+      <calcite-pick-list-item label="T. Rex" description="arm strength impaired" value="trex">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item label="Triceratops" description="3 horn" value="triceratops" selected>
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item label="hi" description="there" value="helloWorld"> ${action} </calcite-pick-list-item>
+    `
   );
 
 export const grouped = (): string =>
   create(
     "calcite-pick-list",
     createAttributes(),
-    dedent`
-    <calcite-pick-list-group group-title="numbers">
-      <calcite-pick-list-item label="one" description="fish" value="one" icon="grip">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="two" description="fish" value="two" icon="grip">
-        ${action}
-      </calcite-pick-list-item>
-    </calcite-pick-list-group>
-    <calcite-pick-list-group group-title="colors">
-      <calcite-pick-list-item label="red" description="fish" value="red" icon="grip">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="blue" description="fish" value="blue" icon="grip">
-        ${action}
-      </calcite-pick-list-item>
-    </calcite-pick-list-group>
-  `
+    html`
+      <calcite-pick-list-group group-title="numbers">
+        <calcite-pick-list-item label="one" description="fish" value="one" icon="grip">
+          ${action}
+        </calcite-pick-list-item>
+        <calcite-pick-list-item label="two" description="fish" value="two" icon="grip">
+          ${action}
+        </calcite-pick-list-item>
+      </calcite-pick-list-group>
+      <calcite-pick-list-group group-title="colors">
+        <calcite-pick-list-item label="red" description="fish" value="red" icon="grip">
+          ${action}
+        </calcite-pick-list-item>
+        <calcite-pick-list-item label="blue" description="fish" value="blue" icon="grip">
+          ${action}
+        </calcite-pick-list-item>
+      </calcite-pick-list-group>
+    `
   );
 
 export const nested = (): string =>
   create(
     "calcite-pick-list",
     createAttributes(),
-    dedent`
-    <calcite-pick-list-group>
-      <calcite-pick-list-item label="All the dogs" value="all-dogs" slot="parent-item">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="Husky" value="husky">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="Pomeranian" value="pom">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="Xoloitzcuintle" value="xolo">
-        ${action}
-      </calcite-pick-list-item>
-    </calcite-pick-list-group>
-    <calcite-pick-list-group>
-      <calcite-pick-list-item label="All the cats" value="all-cats" slot="parent-item">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="Himalayan" value="himalayan">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="Persian" value="persian">
-        ${action}
-      </calcite-pick-list-item>
-      <calcite-pick-list-item label="Spynx" value="spynx">
-        ${action}
-      </calcite-pick-list-item>
-    </calcite-pick-list-group>
-  `
+    html`
+      <calcite-pick-list-group>
+        <calcite-pick-list-item label="All the dogs" value="all-dogs" slot="parent-item">
+          ${action}
+        </calcite-pick-list-item>
+        <calcite-pick-list-item label="Husky" value="husky"> ${action} </calcite-pick-list-item>
+        <calcite-pick-list-item label="Pomeranian" value="pom"> ${action} </calcite-pick-list-item>
+        <calcite-pick-list-item label="Xoloitzcuintle" value="xolo"> ${action} </calcite-pick-list-item>
+      </calcite-pick-list-group>
+      <calcite-pick-list-group>
+        <calcite-pick-list-item label="All the cats" value="all-cats" slot="parent-item">
+          ${action}
+        </calcite-pick-list-item>
+        <calcite-pick-list-item label="Himalayan" value="himalayan"> ${action} </calcite-pick-list-item>
+        <calcite-pick-list-item label="Persian" value="persian"> ${action} </calcite-pick-list-item>
+        <calcite-pick-list-item label="Spynx" value="spynx"> ${action} </calcite-pick-list-item>
+      </calcite-pick-list-group>
+    `
   );

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -1,6 +1,6 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { JSEvalable } from "puppeteer";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 import { CSS as PICK_LIST_ITEM_CSS } from "../calcite-pick-list-item/resources";
 
 type ListType = "pick" | "value";
@@ -409,7 +409,7 @@ export function filterBehavior(listType: ListType): void {
 export function disabledStates(listType: ListType): void {
   it("disabled", async () => {
     const page = await newE2EPage({
-      html: dedent`
+      html: html`
         <calcite-${listType}-list disabled>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
         </calcite-${listType}-list>
@@ -442,7 +442,7 @@ export function disabledStates(listType: ListType): void {
 export function itemRemoval(listType: ListType): void {
   it("handles removing items", async () => {
     const page = await newE2EPage({
-      html: dedent`
+      html: html`
       <calcite-${listType}-list>
         <calcite-${listType}-list-item value="remove-me" label="Remove me!" removable></calcite-${listType}-list-item>
       </calcite-${listType}-list>

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { focusable } from "../../tests/commonTests";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-radio-group", () => {
   it("renders", async () => {
@@ -241,7 +241,7 @@ describe("calcite-radio-group", () => {
   describe("setFocus()", () => {
     it("focuses the first item if there is no selection", async () =>
       focusable(
-        dedent`
+        html`
           <calcite-radio-group>
             <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
             <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
@@ -255,7 +255,7 @@ describe("calcite-radio-group", () => {
 
     it("focuses the selected item", async () =>
       focusable(
-        dedent`
+        html`
           <calcite-radio-group>
             <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
             <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>

--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -1,10 +1,10 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, focusable, reflects, renders } from "../../tests/commonTests";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 import { CSS } from "./resources";
 
 describe("calcite-select", () => {
-  const simpleTestMarkup = dedent`
+  const simpleTestMarkup = html`
     <calcite-select label="required-for-a11y-test">
       <calcite-option>uno</calcite-option>
       <calcite-option>dos</calcite-option>
@@ -46,7 +46,7 @@ describe("calcite-select", () => {
   describe("flat options", () => {
     it("allows selecting items", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option>uno</calcite-option>
             <calcite-option>dos</calcite-option>
@@ -74,7 +74,7 @@ describe("calcite-select", () => {
 
     it("selects the last selected option when multiple are selected", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option selected>uno</calcite-option>
             <calcite-option selected>dos</calcite-option>
@@ -91,7 +91,7 @@ describe("calcite-select", () => {
 
     it("selects the first available option when none are selected", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option>uno</calcite-option>
             <calcite-option>dos</calcite-option>
@@ -108,7 +108,7 @@ describe("calcite-select", () => {
 
     it("internally maps children to native elements", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option>uno</calcite-option>
             <calcite-option>dos</calcite-option>
@@ -142,7 +142,7 @@ describe("calcite-select", () => {
   describe("grouped options", () => {
     it("allows selecting items", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option-group label="letters">
               <calcite-option>a</calcite-option>
@@ -178,7 +178,7 @@ describe("calcite-select", () => {
 
     it("selects the last selected option when multiple are selected", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option-group label="letters">
               <calcite-option selected>a</calcite-option>
@@ -202,7 +202,7 @@ describe("calcite-select", () => {
 
     it("selects the first available option when none are selected", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option-group label="letters">
               <calcite-option>a</calcite-option>
@@ -227,7 +227,7 @@ describe("calcite-select", () => {
     describe("label compatibility", () => {
       it("focuses when enclosing label is clicked", async () => {
         const page = await newE2EPage({
-          html: dedent`
+          html: html`
             <calcite-label>
               Click me!
               <calcite-select>
@@ -249,7 +249,7 @@ describe("calcite-select", () => {
 
       it("focuses when associated label is clicked", async () => {
         const page = await newE2EPage({
-          html: dedent`
+          html: html`
             <calcite-label for="select">Click me!</calcite-label>
             <calcite-select id="select">
               <calcite-option>1</calcite-option>
@@ -269,7 +269,7 @@ describe("calcite-select", () => {
 
     it("internally maps children to native elements", async () => {
       const page = await newE2EPage({
-        html: dedent`
+        html: html`
           <calcite-select>
             <calcite-option-group label="letters">
               <calcite-option>a</calcite-option>
@@ -318,13 +318,13 @@ describe("calcite-select", () => {
 
   it("item is selected before change event", async () => {
     const page = await newE2EPage({
-      html: dedent`
-          <calcite-select>
-            <calcite-option id="1">uno</calcite-option>
-            <calcite-option id="2">dos</calcite-option>
-            <calcite-option id="3">tres</calcite-option>
-          </calcite-select>
-        `
+      html: html`
+        <calcite-select>
+          <calcite-option id="1">uno</calcite-option>
+          <calcite-option id="2">dos</calcite-option>
+          <calcite-option id="3">tres</calcite-option>
+        </calcite-select>
+      `
     });
 
     type TestWindow = typeof window & { selectedOptionId: string };

--- a/src/components/calcite-select/calcite-select.stories.ts
+++ b/src/components/calcite-select/calcite-select.stories.ts
@@ -1,5 +1,5 @@
 import { Attribute, Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { boolean, select, text } from "@storybook/addon-knobs";
 import selectReadme from "../calcite-select/readme.md";
@@ -94,30 +94,30 @@ export const basic = (): string =>
   create(
     "calcite-select",
     createSelectAttributes(),
-    dedent`
-    ${create("calcite-option", createOptionAttributes())}
-    <calcite-option label="some fixed option" value="some-fixed-value"></calcite-option>
-    <calcite-option label="another fixed option" value="another-fixed-value"></calcite-option>
-  `
+    html`
+      ${create("calcite-option", createOptionAttributes())}
+      <calcite-option label="some fixed option" value="some-fixed-value"></calcite-option>
+      <calcite-option label="another fixed option" value="another-fixed-value"></calcite-option>
+    `
   );
 
 export const grouped = (): string =>
   create(
     "calcite-select",
     createSelectAttributes(),
-    dedent`
-    ${create(
-      "calcite-option-group",
-      createOptionGroupAttributes(),
-      dedent`
-        ${create("calcite-option", createOptionAttributes())}
-        <calcite-option label="some fixed option (A)" value="some-fixed-value-a"></calcite-option>
-        <calcite-option label="another fixed option (A)" value="another-fixed-value-a"></calcite-option>
-      `
-    )}
-    <calcite-option-group label="group B (fixed)">
-      <calcite-option label="some fixed option (B)" value="some-fixed-value-b"></calcite-option>
-      <calcite-option label="another fixed option (B)" value="another-fixed-value-b"></calcite-option>
-    </calcite-option-group>
-  `
+    html`
+      ${create(
+        "calcite-option-group",
+        createOptionGroupAttributes(),
+        html`
+          ${create("calcite-option", createOptionAttributes())}
+          <calcite-option label="some fixed option (A)" value="some-fixed-value-a"></calcite-option>
+          <calcite-option label="another fixed option (A)" value="another-fixed-value-a"></calcite-option>
+        `
+      )}
+      <calcite-option-group label="group B (fixed)">
+        <calcite-option label="some fixed option (B)" value="some-fixed-value-b"></calcite-option>
+        <calcite-option label="another fixed option (B)" value="another-fixed-value-b"></calcite-option>
+      </calcite-option-group>
+    `
   );

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -4,7 +4,7 @@ import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, position, scale, theme } = ATTRIBUTES;
 import readme from "./readme.md";
 import panelReadme from "../calcite-shell-panel/readme.md";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 export default {
   title: "App Components/Shell",
@@ -77,7 +77,7 @@ const createShellCenterRowAttributes: (group: string) => Attributes = (group) =>
   ];
 };
 
-const actionBarPrimaryContentHTML = dedent`
+const actionBarPrimaryContentHTML = html`
   <calcite-action-group>
     <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
     <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
@@ -87,7 +87,7 @@ const actionBarPrimaryContentHTML = dedent`
   </calcite-action-group>
 `;
 
-const actionBarContextualContentHTML = dedent`
+const actionBarContextualContentHTML = html`
   <calcite-action-group>
     <calcite-action text="Idea" label="Add Item" icon="lightbulb"></calcite-action>
     <calcite-action text="Information" label="Save Item" icon="information"></calcite-action>
@@ -97,39 +97,37 @@ const actionBarContextualContentHTML = dedent`
   </calcite-action-group>
 `;
 
-const actionBarPrimaryHTML = dedent`
-  <calcite-action-bar theme="dark" slot="action-bar">
-    ${actionBarPrimaryContentHTML}
-  </calcite-action-bar>
+const actionBarPrimaryHTML = html`
+  <calcite-action-bar theme="dark" slot="action-bar"> ${actionBarPrimaryContentHTML} </calcite-action-bar>
 `;
 
-const actionBarContextualHTML = dedent`
-  <calcite-action-bar theme="light" slot="action-bar">
-    ${actionBarContextualContentHTML}
-  </calcite-action-bar>
+const actionBarContextualHTML = html`
+  <calcite-action-bar theme="light" slot="action-bar"> ${actionBarContextualContentHTML} </calcite-action-bar>
 `;
 
-const leadingPanelHTML = dedent`
+const leadingPanelHTML = html`
   ${actionBarPrimaryHTML}
   <p>My Leading Panel</p>
 `;
 
-const centerRowHTML = dedent`
-  <div style="
+const centerRowHTML = html`
+  <div
+    style="
     width:50vw;
     background-color: var(--calcite-app-background-content);
     padding: var(--calcite-app-cap-spacing) var(--calcite-app-side-spacing);
-    ">
+    "
+  >
     <span>My Shell Center Row</span>
   </div>
 `;
 
-const trailingPanelHTML = dedent`
+const trailingPanelHTML = html`
   ${actionBarContextualHTML}
   <p>My Trailing Panel</p>
 `;
 
-const headerHTML = dedent`
+const headerHTML = html`
   <header slot="shell-header">
     <h2>My Shell Header</h2>
   </header>
@@ -137,8 +135,9 @@ const headerHTML = dedent`
 
 const footerHTML = `<footer slot="shell-footer">My Shell Footer</footer>`;
 
-const contentHTML = dedent`
-  <div style="
+const contentHTML = html`
+  <div
+    style="
     width:100%;
     height:100%;
     background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
@@ -147,10 +146,11 @@ const contentHTML = dedent`
       linear-gradient(-45deg, transparent 75%, #ccc 75%);
     background-size: 20px 20px;
     background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
-  "></div>
+  "
+  ></div>
 `;
 
-const centerRowAdvancedHTML = dedent`
+const centerRowAdvancedHTML = html`
   <calcite-tip-manager slot="center-row">
     <calcite-tip-group group-title="Astronomy">
       <calcite-tip heading="The Red Rocks and Blue Water">
@@ -160,43 +160,36 @@ const centerRowAdvancedHTML = dedent`
           content. This paragraph is in an "info" slot.
         </p>
         <p>
-          This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum is
-          a placeholder text commonly used to demonstrate the visual form of a document without relying on
-          meaningful content (also called greeking). Replacing the actual content with placeholder text allows
-          designers to design the form of the content before the content itself has been produced.
+          This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum is a
+          placeholder text commonly used to demonstrate the visual form of a document without relying on meaningful
+          content (also called greeking). Replacing the actual content with placeholder text allows designers to design
+          the form of the content before the content itself has been produced.
         </p>
         <a href="http://www.esri.com">This is the "link" slot.</a>
       </calcite-tip>
       <calcite-tip heading="The Long Trees">
         <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
-        <p>
-          This tip has an image that is a pretty tall. And the text will run out before the end of the image.
-        </p>
+        <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
         <p>In astronomy, the terms object and body are often used interchangeably.</p>
         <a href="http://www.esri.com">View Esri</a>
       </calcite-tip>
     </calcite-tip-group>
     <calcite-tip heading="Square Nature">
       <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-      <p>
-        This tip has an image that is square. And the text will run out before the end of the image.
-      </p>
+      <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
       <p>In astronomy, the terms object and body are often used interchangeably.</p>
       <p>
-        In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
-        visual form of a document without relying on meaningful content (also called greeking). Replacing the
-        actual content with placeholder text allows designers to design the form of the content before the content
-        itself has been produced.
+        In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the visual form
+        of a document without relying on meaningful content (also called greeking). Replacing the actual content with
+        placeholder text allows designers to design the form of the content before the content itself has been produced.
       </p>
       <a href="http://www.esri.com">View Esri</a>
     </calcite-tip>
     <calcite-tip heading="The lack of imagery">
+      <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
       <p>
-        This tip has no image. As such, the content area will take up the entire width of the tip.
-      </p>
-      <p>
-        This is the next paragraph and should show how wide the content area is now. Of course, the width of the
-        overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
+        This is the next paragraph and should show how wide the content area is now. Of course, the width of the overall
+        tip will affect things. In astronomy, the terms object and body are often used interchangeably.
       </p>
       <a href="http://www.esri.com">View Esri</a>
     </calcite-tip>
@@ -207,18 +200,15 @@ export const basic = (): string =>
   create(
     "calcite-shell",
     createAttributes("Shell"),
-    dedent`
-    ${headerHTML}
-    ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), leadingPanelHTML)}
-    ${contentHTML}
-    ${create("calcite-shell-center-row", createShellCenterRowAttributes("Center Row"), centerRowHTML)}
-    ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), trailingPanelHTML)}
-    ${footerHTML}
-  `
+    html`
+      ${headerHTML} ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), leadingPanelHTML)}
+      ${contentHTML} ${create("calcite-shell-center-row", createShellCenterRowAttributes("Center Row"), centerRowHTML)}
+      ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), trailingPanelHTML)} ${footerHTML}
+    `
   );
 
 // TODO: UPDATE
-const advancedLeadingPanelHTML = dedent`
+const advancedLeadingPanelHTML = html`
   ${actionBarPrimaryHTML}
   <calcite-block collapsible open heading="Primary Content" summary="This is the primary.">
     <calcite-block-content>
@@ -251,13 +241,13 @@ const advancedLeadingPanelHTML = dedent`
 `;
 
 // TODO: UPDATE
-const advancedTrailingPanelHTMl = dedent`
+const advancedTrailingPanelHTMl = html`
   ${actionBarContextualHTML}
   <calcite-flow>
     <calcite-panel heading="Layer settings">
-        <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
-        <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
-        <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
+      <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
+      <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
+      <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
       <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
         <calcite-block-content>
           <img alt="demo" src="https://placeimg.com/640/480/any" width="100%" />
@@ -273,7 +263,7 @@ const advancedTrailingPanelHTMl = dedent`
           </calcite-block-section>
         </calcite-block-content>
       </calcite-block>
-      <calcite-button slot="footer-actions" width="half" >Save</calcite-button>
+      <calcite-button slot="footer-actions" width="half">Save</calcite-button>
       <calcite-button slot="footer-actions" width="half" appearance="clear">Cancel</calcite-button>
     </calcite-panel>
     <calcite-panel heading="Deeper flow item">
@@ -307,7 +297,7 @@ const advancedTrailingPanelHTMl = dedent`
           </calcite-block-section>
         </calcite-block-content>
       </calcite-block>
-      <calcite-button slot="footer-actions" width="half" >Save</calcite-button>
+      <calcite-button slot="footer-actions" width="half">Save</calcite-button>
       <calcite-button slot="footer-actions" width="half" appearance="clear">Cancel</calcite-button>
     </calcite-panel>
   </calcite-flow>
@@ -317,12 +307,11 @@ export const advanced = (): string =>
   create(
     "calcite-shell",
     createAttributes("Shell"),
-    dedent`
-    ${headerHTML}
-    ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), advancedLeadingPanelHTML)}
-    ${contentHTML}
-    ${centerRowAdvancedHTML}
-    ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), advancedTrailingPanelHTMl)}
-    ${footerHTML}
-  `
+    html`
+      ${headerHTML}
+      ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), advancedLeadingPanelHTML)}
+      ${contentHTML} ${centerRowAdvancedHTML}
+      ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), advancedTrailingPanelHTMl)}
+      ${footerHTML}
+    `
   );

--- a/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
@@ -3,7 +3,7 @@ import { Attributes, createComponentHTML as create, darkBackground } from "../..
 import readme from "./readme.md";
 import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
@@ -53,54 +53,48 @@ export const basic = (): string =>
   create(
     "calcite-tip-manager",
     createAttributes(),
-    dedent`
-    <calcite-tip-group group-title="Astronomy">
-      <calcite-tip heading="The Red Rocks and Blue Water">
-        <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
-        <p>
-          This tip is how a tip should really look. It has a landscape or square image and a small amount of text
-          content. This paragraph is in an "info" slot.
-        </p>
-        <p>
-          This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum is
-          a placeholder text commonly used to demonstrate the visual form of a document without relying on
-          meaningful content (also called greeking). Replacing the actual content with placeholder text allows
-          designers to design the form of the content before the content itself has been produced.
-        </p>
-        <a href="http://www.esri.com">This is the "link" slot.</a>
-      </calcite-tip>
-      <calcite-tip heading="The Long Trees">
-        <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
-        <p>
-          This tip has an image that is a pretty tall. And the text will run out before the end of the image.
-        </p>
+    html`
+      <calcite-tip-group group-title="Astronomy">
+        <calcite-tip heading="The Red Rocks and Blue Water">
+          <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
+          <p>
+            This tip is how a tip should really look. It has a landscape or square image and a small amount of text
+            content. This paragraph is in an "info" slot.
+          </p>
+          <p>
+            This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum is a
+            placeholder text commonly used to demonstrate the visual form of a document without relying on meaningful
+            content (also called greeking). Replacing the actual content with placeholder text allows designers to
+            design the form of the content before the content itself has been produced.
+          </p>
+          <a href="http://www.esri.com">This is the "link" slot.</a>
+        </calcite-tip>
+        <calcite-tip heading="The Long Trees">
+          <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
+          <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
+          <p>In astronomy, the terms object and body are often used interchangeably.</p>
+          <a href="http://www.esri.com">View Esri</a>
+        </calcite-tip>
+      </calcite-tip-group>
+      <calcite-tip heading="Square Nature">
+        <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
+        <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
         <p>In astronomy, the terms object and body are often used interchangeably.</p>
+        <p>
+          In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the visual
+          form of a document without relying on meaningful content (also called greeking). Replacing the actual content
+          with placeholder text allows designers to design the form of the content before the content itself has been
+          produced.
+        </p>
         <a href="http://www.esri.com">View Esri</a>
       </calcite-tip>
-    </calcite-tip-group>
-    <calcite-tip heading="Square Nature">
-      <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-      <p>
-        This tip has an image that is square. And the text will run out before the end of the image.
-      </p>
-      <p>In astronomy, the terms object and body are often used interchangeably.</p>
-      <p>
-        In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
-        visual form of a document without relying on meaningful content (also called greeking). Replacing the
-        actual content with placeholder text allows designers to design the form of the content before the content
-        itself has been produced.
-      </p>
-      <a href="http://www.esri.com">View Esri</a>
-    </calcite-tip>
-    <calcite-tip heading="The lack of imagery">
-      <p>
-        This tip has no image. As such, the content area will take up the entire width of the tip.
-      </p>
-      <p>
-        This is the next paragraph and should show how wide the content area is now. Of course, the width of the
-        overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
-      </p>
-      <a href="http://www.esri.com">View Esri</a>
-    </calcite-tip>
-  `
+      <calcite-tip heading="The lack of imagery">
+        <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
+        <p>
+          This is the next paragraph and should show how wide the content area is now. Of course, the width of the
+          overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
+        </p>
+        <a href="http://www.esri.com">View Esri</a>
+      </calcite-tip>
+    `
   );

--- a/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
@@ -1,26 +1,26 @@
 import { CSS as PICK_LIST_ITEM_CSS } from "../calcite-pick-list-item/resources";
 import { accessible, focusable, renders } from "../../tests/commonTests";
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-value-list-item", () => {
   it("renders", async () => renders("calcite-value-list-item"));
 
   it("is accessible", async () =>
     Promise.all([
-      accessible(dedent`
+      accessible(html`
         <calcite-value-list>
           <calcite-value-list-item label="test" description="a number" value="one"></calcite-value-list-item>
         </calcite-value-list>
       `),
 
-      accessible(dedent`
+      accessible(html`
         <calcite-value-list>
           <calcite-value-list-item label="test" description="a number" value="one" selected></calcite-value-list-item>
         </calcite-value-list>
       `),
 
-      accessible(dedent`
+      accessible(html`
         <calcite-value-list>
           <calcite-value-list-item label="test" description="a number" value="one" removable></calcite-value-list-item>
         </calcite-value-list>

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -8,8 +8,7 @@ import {
   keyboardNavigation,
   itemRemoval
 } from "../calcite-pick-list/shared-list-tests";
-import { dragAndDrop } from "../../tests/utils";
-import dedent from "dedent";
+import { dragAndDrop, html } from "../../tests/utils";
 
 describe("calcite-value-list", () => {
   it("renders", () => renders("calcite-value-list"));
@@ -17,7 +16,7 @@ describe("calcite-value-list", () => {
   it("honors hidden attribute", async () => hidden("calcite-value-list"));
 
   it("is accessible", () =>
-    accessible(dedent`
+    accessible(html`
       <calcite-value-list>
         <calcite-value-list-item label="Sample" value="one"></calcite-value-list-item>
       </calcite-value-list>

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -2,7 +2,7 @@ import { boolean, select } from "@storybook/addon-knobs";
 import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import dedent from "dedent";
+import { html } from "../../tests/utils";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
@@ -44,24 +44,34 @@ const createAttributes: () => Attributes = () => [
   }
 ];
 
-const action = dedent`
-  <calcite-action slot="actions-end" label="click-me" onClick="console.log('clicked');" appearance="clear" scale="s" icon="ellipsis"></calcite-action>
+const action = html`
+  <calcite-action
+    slot="actions-end"
+    label="click-me"
+    onClick="console.log('clicked');"
+    appearance="clear"
+    scale="s"
+    icon="ellipsis"
+  ></calcite-action>
 `;
 
 export const basic = (): string =>
   create(
     "calcite-value-list",
     createAttributes(),
-    dedent`
-    <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs" >
-      ${action}
-    </calcite-value-list-item>
-    <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats" >
-      ${action}
-    </calcite-value-list-item>
-    <calcite-value-list-item label="Fish. But not just any fish, a tiger fish caught live in the Atlantic Ocean while on vacation."
-      description="Easy to care for." value="fish" >
-      ${action}
-    </calcite-value-list-item>
-  `
+    html`
+      <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
+        ${action}
+      </calcite-value-list-item>
+      <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
+        ${action}
+      </calcite-value-list-item>
+      <calcite-value-list-item
+        label="Fish. But not just any fish, a tiger fish caught live in the Atlantic Ocean while on vacation."
+        description="Easy to care for."
+        value="fish"
+      >
+        ${action}
+      </calcite-value-list-item>
+    `
   );

--- a/src/demos/_assets/head.ts
+++ b/src/demos/_assets/head.ts
@@ -18,9 +18,6 @@
     {
       src: "build/calcite.js",
       noModule: true
-    },
-    {
-      src: "vendor/dedent/dedent.js"
     }
   ];
 

--- a/src/demos/flow/adding-items.html
+++ b/src/demos/flow/adding-items.html
@@ -67,7 +67,7 @@
 
         newNode.heading = "Item " + (flowNode.childElementCount + 1);
         newNode.summary = "I don't have an answer to this questions. Stop asking me this question.";
-        newNode.innerHTML = dedent`
+        newNode.innerHTML = `
           <p><img src="https://via.placeholder.com/300x200" alt="placeholder" /></p>
           <p><img src="https://via.placeholder.com/300x200" alt="placeholder" /></p>
           <calcite-action slot="menu-actions" icon="pencil"></calcite-action>

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,5 +1,6 @@
 import { E2EPage } from "@stencil/core/testing";
 import { BoundingBox, JSONObject } from "puppeteer";
+import dedent from "dedent";
 
 type DragAndDropSelector = string | SelectorOptions;
 
@@ -95,4 +96,28 @@ export async function dragAndDrop(
     await createEventInitializer(dragStartSelector),
     await createEventInitializer(dragEndSelector)
   );
+}
+
+/**
+ * Use this tagged template to help Prettier format any HTML template literals.
+ * @param strings the
+ *
+ * @example
+ *
+ * ```ts
+ * const page = await newE2EPage({
+ *   html: html`
+ *     <calcite-select>
+ *       <calcite-option id="1">uno</calcite-option>
+ *       <calcite-option id="2">dos</calcite-option>
+ *       <calcite-option id="3">tres</calcite-option>
+ *     </calcite-select>
+ *   `
+ * });
+ * ```
+ */
+export function html(strings: string): string;
+export function html(strings: TemplateStringsArray, ...placeholders: any[]): string;
+export function html(strings: any, ...placeholders: any[]): string {
+  return dedent(strings, ...placeholders);
 }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -73,13 +73,7 @@ export const create: () => Config = () => ({
       type: "www",
       baseUrl: "https://stenciljs.com/",
       prerenderConfig: "./prerender.config.ts",
-      copy: [
-        { src: "demos", dest: "demos" },
-        {
-          src: "../node_modules/dedent/dist",
-          dest: "vendor/dedent"
-        }
-      ],
+      copy: [{ src: "demos", dest: "demos" }],
       serviceWorker: {
         unregister: true
       }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Stems from https://github.com/Esri/calcite-components/pull/1386#discussion_r538893225. 

> Prettier runs on each commit, but it doesn't format embedded content if it can't recognize it. [Looking at the docs](https://prettier.io/docs/en/options.html#embedded-language-formatting), I think we could have this work automatically wrapping `dedent` in a tagged template called `html`, which Prettier will pick up. Then we would only need to do something similar to get automatic formatting:
> 
> ```ts
> const page = await newE2EPage({
>   html: html`
>       ...some markup
>   `
> });
> ```
> 
> I'll submit a PR for this. Thanks for the idea! 🎉 

This adds a utility tagged template named `html`, which will give Prettier a hint to format wherever we have embedded HTML (e.g., stories, tests).

Note: this removed the only instance of `dedent` in demos since it isn't likely an issue there. 