### PR TITLE
docs(storybook): add html preview tab

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,10 @@
 module.exports = {
-  addons: ["@storybook/addon-docs", "@storybook/addon-backgrounds", "@storybook/addon-knobs", "@storybook/addon-a11y"],
+  addons: [
+    "@storybook/addon-docs",
+    "@storybook/addon-backgrounds",
+    "@storybook/addon-knobs",
+    "@storybook/addon-a11y",
+    "@whitespace/storybook-addon-html"
+  ],
   stories: ["../src/**/*.stories.(mdx|ts)"]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7082,6 +7082,69 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@whitespace/storybook-addon-html": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-4.0.2.tgz",
+      "integrity": "sha512-JSRIj59UFVrgAsmqAbTqESMBFF5TnTxxsQGd4nPsPzIYz61s7whPs9iMjKWZIFLadN+FZiAubfD+PXU5srrVNg==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.12.10",
+        "@babel/parser": "^7.12.10",
+        "@storybook/api": "^6.1.10",
+        "@storybook/components": "^6.1.10",
+        "prettier": "^2.2.1",
+        "react-syntax-highlighter": "^15.4.3"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+          "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.11",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "react-syntax-highlighter": {
+          "version": "15.4.3",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.3.tgz",
+          "integrity": "sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "^10.4.1",
+            "lowlight": "^1.17.0",
+            "prismjs": "^1.22.0",
+            "refractor": "^3.2.0"
+          }
+        }
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/yargs": "15.0.12",
     "@typescript-eslint/eslint-plugin": "4.11.1",
     "@typescript-eslint/parser": "4.11.1",
+    "@whitespace/storybook-addon-html": "4.0.2",
     "autoprefixer": "10.1.0",
     "awesome-typescript-loader": "5.2.1",
     "axe-core": "4.1.1",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Sets up https://www.npmjs.com/package/@whitespace/storybook-addon-html to include an HTML-preview tab (next to `Knobs` and `Accessibility`). This would allow users to copy/paste component markup after customizing a story.

![Screen Shot 2021-01-06 at 2 39 21 PM](https://user-images.githubusercontent.com/197440/103830947-28514880-5030-11eb-92d9-69638467c6f3.png)
