### PR TITLE
fix(modal): fix styling on mobile safari (#1412), use tailwind

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -12,7 +12,7 @@ describe("calcite-modal properties", () => {
   it("adds localized strings set via intl-* props", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal intl-close="test"></calcite-modal>`);
-    const button = await page.find("calcite-modal >>> .modal__close");
+    const button = await page.find("calcite-modal >>> .close");
     expect(button).toEqualAttribute("aria-label", "test");
   });
 
@@ -22,7 +22,7 @@ describe("calcite-modal properties", () => {
     const modal = await page.find("calcite-modal");
     modal.setProperty("disableCloseButton", true);
     await page.waitForChanges();
-    const closeButton = await page.find("calcite-modal >>> .modal__close");
+    const closeButton = await page.find("calcite-modal >>> .close");
     expect(closeButton).toBe(null);
   });
 
@@ -124,7 +124,7 @@ describe("calcite-modal accessibility checks", () => {
     await page.$eval(".btn-1", (elm) => ($button1 = elm));
     await page.$eval(".btn-2", (elm) => ($button2 = elm));
     await page.$eval("calcite-modal", (elm) => {
-      $close = elm.shadowRoot.querySelector(".modal__close");
+      $close = elm.shadowRoot.querySelector(".close");
     });
     await modal.setProperty("active", true);
     await page.waitForChanges();
@@ -197,7 +197,7 @@ describe("calcite-modal accessibility checks", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
-    const button = await page.find("calcite-modal >>> .modal__close");
+    const button = await page.find("calcite-modal >>> .close");
     await modal.setProperty("active", true);
     await page.waitForChanges();
     expect(modal).toHaveAttribute("is-active");
@@ -210,7 +210,7 @@ describe("calcite-modal accessibility checks", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal close-label="test"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
-    const button = await page.find("calcite-modal >>> .modal__close");
+    const button = await page.find("calcite-modal >>> .close");
     await modal.setProperty("active", true);
     await page.waitForChanges();
     expect(modal).toHaveAttribute("is-active");

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -1,133 +1,81 @@
 :host {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow-y: hidden;
-  color: var(--calcite-ui-text-2);
+  @apply fixed inset-0 flex justify-center items-center overflow-y-hidden text-color-2;
   opacity: 0;
   visibility: hidden !important;
   transition: visibility 0ms linear 300ms, opacity 300ms $easing-function;
   z-index: 101;
-  --calcite-modal-title-padding: 12px 16px;
-  --calcite-modal-title-text: 20px;
-  --calcite-modal-content-padding: 16px;
-  --calcite-modal-content-text: 16px;
-  --calcite-modal-close-padding: 12px;
-  --calcite-modal-footer-padding: 12px;
+  --calcite-modal-padding: theme("spacing.3");
+  --calcite-modal-padding-large: theme("spacing.4");
+  --calcite-modal-title-text: theme("fontSize.2");
+  --calcite-modal-content-text: theme("fontSize.0");
 }
 
 :host([scale="s"]) {
-  --calcite-modal-title-padding: 8px 12px;
-  --calcite-modal-title-text: 18px;
-  --calcite-modal-content-padding: 12px;
-  --calcite-modal-content-text: 14px;
-  --calcite-modal-close-padding: 8px;
-  --calcite-modal-footer-padding: 8px;
+  --calcite-modal-padding: theme("spacing.2");
+  --calcite-modal-padding-large: theme("spacing.3");
+  --calcite-modal-title-text: theme("fontSize.1");
+  --calcite-modal-content-text: theme("fontSize.-1");
 }
 
 :host([scale="l"]) {
-  --calcite-modal-title-padding: 16px 20px;
-  --calcite-modal-title-text: 26px;
-  --calcite-modal-content-padding: 20px;
-  --calcite-modal-content-text: 18px;
-  --calcite-modal-close-padding: 16px;
-  --calcite-modal-footer-padding: 16px;
+  --calcite-modal-padding: theme("spacing.4");
+  --calcite-modal-padding-large: theme("spacing.5");
+  --calcite-modal-title-text: theme("fontSize.3");
+  --calcite-modal-content-text: theme("fontSize.1");
 }
 
 .scrim {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  overflow-y: hidden;
+  @apply fixed inset-0 flex overflow-y-hidden;
 }
 
 .modal {
-  @apply shadow-2-sm;
-  box-sizing: border-box;
+  @apply flex flex-col shadow-2-sm box-border float-none m-6 rounded-1 bg-foreground-1 w-full;
   z-index: 102;
-  float: none;
-  text-align: left;
   -webkit-overflow-scrolling: touch;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: row-wrap;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition: transform 300ms $easing-function, visibility 0ms linear 300ms, opacity 300ms $easing-function;
   transform: translate3d(0, 20px, 0);
-  background-color: var(--calcite-ui-foreground-1);
-  border-radius: var(--calcite-border-radius);
-  margin: $baseline;
-  width: 100%;
-}
-
-// focus styles
-.modal__close {
-  @include focus-style-base();
-  &.modal__close:focus {
-    @include focus-style-inset();
-  }
 }
 
 :host([is-active]) {
+  @apply opacity-100;
   visibility: visible !important;
-  opacity: 1;
   transition-delay: 0ms;
   .modal {
-    pointer-events: auto;
-    visibility: visible;
-    opacity: 1;
-    transition-delay: 0ms;
+    @apply opacity-100 pointer-events-auto visible;
     transform: translate3d(0, 0, 0);
     transition: transform 300ms $easing-function, visibility 0ms linear, opacity 300ms $easing-function,
       max-width 300ms $easing-function, max-height 300ms $easing-function;
+    transition-delay: 0ms;
   }
-}
-
-:host([dir="rtl"]) .modal {
-  text-align: right;
 }
 
 /**
  * Header
  */
-.modal__header {
-  background-color: var(--calcite-ui-foreground-1);
+.header {
+  @apply flex max-w-full min-w-0 rounded-t-1 bg-foreground-1;
   flex: 0 0 auto;
-  display: flex;
-  max-width: 100%;
-  min-width: 0;
   z-index: 2;
-  border-bottom: 1px solid var(--calcite-ui-border-3);
-  border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
+  border-bottom: 1px solid theme("colors.border.3");
 }
 
-.modal__close {
-  padding: var(--calcite-modal-close-padding);
-  margin: 0;
-  order: 2;
+.close {
+  @apply m-0 appearance-none border-none text-color-1 order-2 cursor-pointer;
+  @include focus-style-base();
+  padding: var(--calcite-modal-padding);
   flex: 0 0 auto;
-  transition-delay: 300ms;
   transition: all 0.15s ease-in-out;
   background-color: transparent;
-  -webkit-appearance: none;
-  border: none;
-  color: var(--calcite-ui-text-1);
-  outline: none;
-  cursor: pointer;
   border-radius: 0 var(--calcite-border-radius) 0 0;
   calcite-icon {
     pointer-events: none;
     vertical-align: -2px;
+  }
+  &:focus {
+    @include focus-style-inset();
   }
   &:hover,
   &:focus {
@@ -138,44 +86,32 @@
   }
 }
 
-:host([dir="rtl"]) .modal__close {
+:host([dir="rtl"]) .close {
   border-radius: var(--calcite-border-radius) 0 0 0;
 }
 
-.modal__title {
-  display: flex;
-  align-items: center;
-  padding: var(--calcite-modal-title-padding);
+.title {
+  @apply flex items-center order-1 min-w-0;
   flex: 1 1 auto;
-  order: 1;
-  min-width: 0;
+  padding: var(--calcite-modal-padding) var(--calcite-modal-padding-large);
 }
 
 @include slotted("header", "*") {
-  margin: 0;
-  font-weight: 400;
+  @apply m-0 font-normal text-color-1;
   font-size: var(--calcite-modal-title-text);
-  color: var(--calcite-ui-text-1);
 }
 
 /**
  * Content area
  */
-.modal__content {
-  position: relative;
-  padding: 0;
-  height: 100%;
-  overflow: auto;
+.content {
+  @apply relative p-0 h-full overflow-auto block bg-foreground-1 box-border;
   max-height: calc(100vh - 12rem);
-  overflow-y: auto;
-  display: block;
-  background-color: var(--calcite-ui-foreground-1);
-  box-sizing: border-box;
   z-index: 1;
 }
 
-.modal__content--spaced {
-  padding: var(--calcite-modal-content-padding);
+.content--spaced {
+  padding: var(--calcite-modal-padding-large);
 }
 
 @include slotted("content", "*") {
@@ -184,50 +120,41 @@
 }
 
 :host([background-color="grey"]) {
-  .modal__content {
-    background-color: var(--calcite-ui-background);
+  .content {
+    @apply bg-background;
   }
 }
 
 /**
  * Footer
  */
-.modal__footer {
-  display: flex;
+.footer {
+  @apply flex justify-between mt-auto box-border rounded-b-1 w-full bg-foreground-1;
   flex: 0 0 auto;
-  justify-content: space-between;
-  padding: var(--calcite-modal-footer-padding);
-  margin-top: auto;
-  box-sizing: border-box;
-  border-radius: 0 0 var(--calcite-border-radius) var(--calcite-border-radius);
-  width: 100%;
-  background-color: var(--calcite-ui-foreground-1);
+  padding: var(--calcite-modal-padding);
   border-top: 1px solid var(--calcite-ui-border-3);
   z-index: 2;
 }
 
-.modal__footer--hide-back .modal__back,
-.modal__footer--hide-secondary .modal__secondary {
-  display: none;
+.footer--hide-back .back,
+.footer--hide-secondary .secondary {
+  @apply hidden;
 }
 
-.modal__back {
-  display: block;
-  margin-right: auto;
+.back {
+  @apply block mr-auto;
 }
 
-:host([dir="rtl"]) .modal__back {
-  margin-left: auto;
-  margin-right: unset;
+:host([dir="rtl"]) .back {
+  @apply ml-auto mr-0;
 }
 
-.modal__secondary {
-  display: block;
-  margin: 0 $baseline * 0.25;
+.secondary {
+  @apply block mx-1;
 }
 
 slot[name="primary"] {
-  display: block;
+  @apply block;
 }
 
 /**
@@ -242,30 +169,21 @@ slot[name="primary"] {
   @media screen and (max-width: $width + 2 * $baseline) {
     :host([width="#{$size}"]) {
       .modal {
-        height: 100%;
-        max-height: 100%;
-        width: 100%;
-        max-width: 100%;
-        margin: 0;
-        border-radius: 0;
+        @apply h-full max-h-full w-full max-w-full m-0 rounded-none;
       }
-      .modal__content {
+      .content {
         flex: 1 1 auto;
         max-height: unset;
       }
-      .modal__header,
-      .modal__footer {
-        flex: inherit;
-      }
     }
     :host([width="#{$size}"][docked]) {
-      align-items: flex-end;
+      @apply items-end;
     }
   }
 }
 
 :host([width="small"]) .modal {
-  width: auto;
+  @apply w-auto;
 }
 
 @include modal-size("s", 32rem);
@@ -278,20 +196,12 @@ slot[name="primary"] {
 :host([fullscreen]) {
   background-color: transparent;
   .modal {
+    @apply h-full max-h-full w-full max-w-full m-0;
     transform: translate3D(0, 20px, 0) scale(0.95);
-    height: 100%;
-    max-height: 100%;
-    width: 100%;
-    max-width: 100%;
-    margin: 0;
   }
-  .modal__content {
+  .content {
+    @apply max-h-full;
     flex: 1 1 auto;
-    max-height: 100%;
-  }
-  .modal__header,
-  .modal__footer {
-    flex: inherit;
   }
 }
 
@@ -299,10 +209,10 @@ slot[name="primary"] {
   .modal {
     transform: translate3D(0, 0, 0) scale(1);
   }
-  .modal__header {
+  .header {
     border-radius: 0;
   }
-  .modal__footer {
+  .footer {
     border-radius: 0;
   }
 }
@@ -312,10 +222,10 @@ slot[name="primary"] {
  */
 :host([docked]) {
   .modal {
-    height: auto !important;
+    @apply h-auto;
   }
-  .modal__content {
-    height: auto;
+  .content {
+    @apply h-auto;
     flex: 1 1 auto;
   }
   @media screen and (max-width: $viewport-medium) {
@@ -323,14 +233,14 @@ slot[name="primary"] {
       border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
     }
 
-    .modal__close {
+    .close {
       border-radius: 0 var(--calcite-border-radius) 0 0;
     }
   }
 }
 
 @media screen and (max-width: $viewport-medium) {
-  :host([docked][dir="rtl"]) .modal__close {
+  :host([docked][dir="rtl"]) .close {
     border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
   }
 }
@@ -352,8 +262,8 @@ slot[name="primary"] {
 
 :host([color="red"]),
 :host([color="blue"]) {
-  .modal__header {
-    border-radius: var(--calcite-border-radius);
+  .header {
+    @apply rounded-1;
   }
 }
 
@@ -362,20 +272,10 @@ slot[name="primary"] {
  */
 @media screen and (max-width: $viewport-medium) {
   @include slotted("header", "*") {
-    @include font-size(1);
+    @apply text-1;
   }
-  .modal__title {
-    padding: $baseline * 0.25 $baseline * 0.675;
-  }
-  .modal__close {
-    padding: 0.75rem;
-  }
-  .modal__content--spaced {
-    padding: $baseline * 0.675;
-  }
-  .modal__footer {
-    position: sticky;
-    bottom: 0;
+  .footer {
+    @apply sticky bottom-0;
   }
 }
 
@@ -383,12 +283,12 @@ slot[name="primary"] {
  * Mobile
  */
 @media screen and (max-width: $viewport-small) {
-  .modal__footer {
-    flex-direction: column;
+  .footer {
+    @apply flex-col;
   }
-  .modal__back,
-  .modal__secondary {
-    margin: 0;
-    margin-bottom: $baseline * 0.25;
+  :host([dir="rtl"]) .back,
+  .back,
+  .secondary {
+    @apply m-0 mb-1;
   }
 }

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -110,16 +110,16 @@ export class CalciteModal {
         {this.renderStyle()}
         <div class="modal">
           <div data-focus-fence="true" onFocus={this.focusLastElement} tabindex="0" />
-          <div class="modal__header">
+          <div class="header">
             {this.renderCloseButton()}
-            <header class="modal__title">
+            <header class="title">
               <slot name="header" />
             </header>
           </div>
           <div
             class={{
-              modal__content: true,
-              "modal__content--spaced": !this.noPadding
+              content: true,
+              "content--spaced": !this.noPadding
             }}
             ref={(el) => (this.modalContent = el)}
           >
@@ -134,14 +134,14 @@ export class CalciteModal {
 
   renderFooter(): VNode {
     return this.el.querySelector("[slot=back], [slot=secondary], [slot=primary]") ? (
-      <div class="modal__footer">
-        <span class="modal__back">
+      <div class="footer">
+        <span class="back">
           <slot name="back" />
         </span>
-        <span class="modal__secondary">
+        <span class="secondary">
           <slot name="secondary" />
         </span>
-        <span class="modal__primary">
+        <span class="primary">
           <slot name="primary" />
         </span>
       </div>
@@ -152,7 +152,7 @@ export class CalciteModal {
     return !this.disableCloseButton ? (
       <button
         aria-label={this.intlClose}
-        class="modal__close"
+        class="close"
         onClick={this.close}
         ref={(el) => (this.closeButtonEl = el)}
         title={this.intlClose}
@@ -179,13 +179,9 @@ export class CalciteModal {
             margin: 0;
             border-radius: 0;
           }
-          .modal__content {
+          .content {
             flex: 1 1 auto;
             max-height: unset;
-          }
-          .modal__header,
-          .modal__footer {
-            flex: inherit;
           }
         }
       `}


### PR DESCRIPTION
**Related Issue:** #1412

## Summary

The fix here is to avoid `flex: inherit` as mobile safari apparently can't handle that. 

I've also updated all the styles to use tailwind as I think the rule is "if you're in there, convert it"