### PR TITLE
build: move @stencil/core as a dependency for custom-elements output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4039,8 +4039,7 @@
     "@stencil/core": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.3.0.tgz",
-      "integrity": "sha512-VZ/Ox0E1kngcmHbJhHUufuLELi+xG3of3LuRI3X2AMWyE82JUVYlOEsQci/YBZWpfc9BS9I36R88prBew22oew==",
-      "dev": true
+      "integrity": "sha512-VZ/Ox0E1kngcmHbJhHUufuLELi+xG3of3LuRI3X2AMWyE82JUVYlOEsQci/YBZWpfc9BS9I36R88prBew22oew=="
     },
     "@stencil/eslint-plugin": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@popperjs/core": "2.6.0",
+    "@stencil/core": "2.3.0",
     "@types/color": "3.0.1"
   },
   "devDependencies": {
@@ -64,7 +65,6 @@
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "5.0.0",
     "@esri/calcite-ui-icons": "3.14.3",
-    "@stencil/core": "2.3.0",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "2.0.0",
     "@stencil/sass": "1.4.1",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Per [Stencil documentation](https://stenciljs.com/docs/custom-elements#distributing-custom-elements#:~:text=@stencil/core), this moves `@stencil/core` as a dependency for the `dist-custom-elements-bundle` output target. This will be useful for consumers that want to use a tree-shakeable bundle.