### PR TITLE
fix(label): enforce directionality with new alignment prop

### DIFF
--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -54,6 +54,7 @@ export const WithLabelAndInputMessage = (): string => html`
   <div style="width:300px;max-width:100%;text-align:center;">
     <calcite-label
       status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      alignment="${select("alignment", ["start", "center", "end"], "start", "Label")}"
       scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
       layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
     >

--- a/src/components/calcite-label/calcite-label.e2e.ts
+++ b/src/components/calcite-label/calcite-label.e2e.ts
@@ -38,23 +38,97 @@ describe("calcite-label", () => {
     expect(element).toEqualAttribute("layout", "inline-space-between");
   });
 
-  it("alignment - default", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-label>
-      Label text
-      <calcite-input></calcite-input>
-      </calcite-label>`
+  describe("alignment prop", () => {
+    let page;
+    let element;
+    let style;
+
+    describe("default behavior", () => {
+      it("should render with 'start' alignment", async () => {
+        page = await newE2EPage({
+          html: `<calcite-label>Label text
+          <calcite-input></calcite-input>
+          </calcite-label>`
+        });
+        element = await page.find("calcite-label");
+        expect(await element.getProperty("alignment")).toEqual("start");
+      });
+
+      describe("when in a center-aligned container", () => {
+        describe("when direction is left-to-right", () => {
+          it("should render text left-aligned", async () => {
+            page = await newE2EPage({
+              html: `<div style="text-align: center;">
+              <calcite-label dir="ltr">Label text
+              <calcite-input></calcite-input>
+              </calcite-label>
+              </div>`
+            });
+            element = await page.find("calcite-label");
+            style = await element.getComputedStyle();
+            expect(style["textAlign"]).toEqual("left");
+          });
+        });
+
+        describe("when direction is right-to-left", () => {
+          it("should render text right-aligned", async () => {
+            page = await newE2EPage({
+              html: `<div style="text-align: center;">
+              <calcite-label dir="rtl">Label text
+              <calcite-input></calcite-input>
+              </calcite-label>
+              </div>`
+            });
+            element = await page.find("calcite-label");
+            style = await element.getComputedStyle();
+            expect(style["textAlign"]).toEqual("right");
+          });
+        });
+      });
     });
 
-    const element = await page.find("calcite-label");
+    describe("when alignment prop is provided", () => {
+      describe("'center' alignment", () => {
+        it("should render text center-aligned", async () => {
+          page = await newE2EPage({
+            html: `<calcite-label alignment="center">Label text
+            <calcite-input></calcite-input>
+            </calcite-label>`
+          });
+          element = await page.find("calcite-label");
+          style = await element.getComputedStyle();
+          expect(style["textAlign"]).toEqual("center");
+        });
+      });
 
-    const alignment = await element.getProperty("alignment");
+      describe("'end' alignment", () => {
+        describe("when direction is left-to-right", () => {
+          it("should render text right-aligned", async () => {
+            page = await newE2EPage({
+              html: `<calcite-label alignment="end" dir="ltr">Label text
+              <calcite-input></calcite-input>
+              </calcite-label>`
+            });
+            element = await page.find("calcite-label");
+            style = await element.getComputedStyle();
+            expect(style["textAlign"]).toEqual("right");
+          });
+        });
 
-    expect(alignment).toEqual("start");
-
-    const style = await element.getComputedStyle();
-
-    expect(style["textAlign"]).toEqual("left");
+        describe("when direction is right-to-left", () => {
+          it("should render text left-aligned", async () => {
+            page = await newE2EPage({
+              html: `<calcite-label alignment="end" dir="rtl">Label text
+              <calcite-input></calcite-input>
+              </calcite-label>`
+            });
+            element = await page.find("calcite-label");
+            style = await element.getComputedStyle();
+            expect(style["textAlign"]).toEqual("left");
+          });
+        });
+      });
+    });
   });
 
   it("does not pass id to child label element", async () => {

--- a/src/components/calcite-label/calcite-label.e2e.ts
+++ b/src/components/calcite-label/calcite-label.e2e.ts
@@ -38,6 +38,25 @@ describe("calcite-label", () => {
     expect(element).toEqualAttribute("layout", "inline-space-between");
   });
 
+  it("alignment - default", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-label>
+      Label text
+      <calcite-input></calcite-input>
+      </calcite-label>`
+    });
+
+    const element = await page.find("calcite-label");
+
+    const alignment = await element.getProperty("alignment");
+
+    expect(alignment).toEqual("start");
+
+    const style = await element.getComputedStyle();
+
+    expect(style["textAlign"]).toEqual("left");
+  });
+
   it("does not pass id to child label element", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -1,23 +1,19 @@
 :host-context([theme="dark"]) {
   @include calcite-theme-dark();
 }
-:host([alignment="start"]) {
-  text-align: left;
+
+:host([alignment="start"]),
+:host([alignment="end"][dir="rtl"]) {
+  @apply text-left;
 }
+
+:host([alignment="end"]),
 :host([alignment="start"][dir="rtl"]) {
-  text-align: right;
+  @apply text-right;
 }
 
 :host([alignment="center"]) {
-  text-align: center;
-}
-
-:host([alignment="end"]) {
-  text-align: right;
-}
-
-:host([alignment="end"][dir="rtl"]) {
-  text-align: left;
+  @apply text-center;
 }
 
 :host([scale="s"]) {

--- a/src/components/calcite-label/calcite-label.scss
+++ b/src/components/calcite-label/calcite-label.scss
@@ -1,9 +1,25 @@
 :host-context([theme="dark"]) {
   @include calcite-theme-dark();
 }
-:host([dir="rtl"]) {
+:host([alignment="start"]) {
+  text-align: left;
+}
+:host([alignment="start"][dir="rtl"]) {
   text-align: right;
 }
+
+:host([alignment="center"]) {
+  text-align: center;
+}
+
+:host([alignment="end"]) {
+  text-align: right;
+}
+
+:host([alignment="end"][dir="rtl"]) {
+  text-align: left;
+}
+
 :host([scale="s"]) {
   --calcite-label-margin-bottom: 12px;
   label {

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -33,6 +33,7 @@ export class CalciteLabel {
   //
   //--------------------------------------------------------------------------
 
+  /** specify the text alignment of the label */
   @Prop({ reflect: true }) alignment: "start" | "center" | "end" = "start";
 
   /** specify the status of the label and any child input / input messages */

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -33,6 +33,8 @@ export class CalciteLabel {
   //
   //--------------------------------------------------------------------------
 
+  @Prop({ reflect: true }) alignment: "start" | "center" | "end" = "start";
+
   /** specify the status of the label and any child input / input messages */
   @Prop({ mutable: true, reflect: true }) status: "invalid" | "valid" | "idle" = "idle";
 


### PR DESCRIPTION
**Related Issue:** #1296 

## Summary
When contained in a center-aligned container, labels are now left (or right in rtl) aligned. Also adds the ability to center-align the label text using the new prop.
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
