### PR TITLE
fix(radio-button): Add check for existing input before setting attribute

### DIFF
--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -247,7 +247,7 @@ export class CalciteRadioButton {
 
   private formResetHandler = (): void => {
     this.checked = this.initialChecked;
-    this.initialChecked && this.input && this.input.setAttribute("checked", "");
+    this.initialChecked && this.input?.setAttribute("checked", "");
   };
 
   private onInputBlur = (): void => {

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -247,7 +247,7 @@ export class CalciteRadioButton {
 
   private formResetHandler = (): void => {
     this.checked = this.initialChecked;
-    this.initialChecked && this.input.setAttribute("checked", "");
+    this.initialChecked && this.input && this.input.setAttribute("checked", "");
   };
 
   private onInputBlur = (): void => {


### PR DESCRIPTION
## Summary

I've been running into occasional errors when using the calcite-radio-button in React using beta.47. The internal input sometimes has been removed from the page before the formResetHandler runs, causing an error trying to call `setAttribute` on a non-existent input.

This is a defensive fix and may not be the best way to address it, but its easy and shouldn't introduce any other issues.