### PR TITLE
fix(modal): Remove overflow class when modal is removed from DOM

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -233,4 +233,30 @@ describe("calcite-modal accessibility checks", () => {
     await page.waitForChanges();
     expect(modal).toHaveAttribute("is-active");
   });
+
+  it("correctly adds overflow class on document when open", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    const documentClasses = await page.evaluate(() => {
+      return document.documentElement.classList;
+    });
+    expect(documentClasses).toMatchObject({ "0": "overflow-hidden" });
+  });
+
+  it("correctly removes overflow class on document when open", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    await modal.setProperty("active", true);
+    await page.waitForChanges();
+    await modal.setProperty("active", false);
+    await page.waitForChanges();
+    const documentClasses = await page.evaluate(() => {
+      return document.documentElement.classList;
+    });
+    expect(documentClasses).toEqual({});
+  });
 });

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -240,10 +240,10 @@ describe("calcite-modal accessibility checks", () => {
     const modal = await page.find("calcite-modal");
     await modal.setProperty("active", true);
     await page.waitForChanges();
-    const documentClasses = await page.evaluate(() => {
-      return document.documentElement.classList;
+    const documentClass = await page.evaluate(() => {
+      return document.documentElement.classList.contains("overflow-hidden");
     });
-    expect(documentClasses).toMatchObject({ "0": "overflow-hidden" });
+    expect(documentClass).toEqual(true);
   });
 
   it("correctly removes overflow class on document when open", async () => {
@@ -254,9 +254,9 @@ describe("calcite-modal accessibility checks", () => {
     await page.waitForChanges();
     await modal.setProperty("active", false);
     await page.waitForChanges();
-    const documentClasses = await page.evaluate(() => {
-      return document.documentElement.classList;
+    const documentClass = await page.evaluate(() => {
+      return document.documentElement.classList.contains("overflow-hidden");
     });
-    expect(documentClasses).toEqual({});
+    expect(documentClass).toEqual(false);
   });
 });

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -288,7 +288,6 @@ export class CalciteModal {
       this.calciteModalOpen.emit();
     }, 300);
     document.documentElement.classList.add("overflow-hidden");
-    this.removeOverflowHiddenClass;
   }
 
   /** Close the modal, first running the `beforeClose` method */

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -98,6 +98,10 @@ export class CalciteModal {
     }
   }
 
+  disconnectedCallback(): void {
+    this.removeOverflowHiddenClass;
+  }
+
   render(): VNode {
     const dir = getElementDir(this.el);
     return (
@@ -283,7 +287,7 @@ export class CalciteModal {
       this.focusElement(this.firstFocus);
       this.calciteModalOpen.emit();
     }, 300);
-    document.documentElement.classList.add("overflow-hidden");
+    this.removeOverflowHiddenClass;
   }
 
   /** Close the modal, first running the `beforeClose` method */
@@ -311,4 +315,8 @@ export class CalciteModal {
       focusElement(this.closeButtonEl);
     }
   };
+
+  private removeOverflowHiddenClass(): void {
+    document.documentElement.classList.add("overflow-hidden");
+  }
 }

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -99,7 +99,7 @@ export class CalciteModal {
   }
 
   disconnectedCallback(): void {
-    this.removeOverflowHiddenClass;
+    this.removeOverflowHiddenClass();
   }
 
   render(): VNode {
@@ -287,6 +287,7 @@ export class CalciteModal {
       this.focusElement(this.firstFocus);
       this.calciteModalOpen.emit();
     }, 300);
+    document.documentElement.classList.add("overflow-hidden");
     this.removeOverflowHiddenClass;
   }
 
@@ -296,7 +297,7 @@ export class CalciteModal {
       this.active = false;
       this.isActive = false;
       focusElement(this.previousActiveElement);
-      document.documentElement.classList.remove("overflow-hidden");
+      this.removeOverflowHiddenClass();
       setTimeout(() => this.calciteModalClose.emit(), 300);
     });
   };
@@ -317,6 +318,6 @@ export class CalciteModal {
   };
 
   private removeOverflowHiddenClass(): void {
-    document.documentElement.classList.add("overflow-hidden");
+    document.documentElement.classList.remove("overflow-hidden");
   }
 }


### PR DESCRIPTION
**Related Issue:** Fixes #1394 cc @patrickarlt 

## Summary
Removes the overflow class from the document on `disconnectedCallback()`

Would like to add some tests to this but having trouble accessing the document classList in the e2e test... open to suggestions there.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
