### PR TITLE
fix(rating): clicking on a wrapping calcite-label focuses a rating item

### DIFF
--- a/src/components/calcite-rating/calcite-rating.e2e.ts
+++ b/src/components/calcite-rating/calcite-rating.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { renders, accessible } from "../../tests/commonTests";
+import { renders, accessible, focusable } from "../../tests/commonTests";
 
 describe("calcite-rating", () => {
   it("renders", async () => renders("<calcite-rating></calcite-rating>"));
@@ -419,6 +419,14 @@ describe("calcite-rating", () => {
     expect(averageSpan).not.toBeNull();
   });
 
+  describe("when setFocus method is called", () => {
+    it("should focus input element in shadow DOM", async () => {
+      focusable("calcite-rating", {
+        shadowFocusTargetSelector: "input"
+      });
+    });
+  });
+
   describe("when wrapped inside calcite-label", () => {
     let page;
     let ratingStars;
@@ -428,29 +436,9 @@ describe("calcite-rating", () => {
       page = await newE2EPage();
     });
 
-    describe("when the rating is disabled or read-only", () => {
-      it("should not focus any stars", async () => {
-        await page.setContent(
-          `<calcite-label>Past review 1
-            <calcite-rating value="2" disabled></calcite-rating>
-          </calcite-label>
-          <calcite-label>Past review 2
-            <calcite-rating value="4" read-only></calcite-rating>
-          </calcite-label>`
-        );
-        const labelComponents = await page.findAll("calcite-label");
-        await labelComponents[0].click();
-        ratingStars = await page.findAll("calcite-rating >>> label.focused");
-        expect(ratingStars.length).toEqual(0);
-        await labelComponents[1].click();
-        ratingStars = await page.findAll("calcite-rating >>> label.focused");
-        expect(ratingStars.length).toEqual(0);
-      });
-    });
-
     describe("when a rating value exists", () => {
-      it("should focus the last-selected star", async () => {
-        await page.setContent('<calcite-label>Your rating<calcite-rating value="3"></calcite-rating></calcite-label>');
+      it("should focus the last-selected star on label click", async () => {
+        await page.setContent("<calcite-label>Your rating<calcite-rating value='3'></calcite-rating></calcite-label>");
         label = await page.find("calcite-label");
         await label.click();
         ratingStars = await page.findAll("calcite-rating >>> label.selected");
@@ -463,8 +451,8 @@ describe("calcite-rating", () => {
     });
 
     describe("when no rating value exists", () => {
-      it("should focus the first non-selected star", async () => {
-        await page.setContent('<calcite-label dir="rtl">הדירוג שלי<calcite-rating></calcite-rating></calcite-label>');
+      it("should focus the first non-selected star on label click", async () => {
+        await page.setContent("<calcite-label dir='rtl'>הדירוג שלי<calcite-rating></calcite-rating></calcite-label>");
         label = await page.find("calcite-label");
         await label.click();
         ratingStars = await page.findAll("calcite-rating >>> label");

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -11,7 +11,7 @@ import {
   State,
   VNode
 } from "@stencil/core";
-import { getElementDir, hasLabel, focusElement } from "../../utils/dom";
+import { getElementDir, hasLabel } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import { TEXT } from "./calcite-rating-resources";
 
@@ -140,6 +140,9 @@ export class CalciteRating {
               this.hasFocus = true;
               this.focusValue = i;
             }}
+            ref={(el) =>
+              (i === 1 || i === this.value) && (this.inputFocusRef = el as HTMLInputElement)
+            }
             type="radio"
             value={i}
           />
@@ -193,17 +196,7 @@ export class CalciteRating {
   //--------------------------------------------------------------------------
   @Method()
   async setFocus(): Promise<void> {
-    const {
-      el: { shadowRoot, value }
-    } = this;
-    if (value > 0) {
-      const selected = shadowRoot.querySelectorAll(".selected");
-      const lastSelectedId = selected[selected.length - 1].getAttribute("for");
-      focusElement(shadowRoot.querySelector(`input[id="${lastSelectedId}"]`));
-    } else {
-      focusElement(shadowRoot.querySelector("fieldset input"));
-    }
-    this.hasFocus = true;
+    this.inputFocusRef.focus();
   }
 
   // --------------------------------------------------------------------------
@@ -219,4 +212,6 @@ export class CalciteRating {
   @State() hasFocus: boolean;
 
   private guid = `calcite-ratings-${guid()}`;
+
+  private inputFocusRef: HTMLInputElement;
 }

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -11,7 +11,7 @@ import {
   State,
   VNode
 } from "@stencil/core";
-import { getElementDir, hasLabel } from "../../utils/dom";
+import { getElementDir, hasLabel, focusElement } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import { TEXT } from "./calcite-rating-resources";
 
@@ -193,8 +193,20 @@ export class CalciteRating {
   //--------------------------------------------------------------------------
   @Method()
   async setFocus(): Promise<void> {
-    this.el.querySelector("input").focus();
-    this.hasFocus = true;
+    const {
+      el: { shadowRoot, disabled, value, readOnly }
+    } = this;
+    const nonEditable = !!disabled || !!readOnly;
+    if (!nonEditable) {
+      if (value > 0) {
+        const selected = shadowRoot.querySelectorAll(".selected");
+        const lastSelectedId = selected[selected.length - 1].getAttribute("for");
+        focusElement(shadowRoot.querySelector(`input[id="${lastSelectedId}"]`));
+      } else {
+        focusElement(shadowRoot.querySelector("fieldset input"));
+      }
+      this.hasFocus = true;
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -194,19 +194,16 @@ export class CalciteRating {
   @Method()
   async setFocus(): Promise<void> {
     const {
-      el: { shadowRoot, disabled, value, readOnly }
+      el: { shadowRoot, value }
     } = this;
-    const nonEditable = !!disabled || !!readOnly;
-    if (!nonEditable) {
-      if (value > 0) {
-        const selected = shadowRoot.querySelectorAll(".selected");
-        const lastSelectedId = selected[selected.length - 1].getAttribute("for");
-        focusElement(shadowRoot.querySelector(`input[id="${lastSelectedId}"]`));
-      } else {
-        focusElement(shadowRoot.querySelector("fieldset input"));
-      }
-      this.hasFocus = true;
+    if (value > 0) {
+      const selected = shadowRoot.querySelectorAll(".selected");
+      const lastSelectedId = selected[selected.length - 1].getAttribute("for");
+      focusElement(shadowRoot.querySelector(`input[id="${lastSelectedId}"]`));
+    } else {
+      focusElement(shadowRoot.querySelector("fieldset input"));
     }
+    this.hasFocus = true;
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #1294 

## Summary
When a rating exists, clicking on a wrapping calcite-label will focus the last selected rating item, otherwise it will focus the first rating item.
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
