### PR TITLE
chore(storybook): migrate stories to CSF

### DIFF
--- a/src/components/calcite-alert/calcite-alert.stories.ts
+++ b/src/components/calcite-alert/calcite-alert.stories.ts
@@ -1,238 +1,243 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean, iconNames } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Alert", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Title, message, link",
-    (): string => `
-    <calcite-alert
+export default {
+  title: "Components/Alert",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const TitleMessageLink = (): string => html`
+<calcite-alert
+theme="light"
+${boolean("icon", true)}
+${boolean("auto-dismiss", false)}
+auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
+${boolean("active", true)}
+scale="${select("scale", ["s", "m", "l"], "m")}"
+color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
+<div slot="alert-title">Here's a general bit of information</div></div>
+<div slot="alert-message">
+  Some kind of contextually relevant content
+</div>
+<calcite-link slot="alert-link" title="my action">Take action</calcite-link>
+</calcite-alert>
+`;
+
+TitleMessageLink.story = {
+  name: "Title, message, link"
+};
+
+export const TitleMessage = (): string => html`
+  <calcite-alert
     theme="light"
     ${boolean("icon", true)}
     ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
-    <div slot="alert-title">Here's a general bit of information</div></div>
-    <div slot="alert-message">
-      Some kind of contextually relevant content
-    </div>
-    <calcite-link slot="alert-link" title="my action">Take action</calcite-link>
-  </calcite-alert>
-  `
-  )
-  .add(
-    "Title, message",
-    (): string => `
-    <calcite-alert
-    theme="light"
-    ${boolean("icon", true)}
-    ${boolean("auto-dismiss", false)}
-    auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    ${boolean("active", true)}
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
+    color="${select("color", ["green", "red", "yellow", "blue"], "red")}"
+  >
     <div slot="alert-title">Something failed</div>
-    <div slot="alert-message">
-      That thing you wanted to do didn't work as expected
-    </div>
+    <div slot="alert-message">That thing you wanted to do didn't work as expected</div>
   </calcite-alert>
-  `
-  )
-  .add(
-    "Message, link",
-    (): string => `
-    <calcite-alert
+`;
+
+TitleMessage.story = {
+  name: "Title, message"
+};
+
+export const MessageLink = (): string => html`
+  <calcite-alert
     theme="light"
     ${boolean("icon", true)}
     ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
-    <div slot="alert-message">
-     Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
-    </div>
+    color="${select("color", ["green", "red", "yellow", "blue"], "green")}"
+  >
+    <div slot="alert-message">Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</div>
     <calcite-link slot="alert-link" title="my action">View layer</calcite-link>
   </calcite-alert>
-  `
-  )
-  .add(
-    "Message",
-    (): string => `
-    <calcite-alert
+`;
+
+MessageLink.story = {
+  name: "Message, link"
+};
+
+export const Message = (): string => html`
+  <calcite-alert
     theme="light"
     ${boolean("icon", true)}
     ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "yellow")}">
-    <div slot="alert-message">
-      Network connection interruption detected
-    </div>
+    color="${select("color", ["green", "red", "yellow", "blue"], "yellow")}"
+  >
+    <div slot="alert-message">Network connection interruption detected</div>
   </calcite-alert>
-  `
-  )
-  .add(
-    "Custom icon",
-    (): string => `
-    <calcite-alert
+`;
+
+export const CustomIcon = (): string => html`
+  <calcite-alert
     theme="light"
     icon="${select("icon", iconNames, iconNames[0])}"
     ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
-    <div slot="alert-message">
-     Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
-    </div>
+    color="${select("color", ["green", "red", "yellow", "blue"], "green")}"
+  >
+    <div slot="alert-message">Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</div>
     <calcite-link slot="alert-link" title="my action">View layer</calcite-link>
   </calcite-alert>
-  `
-  )
-  .add(
-    "Queue",
-    (): string => `
-   <div>
+`;
+
+CustomIcon.story = {
+  name: "Custom icon"
+};
+
+export const Queue = (): string => html`
+  <div>
     <h5>Open or add to queue</h5>
     <calcite-button onclick='document.querySelector("#one").setAttribute("active", "")'>Open Alert 1</calcite-button>
     <calcite-button onclick='document.querySelector("#two").setAttribute("active", "")'>Open Alert 2</calcite-button>
-    <calcite-button onclick='document.querySelector("[data-custom-id=my-id]").setAttribute("active", "")'>Open Alert 3</calcite-button>
-    <br/>
-    <br/>
+    <calcite-button onclick='document.querySelector("[data-custom-id=my-id]").setAttribute("active", "")'
+      >Open Alert 3</calcite-button
+    >
+    <br />
+    <br />
     <h5>Close or remove from queue</h5>
-    <calcite-button color="red" onclick='document.querySelector("#one").removeAttribute("active")'>Close Alert 1</calcite-button>
-    <calcite-button color="red" onclick='document.querySelector("#two").removeAttribute("active")'>Close Alert 2</calcite-button>
-    <calcite-button color="red" onclick='document.querySelector("[data-custom-id=my-id]").removeAttribute("active")'>Close Alert 3</calcite-button>
-      <calcite-alert
-      id="one"
-      theme="light"
-      icon
-      color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
+    <calcite-button color="red" onclick='document.querySelector("#one").removeAttribute("active")'
+      >Close Alert 1</calcite-button
+    >
+    <calcite-button color="red" onclick='document.querySelector("#two").removeAttribute("active")'
+      >Close Alert 2</calcite-button
+    >
+    <calcite-button color="red" onclick='document.querySelector("[data-custom-id=my-id]").removeAttribute("active")'
+      >Close Alert 3</calcite-button
+    >
+    <calcite-alert id="one" theme="light" icon color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
       <div slot="alert-title">Your great thing happened</div>
-      <div slot="alert-message">
-        Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
-      </div>
+      <div slot="alert-message">Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</div>
       <calcite-link slot="alert-link" title="my action">View layer</calcite-link>
     </calcite-alert>
-    <calcite-alert
-    id="two"
-    theme="light"
-    icon
-    color="${select("color-2", ["green", "red", "yellow", "blue"], "blue")}">
-    <div slot="alert-title">Your great thing happened</div>
-    <div slot="alert-message">
-    Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
-    </div>
-    <calcite-link slot="alert-link" title="my action">View layer</calcite-link>
+    <calcite-alert id="two" theme="light" icon color="${select("color-2", ["green", "red", "yellow", "blue"], "blue")}">
+      <div slot="alert-title">Your great thing happened</div>
+      <div slot="alert-message">Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</div>
+      <calcite-link slot="alert-link" title="my action">View layer</calcite-link>
     </calcite-alert>
     <calcite-alert
       data-custom-id="my-id"
       theme="light"
       icon
-      color="${select("color-3", ["green", "red", "yellow", "blue"], "red")}">
+      color="${select("color-3", ["green", "red", "yellow", "blue"], "red")}"
+    >
       <div slot="alert-title">That didn't work out</div>
-      <div slot="alert-message">
-        That thing you wanted to do didn't work
-      </div>
+      <div slot="alert-message">That thing you wanted to do didn't work</div>
       <calcite-link slot="alert-link" title="my action">View layer</calcite-link>
     </calcite-alert>
-   </div>
-  `
-  )
-  .add(
-    "Dark Theme",
-    (): string => `
-    <calcite-alert
+  </div>
+`;
+
+export const DarkTheme = (): string => html`
+  <calcite-alert
     theme="dark"
-    ${boolean("icon", true)}
-    ${boolean("auto-dismiss", false)}
-  auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
-    ${boolean("active", true)}
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
-    <div slot="alert-title">Something failed</div>
-    <div slot="alert-message">
-      That thing you wanted to do didn't work as expected
-    </div>
-    <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
-  </calcite-alert>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark Theme Queue",
-    (): string => `
-   <div>
-    <h5 style="color:white">Open or add to queue</h5>
-    <calcite-button theme="dark" onclick='document.querySelector("#one").setAttribute("active", "")'>Open Alert 1</calcite-button>
-    <calcite-button theme="dark" onclick='document.querySelector("#two").setAttribute("active", "")'>Open Alert 2</calcite-button>
-    <calcite-button theme="dark" onclick='document.querySelector("[data-custom-id=my-id]").setAttribute("active", "")'>Open Alert 3</calcite-button>
-    <br/>
-    <br/>
-    <h5 style="color:white">Close or remove from queue</h5>
-    <calcite-button theme="dark" color="red" onclick='document.querySelector("#one").removeAttribute("active")'>Close Alert 1</calcite-button>
-    <calcite-button theme="dark" color="red" onclick='document.querySelector("#two").removeAttribute("active")'>Close Alert 2</calcite-button>
-    <calcite-button theme="dark" color="red" onclick='document.querySelector("[data-custom-id=my-id]").removeAttribute("active")'>Close Alert 3</calcite-button>
-      <calcite-alert
-      id="one"
-      theme="dark"
-      icon
-      color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
-      <div slot="alert-title">Your great thing happened</div>
-      <div slot="alert-message">
-        Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
-      </div>
-      <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
-    </calcite-alert>
-    <calcite-alert
-    id="two"
-    theme="dark"
-    icon
-    color="${select("color-2", ["green", "red", "yellow", "blue"], "blue")}">
-    <div slot="alert-title">Your great thing happened</div>
-    <div slot="alert-message">
-    Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer
-    </div>
-    <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
-    </calcite-alert>
-    <calcite-alert
-      data-custom-id="my-id"
-      theme="dark"
-      icon
-      color="${select("color-3", ["green", "red", "yellow", "blue"], "red")}">
-      <div slot="alert-message">
-        That thing you wanted to do didn't work out so well.
-      </div>
-    </calcite-alert>
-   </div>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "RTL",
-    (): string => `
-    <div dir="rtl">
-    <calcite-alert
-    theme="light"
     ${boolean("icon", true)}
     ${boolean("auto-dismiss", false)}
     auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
     ${boolean("active", true)}
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
+    color="${select("color", ["green", "red", "yellow", "blue"], "red")}"
+  >
     <div slot="alert-title">Something failed</div>
-    <div slot="alert-message">
-      That thing you wanted to do didn't work as expected
-    </div>
-    <calcite-link slot="alert-link" title="my action">Retry</calcite-button>
+    <div slot="alert-message">That thing you wanted to do didn't work as expected</div>
+    <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
   </calcite-alert>
+`;
+
+DarkTheme.story = {
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DarkThemeQueue = (): string => html`
+  <div>
+    <h5 style="color:white">Open or add to queue</h5>
+    <calcite-button theme="dark" onclick='document.querySelector("#one").setAttribute("active", "")'
+      >Open Alert 1</calcite-button
+    >
+    <calcite-button theme="dark" onclick='document.querySelector("#two").setAttribute("active", "")'
+      >Open Alert 2</calcite-button
+    >
+    <calcite-button theme="dark" onclick='document.querySelector("[data-custom-id=my-id]").setAttribute("active", "")'
+      >Open Alert 3</calcite-button
+    >
+    <br />
+    <br />
+    <h5 style="color:white">Close or remove from queue</h5>
+    <calcite-button theme="dark" color="red" onclick='document.querySelector("#one").removeAttribute("active")'
+      >Close Alert 1</calcite-button
+    >
+    <calcite-button theme="dark" color="red" onclick='document.querySelector("#two").removeAttribute("active")'
+      >Close Alert 2</calcite-button
+    >
+    <calcite-button
+      theme="dark"
+      color="red"
+      onclick='document.querySelector("[data-custom-id=my-id]").removeAttribute("active")'
+      >Close Alert 3</calcite-button
+    >
+    <calcite-alert id="one" theme="dark" icon color="${select("color", ["green", "red", "yellow", "blue"], "green")}">
+      <div slot="alert-title">Your great thing happened</div>
+      <div slot="alert-message">Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</div>
+      <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
+    </calcite-alert>
+    <calcite-alert id="two" theme="dark" icon color="${select("color-2", ["green", "red", "yellow", "blue"], "blue")}">
+      <div slot="alert-title">Your great thing happened</div>
+      <div slot="alert-message">Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</div>
+      <calcite-link theme="dark" slot="alert-link" title="my action">My action</calcite-link>
+    </calcite-alert>
+    <calcite-alert
+      data-custom-id="my-id"
+      theme="dark"
+      icon
+      color="${select("color-3", ["green", "red", "yellow", "blue"], "red")}"
+    >
+      <div slot="alert-message">That thing you wanted to do didn't work out so well.</div>
+    </calcite-alert>
   </div>
-  `
-  );
+`;
+
+DarkThemeQueue.story = {
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Rtl = (): string => html`
+<div dir="rtl">
+<calcite-alert
+theme="light"
+${boolean("icon", true)}
+${boolean("auto-dismiss", false)}
+auto-dismiss-duration="${select("auto-dismiss-duration", ["fast", "medium", "slow"], "medium")}"
+${boolean("active", true)}
+scale="${select("scale", ["s", "m", "l"], "m")}"
+color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
+<div slot="alert-title">Something failed</div>
+<div slot="alert-message">
+  That thing you wanted to do didn't work as expected
+</div>
+<calcite-link slot="alert-link" title="my action">Retry</calcite-button>
+</calcite-alert>
+</div>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-avatar/calcite-avatar.stories.ts
+++ b/src/components/calcite-avatar/calcite-avatar.stories.ts
@@ -1,48 +1,54 @@
-import { storiesOf } from "@storybook/html";
 import { select, text } from "@storybook/addon-knobs";
 
 import { darkBackground } from "../../../.storybook/utils";
+import { html } from "../../tests/utils";
 import readme from "./readme.md";
 
-storiesOf("Components/Avatar", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-      <calcite-avatar
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-        full-name="${text("full-name", "John Doe")}"
-        username="${text("username", "jdoe")}"
-        user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
-        thumbnail="${text("thumbnail", "http://placekitten.com/120/120")}"
-      >
-      </calcite-avatar>
-    `
-  )
-  .add(
-    "Missing thumbnail",
-    (): string => `
-      <calcite-avatar
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-        full-name="${text("full-name", "John Doe")}"
-        username="${text("username", "jdoe")}"
-        user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
-      >
-      </calcite-avatar>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark",
-    (): string => `
-      <calcite-avatar
-        theme="dark"
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-        full-name="${text("full-name", "John Doe")}"
-        username="${text("username", "jdoe")}"
-        user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
-      >
-      </calcite-avatar>
-    `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Avatar",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-avatar
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    full-name="${text("full-name", "John Doe")}"
+    username="${text("username", "jdoe")}"
+    user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
+    thumbnail="${text("thumbnail", "http://placekitten.com/120/120")}"
+  >
+  </calcite-avatar>
+`;
+
+export const MissingThumbnail = (): string => html`
+  <calcite-avatar
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    full-name="${text("full-name", "John Doe")}"
+    username="${text("username", "jdoe")}"
+    user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
+  >
+  </calcite-avatar>
+`;
+
+MissingThumbnail.story = {
+  name: "Missing thumbnail",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Dark = (): string => html`
+  <calcite-avatar
+    theme="dark"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    full-name="${text("full-name", "John Doe")}"
+    username="${text("username", "jdoe")}"
+    user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
+  >
+  </calcite-avatar>
+`;
+
+Dark.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-button/calcite-button.stories.ts
+++ b/src/components/calcite-button/calcite-button.stories.ts
@@ -1,96 +1,110 @@
-import { storiesOf } from "@storybook/html";
 import { text, select } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
+import { html } from "../../tests/utils";
 import readme from "./readme.md";
 
-storiesOf("Components/Button", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
+export default {
+  title: "Components/Button",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-button
+    appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("round", false)}
+    ${boolean("floating", false)}
+    href="${text("href", "")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+  >
+    ${text("text", "button text here")}
+  </calcite-button>
+`;
+
+export const WithIconStart = (): string => html`
+  <calcite-button
+    appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("round", false)}
+    ${boolean("floating", false)}
+    href="${text("href", "")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
+  >
+    ${text("text", "button text here")}
+  </calcite-button>
+`;
+
+WithIconStart.story = {
+  name: "With icon-start"
+};
+
+export const WithIconEnd = (): string => html`
+  <calcite-button
+    appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("round", false)}
+    ${boolean("floating", false)}
+    href="${text("href", "")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    icon-end="${select("icon-end", iconNames, iconNames[0])}"
+  >
+    ${text("text", "button text here")}
+  </calcite-button>
+`;
+
+WithIconEnd.story = {
+  name: "With icon-end"
+};
+
+export const WithIconStartAndIconEnd = (): string => html`
+  <calcite-button
+    appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("round", false)}
+    ${boolean("floating", false)}
+    href="${text("href", "")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
+    icon-end="${select("icon-end", iconNames, iconNames[0])}"
+  >
+    ${text("text", "button text here")}
+  </calcite-button>
+`;
+
+WithIconStartAndIconEnd.story = {
+  name: "With icon-start and icon-end"
+};
+
+export const SetWidthContainer = (): string => html`
+  <div style="width: 480px; max-width: 100%; background-color: #fff">
     <calcite-button
-      appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("round", false)}
-      ${boolean("floating", false)}
-      href="${text("href", "")}"
-      ${boolean("loading", false)}
-      ${boolean("disabled", false)}
-    >
-   ${text("text", "button text here")}
-    </calcite-button>
-  `
-  )
-  .add(
-    "With icon-start",
-    (): string => `
-    <calcite-button
-      appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("round", false)}
-      ${boolean("floating", false)}
-      href="${text("href", "")}"
-      ${boolean("loading", false)}
-      ${boolean("disabled", false)}
-      icon-start="${select("icon-start", iconNames, iconNames[0])}">
-      ${text("text", "button text here")}
-    </calcite-button>
-  `
-  )
-  .add(
-    "With icon-end",
-    (): string => `
-    <calcite-button
-      appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("round", false)}
-      ${boolean("floating", false)}
-      href="${text("href", "")}"
-      ${boolean("loading", false)}
-      ${boolean("disabled", false)}
-      icon-end="${select("icon-end", iconNames, iconNames[0])}">
-      ${text("text", "button text here")}
-    </calcite-button>
-  `
-  )
-  .add(
-    "With icon-start and icon-end",
-    (): string => `
-    <calcite-button
-      appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("round", false)}
-      ${boolean("floating", false)}
-      href="${text("href", "")}"
-      ${boolean("loading", false)}
-      ${boolean("disabled", false)}
+      width="${select("width", ["auto", "half", "full"], "auto")}"
       icon-start="${select("icon-start", iconNames, iconNames[0])}"
-      icon-end="${select("icon-end", iconNames, iconNames[0])}">
+    >
       ${text("text", "button text here")}
     </calcite-button>
-  `
-  )
-  .add(
-    "Set width container",
-    (): string => `
-    <div style="width: 480px; max-width: 100%; background-color: #fff">
-      <calcite-button
-        width="${select("width", ["auto", "half", "full"], "auto")}"
-        icon-start="${select("icon-start", iconNames, iconNames[0])}">
-        ${text("text", "button text here")}
-      </calcite-button>
-    </div>
-  `
-  )
-  .add(
-    "Alignment",
-    (): string => `
-    <div style="width: 480px; max-width: 100%; background-color: #fff">
+  </div>
+`;
+
+SetWidthContainer.story = {
+  name: "Set width container"
+};
+
+export const Alignment = (): string => html`
+  <div style="width: 480px; max-width: 100%; background-color: #fff">
     <calcite-button
       alignment="${select(
         "alignment",
@@ -99,37 +113,39 @@ storiesOf("Components/Button", module)
       )}"
       width="${select("width", ["auto", "half", "full"], "auto")}"
       icon-start="${select("icon-start", iconNames, iconNames[0])}"
-      icon-end="${select("icon-end", iconNames, iconNames[0])}">
+      icon-end="${select("icon-end", iconNames, iconNames[0])}"
+    >
       ${text("text", "button text here")}
     </calcite-button>
-    </div>
-    `
-  )
-  .add(
-    "Side by side",
-    (): string => `
-    <div style="width: 300px; max-width: 100%; display: flex; flex-direction: row; background-color: #fff">
+  </div>
+`;
+
+export const SideBySide = (): string => html`
+  <div style="width: 300px; max-width: 100%; display: flex; flex-direction: row; background-color: #fff">
     <calcite-button
-    width="half"
-    appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "outline")}"
-    color="${select("color", ["blue", "red", "dark", "light"], "blue")}">
-    ${text("text", "Back")}
+      width="half"
+      appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "outline")}"
+      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    >
+      ${text("text", "Back")}
     </calcite-button>
     <calcite-button
-    width="half"
-    appearance="${select("appearance-2", ["solid", "clear", "outline", "transparent"], "solid")}"
-    color="${select("color-2", ["blue", "red", "dark", "light"], "blue")}"
-    icon-start="${select("icon-start", iconNames, iconNames[0])}"
+      width="half"
+      appearance="${select("appearance-2", ["solid", "clear", "outline", "transparent"], "solid")}"
+      color="${select("color-2", ["blue", "red", "dark", "light"], "blue")}"
+      icon-start="${select("icon-start", iconNames, iconNames[0])}"
     >
-    ${text("text-2", "Some long string")}
+      ${text("text-2", "Some long string")}
     </calcite-button>
   </div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-button
+`;
+
+SideBySide.story = {
+  name: "Side by side"
+};
+
+export const DarkMode = (): string => html`
+  <calcite-button
     theme="dark"
     appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
     color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
@@ -141,9 +157,12 @@ storiesOf("Components/Button", module)
     ${boolean("disabled", false)}
     icon-start="${select("icon-start", iconNames, iconNames[0])}"
     icon-end="${select("icon-end", iconNames, iconNames[0])}"
-    >
+  >
     ${text("text", "button text here")}
   </calcite-button>
-  `,
-    { backgrounds: darkBackground }
-  );
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-card/calcite-card.stories.ts
+++ b/src/components/calcite-card/calcite-card.stories.ts
@@ -1,287 +1,274 @@
-import { storiesOf } from "@storybook/html";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
+import { html } from "../../tests/utils";
 import readme from "./readme.md";
 
-storiesOf("Components/Card", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <div style="width:260px">
-    <calcite-card
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
+export default {
+  title: "Components/Card",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <div style="width:260px">
+    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
+      <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
       >
-    <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
-    <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-      overly verbose.</span>
-      </calcite-card>
-    </div>
-  `
-  )
-  .add(
-    "Simple with Links",
-    (): string => `
-    <div style="width:260px">
-    <calcite-card
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
+    </calcite-card>
+  </div>
+`;
+
+export const SimpleWithLinks = (): string => html`
+  <div style="width:260px">
+    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
+      <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
       >
-    <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
-    <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-      overly verbose.</span>
       <calcite-link theme="dark" slot="footer-leading">Lead footer</calcite-link>
       <calcite-link theme="dark" slot="footer-trailing">Trail footer</calcite-link>
-      </calcite-card>
-    </div>
-  `
-  )
-  .add(
-    "Footer Button",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
+    </calcite-card>
+  </div>
+`;
+
+SimpleWithLinks.story = {
+  name: "Simple with Links"
+};
+
+export const FooterButton = (): string => html`
+  <div style="width:260px">
+    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
       <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">Untitled experience</h3>
       <span slot="subtitle">Subtext</span>
       <calcite-button slot="footer-leading" width="full">Go</calcite-button>
     </calcite-card>
-    `
-  )
-  .add(
-    "Footer Links",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
+  </div>
+`;
+
+export const FooterLinks = (): string => html`
+  <div style="width:260px">
+    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
       <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My perhaps multiline card title</h3>
-      <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-      overly verbose.</span>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+      >
       <calcite-link theme="dark" slot="footer-leading">Lead footer</calcite-link>
       <calcite-link theme="dark" slot="footer-trailing">Trail footer</calcite-link>
     </calcite-card>
   </div>
-    `
-  )
-  .add(
-    "Footer Text, Buttons, Tooltips",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
+`;
+
+export const FooterTextButtonsTooltips = (): string => html`
+  <div style="width:260px">
+    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
       <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My great project that might wrap two lines</h3>
       <span slot="subtitle">Johnathan Smith</span>
       <span slot="footer-leading">Nov 25, 2018</span>
       <div slot="footer-trailing">
-        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start='circle'>
+        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start="circle">
         </calcite-button>
-        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start='circle'>
+        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start="circle">
         </calcite-button>
       </div>
     </calcite-card>
   </div>
-  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure
-  </calcite-tooltip>
-  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete
-  </calcite-tooltip>
-    `
-  )
-  .add(
-    "Footer Buttons, Tooltips, Dropdown",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
-        <img alt="" slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
-        <h3 slot="title">Portland Businesses</h3>
-        <span slot="subtitle">by
-          <calcite-link href="">example_user</calcite-button>
-        </span>
-        <div>
-          Created: Apr 22, 2019
-          <br />
-          Updated: Dec 9, 2019
-          <br />
-          View Count: 0
-        </div>
-        <calcite-button slot="footer-leading" color="light" scale="s" icon-start='circle'></calcite-button>
-        <div slot="footer-trailing">
-          <calcite-button scale="s" color="light" id="card-icon-test-2" icon-start='circle'></calcite-button>
-          <calcite-button scale="s" color="light" id="card-icon-test-1" icon-start='circle'></calcite-button>
-          <calcite-dropdown>
-            <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="light" icon-start='circle'></calcite-button>
-            <calcite-dropdown-group selection-mode="none">
-              <calcite-dropdown-item>View details</calcite-dropdown-item>
-              <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-              <calcite-dropdown-item>Delete</calcite-dropdown-item>
-            </calcite-dropdown-group>
-          </calcite-dropdown>
-        </div>
-      </calcite-card>
+  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure </calcite-tooltip>
+  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete </calcite-tooltip>
+`;
+
+FooterTextButtonsTooltips.story = {
+  name: "Footer Text, Buttons, Tooltips"
+};
+
+export const FooterButtonsTooltipsDropdown = (): string => html`
+<div style="width:260px">
+  <calcite-card
+  ${boolean("loading", false)}
+  ${boolean("selectable", false)}
+  >
+    <img alt="" slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+    <h3 slot="title">Portland Businesses</h3>
+    <span slot="subtitle">by
+      <calcite-link href="">example_user</calcite-button>
+    </span>
+    <div>
+      Created: Apr 22, 2019
+      <br />
+      Updated: Dec 9, 2019
+      <br />
+      View Count: 0
     </div>
-    <calcite-tooltip placement="bottom" reference-element="card-icon-test-1">My great tooltip example
-    </calcite-tooltip>
-    <calcite-tooltip placement="bottom" reference-element="card-icon-test-2">Sharing level: 2
-    </calcite-tooltip>
-    <calcite-tooltip placement="top" reference-element="card-icon-test-5">More options
-    </calcite-tooltip>
-    `
-  )
-  .add(
-    "Dark Theme - Simple",
-    (): string => `
-    <div style="width:260px">
-    <calcite-card
-      theme="dark"
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
-    <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
-    <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-      overly verbose.</span>
-      </calcite-card>
+    <calcite-button slot="footer-leading" color="light" scale="s" icon-start='circle'></calcite-button>
+    <div slot="footer-trailing">
+      <calcite-button scale="s" color="light" id="card-icon-test-2" icon-start='circle'></calcite-button>
+      <calcite-button scale="s" color="light" id="card-icon-test-1" icon-start='circle'></calcite-button>
+      <calcite-dropdown>
+        <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="light" icon-start='circle'></calcite-button>
+        <calcite-dropdown-group selection-mode="none">
+          <calcite-dropdown-item>View details</calcite-dropdown-item>
+          <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+          <calcite-dropdown-item>Delete</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
     </div>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark Theme - Simple with Links",
-    (): string => `
-    <div style="width:260px">
-    <calcite-card
-    theme="dark"
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
+  </calcite-card>
+</div>
+<calcite-tooltip placement="bottom" reference-element="card-icon-test-1">My great tooltip example
+</calcite-tooltip>
+<calcite-tooltip placement="bottom" reference-element="card-icon-test-2">Sharing level: 2
+</calcite-tooltip>
+<calcite-tooltip placement="top" reference-element="card-icon-test-5">More options
+</calcite-tooltip>
+`;
+
+FooterButtonsTooltipsDropdown.story = {
+  name: "Footer Buttons, Tooltips, Dropdown"
+};
+
+export const DarkThemeSimple = (): string => html`
+  <div style="width:260px">
+    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
+      <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
       >
-    <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
-    <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-      overly verbose.</span>
+    </calcite-card>
+  </div>
+`;
+
+DarkThemeSimple.story = {
+  name: "Dark Theme - Simple",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DarkThemeSimpleWithLinks = (): string => html`
+  <div style="width:260px">
+    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
+      <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+      >
       <calcite-link theme="dark" theme="dark" slot="footer-leading">Lead footer</calcite-link>
       <calcite-link theme="dark" theme="dark" slot="footer-trailing">Trail footer</calcite-link>
-      </calcite-card>
-    </div>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark Theme - Footer Button",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      theme="dark"
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
+    </calcite-card>
+  </div>
+`;
+
+DarkThemeSimpleWithLinks.story = {
+  name: "Dark Theme - Simple with Links",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DarkThemeFooterButton = (): string => html`
+  <div style="width:260px">
+    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
       <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">Untitled experience</h3>
       <span slot="subtitle">Subtext</span>
       <calcite-button theme="dark" slot="footer-leading" width="full">Go</calcite-button>
     </calcite-card>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark Theme - Footer Links",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      theme="dark"
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
+  </div>
+`;
+
+DarkThemeFooterButton.story = {
+  name: "Dark Theme - Footer Button",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DarkThemeFooterLinks = (): string => html`
+  <div style="width:260px">
+    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
       <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My perhaps multiline card title</h3>
-      <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-      overly verbose.</span>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+      >
       <calcite-link theme="dark" slot="footer-leading">Lead footer</calcite-link>
       <calcite-link theme="dark" slot="footer-trailing">Trail footer</calcite-link>
     </calcite-card>
   </div>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark Theme - Footer Text, Buttons, Tooltips",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      theme="dark"
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
+`;
+
+DarkThemeFooterLinks.story = {
+  name: "Dark Theme - Footer Links",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DarkThemeFooterTextButtonsTooltips = (): string => html`
+  <div style="width:260px">
+    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
       <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" />
       <h3 slot="title">My great project that might wrap two lines</h3>
       <span slot="subtitle">Johnathan Smith</span>
       <span slot="footer-leading">Nov 25, 2018</span>
       <div slot="footer-trailing">
-        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start='circle'>
+        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="dark" icon-start="circle">
         </calcite-button>
-        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start='circle'>
+        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="dark" icon-start="circle">
         </calcite-button>
       </div>
     </calcite-card>
   </div>
-  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure
-  </calcite-tooltip>
-  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete
-  </calcite-tooltip>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Dark Theme - Footer Buttons, Tooltips, Dropdown",
-    (): string => `
-    <div style="width:260px">
-      <calcite-card
-      theme="dark"
-      ${boolean("loading", false)}
-      ${boolean("selectable", false)}
-      >
-        <img alt="" slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
-        <h3 slot="title">Portland Businesses</h3>
-        <span slot="subtitle">by
-          <calcite-link theme="dark" href="">example_user</calcite-link>
-        </span>
-        <div>
-          Created: Apr 22, 2019
-          <br />
-          Updated: Dec 9, 2019
-          <br />
-          View Count: 0
-        </div>
-        <calcite-button slot="footer-leading" color="dark" scale="s" icon-start='circle'></calcite-button>
-        <div slot="footer-trailing">
-          <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-2" icon-start='circle'></calcite-button>
-          <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-1" icon-start='circle'></calcite-button>
-          <calcite-dropdown>
-            <calcite-button theme="dark" color="dark" id="card-icon-test-5" slot="dropdown-trigger" scale="s" icon-start='circle'></calcite-button>
-            <calcite-dropdown-group selection-mode="none">
-              <calcite-dropdown-item>View details</calcite-dropdown-item>
-              <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-              <calcite-dropdown-item>Delete</calcite-dropdown-item>
-            </calcite-dropdown-group>
-          </calcite-dropdown>
-        </div>
-      </calcite-card>
-    </div>
-    <calcite-tooltip placement="bottom" reference-element="card-icon-test-1">My great tooltip example
-    </calcite-tooltip>
-    <calcite-tooltip placement="bottom" reference-element="card-icon-test-2">Sharing level: 2
-    </calcite-tooltip>
-    <calcite-tooltip placement="top" reference-element="card-icon-test-5">More options
-    </calcite-tooltip>
-    `,
-    { backgrounds: darkBackground }
-  );
+  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure </calcite-tooltip>
+  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete </calcite-tooltip>
+`;
+
+DarkThemeFooterTextButtonsTooltips.story = {
+  name: "Dark Theme - Footer Text, Buttons, Tooltips",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DarkThemeFooterButtonsTooltipsDropdown = (): string => html`
+  <div style="width:260px">
+    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
+      <img alt="" slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+      <h3 slot="title">Portland Businesses</h3>
+      <span slot="subtitle"
+        >by
+        <calcite-link theme="dark" href="">example_user</calcite-link>
+      </span>
+      <div>
+        Created: Apr 22, 2019
+        <br />
+        Updated: Dec 9, 2019
+        <br />
+        View Count: 0
+      </div>
+      <calcite-button slot="footer-leading" color="dark" scale="s" icon-start="circle"></calcite-button>
+      <div slot="footer-trailing">
+        <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-2" icon-start="circle"></calcite-button>
+        <calcite-button theme="dark" color="dark" scale="s" id="card-icon-test-1" icon-start="circle"></calcite-button>
+        <calcite-dropdown>
+          <calcite-button
+            theme="dark"
+            color="dark"
+            id="card-icon-test-5"
+            slot="dropdown-trigger"
+            scale="s"
+            icon-start="circle"
+          ></calcite-button>
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>View details</calcite-dropdown-item>
+            <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+            <calcite-dropdown-item>Delete</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+      </div>
+    </calcite-card>
+  </div>
+  <calcite-tooltip placement="bottom" reference-element="card-icon-test-1">My great tooltip example </calcite-tooltip>
+  <calcite-tooltip placement="bottom" reference-element="card-icon-test-2">Sharing level: 2 </calcite-tooltip>
+  <calcite-tooltip placement="top" reference-element="card-icon-test-5">More options </calcite-tooltip>
+`;
+
+DarkThemeFooterButtonsTooltipsDropdown.story = {
+  name: "Dark Theme - Footer Buttons, Tooltips, Dropdown",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-checkbox/calcite-checkbox.stories.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.stories.ts
@@ -1,37 +1,43 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
+import { html } from "../../tests/utils";
 import readme from "./readme.md";
 
-storiesOf("Components/Checkbox", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <label>
-      <calcite-checkbox
-        ${boolean("checked", true)}
-        ${boolean("disabled", false)}
-        ${boolean("indeterminate", false)}
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-      ></calcite-checkbox>
-      Text for the checkbox
-    </label>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <label>
-      <calcite-checkbox
-        theme="dark"
-        ${boolean("checked", true)}
-        ${boolean("disabled", false)}
-        ${boolean("indeterminate", false)}
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-      >Text for the checkbox</calcite-checkbox>
-    </label>
-`,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Checkbox",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <label>
+    <calcite-checkbox
+      ${boolean("checked", true)}
+      ${boolean("disabled", false)}
+      ${boolean("indeterminate", false)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+    ></calcite-checkbox>
+    Text for the checkbox
+  </label>
+`;
+
+export const DarkMode = (): string => html`
+  <label>
+    <calcite-checkbox
+      theme="dark"
+      ${boolean("checked", true)}
+      ${boolean("disabled", false)}
+      ${boolean("indeterminate", false)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      >Text for the checkbox</calcite-checkbox
+    >
+  </label>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-chip/calcite-chip.stories.ts
+++ b/src/components/calcite-chip/calcite-chip.stories.ts
@@ -1,96 +1,111 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Chip", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <div style="background-color:white;padding:100px">
+export default {
+  title: "Components/Chip",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <div style="background-color:white;padding:100px">
     <calcite-chip
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    appearance="${select("appearance", ["solid", "clear"], "solid")}"
-    color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
-    ${boolean("dismissible", false)}
-    >My great chip</calcite-chip>
-    </div>
-  `
-  )
-  .add(
-    "With Icon",
-    (): string => `
-    <div style="background-color:white;padding:100px">
-    <calcite-chip
-    icon="${select("icon", iconNames, iconNames[0])}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    appearance="${select("appearance", ["solid", "clear"], "solid")}"
-    color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
-    ${boolean("dismissible", false)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      appearance="${select("appearance", ["solid", "clear"], "solid")}"
+      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      ${boolean("dismissible", false)}
+      >My great chip</calcite-chip
     >
-    My great chip</calcite-chip>
-    </div>
-  `
-  )
-  .add(
-    "With Image",
-    (): string => `
-    <div style="background-color:white;padding:100px">
+  </div>
+`;
+
+export const WithIcon = (): string => html`
+  <div style="background-color:white;padding:100px">
     <calcite-chip
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    appearance="${select("appearance", ["solid", "clear"], "solid")}"
-    color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
-    ${boolean("dismissible", false)}
+      icon="${select("icon", iconNames, iconNames[0])}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      appearance="${select("appearance", ["solid", "clear"], "solid")}"
+      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      ${boolean("dismissible", false)}
     >
-    <img alt="" slot="chip-image" src="https://placekitten.com/50/50" />
-    My great chip</calcite-chip>
-    </div>
-  `
-  )
-  .add("With Avatar", (): string => {
-    const scale = select("scale", ["s", "m", "l"], "m");
-    return `
-      <div style="background-color:white;padding:100px">
-        <calcite-chip
+      My great chip</calcite-chip
+    >
+  </div>
+`;
+
+export const WithImage = (): string => html`
+  <div style="background-color:white;padding:100px">
+    <calcite-chip
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      appearance="${select("appearance", ["solid", "clear"], "solid")}"
+      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      ${boolean("dismissible", false)}
+    >
+      <img alt="" slot="chip-image" src="https://placekitten.com/50/50" />
+      My great chip</calcite-chip
+    >
+  </div>
+`;
+
+export const WithAvatar = (): string => {
+  const scale = select("scale", ["s", "m", "l"], "m");
+
+  return html`
+    <div style="background-color:white;padding:100px">
+      <calcite-chip
+        scale="${scale}"
+        appearance="${select("appearance", ["solid", "clear"], "solid")}"
+        color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+        ${boolean("dismissible", false)}
+      >
+        <calcite-avatar
+          slot="chip-image"
           scale="${scale}"
-          appearance="${select("appearance", ["solid", "clear"], "solid")}"
-          color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
-          ${boolean("dismissible", false)}
-        >
-          <calcite-avatar slot="chip-image" scale="${scale}" user-id="25684463a00c449585dbb32a065f6b74" full-name="user name"></calcite-avatar>
-          User Name
-        </calcite-chip>
-      </div>
-    `;
-  })
-  .add(
-    "Dark theme",
-    (): string => `
-    <div style="background-color:#2b2b2b;padding:100px">
-    <calcite-chip
-    theme="dark"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    appearance="${select("appearance", ["solid", "clear"], "solid")}"
-    color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
-    ${boolean("dismissible", false)}
-    >My great chip</calcite-chip>
+          user-id="25684463a00c449585dbb32a065f6b74"
+          full-name="user name"
+        ></calcite-avatar>
+        User Name
+      </calcite-chip>
     </div>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "RTL",
-    (): string => `
-    <div style="background-color:white;padding:100px" dir="rtl">
+  `;
+};
+
+export const DarkTheme = (): string => html`
+  <div style="background-color:#2b2b2b;padding:100px">
     <calcite-chip
-    icon="${select("icon", iconNames, iconNames[0])}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    appearance="${select("appearance", ["solid", "clear"], "solid")}"
-    color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
-    ${boolean("dismissible", false)}
-    >My great chip</calcite-chip>
-    </div>
-  `
-  );
+      theme="dark"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      appearance="${select("appearance", ["solid", "clear"], "solid")}"
+      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      ${boolean("dismissible", false)}
+      >My great chip</calcite-chip
+    >
+  </div>
+`;
+
+DarkTheme.story = {
+  name: "Dark theme",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Rtl = (): string => html`
+  <div style="background-color:white;padding:100px" dir="rtl">
+    <calcite-chip
+      icon="${select("icon", iconNames, iconNames[0])}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      appearance="${select("appearance", ["solid", "clear"], "solid")}"
+      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      ${boolean("dismissible", false)}
+      >My great chip</calcite-chip
+    >
+  </div>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-color/calcite-color.stories.ts
+++ b/src/components/calcite-color/calcite-color.stories.ts
@@ -1,37 +1,41 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { darkBackground } from "../../../.storybook/utils";
 import { boolean } from "../../../.storybook/helpers";
 import colorReadme from "./readme.md";
 import colorSwatchReadme from "../calcite-color-swatch/readme.md";
 import hexInputReadme from "../calcite-color-hex-input/readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Color", module)
-  .addParameters({ notes: [colorReadme, colorSwatchReadme, hexInputReadme] })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-color
-      ${boolean("hide hex", false)}
-      ${boolean("hide channels", false)}
-      ${boolean("hide saved", false)}
-      theme="light"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      value="#beefee"
-    ></calcite-color>
-  `
-  )
-  .add(
-    "Dark Mode",
-    (): string => `
-      <calcite-color
-      hide-channels=${boolean("hide channels", false)}
-      hide-hex=${boolean("hide hex", false)}
-      hide-saved=${boolean("hide saved", false)}
-      theme="dark"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      value="#beefee"
-    ></calcite-color>
-    `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Color",
+
+  parameters: {
+    notes: [colorReadme, colorSwatchReadme, hexInputReadme]
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-color
+    ${boolean("hide hex", false)}
+    ${boolean("hide channels", false)}
+    ${boolean("hide saved", false)}
+    theme="light"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    value="#beefee"
+  ></calcite-color>
+`;
+
+export const DarkMode = (): string => html`
+  <calcite-color
+    hide-channels=${boolean("hide channels", false)}
+    hide-hex=${boolean("hide hex", false)}
+    hide-saved=${boolean("hide saved", false)}
+    theme="dark"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    value="#beefee"
+  ></calcite-color>
+`;
+
+DarkMode.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -1,117 +1,122 @@
-import { storiesOf } from "@storybook/html";
 import { select, number, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-combobox-item/readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Combobox", module)
-  .addParameters({ notes: [readme1, readme2] })
-  .add(
-    "Simple",
-    (): string => `
-    <div style="width:400px;max-width:100%;background-color:white;padding:100px"">
-    <calcite-combobox
-      label="demo combobox"
-      placeholder="${text("placeholder", "placeholder")}"
-      label="${text("label (for screen readers)", "demo")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("disabled", false)}
-      ${boolean("allow-custom-values", false)}
-      max-items="${number("max-items", 0)}"
-      >
-      <calcite-combobox-item value="Trees" text-label="Trees">
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
-      </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
-      </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
-      </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
-    </calcite-combobox>
-    </div>
-  `
-  )
+export default {
+  title: "Components/Combobox",
 
-  .add(
-    "Dark Theme",
-    (): string => `
-    <div style="width:400px;max-width:100%;background-color:white;padding:100px"">
-    <calcite-combobox
-    label="demo combobox"
-    theme="dark"
-    placeholder="${text("placeholder", "placeholder")}"
-    label="${text("label (for screen readers)", "demo")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    ${boolean("disabled", false)}
-    ${boolean("allow-custom-values", false)}
-    max-items="${number("max-items", 0)}"
-    >
-    <calcite-combobox-item value="Trees" text-label="Trees">
-      <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
-    </calcite-combobox-item>
-    <calcite-combobox-item value="Flowers" text-label="Flowers">
-      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-      <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
-    </calcite-combobox-item>
-    <calcite-combobox-item value="Animals" text-label="Animals">
-      <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-      <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-      <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
-    </calcite-combobox-item>
-    <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-    <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-    <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
-  </calcite-combobox>
-  </div>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "RTL",
-    (): string => `
-    <div style="width:400px;max-width:100%;background-color:white;padding:100px"">
-    <calcite-combobox
-    placeholder="${text("placeholder", "placeholder")}"
-    label="${text("label (for screen readers)", "demo")}"
-    dir="rtl"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    ${boolean("disabled", false)}
-    ${boolean("allow-custom-values", false)}
-    >
-    <calcite-combobox-item value="Trees" text-label="Trees">
-      <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
-    </calcite-combobox-item>
-    <calcite-combobox-item value="Flowers" text-label="Flowers">
-      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-      <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
-    </calcite-combobox-item>
-    <calcite-combobox-item value="Animals" text-label="Animals">
-      <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-      <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-      <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
-    </calcite-combobox-item>
-    <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-    <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-    <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
-  </calcite-combobox>
-  </div>
-  `
-  );
+  parameters: {
+    notes: [readme1, readme2]
+  }
+};
+
+export const Simple = (): string => html`
+<div style="width:400px;max-width:100%;background-color:white;padding:100px"">
+<calcite-combobox
+  label="demo combobox"
+  placeholder="${text("placeholder", "placeholder")}"
+  label="${text("label (for screen readers)", "demo")}"
+  scale="${select("scale", ["s", "m", "l"], "m")}"
+  ${boolean("disabled", false)}
+  ${boolean("allow-custom-values", false)}
+  max-items="${number("max-items", 0)}"
+  >
+  <calcite-combobox-item value="Trees" text-label="Trees">
+    <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+    <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+    <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+  </calcite-combobox-item>
+  <calcite-combobox-item value="Flowers" text-label="Flowers">
+    <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+    <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+    <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+  </calcite-combobox-item>
+  <calcite-combobox-item value="Animals" text-label="Animals">
+    <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+    <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+    <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+  </calcite-combobox-item>
+  <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+  <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+  <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+</calcite-combobox>
+</div>
+`;
+
+export const DarkTheme = (): string => html`
+<div style="width:400px;max-width:100%;background-color:white;padding:100px"">
+<calcite-combobox
+label="demo combobox"
+theme="dark"
+placeholder="${text("placeholder", "placeholder")}"
+label="${text("label (for screen readers)", "demo")}"
+scale="${select("scale", ["s", "m", "l"], "m")}"
+${boolean("disabled", false)}
+${boolean("allow-custom-values", false)}
+max-items="${number("max-items", 0)}"
+>
+<calcite-combobox-item value="Trees" text-label="Trees">
+  <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+  <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+  <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+</calcite-combobox-item>
+<calcite-combobox-item value="Flowers" text-label="Flowers">
+  <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+  <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+  <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+</calcite-combobox-item>
+<calcite-combobox-item value="Animals" text-label="Animals">
+  <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+  <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+  <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+</calcite-combobox-item>
+<calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+<calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+<calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+</calcite-combobox>
+</div>
+`;
+
+DarkTheme.story = {
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Rtl = (): string => html`
+<div style="width:400px;max-width:100%;background-color:white;padding:100px"">
+<calcite-combobox
+placeholder="${text("placeholder", "placeholder")}"
+label="${text("label (for screen readers)", "demo")}"
+dir="rtl"
+scale="${select("scale", ["s", "m", "l"], "m")}"
+${boolean("disabled", false)}
+${boolean("allow-custom-values", false)}
+>
+<calcite-combobox-item value="Trees" text-label="Trees">
+  <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+  <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+  <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+</calcite-combobox-item>
+<calcite-combobox-item value="Flowers" text-label="Flowers">
+  <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+  <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+  <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+</calcite-combobox-item>
+<calcite-combobox-item value="Animals" text-label="Animals">
+  <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+  <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+  <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+</calcite-combobox-item>
+<calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+<calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+<calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+</calcite-combobox>
+</div>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-date/calcite-date.stories.ts
+++ b/src/components/calcite-date/calcite-date.stories.ts
@@ -1,8 +1,8 @@
-import { storiesOf } from "@storybook/html";
 import { select, text, boolean } from "@storybook/addon-knobs";
 
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
 const locales = [
   "ar",
@@ -55,30 +55,33 @@ const locales = [
   "zh-TW"
 ];
 
-storiesOf("Components/Date", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <div style="width: 400px">
+export default {
+  title: "Components/Date",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <div style="width: 400px">
     <calcite-label layout="inline">
-    Date
-    <calcite-date
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      value="${text("value", "")}"
-      min="${text("min", "2016-08-09")}"
-      max="${text("max", "2023-12-18")}"
-      locale="${select("locale", locales, "en-US")}"
-      intl-next-month="${text("intl-next-month", "Next month")}"
-      intl-prev-month="${text("intl-prev-month", "Previous month")}"
-    ></calcite-date></calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "No input",
-    (): string => `
-    <div style="width: 400px">
+      Date
+      <calcite-date
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        value="${text("value", "")}"
+        min="${text("min", "2016-08-09")}"
+        max="${text("max", "2023-12-18")}"
+        locale="${select("locale", locales, "en-US")}"
+        intl-next-month="${text("intl-next-month", "Next month")}"
+        intl-prev-month="${text("intl-prev-month", "Previous month")}"
+      ></calcite-date
+    ></calcite-label>
+  </div>
+`;
+
+export const NoInput = (): string => html`
+  <div style="width: 400px">
     <calcite-date
       scale="${select("scale", ["s", "m", "l"], "m")}"
       value="${text("value", "")}"
@@ -90,34 +93,39 @@ storiesOf("Components/Date", module)
       intl-next-month="${text("intl-next-month", "Next month")}"
       intl-prev-month="${text("intl-prev-month", "Previous month")}"
     ></calcite-date>
-    </div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <div style="width: 400px">
+  </div>
+`;
+
+NoInput.story = {
+  name: "No input"
+};
+
+export const DarkMode = (): string => html`
+  <div style="width: 400px">
     <calcite-label layout="inline" theme="dark">
-    Date
-    <calcite-date
-      theme="dark"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      value="${text("value", "")}"
-      min="${text("min", "2016-08-09")}"
-      max="${text("max", "2023-12-18")}"
-      locale="${select("locale", locales, "en-US")}"
-      intl-next-month="${text("intl-next-month", "Next month")}"
-      intl-prev-month="${text("intl-prev-month", "Previous month")}"
-      range="${boolean("range", false)}"
-    ></calcite-date></calcite-label>
-    </div>
-`,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Range",
-    (): string => `
-    <div style="width: 400px">
+      Date
+      <calcite-date
+        theme="dark"
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        value="${text("value", "")}"
+        min="${text("min", "2016-08-09")}"
+        max="${text("max", "2023-12-18")}"
+        locale="${select("locale", locales, "en-US")}"
+        intl-next-month="${text("intl-next-month", "Next month")}"
+        intl-prev-month="${text("intl-prev-month", "Previous month")}"
+        range="${boolean("range", false)}"
+      ></calcite-date
+    ></calcite-label>
+  </div>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Range = (): string => html`
+  <div style="width: 400px">
     <calcite-date
       scale="${select("scale", ["s", "m", "l"], "m")}"
       start="${text("start", "")}"
@@ -130,6 +138,5 @@ storiesOf("Components/Date", module)
       range="${boolean("range", true)}"
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
     ></calcite-date>
-    </div>
-  `
-  );
+  </div>
+`;

--- a/src/components/calcite-dropdown/calcite-dropdown.stories.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.stories.ts
@@ -1,82 +1,78 @@
-import { storiesOf } from "@storybook/html";
 import { number, select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-dropdown-group/readme.md";
 import readme3 from "../calcite-dropdown-item/readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Dropdown", module)
-  .addParameters({ notes: [readme1, readme2, readme3] })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-dropdown
-      alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["s", "m", "l"], "m")}"
-      type="${select("type", ["click", "hover"], "click")}"
-      ${boolean("disable-close-on-select", false)}
-      ${boolean("disabled", false)}
+export default {
+  title: "Components/Dropdown",
+
+  parameters: {
+    notes: [readme1, readme2, readme3]
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-dropdown
+    alignment="${select("alignment", ["start", "center", "end"], "start")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "m")}"
+    type="${select("type", ["click", "hover"], "click")}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
+  >
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Sort by"
     >
-      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Sort by">
-        <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item>Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  `
-  )
-  .add(
-    "With Icons",
-    (): string => `
-    <calcite-dropdown
-      alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["s", "m", "l"], "m")}"
-      type="${select("type", ["click", "hover"], "click")}"
-      ${boolean("disable-close-on-select", false)}
-      ${boolean("disabled", false)}
+      <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+      <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+      <calcite-dropdown-item>Title</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;
+
+export const WithIcons = (): string => html`
+  <calcite-dropdown
+    alignment="${select("alignment", ["start", "center", "end"], "start")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "m")}"
+    type="${select("type", ["click", "hover"], "click")}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
+  >
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Icon Start"
     >
-      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Icon Start">
       <calcite-dropdown-item icon-start="list">List</calcite-dropdown-item>
       <calcite-dropdown-item icon-start="grid" active>Grid</calcite-dropdown-item>
       <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
-      </calcite-dropdown-group>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Icon End">
+    </calcite-dropdown-group>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Icon End"
+    >
       <calcite-dropdown-item icon-end="list">List</calcite-dropdown-item>
       <calcite-dropdown-item icon-end="grid" active>Grid</calcite-dropdown-item>
       <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
-      </calcite-dropdown-group>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Icon Both">
-      <calcite-dropdown-item icon-start="list" icon-end="data-check" >List</calcite-dropdown-item>
-      <calcite-dropdown-item icon-start="grid"  icon-end="data-check" active>Grid</calcite-dropdown-item>
-      <calcite-dropdown-item icon-start="table" icon-end="data-check" >Table</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  `
-  )
-  .add(
-    "Groups and selection modes",
-    (): string => `
+    </calcite-dropdown-group>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Icon Both"
+    >
+      <calcite-dropdown-item icon-start="list" icon-end="data-check">List</calcite-dropdown-item>
+      <calcite-dropdown-item icon-start="grid" icon-end="data-check" active>Grid</calcite-dropdown-item>
+      <calcite-dropdown-item icon-start="table" icon-end="data-check">Table</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;
+
+export const GroupsAndSelectionModes = (): string => html`
   <calcite-dropdown
     alignment="${select("alignment", ["start", "center", "end"], "start")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -101,11 +97,13 @@ storiesOf("Components/Dropdown", module)
       <calcite-dropdown-item>Add peas</calcite-dropdown-item>
     </calcite-dropdown-group>
   </calcite-dropdown>
-`
-  )
-  .add(
-    "Items as Links",
-    (): string => `
+`;
+
+GroupsAndSelectionModes.story = {
+  name: "Groups and selection modes"
+};
+
+export const ItemsAsLinks = (): string => html`
   <calcite-dropdown
     alignment="${select("alignment", ["start", "center", "end"], "start")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -116,18 +114,30 @@ storiesOf("Components/Dropdown", module)
   >
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group selection-mode="none" group-title="Select one">
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Throw Apples</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Visit Oranges</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Eat Grapes</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-start="camera-flash-on">Plant beans</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-end="camera-flash-on">Add peas</calcite-dropdown-item>
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Throw Apples</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Visit Oranges</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Eat Grapes</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-start="camera-flash-on"
+        >Plant beans</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-end="camera-flash-on"
+        >Add peas</calcite-dropdown-item
+      >
     </calcite-dropdown-group>
   </calcite-dropdown>
-`
-  )
-  .add(
-    "A mix of links and non-links",
-    (): string => `
+`;
+
+ItemsAsLinks.story = {
+  name: "Items as Links"
+};
+
+export const AMixOfLinksAndNonLinks = (): string => html`
   <calcite-dropdown
     alignment="${select("alignment", ["start", "center", "end"], "start")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -140,86 +150,92 @@ storiesOf("Components/Dropdown", module)
     <calcite-dropdown-group selection-mode="none" group-title="Select one">
       <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">A link</calcite-dropdown-item>
       <calcite-dropdown-item onclick='alert("not a link")'>Not a link</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Another Link</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-end="camera-flash-on">Another link that might wrap to another line</calcite-dropdown-item>
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Another Link</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-end="camera-flash-on"
+        >Another link that might wrap to another line</calcite-dropdown-item
+      >
       <calcite-dropdown-item onclick='alert("not a link")'>Not a link</calcite-dropdown-item>
     </calcite-dropdown-group>
   </calcite-dropdown>
-`
-  )
-  .add(
-    "Dark theme",
-    (): string => `
-    <calcite-dropdown
-      theme="dark"
-      alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-       width="${select("width", ["s", "m", "l"], "m")}"
-      type="${select("type", ["click", "hover"], "click")}"
-      ${boolean("disable-close-on-select", false)}
-      ${boolean("disabled", false)}
+`;
+
+AMixOfLinksAndNonLinks.story = {
+  name: "A mix of links and non-links"
+};
+
+export const DarkTheme = (): string => html`
+  <calcite-dropdown
+    theme="dark"
+    alignment="${select("alignment", ["start", "center", "end"], "start")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "m")}"
+    type="${select("type", ["click", "hover"], "click")}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
+  >
+    <calcite-button slot="dropdown-trigger" theme="dark">Open Dropdown</calcite-button>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Sort by"
     >
-      <calcite-button slot="dropdown-trigger" theme="dark">Open Dropdown</calcite-button>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Sort by">
-        <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item>Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "With Icons - Dark theme",
-    (): string => `
-    <calcite-dropdown
-      theme="dark"
-      alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["s", "m", "l"], "m")}"
-      type="${select("type", ["click", "hover"], "click")}"
-      ${boolean("disable-close-on-select", false)}
-      ${boolean("disabled", false)}
+      <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+      <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+      <calcite-dropdown-item>Title</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;
+
+DarkTheme.story = {
+  name: "Dark theme",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const WithIconsDarkTheme = (): string => html`
+  <calcite-dropdown
+    theme="dark"
+    alignment="${select("alignment", ["start", "center", "end"], "start")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "m")}"
+    type="${select("type", ["click", "hover"], "click")}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
+  >
+    <calcite-button theme="dark" slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Icon Start"
     >
-      <calcite-button theme="dark" slot="dropdown-trigger">Open Dropdown</calcite-button>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Icon Start">
       <calcite-dropdown-item icon-start="list">List</calcite-dropdown-item>
       <calcite-dropdown-item icon-start="grid" active>Grid</calcite-dropdown-item>
       <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
-      </calcite-dropdown-group>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Icon End">
+    </calcite-dropdown-group>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Icon End"
+    >
       <calcite-dropdown-item icon-end="list">List</calcite-dropdown-item>
       <calcite-dropdown-item icon-end="grid" active>Grid</calcite-dropdown-item>
       <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
-      </calcite-dropdown-group>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Icon Both">
-      <calcite-dropdown-item icon-start="list" icon-end="data-check" >List</calcite-dropdown-item>
-      <calcite-dropdown-item icon-start="grid"  icon-end="data-check" active>Grid</calcite-dropdown-item>
-      <calcite-dropdown-item icon-start="table" icon-end="data-check" >Table</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Groups and selection modes dark theme",
-    (): string => `
+    </calcite-dropdown-group>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Icon Both"
+    >
+      <calcite-dropdown-item icon-start="list" icon-end="data-check">List</calcite-dropdown-item>
+      <calcite-dropdown-item icon-start="grid" icon-end="data-check" active>Grid</calcite-dropdown-item>
+      <calcite-dropdown-item icon-start="table" icon-end="data-check">Table</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;
+
+WithIconsDarkTheme.story = {
+  name: "With Icons - Dark theme",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const GroupsAndSelectionModesDarkTheme = (): string => html`
   <calcite-dropdown
     theme="dark"
     alignment="${select("alignment", ["start", "center", "end"], "start")}"
@@ -244,12 +260,14 @@ storiesOf("Components/Dropdown", module)
       <calcite-dropdown-item>Add peas</calcite-dropdown-item>
     </calcite-dropdown-group>
   </calcite-dropdown>
-`,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Items as Links - dark theme",
-    (): string => `
+`;
+
+GroupsAndSelectionModesDarkTheme.story = {
+  name: "Groups and selection modes dark theme",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const ItemsAsLinksDarkTheme = (): string => html`
   <calcite-dropdown
     theme="dark"
     alignment="${select("alignment", ["start", "center", "end"], "start")}"
@@ -261,68 +279,84 @@ storiesOf("Components/Dropdown", module)
   >
     <calcite-button theme="dark" slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group selection-mode="none" group-title="Select one">
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Throw Apples</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Visit Oranges</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">Eat Grapes</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-start="camera-flash-on">Plant beans</calcite-dropdown-item>
-      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-end="camera-flash-on">Add peas</calcite-dropdown-item>
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Throw Apples</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Visit Oranges</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title"
+        >Eat Grapes</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-start="camera-flash-on"
+        >Plant beans</calcite-dropdown-item
+      >
+      <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title" icon-end="camera-flash-on"
+        >Add peas</calcite-dropdown-item
+      >
     </calcite-dropdown-group>
   </calcite-dropdown>
-`,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Simple - RTL",
-    (): string => `
-    <calcite-dropdown
-      dir="rtl"
-      alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["s", "m", "l"], "m")}"
-      type="${select("type", ["click", "hover"], "click")}"
-      ${boolean("disable-close-on-select", false)}
-      ${boolean("disabled", false)}
+`;
+
+ItemsAsLinksDarkTheme.story = {
+  name: "Items as Links - dark theme",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const SimpleRtl = (): string => html`
+  <calcite-dropdown
+    dir="rtl"
+    alignment="${select("alignment", ["start", "center", "end"], "start")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "m")}"
+    type="${select("type", ["click", "hover"], "click")}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
+  >
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group
+      selection-mode="${select("group selection mode", ["single", "multi", "none"], "single")}"
+      group-title="Sort by"
     >
-      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-      <calcite-dropdown-group selection-mode="${select(
-        "group selection mode",
-        ["single", "multi", "none"],
-        "single"
-      )}" group-title="Sort by">
-        <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
-        <calcite-dropdown-item>Title</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  `
-  )
-  .add(
-    "Scrolling after certain items",
-    (): string => `
-    <calcite-dropdown
-      alignment="${select("alignment", ["start", "center", "end"], "start")}"
-      max-items="${number("max-items", 7, { min: 0, max: 10, step: 1 })}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["s", "m", "l"], "m")}"
-      type="${select("type", ["click", "hover"], "click")}"
-      ${boolean("disable-close-on-select", false)}
-      ${boolean("disabled", false)}
-    >
-      <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-      <calcite-dropdown-group group-title="First group">
-        <calcite-dropdown-item>1</calcite-dropdown-item>
-        <calcite-dropdown-item>2</calcite-dropdown-item>
-        <calcite-dropdown-item>3</calcite-dropdown-item>
-        <calcite-dropdown-item>4</calcite-dropdown-item>
-        <calcite-dropdown-item>5</calcite-dropdown-item>
-      </calcite-dropdown-group>
-      <calcite-dropdown-group group-title="Second group">
-        <calcite-dropdown-item>6</calcite-dropdown-item>
-        <calcite-dropdown-item>7</calcite-dropdown-item>
-        <calcite-dropdown-item>8</calcite-dropdown-item>
-        <calcite-dropdown-item>9</calcite-dropdown-item>
-        <calcite-dropdown-item>10</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  `
-  );
+      <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+      <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+      <calcite-dropdown-item>Title</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;
+
+SimpleRtl.story = {
+  name: "Simple - RTL"
+};
+
+export const ScrollingAfterCertainItems = (): string => html`
+  <calcite-dropdown
+    alignment="${select("alignment", ["start", "center", "end"], "start")}"
+    max-items="${number("max-items", 7, { min: 0, max: 10, step: 1 })}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "m")}"
+    type="${select("type", ["click", "hover"], "click")}"
+    ${boolean("disable-close-on-select", false)}
+    ${boolean("disabled", false)}
+  >
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group group-title="First group">
+      <calcite-dropdown-item>1</calcite-dropdown-item>
+      <calcite-dropdown-item>2</calcite-dropdown-item>
+      <calcite-dropdown-item>3</calcite-dropdown-item>
+      <calcite-dropdown-item>4</calcite-dropdown-item>
+      <calcite-dropdown-item>5</calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group group-title="Second group">
+      <calcite-dropdown-item>6</calcite-dropdown-item>
+      <calcite-dropdown-item>7</calcite-dropdown-item>
+      <calcite-dropdown-item>8</calcite-dropdown-item>
+      <calcite-dropdown-item>9</calcite-dropdown-item>
+      <calcite-dropdown-item>10</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;
+
+ScrollingAfterCertainItems.story = {
+  name: "Scrolling after certain items"
+};

--- a/src/components/calcite-icon/calcite-icon.stories.ts
+++ b/src/components/calcite-icon/calcite-icon.stories.ts
@@ -2,20 +2,21 @@ import { select } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
 export default {
   title: "Components/Icon",
   parameters: { notes: readme }
 };
 
-export const simple = (): string => `
+export const simple = (): string => html`
   <calcite-icon
     icon="${select("icon", iconNames, iconNames[0])}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
   ></calcite-icon>
 `;
 
-export const RTL = (): string => `
+export const RTL = (): string => html`
   <calcite-icon
     dir="rtl"
     icon="${select("icon", iconNames, iconNames[0])}"
@@ -23,12 +24,8 @@ export const RTL = (): string => `
   ></calcite-icon>
 `;
 
-export const darkMode = (): string => `
-  <calcite-icon
-    dir="rtl"
-    icon="${select("icon", iconNames, iconNames[0])}"
-    theme="dark"
-  ></calcite-icon>
+export const darkMode = (): string => html`
+  <calcite-icon dir="rtl" icon="${select("icon", iconNames, iconNames[0])}" theme="dark"></calcite-icon>
 `;
 
 darkMode.parameters = { backgrounds: darkBackground };

--- a/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
@@ -1,96 +1,113 @@
 import readme from "./readme.md";
 import { boolean, select, text } from "@storybook/addon-knobs";
 import { darkBackground } from "../../../.storybook/utils";
-import { storiesOf } from "@storybook/html";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Inline Editable", module)
-  .addParameters({ notes: readme })
-  .add(
-    "With label",
-    (): string => `
-    <div style="width:300px;max-width:100%;">
+export default {
+  title: "Components/Inline Editable",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const WithLabel = (): string => html`
+  <div style="width:300px;max-width:100%;">
     <calcite-label
-        status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
-        scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
-        layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}">
+      status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+      layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+    >
       ${text("label text", "My great label", "Label")}
       <calcite-inline-editable
-          ${boolean("controls", false, "InlineEditable") && "controls"}
-          ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
-          ${boolean("loading", false, "InlineEditable") && "loading"}
-          ${boolean("disabled", false, "InlineEditable") && "disabled"}
-          intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
-          intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
-          intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
+        ${boolean("controls", false, "InlineEditable") && "controls"}
+        ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
+        ${boolean("loading", false, "InlineEditable") && "loading"}
+        ${boolean("disabled", false, "InlineEditable") && "disabled"}
+        intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
+        intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
+        intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}"
+      >
         <calcite-input
-            alignment="${select("alignment", ["start", "end"], "start", "Input")}"
-            placeholder="${text("placeholder", "Placeholder text", "Input")}">
+          alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+          placeholder="${text("placeholder", "Placeholder text", "Input")}"
+        >
         </calcite-input>
       </calcite-inline-editable>
       <calcite-input-message
-          ${boolean("active", false, "InputMessage") && "active"}
-          ${boolean("icon", false, "InputMessage") && "icon"}
-          type="${select("type", ["default", "floating"], "default", "InputMessage")}"
-          status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}">
+        ${boolean("active", false, "InputMessage") && "active"}
+        ${boolean("icon", false, "InputMessage") && "icon"}
+        type="${select("type", ["default", "floating"], "default", "InputMessage")}"
+        status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}"
+      >
         ${text("text", "My great input message", "InputMessage")}
       </calcite-input-message>
     </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "Without Label",
-    (): string => `
-    <div style="width:300px;max-width:100%;">
-      <calcite-inline-editable
-          scale="${select("scale", ["s", "m", "l"], "m", "InlineEditable")}"
-          ${boolean("controls", false, "InlineEditable") && "controls"}
-          ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
-          ${boolean("loading", false, "InlineEditable") && "loading"}
-          ${boolean("disabled", false, "InlineEditable") && "disabled"}
-          intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
-          intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
-          intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
-        <calcite-input
-            alignment="${select("alignment", ["start", "end"], "start", "Input")}"
-            placeholder="${text("placeholder", "Placeholder text", "Input")}">
-        </calcite-input>
-      </calcite-inline-editable>
-    </div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <div style="width:300px;max-width:100%;">
+  </div>
+`;
+
+WithLabel.story = {
+  name: "With label"
+};
+
+export const WithoutLabel = (): string => html`
+  <div style="width:300px;max-width:100%;">
+    <calcite-inline-editable
+      scale="${select("scale", ["s", "m", "l"], "m", "InlineEditable")}"
+      ${boolean("controls", false, "InlineEditable") && "controls"}
+      ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
+      ${boolean("loading", false, "InlineEditable") && "loading"}
+      ${boolean("disabled", false, "InlineEditable") && "disabled"}
+      intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
+      intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
+      intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}"
+    >
+      <calcite-input
+        alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+        placeholder="${text("placeholder", "Placeholder text", "Input")}"
+      >
+      </calcite-input>
+    </calcite-inline-editable>
+  </div>
+`;
+
+export const DarkMode = (): string => html`
+  <div style="width:300px;max-width:100%;">
     <calcite-label
-        theme="dark"
-        status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
-        scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
-        layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}">
+      theme="dark"
+      status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+      layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+    >
       ${text("label text", "My great label", "Label")}
       <calcite-inline-editable
-          ${boolean("controls", false, "InlineEditable") && "controls"}
-          ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
-          ${boolean("loading", false, "InlineEditable") && "loading"}
-          ${boolean("disabled", false, "InlineEditable") && "disabled"}
-          intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
-          intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
-          intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}">
+        ${boolean("controls", false, "InlineEditable") && "controls"}
+        ${boolean("editing-enabled", false, "InlineEditable") && "editing-enabled"}
+        ${boolean("loading", false, "InlineEditable") && "loading"}
+        ${boolean("disabled", false, "InlineEditable") && "disabled"}
+        intl-cancel-editing="${text("intl-cancel-editing", "Cancelar", "InlineEditable")}"
+        intl-enable-editing="${text("intl-enable-editing", "Haga clic para editar", "InlineEditable")}"
+        intl-confirm-changes="${text("intl-confirm-changes", "Guardar", "InlineEditable")}"
+      >
         <calcite-input
-            alignment="${select("alignment", ["start", "end"], "start", "Input")}"
-            placeholder="${text("placeholder", "Placeholder text", "Input")}">
+          alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+          placeholder="${text("placeholder", "Placeholder text", "Input")}"
+        >
         </calcite-input>
       </calcite-inline-editable>
       <calcite-input-message
-          ${boolean("active", false, "InputMessage") && "active"}
-          ${boolean("icon", false, "InputMessage") && "icon"}
-          type="${select("type", ["default", "floating"], "default", "InputMessage")}"
-          status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}">
+        ${boolean("active", false, "InputMessage") && "active"}
+        ${boolean("icon", false, "InputMessage") && "icon"}
+        type="${select("type", ["default", "floating"], "default", "InputMessage")}"
+        status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}"
+      >
         ${text("text", "My great input message", "InputMessage")}
       </calcite-input-message>
     </calcite-label>
-    </div>
-  `,
-    { backgrounds: darkBackground }
-  );
+  </div>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -1,94 +1,101 @@
-import { storiesOf } from "@storybook/html";
 import { select, text, number } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Input", module)
-  .addParameters({ notes: readme })
-  .add(
-    "With Label",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    >
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${number("min", 0)}"
-      max="${number("max", 100)}"
-      step="${number("step", 1)}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
-    </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "With Label and Input Message",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+export default {
+  title: "Components/Input",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const WithLabel = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
     <calcite-label
-    status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
-    scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
-    layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
     >
-    ${text("label text", "My great label", "Label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text",
-        "Input"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
-      alignment="${select("alignment", ["start", "end"], "start", "Input")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
-      min="${number("min", 0)}"
-      max="${number("max", 100)}"
-      step="${number("step", 1)}"
-      prefix-text="${text("prefix-text", "", "Input")}"
-      suffix-text="${text("suffix-text", "", "Input")}"
-      ${boolean("loading", false, "Input")}
-      ${boolean("autofocus", false, "Input")}
-      ${boolean("required", false, "Input")}
-      value="${text("value", "", "Input")}"
-      placeholder="${text("placeholder", "Placeholder text", "Input")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("active", true, "Input Message")}
-    ${boolean("icon", true, "Input Message")}
-    type="${select("type", ["default", "floating"], "default", "Input Message")}"
-   >${text("input message text", "My great input message", "Input Message")}</calcite-input-message>
+      ${text("label text", "My great label")}
+      <calcite-input
+        type="${select(
+          "type",
+          ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+          "text"
+        )}"
+        status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+        alignment="${select("alignment", ["start", "end"], "start")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "")}"
+        suffix-text="${text("suffix-text", "")}"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+      </calcite-input>
+      <calcite-input-message
+        ${boolean("input-message-active", false)}
+        type="${select("input message type", ["default", "floating"], "default")}"
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
     </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "Without Label",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+  </div>
+`;
+
+export const WithLabelAndInputMessage = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+      layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+    >
+      ${text("label text", "My great label", "Label")}
+      <calcite-input
+        type="${select(
+          "type",
+          ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+          "text",
+          "Input"
+        )}"
+        status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
+        alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "", "Input")}"
+        suffix-text="${text("suffix-text", "", "Input")}"
+        ${boolean("loading", false, "Input")}
+        ${boolean("autofocus", false, "Input")}
+        ${boolean("required", false, "Input")}
+        value="${text("value", "", "Input")}"
+        placeholder="${text("placeholder", "Placeholder text", "Input")}"
+      >
+      </calcite-input>
+      <calcite-input-message
+        ${boolean("active", true, "Input Message")}
+        ${boolean("icon", true, "Input Message")}
+        type="${select("type", ["default", "floating"], "default", "Input Message")}"
+        >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;
+
+WithLabelAndInputMessage.story = {
+  name: "With Label and Input Message"
+};
+
+export const WithoutLabel = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
     <calcite-input
       scale="${select("scale", ["s", "m", "l"], "m")}"
       status="${select("status", ["idle", "valid", "invalid"], "idle")}"
@@ -97,7 +104,6 @@ storiesOf("Components/Input", module)
         ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
         "text"
       )}"
-
       status="${select("status", ["idle", "invalid", "valid"], "idle")}"
       alignment="${select("alignment", ["start", "end"], "start")}"
       number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
@@ -110,111 +116,110 @@ storiesOf("Components/Input", module)
       ${boolean("clearable", false)}
       ${boolean("disabled", false)}
       value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    </div>
-  `
-  )
-  .add(
-    "With Slotted Action",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
+      placeholder="${text("placeholder", "Placeholder text")}"
     >
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${number("min", 0)}"
-      max="${number("max", 100)}"
-      step="${number("step", 1)}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-      <calcite-button slot="input-action">${text("action button text", "Go")}</calcite-button>
     </calcite-input>
-    <calcite-input-message
-    ${boolean("input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
+  </div>
+`;
+
+export const WithSlottedAction = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+    >
+      ${text("label text", "My great label")}
+      <calcite-input
+        type="${select(
+          "type",
+          ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+          "text"
+        )}"
+        status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+        alignment="${select("alignment", ["start", "end"], "start")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "")}"
+        suffix-text="${text("suffix-text", "")}"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+        <calcite-button slot="input-action">${text("action button text", "Go")}</calcite-button>
+      </calcite-input>
+      <calcite-input-message
+        ${boolean("input-message-active", false)}
+        type="${select("input message type", ["default", "floating"], "default")}"
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
     </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "Textarea",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+  </div>
+`;
+
+export const Textarea = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
     <calcite-label status="${select("status", ["idle", "valid", "invalid"], "idle")}">
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="textarea"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
+      ${text("label text", "My great label")}
+      <calcite-input
+        type="textarea"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+      </calcite-input>
+      <calcite-input-message
+        ${boolean("input-message-active", false)}
+        type="${select("input message type", ["default", "floating"], "default")}"
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
     </calcite-label>
-    </div>
-  `
-  )
-  .add(
-    "Simple - Dark mode",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
+  </div>
+`;
+
+export const SimpleDarkMode = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
     <calcite-label theme="dark" status="${select("status", ["idle", "valid", "invalid"], "idle")}">
-    ${text("label text", "My great label")}
-    <calcite-input
-      type="${select(
-        "type",
-        ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
-        "text"
-      )}"
-      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
-      alignment="${select("alignment", ["start", "end"], "start")}"
-      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
-      min="${number("min", 0)}"
-      max="${number("max", 100)}"
-      step="${number("step", 1)}"
-      prefix-text="${text("prefix-text", "")}"
-      suffix-text="${text("suffix-text", "")}"
-      ${boolean("loading", false)}
-      ${boolean("clearable", false)}
-      ${boolean("disabled", false)}
-      value="${text("value", "")}"
-      placeholder="${text("placeholder", "Placeholder text")}">
-    </calcite-input>
-    <calcite-input-message
-    ${boolean("calcite-input-message-active", false)}
-    type="${select("input message type", ["default", "floating"], "default")}"
-    status="${select("input message status", ["idle", "valid", "invalid"], "idle")}">${text(
-      "input message text",
-      "My great input message"
-    )}</calcite-input-message>
+      ${text("label text", "My great label")}
+      <calcite-input
+        type="${select(
+          "type",
+          ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+          "text"
+        )}"
+        status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+        alignment="${select("alignment", ["start", "end"], "start")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "")}"
+        suffix-text="${text("suffix-text", "")}"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+      </calcite-input>
+      <calcite-input-message
+        ${boolean("calcite-input-message-active", false)}
+        type="${select("input message type", ["default", "floating"], "default")}"
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
     </calcite-label>
-    </div>
-  `,
-    { backgrounds: darkBackground }
-  );
+  </div>
+`;
+
+SimpleDarkMode.story = {
+  name: "Simple - Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-label/calcite-label.stories.ts
+++ b/src/components/calcite-label/calcite-label.stories.ts
@@ -1,145 +1,151 @@
-import { storiesOf } from "@storybook/html";
-
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Label", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Wrapping components other than input",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-      <calcite-label>
+export default {
+  title: "Components/Label",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const WrappingComponentsOtherThanInput = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label>
       Default label wrapping a switch
       <calcite-switch></calcite-switch>
-      </calcite-label>
-      <calcite-label>
+    </calcite-label>
+    <calcite-label>
       Default label wrapping a radio group
       <calcite-radio-group>
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       </calcite-radio-group>
-      </calcite-label>
-      <calcite-label layout="inline">
+    </calcite-label>
+    <calcite-label layout="inline">
       Text leading inline
       <calcite-switch></calcite-switch>
-      </calcite-label>
-      <calcite-label layout="inline">
+    </calcite-label>
+    <calcite-label layout="inline">
       <calcite-switch></calcite-switch>
       Text trailing inline
-      </calcite-label>
-      <calcite-label layout="inline">
+    </calcite-label>
+    <calcite-label layout="inline">
       Off
       <calcite-switch></calcite-switch>
       On
-      </calcite-label>
-      <calcite-label layout="inline">
+    </calcite-label>
+    <calcite-label layout="inline">
       Text leading inline
       <calcite-checkbox></calcite-checkbox>
-      </calcite-label>
-      <calcite-label>
+    </calcite-label>
+    <calcite-label>
       Focus slider test
       <calcite-slider></calcite-slider>
-      </calcite-label>
-      <calcite-label>
+    </calcite-label>
+    <calcite-label>
       Focus slider test
       <calcite-slider min-value="10" max-value="80"></calcite-slider>
-      </calcite-label>
-      <calcite-label layout="inline">
+    </calcite-label>
+    <calcite-label layout="inline">
       <calcite-checkbox></calcite-checkbox>
       Text trailing inline
-      </calcite-label>
-      <calcite-label layout="inline-space-between">
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
       Text leading inline-space-between
       <calcite-switch></calcite-switch>
-      </calcite-label>
-      <calcite-label layout="inline-space-between">
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
       <calcite-switch></calcite-switch>
       Text trailing inline-space-between
-      </calcite-label>
-      <calcite-label layout="inline-space-between">
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
       Text leading inline-space-between
       <calcite-checkbox></calcite-checkbox>
-      </calcite-label>
-      <calcite-label layout="inline-space-between">
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
       <calcite-checkbox></calcite-checkbox>
       Text trailing inline-space-between
-      </calcite-label>
-      <calcite-label>
-        Default label wrapping a select
-        <calcite-select>
-          <calcite-option>a</calcite-option>
-          <calcite-option>b</calcite-option>
-          <calcite-option>c</calcite-option>
-        </calcite-select>
-      </calcite-label>
-    </div>
-  `
-  )
+    </calcite-label>
+    <calcite-label>
+      Default label wrapping a select
+      <calcite-select>
+        <calcite-option>a</calcite-option>
+        <calcite-option>b</calcite-option>
+        <calcite-option>c</calcite-option>
+      </calcite-select>
+    </calcite-label>
+  </div>
+`;
 
-  .add(
-    "Dark Theme",
-    (): string => `
-    <div style="width:300px;max-width:100%;text-align:center;">
-      <calcite-label theme="dark">
+WrappingComponentsOtherThanInput.story = {
+  name: "Wrapping components other than input"
+};
+
+export const DarkTheme = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label theme="dark">
       Default label wrapping a switch
       <calcite-switch theme="dark"></calcite-switch>
-      </calcite-label>
-      <calcite-label theme="dark">
+    </calcite-label>
+    <calcite-label theme="dark">
       Default label wrapping a radio group
       <calcite-radio-group>
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       </calcite-radio-group>
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline">
       Text leading inline
       <calcite-switch theme="dark"></calcite-switch>
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline">
       <calcite-switch theme="dark"></calcite-switch>
       Text trailing inline
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline">
       Off
       <calcite-switch theme="dark"></calcite-switch>
       On
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline">
       Text leading inline
       <calcite-checkbox theme="dark"></calcite-checkbox>
-      </calcite-label>
-      <calcite-label theme="dark">
+    </calcite-label>
+    <calcite-label theme="dark">
       Focus slider test
       <calcite-slider theme="dark"></calcite-slider>
-      </calcite-label>
-      <calcite-label theme="dark">
+    </calcite-label>
+    <calcite-label theme="dark">
       Focus slider test
       <calcite-slider theme="dark" min-value="10" max-value="80"></calcite-slider>
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline">
       <calcite-checkbox theme="dark"></calcite-checkbox>
       Text trailing inline
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline-space-between">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline-space-between">
       Text leading inline-space-between
       <calcite-switch theme="dark"></calcite-switch>
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline-space-between">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline-space-between">
       <calcite-switch theme="dark"></calcite-switch>
       Text trailing inline-space-between
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline-space-between">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline-space-between">
       Text leading inline-space-between
       <calcite-checkbox theme="dark"></calcite-checkbox>
-      </calcite-label>
-      <calcite-label theme="dark" layout="inline-space-between">
+    </calcite-label>
+    <calcite-label theme="dark" layout="inline-space-between">
       <calcite-checkbox theme="dark"></calcite-checkbox>
       Text trailing inline-space-between
-      </calcite-label>
-    </div>
-  `,
-    { backgrounds: darkBackground }
-  );
+    </calcite-label>
+  </div>
+`;
+
+DarkTheme.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-link/calcite-link.stories.ts
+++ b/src/components/calcite-link/calcite-link.stories.ts
@@ -1,100 +1,129 @@
-import { storiesOf } from "@storybook/html";
 import { text, select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import * as icons from "../../../node_modules/@esri/calcite-ui-icons";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
 // we can get all unique icon names from all size 16 non-filled icons.
 const iconNames = Object.keys(icons)
   .filter((iconName) => iconName.endsWith("16"))
   .map((iconName) => iconName.replace("16", ""));
 
-storiesOf("Components/Link", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <div style="font-size: ${select(
+export default {
+  title: "Components/Link",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <div
+    style="font-size: ${select(
       "containing font size",
       ["12", "14", "16", "18", "20", "24", "32"],
       "16"
-    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};">
-    Some wrapping text <calcite-link
-      href="${text("href", "")}"
-      ${boolean("disabled", false)}
+    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};"
+  >
+    Some wrapping text
+    <calcite-link href="${text("href", "")}" ${boolean("disabled", false)}>
+      ${text("text", "link text here")}</calcite-link
     >
-   ${text("text", "link text here")}</calcite-link>
-   around the link
-    </div>
-  `
-  )
-  .add(
-    "With icon-start",
-    (): string => `
-    <div style="font-size: ${select(
+    around the link
+  </div>
+`;
+
+export const WithIconStart = (): string => html`
+  <div
+    style="font-size: ${select(
       "containing font size",
       ["12", "14", "16", "18", "20", "24", "32"],
       "16"
-    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};">
-    Some wrapping text <calcite-link
-      href="${text("href", "")}"
-      ${boolean("disabled", false)}
-      icon-start="${select("icon-start", iconNames, iconNames[0])}">
-      ${text("text", "link text here")}</calcite-link>
-      around the link
-      </div>
-  `
-  )
-  .add(
-    "With icon-end",
-    (): string => `
-    <div style="font-size: ${select(
-      "containing font size",
-      ["12", "14", "16", "18", "20", "24", "32"],
-      "16"
-    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};">
-    Some wrapping text <calcite-link
-      href="${text("href", "")}"
-      ${boolean("disabled", false)}
-      icon-end="${select("icon-end", iconNames, iconNames[0])}">
-      ${text("text", "link text here")}</calcite-link>
-      around the link
-      </div>
-  `
-  )
-  .add(
-    "With icon-start and icon-end",
-    (): string => `
-    <div style="font-size: ${select(
-      "containing font size",
-      ["12", "14", "16", "18", "20", "24", "32"],
-      "16"
-    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};">
-    Some wrapping text <calcite-link
+    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};"
+  >
+    Some wrapping text
+    <calcite-link
       href="${text("href", "")}"
       ${boolean("disabled", false)}
       icon-start="${select("icon-start", iconNames, iconNames[0])}"
-      icon-end="${select("icon-end", iconNames, iconNames[0])}">
-      ${text("text", "link text here")}</calcite-link>
-      around the link
-      </div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <div style="color: white; font-size: ${select(
+    >
+      ${text("text", "link text here")}</calcite-link
+    >
+    around the link
+  </div>
+`;
+
+WithIconStart.story = {
+  name: "With icon-start"
+};
+
+export const WithIconEnd = (): string => html`
+  <div
+    style="font-size: ${select(
       "containing font size",
       ["12", "14", "16", "18", "20", "24", "32"],
       "16"
-    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};">
-    Some wrapping text <calcite-link
-    theme="dark"
-    href="${text("href", "")}"
-    ${boolean("disabled", false)}>${text("text", "link text here")}</calcite-link>
-  around the link
+    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};"
+  >
+    Some wrapping text
+    <calcite-link
+      href="${text("href", "")}"
+      ${boolean("disabled", false)}
+      icon-end="${select("icon-end", iconNames, iconNames[0])}"
+    >
+      ${text("text", "link text here")}</calcite-link
+    >
+    around the link
   </div>
-  `,
-    { backgrounds: darkBackground }
-  );
+`;
+
+WithIconEnd.story = {
+  name: "With icon-end"
+};
+
+export const WithIconStartAndIconEnd = (): string => html`
+  <div
+    style="font-size: ${select(
+      "containing font size",
+      ["12", "14", "16", "18", "20", "24", "32"],
+      "16"
+    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};"
+  >
+    Some wrapping text
+    <calcite-link
+      href="${text("href", "")}"
+      ${boolean("disabled", false)}
+      icon-start="${select("icon-start", iconNames, iconNames[0])}"
+      icon-end="${select("icon-end", iconNames, iconNames[0])}"
+    >
+      ${text("text", "link text here")}</calcite-link
+    >
+    around the link
+  </div>
+`;
+
+WithIconStartAndIconEnd.story = {
+  name: "With icon-start and icon-end"
+};
+
+export const DarkMode = (): string => html`
+  <div
+    style="color: white; font-size: ${select(
+      "containing font size",
+      ["12", "14", "16", "18", "20", "24", "32"],
+      "16"
+    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};"
+  >
+    Some wrapping text
+    <calcite-link theme="dark" href="${text("href", "")}" ${boolean("disabled", false)}
+      >${text("text", "link text here")}</calcite-link
+    >
+    around the link
+  </div>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-loader/calcite-loader.stories.ts
+++ b/src/components/calcite-loader/calcite-loader.stories.ts
@@ -1,61 +1,67 @@
-import { storiesOf } from "@storybook/html";
 import { number, color, select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Loader", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-loader
-      active
-      type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("no-padding", false)}
-      value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
-    />
-  `
-  )
-  .add(
-    "Inline",
-    (): string => `
-  <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
-    <calcite-loader
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      inline
-      active
-    /></calcite-loader><span style="margin:0 10px">Next to some text</span>
-    </div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-loader
-      type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("no-padding", false)}
-      value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
-      active
-      theme="dark" />
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Custom theme",
-    (): string => `
-    <calcite-loader
+export default {
+  title: "Components/Loader",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-loader
+    active
     type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     ${boolean("no-padding", false)}
     value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
-      style="
-        --calcite-ui-blue-1: ${color("calcite-ui-blue-1", "#50ba5f")};
-        --calcite-ui-blue-2: ${color("calcite-ui-blue-2", "#1a6324")};
-        --calcite-ui-blue-3: ${color("calcite-ui-blue-3", "#338033")};"
-      active
-    />
-  `
-  );
+  />
+`;
+
+export const Inline = (): string => html`
+<div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
+<calcite-loader
+  scale="${select("scale", ["s", "m", "l"], "m")}"
+  inline
+  active
+/></calcite-loader><span style="margin:0 10px">Next to some text</span>
+</div>
+`;
+
+export const DarkMode = (): string => html`
+  <calcite-loader
+    type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("no-padding", false)}
+    value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
+    active
+    theme="dark"
+  />
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const CustomTheme = (): string => html`
+  <calcite-loader
+    type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("no-padding", false)}
+    value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
+    style="
+    --calcite-ui-blue-1: ${color("calcite-ui-blue-1", "#50ba5f")};
+    --calcite-ui-blue-2: ${color("calcite-ui-blue-2", "#1a6324")};
+    --calcite-ui-blue-3: ${color("calcite-ui-blue-3", "#338033")};"
+    active
+  />
+`;
+
+CustomTheme.story = {
+  name: "Custom theme"
+};

--- a/src/components/calcite-modal/calcite-modal.stories.ts
+++ b/src/components/calcite-modal/calcite-modal.stories.ts
@@ -1,13 +1,18 @@
-import { storiesOf } from "@storybook/html";
 import { select, text, number } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 
-storiesOf("Components/Modal", module)
-  .addParameters({ notes: readme })
-  .add("Simple", () => {
-    return `
+export default {
+  title: "Components/Modal",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => {
+  return `
       <calcite-modal
         ${boolean("active", true)}
         color="${select("color", { blue: "blue", red: "red", none: null }, null)}"
@@ -31,9 +36,10 @@ storiesOf("Components/Modal", module)
         <calcite-button slot="primary" width="full">Save</calcite-button>
       </calcite-modal>
     `;
-  })
-  .add("Custom Size", () => {
-    return `
+};
+
+export const CustomSize = (): string => {
+  return `
       <calcite-modal
         active
         width="${number("width", 500)}"
@@ -50,35 +56,37 @@ storiesOf("Components/Modal", module)
         <calcite-button slot="primary" width="full">Save</calcite-button>
       </calcite-modal>
     `;
-  })
-  .add(
-    "Dark mode",
-    () => {
-      return `
-      <calcite-modal
-        theme="dark"
-        ${boolean("active", true)}
-        color="${select("color", { blue: "blue", red: "red", none: null }, null)}"
-        background-color="${select("background-color", ["white", "grey"], "white")}"
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-        width="${select("width", ["s", "m", "l"], "s")}"
-        ${boolean("fullscreen", false)}
-        ${boolean("docked", false)}
-        ${boolean("disable-escape", false)}
-        ${boolean("no-padding", false)}
-        close-label="${text("close-label", "Close")}"
-      >
-        <h3 slot="header">Small Modal</h3>
-        <div slot="content">
-          <p>
-            The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
-          </p>
-        </div>
-        <calcite-button theme="dark" slot="back" color="light" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
-        <calcite-button theme="dark" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-        <calcite-button theme="dark" slot="primary" width="full">Save</calcite-button>
-      </calcite-modal>
-    `;
-    },
-    { backgrounds: darkBackground }
-  );
+};
+
+export const DarkMode = (): string => {
+  return `
+  <calcite-modal
+    theme="dark"
+    ${boolean("active", true)}
+    color="${select("color", { blue: "blue", red: "red", none: null }, null)}"
+    background-color="${select("background-color", ["white", "grey"], "white")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "s")}"
+    ${boolean("fullscreen", false)}
+    ${boolean("docked", false)}
+    ${boolean("disable-escape", false)}
+    ${boolean("no-padding", false)}
+    close-label="${text("close-label", "Close")}"
+  >
+    <h3 slot="header">Small Modal</h3>
+    <div slot="content">
+      <p>
+        The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
+      </p>
+    </div>
+    <calcite-button theme="dark" slot="back" color="light" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
+    <calcite-button theme="dark" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button theme="dark" slot="primary" width="full">Save</calcite-button>
+  </calcite-modal>
+`;
+};
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-notice/calcite-notice.stories.ts
+++ b/src/components/calcite-notice/calcite-notice.stories.ts
@@ -1,92 +1,97 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean, iconNames } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Notice", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <div style="width:600px;max-width:100%;text-align:center;">
+export default {
+  title: "Components/Notice",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <div style="width:600px;max-width:100%;text-align:center;">
     <calcite-notice
-    theme="light"
-    ${boolean("icon", true)}
-    ${boolean("active", true)}
-    ${boolean("dismissible", true)}
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    width="${select("width", ["auto", "half", "full"], "auto")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
-    <div slot="notice-title">Your settings area has changed</div>
-    <div slot="notice-message">
-      Look around and let us know what you think
-    </div>
+      theme="light"
+      ${boolean("icon", true)}
+      ${boolean("active", true)}
+      ${boolean("dismissible", true)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      color="${select("color", ["green", "red", "yellow", "blue"], "blue")}"
+    >
+      <div slot="notice-title">Your settings area has changed</div>
+      <div slot="notice-message">Look around and let us know what you think</div>
       <calcite-link slot="notice-link" title="my action">Learn more</calcite-link>
     </calcite-notice>
-    </div>
-  `
-  )
-  .add(
-    "Custom icon",
-    (): string => `
-    <div style="width:600px;max-width:100%;text-align:center;">
+  </div>
+`;
+
+export const CustomIcon = (): string => html`
+  <div style="width:600px;max-width:100%;text-align:center;">
     <calcite-notice
-    theme="light"
-    icon="${select("icon", iconNames, iconNames[0])}"
-    ${boolean("active", true)}
-    ${boolean("dismissible", true)}
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    width="${select("width", ["auto", "half", "full"], "auto")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "blue")}">
-    <div slot="notice-title">Your settings area has changed</div>
-    <div slot="notice-message">
-      Look around and let us know what you think
-    </div>
+      theme="light"
+      icon="${select("icon", iconNames, iconNames[0])}"
+      ${boolean("active", true)}
+      ${boolean("dismissible", true)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      color="${select("color", ["green", "red", "yellow", "blue"], "blue")}"
+    >
+      <div slot="notice-title">Your settings area has changed</div>
+      <div slot="notice-message">Look around and let us know what you think</div>
       <calcite-link slot="notice-link" title="my action">Learn more</calcite-link>
     </calcite-notice>
-    </div>
-  `
-  )
-  .add(
-    "Dark Mode",
-    (): string => `
-    <div style="width:600px;max-width:100%;text-align:center;">
+  </div>
+`;
+
+CustomIcon.story = {
+  name: "Custom icon"
+};
+
+export const DarkMode = (): string => html`
+  <div style="width:600px;max-width:100%;text-align:center;">
     <calcite-notice
-    theme="dark"
-    ${boolean("icon", true)}
-    ${boolean("active", true)}
-    ${boolean("dismissible", false)}
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    width="${select("width", ["auto", "half", "full"], "auto")}"
-    color="${select("color", ["green", "red", "yellow", "blue"], "red")}">
-    <div slot="notice-title">This is a destructive action</div>
-    <div slot="notice-message">
-     Be sure you know what you are doin, folks.
-    </div>
+      theme="dark"
+      ${boolean("icon", true)}
+      ${boolean("active", true)}
+      ${boolean("dismissible", false)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      color="${select("color", ["green", "red", "yellow", "blue"], "red")}"
+    >
+      <div slot="notice-title">This is a destructive action</div>
+      <div slot="notice-message">Be sure you know what you are doin, folks.</div>
     </calcite-notice>
-    </div>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "RTL",
-    (): string => `
-      <div dir="rtl" style="width:600px;max-width:100%;text-align:center;">
-      <calcite-notice
+  </div>
+`;
+
+DarkMode.story = {
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Rtl = (): string => html`
+  <div dir="rtl" style="width:600px;max-width:100%;text-align:center;">
+    <calcite-notice
       theme="light"
       ${boolean("icon", true)}
       ${boolean("active", true)}
       ${boolean("dismissible", true)}
       width="${select("width", ["auto", "half", "full"], "auto")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      color="${select("color", ["green", "red", "yellow", "blue"], "blue")}" active>
+      color="${select("color", ["green", "red", "yellow", "blue"], "blue")}"
+      active
+    >
       <div slot="notice-title">Your settings area has changed</div>
-      <div slot="notice-message">
-        Look around and let us know what you think
-      </div>
-        <calcite-link slot="notice-link" title="my action">Learn more</calcite-link>
-      </calcite-notice>
-      </div>
-      `
-  );
+      <div slot="notice-message">Look around and let us know what you think</div>
+      <calcite-link slot="notice-link" title="my action">Learn more</calcite-link>
+    </calcite-notice>
+  </div>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-pagination/calcite-pagination.stories.ts
+++ b/src/components/calcite-pagination/calcite-pagination.stories.ts
@@ -1,37 +1,41 @@
-import { storiesOf } from "@storybook/html";
 import { number, select } from "@storybook/addon-knobs";
 
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Pagination", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-pagination
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      start="${number("start", 1)}"
-      total="${number("total", 128)}"
-      num="${number("num", 20)}"
-      dir="${select("dir", ["ltr", "rtl"], "ltr")}"
-      theme="light"
-    >
-    </calcite-pagination>
-  `
-  )
-  .add(
-    "Dark Mode",
-    (): string => `
-    <calcite-pagination
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      start="${number("start", 1)}"
-      total="${number("total", 128)}"
-      num="${number("num", 20)}"
-      dir="${select("dir", ["ltr", "rtl"], "ltr")}"
-      theme="dark"
-    >
-    </calcite-pagination>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Pagination",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-pagination
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    start="${number("start", 1)}"
+    total="${number("total", 128)}"
+    num="${number("num", 20)}"
+    dir="${select("dir", ["ltr", "rtl"], "ltr")}"
+    theme="light"
+  >
+  </calcite-pagination>
+`;
+
+export const DarkMode = (): string => html`
+  <calcite-pagination
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    start="${number("start", 1)}"
+    total="${number("total", 128)}"
+    num="${number("num", 20)}"
+    dir="${select("dir", ["ltr", "rtl"], "ltr")}"
+    theme="dark"
+  >
+  </calcite-pagination>
+`;
+
+DarkMode.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-popover/calcite-popover.stories.ts
+++ b/src/components/calcite-popover/calcite-popover.stories.ts
@@ -1,4 +1,3 @@
-import { storiesOf } from "@storybook/html";
 import { select, number, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
@@ -36,10 +35,16 @@ const contentHTML = `
 
 const referenceElementHTML = `<calcite-popover-manager>Ut enim ad minim veniam, quis <calcite-button title="Reference Element" id="reference-element">nostrud exercitation</calcite-button> ullamco laboris nisi ut aliquip ex ea commodo consequat.</calcite-popover-manager>`;
 
-storiesOf("Components/Popover", module)
-  .addParameters({ notes: readme })
-  .add("Simple", () => {
-    return `
+export default {
+  title: "Components/Popover",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => {
+  return `
       <div>
         ${referenceElementHTML}
         <calcite-popover
@@ -58,9 +63,10 @@ storiesOf("Components/Popover", module)
         </calcite-popover>
       </div>
     `;
-  })
-  .add("Dark Mode", () => {
-    return `
+};
+
+export const DarkMode = (): string => {
+  return `
       <div>
         ${referenceElementHTML}
         <calcite-popover
@@ -79,4 +85,4 @@ storiesOf("Components/Popover", module)
         </calcite-popover>
       </div>
     `;
-  });
+};

--- a/src/components/calcite-progress/calcite-progress.stories.ts
+++ b/src/components/calcite-progress/calcite-progress.stories.ts
@@ -1,40 +1,43 @@
-import { storiesOf } from "@storybook/html";
 import { select, number, text, boolean } from "@storybook/addon-knobs";
 
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Progress", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Determinate",
-    (): string => `
-    <calcite-progress
-      type="determinate"
-      value="${number("value", 0, { range: true, min: 0, max: 1, step: 0.01 })}"
-      text="${text("text", "")}"
-    ></calcite-progress>
-  `
-  )
-  .add(
-    "Indeterminate",
-    (): string => `
-    <calcite-progress
-      reversed=${boolean("reversed", false)}
-      type="indeterminate"
-      text="${text("text", "")}"
-    ></calcite-progress>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-progress
-      theme="dark"
-      type="${select("type", { determinate: "determinate", indeterminate: "indeterminate" }, "indeterminate")}"
-      value="${number("value", 0, { range: true, min: 0, max: 1, step: 0.01 })}"
-      text="${text("text", "")}"
-    ></calcite-progress>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Progress",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Determinate = (): string => html`
+  <calcite-progress
+    type="determinate"
+    value="${number("value", 0, { range: true, min: 0, max: 1, step: 0.01 })}"
+    text="${text("text", "")}"
+  ></calcite-progress>
+`;
+
+export const Indeterminate = (): string => html`
+  <calcite-progress
+    reversed=${boolean("reversed", false)}
+    type="indeterminate"
+    text="${text("text", "")}"
+  ></calcite-progress>
+`;
+
+export const DarkMode = (): string => html`
+  <calcite-progress
+    theme="dark"
+    type="${select("type", { determinate: "determinate", indeterminate: "indeterminate" }, "indeterminate")}"
+    value="${number("value", 0, { range: true, min: 0, max: 1, step: 0.01 })}"
+    text="${text("text", "")}"
+  ></calcite-progress>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.ts
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.ts
@@ -1,44 +1,48 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Radio Button Group", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Light Theme",
-    (): string => `
-    <calcite-radio-button-group
-      name="simple"
-      ${boolean("disabled", false)}
-      ${boolean("hidden", false)}
-      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-    >
-      <calcite-radio-button value="react">React</calcite-radio-button>
-      <calcite-radio-button value="ember">Ember</calcite-radio-button>
-      <calcite-radio-button value="angular">Angular</calcite-radio-button>
-      <calcite-radio-button value="vue">Vue</calcite-radio-button>
-    </calcite-radio-button-group>
-  `
-  )
-  .add(
-    "Dark Theme",
-    (): string => `
-    <calcite-radio-button-group
-      theme="dark"
-      name="dark"
-      ${boolean("disabled", false)}
-      ${boolean("hidden", false)}
-      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-    >
-      <calcite-radio-button value="react">React</calcite-radio-button>
-      <calcite-radio-button value="ember">Ember</calcite-radio-button>
-      <calcite-radio-button value="angular">Angular</calcite-radio-button>
-      <calcite-radio-button value="vue">Vue</calcite-radio-button>
-    </calcite-radio-button-group>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Radio Button Group",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const LightTheme = (): string => html`
+  <calcite-radio-button-group
+    name="simple"
+    ${boolean("disabled", false)}
+    ${boolean("hidden", false)}
+    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+  >
+    <calcite-radio-button value="react">React</calcite-radio-button>
+    <calcite-radio-button value="ember">Ember</calcite-radio-button>
+    <calcite-radio-button value="angular">Angular</calcite-radio-button>
+    <calcite-radio-button value="vue">Vue</calcite-radio-button>
+  </calcite-radio-button-group>
+`;
+
+export const DarkTheme = (): string => html`
+  <calcite-radio-button-group
+    theme="dark"
+    name="dark"
+    ${boolean("disabled", false)}
+    ${boolean("hidden", false)}
+    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+  >
+    <calcite-radio-button value="react">React</calcite-radio-button>
+    <calcite-radio-button value="ember">Ember</calcite-radio-button>
+    <calcite-radio-button value="angular">Angular</calcite-radio-button>
+    <calcite-radio-button value="vue">Vue</calcite-radio-button>
+  </calcite-radio-button-group>
+`;
+
+DarkTheme.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-radio-button/calcite-radio-button.stories.ts
+++ b/src/components/calcite-radio-button/calcite-radio-button.stories.ts
@@ -1,42 +1,46 @@
-import { storiesOf } from "@storybook/html";
 import { select, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Radio Button", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Light Theme",
-    (): string => `
-      <calcite-radio-button
-        ${boolean("checked", false)}
-        ${boolean("disabled", false)}
-        ${boolean("hidden", false)}
-        ${boolean("focused", false)}
-        name="simple"
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-        value="value"
-      >
-        ${text("label", "Radio Button")}
-      </calcite-radio-button>
-  `
-  )
-  .add(
-    "Dark Theme",
-    (): string => `
-    <calcite-radio-button
-      ${boolean("checked", false)}
-      ${boolean("disabled", false)}
-      ${boolean("hidden", false)}
-      ${boolean("focused", false)}
-      name="dark"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      theme="dark"
-      value="value"
-    >
-      ${text("label", "Radio Button")}
-    </calcite-radio-button>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Radio Button",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const LightTheme = (): string => html`
+  <calcite-radio-button
+    ${boolean("checked", false)}
+    ${boolean("disabled", false)}
+    ${boolean("hidden", false)}
+    ${boolean("focused", false)}
+    name="simple"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    value="value"
+  >
+    ${text("label", "Radio Button")}
+  </calcite-radio-button>
+`;
+
+export const DarkTheme = (): string => html`
+  <calcite-radio-button
+    ${boolean("checked", false)}
+    ${boolean("disabled", false)}
+    ${boolean("hidden", false)}
+    ${boolean("focused", false)}
+    name="dark"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    theme="dark"
+    value="value"
+  >
+    ${text("label", "Radio Button")}
+  </calcite-radio-button>
+`;
+
+DarkTheme.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-radio-group/calcite-radio-group.stories.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.stories.ts
@@ -1,33 +1,35 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-radio-group-item/readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Radio Group", module)
-  .addParameters({ notes: [readme1, readme2] })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-radio-group
-      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-      appearance="${select("appearance", ["solid", "outline"], "solid")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["auto", "full"], "auto")}"
-      ${boolean("disabled", false)}
-    >
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-    </calcite-radio-group>
-  `
-  )
-  .add(
-    "Wrapping Calcite Label",
-    (): string => `
-    <calcite-label scale="${select("scale", ["s", "m", "l"], "m")}">
+export default {
+  title: "Components/Radio Group",
+
+  parameters: {
+    notes: [readme1, readme2]
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-radio-group
+    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    appearance="${select("appearance", ["solid", "outline"], "solid")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["auto", "full"], "auto")}"
+    ${boolean("disabled", false)}
+  >
+    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+    <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+  </calcite-radio-group>
+`;
+
+export const WrappingCalciteLabel = (): string => html`
+  <calcite-label scale="${select("scale", ["s", "m", "l"], "m")}">
     My great radio group
     <calcite-radio-group
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
@@ -40,13 +42,11 @@ storiesOf("Components/Radio Group", module)
       <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
     </calcite-radio-group>
-    </calcite-label>
-  `
-  )
-  .add(
-    "With icons",
-    (): string => `
-    <calcite-label scale="${select("scale", ["s", "m", "l"], "m")}">
+  </calcite-label>
+`;
+
+export const WithIcons = (): string => html`
+  <calcite-label scale="${select("scale", ["s", "m", "l"], "m")}">
     My great radio group
     <calcite-radio-group
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
@@ -58,44 +58,50 @@ storiesOf("Components/Radio Group", module)
       <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
       <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
     </calcite-radio-group>
-    </calcite-label>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
+  </calcite-label>
+`;
+
+WithIcons.story = {
+  name: "With icons"
+};
+
+export const DarkMode = (): string => html`
+  <calcite-radio-group
+    theme="dark"
+    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    appearance="${select("appearance", ["solid", "outline"], "solid")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["auto", "full"], "auto")}"
+    ${boolean("disabled", false)}
+  >
+    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+    <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+  </calcite-radio-group>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const FullWidth = (): string => html`
+  <div style="width:33vw;">
     <calcite-radio-group
-      theme="dark"
       layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
       appearance="${select("appearance", ["solid", "outline"], "solid")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      width="${select("width", ["auto", "full"], "auto")}"
+      width="${select("width", ["auto", "full"], "full")}"
       ${boolean("disabled", false)}
     >
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
       <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+      <calcite-radio-group-item value="long-text-1">Longer text wraps.</calcite-radio-group-item>
+      <calcite-radio-group-item value="long-text-2">Longer text wraps.</calcite-radio-group-item>
     </calcite-radio-group>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Full width",
-    (): string => `
-    <div style="width:33vw;">
-      <calcite-radio-group
-        layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-        appearance="${select("appearance", ["solid", "outline"], "solid")}"
-        width="${select("width", ["auto", "full"], "full")}"
-        ${boolean("disabled", false)}
-      >
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="long-text-1">Longer text wraps.</calcite-radio-group-item>
-        <calcite-radio-group-item value="long-text-2">Longer text wraps.</calcite-radio-group-item>
-      </calcite-radio-group>
-    </div>
+  </div>
+`;
 
-  `
-  );
+FullWidth.story = {
+  name: "Full width"
+};

--- a/src/components/calcite-rating/calcite-rating.stories.ts
+++ b/src/components/calcite-rating/calcite-rating.stories.ts
@@ -1,15 +1,19 @@
-import { storiesOf } from "@storybook/html";
 import { number, select, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Rating", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    () => `
-   <calcite-rating
+export default {
+  title: "Components/Rating",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-rating
     scale="${select("scale", ["s", "m", "l"], "m")}"
     value="${number("value", 0)}"
     average="${number("average", 0)}"
@@ -18,30 +22,30 @@ storiesOf("Components/Rating", module)
     ${boolean("disabled", false)}
     intl-rating="${text("intl-rating", "Rating")}"
     intl-stars="${text("intl-rating", "Stars: ${num}")}"
-   ></calcite-rating>
-  `
-  )
-  .add(
-    "Dark mode",
-    () => `
-    <calcite-rating
-      theme="dark"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      value="${number("value", 0)}"
-      average="${number("average", 0)}"
-      count="${number("count", 0)}"
-      ${boolean("read-only", false)}
-      ${boolean("disabled", false)}
-      intl-rating="${text("intl-rating", "Rating")}"
-      intl-stars="${text("intl-rating", "Stars: ${num}")}"
-    ></calcite-rating>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "Wrapped in calcite-label",
-    () => `
-    <calcite-label layout="${select("input layout", ["default", "inline", "inline-space-between"], "default")}">
+  ></calcite-rating>
+`;
+
+export const DarkMode = (): string => html`
+  <calcite-rating
+    theme="dark"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    value="${number("value", 0)}"
+    average="${number("average", 0)}"
+    count="${number("count", 0)}"
+    ${boolean("read-only", false)}
+    ${boolean("disabled", false)}
+    intl-rating="${text("intl-rating", "Rating")}"
+    intl-stars="${text("intl-rating", "Stars: ${num}")}"
+  ></calcite-rating>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const WrappedInCalciteLabel = (): string => html`
+  <calcite-label layout="${select("input layout", ["default", "inline", "inline-space-between"], "default")}">
     Rate this!
     <calcite-rating
       scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -53,13 +57,15 @@ storiesOf("Components/Rating", module)
       intl-rating="${text("intl-rating", "Rating")}"
       intl-stars="${text("intl-rating", "Stars: ${num}")}"
     ></calcite-rating>
-   </calcite-label>
-  `
-  )
-  .add(
-    "RTL",
-    () => `
-    <div dir="rtl">
+  </calcite-label>
+`;
+
+WrappedInCalciteLabel.story = {
+  name: "Wrapped in calcite-label"
+};
+
+export const Rtl = (): string => html`
+  <div dir="rtl">
     <calcite-rating
       scale="${select("scale", ["s", "m", "l"], "m")}"
       value="${number("value", 0)}"
@@ -70,6 +76,9 @@ storiesOf("Components/Rating", module)
       intl-rating="${text("intl-rating", "Rating")}"
       intl-stars="${text("intl-rating", "Stars: ${num}")}"
     ></calcite-rating>
-   </div>
-  `
-  );
+  </div>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-scrim/calcite-scrim.stories.ts
+++ b/src/components/calcite-scrim/calcite-scrim.stories.ts
@@ -1,6 +1,7 @@
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
 export default {
   title: "Components/Scrim",

--- a/src/components/calcite-scrim/calcite-scrim.stories.ts
+++ b/src/components/calcite-scrim/calcite-scrim.stories.ts
@@ -1,47 +1,74 @@
-import { storiesOf } from "@storybook/html";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 
-storiesOf("Components/Scrim", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <div
-    tabindex="0"
-    style="position: relative; width: 400px; height: 400px; overflow: auto;"
-  ><calcite-scrim
-      ${boolean("loading", false)}
-    >
-      <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+export default {
+  title: "Components/Scrim",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <div tabindex="0" style="position: relative; width: 400px; height: 400px; overflow: auto;">
+    <calcite-scrim ${boolean("loading", false)}>
+      <p>
+        Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor
+        quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean
+        ultricies mi vitae est. Mauris placerat eleifend leo.
+      </p>
       <ul>
-        <li>Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu. Cras consequat.</li>
-        <li>Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.</li>
-        <li>Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.</li>
-        <li>Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc.</li>
+        <li>
+          Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed
+          arcu. Cras consequat.
+        </li>
+        <li>
+          Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.
+          Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+        </li>
+        <li>
+          Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique
+          cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.
+        </li>
+        <li>
+          Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc.
+        </li>
       </ul>
-    </calcite-scrim></div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <div
-    tabindex="0"
-    style="position: relative; width: 400px; height: 400px; overflow: auto;"
-  ><calcite-scrim
-      theme="dark"
-      ${boolean("loading", false)}
-    >
-      <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+    </calcite-scrim>
+  </div>
+`;
+
+export const DarkMode = (): string => html`
+  <div tabindex="0" style="position: relative; width: 400px; height: 400px; overflow: auto;">
+    <calcite-scrim theme="dark" ${boolean("loading", false)}>
+      <p>
+        Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor
+        quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean
+        ultricies mi vitae est. Mauris placerat eleifend leo.
+      </p>
       <ul>
-        <li>Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu. Cras consequat.</li>
-        <li>Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.</li>
-        <li>Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.</li>
-        <li>Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc.</li>
+        <li>
+          Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed
+          arcu. Cras consequat.
+        </li>
+        <li>
+          Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.
+          Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+        </li>
+        <li>
+          Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique
+          cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.
+        </li>
+        <li>
+          Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate, nunc.
+        </li>
       </ul>
-    </calcite-scrim></div>
-  `,
-    { backgrounds: darkBackground }
-  );
+    </calcite-scrim>
+  </div>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-slider/calcite-slider.stories.ts
+++ b/src/components/calcite-slider/calcite-slider.stories.ts
@@ -1,80 +1,81 @@
-import { storiesOf } from "@storybook/html";
 import { text, number, array } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Slider", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Single value",
-    (): string => `
-    <calcite-slider
-      min="${number("min", 0)}"
-      max="${number("max", 100)}"
-      value="${number("value", 50)}"
-      step="${number("step", 1)}"
-      label="${text("label", "Temperature")}"
-      ${boolean("disabled", false)}
-      ${boolean("label-handles", false)}
-      ${boolean("label-ticks", false)}
-      ticks="${number("ticks", undefined)}
-      page-step="${number("page-step", false)}"
-      ${boolean("precise", false)}
-      ${boolean("snap", true)}
-    ></calcite-slider>
-  `
-  )
-  .add(
-    "Range",
-    (): string => `
-    <calcite-slider
-      min="${number("min", 0)}"
-      min-label="${text("min-label", "Temperature, lower bound")}"
-      min-value="${number("min-value", 25)}"
-      max="${number("max", 100)}"
-      max-label="${text("max-label", "Temperature, upper bound")}"
-      max-value="${number("max-value", 75)}"
-      step="${number("step", 1)}"
-      ${boolean("label-handles", false)}
-      ${boolean("label-ticks", false)}
-      ticks="${number("ticks", 20)}"
-      ${boolean("precise", false)}
-      ${boolean("snap", true)}
-    ></calcite-slider>
-  `
-  )
-  .add("Histogram", () => {
-    const slider = document.createElement("calcite-slider");
-    slider.min = number("min", 0);
-    slider.minValue = number("min-value", 25);
-    slider.max = number("max", 100);
-    slider.maxValue = number("max-value", 75);
-    slider.histogram = array(
-      "histogram",
-      [
-        [0, 0],
-        [20, 12],
-        [40, 25],
-        [60, 55],
-        [80, 10],
-        [100, 0]
-      ],
-      "  "
-    );
-    return slider;
-  })
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-slider
-      min="0"
-      max="100"
-      value="50"
-      step="1"
-      label="Temperature"
-      theme="dark"
-    ></calcite-slider>
-  `,
-    { backgrounds: darkBackground }
+export default {
+  title: "Components/Slider",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const SingleValue = (): string => html`
+<calcite-slider
+  min="${number("min", 0)}"
+  max="${number("max", 100)}"
+  value="${number("value", 50)}"
+  step="${number("step", 1)}"
+  label="${text("label", "Temperature")}"
+  ${boolean("disabled", false)}
+  ${boolean("label-handles", false)}
+  ${boolean("label-ticks", false)}
+  ticks="${number("ticks", undefined)}
+  page-step="${number("page-step", false)}"
+  ${boolean("precise", false)}
+  ${boolean("snap", true)}
+></calcite-slider>
+`;
+
+SingleValue.story = {
+  name: "Single value"
+};
+
+export const Range = (): string => html`
+  <calcite-slider
+    min="${number("min", 0)}"
+    min-label="${text("min-label", "Temperature, lower bound")}"
+    min-value="${number("min-value", 25)}"
+    max="${number("max", 100)}"
+    max-label="${text("max-label", "Temperature, upper bound")}"
+    max-value="${number("max-value", 75)}"
+    step="${number("step", 1)}"
+    ${boolean("label-handles", false)}
+    ${boolean("label-ticks", false)}
+    ticks="${number("ticks", 20)}"
+    ${boolean("precise", false)}
+    ${boolean("snap", true)}
+  ></calcite-slider>
+`;
+
+export const Histogram = (): HTMLCalciteSliderElement => {
+  const slider = document.createElement("calcite-slider");
+  slider.min = number("min", 0);
+  slider.minValue = number("min-value", 25);
+  slider.max = number("max", 100);
+  slider.maxValue = number("max-value", 75);
+  slider.histogram = array(
+    "histogram",
+    [
+      [0, 0],
+      [20, 12],
+      [40, 25],
+      [60, 55],
+      [80, 10],
+      [100, 0]
+    ],
+    "  "
   );
+  return slider;
+};
+
+export const DarkMode = (): string => html`
+  <calcite-slider min="0" max="100" value="50" step="1" label="Temperature" theme="dark"></calcite-slider>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-split-button/calcite-split-button.stories.ts
+++ b/src/components/calcite-split-button/calcite-split-button.stories.ts
@@ -1,119 +1,135 @@
-import { storiesOf } from "@storybook/html";
 import { text, select } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Split Button", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
+export default {
+  title: "Components/Split Button",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-split-button
+    appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("size", ["s", "m", "l"], "m")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
+    primary-text="${text("primary-text", "Primary Option")}"
+    primary-label="${text("primary-label", "Primary Option")}"
+    dropdown-label="${text("dropdown-label", "Additional Options")}"
+    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+  >
+    <calcite-dropdown-group selection-mode="none">
+      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-split-button>
+`;
+
+export const SimplePrimaryIconEnd = (): string => html`
+  <calcite-split-button
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("size", ["s", "m", "l"], "m")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
+    primary-text="${text("primary-text", "Primary Option")}"
+    primary-label="${text("primary-label", "Primary Option")}"
+    dropdown-label="${text("dropdown-label", "Additional Options")}"
+    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+  >
+    <calcite-dropdown-group selection-mode="none">
+      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-split-button>
+`;
+
+SimplePrimaryIconEnd.story = {
+  name: "Simple primary-icon-end"
+};
+
+export const SimplePrimaryIconStartAndPrimaryIconEnd = (): string => html`
+  <calcite-split-button
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("size", ["s", "m", "l"], "m")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    primary-icon-start="${select("primary-icon-end", iconNames, iconNames[0])}"
+    primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
+    primary-text="${text("primary-text", "Primary Option")}"
+    primary-label="${text("primary-label", "Primary Option")}"
+    dropdown-label="${text("dropdown-label", "Additional Options")}"
+    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+  >
+    <calcite-dropdown-group selection-mode="none">
+      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-split-button>
+`;
+
+SimplePrimaryIconStartAndPrimaryIconEnd.story = {
+  name: "Simple primary-icon-start and primary-icon-end"
+};
+
+export const Rtl = (): string => html`
+  <div dir="rtl">
     <calcite-split-button
-        appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
-        color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-        scale="${select("size", ["s", "m", "l"], "m")}"
-        ${boolean("loading", false)}
-        ${boolean("disabled", false)}
-        primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
-        primary-text="${text("primary-text", "Primary Option")}"
-        primary-label="${text("primary-label", "Primary Option")}"
-        dropdown-label="${text("dropdown-label", "Additional Options")}"
-        dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}">
+      appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
+      color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+      scale="${select("size", ["s", "m", "l"], "m")}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
+      primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
+      primary-text="${text("primary-text", "Primary Option")}"
+      dropdown-label="${text("dropdown-label", "Additional Options")}"
+      dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+    >
       <calcite-dropdown-group selection-mode="none">
         <calcite-dropdown-item>Option 2</calcite-dropdown-item>
         <calcite-dropdown-item>Option 3</calcite-dropdown-item>
         <calcite-dropdown-item>Option 4</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-split-button>
-  `
-  )
-  .add(
-    "Simple primary-icon-end",
-    (): string => `
-    <calcite-split-button
-        color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-        scale="${select("size", ["s", "m", "l"], "m")}"
-        ${boolean("loading", false)}
-        ${boolean("disabled", false)}
-        primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
-        primary-text="${text("primary-text", "Primary Option")}"
-        primary-label="${text("primary-label", "Primary Option")}"
-        dropdown-label="${text("dropdown-label", "Additional Options")}"
-        dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}">
-      <calcite-dropdown-group selection-mode="none">
-        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-split-button>
-  `
-  )
-  .add(
-    "Simple primary-icon-start and primary-icon-end",
-    (): string => `
-    <calcite-split-button
-        color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-        scale="${select("size", ["s", "m", "l"], "m")}"
-        ${boolean("loading", false)}
-        ${boolean("disabled", false)}
-        primary-icon-start="${select("primary-icon-end", iconNames, iconNames[0])}"
-        primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
-        primary-text="${text("primary-text", "Primary Option")}"
-        primary-label="${text("primary-label", "Primary Option")}"
-        dropdown-label="${text("dropdown-label", "Additional Options")}"
-        dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}">
-      <calcite-dropdown-group selection-mode="none">
-        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-split-button>
-  `
-  )
-  .add(
-    "RTL",
-    (): string => `
-    <div dir='rtl'>
-      <calcite-split-button
-          appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
-          color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-          scale="${select("size", ["s", "m", "l"], "m")}"
-          ${boolean("loading", false)}
-          ${boolean("disabled", false)}
-          primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
-          primary-text="${text("primary-text", "Primary Option")}"
-          dropdown-label="${text("dropdown-label", "Additional Options")}"
-          dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-split-button
-        appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
-        color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
-        scale="${select("size", ["s", "m", "l"], "m")}"
-        ${boolean("loading", false)}
-        ${boolean("disabled", false)}
-        primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
-        primary-text="${text("primary-text", "Primary Option")}"
-        dropdown-label="${text("dropdown-label", "Additional Options")}"
-        dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
-        theme="dark">
-      <calcite-dropdown-group selection-mode="none">
-        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-split-button>
-  `,
-    { backgrounds: darkBackground }
-  );
+  </div>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};
+
+export const DarkMode = (): string => html`
+  <calcite-split-button
+    appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "dark", "light"], "blue")}"
+    scale="${select("size", ["s", "m", "l"], "m")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
+    primary-text="${text("primary-text", "Primary Option")}"
+    dropdown-label="${text("dropdown-label", "Additional Options")}"
+    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+    theme="dark"
+  >
+    <calcite-dropdown-group selection-mode="none">
+      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-split-button>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-stepper/calcite-stepper.stories.ts
+++ b/src/components/calcite-stepper/calcite-stepper.stories.ts
@@ -1,148 +1,156 @@
-import { storiesOf } from "@storybook/html";
 import { select, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
 import readme2 from "../calcite-stepper-item/readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Stepper", module)
-  .addParameters({ notes: [readme1, readme2] })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-stepper
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    ${boolean("numbered", true)}
-    ${boolean("icon", true)}">
-    <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
-      "item-1-subtitle",
-      "Add members without sending invitations"
-    )}" complete>
-    <calcite-notice active width="full"><div slot="notice-message">Step 1 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item
-      item-title="${text("item-2-title", "Compile member list")}"
-    item-subtitle="${text("item-2-subtitle", "")}"
-      complete error>
-      <calcite-notice active width="full"><div slot="notice-message">Step 2 Content Goes Here</div></calcite-notice>
-      </calcite-stepper-item>
-    <calcite-stepper-item
-    item-title="${text("item-3-title", "Set member properties")}"
-    item-subtitle="${text("item-3-subtitle", "")}"
-    active>
-    <calcite-notice active width="full"><div slot="notice-message">Step 3 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item
-    item-title="${text("item-4-title", "Confirm and complete")}"
-    item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
-    <calcite-notice active width="full"><div slot="notice-message">Step 4 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  `
-  )
-  .add(
-    "No content",
-    (): string => `
-    <calcite-stepper
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    ${boolean("numbered", true)}
-    ${boolean("icon", true)}">
-    <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
-      "item-1-subtitle",
-      "Add members without sending invitations"
-    )}" complete>
+export default {
+  title: "Components/Stepper",
 
-    </calcite-stepper-item>
-    <calcite-stepper-item
-      item-title="${text("item-2-title", "Compile member list")}"
-    item-subtitle="${text("item-2-subtitle", "")}"
-      complete error>
-      </calcite-stepper-item>
-    <calcite-stepper-item
-    item-title="${text("item-3-title", "Set member properties")}"
-    item-subtitle="${text("item-3-subtitle", "")}"
-    active>
-    </calcite-stepper-item>
-    <calcite-stepper-item
-    item-title="${text("item-4-title", "Confirm and complete")}"
-    item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  `
-  )
-  .add(
-    "Dark Mode",
-    (): string => `
-    <calcite-stepper
-    theme="dark"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-    scale="${select("scale", ["s", "m", "l"], "m")}"
-    ${boolean("numbered", true)}
-    ${boolean("icon", true)}">
-    <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
-      "item-1-subtitle",
-      "Add members without sending invitations"
-    )}" complete>
-    <calcite-notice active width="full"><div slot="notice-message">Step 1 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item
-      item-title="${text("item-2-title", "Compile member list")}"
-    item-subtitle="${text("item-2-subtitle", "")}"
-      complete error>
+  parameters: {
+    notes: [readme1, readme2]
+  }
+};
+
+export const Simple = (): string => html`
+<calcite-stepper
+scale="${select("scale", ["s", "m", "l"], "m")}"
+layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+scale="${select("scale", ["s", "m", "l"], "m")}"
+${boolean("numbered", true)}
+${boolean("icon", true)}">
+<calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
+  "item-1-subtitle",
+  "Add members without sending invitations"
+)}" complete>
+<calcite-notice active width="full"><div slot="notice-message">Step 1 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+<calcite-stepper-item
+  item-title="${text("item-2-title", "Compile member list")}"
+item-subtitle="${text("item-2-subtitle", "")}"
+  complete error>
+  <calcite-notice active width="full"><div slot="notice-message">Step 2 Content Goes Here</div></calcite-notice>
+  </calcite-stepper-item>
+<calcite-stepper-item
+item-title="${text("item-3-title", "Set member properties")}"
+item-subtitle="${text("item-3-subtitle", "")}"
+active>
+<calcite-notice active width="full"><div slot="notice-message">Step 3 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+<calcite-stepper-item
+item-title="${text("item-4-title", "Confirm and complete")}"
+item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
+<calcite-notice active width="full"><div slot="notice-message">Step 4 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+</calcite-stepper>
+`;
+
+export const NoContent = (): string => html`
+<calcite-stepper
+scale="${select("scale", ["s", "m", "l"], "m")}"
+layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+scale="${select("scale", ["s", "m", "l"], "m")}"
+${boolean("numbered", true)}
+${boolean("icon", true)}">
+<calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
+  "item-1-subtitle",
+  "Add members without sending invitations"
+)}" complete>
+
+</calcite-stepper-item>
+<calcite-stepper-item
+  item-title="${text("item-2-title", "Compile member list")}"
+item-subtitle="${text("item-2-subtitle", "")}"
+  complete error>
+  </calcite-stepper-item>
+<calcite-stepper-item
+item-title="${text("item-3-title", "Set member properties")}"
+item-subtitle="${text("item-3-subtitle", "")}"
+active>
+</calcite-stepper-item>
+<calcite-stepper-item
+item-title="${text("item-4-title", "Confirm and complete")}"
+item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
+</calcite-stepper-item>
+</calcite-stepper>
+`;
+
+NoContent.story = {
+  name: "No content"
+};
+
+export const DarkMode = (): string => html`
+<calcite-stepper
+theme="dark"
+scale="${select("scale", ["s", "m", "l"], "m")}"
+layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+scale="${select("scale", ["s", "m", "l"], "m")}"
+${boolean("numbered", true)}
+${boolean("icon", true)}">
+<calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
+  "item-1-subtitle",
+  "Add members without sending invitations"
+)}" complete>
+<calcite-notice active width="full"><div slot="notice-message">Step 1 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+<calcite-stepper-item
+  item-title="${text("item-2-title", "Compile member list")}"
+item-subtitle="${text("item-2-subtitle", "")}"
+  complete error>
+  <calcite-notice active width="full"><div slot="notice-message">Step 2 Content Goes Here</div></calcite-notice>
+  </calcite-stepper-item>
+<calcite-stepper-item
+item-title="${text("item-3-title", "Set member properties")}"
+item-subtitle="${text("item-3-subtitle", "")}"
+active>
+<calcite-notice active width="full"><div slot="notice-message">Step 3 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+<calcite-stepper-item
+item-title="${text("item-4-title", "Confirm and complete")}"
+item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
+<calcite-notice active width="full"><div slot="notice-message">Step 4 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+</calcite-stepper>
+`;
+
+DarkMode.story = {
+  parameters: { backgrounds: darkBackground }
+};
+
+export const Rtl = (): string => html`
+  <div dir="rtl">
+  <calcite-stepper
+  layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+  ${boolean("numbered", true)}
+  ${boolean("icon", true)}">
+  <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
+  "item-1-subtitle",
+  "Add members without sending invitations"
+)}" complete>
+  <calcite-notice active width="full"><div slot="notice-message">Step 1 Content Goes Here</div></calcite-notice>
+</calcite-stepper-item>
+  <calcite-stepper-item
+    item-title="${text("item-2-title", "Compile member list")}"
+item-subtitle="${text("item-3-2ubtitle", "")}"
+    complete error>
       <calcite-notice active width="full"><div slot="notice-message">Step 2 Content Goes Here</div></calcite-notice>
-      </calcite-stepper-item>
-    <calcite-stepper-item
-    item-title="${text("item-3-title", "Set member properties")}"
-    item-subtitle="${text("item-3-subtitle", "")}"
-    active>
+    </calcite-stepper-item>
+  <calcite-stepper-item
+  item-title="${text("item-3-title", "Set member properties")}"
+  item-subtitle="${text("item-3-subtitle", "")}"
+  active>
     <calcite-notice active width="full"><div slot="notice-message">Step 3 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item
-    item-title="${text("item-4-title", "Confirm and complete")}"
-    item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
+  </calcite-stepper-item>
+  <calcite-stepper-item
+  item-title="${text("item-4-title", "Confirm and complete")}"
+  item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
     <calcite-notice active width="full"><div slot="notice-message">Step 4 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-    `,
-    { backgrounds: darkBackground }
-  )
-  .add(
-    "RTL",
-    (): string => `
-      <div dir="rtl">
-      <calcite-stepper
-      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-      ${boolean("numbered", true)}
-      ${boolean("icon", true)}">
-      <calcite-stepper-item item-title="${text("item-1-title", "Choose method")}" item-subtitle="${text(
-      "item-1-subtitle",
-      "Add members without sending invitations"
-    )}" complete>
-      <calcite-notice active width="full"><div slot="notice-message">Step 1 Content Goes Here</div></calcite-notice>
-    </calcite-stepper-item>
-      <calcite-stepper-item
-        item-title="${text("item-2-title", "Compile member list")}"
-    item-subtitle="${text("item-3-2ubtitle", "")}"
-        complete error>
-          <calcite-notice active width="full"><div slot="notice-message">Step 2 Content Goes Here</div></calcite-notice>
-        </calcite-stepper-item>
-      <calcite-stepper-item
-      item-title="${text("item-3-title", "Set member properties")}"
-      item-subtitle="${text("item-3-subtitle", "")}"
-      active>
-        <calcite-notice active width="full"><div slot="notice-message">Step 3 Content Goes Here</div></calcite-notice>
-      </calcite-stepper-item>
-      <calcite-stepper-item
-      item-title="${text("item-4-title", "Confirm and complete")}"
-      item-subtitle="${text("item-4-subtitle", "Disabled example")}" disabled>
-        <calcite-notice active width="full"><div slot="notice-message">Step 4 Content Goes Here</div></calcite-notice>
-      </calcite-stepper-item>
-    </calcite-stepper>
-    </div>
-      `
-  );
+  </calcite-stepper-item>
+</calcite-stepper>
+</div>
+  `;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-switch/calcite-switch.stories.ts
+++ b/src/components/calcite-switch/calcite-switch.stories.ts
@@ -1,64 +1,75 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Switch", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-      <calcite-switch
-        name="setting"
-        value="enabled"
-        ${boolean("switched", true)}
-        ${boolean("disabled", false)}
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-      ></calcite-switch>
-  `
-  )
-  .add(
-    "Wrapping calcite-label",
-    (): string => `
-      <calcite-label layout="${select("layout", ["inline", "inline-space-between", "default"], "inline")}"
-       ${boolean("disabled", false)}>
-      Enable setting
-      <calcite-switch
-        name="setting"
-        value="enabled"
-        ${boolean("switched", true)}
-        ${boolean("disabled", false)}
-      ></calcite-switch>
-      </calcite-label>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-      <calcite-switch
-        theme="dark"
-        name="setting"
-        value="enabled"
-        ${boolean("switched", true)}
+export default {
+  title: "Components/Switch",
 
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-      ></calcite-switch>
- `,
-    {
-      backgrounds: darkBackground
-    }
-  )
-  .add(
-    "RTL",
-    (): string => `
-      Enable setting
-      <calcite-switch
-        dir="rtl"
-        name="setting"
-        value="enabled"
-        ${boolean("switched", true)}
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-      ></calcite-switch>
-`
-  );
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-switch
+    name="setting"
+    value="enabled"
+    ${boolean("switched", true)}
+    ${boolean("disabled", false)}
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+  ></calcite-switch>
+`;
+
+export const WrappingCalciteLabel = (): string => html`
+  <calcite-label
+    layout="${select("layout", ["inline", "inline-space-between", "default"], "inline")}"
+    ${boolean("disabled", false)}
+  >
+    Enable setting
+    <calcite-switch
+      name="setting"
+      value="enabled"
+      ${boolean("switched", true)}
+      ${boolean("disabled", false)}
+    ></calcite-switch>
+  </calcite-label>
+`;
+
+WrappingCalciteLabel.story = {
+  name: "Wrapping calcite-label"
+};
+
+export const DarkMode = (): string => html`
+  <calcite-switch
+    theme="dark"
+    name="setting"
+    value="enabled"
+    ${boolean("switched", true)}
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+  ></calcite-switch>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+
+  parameters: {
+    backgrounds: darkBackground
+  }
+};
+
+export const Rtl = (): string => html`
+  Enable setting
+  <calcite-switch
+    dir="rtl"
+    name="setting"
+    value="enabled"
+    ${boolean("switched", true)}
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+  ></calcite-switch>
+`;
+
+Rtl.story = {
+  name: "RTL"
+};

--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -1,4 +1,3 @@
-import { storiesOf } from "@storybook/html";
 import { select, optionsKnob } from "@storybook/addon-knobs";
 import { iconNames } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
@@ -6,97 +5,104 @@ import readme1 from "./readme.md";
 import readme2 from "../calcite-tab/readme.md";
 import readme3 from "../calcite-tab-nav/readme.md";
 import readme4 from "../calcite-tab-title/readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Tabs", module)
-  .addParameters({ notes: [readme1, readme2, readme3, readme4] })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-tabs
-      layout="${select("layout", ["inline", "center"], "inline")}"
-      position="${select("position", ["above", "below"], "above")}"
-    >
-      <calcite-tab-nav slot="tab-nav">
-        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      </calcite-tab-nav>
+export default {
+  title: "Components/Tabs",
 
-      <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
-      <calcite-tab><p>Tab 2 Content</p></calcite-tab>
-      <calcite-tab><p>Tab 3 Content</p></calcite-tab>
-      <calcite-tab><p>Tab 4 Content</p></calcite-tab>
-    </calcite-tabs>
-  `
-  )
-  .add(
-    "With icons",
-    (): string => `
-    <calcite-tabs
-      layout="${select("layout", ["inline", "center"], "inline")}"
-      position="${select("position", ["above", "below"], "above")}"
-    >
-      <calcite-tab-nav
-      slot="tab-nav">
-        <calcite-tab-title active
-        icon-start="${select("tab 1 icon-start", iconNames, iconNames[0])}"
-        >Tab 1 Title</calcite-tab-title>
-        <calcite-tab-title
-        icon-end="${select("tab 2 icon-end", iconNames, iconNames[0])}"
-        >Tab 2 Title</calcite-tab-title>
-        <calcite-tab-title
-        icon-start="${select("tab 3 icon-start", iconNames, iconNames[0])}"
-        icon-end="${select("tab 3 icon-end", iconNames, iconNames[0])}"
-        >Tab 3 Title</calcite-tab-title>
-        <calcite-tab-title
-        icon-start="${select("tab 4 icon-start", iconNames, iconNames[0])}"></calcite-tab-title>
-      </calcite-tab-nav>
+  parameters: {
+    notes: [readme1, readme2, readme3, readme4]
+  }
+};
 
-      <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
-      <calcite-tab><p>Tab 2 Content</p></calcite-tab>
-      <calcite-tab><p>Tab 3 Content</p></calcite-tab>
-      <calcite-tab><p>Tab 4 Content</p></calcite-tab>
-    </calcite-tabs>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-tabs theme="dark"
+export const Simple = (): string => html`
+  <calcite-tabs
     layout="${select("layout", ["inline", "center"], "inline")}"
     position="${select("position", ["above", "below"], "above")}"
-    >
-      <calcite-tab-nav slot="tab-nav">
-        <calcite-tab-title active>Icon 1</calcite-tab-title>
-        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      </calcite-tab-nav>
-    </calcite-tabs>
-  `,
-    { backgrounds: darkBackground }
-  )
-  .add("Disabled tabs", () => {
-    const disabledLabel = "Disabled Tabs";
-    const disabledValuesObj = {
-      Tab1: "tab1",
-      Tab2: "tab2",
-      Tab3: "tab3"
-    };
-    const defaultValue = "tab2";
-    const optionsKnobSelections = optionsKnob(
-      disabledLabel,
-      disabledValuesObj,
-      defaultValue,
-      { display: "multi-select" },
-      "DISABLED-TABS"
-    );
-    const tab1disabled = optionsKnobSelections.includes(disabledValuesObj.Tab1);
-    const tab2disabled = optionsKnobSelections.includes(disabledValuesObj.Tab2);
-    const tab3disabled = optionsKnobSelections.includes(disabledValuesObj.Tab3);
+  >
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+    </calcite-tab-nav>
 
-    return `
+    <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 3 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 4 Content</p></calcite-tab>
+  </calcite-tabs>
+`;
+
+export const WithIcons = (): string => html`
+  <calcite-tabs
+    layout="${select("layout", ["inline", "center"], "inline")}"
+    position="${select("position", ["above", "below"], "above")}"
+  >
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active icon-start="${select("tab 1 icon-start", iconNames, iconNames[0])}"
+        >Tab 1 Title</calcite-tab-title
+      >
+      <calcite-tab-title icon-end="${select("tab 2 icon-end", iconNames, iconNames[0])}">Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title
+        icon-start="${select("tab 3 icon-start", iconNames, iconNames[0])}"
+        icon-end="${select("tab 3 icon-end", iconNames, iconNames[0])}"
+        >Tab 3 Title</calcite-tab-title
+      >
+      <calcite-tab-title icon-start="${select("tab 4 icon-start", iconNames, iconNames[0])}"></calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 3 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 4 Content</p></calcite-tab>
+  </calcite-tabs>
+`;
+
+WithIcons.story = {
+  name: "With icons"
+};
+
+export const DarkMode = (): string => html`
+  <calcite-tabs
+    theme="dark"
+    layout="${select("layout", ["inline", "center"], "inline")}"
+    position="${select("position", ["above", "below"], "above")}"
+  >
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active>Icon 1</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+    </calcite-tab-nav>
+  </calcite-tabs>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};
+
+export const DisabledTabs = (): string => {
+  const disabledLabel = "Disabled Tabs";
+  const disabledValuesObj = {
+    Tab1: "tab1",
+    Tab2: "tab2",
+    Tab3: "tab3"
+  };
+  const defaultValue = "tab2";
+  const optionsKnobSelections = optionsKnob(
+    disabledLabel,
+    disabledValuesObj,
+    defaultValue,
+    { display: "multi-select" },
+    "DISABLED-TABS"
+  );
+  const tab1disabled = optionsKnobSelections.includes(disabledValuesObj.Tab1);
+  const tab2disabled = optionsKnobSelections.includes(disabledValuesObj.Tab2);
+  const tab3disabled = optionsKnobSelections.includes(disabledValuesObj.Tab3);
+
+  return `
       <calcite-tabs>
         <calcite-tab-nav slot="tab-nav">
           <calcite-tab-title active ${tab1disabled ? "disabled" : ""}>Tab 1 Title</calcite-tab-title>
@@ -109,4 +115,8 @@ storiesOf("Components/Tabs", module)
         <calcite-tab><p>Tab 3 Content</p></calcite-tab>
       </calcite-tabs>
     `;
-  });
+};
+
+DisabledTabs.story = {
+  name: "Disabled tabs"
+};

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
@@ -1,107 +1,108 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { darkBackground } from "../../../.storybook/utils";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Tile Select Group", module)
-  .add(
-    "Light",
-    (): string => `
-    <calcite-tile-select-group>
-      <calcite-tile-select
-        checked
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
-        icon="layers"
-        name="light"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="one"
-      >
-      </calcite-tile-select>
-      <calcite-tile-select
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum"
-        icon="layers"
-        name="light"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="two"
-      >
-      </calcite-tile-select>
-      <calcite-tile-select
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum"
-        icon="layers"
-        name="light"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="three"
-      >
-      </calcite-tile-select>
-      <calcite-tile-select
-        checked
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
-        icon="layers"
-        name="light"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="four"
-      >
-      </calcite-tile-select>
-    </calcite-tile-select-group>
-  `
-  )
-  .add(
-    "Dark",
-    (): string => `
-    <calcite-tile-select-group>
-      <calcite-tile-select
-        checked
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
-        icon="layers"
-        name="dark"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        theme="dark"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="one"
-      >
-      </calcite-tile-select>
-      <calcite-tile-select
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum"
-        icon="layers"
-        name="dark"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        theme="dark"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="two"
-      >
-      </calcite-tile-select>
-      <calcite-tile-select
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum"
-        icon="layers"
-        name="dark"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        theme="dark"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="three"
-      >
-      </calcite-tile-select>
-      <calcite-tile-select
-        checked
-        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
-        icon="layers"
-        name="dark"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        theme="dark"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="four"
-      >
-    </calcite-tile-select-group>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Tile Select Group"
+};
+
+export const Light = (): string => html`
+  <calcite-tile-select-group>
+    <calcite-tile-select
+      checked
+      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+      heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+      icon="layers"
+      name="light"
+      show-input="${select("show-input", ["left", "right", "none"], "left")}"
+      type="${select("type", ["radio", "checkbox"], "radio")}"
+      value="one"
+    >
+    </calcite-tile-select>
+    <calcite-tile-select
+      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+      heading="Tile title lorem ipsum"
+      icon="layers"
+      name="light"
+      show-input="${select("show-input", ["left", "right", "none"], "left")}"
+      type="${select("type", ["radio", "checkbox"], "radio")}"
+      value="two"
+    >
+    </calcite-tile-select>
+    <calcite-tile-select
+      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+      heading="Tile title lorem ipsum"
+      icon="layers"
+      name="light"
+      show-input="${select("show-input", ["left", "right", "none"], "left")}"
+      type="${select("type", ["radio", "checkbox"], "radio")}"
+      value="three"
+    >
+    </calcite-tile-select>
+    <calcite-tile-select
+      checked
+      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+      heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+      icon="layers"
+      name="light"
+      show-input="${select("show-input", ["left", "right", "none"], "left")}"
+      type="${select("type", ["radio", "checkbox"], "radio")}"
+      value="four"
+    >
+    </calcite-tile-select>
+  </calcite-tile-select-group>
+`;
+
+export const Dark = (): string => html`
+<calcite-tile-select-group>
+  <calcite-tile-select
+    checked
+    description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+    icon="layers"
+    name="dark"
+    show-input="${select("show-input", ["left", "right", "none"], "left")}"
+    theme="dark"
+    type="${select("type", ["radio", "checkbox"], "radio")}"
+    value="one"
+  >
+  </calcite-tile-select>
+  <calcite-tile-select
+    description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    heading="Tile title lorem ipsum"
+    icon="layers"
+    name="dark"
+    show-input="${select("show-input", ["left", "right", "none"], "left")}"
+    theme="dark"
+    type="${select("type", ["radio", "checkbox"], "radio")}"
+    value="two"
+  >
+  </calcite-tile-select>
+  <calcite-tile-select
+    description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    heading="Tile title lorem ipsum"
+    icon="layers"
+    name="dark"
+    show-input="${select("show-input", ["left", "right", "none"], "left")}"
+    theme="dark"
+    type="${select("type", ["radio", "checkbox"], "radio")}"
+    value="three"
+  >
+  </calcite-tile-select>
+  <calcite-tile-select
+    checked
+    description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+    icon="layers"
+    name="dark"
+    show-input="${select("show-input", ["left", "right", "none"], "left")}"
+    theme="dark"
+    type="${select("type", ["radio", "checkbox"], "radio")}"
+    value="four"
+  >
+</calcite-tile-select-group>
+`;
+
+Dark.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-tile-select/calcite-tile-select.stories.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.stories.ts
@@ -1,54 +1,58 @@
-import { storiesOf } from "@storybook/html";
 import { select, text } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Tile Select", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Light",
-    (): string => `
-      <calcite-tile-select
-        ${boolean("checked", false)}
-        description="${text(
-          "description",
-          "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        )}"
-        ${boolean("disabled", false)}
-        ${boolean("focused", false)}
-        heading="${text("heading", "Tile heading lorem ipsum")}"
-        ${boolean("hidden", false)}
-        icon="${select("icon", iconNames, iconNames[296])}"
-        name="${text("name", "tile-select-demo")}"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="${text("value", "one")}"
-      >
-      </calcite-tile-select>
-  `
-  )
-  .add(
-    "Dark",
-    (): string => `
-      <calcite-tile-select
-        ${boolean("checked", false)}
-        description="${text(
-          "description",
-          "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        )}"
-        ${boolean("disabled", false)}
-        ${boolean("focused", false)}
-        heading="${text("heading", "Tile heading lorem ipsum")}"
-        ${boolean("hidden", false)}
-        icon="${select("icon", iconNames, iconNames[296])}"
-        name="${text("name", "tile-select-demo")}"
-        show-input="${select("show-input", ["left", "right", "none"], "left")}"
-        theme="dark"
-        type="${select("type", ["radio", "checkbox"], "radio")}"
-        value="${text("value", "one")}"
-      >
-      </calcite-tile-select>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Tile Select",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Light = (): string => html`
+  <calcite-tile-select
+    ${boolean("checked", false)}
+    description="${text(
+      "description",
+      "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    )}"
+    ${boolean("disabled", false)}
+    ${boolean("focused", false)}
+    heading="${text("heading", "Tile heading lorem ipsum")}"
+    ${boolean("hidden", false)}
+    icon="${select("icon", iconNames, iconNames[296])}"
+    name="${text("name", "tile-select-demo")}"
+    show-input="${select("show-input", ["left", "right", "none"], "left")}"
+    type="${select("type", ["radio", "checkbox"], "radio")}"
+    value="${text("value", "one")}"
+  >
+  </calcite-tile-select>
+`;
+
+export const Dark = (): string => html`
+  <calcite-tile-select
+    ${boolean("checked", false)}
+    description="${text(
+      "description",
+      "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    )}"
+    ${boolean("disabled", false)}
+    ${boolean("focused", false)}
+    heading="${text("heading", "Tile heading lorem ipsum")}"
+    ${boolean("hidden", false)}
+    icon="${select("icon", iconNames, iconNames[296])}"
+    name="${text("name", "tile-select-demo")}"
+    show-input="${select("show-input", ["left", "right", "none"], "left")}"
+    theme="dark"
+    type="${select("type", ["radio", "checkbox"], "radio")}"
+    value="${text("value", "one")}"
+  >
+  </calcite-tile-select>
+`;
+
+Dark.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-tile/calcite-tile.stories.ts
+++ b/src/components/calcite-tile/calcite-tile.stories.ts
@@ -1,46 +1,50 @@
-import { storiesOf } from "@storybook/html";
 import { select, text } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
-storiesOf("Components/Tile", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Light",
-    (): string => `
-      <calcite-tile
-        ${boolean("active", false)}
-        description="${text(
-          "description",
-          "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        )}"
-        ${boolean("focused", false)}
-        heading="${text("heading", "Tile heading lorem ipsum")}"
-        ${boolean("hidden", false)}
-        href="${text("href", "#")}"
-        icon="${select("icon", iconNames, iconNames[296])}"
-      >
-      </calcite-tile>
-  `
-  )
-  .add(
-    "Dark",
-    (): string => `
-    <calcite-tile
-        ${boolean("active", false)}
-        description="${text(
-          "description",
-          "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-        )}"
-        ${boolean("focused", false)}
-        heading="${text("heading", "Tile heading lorem ipsum")}"
-        ${boolean("hidden", false)}
-        href="${text("href", "#")}"
-        icon="${select("icon", iconNames, iconNames[296])}"
-        theme="dark"
-      >
-      </calcite-tile>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Tile",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Light = (): string => html`
+  <calcite-tile
+    ${boolean("active", false)}
+    description="${text(
+      "description",
+      "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    )}"
+    ${boolean("focused", false)}
+    heading="${text("heading", "Tile heading lorem ipsum")}"
+    ${boolean("hidden", false)}
+    href="${text("href", "#")}"
+    icon="${select("icon", iconNames, iconNames[296])}"
+  >
+  </calcite-tile>
+`;
+
+export const Dark = (): string => html`
+  <calcite-tile
+    ${boolean("active", false)}
+    description="${text(
+      "description",
+      "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+    )}"
+    ${boolean("focused", false)}
+    heading="${text("heading", "Tile heading lorem ipsum")}"
+    ${boolean("hidden", false)}
+    href="${text("href", "#")}"
+    icon="${select("icon", iconNames, iconNames[296])}"
+    theme="dark"
+  >
+  </calcite-tile>
+`;
+
+Dark.story = {
+  parameters: { backgrounds: darkBackground }
+};

--- a/src/components/calcite-tooltip/calcite-tooltip.stories.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.stories.ts
@@ -1,4 +1,3 @@
-import { storiesOf } from "@storybook/html";
 import { select, number } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
@@ -30,10 +29,16 @@ const contentHTML = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, se
 
 const referenceElementHTML = `<calcite-tooltip-manager>Ut enim ad minim veniam, quis <calcite-button appearance="inline" title="Reference element" id="reference-element">nostrud exercitation</calcite-button> ullamco laboris nisi ut aliquip ex ea commodo consequat.</calcite-tooltip-manager>`;
 
-storiesOf("Components/Tooltip", module)
-  .addParameters({ notes: readme })
-  .add("Simple", () => {
-    return `
+export default {
+  title: "Components/Tooltip",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => {
+  return `
       <div>
         ${referenceElementHTML}
         <calcite-tooltip
@@ -48,9 +53,10 @@ storiesOf("Components/Tooltip", module)
         </calcite-tooltip>
       </div>
     `;
-  })
-  .add("Dark Mode", () => {
-    return `
+};
+
+export const DarkMode = (): string => {
+  return `
       <div>
         ${referenceElementHTML}
         <calcite-tooltip
@@ -65,4 +71,4 @@ storiesOf("Components/Tooltip", module)
         </calcite-tooltip>
       </div>
     `;
-  });
+};

--- a/src/components/calcite-tree/calcite-tree.stories.ts
+++ b/src/components/calcite-tree/calcite-tree.stories.ts
@@ -1,8 +1,8 @@
-import { storiesOf } from "@storybook/html";
 import { select } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
 const treeItems = `
   <calcite-tree-item>
@@ -40,31 +40,36 @@ const treeItems = `
   </calcite-tree-item>
 `;
 
-storiesOf("Components/Tree", module)
-  .addParameters({ notes: readme })
-  .add(
-    "Simple",
-    (): string => `
-    <calcite-tree
-      ${boolean("lines", false)}
-      selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
-      size="${select("size", ["s", "m"], "m")}"
-    >
-      ${treeItems}
-    </calcite-tree>
-  `
-  )
-  .add(
-    "Dark mode",
-    (): string => `
-    <calcite-tree
-      theme="dark"
-      ${boolean("lines", false)}
-      selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
-      size="${select("size", ["s", "m"], "m")}"
-    >
-      ${treeItems}
-    </calcite-tree>
-  `,
-    { backgrounds: darkBackground }
-  );
+export default {
+  title: "Components/Tree",
+
+  parameters: {
+    notes: readme
+  }
+};
+
+export const Simple = (): string => html`
+  <calcite-tree
+    ${boolean("lines", false)}
+    selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
+    size="${select("size", ["s", "m"], "m")}"
+  >
+    ${treeItems}
+  </calcite-tree>
+`;
+
+export const DarkMode = (): string => html`
+  <calcite-tree
+    theme="dark"
+    ${boolean("lines", false)}
+    selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
+    size="${select("size", ["s", "m"], "m")}"
+  >
+    ${treeItems}
+  </calcite-tree>
+`;
+
+DarkMode.story = {
+  name: "Dark mode",
+  parameters: { backgrounds: darkBackground }
+};


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This migrates stories to use [Component Storybook Format](https://storybook.js.org/docs/react/api/csf) using [`@storybook/codemod`](https://www.npmjs.com/package/@storybook/codemod) + a few tweaks since the codemod doesn't dig functions with return types. This also adds the `html` helper to automatically format embedded HTML. 

**Bonus**: this fixes the sorting order of components in the navigation panel.

There may still be some tidying up to do (e.g., some `name` entries seem redundant`), but this can be done in follow-up PRs.