### PR TITLE
fix(select): handle case where mutation observer fires before internal select is stored

### DIFF
--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -208,7 +208,7 @@ export class CalciteSelect {
     this.clearInternalSelect();
 
     optionsAndGroups.forEach((optionOrGroup) =>
-      this.selectEl.append(this.toNativeElement(optionOrGroup))
+      this.selectEl?.append(this.toNativeElement(optionOrGroup))
     );
   };
 


### PR DESCRIPTION
**Related Issue:** #1409 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This fixes an incorrect assumption made by the code where the mutation observer callback that updates the internal select would always fire **after** initial render and the ref to the internal select is set. This seems to happen when the component is used inside another VDOM engine (Ember, React, maquette).

I wasn't sure how to repro this error purely w/ the Stencil test tooling, so I created the following codepen that shows the issue: https://codepen.io/jcfranco-the-scripter/pen/poEVyxj?editors=0010. It uses maquette and you can see an exception in the console shortly after it loads and renders.