### PR TITLE
fix(dropdown): Set dropdown scale to 0 when inactive. #1381

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -80,7 +80,17 @@ $popper-transform-right: translateX(-5px);
   display: block;
   position: absolute;
   z-index: 999;
-  top: -999999px;
+  transform: scale(0);
+}
+
+@mixin popperWrapper {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+@mixin popperWrapperActive {
+  pointer-events: initial;
+  visibility: visible;
 }
 
 @mixin popperHost {

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -47,16 +47,14 @@ input {
 
 .list-container {
   @include popperContainer();
-  visibility: hidden;
-  pointer-events: none;
+  @include popperWrapper();
 }
 
 @include popperElemAnim(".list-container");
 
 :host([active]) .list-container {
   width: 100%;
-  pointer-events: initial;
-  visibility: visible;
+  @include popperWrapperActive();
 }
 
 .list {

--- a/src/components/calcite-date/calcite-date.scss
+++ b/src/components/calcite-date/calcite-date.scss
@@ -64,13 +64,11 @@
 
 :host(:not([no-calendar-input])) .menu-container {
   @include popperContainer();
-  visibility: hidden;
-  pointer-events: none;
+  @include popperWrapper();
   width: 100%;
 }
 :host(:not([no-calendar-input])[active]) .menu-container {
-  pointer-events: initial;
-  visibility: visible;
+  @include popperWrapperActive();
 }
 
 :host(:not([no-calendar-input])) {

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -17,15 +17,13 @@
 
 :host .calcite-dropdown-wrapper {
   @include popperContainer();
-  visibility: hidden;
-  pointer-events: none;
+  @include popperWrapper();
 }
 
 @include popperElemAnim(".calcite-dropdown-wrapper");
 
 :host([active]) .calcite-dropdown-wrapper {
-  pointer-events: initial;
-  visibility: visible;
+  @include popperWrapperActive();
 }
 
 :host .calcite-dropdown-content {


### PR DESCRIPTION
**Related Issue:** #1381

## Summary

fix(dropdown): Set dropdown scale to 0 when inactive. #1381

Sets the transform scale to zero instead of positioning offscreen which causes scrolling issues. This way, the menu is not taking up any space when invisible but still lets popper calculate the height it needs in order to correctly position the element. Using `display:none` would not allow that and would also kill the animation.
