### PR TITLE
feat(combobox): add custom-values prop that allows free entry of new tags

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -264,4 +264,67 @@ describe("calcite-combobox", () => {
       expect(chips.length).toEqual(2);
     });
   });
+
+  describe("allows free entry of text", () => {
+    it("should allow typing a new unknown tag", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox custom-values>
+            <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
+            <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          </calcite-combobox>
+        `
+      );
+      let chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeNull();
+
+      const input = await page.find("calcite-combobox >>> input");
+      await input.click();
+
+      await input.press("K");
+      await input.press("Enter");
+
+      chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeDefined();
+      expect(await chip.getProperty("value")).toBe("K");
+
+      await input.click();
+
+      await input.press("K");
+      await input.press("Enter");
+      const chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      expect(chips.length).toBe(1);
+    });
+
+    it("should select known tag when input", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox custom-values>
+            <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
+            <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          </calcite-combobox>
+        `
+      );
+      let chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeNull();
+
+      const input = await page.find("calcite-combobox >>> input");
+      await input.click();
+
+      await input.press("o");
+      await input.press("n");
+      await input.press("e");
+      await input.press("Enter");
+
+      chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeDefined();
+      expect(await chip.getProperty("value")).toBe("one");
+      const item1 = await page.find("calcite-combobox-item#one");
+      expect(await item1.getProperty("selected")).toBe(true);
+    });
+  });
 });

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -270,7 +270,7 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(
         html`
-          <calcite-combobox custom-values>
+          <calcite-combobox allow-custom-values>
             <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
             <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
             <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
@@ -302,7 +302,7 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(
         html`
-          <calcite-combobox custom-values>
+          <calcite-combobox allow-custom-values>
             <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
             <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
             <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -18,7 +18,7 @@ storiesOf("Components/Combobox", module)
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
-      ${boolean("custom-values", false)}
+      ${boolean("allow-custom-values", false)}
       max-items="${number("max-items", 0)}"
       >
       <calcite-combobox-item value="Trees" text-label="Trees">
@@ -55,7 +55,7 @@ storiesOf("Components/Combobox", module)
     label="${text("label (for screen readers)", "demo")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("disabled", false)}
-    ${boolean("custom-values", false)}
+    ${boolean("allow-custom-values", false)}
     max-items="${number("max-items", 0)}"
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
@@ -91,7 +91,7 @@ storiesOf("Components/Combobox", module)
     dir="rtl"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("disabled", false)}
-    ${boolean("custom-values", false)}
+    ${boolean("allow-custom-values", false)}
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -18,6 +18,7 @@ storiesOf("Components/Combobox", module)
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
+      ${boolean("custom-values", false)}
       max-items="${number("max-items", 0)}"
       >
       <calcite-combobox-item value="Trees" text-label="Trees">
@@ -54,6 +55,7 @@ storiesOf("Components/Combobox", module)
     label="${text("label (for screen readers)", "demo")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("disabled", false)}
+    ${boolean("custom-values", false)}
     max-items="${number("max-items", 0)}"
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
@@ -89,6 +91,7 @@ storiesOf("Components/Combobox", module)
     dir="rtl"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("disabled", false)}
+    ${boolean("custom-values", false)}
     >
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -214,7 +214,7 @@ export class CalciteCombobox {
 
   connectedCallback(): void {
     if (Build.isBrowser) {
-      this.observer = new MutationObserver(this.updateItems.bind(this));
+      this.observer = new MutationObserver(this.updateItems);
     }
 
     this.createPopper();
@@ -416,14 +416,13 @@ export class CalciteCombobox {
   }
 
   getSelectedItems(): HTMLCalciteComboboxItemElement[] {
-    const current = [...this.selectedItems];
     return (
-      [...this.items]
+      this.items
         .filter((item) => item.selected)
         /** Preserve order of entered tags */
         .sort((a, b) => {
-          const aIdx = current.indexOf(a);
-          const bIdx = current.indexOf(b);
+          const aIdx = this.selectedItems.indexOf(a);
+          const bIdx = this.selectedItems.indexOf(b);
           if (aIdx > -1 && bIdx > -1) {
             return aIdx - bIdx;
           }
@@ -432,12 +431,12 @@ export class CalciteCombobox {
     );
   }
 
-  updateItems(): void {
+  updateItems = (): void => {
     this.items = this.getItems();
     this.data = this.getData();
     this.selectedItems = this.getSelectedItems();
     this.visibleItems = this.getVisibleItems();
-  }
+  };
 
   getData(): ItemData[] {
     return this.items.map((item) => ({
@@ -467,9 +466,7 @@ export class CalciteCombobox {
       item.textLabel = value;
       item.guid = guid();
       item.selected = true;
-      // construct a new item
-      const parent = this.el.querySelector(COMBO_BOX_ITEM)?.parentElement;
-      parent?.appendChild(item);
+      this.el.appendChild(item);
       this.resetText();
       this.setFocus();
       this.updateItems();

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -77,7 +77,7 @@ export class CalciteCombobox {
   @Prop() maxItems = 0;
 
   /** Allow entry of custom values which are not in the original set of items */
-  @Prop() customValues: boolean;
+  @Prop() allowCustomValues: boolean;
 
   /** Specify the scale of the combobox, defaults to m */
   @Prop({ reflect: true }) scale: "s" | "m" | "l" = "m";
@@ -157,7 +157,7 @@ export class CalciteCombobox {
           this.toggleSelection(this.visibleItems[this.activeItemIndex]);
         } else if (this.activeChipIndex > -1) {
           this.removeActiveChip();
-        } else if (this.customValues && this.text) {
+        } else if (this.allowCustomValues && this.text) {
           this.addCustomChip(this.text);
         }
         break;

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -50,6 +50,30 @@
     <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
   </calcite-combobox>
 
+  <h2>Custom Values</h2>
+  <calcite-combobox label="custom values" custom-values placeholder="placeholder" max-items="6">
+    <calcite-combobox-item value="Trees" text-label="Trees">
+      <calcite-combobox-item value="Pine" text-label="Pine">
+        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+    </calcite-combobox-item>
+    <calcite-combobox-item value="Flowers" text-label="Flowers">
+      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+      <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+    </calcite-combobox-item>
+    <calcite-combobox-item value="Animals" text-label="Animals">
+      <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+      <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+      <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+    </calcite-combobox-item>
+    <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+    <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+    <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+  </calcite-combobox>
+
 
   <h2>Scale S</h2>
 

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -51,7 +51,7 @@
   </calcite-combobox>
 
   <h2>Custom Values</h2>
-  <calcite-combobox label="custom values" custom-values placeholder="placeholder" max-items="6">
+  <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
     <calcite-combobox-item value="Trees" text-label="Trees">
       <calcite-combobox-item value="Pine" text-label="Pine">
         <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>


### PR DESCRIPTION
**Related Issue:** #558

## Summary

New prop `custom-values` allows users to enter values in the combobox that don't appear in the known items list. This is useful for tags where new option entry is allowed.