### PR TITLE
Updates disabled select styling, updates disabled opacity value across components

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -17,7 +17,7 @@
 
   --calcite-border-radius: 3px;
   --calcite-icon-size: 1rem;
-  --calcite-ui-opacity-disabled: 0.3;
+  --calcite-ui-opacity-disabled: 0.5;
 
   --calcite-ui-text-weight-light: 300;
   --calcite-ui-text-weight: 400;

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -203,7 +203,7 @@
   button,
   a {
     pointer-events: none;
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
 }
 

--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -62,7 +62,7 @@
 }
 :host([disabled]) {
   cursor: default;
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
   pointer-events: none;
 }
 :host([scale="s"]) {

--- a/src/components/calcite-date-day/calcite-date-day.scss
+++ b/src/components/calcite-date-day/calcite-date-day.scss
@@ -28,7 +28,7 @@
   transition: all $transition;
   background: none;
   box-shadow: 0 0 0 2px transparent, 0 0 0 0px transparent;
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
 }
 
 .text {

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -12,7 +12,7 @@
 // disabled styles
 :host([disabled]) {
   pointer-events: none;
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
 }
 
 :host .calcite-dropdown-wrapper {

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -81,7 +81,7 @@
   pointer-events: none;
 
   & .calcite-input-wrapper {
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
     pointer-events: none;
   }
   & textarea,
@@ -255,7 +255,7 @@ input[type="time"]::-webkit-clear-button {
     background-color: var(--calcite-ui-foreground-3);
   }
   &:disabled {
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
 }
 

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -97,7 +97,7 @@
 :host([disabled]) {
   & > label {
     pointer-events: none;
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
   ::slotted(*) {
     pointer-events: none;

--- a/src/components/calcite-link/calcite-link.scss
+++ b/src/components/calcite-link/calcite-link.scss
@@ -52,7 +52,7 @@
   span,
   a {
     pointer-events: none;
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
 }
 // icon positioning and styles

--- a/src/components/calcite-pagination/calcite-pagination.scss
+++ b/src/components/calcite-pagination/calcite-pagination.scss
@@ -85,7 +85,7 @@
     background-color: transparent;
     pointer-events: none;
     & > calcite-icon {
-      opacity: 0.4;
+      opacity: var(--calcite-ui-opacity-disabled);
     }
   }
 }

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -31,6 +31,6 @@
 
 // disabled styles
 :host([disabled]) {
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
   pointer-events: none;
 }

--- a/src/components/calcite-radio/calcite-radio.scss
+++ b/src/components/calcite-radio/calcite-radio.scss
@@ -18,7 +18,7 @@
 :host([disabled]) {
   .radio {
     cursor: default;
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
 }
 :host([hovered][disabled]) {

--- a/src/components/calcite-select/calcite-select.scss
+++ b/src/components/calcite-select/calcite-select.scss
@@ -66,6 +66,17 @@
   border-left: none;
 }
 
+// override user agent stylesheet disabled styling
+select:disabled {
+  border-color: var(--calcite-ui-border-1);
+  opacity: 1;
+}
+
+:host([disabled]) {
+  pointer-events: none;
+  opacity: var(--calcite-ui-opacity-disabled);
+}
+
 .icon-container {
   align-items: center;
   background-color: transparent;

--- a/src/components/calcite-select/calcite-select.scss
+++ b/src/components/calcite-select/calcite-select.scss
@@ -73,7 +73,7 @@ select:disabled {
 }
 
 :host([disabled]) {
-  pointer-events: none;
+  @apply pointer-events-none select-none;
   opacity: var(--calcite-ui-opacity-disabled);
 }
 

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -10,7 +10,7 @@ import {
   Prop,
   VNode
 } from "@stencil/core";
-import { focusElement, getElementDir } from "../../utils/dom";
+import { focusElement, getElementDir, getElementTheme } from "../../utils/dom";
 import { Scale, Theme } from "../../interfaces/common";
 import { CSS } from "./resources";
 import { FocusRequest } from "../../interfaces/Label";
@@ -77,7 +77,7 @@ export class CalciteSelect {
   @Prop({
     reflect: true
   })
-  theme: Theme = "light";
+  theme: Theme;
 
   /**
    * The component width.
@@ -311,9 +311,9 @@ export class CalciteSelect {
 
   render(): VNode {
     const dir = getElementDir(this.el);
-
+    const theme = getElementTheme(this.el);
     return (
-      <Host dir={dir}>
+      <Host dir={dir} theme={theme}>
         <select
           aria-label={this.label}
           class={{ [CSS.select]: true }}

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -10,7 +10,7 @@ import {
   Prop,
   VNode
 } from "@stencil/core";
-import { focusElement, getElementDir, getElementTheme } from "../../utils/dom";
+import { focusElement, getElementDir, getElementProp } from "../../utils/dom";
 import { Scale, Theme } from "../../interfaces/common";
 import { CSS } from "./resources";
 import { FocusRequest } from "../../interfaces/Label";
@@ -115,6 +115,8 @@ export class CalciteSelect {
       subtree: true,
       childList: true
     });
+
+    if (!this.theme) this.theme = getElementProp(this.el, "theme", "light");
   }
 
   disconnectedCallback(): void {
@@ -311,9 +313,9 @@ export class CalciteSelect {
 
   render(): VNode {
     const dir = getElementDir(this.el);
-    const theme = getElementTheme(this.el);
+
     return (
-      <Host dir={dir} theme={theme}>
+      <Host dir={dir}>
         <select
           aria-label={this.label}
           class={{ [CSS.select]: true }}

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -26,7 +26,7 @@ $tick-height: 4px;
 }
 
 :host([disabled]) {
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
   pointer-events: none;
   .track__range,
   .tick--active {
@@ -143,19 +143,19 @@ $tick-height: 4px;
 //     top: -16px;
 //     left: -7px;
 //     background-color: #ccc;
-//     opacity: 0.3;
+//     opacity: var(--calcite-ui-opacity-disabled);
 //   }
 //   .handle__label {
 //     &.static {
 //       background-color: var(--calcite-ui-blue-1);
-//       opacity: 0.3;
+//       opacity: var(--calcite-ui-opacity-disabled);
 //       color: transparent;
 //     }
 //     &.transformed:not([style*="translateX(0px)"]),
 //     &.transformed:not([style*="margin-left: 0px"]),
 //     &.transformed:not([style*="margin-right: 0px"]) {
 //       background-color: red;
-//       opacity: 0.3;
+//       opacity: var(--calcite-ui-opacity-disabled);
 //       color: transparent;
 //     }
 //   }

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -27,7 +27,7 @@
 
 :host([disabled]) {
   .split-button__divider-container {
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
 
   calcite-dropdown > calcite-button {

--- a/src/components/calcite-stepper-item/calcite-stepper-item.scss
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.scss
@@ -92,7 +92,7 @@
   margin-right: var(--calcite-stepper-item-spacing-unit-l);
   margin-top: var(--calcite-stepper-item-spacing-unit-s);
   color: var(--calcite-ui-text-3);
-  opacity: 0.5;
+  opacity: var(--calcite-ui-opacity-disabled);
   height: 12px;
   display: inline-flex;
   flex-shrink: 0;
@@ -147,7 +147,7 @@
   margin-right: initial;
 }
 :host([disabled]) {
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
 }
 :host([disabled]),
 :host([disabled]) * {

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -48,7 +48,7 @@
 }
 
 :host([disabled]) {
-  opacity: 0.4;
+  opacity: var(--calcite-ui-opacity-disabled);
   pointer-events: none;
   cursor: default;
 }

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -57,7 +57,7 @@ $tab-margin: 1.25rem;
   span,
   a {
     pointer-events: none;
-    opacity: 0.4;
+    opacity: var(--calcite-ui-opacity-disabled);
   }
 }
 

--- a/src/demos/calcite-select.html
+++ b/src/demos/calcite-select.html
@@ -49,6 +49,14 @@
       <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
     </calcite-select>
 
+    <h3>Basic disabled</h3>
+
+    <calcite-select disabled scale="m">
+      <calcite-option>uno</calcite-option>
+      <calcite-option>dos</calcite-option>
+      <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+    </calcite-select>
+
     <h3>Grouped</h3>
     <div style="width:33vw;">
     <calcite-select>
@@ -94,6 +102,16 @@
         <calcite-option>😃</calcite-option>
         <calcite-option>😂</calcite-option>
       </calcite-select>
+
+
+    <h3>Basic disabled</h3>
+
+    <calcite-select disabled theme="dark">
+      <calcite-option>uno</calcite-option>
+      <calcite-option>dos</calcite-option>
+      <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+    </calcite-select>
+
     </div>
 
     <h3>RTL</h3>

--- a/src/demos/calcite-select.html
+++ b/src/demos/calcite-select.html
@@ -49,6 +49,28 @@
       <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
     </calcite-select>
 
+    <h3>Wrapped with calcite-label</h3>
+
+    <calcite-label>
+      Choose uno
+      <calcite-select scale="m">
+        <calcite-option>uno</calcite-option>
+        <calcite-option>dos</calcite-option>
+        <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+      </calcite-select>
+    </calcite-label>
+
+    <h3>Wrapped with disabled calcite-label</h3>
+
+    <calcite-label disabled>
+      Choose uno
+      <calcite-select scale="m">
+        <calcite-option>uno</calcite-option>
+        <calcite-option>dos</calcite-option>
+        <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+      </calcite-select>
+    </calcite-label>
+
     <h3>Basic disabled</h3>
 
     <calcite-select disabled scale="m">
@@ -58,27 +80,27 @@
     </calcite-select>
 
     <h3>Grouped</h3>
-    <div style="width:33vw;">
-    <calcite-select>
-      <calcite-option-group label="letters">
-        <calcite-option>a</calcite-option>
-        <calcite-option>b</calcite-option>
-        <calcite-option>c</calcite-option>
-        <calcite-option disabled>d (disabled)</calcite-option>
-      </calcite-option-group>
-      <calcite-option-group label="numbers">
-        <calcite-option label="one">1</calcite-option>
-        <calcite-option label="two" selected>2</calcite-option>
-        <calcite-option label="three">3</calcite-option>
-      </calcite-option-group>
-      <calcite-option-group label="unselectables" disabled>
-        <calcite-option>You-Know-Who</calcite-option>
-        <calcite-option selected>Tom Marvolo Riddle</calcite-option>
-        <calcite-option>He-Who-Must-Not-Be-Named</calcite-option>
-        <calcite-option>Voldemort</calcite-option>
-      </calcite-option-group>
-    </calcite-select>
-  </div>
+    <div style="width: 33vw">
+      <calcite-select>
+        <calcite-option-group label="letters">
+          <calcite-option>a</calcite-option>
+          <calcite-option>b</calcite-option>
+          <calcite-option>c</calcite-option>
+          <calcite-option disabled>d (disabled)</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="numbers">
+          <calcite-option label="one">1</calcite-option>
+          <calcite-option label="two" selected>2</calcite-option>
+          <calcite-option label="three">3</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="unselectables" disabled>
+          <calcite-option>You-Know-Who</calcite-option>
+          <calcite-option selected>Tom Marvolo Riddle</calcite-option>
+          <calcite-option>He-Who-Must-Not-Be-Named</calcite-option>
+          <calcite-option>Voldemort</calcite-option>
+        </calcite-option-group>
+      </calcite-select>
+    </div>
 
     <h3>Side by side (container is flex-box)</h3>
     <div class="demo-side-by-side">
@@ -103,15 +125,35 @@
         <calcite-option>😂</calcite-option>
       </calcite-select>
 
+      <h3>Wrapped with calcite-label and theme set on label</h3>
 
-    <h3>Basic disabled</h3>
+      <calcite-label theme="dark">
+        Choose uno
+        <calcite-select>
+          <calcite-option>uno</calcite-option>
+          <calcite-option>dos</calcite-option>
+          <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+        </calcite-select>
+      </calcite-label>
 
-    <calcite-select disabled theme="dark">
-      <calcite-option>uno</calcite-option>
-      <calcite-option>dos</calcite-option>
-      <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
-    </calcite-select>
+      <h3>Wrapped with disabled calcite-label and theme set on label</h3>
 
+      <calcite-label theme="dark" disabled>
+        Choose uno
+        <calcite-select>
+          <calcite-option>uno</calcite-option>
+          <calcite-option>dos</calcite-option>
+          <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+        </calcite-select>
+      </calcite-label>
+
+      <h3>Basic disabled</h3>
+
+      <calcite-select disabled theme="dark">
+        <calcite-option>uno</calcite-option>
+        <calcite-option>dos</calcite-option>
+        <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>
+      </calcite-select>
     </div>
 
     <h3>RTL</h3>
@@ -125,7 +167,9 @@
         <calcite-option-group label="números">
           <calcite-option label="uno">1</calcite-option>
           <calcite-option label="dos" selected>2</calcite-option>
-          <calcite-option label="Some long content that will probably be enough to extend past the end">3</calcite-option>
+          <calcite-option label="Some long content that will probably be enough to extend past the end"
+            >3</calcite-option
+          >
         </calcite-option-group>
       </calcite-select>
     </div>


### PR DESCRIPTION
**Related Issue:** Fixes #1416 cc @nwhittaker 

- Prevents pointer events on a disabled select
- Overrides browser-supplied disabled select styling
- Applies styling to disabled select
- Updates dev demo with examples of disabled select

Also:

- Updates value of disabled opacity css variable, updates across components
-- This was previously set to 0.3 -> this updates to 0.5 across the board and updates a few instances that weren't using the css var (that were set at 0.4). cc @bstifle cc @asangma 
- Select now inherits theme from a parent if set. cc @jcfranco
-- Updates dev demo with examples of inheriting theme from wrapping calcite-label
 
## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
