### PR TITLE
feat(color): allow setting color value format

### DIFF
--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -80,9 +80,20 @@ export class CalciteColor {
       return;
     }
 
-    const value = this.toValue(color);
+    this.value = this.toValue(color);
+  }
 
-    this.value = value;
+  /**
+   * The format of the value property.
+   *
+   * When "auto", the format will be inferred from `value` when set.
+   */
+  @Prop() format: "auto" | SupportedMode = "auto";
+
+  @Watch("format")
+  handleFormatChange(format: CalciteColor["format"]): void {
+    this.mode = format === "auto" ? this.mode : format;
+    this.value = this.toValue(this.color);
   }
 
   /** When true, hides the hex input */
@@ -194,14 +205,14 @@ export class CalciteColor {
 
   @Watch("value")
   handleValueChange(value: ColorValue | null, oldValue: ColorValue | null): void {
-    const { allowEmpty } = this;
+    const { allowEmpty, format } = this;
     const checkMode = !allowEmpty || value;
     let modeChanged = false;
 
     if (checkMode) {
       const nextMode = parseMode(value);
 
-      if (!nextMode) {
+      if (!nextMode || (format !== "auto" && nextMode !== format)) {
         console.warn(`ignoring invalid color value: ${value}`);
         this.value = oldValue;
         return;

--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -24,7 +24,7 @@ import {
   TEXT
 } from "./resources";
 import { focusElement, getElementDir } from "../../utils/dom";
-import { colorEqual, CSSColorMode, normalizeHex, parseMode, SupportedMode } from "./utils";
+import { colorEqual, CSSColorMode, Format, normalizeHex, parseMode, SupportedMode } from "./utils";
 import { throttle } from "lodash-es";
 import { getKey } from "../../utils/key";
 
@@ -88,7 +88,7 @@ export class CalciteColor {
    *
    * When "auto", the format will be inferred from `value` when set.
    */
-  @Prop() format: "auto" | SupportedMode = "auto";
+  @Prop() format: Format = "auto";
 
   @Watch("format")
   handleFormatChange(format: CalciteColor["format"]): void {

--- a/src/components/calcite-color/utils.ts
+++ b/src/components/calcite-color/utils.ts
@@ -63,25 +63,34 @@ export function hexToRGB(hex: string): RGB {
   return { r, g, b };
 }
 
-export enum CSSColorMode {
-  HEX = "hex",
-  HEXA = "hexa",
-  RGB_CSS = "rgb-css",
-  RGBA_CSS = "rgba-css",
-  HSL_CSS = "hsl-css",
-  HSLA_CSS = "hsla-css"
-}
+// these utils allow users to pass enum values as strings without having to access the enum
+// based on the approach suggested by https://github.com/microsoft/TypeScript/issues/17690#issuecomment-321365759,
+const enumify = <T extends { [index: string]: U }, U extends string>(x: T) => x;
+type Enumify<T> = T[keyof T];
 
-export enum ObjectColorMode {
-  RGB = "rgb",
-  RGBA = "rgba",
-  HSL = "hsl",
-  HSLA = "hsla",
-  HSV = "hsv",
-  HSVA = "hsva"
-}
+export const CSSColorMode = enumify({
+  HEX: "hex",
+  HEXA: "hexa",
+  RGB_CSS: "rgb-css",
+  RGBA_CSS: "rgba-css",
+  HSL_CSS: "hsl-css",
+  HSLA_CSS: "hsla-css"
+});
+type CSSColorMode = Enumify<typeof CSSColorMode>;
+
+export const ObjectColorMode = enumify({
+  RGB: "rgb",
+  RGBA: "rgba",
+  HSL: "hsl",
+  HSLA: "hsla",
+  HSV: "hsv",
+  HSVA: "hsva"
+});
+type ObjectColorMode = Enumify<typeof ObjectColorMode>;
 
 export type SupportedMode = CSSColorMode | ObjectColorMode;
+
+export type Format = "auto" | SupportedMode;
 
 export function parseMode(colorValue: ColorValue): SupportedMode | null {
   if (typeof colorValue === "string") {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Stems from https://github.com/Esri/calcite-components/issues/917#issuecomment-749238586. 

This will allow users to explicitly set the color format used by `value`. This is automatically inferred from `value` by default and preserved during color updates until a new value w/ different format is provided.

cc @pemberdom

### API 

```ts
interface CalciteColor {
  format: "auto" | "hex" | "rgb-css" | "hsl-css" | "rgb" | "hsl" | "hsv";
}
```

### Question

Are the following format names OK? They are currently the previously internal values. Is there an official name to distinguish a color object vs CSS value (e.g., RGB object vs RGB CSS string)?

* `hex`(string)
* `rgb-css`(string)
* `hsl-css`(string)
* `rgb`(object)
* `hsl`(object)
* `hsv`(object)