### PR TITLE
chore(stories): improve component helper for stories

### DIFF
--- a/.storybook/utils.tsx
+++ b/.storybook/utils.tsx
@@ -65,38 +65,27 @@ export const parseReadme = (content) =>
     // markdown uses relative paths for component links
     .replace(/\.\.\//g, "https://github.com/Esri/calcite-components/tree/master/src/components/");
 
-export interface KnobbedAttribute {
-  name: string;
-  value: ReturnType<
-    | typeof boolean
-    | typeof color
-    | typeof date
-    | typeof number
-    | typeof array
-    | typeof files
-    | typeof button
-    | typeof object
-    | typeof radios
-    | typeof options
-    | typeof select
-    | typeof text
-  >;
-}
+export const globalDocsPage: typeof DocsPage = () => (
+  <React.Fragment>
+    {/* omit <Title /> as Description includes it (from component READMEs) */}
+    <Description />
+  </React.Fragment>
+);
 
-export interface SimpleAttribute {
-  name: string;
-  value: string | boolean | number;
-}
-
-export type Attribute = KnobbedAttribute | SimpleAttribute;
-export type Attributes = Attribute[];
-
+/**
+ * This utility helps build the HTML for a story element.
+ * It allows configuration and reuse of attributes between stories.
+ *
+ * @param tagName - the element tag to create
+ * @param attributes - the attribute configuration to apply on the element
+ * @param contentHTML - the element's HTML content
+ */
 export const createComponentHTML = (
   tagName: string,
-  attributes: Attributes,
+  attributes: SupportedAttributes,
   contentHTML: string = ""
 ): string =>
-  `<${tagName} ${attributes
+  `<${tagName} ${getAttributes(attributes)
     .map(({ name, value }) => {
       const booleanAttr = typeof value === "boolean";
       if (booleanAttr) {
@@ -106,9 +95,135 @@ export const createComponentHTML = (
     })
     .join(" ")}>${contentHTML}</${tagName}>`;
 
-export const globalDocsPage: typeof DocsPage = () => (
-  <React.Fragment>
-    {/* omit <Title /> as Description includes it (from component READMEs) */}
-    <Description />
-  </React.Fragment>
-);
+/**
+ * Represents an HTML attribute with an associated storybook knob
+ */
+interface KnobbedAttribute {
+  name: string;
+  value: KnobbedAttributeValue;
+}
+
+type KnobbedAttributeValue = ReturnType<
+  | typeof boolean
+  | typeof color
+  | typeof date
+  | typeof number
+  | typeof array
+  | typeof files
+  | typeof button
+  | typeof object
+  | typeof radios
+  | typeof options
+  | typeof select
+  | typeof text
+>;
+
+type AttributeValue = string | boolean | number;
+
+/**
+ * Represents an HTML attribute and its respective value.
+ */
+interface SimpleAttribute {
+  name: string;
+  value: AttributeValue;
+}
+
+/**
+ * Represents an HTML attribute whose value will be committed dynamically.
+ *
+ * @deprecated - use attribute map instead.
+ */
+export interface DeferredAttribute {
+  name: string;
+  commit: () => Attribute;
+}
+
+/**
+ * Represents supported HTML attributes in a story.
+ */
+export type Attribute = KnobbedAttribute | SimpleAttribute;
+
+/**
+ * Represents a collection of HTML attributes in a story.
+ *
+ * @deprecated - use attribute map instead.
+ */
+export type Attributes = Attribute[];
+
+/**
+ * A map where key represents an HTML attribute and the value holds the attribute's value.
+ */
+export type AttributeMap = Record<string, AttributeFactory>;
+
+/**
+ * A function that generates an HTML attribute's associated value to be used in a story.
+ */
+type AttributeFactory = () => KnobbedAttributeValue | AttributeValue;
+
+/**
+ * This object should be used whenever there is an attribute map that needs override support.
+ */
+type OverridableAttributeMap = {
+  map: AttributeMap;
+  overrides: AttributeMap;
+};
+
+/**
+ * This object should be used whenever there is an attribute map that needs excluding attributes.
+ */
+type IgnorableAttributeMap = {
+  map: AttributeMap;
+  ignore: string[];
+};
+
+type AttributeMapOptions = OverridableAttributeMap | IgnorableAttributeMap;
+
+type AttributeMapCompatible = AttributeMap | AttributeMapOptions;
+
+type SupportedAttributes = Attributes | AttributeMapCompatible;
+
+const getAttributes = (attributes: SupportedAttributes): Attribute[] => {
+  if (!isAttributeMapCompatible(attributes)) {
+    return attributes.map(({ name, value }) => {
+      if (typeof value === "function") {
+        value = value();
+      }
+
+      return {
+        name,
+        value
+      };
+    });
+  }
+
+  if (!hasMapOptions(attributes)) {
+    return toAttributes(attributes);
+  }
+
+  const overrides = "overrides" in attributes ? attributes.overrides : {};
+
+  let attrMap = { ...attributes.map, ...overrides };
+
+  if ("ignore" in attributes) {
+    attributes.ignore.forEach((attr) => delete attrMap[attr]);
+  }
+
+  return toAttributes(attrMap);
+};
+
+const isAttributeMapCompatible = (
+  attributes: SupportedAttributes
+): attributes is AttributeMapCompatible => !Array.isArray(attributes);
+
+const hasMapOptions = (attributeMap: AttributeMapCompatible): attributeMap is AttributeMapOptions =>
+  "map" in attributeMap;
+
+const toAttributes = (attributeMap: AttributeMap): Attribute[] =>
+  Object.keys(attributeMap).map((attr) => {
+    const value = attributeMap[attr]();
+
+    return {
+      name: attr,
+      value
+    };
+  });

--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -1,4 +1,4 @@
-import { Attribute, Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import { html } from "../../tests/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { iconNames } from "../../../.storybook/helpers";
@@ -6,101 +6,33 @@ import { select, text } from "@storybook/addon-knobs";
 import accordionReadme from "./readme.md";
 import accordionItemReadme from "../calcite-accordion-item/readme.md";
 
-const createAccordionAttributes: (options?: { except: string[] }) => Attributes = ({ except } = { except: [] }) => {
+const createAccordionAttributeMap = (): AttributeMap => {
   const group = "accordion";
   const { dir, theme, scale } = ATTRIBUTES;
 
-  interface DeferredAttribute {
-    name: string;
-    commit: () => Attribute;
-  }
-
-  return ([
-    {
-      name: "dir",
-      commit(): Attribute {
-        this.value = select("dir", dir.values, dir.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "scale",
-      commit(): Attribute {
-        this.value = select("scale", scale.values, scale.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "theme",
-      commit(): Attribute {
-        this.value = select("theme", theme.values, theme.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "appearance",
-      commit(): Attribute {
-        this.value = select("appearance", ["default", "minimal", "transparent"], "default", group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "icon-position",
-      commit(): Attribute {
-        this.value = select("icon-position", ["start", "end"], "end", group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "icon-type",
-      commit(): Attribute {
-        this.value = select("icon-type", ["chevron", "caret", "plus-minus"], "chevron", group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "selection-mode",
-      commit(): Attribute {
-        this.value = select("selection-mode", ["multi", "single", "single-persist"], "multi", group);
-        delete this.build;
-        return this;
-      }
-    }
-  ] as DeferredAttribute[])
-    .filter((attr) => !except.find((excluded) => excluded === attr.name))
-    .map((attr) => attr.commit());
+  return {
+    dir: () => select("dir", dir.values, dir.defaultValue, group),
+    scale: () => select("scale", scale.values, scale.defaultValue, group),
+    theme: () => select("theme", theme.values, theme.defaultValue, group),
+    appearance: () => select("appearance", ["default", "minimal", "transparent"], "default", group),
+    "icon-position": () => select("icon-position", ["start", "end"], "end", group),
+    "icon-type": () => select("icon-type", ["chevron", "caret", "plus-minus"], "chevron", group),
+    "selection-mode": () => select("selection-mode", ["multi", "single", "single-persist"], "multi", group)
+  };
 };
 
-const createAccordionItemAttributes: (options?: { icon?: boolean; group?: string }) => Attributes = ({
-  icon,
-  group
-}) => {
+const createAccordionItemAttributeMap = ({ icon, group }: { icon?: boolean; group?: string }): AttributeMap => {
   const groupTitle = group ? group : "";
-  const defaultAttributes = [
-    {
-      name: "item-title",
-      value: text("item-title", "Item title", groupTitle)
-    },
-    {
-      name: "item-subtitle",
-      value: text("item-subtitle", "Item subtitle", groupTitle)
-    }
-  ];
 
-  const iconAttribute = [
-    {
-      name: "icon",
-      value: select("icon", iconNames, iconNames[0], groupTitle)
-    }
-  ];
+  const iconAttribute = {
+    icon: () => select("icon", iconNames, iconNames[0], groupTitle)
+  };
 
-  return icon ? iconAttribute.concat(defaultAttributes) : defaultAttributes;
+  return {
+    ...(icon ? iconAttribute : null),
+    "item-title": () => text("item-title", "Item title", groupTitle),
+    "item-subtitle": () => text("item-subtitle", "Item subtitle", groupTitle)
+  };
 };
 
 const accordionItemContent = `Custom content here<br/><img src="https://placem.at/places?w=200&txt=0"><br/>More custom content here`;
@@ -119,21 +51,21 @@ export default {
 export const basic = (): string =>
   create(
     "calcite-accordion",
-    createAccordionAttributes(),
+    createAccordionAttributeMap(),
     html`
       ${create(
         "calcite-accordion-item",
-        createAccordionItemAttributes({ group: "accordion-item-1" }),
+        createAccordionItemAttributeMap({ group: "accordion-item-1" }),
         accordionItemContent
       )}
       ${create(
         "calcite-accordion-item",
-        createAccordionItemAttributes({ group: "accordion-item-2" }),
+        createAccordionItemAttributeMap({ group: "accordion-item-2" }),
         accordionItemContent
       )}
       ${create(
         "calcite-accordion-item",
-        createAccordionItemAttributes({ group: "accordion-item-3" }),
+        createAccordionItemAttributeMap({ group: "accordion-item-3" }),
         accordionItemContent
       )}
     `
@@ -142,21 +74,21 @@ export const basic = (): string =>
 export const icon = (): string =>
   create(
     "calcite-accordion",
-    createAccordionAttributes(),
+    createAccordionAttributeMap(),
     html`
       ${create(
         "calcite-accordion-item",
-        createAccordionItemAttributes({ icon: true, group: "accordion-item-1" }),
+        createAccordionItemAttributeMap({ icon: true, group: "accordion-item-1" }),
         accordionItemContent
       )}
       ${create(
         "calcite-accordion-item",
-        createAccordionItemAttributes({ icon: true, group: "accordion-item-2" }),
+        createAccordionItemAttributeMap({ icon: true, group: "accordion-item-2" }),
         accordionItemContent
       )}
       ${create(
         "calcite-accordion-item",
-        createAccordionItemAttributes({ icon: true, group: "accordion-item-3" }),
+        createAccordionItemAttributeMap({ icon: true, group: "accordion-item-3" }),
         accordionItemContent
       )}
     `

--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { AttributeMap, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { html } from "../../tests/utils";
@@ -14,41 +14,20 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "expand",
-    value: boolean("expand", true)
-  },
-  {
-    name: "expanded",
-    value: boolean("expanded", false)
-  },
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "intl-expand",
-    value: text("intlExpand", TEXT.expand)
-  },
-  {
-    name: "intl-collapse",
-    value: text("intlCollapse", TEXT.collapse)
-  },
-  {
-    name: "position",
-    value: select("position", position.values, position.defaultValue)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  expand: () => boolean("expand", true),
+  expanded: () => boolean("expanded", false),
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  "intl-expand": () => text("intlExpand", TEXT.expand),
+  "intl-collapse": () => text("intlCollapse", TEXT.collapse),
+  position: () => select("position", position.values, position.defaultValue),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
 export const basic = (): string =>
   create(
     "calcite-action-bar",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-action-group>
         <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { AttributeMap, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { html } from "../../tests/utils";
@@ -14,41 +14,20 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "expand",
-    value: boolean("expand", true)
-  },
-  {
-    name: "expanded",
-    value: boolean("expanded", false)
-  },
-  {
-    name: "position",
-    value: select("position", position.values, position.defaultValue)
-  },
-  {
-    name: "intl-expand",
-    value: text("intlExpand", TEXT.expand)
-  },
-  {
-    name: "intl-collapse",
-    value: text("intlCollapse", TEXT.collapse)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  expand: () => boolean("expand", true),
+  expanded: () => boolean("expanded", false),
+  position: () => select("position", position.values, position.defaultValue),
+  "intl-expand": () => text("intlExpand", TEXT.expand),
+  "intl-collapse": () => text("intlCollapse", TEXT.collapse),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
 export const basic = (): string =>
   create(
     "calcite-action-pad",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-action-group>
         <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>

--- a/src/components/calcite-action/calcite-action.stories.ts
+++ b/src/components/calcite-action/calcite-action.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { AttributeMap, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { appearance, dir, scale, theme } = ATTRIBUTES;
@@ -12,55 +12,19 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "appearance",
-    value: select("appearance", appearance.values, appearance.defaultValue)
-  },
-  {
-    name: "active",
-    value: boolean("active", false)
-  },
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "disabled",
-    value: boolean("disabled", false)
-  },
-  {
-    name: "icon",
-    value: text("icon", "beaker")
-  },
-  {
-    name: "indicator",
-    value: boolean("indicator", false)
-  },
-  {
-    name: "label",
-    value: text("label", "Label")
-  },
-  {
-    name: "loading",
-    value: boolean("loading", false)
-  },
-  {
-    name: "scale",
-    value: select("scale", scale.values, scale.defaultValue)
-  },
-  {
-    name: "text",
-    value: text("text", "Text")
-  },
-  {
-    name: "text-enabled",
-    value: boolean("textEnabled", false)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  appearance: () => select("appearance", appearance.values, appearance.defaultValue),
+  active: () => boolean("active", false),
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  disabled: () => boolean("disabled", false),
+  icon: () => text("icon", "beaker"),
+  indicator: () => boolean("indicator", false),
+  label: () => text("label", "Label"),
+  loading: () => boolean("loading", false),
+  scale: () => select("scale", scale.values, scale.defaultValue),
+  text: () => text("text", "Text"),
+  "text-enabled": () => boolean("textEnabled", false),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
-export const basic = (): string => create("calcite-action", createAttributes());
+export const basic = (): string => create("calcite-action", createAttributeMap());

--- a/src/components/calcite-block/calcite-block.stories.ts
+++ b/src/components/calcite-block/calcite-block.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attribute, Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { AttributeMap, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
 import blockReadme from "./readme.md";
 import sectionReadme from "../calcite-block-section/readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -16,137 +16,45 @@ export default {
   }
 };
 
-const createBlockAttributes: (options?: { except: string[] }) => Attributes = ({ except } = { except: [] }) => {
+const createBlockAttributeMap = (): AttributeMap => {
   const group = "block";
   const { dir, theme } = ATTRIBUTES;
 
-  interface DeferredAttribute {
-    name: string;
-    commit: () => Attribute;
-  }
-
-  return ([
-    {
-      name: "heading",
-      commit(): Attribute {
-        this.value = text("heading", "Heading", group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "dir",
-      commit(): Attribute {
-        this.value = select("dir", dir.values, dir.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "summary",
-      commit(): Attribute {
-        this.value = text("summary", "summary", group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "open",
-      commit(): Attribute {
-        this.value = boolean("open", true, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "collapsible",
-      commit(): Attribute {
-        this.value = boolean("collapsible", true, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "loading",
-      commit(): Attribute {
-        this.value = boolean("loading", false, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "disabled",
-      commit(): Attribute {
-        this.value = boolean("disabled", false, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "theme",
-      commit(): Attribute {
-        this.value = select("theme", theme.values, theme.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "intl-collapse",
-      commit(): Attribute {
-        this.value = text("intlCollapse", "Collapse", group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "intl-expand",
-      commit(): Attribute {
-        this.value = text("intlExpand", "Expand", group);
-        delete this.build;
-        return this;
-      }
-    }
-  ] as DeferredAttribute[])
-    .filter((attr) => !except.find((excluded) => excluded === attr.name))
-    .map((attr) => attr.commit());
+  return {
+    heading: () => text("heading", "Heading", group),
+    dir: () => select("dir", dir.values, dir.defaultValue, group),
+    summary: () => text("summary", "summary", group),
+    open: () => boolean("open", true, group),
+    collapsible: () => boolean("collapsible", true, group),
+    loading: () => boolean("loading", false, group),
+    disabled: () => boolean("disabled", false, group),
+    theme: () => select("theme", theme.values, theme.defaultValue, group),
+    "intl-collapse": () => text("intlCollapse", "Collapse", group),
+    "intl-expand": () => text("intlExpand", "Expand", group)
+  };
 };
 
-const createSectionAttributes: () => Attributes = () => {
+const createSectionAttributeMap = (): AttributeMap => {
   const group = "section (animals)";
   const toggleDisplayOptions = ["button", "switch"];
 
-  return [
-    {
-      name: "text",
-      value: text("text", "Animals", group)
-    },
-    {
-      name: "open",
-      value: boolean("open", true, group)
-    },
-    {
-      name: "toggle-display",
-      value: select("toggleDisplay", toggleDisplayOptions, toggleDisplayOptions[0], group)
-    },
-    {
-      name: "intl-collapse",
-      value: text("intlCollapse", "Collapse", group)
-    },
-    {
-      name: "intl-expand",
-      value: text("intlExpand", "Expand", group)
-    }
-  ];
+  return {
+    text: () => text("text", "Animals", group),
+    open: () => boolean("open", true, group),
+    "toggle-display": () => select("toggleDisplay", toggleDisplayOptions, toggleDisplayOptions[0], group),
+    "intl-collapse": () => text("intlCollapse", "Collapse", group),
+    "intl-expand": () => text("intlExpand", "Expand", group)
+  };
 };
 
 export const basic = (): string =>
   create(
     "calcite-block",
-    createBlockAttributes(),
+    createBlockAttributeMap(),
     html`
       ${create(
         "calcite-block-section",
-        createSectionAttributes(),
+        createSectionAttributeMap(),
         `<img alt="demo" src="https://placeimg.com/320/240/animals" />`
       )}
 
@@ -159,9 +67,13 @@ export const basic = (): string =>
 export const withHeaderControl = (): string =>
   create(
     "calcite-block",
-    createBlockAttributes({ except: ["open", "collapsible"] }),
+    { map: createBlockAttributeMap(), ignore: ["open", "collapsible"] },
     `<label slot="control">test <input placeholder="I'm a header control"/></label>`
   );
 
 export const withIconAndHeader = (): string =>
-  create("calcite-block", createBlockAttributes({ except: ["open", "collapsible"] }), `<div slot="icon">✅</div>`);
+  create(
+    "calcite-block",
+    { map: createBlockAttributeMap(), ignore: ["open", "collapsible"] },
+    `<div slot="icon">✅</div>`
+  );

--- a/src/components/calcite-color/calcite-color.stories.ts
+++ b/src/components/calcite-color/calcite-color.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import colorReadme from "./readme.md";
 import swatchReadme from "../calcite-color-swatch/readme.md";
 import hexInputReadme from "../calcite-color-hex-input/readme.md";
@@ -13,59 +13,43 @@ export default {
   }
 };
 
-const createColorAttributes: () => Attributes = () => {
+const createAttributeMap = (): AttributeMap => {
   const { dir, scale } = ATTRIBUTES;
 
-  return [
-    {
-      name: "dir",
-      value: select("dir", dir.values, dir.defaultValue)
-    },
-    {
-      name: "hide-channels",
-      value: boolean("hide-channels", false)
-    },
-    {
-      name: "hide-hex",
-      value: boolean("hide-hex", false)
-    },
-    {
-      name: "hide-saved",
-      value: boolean("hide-saved", false)
-    },
-    {
-      name: "scale",
-      value: select("scale", scale.values, scale.defaultValue)
-    }
-  ];
+  return {
+    dir: () => select("dir", dir.values, dir.defaultValue),
+    "hide-channels": () => boolean("hide-channels", false),
+    "hide-hex": () => boolean("hide-hex", false),
+    "hide-saved": () => boolean("hide-saved", false),
+    scale: () => select("scale", scale.values, scale.defaultValue)
+  };
 };
 
+const createValueOverride = (): AttributeMap => ({
+  value: () => text("value", "#b33f33")
+});
+
 export const Simple = (): string =>
-  create("calcite-color", [
-    ...createColorAttributes(),
-    {
-      name: "value",
-      value: text("value", "#b33f33")
-    }
-  ]);
+  create("calcite-color", { mapping: createAttributeMap(), overrides: createValueOverride() });
 
 export const DarkMode = (): string =>
-  create("calcite-color", [
-    ...createColorAttributes(),
-    { name: "theme", value: "dark" },
-    {
-      name: "value",
-      value: text("value", "#b33f33")
+  create("calcite-color", {
+    mapping: createAttributeMap(),
+    overrides: {
+      theme: () => "dark",
+      ...createValueOverride()
     }
-  ]);
+  });
 
 DarkMode.story = {
   parameters: { backgrounds: darkBackground }
 };
 
 export const AllowingEmpty = (): string =>
-  create("calcite-color", [
-    ...createColorAttributes(),
-    { name: "allow-empty", value: true },
-    { name: "value", value: text("value", "") }
-  ]);
+  create("calcite-color", {
+    mapping: createAttributeMap(),
+    overrides: {
+      "allow-empty": () => true,
+      value: () => text("value", "")
+    }
+  });

--- a/src/components/calcite-color/calcite-color.stories.ts
+++ b/src/components/calcite-color/calcite-color.stories.ts
@@ -30,11 +30,11 @@ const createValueOverride = (): AttributeMap => ({
 });
 
 export const Simple = (): string =>
-  create("calcite-color", { mapping: createAttributeMap(), overrides: createValueOverride() });
+  create("calcite-color", { map: createAttributeMap(), overrides: createValueOverride() });
 
 export const DarkMode = (): string =>
   create("calcite-color", {
-    mapping: createAttributeMap(),
+    map: createAttributeMap(),
     overrides: {
       theme: () => "dark",
       ...createValueOverride()
@@ -47,7 +47,7 @@ DarkMode.story = {
 
 export const AllowingEmpty = (): string =>
   create("calcite-color", {
-    mapping: createAttributeMap(),
+    map: createAttributeMap(),
     overrides: {
       "allow-empty": () => true,
       value: () => text("value", "")

--- a/src/components/calcite-fab/calcite-fab.stories.ts
+++ b/src/components/calcite-fab/calcite-fab.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { ICONS } from "./resources";
@@ -13,47 +13,17 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "appearance",
-    value: select("appearance", appearance.values, appearance.values[2])
-  },
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "disabled",
-    value: boolean("disabled", false)
-  },
-  {
-    name: "icon",
-    value: text("icon", ICONS.plus)
-  },
-  {
-    name: "label",
-    value: text("label", "Label")
-  },
-  {
-    name: "loading",
-    value: boolean("loading", false)
-  },
-  {
-    name: "text",
-    value: text("text", "Text")
-  },
-  {
-    name: "text-enabled",
-    value: boolean("textEnabled", false)
-  },
-  {
-    name: "scale",
-    value: select("scale", scale.values, scale.defaultValue)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  appearance: () => select("appearance", appearance.values, appearance.values[2]),
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  disabled: () => boolean("disabled", false),
+  icon: () => text("icon", ICONS.plus),
+  label: () => text("label", "Label"),
+  loading: () => boolean("loading", false),
+  text: () => text("text", "Text"),
+  "text-enabled": () => boolean("textEnabled", false),
+  scale: () => select("scale", scale.values, scale.defaultValue),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
-export const basic = (): string => create("calcite-fab", createAttributes());
+export const basic = (): string => create("calcite-fab", createAttributeMap());

--- a/src/components/calcite-flow/calcite-flow.stories.ts
+++ b/src/components/calcite-flow/calcite-flow.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, theme } = ATTRIBUTES;
 import readme from "./readme.md";
@@ -18,56 +18,26 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => {
+const createAttributeMap = (): AttributeMap => {
   const group = "Flow";
 
-  return [
-    {
-      name: "dir",
-      value: select("dir", dir.values, dir.defaultValue, group)
-    },
-    {
-      name: "theme",
-      value: select("theme", theme.values, theme.defaultValue, group)
-    }
-  ];
+  return {
+    dir: () => select("dir", dir.values, dir.defaultValue, group),
+    theme: () => select("theme", theme.values, theme.defaultValue, group)
+  };
 };
 
-const createFlowItemAttributes: (group: string) => Attributes = (group) => {
-  return [
-    {
-      name: "disabled",
-      value: boolean("disabled", false, group)
-    },
-    {
-      name: "heading",
-      value: text("heading", "Heading", group)
-    },
-    {
-      name: "loading",
-      value: boolean("loading", false, group)
-    },
-    {
-      name: "menu-open",
-      value: boolean("menuOpen", false, group)
-    },
-    {
-      name: "summary",
-      value: text("summary", "Summary", group)
-    },
-    {
-      name: "intl-back",
-      value: text("intlBack", TEXT.back, group)
-    },
-    {
-      name: "intl-open",
-      value: text("intlOpen", TEXT.open, group)
-    },
-    {
-      name: "intl-close",
-      value: text("intlClose", TEXT.close, group)
-    }
-  ];
+const createFlowItemAttributeMap = (group: string): AttributeMap => {
+  return {
+    disabled: () => boolean("disabled", false, group),
+    heading: () => text("heading", "Heading", group),
+    loading: () => boolean("loading", false, group),
+    "menu-open": () => boolean("menuOpen", false, group),
+    summary: () => text("summary", "Summary", group),
+    "intl-back": () => text("intlBack", TEXT.back, group),
+    "intl-open": () => text("intlOpen", TEXT.open, group),
+    "intl-close": () => text("intlClose", TEXT.close, group)
+  };
 };
 
 const menuActionsHTML = html`
@@ -154,7 +124,7 @@ const item2HTML = html`
 export const basic = (): string =>
   create(
     "calcite-flow",
-    createAttributes(),
-    `${create("calcite-panel", createFlowItemAttributes("Panel 1"), createItemHTML(item1HTML))}
-    ${create("calcite-panel", createFlowItemAttributes("Panel 2"), createItemHTML(item2HTML))}`
+    createAttributeMap(),
+    `${create("calcite-panel", createFlowItemAttributeMap("Panel 1"), createItemHTML(item1HTML))}
+    ${create("calcite-panel", createFlowItemAttributeMap("Panel 2"), createItemHTML(item2HTML))}`
   );

--- a/src/components/calcite-panel/calcite-panel.stories.ts
+++ b/src/components/calcite-panel/calcite-panel.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, theme, scale } = ATTRIBUTES;
 import readme from "./readme.md";
@@ -14,40 +14,16 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "dismissed",
-    value: boolean("dismissed", false)
-  },
-  {
-    name: "disabled",
-    value: boolean("disabled", false)
-  },
-  {
-    name: "dismissible",
-    value: boolean("dismissible", false)
-  },
-  {
-    name: "height-scale",
-    value: select("heightScale", scale.values, scale.defaultValue)
-  },
-  {
-    name: "loading",
-    value: boolean("loading", false)
-  },
-  {
-    name: "intl-close",
-    value: text("intlClose", TEXT.close)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  dismissed: () => boolean("dismissed", false),
+  disabled: () => boolean("disabled", false),
+  dismissible: () => boolean("dismissible", false),
+  "height-scale": () => select("heightScale", scale.values, scale.defaultValue),
+  loading: () => boolean("loading", false),
+  "intl-close": () => text("intlClose", TEXT.close),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
 const headerHTML = `<h3 class="heading" slot="${SLOTS.headerContent}">Heading</h3>`;
 
@@ -84,7 +60,7 @@ const footerHTML = html`
 export const basic = (): string =>
   create(
     "calcite-panel",
-    createAttributes(),
+    createAttributeMap(),
     `${headerHTML}
     <calcite-action text="Action" label="Action" slot="${SLOTS.headerLeadingContent}" icon="bluetooth"></calcite-action>
     <calcite-action text="Action" label="Action" slot="${SLOTS.headerTrailingContent}" icon="attachment"></calcite-action>

--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { html } from "../../tests/utils";
@@ -13,32 +13,16 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "disabled",
-    value: boolean("disabled", false)
-  },
-  {
-    name: "filter-enabled",
-    value: boolean("filterEnabled", false)
-  },
-  {
-    name: "loading",
-    value: boolean("loading", false)
-  },
-  {
-    name: "multiple",
-    value: boolean("multiple", false)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => {
+  return {
+    dir: () => select("dir", dir.values, dir.defaultValue),
+    disabled: () => boolean("disabled", false),
+    "filter-enabled": () => boolean("filterEnabled", false),
+    loading: () => boolean("loading", false),
+    multiple: () => boolean("multiple", false),
+    theme: () => select("theme", theme.values, theme.defaultValue)
+  };
+};
 
 const action = html`
   <calcite-action
@@ -54,7 +38,7 @@ const action = html`
 export const basic = (): string =>
   create(
     "calcite-pick-list",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-pick-list-item label="T. Rex" description="arm strength impaired" value="trex">
         ${action}
@@ -69,7 +53,7 @@ export const basic = (): string =>
 export const grouped = (): string =>
   create(
     "calcite-pick-list",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-pick-list-group group-title="numbers">
         <calcite-pick-list-item label="one" description="fish" value="one" icon="grip">
@@ -93,7 +77,7 @@ export const grouped = (): string =>
 export const nested = (): string =>
   create(
     "calcite-pick-list",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-pick-list-group>
         <calcite-pick-list-item label="All the dogs" value="all-dogs" slot="parent-item">

--- a/src/components/calcite-select/calcite-select.stories.ts
+++ b/src/components/calcite-select/calcite-select.stories.ts
@@ -1,4 +1,4 @@
-import { Attribute, Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import { html } from "../../tests/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { boolean, select, text } from "@storybook/addon-knobs";
@@ -6,76 +6,34 @@ import selectReadme from "../calcite-select/readme.md";
 import optionReadme from "../calcite-option/readme.md";
 import optionGroupReadme from "../calcite-option-group/readme.md";
 
-const createSelectAttributes: (options?: { except: string[] }) => Attributes = ({ except } = { except: [] }) => {
+const createSelectAttributeMap = (): AttributeMap => {
   const group = "select";
   const { dir, theme } = ATTRIBUTES;
 
-  interface DeferredAttribute {
-    name: string;
-    commit: () => Attribute;
-  }
-
-  return ([
-    {
-      name: "dir",
-      commit(): Attribute {
-        this.value = select("dir", dir.values, dir.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "disabled",
-      commit(): Attribute {
-        this.value = boolean("disabled", false, group);
-        delete this.build;
-        return this;
-      }
-    },
-    {
-      name: "theme",
-      commit(): Attribute {
-        this.value = select("theme", theme.values, theme.defaultValue, group);
-        delete this.build;
-        return this;
-      }
-    }
-  ] as DeferredAttribute[])
-    .filter((attr) => !except.find((excluded) => excluded === attr.name))
-    .map((attr) => attr.commit());
+  return {
+    dir: () => select("dir", dir.values, dir.defaultValue, group),
+    disabled: () => boolean("disabled", false, group),
+    theme: () => select("theme", theme.values, theme.defaultValue, group)
+  };
 };
 
-const createOptionAttributes: () => Attributes = () => {
+const createOptionAttributeMap = (): AttributeMap => {
   const group = "option";
 
-  return [
-    {
-      name: "disabled",
-      value: boolean("disabled", false, group)
-    },
-    {
-      name: "label",
-      value: text("label", "fancy label", group)
-    },
-    {
-      name: "selected",
-      value: boolean("selected", false, group)
-    },
-    {
-      name: "value",
-      value: text("value", "value", group)
-    }
-  ];
+  return {
+    disabled: () => boolean("disabled", false, group),
+    label: () => text("label", "fancy label", group),
+    selected: () => boolean("selected", false, group),
+    value: () => text("value", "value", group)
+  };
 };
 
-const createOptionGroupAttributes: () => Attributes = () => {
+const createOptionGroupAttributeMap = (): AttributeMap => {
   const group = "option-group";
-  return [
-    {
-      name: "label",
-      value: text("label", "My fancy group label", group)
-    }
-  ];
+
+  return {
+    label: () => text("label", "My fancy group label", group)
+  };
 };
 
 export default {
@@ -93,9 +51,9 @@ export default {
 export const basic = (): string =>
   create(
     "calcite-select",
-    createSelectAttributes(),
+    createSelectAttributeMap(),
     html`
-      ${create("calcite-option", createOptionAttributes())}
+      ${create("calcite-option", createOptionAttributeMap())}
       <calcite-option label="some fixed option" value="some-fixed-value"></calcite-option>
       <calcite-option label="another fixed option" value="another-fixed-value"></calcite-option>
     `
@@ -104,13 +62,13 @@ export const basic = (): string =>
 export const grouped = (): string =>
   create(
     "calcite-select",
-    createSelectAttributes(),
+    createSelectAttributeMap(),
     html`
       ${create(
         "calcite-option-group",
-        createOptionGroupAttributes(),
+        createOptionGroupAttributeMap(),
         html`
-          ${create("calcite-option", createOptionAttributes())}
+          ${create("calcite-option", createOptionAttributeMap())}
           <calcite-option label="some fixed option (A)" value="some-fixed-value-a"></calcite-option>
           <calcite-option label="another fixed option (A)" value="another-fixed-value-a"></calcite-option>
         `

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, position, scale, theme } = ATTRIBUTES;
 import readme from "./readme.md";
@@ -17,64 +17,29 @@ export default {
   }
 };
 
-const createAttributes: (group: string) => Attributes = (group) => {
-  return [
-    {
-      name: "dir",
-      value: select("dir", dir.values, dir.defaultValue, group)
-    },
-    {
-      name: "theme",
-      value: select("theme", theme.values, theme.defaultValue, group)
-    }
-  ];
+const createAttributeMap = (group: string): AttributeMap => ({
+  dir: () => select("dir", dir.values, dir.defaultValue, group),
+  theme: () => select("theme", theme.values, theme.defaultValue, group)
+});
+
+const createShellPanelAttributeMap = (group: "Leading Panel" | "Trailing Panel"): AttributeMap => {
+  return {
+    slot: () => (group === "Leading Panel" ? "primary-panel" : "contextual-panel"),
+    collapsed: () => boolean("collapsed", false, group),
+    detached: () => boolean("detached", false, group),
+    position: () =>
+      select("position", position.values, group === "Leading Panel" ? position.values[0] : position.values[1], group)
+  };
 };
 
-const createShellPanelAttributes: (group: "Leading Panel" | "Trailing Panel") => Attributes = (group) => {
-  return [
-    {
-      name: "slot",
-      value: group === "Leading Panel" ? "primary-panel" : "contextual-panel"
-    },
-    {
-      name: "collapsed",
-      value: boolean("collapsed", false, group)
-    },
-    {
-      name: "detached",
-      value: boolean("detached", false, group)
-    },
-    {
-      name: "position",
-      value: select(
-        "position",
-        position.values,
-        group === "Leading Panel" ? position.values[0] : position.values[1],
-        group
-      )
-    }
-  ];
-};
-
-const createShellCenterRowAttributes: (group: string) => Attributes = (group) => {
-  return [
-    {
-      name: "detached",
-      value: boolean("detached", false, group)
-    },
-    {
-      name: "height-scale",
-      value: select("heightScale", scale.values, scale.values[0], group)
-    },
-    {
-      name: "position",
-      value: select("position", position.values, position.values[1], group)
-    },
-    {
-      name: "slot",
-      value: "center-row"
-    }
-  ];
+const createShellCenterRowAttributeMap = (group: string): AttributeMap => {
+  return {
+    detached: () => boolean("detached", false, group),
+    "height-scale": () => select("heightScale", scale.values, scale.values[0], group),
+    position: () => select("position", position.values, position.values[1], group),
+    name: () => "slot",
+    slot: () => "center-row"
+  };
 };
 
 const actionBarPrimaryContentHTML = html`
@@ -199,11 +164,12 @@ const centerRowAdvancedHTML = html`
 export const basic = (): string =>
   create(
     "calcite-shell",
-    createAttributes("Shell"),
+    createAttributeMap("Shell"),
     html`
-      ${headerHTML} ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), leadingPanelHTML)}
-      ${contentHTML} ${create("calcite-shell-center-row", createShellCenterRowAttributes("Center Row"), centerRowHTML)}
-      ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), trailingPanelHTML)} ${footerHTML}
+      ${headerHTML} ${create("calcite-shell-panel", createShellPanelAttributeMap("Leading Panel"), leadingPanelHTML)}
+      ${contentHTML}
+      ${create("calcite-shell-center-row", createShellCenterRowAttributeMap("Center Row"), centerRowHTML)}
+      ${create("calcite-shell-panel", createShellPanelAttributeMap("Trailing Panel"), trailingPanelHTML)} ${footerHTML}
     `
   );
 
@@ -306,12 +272,12 @@ const advancedTrailingPanelHTMl = html`
 export const advanced = (): string =>
   create(
     "calcite-shell",
-    createAttributes("Shell"),
+    createAttributeMap("Shell"),
     html`
       ${headerHTML}
-      ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), advancedLeadingPanelHTML)}
+      ${create("calcite-shell-panel", createShellPanelAttributeMap("Leading Panel"), advancedLeadingPanelHTML)}
       ${contentHTML} ${centerRowAdvancedHTML}
-      ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), advancedTrailingPanelHTMl)}
+      ${create("calcite-shell-panel", createShellPanelAttributeMap("Trailing Panel"), advancedTrailingPanelHTMl)}
       ${footerHTML}
     `
   );

--- a/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -14,45 +14,21 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "closed",
-    value: boolean("closed", false)
-  },
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "intl-close",
-    value: text("intlClose", TEXT.close)
-  },
-  {
-    name: "intl-default-title",
-    value: text("intlDefaultTitle", TEXT.defaultGroupTitle)
-  },
-  {
-    name: "intl-pagination-label",
-    value: text("intlPaginationLabel", TEXT.defaultPaginationLabel)
-  },
-  {
-    name: "intl-next",
-    value: text("intlNext", TEXT.next)
-  },
-  {
-    name: "intl-previous",
-    value: text("intlPrevious", TEXT.previous)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  closed: () => boolean("closed", false),
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  "intl-close": () => text("intlClose", TEXT.close),
+  "intl-default-title": () => text("intlDefaultTitle", TEXT.defaultGroupTitle),
+  "intl-pagination-label": () => text("intlPaginationLabel", TEXT.defaultPaginationLabel),
+  "intl-next": () => text("intlNext", TEXT.next),
+  "intl-previous": () => text("intlPrevious", TEXT.previous),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
 export const basic = (): string =>
   create(
     "calcite-tip-manager",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-tip-group group-title="Astronomy">
         <calcite-tip heading="The Red Rocks and Blue Water">

--- a/src/components/calcite-tip/calcite-tip.stories.ts
+++ b/src/components/calcite-tip/calcite-tip.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
@@ -14,33 +14,15 @@ export default {
 
 const { dir, theme } = ATTRIBUTES;
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "dismissed",
-    value: boolean("dismissed", false)
-  },
-  {
-    name: "non-dismissible",
-    value: boolean("nonDismissible", false)
-  },
-  {
-    name: "heading",
-    value: text("heading", "My Tip")
-  },
-  {
-    name: "intl-close",
-    value: text("intlClose", TEXT.close)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  dismissed: () => boolean("dismissed", false),
+  "non-dismissible": () => boolean("nonDismissible", false),
+  heading: () => text("heading", "My Tip"),
+  "intl-close": () => text("intlClose", TEXT.close),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
 const html = `<img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non. Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti consectetur. Non porttitor tempor orci dictumst magna porta vitae.</div><a href="http://www.esri.com">This is a "link".</a>`;
 
-export const basic = (): string => create("calcite-tip", createAttributes(), html);
+export const basic = (): string => create("calcite-tip", createAttributeMap(), html);

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select } from "@storybook/addon-knobs";
-import { Attributes, createComponentHTML as create, darkBackground } from "../../../.storybook/utils";
+import { createComponentHTML as create, darkBackground, AttributeMap } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { html } from "../../tests/utils";
@@ -13,36 +13,15 @@ export default {
   }
 };
 
-const createAttributes: () => Attributes = () => [
-  {
-    name: "dir",
-    value: select("dir", dir.values, dir.defaultValue)
-  },
-  {
-    name: "disabled",
-    value: boolean("disabled", false)
-  },
-  {
-    name: "drag-enabled",
-    value: boolean("dragEnabled", false)
-  },
-  {
-    name: "filter-enabled",
-    value: boolean("filterEnabled", false)
-  },
-  {
-    name: "loading",
-    value: boolean("loading", false)
-  },
-  {
-    name: "multiple",
-    value: boolean("multiple", false)
-  },
-  {
-    name: "theme",
-    value: select("theme", theme.values, theme.defaultValue)
-  }
-];
+const createAttributeMap = (): AttributeMap => ({
+  dir: () => select("dir", dir.values, dir.defaultValue),
+  disabled: () => boolean("disabled", false),
+  "drag-enabled": () => boolean("dragEnabled", false),
+  "filter-enabled": () => boolean("filterEnabled", false),
+  loading: () => boolean("loading", false),
+  multiple: () => boolean("multiple", false),
+  theme: () => select("theme", theme.values, theme.defaultValue)
+});
 
 const action = html`
   <calcite-action
@@ -58,7 +37,7 @@ const action = html`
 export const basic = (): string =>
   create(
     "calcite-value-list",
-    createAttributes(),
+    createAttributeMap(),
     html`
       <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
         ${action}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This introduces a new pattern to ease creating shared component/attributes between stories:

* Moves to using maps to configure attributes
* Adds doc to helper and interfaces
* Updates stories to use the latest API
* Filtering and overrides are built into the utility (before, each story that needed this had to write from scratch)
* Less type imports are required
* Deprecates previous interfaces, still backwards-compatible

### Questions

* Is the new pattern simpler to both write and read? Previous object shape was more readable, albeit very verbose.

### Pending

- [ ] Consistent group order in panels – because of how knobs are evaluated, the ordering of groups will depend on the order their IDs are created. IMO, this is a showstopper since we would want the main group to always be displayed first.
