### PR TITLE
feat(input-message): allow custom icons

### DIFF
--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, renders } from "../../tests/commonTests";
+import bananaShape from "../calcite-icon/assets/banana16.json";
 
 describe("calcite-input-message", () => {
   it("renders", async () => renders("calcite-input-message", false));
@@ -61,5 +62,15 @@ describe("calcite-input-message", () => {
 
     const icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
     expect(icon).not.toBeNull();
+  });
+
+  describe("when a custom icon is provided", () => {
+    it("should render the requested icon", async () => {
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input-message icon='banana'>Nah</calcite-input-message>");
+      const requestedIcon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+      const svgPath = await requestedIcon.shadowRoot.querySelector("svg > path");
+      expect(await svgPath.getAttribute("d")).toEqual(bananaShape);
+    });
   });
 });

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -1,6 +1,9 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, renders } from "../../tests/commonTests";
-import bananaShape from "../calcite-icon/assets/banana16.json";
+import banana16 from "../calcite-icon/assets/banana16.json";
+import information16 from "../calcite-icon/assets/information16.json";
+import checkCircle16 from "../calcite-icon/assets/checkCircle16.json";
+import exclamationMarkTriangle16 from "../calcite-icon/assets/exclamationMarkTriangle16.json";
 
 describe("calcite-input-message", () => {
   it("renders", async () => renders("calcite-input-message", false));
@@ -54,23 +57,88 @@ describe("calcite-input-message", () => {
     expect(icon).toBeNull();
   });
 
-  it("renders an icon if requested", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input-message icon>Text</calcite-input-message>
-    `);
+  describe("when icon prop is provided", () => {
+    let page;
+    let element;
+    let icon;
+    let svgPath;
 
-    const icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-    expect(icon).not.toBeNull();
-  });
+    beforeEach(async () => {
+      page = await newE2EPage();
+    });
 
-  describe("when a custom icon is provided", () => {
-    it("should render the requested icon", async () => {
-      const page = await newE2EPage();
-      await page.setContent("<calcite-input-message icon='banana'>Nah</calcite-input-message>");
-      const requestedIcon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-      const svgPath = await requestedIcon.shadowRoot.querySelector("svg > path");
-      expect(await svgPath.getAttribute("d")).toEqual(bananaShape);
+    describe("when it's a boolean type", () => {
+      describe("when value is true", () => {
+        it("should render the default status icon", async () => {
+          await page.setContent(`
+          <calcite-input-message icon>Text</calcite-input-message>
+          `);
+          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          svgPath = await icon.shadowRoot.querySelector("path");
+          expect(await svgPath.getAttribute("d")).toEqual(information16);
+          expect(icon).not.toBeNull();
+        });
+
+        describe("when element status is changed", () => {
+          it("should render icon based on new status", async () => {
+            await page.setContent(`
+              <calcite-input-message icon status="invalid">An example with icon</calcite-input-message>
+            `);
+            element = await page.find("calcite-input-message");
+            icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+            svgPath = await icon.shadowRoot.querySelector("path");
+            expect(await element.getProperty("status")).toEqual("invalid");
+            expect(await svgPath.getAttribute("d")).toEqual(exclamationMarkTriangle16);
+            expect(icon).not.toBeNull();
+
+            element.setProperty("status", "valid");
+            await page.waitForChanges();
+
+            icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+            svgPath = await icon.shadowRoot.querySelector("path");
+            expect(await element.getProperty("status")).toEqual("valid");
+            expect(await svgPath.getAttribute("d")).toEqual(checkCircle16);
+            expect(icon).not.toBeNull();
+          });
+        });
+      });
+
+      describe("when value is false", () => {
+        it("should render no icon", async () => {
+          const page = await newE2EPage();
+          await page.setContent(`
+          <calcite-input-message !icon>Text</calcite-input-message>
+          `);
+          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          expect(icon).toBeNull();
+        });
+      });
+    });
+
+    describe("when it's a string type", () => {
+      it("should render the requested custom icon", async () => {
+        await page.setContent("<calcite-input-message icon='banana'>Nah</calcite-input-message>");
+        icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+        svgPath = await icon.shadowRoot.querySelector("path");
+        expect(await svgPath.getAttribute("d")).toEqual(banana16);
+      });
+
+      describe("when the icon is changed", () => {
+        it("should render the new icon", async () => {
+          await page.setContent("<calcite-input-message icon='information'>More info</calcite-input-message>");
+          element = await page.find("calcite-input-message");
+          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          svgPath = await icon.shadowRoot.querySelector("path");
+          expect(await svgPath.getAttribute("d")).toEqual(information16);
+
+          await element.setAttribute("icon", "banana");
+          await page.waitForChanges();
+
+          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          svgPath = await icon.shadowRoot.querySelector("path");
+          expect(await svgPath.getAttribute("d")).toEqual(banana16);
+        });
+      });
     });
   });
 });

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -1,9 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, renders } from "../../tests/commonTests";
-import banana16 from "../calcite-icon/assets/banana16.json";
-import information16 from "../calcite-icon/assets/information16.json";
-import checkCircle16 from "../calcite-icon/assets/checkCircle16.json";
-import exclamationMarkTriangle16 from "../calcite-icon/assets/exclamationMarkTriangle16.json";
+import { StatusIconDefaults } from "./interfaces";
 
 describe("calcite-input-message", () => {
   it("renders", async () => renders("calcite-input-message", false));
@@ -60,8 +57,8 @@ describe("calcite-input-message", () => {
   describe("when icon prop is provided", () => {
     let page;
     let element;
-    let icon;
-    let svgPath;
+    let iconEl;
+    let requestedIcon;
 
     beforeEach(async () => {
       page = await newE2EPage();
@@ -73,10 +70,10 @@ describe("calcite-input-message", () => {
           await page.setContent(`
           <calcite-input-message icon>Text</calcite-input-message>
           `);
-          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-          svgPath = await icon.shadowRoot.querySelector("path");
-          expect(await svgPath.getAttribute("d")).toEqual(information16);
-          expect(icon).not.toBeNull();
+          iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          requestedIcon = await iconEl.getAttribute("icon");
+          expect(requestedIcon).toEqual(StatusIconDefaults.idle);
+          expect(iconEl).not.toBeNull();
         });
 
         describe("when element status is changed", () => {
@@ -85,20 +82,18 @@ describe("calcite-input-message", () => {
               <calcite-input-message icon status="invalid">An example with icon</calcite-input-message>
             `);
             element = await page.find("calcite-input-message");
-            icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-            svgPath = await icon.shadowRoot.querySelector("path");
-            expect(await element.getProperty("status")).toEqual("invalid");
-            expect(await svgPath.getAttribute("d")).toEqual(exclamationMarkTriangle16);
-            expect(icon).not.toBeNull();
+            iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+            requestedIcon = await iconEl.getAttribute("icon");
+            expect(requestedIcon).toEqual(StatusIconDefaults.invalid);
+            expect(iconEl).not.toBeNull();
 
-            element.setProperty("status", "valid");
+            await element.setAttribute("status", "valid");
             await page.waitForChanges();
 
-            icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-            svgPath = await icon.shadowRoot.querySelector("path");
-            expect(await element.getProperty("status")).toEqual("valid");
-            expect(await svgPath.getAttribute("d")).toEqual(checkCircle16);
-            expect(icon).not.toBeNull();
+            iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+            requestedIcon = await iconEl.getAttribute("icon");
+            expect(requestedIcon).toEqual(StatusIconDefaults.valid);
+            expect(iconEl).not.toBeNull();
           });
         });
       });
@@ -109,8 +104,8 @@ describe("calcite-input-message", () => {
           await page.setContent(`
           <calcite-input-message !icon>Text</calcite-input-message>
           `);
-          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-          expect(icon).toBeNull();
+          iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          expect(iconEl).toBeNull();
         });
       });
     });
@@ -118,25 +113,33 @@ describe("calcite-input-message", () => {
     describe("when it's a string type", () => {
       it("should render the requested custom icon", async () => {
         await page.setContent("<calcite-input-message icon='banana'>Nah</calcite-input-message>");
-        icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-        svgPath = await icon.shadowRoot.querySelector("path");
-        expect(await svgPath.getAttribute("d")).toEqual(banana16);
+        element = await page.find("calcite-input-message");
+        iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+        requestedIcon = await iconEl.getAttribute("icon");
+        expect(requestedIcon).toEqual("banana");
       });
 
       describe("when the icon is changed", () => {
         it("should render the new icon", async () => {
           await page.setContent("<calcite-input-message icon='information'>More info</calcite-input-message>");
           element = await page.find("calcite-input-message");
-          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-          svgPath = await icon.shadowRoot.querySelector("path");
-          expect(await svgPath.getAttribute("d")).toEqual(information16);
+          iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          requestedIcon = await iconEl.getAttribute("icon");
+          expect(requestedIcon).toEqual(StatusIconDefaults.idle);
 
           await element.setAttribute("icon", "banana");
           await page.waitForChanges();
 
-          icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
-          svgPath = await icon.shadowRoot.querySelector("path");
-          expect(await svgPath.getAttribute("d")).toEqual(banana16);
+          iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          requestedIcon = await iconEl.getAttribute("icon");
+          expect(requestedIcon).toEqual("banana");
+
+          await element.setAttribute("icon", "view-hide");
+          await page.waitForChanges();
+
+          iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
+          requestedIcon = await iconEl.getAttribute("icon");
+          expect(requestedIcon).toEqual("view-hide");
         });
       });
     });

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Host, h, Prop, VNode, Watch } from "@stencil/core";
 import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
 import { Scale, Status, Theme } from "../interfaces";
-import { InputMessageType } from "./interfaces";
+import { InputMessageType, StatusIconDefaults } from "./interfaces";
 
 @Component({
   tag: "calcite-input-message",
@@ -44,7 +44,7 @@ export class CalciteInputMessage {
   @Watch("status")
   @Watch("icon")
   handleIconEl(): void {
-    this.requestedIcon = setRequestedIcon(this.iconDefaults, this.icon, this.status);
+    this.requestedIcon = setRequestedIcon(StatusIconDefaults, this.icon, this.status);
   }
 
   //--------------------------------------------------------------------------
@@ -56,7 +56,7 @@ export class CalciteInputMessage {
   connectedCallback(): void {
     this.status = getElementProp(this.el, "status", this.status);
     this.scale = getElementProp(this.el, "scale", this.scale);
-    this.requestedIcon = setRequestedIcon(this.iconDefaults, this.icon, this.status);
+    this.requestedIcon = setRequestedIcon(StatusIconDefaults, this.icon, this.status);
   }
 
   render(): VNode {
@@ -75,13 +75,6 @@ export class CalciteInputMessage {
   //  Private State/Props
   //
   //--------------------------------------------------------------------------
-
-  // icons for status and validation
-  private iconDefaults = {
-    valid: "check-circle",
-    invalid: "exclamation-mark-triangle",
-    idle: "information"
-  };
 
   /** the computed icon to render */
   private requestedIcon?: string;

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Host, h, Prop, VNode } from "@stencil/core";
-import { getElementDir, getElementProp } from "../../utils/dom";
+import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
 import { Scale, Status, Theme } from "../interfaces";
 import { InputMessageType } from "./interfaces";
 
@@ -26,7 +26,7 @@ export class CalciteInputMessage {
   @Prop({ reflect: true }) active = false;
 
   /** optionally display an icon based on status */
-  @Prop({ reflect: true }) icon: boolean;
+  @Prop({ reflect: true }) icon: boolean | string;
 
   /** specify the scale of the input, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -49,14 +49,22 @@ export class CalciteInputMessage {
   connectedCallback(): void {
     this.status = getElementProp(this.el, "status", this.status);
     this.scale = getElementProp(this.el, "scale", this.scale);
+    this.requestedIcon = setRequestedIcon(this.iconDefaults, this.icon, this.status);
   }
 
   render(): VNode {
     const dir = getElementDir(this.el);
     const hidden = !this.active;
+    let iconEl = null;
+    if (this.icon && !this.requestedIcon) {
+      iconEl = this.renderIcon(this.iconDefaults[this.status]);
+    }
+    if (!!this.requestedIcon) {
+      iconEl = this.renderIcon(this.requestedIcon);
+    }
     return (
       <Host calcite-hydrated-hidden={hidden} dir={dir} theme={this.theme}>
-        {this.icon ? this.renderIcon(this.iconDefaults[this.status]) : null}
+        {iconEl}
         <slot />
       </Host>
     );
@@ -74,6 +82,9 @@ export class CalciteInputMessage {
     invalid: "exclamation-mark-triangle",
     idle: "information"
   };
+
+  /** the custom icon to render */
+  private requestedIcon?: string;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, h, Prop, VNode } from "@stencil/core";
+import { Component, Element, Host, h, Prop, VNode, Watch } from "@stencil/core";
 import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
 import { Scale, Status, Theme } from "../interfaces";
 import { InputMessageType } from "./interfaces";
@@ -25,7 +25,8 @@ export class CalciteInputMessage {
 
   @Prop({ reflect: true }) active = false;
 
-  /** optionally display an icon based on status */
+  /** when used as a boolean set to true, show a default icon based on status. You can
+   * also pass a calcite-ui-icon name to this prop to display a custom icon */
   @Prop({ reflect: true }) icon: boolean | string;
 
   /** specify the scale of the input, defaults to m */
@@ -39,6 +40,12 @@ export class CalciteInputMessage {
 
   /** specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input) */
   @Prop({ reflect: true }) type: InputMessageType = "default";
+
+  @Watch("status")
+  @Watch("icon")
+  handleIconEl(): void {
+    this.requestedIcon = setRequestedIcon(this.iconDefaults, this.icon, this.status);
+  }
 
   //--------------------------------------------------------------------------
   //
@@ -55,16 +62,9 @@ export class CalciteInputMessage {
   render(): VNode {
     const dir = getElementDir(this.el);
     const hidden = !this.active;
-    let iconEl = null;
-    if (this.icon && !this.requestedIcon) {
-      iconEl = this.renderIcon(this.iconDefaults[this.status]);
-    }
-    if (!!this.requestedIcon) {
-      iconEl = this.renderIcon(this.requestedIcon);
-    }
     return (
       <Host calcite-hydrated-hidden={hidden} dir={dir} theme={this.theme}>
-        {iconEl}
+        {this.renderIcon(this.requestedIcon)}
         <slot />
       </Host>
     );
@@ -83,7 +83,7 @@ export class CalciteInputMessage {
     idle: "information"
   };
 
-  /** the custom icon to render */
+  /** the computed icon to render */
   private requestedIcon?: string;
 
   //--------------------------------------------------------------------------
@@ -92,7 +92,9 @@ export class CalciteInputMessage {
   //
   //--------------------------------------------------------------------------
 
-  private renderIcon(iconName): VNode {
-    return <calcite-icon class="calcite-input-message-icon" icon={iconName} scale="s" />;
+  private renderIcon(iconName: string): VNode {
+    if (iconName) {
+      return <calcite-icon class="calcite-input-message-icon" icon={iconName} scale="s" />;
+    }
   }
 }

--- a/src/components/calcite-input-message/interfaces.ts
+++ b/src/components/calcite-input-message/interfaces.ts
@@ -1,1 +1,7 @@
 export type InputMessageType = "default" | "floating";
+
+export enum StatusIconDefaults {
+  valid = "check-circle",
+  invalid = "exclamation-mark-triangle",
+  idle = "information"
+}

--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -1,5 +1,5 @@
 import { select, text, number } from "@storybook/addon-knobs";
-import { boolean } from "../../../.storybook/helpers";
+import { boolean, iconNames } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { html } from "../../tests/utils";
@@ -83,7 +83,8 @@ export const WithLabelAndInputMessage = (): string => html`
       </calcite-input>
       <calcite-input-message
         ${boolean("active", true, "Input Message")}
-        ${boolean("icon", true, "Input Message")}
+        ${boolean("icon", false, "Input Message")}
+        icon="${select("icon", iconNames, "", "Input Message")}"
         type="${select("type", ["default", "floating"], "default", "Input Message")}"
         >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
       >

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -42,23 +42,6 @@
               <calcite-input value="My great value" prefix-text="pre" icon="banana" suffix-text="suf"> </calcite-input>
               <calcite-input-message icon active>Some information about the input</calcite-input-message>
             </calcite-label>
-            <calcite-label scale="s">
-              With input message 1
-              <calcite-input></calcite-input>
-              <calcite-input-message active>Default active input message, no icon</calcite-input-message>
-            </calcite-label>
-            <calcite-label scale="s">
-              With input message 2
-              <calcite-input value="Pumpkin Pie"></calcite-input>
-              <calcite-input-message icon active status="valid">Valid active input message with default status icon</calcite-input-message>
-              <calcite-input-message icon active status="invalid">Invalid active input message with default status icon</calcite-input-message>
-            </calcite-label>
-            <calcite-label scale="s" status="invalid">
-              With input message 3
-              <calcite-input></calcite-input>
-              <calcite-input-message icon="arcgis-online" active>Invalid status input message with custom icon</calcite-input-message>
-              <calcite-input-message icon="banana" active>Invalid status input message with custom icon</calcite-input-message>
-            </calcite-label>
 
             <calcite-label scale="m">
               Scale m
@@ -490,6 +473,42 @@
               <calcite-input type="tel" placeholder="Enter your cell phone"></calcite-input>
               <calcite-input-message icon active status="idle">This is where we'll call you</calcite-input-message>
             </calcite-label>
+            <calcite-card>
+              <div style="display:inline-flex; width: 100%; padding:var(--calcite-spacing-half) 0;">
+                <calcite-input-message icon active id="toggle-status">
+                  Input message + status icon
+                </calcite-input-message>
+                <calcite-button appearance="outline" color="blue" scale="s" round onclick="toggleStatus();">
+                  Toggle status
+                </calcite-button>
+              </div>
+              <div style="display:inline-flex; width: 100%; padding:var(--calcite-spacing-half) 0;">
+                <calcite-input-message icon active id="toggle-icon">
+                  Input message + custom icon
+                </calcite-input-message>
+                <calcite-button appearance="outline" color="red" scale="s" round onclick="toggleIcon();">
+                  Toggle icon
+                </calcite-button>
+              </div>
+              <script>
+                function toggleStatus() {
+                  let el = document.getElementById("toggle-status");
+                  if (el.status === "idle") {
+                    el.status = "invalid";
+                  } else if (el.status === "invalid") {
+                    el.status = "valid";
+                  } else {
+                    el.status = "idle";
+                  }
+                }
+                function toggleIcon() {
+                  let el = document.getElementById("toggle-icon");
+                  const iconOptions = ["banana","layer-basemap","arcgis-online","3d-glasses","add-layer","a-z"];
+                  let num = Math.floor(Math.random() * Math.floor(iconOptions.length));
+                  el.icon = iconOptions[num];
+                }
+              </script>
+            </calcite-card>
           </calcite-accordion-item>
 
           <calcite-accordion-item active item-title="Interactions with native elements">
@@ -527,7 +546,6 @@
             <calcite-label dir="rtl">
               Icon flip rtl not requested
               <calcite-input icon="camera" placeholder="Enter your cell phone"></calcite-input>
-              <calcite-input-message icon="upload" active>Please upload your image here</calcite-input-message>
             </calcite-label>
             <calcite-label dir="rtl">
               Icon flip rtl requested

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -966,7 +966,7 @@
                 <calcite-input id="validate-input-example-password-2" type="password" placeholder="•••••">
                 </calcite-input>
               </calcite-label>
-              <!-- <calcite-button width="full">Register</calcite-button> -->
+              <calcite-button width="full">Register</calcite-button>
             </form>
             <calcite-notice width="full" id="validate-input-example-focus-notice"> </calcite-notice>
             <calcite-notice width="full" id="validate-input-example-blur-notice"> </calcite-notice>

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -42,6 +42,23 @@
               <calcite-input value="My great value" prefix-text="pre" icon="banana" suffix-text="suf"> </calcite-input>
               <calcite-input-message icon active>Some information about the input</calcite-input-message>
             </calcite-label>
+            <calcite-label scale="s">
+              With input message 1
+              <calcite-input></calcite-input>
+              <calcite-input-message active>Default active input message, no icon</calcite-input-message>
+            </calcite-label>
+            <calcite-label scale="s">
+              With input message 2
+              <calcite-input value="Pumpkin Pie"></calcite-input>
+              <calcite-input-message icon active status="valid">Valid active input message with default status icon</calcite-input-message>
+              <calcite-input-message icon active status="invalid">Invalid active input message with default status icon</calcite-input-message>
+            </calcite-label>
+            <calcite-label scale="s" status="invalid">
+              With input message 3
+              <calcite-input></calcite-input>
+              <calcite-input-message icon="arcgis-online" active>Invalid status input message with custom icon</calcite-input-message>
+              <calcite-input-message icon="banana" active>Invalid status input message with custom icon</calcite-input-message>
+            </calcite-label>
 
             <calcite-label scale="m">
               Scale m
@@ -510,6 +527,7 @@
             <calcite-label dir="rtl">
               Icon flip rtl not requested
               <calcite-input icon="camera" placeholder="Enter your cell phone"></calcite-input>
+              <calcite-input-message icon="upload" active>Please upload your image here</calcite-input-message>
             </calcite-label>
             <calcite-label dir="rtl">
               Icon flip rtl requested
@@ -948,7 +966,7 @@
                 <calcite-input id="validate-input-example-password-2" type="password" placeholder="•••••">
                 </calcite-input>
               </calcite-label>
-              <calcite-button width="full">Register</calcite-button>
+              <!-- <calcite-button width="full">Register</calcite-button> -->
             </form>
             <calcite-notice width="full" id="validate-input-example-focus-notice"> </calcite-notice>
             <calcite-notice width="full" id="validate-input-example-blur-notice"> </calcite-notice>


### PR DESCRIPTION
**Related Issue:** #1330 

## Summary
Allows a custom icon to be passed, in addition to the status-based defaults.
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
