### PR TITLE
feat(combobox): improved interaction, a11y support

### DIFF
--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -34,7 +34,7 @@ export class CalciteChip {
   /** Optionally show a button the user can click to dismiss the chip */
   @Prop({ reflect: true }) dismissible?: boolean = false;
 
-  /** Optionally show a button the user can click to dismiss the chip */
+  /** Aria label for the "x" button */
   @Prop() dismissLabel?: string = TEXT.close;
 
   /** optionally pass an icon to display - accepts Calcite UI icon names  */
@@ -91,6 +91,7 @@ export class CalciteChip {
   };
 
   private closeButton: HTMLButtonElement;
+
   private guid: string = guid();
 
   //--------------------------------------------------------------------------
@@ -115,10 +116,10 @@ export class CalciteChip {
 
     const closeButton = (
       <button
+        aria-describedby={this.guid}
+        aria-label={this.dismissLabel}
         class={CSS.close}
         onClick={this.closeClickHandler}
-        aria-label={this.dismissLabel}
-        aria-describedby={this.guid}
         ref={(el) => (this.closeButton = el)}
       >
         <calcite-icon icon="x" scale={iconScale} />

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -1,5 +1,16 @@
-import { Component, h, Host, Prop, Event, EventEmitter, Element, VNode } from "@stencil/core";
+import {
+  Component,
+  h,
+  Host,
+  Prop,
+  Event,
+  EventEmitter,
+  Element,
+  VNode,
+  Method
+} from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
+import { guid } from "../../utils/guid";
 import { CSS, TEXT } from "./resources";
 
 @Component({
@@ -23,6 +34,9 @@ export class CalciteChip {
   /** Optionally show a button the user can click to dismiss the chip */
   @Prop({ reflect: true }) dismissible?: boolean = false;
 
+  /** Optionally show a button the user can click to dismiss the chip */
+  @Prop() dismissLabel?: string = TEXT.close;
+
   /** optionally pass an icon to display - accepts Calcite UI icon names  */
   @Prop({ reflect: true }) icon?: string;
 
@@ -45,6 +59,17 @@ export class CalciteChip {
 
   @Element() el: HTMLCalciteChipElement;
 
+  //--------------------------------------------------------------------------
+  //
+  //  Public Methods
+  //
+  //--------------------------------------------------------------------------
+
+  @Method()
+  async setFocus(): Promise<void> {
+    this.closeButton?.focus();
+  }
+
   // --------------------------------------------------------------------------
   //
   //  Events
@@ -64,6 +89,9 @@ export class CalciteChip {
     event.preventDefault();
     this.calciteChipDismiss.emit(this.el);
   };
+
+  private closeButton: HTMLButtonElement;
+  private guid: string = guid();
 
   //--------------------------------------------------------------------------
   //
@@ -86,7 +114,13 @@ export class CalciteChip {
     );
 
     const closeButton = (
-      <button class={CSS.close} onClick={this.closeClickHandler} title={TEXT.close}>
+      <button
+        class={CSS.close}
+        onClick={this.closeClickHandler}
+        aria-label={this.dismissLabel}
+        aria-describedby={this.guid}
+        ref={(el) => (this.closeButton = el)}
+      >
         <calcite-icon icon="x" scale={iconScale} />
       </button>
     );
@@ -95,7 +129,7 @@ export class CalciteChip {
       <Host dir={dir}>
         <slot name="chip-image" />
         {this.icon ? iconEl : null}
-        <span>
+        <span id={this.guid}>
           <slot />
         </span>
         {this.dismissible ? closeButton : null}

--- a/src/components/calcite-combobox-item/calcite-combobox-item.scss
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.scss
@@ -2,135 +2,107 @@
   @include calcite-theme-dark();
 }
 
-// todo update to font and spacing value when added to calcite-base
-:host([scale="xs"]) {
-  font-size: 10px;
-  --calcite-combobox-item-spacing-unit-l: 8px;
-  --calcite-combobox-item-spacing-unit-s: 4px;
-}
 :host([scale="s"]) {
-  font-size: 12px;
-  --calcite-combobox-item-spacing-unit-l: 12px;
-  --calcite-combobox-item-spacing-unit-s: 8px;
+  @apply text--2;
+  --calcite-combobox-item-spacing-unit-l: theme("spacing.3");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing.2");
+  --calcite-combobox-item-spacing-indent-1: theme("spacing.2");
+  --calcite-combobox-item-spacing-indent-2: theme("spacing.4");
 }
 
 :host([scale="m"]) {
-  font-size: 14px;
-  --calcite-combobox-item-spacing-unit-l: 16px;
-  --calcite-combobox-item-spacing-unit-s: 12px;
+  @apply text--1;
+  --calcite-combobox-item-spacing-unit-l: theme("spacing.4");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing.3");
+  --calcite-combobox-item-spacing-indent-1: theme("spacing.3");
+  --calcite-combobox-item-spacing-indent-2: theme("spacing.6");
 }
 
 :host([scale="l"]) {
-  font-size: 16px;
-  --calcite-combobox-item-spacing-unit-l: 20px;
-  --calcite-combobox-item-spacing-unit-s: 16px;
+  @apply text-0;
+  --calcite-combobox-item-spacing-unit-l: theme("spacing.5");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing.4");
+  --calcite-combobox-item-spacing-indent-1: theme("spacing.4");
+  --calcite-combobox-item-spacing-indent-2: theme("spacing.8");
 }
 
-:host([scale="xl"]) {
-  font-size: 18px;
-  --calcite-combobox-item-spacing-unit-l: 24px;
-  --calcite-combobox-item-spacing-unit-s: 20px;
+:host {
+  --calcite-combobox-item-indent-start-1: var(--calcite-combobox-item-spacing-indent-1);
+  --calcite-combobox-item-indent-end-1: unset;
+  --calcite-combobox-item-indent-start-2: var(--calcite-combobox-item-spacing-indent-2);
+  --calcite-combobox-item-indent-end-2: unset;
 }
 
-:host,
-:host ul {
-  display: flex;
-  flex-direction: column;
-  margin: 0;
-  padding: 0;
-  outline: none;
-}
-
-//focus
-:host .combobox-item-label {
-  @include focus-style-base();
-}
-:host(:focus) .combobox-item-label {
-  @include focus-style-inset();
-}
-
-:host .combobox-item-label {
-  display: flex;
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 100%;
-  align-items: center;
-  color: var(--calcite-ui-text-3);
-  transition: $transition;
-  padding: var(--calcite-combobox-item-spacing-unit-s);
-  cursor: pointer;
-  text-decoration: none;
-  position: relative;
-  & .combobox-item-icon {
-    display: inline-flex;
-    opacity: 0;
-    margin-right: var(--calcite-combobox-item-spacing-unit-s);
-    transition: $transition;
-    color: var(--calcite-ui-border-1);
-  }
-}
-
-:host([dir="rtl"]) .combobox-item-label .combobox-item-icon {
-  margin-left: var(--calcite-combobox-item-spacing-unit-l);
-  margin-right: unset;
-}
-
-// indentation on children
-:host .combobox-item-label.combobox-item-nested {
-  padding-left: var(--calcite-combobox-item-spacing-unit-s);
-  & .combobox-item-icon {
-    padding-left: var(--calcite-combobox-item-spacing-unit-l);
-  }
-}
-
-:host([dir="rtl"]) .combobox-item-label.combobox-item-nested {
-  padding-right: var(--calcite-combobox-item-spacing-unit-s);
-  padding-left: unset;
-  & .combobox-item-icon {
-    padding-right: var(--calcite-combobox-item-spacing-unit-l);
-    padding-left: unset;
-  }
-}
-
-:host(:not([disabled])) .combobox-item-label:hover,
-:host(:not([disabled])) .combobox-item-label:active {
-  @apply shadow-none;
-  background-color: var(--calcite-ui-foreground-2);
-  color: var(--calcite-ui-text-1);
-  text-decoration: none;
-  & .combobox-item-icon {
-    opacity: 1;
-  }
-}
-
-:host(:focus:not([disabled])) .combobox-item-label {
-  @apply shadow-none;
-  color: var(--calcite-ui-text-1);
-  text-decoration: none;
-  & .combobox-item-icon {
-    opacity: 1;
-  }
-}
-
-:host([disabled]) .combobox-item-label:hover .combobox-item-icon {
-  opacity: 1;
-}
-
-:host([disabled]) .combobox-item-label:hover {
-  cursor: default;
+:host([dir="rtl"]) {
+  --calcite-combobox-item-indent-start-1: unset;
+  --calcite-combobox-item-indent-end-1: var(--calcite-combobox-item-spacing-indent-1);
+  --calcite-combobox-item-indent-start-2: unset;
+  --calcite-combobox-item-indent-end-2: var(--calcite-combobox-item-spacing-indent-2);
 }
 
 :host(:focus) {
   @apply shadow-none;
 }
 
-// selected state
-:host .combobox-item-label.selected {
-  color: var(--calcite-ui-text-1);
-  font-weight: 500;
+:host,
+ul {
+  @apply flex flex-col m-0 p-0 outline-none;
+}
 
-  & .combobox-item-icon {
-    color: var(--calcite-ui-blue-1);
-    opacity: 1;
-  }
+.label {
+  @include focus-style-base();
+  @apply flex box-border w-full min-w-full items-center text-color-3 cursor-pointer relative;
+  transition: $transition;
+  padding: var(--calcite-combobox-item-spacing-unit-s);
+  text-decoration: none;
+}
+
+:host([disabled]) .label {
+  @apply cursor-default;
+}
+
+// selected state
+.label--selected {
+  @apply text-color-1 font-medium;
+}
+
+.label--active {
+  @include focus-style-inset();
+}
+
+.label:hover, .label:active {
+  @apply text-color-1 bg-foreground-2 shadow-none;
+  text-decoration: none;
+}
+
+.title {
+  padding: 0 var(--calcite-combobox-item-spacing-unit-s);
+}
+
+.icon {
+  @apply inline-flex opacity-0;
+  transition: $transition;
+  color: theme("colors.border.1");
+}
+
+.icon--indent-1 {
+  padding-left: var(--calcite-combobox-item-indent-start-1);
+  padding-right: var(--calcite-combobox-item-indent-end-1);
+}
+
+.icon--indent-2 {
+  padding-left: var(--calcite-combobox-item-indent-start-2);
+  padding-right: var(--calcite-combobox-item-indent-end-2);
+}
+
+.label--active .icon {
+  @apply opacity-100;
+}
+
+.label--selected .icon {
+  @apply text-blue-1 opacity-100;
+}
+
+:host(:hover[disabled]) .icon {
+  @apply opacity-100;
 }

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -15,6 +15,7 @@ import {
 import { getElementDir, getElementProp } from "../../utils/dom";
 import { CSS } from "./resources";
 import { getKey } from "../../utils/key";
+import { guid } from "../../utils/guid";
 
 @Component({
   tag: "calcite-combobox-item",
@@ -31,13 +32,18 @@ export class CalciteComboboxItem {
   /** When true, the item cannot be clicked and is visually muted. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** The parent combobox item element */
-  @Prop() parentItem?: HTMLCalciteComboboxItemElement;
-
   /** Set this to true to pre-select an item. Toggles when an item is checked/unchecked. */
   @Prop({ reflect: true }) selected = false;
 
-  @Watch("selected") selectedWatchHandler(newValue: boolean): void {
+  /** True when item is highlighted either from keyboard or mouse hover */
+  @Prop() active = false;
+
+  @Prop({mutable: true}) anscestors: HTMLCalciteComboboxItemElement[];
+
+  @Prop() guid: string = guid();
+
+  @Watch("selected")
+  selectedWatchHandler(newValue: boolean): void {
     this.isSelected = newValue;
   }
 
@@ -70,7 +76,9 @@ export class CalciteComboboxItem {
   // --------------------------------------------------------------------------
 
   componentWillLoad(): void {
-    this.isNested = this.getDepth();
+    const parent = this.el.parentElement?.closest("calcite-combobox-item");
+    const grandparent = parent?.parentElement?.closest("calcite-combobox-item");
+    this.anscestors = [parent, grandparent].filter(el => el);
     this.hasDefaultSlot = this.el.querySelector(":not([slot])") !== null;
   }
 
@@ -88,13 +96,16 @@ export class CalciteComboboxItem {
 
   @Event() calciteComboboxItemKeyEvent: EventEmitter;
 
+  @Event() calciteComboboxItemHover: EventEmitter;
+
   // --------------------------------------------------------------------------
   //
   //  Event Listeners
   //
   // --------------------------------------------------------------------------
 
-  @Listen("keydown") keyDownHandler(event: KeyboardEvent): void {
+  @Listen("keydown")
+  keyDownHandler(event: KeyboardEvent): void {
     event.stopPropagation();
     switch (getKey(event.key)) {
       case " ":
@@ -128,7 +139,8 @@ export class CalciteComboboxItem {
    * Used to toggle the selection state. By default this won't trigger an event.
    * The first argument allows the value to be coerced, rather than swapping values.
    */
-  @Method() async toggleSelected(coerce?: boolean): Promise<void> {
+  @Method()
+  async toggleSelected(coerce?: boolean): Promise<void> {
     if (this.disabled) {
       return;
     }
@@ -151,8 +163,20 @@ export class CalciteComboboxItem {
     this.calciteComboboxItemChange.emit(this.el);
   };
 
-  getDepth(): boolean {
-    return !!this.el.parentElement?.closest("calcite-combobox-item");
+  itemHoverHandler = (): void => {
+    this.calciteComboboxItemHover.emit(this.el);
+  };
+
+  getDepth(): number {
+    const parent = this.el.parentElement?.closest("calcite-combobox-item");
+    if (!parent) {
+      return 0;
+    }
+    const grandparent = parent.parentElement?.closest("calcite-combobox-item");
+    if (!grandparent) {
+      return 1;
+    }
+    return 2;
   }
   // --------------------------------------------------------------------------
   //
@@ -161,9 +185,10 @@ export class CalciteComboboxItem {
   // --------------------------------------------------------------------------
 
   renderIcon(scale: string): VNode {
+    const level = `${CSS.icon}--indent-${this.getDepth()}`;
     const iconScale = scale !== "l" ? "s" : "m";
     const iconPath = this.disabled ? "circle-disallowed" : "check";
-    return <calcite-icon class={CSS.icon} icon={iconPath} scale={iconScale} />;
+    return <calcite-icon class={`${CSS.icon} ${level}`} icon={iconPath} scale={iconScale} />;
   }
 
   renderChildren(): VNode {
@@ -181,6 +206,7 @@ export class CalciteComboboxItem {
     const classes = {
       [CSS.label]: true,
       [CSS.selected]: this.isSelected,
+      [CSS.active]: this.active,
       [CSS.nested]: this.isNested,
       [CSS.parent]: !this.isNested
     };
@@ -189,21 +215,23 @@ export class CalciteComboboxItem {
 
     return (
       <Host
-        aria-selected={this.isSelected.toString()}
         dir={dir}
         disabled={this.disabled}
-        role="option"
         scale={scale}
-        tabIndex={this.disabled ? null : 0}
+        aria-hidden
+        tabIndex={-1}
       >
-        <div
+        <li
+          id={this.guid}
           class={classes}
           onClick={this.itemClickHandler}
+          onMouseOver={this.itemHoverHandler}
           ref={(el) => (this.comboboxItemEl = el as HTMLElement)}
+          tabIndex={-1}
         >
           {this.renderIcon(scale)}
           <span class={CSS.title}>{this.textLabel}</span>
-        </div>
+        </li>
         {this.renderChildren()}
       </Host>
     );

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -4,7 +4,6 @@ import {
   Event,
   EventEmitter,
   Host,
-  Listen,
   Method,
   Prop,
   h,
@@ -14,7 +13,6 @@ import {
 } from "@stencil/core";
 import { getElementDir, getElementProp } from "../../utils/dom";
 import { CSS } from "./resources";
-import { getKey } from "../../utils/key";
 import { guid } from "../../utils/guid";
 
 @Component({
@@ -38,7 +36,7 @@ export class CalciteComboboxItem {
   /** True when item is highlighted either from keyboard or mouse hover */
   @Prop() active = false;
 
-  @Prop({mutable: true}) anscestors: HTMLCalciteComboboxItemElement[];
+  @Prop({ mutable: true }) anscestors: HTMLCalciteComboboxItemElement[];
 
   @Prop() guid: string = guid();
 
@@ -78,7 +76,7 @@ export class CalciteComboboxItem {
   componentWillLoad(): void {
     const parent = this.el.parentElement?.closest("calcite-combobox-item");
     const grandparent = parent?.parentElement?.closest("calcite-combobox-item");
-    this.anscestors = [parent, grandparent].filter(el => el);
+    this.anscestors = [parent, grandparent].filter((el) => el);
     this.hasDefaultSlot = this.el.querySelector(":not([slot])") !== null;
   }
 
@@ -93,41 +91,6 @@ export class CalciteComboboxItem {
    * @event calciteComboboxItemChange
    */
   @Event() calciteComboboxItemChange: EventEmitter;
-
-  @Event() calciteComboboxItemKeyEvent: EventEmitter;
-
-  @Event() calciteComboboxItemHover: EventEmitter;
-
-  // --------------------------------------------------------------------------
-  //
-  //  Event Listeners
-  //
-  // --------------------------------------------------------------------------
-
-  @Listen("keydown")
-  keyDownHandler(event: KeyboardEvent): void {
-    event.stopPropagation();
-    switch (getKey(event.key)) {
-      case " ":
-      case "Enter":
-        this.isSelected = !this.isSelected;
-        this.calciteComboboxItemChange.emit(this.el);
-        event.preventDefault();
-        break;
-      case "ArrowUp":
-      case "ArrowDown":
-      case "Home":
-      case "End":
-      case "Tab":
-      case "Escape":
-        this.calciteComboboxItemKeyEvent.emit({
-          event: event,
-          item: this.el
-        });
-        event.preventDefault();
-        break;
-    }
-  }
 
   // --------------------------------------------------------------------------
   //
@@ -161,10 +124,6 @@ export class CalciteComboboxItem {
 
     this.isSelected = !this.isSelected;
     this.calciteComboboxItemChange.emit(this.el);
-  };
-
-  itemHoverHandler = (): void => {
-    this.calciteComboboxItemHover.emit(this.el);
   };
 
   getDepth(): number {
@@ -206,26 +165,17 @@ export class CalciteComboboxItem {
     const classes = {
       [CSS.label]: true,
       [CSS.selected]: this.isSelected,
-      [CSS.active]: this.active,
-      [CSS.nested]: this.isNested,
-      [CSS.parent]: !this.isNested
+      [CSS.active]: this.active
     };
     const scale = getElementProp(this.el, "scale", "m");
     const dir = getElementDir(this.el);
 
     return (
-      <Host
-        dir={dir}
-        disabled={this.disabled}
-        scale={scale}
-        aria-hidden
-        tabIndex={-1}
-      >
+      <Host aria-hidden dir={dir} disabled={this.disabled} scale={scale} tabIndex={-1}>
         <li
-          id={this.guid}
           class={classes}
+          id={this.guid}
           onClick={this.itemClickHandler}
-          onMouseOver={this.itemHoverHandler}
           ref={(el) => (this.comboboxItemEl = el as HTMLElement)}
           tabIndex={-1}
         >

--- a/src/components/calcite-combobox-item/resources.ts
+++ b/src/components/calcite-combobox-item/resources.ts
@@ -1,8 +1,6 @@
 export const CSS = {
   icon: "icon",
   label: "label",
-  nested: "label--nested",
-  parent: "label--parent",
   active: "label--active",
   selected: "label--selected",
   title: "title",

--- a/src/components/calcite-combobox-item/resources.ts
+++ b/src/components/calcite-combobox-item/resources.ts
@@ -1,9 +1,10 @@
 export const CSS = {
-  icon: "combobox-item-icon",
-  label: "combobox-item-label",
-  nested: "combobox-item-nested",
-  parent: "combobox-item-parent",
-  selected: "selected",
+  icon: "icon",
+  label: "label",
+  nested: "label--nested",
+  parent: "label--parent",
+  active: "label--active",
+  selected: "label--selected",
   title: "title",
   textContainer: "text-container"
 };

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -7,7 +7,9 @@
   @include calcite-theme-dark();
 }
 
-// todo update to font and spacing value when added to calcite-base
+:host([disabled]) {
+  @apply pointer-events-none select-none opacity-50;
+}
 
 :host([scale="s"]) {
   @apply text--2;

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -10,79 +10,118 @@
 // todo update to font and spacing value when added to calcite-base
 
 :host([scale="s"]) {
-  font-size: 12px;
-  --calcite-combobox-item-spacing-unit-l: 12px;
-  --calcite-combobox-item-spacing-unit-s: 8px;
-}
-
-:host([scale="m"]) {
-  font-size: 14px;
-  --calcite-combobox-item-spacing-unit-l: 16px;
-  --calcite-combobox-item-spacing-unit-s: 12px;
-}
-
-:host([scale="l"]) {
-  font-size: 16px;
-  --calcite-combobox-item-spacing-unit-l: 20px;
-  --calcite-combobox-item-spacing-unit-s: 16px;
-}
-
-[role="combobox"] {
-  display: flex;
-}
-
-input {
-  flex-grow: 1;
-  font-size: inherit;
-  font-family: inherit;
-  padding: var(--calcite-combobox-item-spacing-unit-s) var(--calcite-combobox-item-spacing-unit-l);
-  background-color: var(--calcite-ui-foreground-1);
-  border: 1px solid var(--calcite-ui-border-1);
-  color: 1px solid var(--calcite-ui-text-1);
-  @include focus-style-base();
-  &:focus {
-    @include focus-style-inset();
+  @apply text--2;
+  --calcite-combobox-item-spacing-unit-l: theme("spacing.3");
+  --calcite-combobox-item-spacing-unit-m: theme("spacing.2");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing.1");
+  .input {
+    @apply h-5 leading-5 mb-2;
   }
 }
 
-.list-container {
-  @include popperContainer();
-  @include popperWrapper();
+:host([scale="m"]) {
+  @apply text--1;
+  --calcite-combobox-item-spacing-unit-l: theme("spacing.4");
+  --calcite-combobox-item-spacing-unit-m: theme("spacing.3");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing.2");
+  .input {
+    @apply h-8 leading-8 mb-3;
+  }
 }
 
-@include popperElemAnim(".list-container");
+:host([scale="l"]) {
+  @apply text-0;
+  --calcite-combobox-item-spacing-unit-l: theme("spacing.5");
+  --calcite-combobox-item-spacing-unit-m: theme("spacing.4");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing.3");
+  .input {
+    @apply h-10 leading-10 mb-4;
+  }
+}
 
-:host([active]) .list-container {
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  padding: var(--calcite-combobox-item-spacing-unit-m) var(--calcite-combobox-item-spacing-unit-l) 0
+    var(--calcite-combobox-item-spacing-unit-l);
+  background-color: var(--calcite-ui-foreground-1);
+  border: 1px solid var(--calcite-ui-border-1);
+  color: var(--calcite-ui-text-1);
+  @include focus-style-base();
+}
+
+.wrapper--active {
+  @include focus-style-inset();
+}
+
+.input {
+  flex-grow: 1;
+  font-size: inherit;
+  font-family: inherit;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  color: var(--calcite-ui-text-1);
+  appearance: none;
+  min-width: 120px;
+  margin-top: 1px;
+  &:focus {
+    outline: none;
+  }
+}
+
+.input--hidden {
+  opacity: 0;
+}
+
+.popper-container {
+  @include popperContainer();
+  @include popperWrapper();
   width: 100%;
+}
+
+@include popperElemAnim(".popper-container");
+
+:host([active]) .popper-container {
   @include popperWrapperActive();
+}
+
+.sr {
+  @apply sr-only;
+}
+
+.list-container {
+  overflow-y: auto;
+  max-height: 100vh;
+  width: var(--calcite-dropdown-width);
+  background: var(--calcite-ui-foreground-1);
 }
 
 .list {
   display: block;
   margin: 0;
   padding: 0;
-  max-height: 100vh;
-  width: var(--calcite-dropdown-width);
-  background: var(--calcite-ui-foreground-1);
-  overflow: hidden;
-  overflow-y: scroll;
 }
 
-.selections calcite-chip {
+.chip {
   margin-right: var(--calcite-combobox-item-spacing-unit-s);
   margin-bottom: var(--calcite-combobox-item-spacing-unit-s);
 }
 
-.selections calcite-chip:last-child {
+.chip--active {
+  @apply bg-foreground-3;
+}
+
+.chip:last-child {
   margin-right: 0;
 }
 
-:host([dir="rtl"]) .selections calcite-chip {
+:host([dir="rtl"]) .chip {
   margin-right: unset;
-  margin-left: var(--calcite-combobox-item-spacing-unit-s);
+  margin-left: var(--calcite-combobox-item-spacing-unit-m);
 }
 
-:host([dir="rtl"]) .selections calcite-chip:last-child {
+:host([dir="rtl"]) .chip:last-child {
   margin-left: 0;
 }
 

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -88,7 +88,7 @@
   @include popperWrapperActive();
 }
 
-.sr {
+.screen-readers-only {
   @apply sr-only;
 }
 

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/html";
-import { select, number } from "@storybook/addon-knobs";
+import { select, number, text } from "@storybook/addon-knobs";
+import { boolean } from "../../../.storybook/helpers";
 
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
@@ -13,7 +14,10 @@ storiesOf("Components/Combobox", module)
     <div style="width:400px;max-width:100%;background-color:white;padding:100px"">
     <calcite-combobox
       label="demo combobox"
+      placeholder="${text("placeholder", "placeholder")}"
+      label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
+      ${boolean("disabled", false)}
       max-items="${number("max-items", 0)}"
       >
       <calcite-combobox-item value="Trees" text-label="Trees">
@@ -46,7 +50,10 @@ storiesOf("Components/Combobox", module)
     <calcite-combobox
     label="demo combobox"
     theme="dark"
+    placeholder="${text("placeholder", "placeholder")}"
+    label="${text("label (for screen readers)", "demo")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("disabled", false)}
     max-items="${number("max-items", 0)}"
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
@@ -77,8 +84,11 @@ storiesOf("Components/Combobox", module)
     (): string => `
     <div style="width:400px;max-width:100%;background-color:white;padding:100px"">
     <calcite-combobox
+    placeholder="${text("placeholder", "placeholder")}"
+    label="${text("label (for screen readers)", "demo")}"
     dir="rtl"
     scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("disabled", false)}
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -605,7 +605,7 @@ export class CalciteCombobox {
           role="combobox"
         >
           {this.renderChips()}
-          <label class="sr" htmlFor={`${guid}-input`} id={labelId}>
+          <label class="screen-readers-only" htmlFor={`${guid}-input`} id={labelId}>
             {label}
           </label>
           <input
@@ -626,7 +626,7 @@ export class CalciteCombobox {
         <ul
           aria-labelledby={labelId}
           aria-multiselectable="true"
-          class="sr"
+          class="screen-readers-only"
           id={guid}
           role="listbox"
           tabIndex={-1}

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -19,6 +19,7 @@ import { debounce } from "lodash-es";
 import { getKey } from "../../utils/key";
 import { createPopper, updatePopper, CSS as PopperCSS } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
+import { guid } from "../../utils/guid";
 
 const COMBO_BOX_ITEM = "calcite-combobox-item";
 
@@ -37,16 +38,17 @@ interface ItemData {
 export class CalciteCombobox {
   //--------------------------------------------------------------------------
   //
+  //  Element
+  //
+  //--------------------------------------------------------------------------
+  @Element() el: HTMLCalciteComboboxElement;
+
+  //--------------------------------------------------------------------------
+  //
   //  Public Properties
   //
   //--------------------------------------------------------------------------
-
   @Prop({ reflect: true }) active = false;
-
-  @Watch("active")
-  activeHandler(): void {
-    this.reposition();
-  }
 
   @Prop({ reflect: true }) disabled = false;
 
@@ -63,93 +65,20 @@ export class CalciteCombobox {
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: "light" | "dark";
 
-  // --------------------------------------------------------------------------
-  //
-  //  Private Properties
-  //
-  // --------------------------------------------------------------------------
-
-  @Element() el: HTMLCalciteComboboxElement;
-
-  @State() items: HTMLCalciteComboboxItemElement[] = [];
-
-  @State() selectedItems: HTMLCalciteComboboxItemElement[] = [];
-
-  @State() visibleItems: HTMLCalciteComboboxItemElement[] = [];
-
-  textInput: HTMLInputElement = null;
-
-  data: ItemData[];
-
-  observer: MutationObserver = null;
-
-  /** specifies the item wrapper height; it is updated when maxItems is > 0  **/
-  private maxScrollerHeight = 0;
-
-  private popper: Popper;
-
-  private menuEl: HTMLDivElement;
-
-  private referenceEl: HTMLDivElement;
-
-  // --------------------------------------------------------------------------
-  //
-  //  Lifecycle
-  //
-  // --------------------------------------------------------------------------
-
-  connectedCallback(): void {
-    if (Build.isBrowser) {
-      this.observer = new MutationObserver(this.updateItems);
-    }
-
-    this.createPopper();
+  @Watch("active") activeHandler(): void {
+    this.reposition();
   }
 
-  componentWillLoad(): void {
-    this.updateItems();
-  }
-
-  componentDidLoad(): void {
-    this.observer?.observe(this.el, { childList: true, subtree: true });
-    this.maxScrollerHeight = this.getMaxScrollerHeight(this.items);
-  }
-
-  disconnectedCallback(): void {
-    this.observer?.disconnect();
-    this.destroyPopper();
+  /** when search text is cleared, reset active to  */
+  @Watch("text") textHandler(): void {
+    this.updateActiveItemIndex(-1);
   }
 
   //--------------------------------------------------------------------------
   //
-  //  Public Methods
+  //  Event Listeners
   //
   //--------------------------------------------------------------------------
-
-  @Method()
-  async reposition(): Promise<void> {
-    const { popper, menuEl } = this;
-    const modifiers = this.getModifiers();
-
-    popper
-      ? updatePopper({
-          el: menuEl,
-          modifiers,
-          placement: DEFAULT_PLACEMENT,
-          popper
-        })
-      : this.createPopper();
-  }
-
-  // --------------------------------------------------------------------------
-  //
-  //  Events
-  //
-  // --------------------------------------------------------------------------
-
-  @Event() calciteLookupChange: EventEmitter;
-
-  @Event() calciteComboboxChipDismiss: EventEmitter;
 
   @Listen("click", { target: "document" })
   documentClickHandler(event: Event): void {
@@ -176,6 +105,175 @@ export class CalciteCombobox {
     this.calciteComboboxChipDismiss.emit(event.detail);
   }
 
+  @Listen("keydown") keydownHandler(event: KeyboardEvent): void {
+    const key = getKey(event.key, getElementDir(this.el));
+
+    switch (key) {
+      case "Tab":
+        this.activeChipIndex = -1;
+        this.activeItemIndex = -1;
+        this.active = false;
+        break;
+      case "ArrowLeft":
+        this.previousChip();
+        break;
+      case "ArrowRight":
+        this.nextChip();
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        this.active = true;
+        this.shiftActiveItemIndex(-1);
+        break;
+      case "ArrowDown":
+        event.preventDefault();
+        this.shiftActiveItemIndex(1);
+        break;
+      case "Home":
+        this.active = true;
+        this.updateActiveItemIndex(0);
+        break;
+      case "End":
+        this.active = true;
+        this.updateActiveItemIndex(this.visibleItems.length - 1);
+        break;
+      case "Escape":
+        this.active = false;
+        break;
+      case "Enter":
+        if (this.activeItemIndex > -1) {
+          this.toggleSelection(this.visibleItems[this.activeItemIndex]);
+        } else if (this.activeChipIndex > -1) {
+          this.removeActiveChip();
+        }
+        break;
+      case "Delete":
+      case "Backspace":
+        if (this.activeChipIndex > -1) {
+          this.removeActiveChip();
+        } else if (!this.text) {
+          this.removeLastChip();
+        }
+        break;
+      default:
+        if (!this.active) {
+          this.setFocus();
+        }
+        break;
+    }
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Public Methods
+  //
+  //--------------------------------------------------------------------------
+
+  @Method() async reposition(): Promise<void> {
+    const { popper, menuEl } = this;
+    const modifiers = this.getModifiers();
+    popper
+      ? updatePopper({
+          el: menuEl,
+          modifiers,
+          placement: DEFAULT_PLACEMENT,
+          popper
+        })
+      : this.createPopper();
+  }
+
+  @Method() async setFocus(): Promise<void> {
+    this.active = true;
+    this.textInput?.focus();
+    this.activeChipIndex = -1;
+    this.activeItemIndex = -1;
+  }
+
+  // --------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  // --------------------------------------------------------------------------
+
+  @Event() calciteLookupChange: EventEmitter;
+
+  @Event() calciteComboboxChipDismiss: EventEmitter;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    if (Build.isBrowser) {
+      this.observer = new MutationObserver(this.updateItems);
+    }
+
+    this.createPopper();
+  }
+
+  componentWillLoad(): void {
+    this.updateItems();
+  }
+
+  componentDidLoad(): void {
+    this.observer?.observe(this.el, { childList: true, subtree: true });
+    this.maxScrollerHeight = this.getMaxScrollerHeight(this.items);
+  }
+
+  componentDidRender(): void {
+    if (this.el.offsetHeight !== this.inputHeight) {
+      this.reposition();
+      this.inputHeight = this.el.offsetHeight;
+    }
+  }
+
+  disconnectedCallback(): void {
+    this.observer?.disconnect();
+    this.destroyPopper();
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private State/Props
+  //
+  //--------------------------------------------------------------------------
+  @State() items: HTMLCalciteComboboxItemElement[] = [];
+
+  @State() selectedItems: HTMLCalciteComboboxItemElement[] = [];
+
+  @State() visibleItems: HTMLCalciteComboboxItemElement[] = [];
+
+  @State() activeItemIndex = -1;
+
+  @State() activeChipIndex = -1;
+
+  @State() activeDescendant = "";
+
+  @State() text = "";
+
+  textInput: HTMLInputElement = null;
+
+  data: ItemData[];
+
+  observer: MutationObserver = null;
+
+  private guid: string = guid();
+
+  /** specifies the item wrapper height; it is updated when maxItems is > 0  **/
+  private maxScrollerHeight = 0;
+
+  private inputHeight = 0;
+
+  private popper: Popper;
+
+  private menuEl: HTMLDivElement;
+
+  private referenceEl: HTMLDivElement;
+
+  private listContainerEl: HTMLDivElement;
+
   // --------------------------------------------------------------------------
   //
   //  Private Methods
@@ -192,6 +290,10 @@ export class CalciteCombobox {
 
   setMenuEl = (el: HTMLDivElement): void => {
     this.menuEl = el;
+  };
+
+  setListContainerEl = (el: HTMLDivElement): void => {
+    this.listContainerEl = el;
   };
 
   setReferenceEl = (el: HTMLDivElement): void => {
@@ -240,41 +342,30 @@ export class CalciteCombobox {
     let maxScrollerHeight = 0;
     items.forEach((item) => {
       if (itemsToProcess < maxItems && maxItems > 0) {
-        maxScrollerHeight += item.offsetHeight;
-        itemsToProcess += 1;
-        // if item has children items, don't count their height twice
-        const children = item.querySelectorAll<HTMLCalciteComboboxItemElement>(
-          "calcite-combobox-item"
-        );
-        children.forEach((child) => {
-          maxScrollerHeight -= child.offsetHeight;
-        });
+        maxScrollerHeight += this.calculateSingleItemHeight(item);
+        itemsToProcess++;
       }
     });
 
     return maxScrollerHeight;
   }
 
-  inputHandler = (event: Event): void => {
-    const target = event.target as HTMLInputElement;
-    this.filterItems(target.value);
-  };
+  private calculateSingleItemHeight(item: HTMLCalciteComboboxItemElement): number {
+    let height = item.offsetHeight;
+    // if item has children items, don't count their height twice
+    const children = item.querySelectorAll<HTMLCalciteComboboxItemElement>("calcite-combobox-item");
+    children.forEach((child) => {
+      height -= child.offsetHeight;
+    });
+    return height;
+  }
 
-  handleInputKeyDown = (event: KeyboardEvent): void => {
-    if (event.target === this.textInput) {
-      const key = getKey(event.key);
-      if (event.shiftKey && key === "Tab") {
-        return;
-      } else if (key === "Escape") {
-        this.active = false;
-      } else if (key === "ArrowDown") {
-        this.focusFirstItem();
-      } else if (key === "ArrowUp") {
-        this.focusLastItem();
-      } else {
-        this.active = true;
-        this.textInput.focus();
-      }
+  inputHandler = (event: Event): void => {
+    const value = (event.target as HTMLInputElement).value;
+    this.text = value;
+    this.filterItems(value);
+    if (value) {
+      this.activeChipIndex = -1;
     }
   };
 
@@ -282,18 +373,17 @@ export class CalciteCombobox {
     const filteredData = filter(this.data, value);
     const values = filteredData.map((item) => item.value);
     this.items.forEach((item) => {
-      item.hidden = values.indexOf(item.value) === -1;
-      // If item is nested inside another item...
-      const { parentItem } = item;
-      if (parentItem) {
-        // If the parent item is a match, show me.
-        if (values.indexOf(parentItem.value) !== -1) {
-          item.hidden = false;
-        }
-        // If I am a match, show my parent.
-        if (values.indexOf(item.value) !== -1) {
-          parentItem.hidden = false;
-        }
+      const hidden = values.indexOf(item.value) === -1;
+      item.hidden = hidden;
+      const [parent, grandparent] = item.anscestors;
+      if (
+        (parent || grandparent) &&
+        (values.indexOf(parent?.value) > -1 || values.indexOf(grandparent?.value) > -1)
+      ) {
+        item.hidden = false;
+      }
+      if (!hidden) {
+        item.anscestors.forEach((anscestor) => (anscestor.hidden = false));
       }
     });
 
@@ -304,14 +394,27 @@ export class CalciteCombobox {
     item.selected = value;
     this.selectedItems = this.getSelectedItems();
     this.calciteLookupChange.emit(this.selectedItems);
+    this.textInput.value = "";
+    this.text = "";
+    this.textInput.focus();
+    this.filterItems("");
   }
 
   getVisibleItems(): HTMLCalciteComboboxItemElement[] {
     return this.items.filter((item) => !item.hidden);
   }
 
+  /** Preserve order of entered tags */
   getSelectedItems(): HTMLCalciteComboboxItemElement[] {
-    return this.items.filter((item) => item.selected);
+    const current = [...this.selectedItems];
+    return this.items.filter(item => item.selected).sort((a, b) => {
+      const aIdx = current.indexOf(a);
+      const bIdx = current.indexOf(b);
+      if (aIdx > -1 && bIdx > -1) {
+        return aIdx - bIdx;
+      }
+      return bIdx - aIdx;
+    });
   }
 
   updateItems(): void {
@@ -330,87 +433,85 @@ export class CalciteCombobox {
 
   getItems(): HTMLCalciteComboboxItemElement[] {
     const items = Array.from(this.el.querySelectorAll(COMBO_BOX_ITEM));
-
-    return items
-      .filter((item) => !item.disabled)
-      .map((item) => {
-        const { parentElement } = item;
-
-        item.parentItem = parentElement.matches(COMBO_BOX_ITEM)
-          ? (parentElement as HTMLCalciteComboboxItemElement)
-          : null;
-
-        return item;
-      });
+    return items.filter((item) => !item.disabled);
   }
 
-  @Listen("calciteComboboxItemKeyEvent")
-  calciteComboboxItemKeyEventHandler(
-    event: CustomEvent<{
-      event: KeyboardEvent;
-      item: HTMLCalciteComboboxItemElement;
-    }>
-  ): void {
-    const { item, event: keyboardEvent } = event.detail;
-    const isFirstItem = this.itemIndex(item) === 0;
-    const isLastItem = this.itemIndex(item) === this.items.length - 1;
-    const shiftKey = keyboardEvent.shiftKey;
-    const keyCode = getKey(keyboardEvent.key);
-    switch (keyCode) {
-      case "Tab":
-        if (isFirstItem && shiftKey) this.closeCalciteCombobox();
-        if (isLastItem && !shiftKey) this.closeCalciteCombobox();
-        else if (isFirstItem && shiftKey) this.textInput.focus();
-        else if (shiftKey) this.focusPrevItem(item);
-        else this.focusNextItem(item);
-        break;
-      case "ArrowDown":
-        this.focusNextItem(item);
-        break;
-      case "ArrowUp":
-        this.focusPrevItem(item);
-        break;
-      case "Home":
-        this.focusFirstItem();
-        break;
-      case "End":
-        this.focusLastItem();
-        break;
-      case "Escape":
-        this.closeCalciteCombobox();
-        break;
+  removeActiveChip(): void {
+    this.toggleSelection(this.selectedItems[this.activeChipIndex], false);
+    this.setFocus();
+  }
+
+  removeLastChip(): void {
+    this.toggleSelection(this.selectedItems[this.selectedItems.length - 1], false);
+    this.setFocus();
+  }
+
+  previousChip(): void {
+    if (this.text) {
+      return;
+    }
+    const length = this.selectedItems.length - 1;
+    const active = this.activeChipIndex;
+    this.activeChipIndex = active === -1 ? length : Math.max(active - 1, 0);
+    this.updateActiveItemIndex(-1);
+    this.active = false;
+    this.focusChip();
+  }
+
+  nextChip(): void {
+    if (this.text) {
+      return;
+    }
+    const last = this.selectedItems.length - 1;
+    const newIndex = this.activeChipIndex + 1;
+    if (newIndex > last) {
+      this.activeChipIndex = -1;
+      this.setFocus();
+    } else {
+      this.activeChipIndex = newIndex;
+      this.active = false;
+      this.focusChip();
+    }
+    this.updateActiveItemIndex(-1);
+  }
+
+  focusChip(): void {
+    const guid = this.selectedItems[this.activeChipIndex]?.guid;
+    const chip = this.referenceEl.querySelector<HTMLCalciteChipElement>(`#chip-${guid}`);
+    console.log(this.el, chip, guid);
+    chip?.setFocus();
+  }
+
+  shiftActiveItemIndex(delta: number): void {
+    const length = this.visibleItems.length;
+    const newIndex = (this.activeItemIndex + length + delta) % length;
+    this.updateActiveItemIndex(newIndex);
+    // ensure active item is in view if we have scrolling
+    const activeItem = this.visibleItems[this.activeItemIndex];
+    const height = this.calculateSingleItemHeight(activeItem);
+    const { offsetHeight, scrollTop } = this.listContainerEl;
+    if (offsetHeight + scrollTop < activeItem.offsetTop + height) {
+      this.listContainerEl.scrollTop = activeItem.offsetTop - offsetHeight + height;
+    } else if (activeItem.offsetTop < scrollTop) {
+      this.listContainerEl.scrollTop = activeItem.offsetTop;
     }
   }
 
-  closeCalciteCombobox(): void {
-    this.textInput.focus();
-    this.active = false;
-  }
-
-  focusFirstItem(): void {
-    const firstItem = this.items[0];
-    firstItem.focus();
-  }
-
-  focusLastItem(): void {
-    const lastItem = this.items[this.items.length - 1];
-    lastItem.focus();
-  }
-
-  focusNextItem(item: HTMLCalciteComboboxItemElement): void {
-    const index = this.itemIndex(item);
-    const nextItem = this.items[index + 1] || this.items[0];
-    nextItem.focus();
-  }
-
-  focusPrevItem(item: HTMLCalciteComboboxItemElement): void {
-    const index = this.itemIndex(item);
-    const prevItem = this.items[index - 1] || this.items[this.items.length - 1];
-    prevItem.focus();
-  }
-
-  itemIndex(item: HTMLCalciteComboboxItemElement): number {
-    return this.items.indexOf(item);
+  updateActiveItemIndex(index: number): void {
+    this.activeItemIndex = index;
+    let activeDescendant: string = null;
+    this.visibleItems.forEach((el, i) => {
+      if (i === index) {
+        el.active = true;
+        activeDescendant = el.guid;
+      } else {
+        el.active = false;
+      }
+    });
+    this.activeDescendant = activeDescendant;
+    if (this.activeItemIndex > -1) {
+      this.activeChipIndex = -1;
+    }
   }
 
   comboboxFocusHandler = (): void => {
@@ -429,67 +530,84 @@ export class CalciteCombobox {
   //--------------------------------------------------------------------------
 
   render(): VNode {
-    const {
-      active,
-      disabled,
-      el,
-      label,
-      placeholder,
-      scale,
-      selectedItems,
-      maxScrollerHeight
-    } = this;
+    const { guid, active, disabled, el, label, placeholder, scale, selectedItems } = this;
     const dir = getElementDir(el);
-    const listBoxId = "listbox";
     return (
       <Host active={active} dir={dir}>
-        <div class="selections">
-          {selectedItems.map((item) => {
+        <div
+          role="combobox"
+          aria-expanded={active.toString()}
+          aria-haspopup="listbox"
+          aria-owns={guid}
+          aria-autocomplete="list"
+          aria-label={label}
+          aria-active
+          class={{ wrapper: true, "wrapper--active": active }}
+          onClick={() => this.setFocus()}
+          ref={this.setReferenceEl}
+
+        >
+          {selectedItems.map((item, i) => {
+            const chipClasses = { chip: true, "chip--active": this.activeChipIndex === i };
             return (
-              <calcite-chip dir={dir} dismissible key={item.value} scale={scale} value={item.value}>
+              <calcite-chip
+                class={chipClasses}
+                dir={dir}
+                dismissible
+                dismissLabel={"remove tag"}
+                key={item.value}
+                scale={scale}
+                value={item.value}
+                id={`chip-${item.guid}`}
+              >
                 {item.textLabel}
               </calcite-chip>
             );
           })}
-        </div>
-        <div
-          aria-expanded={active.toString()}
-          aria-haspopup="listbox"
-          aria-owns={listBoxId}
-          ref={this.setReferenceEl}
-          role="combobox"
-        >
           <input
+            role="textbox"
             aria-autocomplete="list"
-            aria-controls={listBoxId}
-            aria-label={label}
+            aria-controls={guid}
+            aria-activedescendant={this.activeDescendant}
+            class={{ input: true, "input--hidden": this.activeChipIndex > -1 }}
             disabled={disabled}
             onBlur={this.comboboxBlurHandler}
             onFocus={this.comboboxFocusHandler}
             onInput={this.inputHandler}
-            onKeyDown={this.handleInputKeyDown}
             placeholder={placeholder}
             ref={(el) => (this.textInput = el as HTMLInputElement)}
             type="text"
           />
         </div>
-        <div aria-hidden={(!active).toString()} class="list-container" ref={this.setMenuEl}>
-          <ul
-            aria-label={label}
-            aria-multiselectable="true"
+        <ul
+          class="sr"
+          aria-multiselectable="true"
+          id={guid}
+          role="listbox"
+          tabIndex={-1}
+        >
+          {this.visibleItems.map((item) => (
+            <li role="option" tabindex="-1" id={item.guid} aria-selected={ (!!item.selected).toString() }>
+              {item.value}
+            </li>
+          ))}
+        </ul>
+        <div aria-hidden="true" class="popper-container" ref={this.setMenuEl}>
+          <div
             class={{
-              list: true,
+              "list-container": true,
               [PopperCSS.animation]: true,
               [PopperCSS.animationActive]: active
             }}
-            id={listBoxId}
-            role="listbox"
             style={{
-              maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
+              maxHeight: this.maxScrollerHeight > 0 ? `${this.maxScrollerHeight}px` : ""
             }}
+            ref={this.setListContainerEl}
           >
-            <slot />
-          </ul>
+            <ul class="list">
+              <slot />
+            </ul>
+          </div>
         </div>
       </Host>
     );

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -27,9 +27,11 @@
   <h1>Calcite Combobox</h1>
   <h2>Scale M</h2>
 
-  <calcite-combobox label="test" max-items="4">
+  <calcite-combobox label="test" max-items="6">
     <calcite-combobox-item value="Trees" text-label="Trees">
-      <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+      <calcite-combobox-item value="Pine" text-label="Pine">
+        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+      </calcite-combobox-item>
       <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
       <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
     </calcite-combobox-item>

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -27,7 +27,7 @@
   <h1>Calcite Combobox</h1>
   <h2>Scale M</h2>
 
-  <calcite-combobox label="test" max-items="6">
+  <calcite-combobox label="test" placeholder="placeholder" max-items="6">
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine">
         <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
@@ -53,7 +53,7 @@
 
   <h2>Scale S</h2>
 
-  <calcite-combobox label="test" scale="s">
+  <calcite-combobox label="test" placeholder="placeholder" scale="s">
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
       <calcite-combobox-item value="Sequoia" text-label="Sequoia"></calcite-combobox-item>
@@ -75,7 +75,7 @@
   </calcite-combobox>
   <h2>Scale L</h2>
 
-  <calcite-combobox label="test" scale="l">
+  <calcite-combobox label="test" placeholder="placeholder" scale="l">
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
       <calcite-combobox-item value="Sequoia" text-label="Sequoia"></calcite-combobox-item>
@@ -98,7 +98,7 @@
 
   <h2>RTL</h2>
 
-  <calcite-combobox label="test" dir="rtl">
+  <calcite-combobox label="test" placeholder="placeholder" dir="rtl">
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
       <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
@@ -123,7 +123,7 @@
   <div class="demo-background-dark">
     <h2>Scale M</h2>
 
-    <calcite-combobox theme="dark" label="test">
+    <calcite-combobox theme="dark" label="test" placeholder="placeholder">
       <calcite-combobox-item value="Trees" text-label="Trees">
         <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
         <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -1,7 +1,7 @@
 /**
  * Standardize key property of keyboard event (mostly for ie11)
  */
-export function getKey(key: string): string {
+export function getKey(key: string, dir?: "rtl" | "ltr"): string {
   const lookup = {
     Up: "ArrowUp",
     Down: "ArrowDown",
@@ -10,5 +10,16 @@ export function getKey(key: string): string {
     Spacebar: " ",
     Esc: "Escape"
   };
-  return lookup[key] || key;
+  const adjustedKey = lookup[key] || key;
+  const isRTL = dir === "rtl";
+
+  if (isRTL && adjustedKey === "ArrowLeft") {
+    return "ArrowRight";
+  }
+
+  if (isRTL && adjustedKey === "ArrowRight") {
+    return "ArrowLeft";
+  }
+
+  return adjustedKey;
 }


### PR DESCRIPTION
## Summary

Prior to updating the tests for this component, I wanted to get everybody's feedback/design review on this new interaction model for the combobox. This is not a breaking change as it doesn't actually change the API at all, just the internal implementation. 



Main change:
- selected chips appear inside text box rather than above
- don't have to focus through every chip, focus is managed entirely by component. This model is valid per the combobox spec:

> If the popup element supports `aria-activedescendant`, in lieu of moving focus, such keyboard mechanisms can control the value of `aria-activedescendant` on the textbox element. When a descendant of the popup element is active, authors MAY set `aria-activedescendant` on the textbox to a value that refers to the active element within the popup while focus remains on the textbox element.

Other improvements so far:

- Better screen reader support for actively selected chips
- Full screen reader support for list/focus management
- Maintain ordering of selected chips each render
- Allow three levels of hierarchy (previously 2)
- Chips display inside the input (indirectly fixes #1181)
- Allow delete of chips from inside input
- Ability to rapidly add multiple options via keyboard
- update styles to use the tailwind values
- fixes weird popper placement issues
- Improved labelling of chip dismiss button (was previously "close" untraslated)
- Added `setFocus` method on calcite chip

The focus/active styles could be improved, IMO. Also interested in general thoughts/feedback.