### PR TITLE
fix(tab-nav): change rtl tab indicator position to fix nested layouts

### DIFF
--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -145,7 +145,10 @@ export class CalciteTabNav {
           onScroll={this.handleContainerScroll}
           ref={(el: HTMLDivElement) => (this.tabNavEl = el)}
         >
-          <div class="tab-nav-active-indicator-container">
+          <div
+            class="tab-nav-active-indicator-container"
+            ref={(el) => (this.activeIndicatorContainerEl = el as HTMLElement)}
+          >
             <div
               class="tab-nav-active-indicator"
               ref={(el) => (this.activeIndicatorEl = el as HTMLElement)}
@@ -254,6 +257,8 @@ export class CalciteTabNav {
 
   private activeIndicatorEl: HTMLElement;
 
+  private activeIndicatorContainerEl: HTMLElement;
+
   private animationActiveDuration = 0.3;
 
   //--------------------------------------------------------------------------
@@ -270,10 +275,12 @@ export class CalciteTabNav {
 
   private updateOffsetPosition(): void {
     const dir = getElementDir(this.el);
+    const navWidth = this.activeIndicatorContainerEl?.offsetWidth;
+    const tabLeft = this.selectedTabEl?.offsetLeft;
+    const tabWidth = this.selectedTabEl?.offsetWidth;
+    const offsetRight = navWidth - (tabLeft + tabWidth);
     this.indicatorOffset =
-      dir !== "rtl"
-        ? this.selectedTabEl?.offsetLeft - this.tabNavEl?.scrollLeft
-        : this.tabNavEl?.offsetWidth - this.selectedTabEl.getBoundingClientRect().right;
+      dir !== "rtl" ? tabLeft - this.tabNavEl?.scrollLeft : offsetRight + this.tabNavEl?.scrollLeft;
   }
 
   private updateActiveWidth(): void {

--- a/src/components/calcite-tab-nav/calcite-tab-nav.tsx
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.tsx
@@ -147,7 +147,7 @@ export class CalciteTabNav {
         >
           <div
             class="tab-nav-active-indicator-container"
-            ref={(el) => (this.activeIndicatorContainerEl = el as HTMLElement)}
+            ref={(el) => (this.activeIndicatorContainerEl = el)}
           >
             <div
               class="tab-nav-active-indicator"
@@ -257,7 +257,7 @@ export class CalciteTabNav {
 
   private activeIndicatorEl: HTMLElement;
 
-  private activeIndicatorContainerEl: HTMLElement;
+  private activeIndicatorContainerEl: HTMLDivElement;
 
   private animationActiveDuration = 0.3;
 

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -395,6 +395,40 @@
     <calcite-tab>Tab 4 Content</calcite-tab>
   </calcite-tabs>
 
+  <h1 class="leader-1">Scrollable RTL Tabs in Container</h1>
+  <div dir="rtl" style="width: 100%">
+    <div style="width: 500px">
+      <calcite-tabs >
+        <calcite-tab-nav slot="tab-nav">
+          <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 12 Title</calcite-tab-title>
+        </calcite-tab-nav>
+
+        <calcite-tab>Tab 1 Content</calcite-tab>
+        <calcite-tab>Tab 2 Content</calcite-tab>
+        <calcite-tab>Tab 3 Content</calcite-tab>
+        <calcite-tab>Tab 4 Content</calcite-tab>
+        <calcite-tab>Tab 5 Content</calcite-tab>
+        <calcite-tab>Tab 6 Content</calcite-tab>
+        <calcite-tab>Tab 7 Content</calcite-tab>
+        <calcite-tab>Tab 8 Content</calcite-tab>
+        <calcite-tab>Tab 9 Content</calcite-tab>
+        <calcite-tab>Tab 10 Content</calcite-tab>
+        <calcite-tab>Tab 11 Content</calcite-tab>
+        <calcite-tab>Tab 12 Content</calcite-tab>
+      </calcite-tabs>
+    </div>
+  </div>
   <h1 class="leader-1">Centered RTL</h1>
 
   <calcite-tabs layout="center" dir="rtl">


### PR DESCRIPTION
**Related Issue:** none

## Summary
Sort of a follow-on to #1385.  While I was installing the fix introduced in that PR in my app, it didn't totally fix the problem I was seeing.  

It seems like the way we were calculating the tab indicator offset in RTL worked for our simple demo examples, but not for more complex, nested layouts.  I added an example on the tabs demo page to show the problem:
![brokenRTLtabs](https://user-images.githubusercontent.com/17748358/101694397-0ec4dd00-3a41-11eb-9ce7-c8c676b23199.gif)
The first "RTL tabs" example shows the current implementation of the offset calculation working correctly.  This is just a `calcite-tabs` element at the top level of the document.

The second "Scrollable RTL Tabs in Container" example shows where the calculation breaks down.  It's a `calcite-tabs` element contained within two wrapping divs, an outer of 100% width and an inner of 500px width.  Its tab indicator is placed far offscreen to the right, and only comes on screen when clicking tabs further to the left.

I updated the way we were calculating the offset in RTL to I think better match what we're doing in LTR.  It fixes the problem I was seeing:
![fixedRTLtabs](https://user-images.githubusercontent.com/17748358/101694408-11bfcd80-3a41-11eb-985d-9392834567b6.gif)

I also left the example in the GIFs on the demos page since I thought it'd be a good testing reference for tabs in the future.
