### PR TITLE
fix(date): start Slovak calendar week on Monday, not Sunday

### DIFF
--- a/src/components/calcite-date/calcite-date-nls/sk.json
+++ b/src/components/calcite-date/calcite-date-nls/sk.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "d. M. y",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "d. M. y",
   "days": {
     "abbreviated": ["ne", "po", "ut", "st", "št", "pi", "so"],

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -131,4 +131,19 @@ describe("calcite-date", () => {
     await page.waitForChanges();
     expect(changedEvent).toHaveReceivedEventTimes(1);
   });
+
+  describe("when the locale is set to Slovak calendar", () => {
+    it("should start the week on Monday", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-date scale="m" locale="sk" value="2000-11-27" no-calendar-input="true" active></calcite-date>`
+      });
+      const weekStartDayAbbr = await page.evaluate(() => {
+        return document
+          .querySelector("calcite-date")
+          .shadowRoot.querySelector("calcite-date-month")
+          .shadowRoot.querySelector("span.week-header:nth-child(1)").textContent;
+      });
+      expect(weekStartDayAbbr).toEqual("po");
+    });
+  });
 });

--- a/src/components/calcite-date/calcite-date.e2e.ts
+++ b/src/components/calcite-date/calcite-date.e2e.ts
@@ -137,13 +137,16 @@ describe("calcite-date", () => {
       const page = await newE2EPage({
         html: `<calcite-date scale="m" locale="sk" value="2000-11-27" no-calendar-input="true" active></calcite-date>`
       });
-      const weekStartDayAbbr = await page.evaluate(() => {
-        return document
-          .querySelector("calcite-date")
-          .shadowRoot.querySelector("calcite-date-month")
-          .shadowRoot.querySelector("span.week-header:nth-child(1)").textContent;
-      });
-      expect(weekStartDayAbbr).toEqual("po");
+      const handle = (
+        await page.waitForFunction(() => {
+          return document
+            .querySelector("calcite-date")
+            .shadowRoot.querySelector("calcite-date-month")
+            .shadowRoot.querySelector("span.week-header:first-child");
+        })
+      ).asElement();
+      const text = await handle.getProperty("textContent");
+      expect(await text.jsonValue()).toEqual("po");
     });
   });
 });


### PR DESCRIPTION
**Related Issue:** #1355

## Summary
When calendar locale is set to Slovak, the week now starts on Monday ("Pondelok").
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
