### PR TITLE
feat(combobox): single select mode

### DIFF
--- a/src/components/calcite-combobox-item/calcite-combobox-item.scss
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.scss
@@ -96,6 +96,28 @@ ul {
   padding-right: var(--calcite-combobox-item-indent-end-2);
 }
 
+.icon--custom {
+  margin-top: -1px;
+  @apply text-color-3;
+}
+
+.icon--active {
+  @apply text-color-1;
+}
+
+.icon--dot {
+  @apply flex justify-end;
+  width: var(--calcite-combobox-item-spacing-unit-l);
+}
+
+.icon--dot:before {
+  content: "\2022";
+}
+
+:host([dir="rtl"]) .icon--dot:before {
+  @apply text-right;
+}
+
 .label--active .icon {
   @apply opacity-100;
 }

--- a/src/components/calcite-combobox-item/calcite-combobox-item.scss
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.scss
@@ -123,7 +123,8 @@ ul {
 }
 
 .label--selected .icon {
-  @apply text-color-link opacity-100;
+  @apply opacity-100;
+  color: var(--calcite-ui-blue-1);
 }
 
 :host(:hover[disabled]) .icon {

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -40,6 +40,8 @@ export class CalciteComboboxItem {
 
   @Prop() guid: string = guid();
 
+  @Prop() icon?: string;
+
   @Watch("selected")
   selectedWatchHandler(newValue: boolean): void {
     this.isSelected = newValue;
@@ -143,11 +145,32 @@ export class CalciteComboboxItem {
   //
   // --------------------------------------------------------------------------
 
-  renderIcon(scale: string): VNode {
+  renderIcon(scale: string, isSingle: boolean): VNode {
     const level = `${CSS.icon}--indent-${this.getDepth()}`;
     const iconScale = scale !== "l" ? "s" : "m";
-    const iconPath = this.disabled ? "circle-disallowed" : "check";
-    return <calcite-icon class={`${CSS.icon} ${level}`} icon={iconPath} scale={iconScale} />;
+    const defaultIcon = isSingle ? "dot" : "check";
+    const iconPath = this.disabled ? "circle-disallowed" : defaultIcon;
+    const showDot = isSingle && !this.icon && !this.disabled;
+    return showDot ? (
+      <span
+        class={{
+          [CSS.icon]: true,
+          [CSS.dot]: true,
+          [level]: true
+        }}
+      />
+    ) : (
+      <calcite-icon
+        class={{
+          [CSS.icon]: !this.icon,
+          [CSS.custom]: !!this.icon,
+          [CSS.iconActive]: this.icon && this.isSelected,
+          [level]: true
+        }}
+        icon={this.icon || iconPath}
+        scale={iconScale}
+      />
+    );
   }
 
   renderChildren(): VNode {
@@ -162,12 +185,15 @@ export class CalciteComboboxItem {
   }
 
   render(): VNode {
+    const isSingleSelect = getElementProp(this.el, "selection-mode", "multi") === "single";
     const classes = {
       [CSS.label]: true,
       [CSS.selected]: this.isSelected,
-      [CSS.active]: this.active
+      [CSS.active]: this.active,
+      [CSS.single]: isSingleSelect
     };
     const scale = getElementProp(this.el, "scale", "m");
+
     const dir = getElementDir(this.el);
 
     return (
@@ -179,7 +205,7 @@ export class CalciteComboboxItem {
           ref={(el) => (this.comboboxItemEl = el as HTMLElement)}
           tabIndex={-1}
         >
-          {this.renderIcon(scale)}
+          {this.renderIcon(scale, isSingleSelect)}
           <span class={CSS.title}>{this.textLabel}</span>
         </li>
         {this.renderChildren()}

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -36,10 +36,13 @@ export class CalciteComboboxItem {
   /** True when item is highlighted either from keyboard or mouse hover */
   @Prop() active = false;
 
+  /** Parent and grandparent combobox items, this is set internally for use from combobox */
   @Prop({ mutable: true }) anscestors: HTMLCalciteComboboxItemElement[];
 
+  /** Unique identifier, used for accessibility */
   @Prop() guid: string = guid();
 
+  /** Custom icon to display both in combobox chips and next to combobox item text */
   @Prop() icon?: string;
 
   @Watch("selected")

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -149,11 +149,12 @@ export class CalciteComboboxItem {
   // --------------------------------------------------------------------------
 
   renderIcon(scale: string, isSingle: boolean): VNode {
+    const { icon, disabled, isSelected } = this;
     const level = `${CSS.icon}--indent-${this.getDepth()}`;
     const iconScale = scale !== "l" ? "s" : "m";
     const defaultIcon = isSingle ? "dot" : "check";
-    const iconPath = this.disabled ? "circle-disallowed" : defaultIcon;
-    const showDot = isSingle && !this.icon && !this.disabled;
+    const iconPath = disabled ? "circle-disallowed" : defaultIcon;
+    const showDot = isSingle && !icon && !disabled;
     return showDot ? (
       <span
         class={{
@@ -165,12 +166,12 @@ export class CalciteComboboxItem {
     ) : (
       <calcite-icon
         class={{
-          [CSS.icon]: !this.icon,
-          [CSS.custom]: !!this.icon,
-          [CSS.iconActive]: this.icon && this.isSelected,
+          [CSS.icon]: !icon,
+          [CSS.custom]: !!icon,
+          [CSS.iconActive]: icon && isSelected,
           [level]: true
         }}
-        icon={this.icon || iconPath}
+        icon={icon || iconPath}
         scale={iconScale}
       />
     );

--- a/src/components/calcite-combobox-item/resources.ts
+++ b/src/components/calcite-combobox-item/resources.ts
@@ -1,5 +1,9 @@
 export const CSS = {
   icon: "icon",
+  iconActive: "icon--active",
+  custom: "icon--custom",
+  dot: "icon--dot",
+  single: "label--single",
   label: "label",
   active: "label--active",
   selected: "label--selected",

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -327,4 +327,118 @@ describe("calcite-combobox", () => {
       expect(await item1.getProperty("selected")).toBe(true);
     });
   });
+
+  describe("single select", () => {
+    it("should allow selection of single item", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox selection-mode="single">
+            <calcite-combobox-item id="one" value="one" text-label="One"></calcite-combobox-item>
+            <calcite-combobox-item id="two" value="two" text-label="Two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          </calcite-combobox>
+        `
+      );
+      const chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeNull();
+
+      const input = await page.find("calcite-combobox >>> input");
+      const value = await input.getProperty("value");
+      expect(value).toBe("");
+      await input.click();
+
+      const container = await page.find("calcite-combobox >>> .popper-container");
+      let visible = await container.isVisible();
+      expect(visible).toBe(true);
+
+      const items = await page.findAll("calcite-combobox-item");
+      expect(items.length).toBe(3);
+
+      const item1 = await page.find("calcite-combobox-item[value=one]");
+      await item1.click();
+      await page.waitForChanges();
+      const label = await page.find("calcite-combobox >>> .label");
+      const labelVisible = await label.isVisible();
+      expect(labelVisible).toBe(true);
+      expect(label.textContent).toBe("One");
+
+      visible = await container.isVisible();
+      expect(visible).toBe(false);
+    });
+  });
+
+  describe("custom icons", () => {
+    it("should use icons if set on items", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox>
+            <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
+            <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          </calcite-combobox>
+        `
+      );
+      const chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeNull();
+
+      await page.keyboard.press("Tab");
+      await page.waitForChanges();
+
+      const items = await page.findAll("calcite-combobox-item");
+      await items[0].click();
+      await items[1].click();
+      await items[2].click();
+      await page.waitForChanges();
+
+      const chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      const icon1 = await chips[0].getProperty("icon");
+      const icon2 = await chips[1].getProperty("icon");
+      const icon3 = await chips[2].getProperty("icon");
+
+      expect(icon1).toBe("banana");
+      expect(icon2).toBe("beaker");
+      expect(icon3).toBeUndefined();
+    });
+
+    it("should use icon in single select", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox selection-mode="single">
+            <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
+            <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          </calcite-combobox>
+        `
+      );
+      const element = await page.find("calcite-combobox");
+      let selected = await page.find("calcite-combobox >>> .selected-icon");
+      expect(selected).toBeNull();
+
+      await element.click();
+      await page.waitForChanges();
+
+      const items = await page.findAll("calcite-combobox-item");
+      await items[0].click();
+
+      selected = await page.find("calcite-combobox >>> .selected-icon");
+      let icon = await selected.getProperty("icon");
+      expect(icon).toBe("banana");
+
+      await element.click();
+
+      await items[1].click();
+      selected = await page.find("calcite-combobox >>> .selected-icon");
+      icon = await selected.getProperty("icon");
+      expect(icon).toBe("beaker");
+
+      await element.click();
+
+      await items[2].click();
+      selected = await page.find("calcite-combobox >>> .selected-icon");
+      expect(selected).toBeNull();
+    });
+  });
 });

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -16,9 +16,7 @@
   --calcite-combobox-item-spacing-unit-l: theme("spacing.3");
   --calcite-combobox-item-spacing-unit-m: theme("spacing.2");
   --calcite-combobox-item-spacing-unit-s: theme("spacing.1");
-  .input {
-    @apply h-5 leading-5 mb-2;
-  }
+  --calcite-combobox-input-height: theme("spacing.5");
 }
 
 :host([scale="m"]) {
@@ -26,9 +24,7 @@
   --calcite-combobox-item-spacing-unit-l: theme("spacing.4");
   --calcite-combobox-item-spacing-unit-m: theme("spacing.3");
   --calcite-combobox-item-spacing-unit-s: theme("spacing.2");
-  .input {
-    @apply h-8 leading-8 mb-3;
-  }
+  --calcite-combobox-input-height: theme("spacing.8");
 }
 
 :host([scale="l"]) {
@@ -36,9 +32,7 @@
   --calcite-combobox-item-spacing-unit-l: theme("spacing.5");
   --calcite-combobox-item-spacing-unit-m: theme("spacing.4");
   --calcite-combobox-item-spacing-unit-s: theme("spacing.3");
-  .input {
-    @apply h-10 leading-10 mb-4;
-  }
+  --calcite-combobox-input-height: theme("spacing.10");
 }
 
 .wrapper {
@@ -56,6 +50,11 @@
   @include focus-style-inset();
 }
 
+.wrapper--single {
+  padding: var(--calcite-combobox-item-spacing-unit-s) var(--calcite-combobox-item-spacing-unit-m);
+  cursor: pointer;
+}
+
 .input {
   flex-grow: 1;
   font-size: inherit;
@@ -65,15 +64,64 @@
   border: none;
   color: var(--calcite-ui-text-1);
   appearance: none;
+  height: var(--calcite-combobox-input-height);
+  line-height: var(--calcite-combobox-input-height);
   min-width: 120px;
   margin-top: 1px;
+  margin-bottom: var(--calcite-combobox-item-spacing-unit-m);
   &:focus {
     outline: none;
   }
 }
 
-.input--hidden {
+.input--transparent {
   opacity: 0;
+}
+
+.input--single {
+  @apply mb-0 mt-0 cursor-pointer p-0;
+}
+
+.wrapper--active .input-single {
+  @apply cursor-text;
+}
+
+.input--hidden {
+  width: 0;
+  min-width: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.input--icon {
+  padding: 0 var(--calcite-combobox-item-spacing-unit-m);
+}
+
+.input-wrap {
+  display: flex;
+}
+
+.input-wrap--single {
+  flex: 1 1 auto;
+}
+
+.label {
+  height: var(--calcite-combobox-input-height);
+  line-height: var(--calcite-combobox-input-height);
+  padding: 0;
+  display: block;
+  flex: 1 1 auto;
+  pointer-events: none;
+}
+
+.label--spaced {
+  padding: 0 var(--calcite-combobox-item-spacing-unit-m);
+}
+
+.icon-end,
+.icon-start {
+  @apply cursor-pointer flex items-center;
+  width: var(--calcite-combobox-item-spacing-unit-l);
 }
 
 .popper-container {

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -20,6 +20,7 @@ export const Simple = (): string => html`
       label="demo combobox"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
+      selection-mode="${select("selection-mode", ["multi", "single"], "multi")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -47,10 +48,39 @@ export const Simple = (): string => html`
   </div>
 `;
 
+export const Single = (): string => html`
+  <div style="width:400px;max-width:100%;background-color:white;padding:100px"">
+    <calcite-combobox
+      label="demo combobox"
+      selection-mode="${select("selection-mode", ["multi", "single"], "single")}"
+      placeholder="${text("placeholder", "placeholder")}"
+      label="${text("label (for screen readers)", "demo")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      ${boolean("disabled", false)}
+      max-items="${number("max-items", 0)}"
+    >
+      <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude"></calcite-combobox-item>
+      <calcite-combobox-item icon="article" value="article" text-label="Article"></calcite-combobox-item>
+      <calcite-combobox-item icon="attachment" value="attachment" text-label="Attachment"></calcite-combobox-item>
+      <calcite-combobox-item icon="banana" value="banana" text-label="Banana"></calcite-combobox-item>
+      <calcite-combobox-item icon="battery" value="-battery" text-label="Batterycharging"></calcite-combobox-item>
+      <calcite-combobox-item icon="beaker" value="beaker" text-label="Beaker"></calcite-combobox-item>
+      <calcite-combobox-item icon="bell" value="bell" text-label="Bell"></calcite-combobox-item>
+      <calcite-combobox-item icon="bookmark" value="bookmark" text-label="Bookmark"></calcite-combobox-item>
+      <calcite-combobox-item icon="brightness" value="brightness" text-label="Brightness"></calcite-combobox-item>
+      <calcite-combobox-item icon="calendar" value="calendar" text-label="Calendar"></calcite-combobox-item>
+      <calcite-combobox-item icon="camera" value="camera" text-label="Camera"></calcite-combobox-item>
+      <calcite-combobox-item icon="car" value="car" text-label="Car"></calcite-combobox-item>
+      <calcite-combobox-item icon="clock" value="clock" text-label="Clock"></calcite-combobox-item>
+    </calcite-combobox>
+  </div>
+`;
+
 export const DarkTheme = (): string => html`
   <div style="width:400px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
       label="demo combobox"
+      selection-mode="${select("selection-mode", ["multi", "single"], "multi")}"
       theme="dark"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
@@ -90,6 +120,7 @@ export const Rtl = (): string => html`
     <calcite-combobox
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
+      selection-mode="${select("selection-mode", ["multi", "single"], "multi")}"
       dir="rtl"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -626,7 +626,7 @@ export class CalciteCombobox {
   }
 
   renderInput(): VNode {
-    const { active, disabled, placeholder, selectionMode, needsIcon } = this;
+    const { active, disabled, placeholder, selectionMode, needsIcon, label } = this;
     const single = selectionMode === "single";
     const showLabel = !active && single && !!this.selectedItem;
     return (
@@ -653,6 +653,7 @@ export class CalciteCombobox {
           aria-activedescendant={this.activeDescendant}
           aria-autocomplete="list"
           aria-controls={guid}
+          aria-label={label}
           class={{
             input: true,
             "input--transparent": this.activeChipIndex > -1,

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -21,6 +21,7 @@ import { createPopper, updatePopper, CSS as PopperCSS } from "../../utils/popper
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale, Theme } from "../interfaces";
+import { ComboboxSelectionMode } from "./interfaces";
 
 const COMBO_BOX_ITEM = "calcite-combobox-item";
 
@@ -71,6 +72,9 @@ export class CalciteCombobox {
 
   /** Allow entry of custom values which are not in the original set of items */
   @Prop() allowCustomValues: boolean;
+
+  /** specify the selection mode - multi (allow any number of selected items), single (only one selction), defaults to multi */
+  @Prop({ reflect: true }) selectionMode: ComboboxSelectionMode = "multi";
 
   /** Specify the scale of the combobox, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -158,7 +162,7 @@ export class CalciteCombobox {
       case "Backspace":
         if (this.activeChipIndex > -1) {
           this.removeActiveChip();
-        } else if (!this.text) {
+        } else if (!this.text && this.selectionMode === "multi") {
           this.removeLastChip();
         }
         break;
@@ -251,7 +255,11 @@ export class CalciteCombobox {
 
   @State() selectedItems: HTMLCalciteComboboxItemElement[] = [];
 
+  @State() selectedItem: HTMLCalciteComboboxItemElement;
+
   @State() visibleItems: HTMLCalciteComboboxItemElement[] = [];
+
+  @State() needsIcon: boolean;
 
   @State() activeItemIndex = -1;
 
@@ -296,6 +304,13 @@ export class CalciteCombobox {
   setInactiveIfNotContained = (target: HTMLElement): void => {
     if (!this.active || this.el.contains(target)) {
       return;
+    }
+
+    if (this.selectionMode === "single") {
+      this.textInput.value = "";
+      this.text = "";
+      this.filterItems("");
+      this.updateActiveItemIndex(-1);
     }
 
     this.active = false;
@@ -404,12 +419,25 @@ export class CalciteCombobox {
   }, 100);
 
   toggleSelection(item: HTMLCalciteComboboxItemElement, value = !item.selected): void {
-    item.selected = value;
-    this.selectedItems = this.getSelectedItems();
-    this.calciteLookupChange.emit(this.selectedItems);
-    this.resetText();
-    this.textInput.focus();
-    this.filterItems("");
+    if (this.selectionMode === "multi") {
+      item.selected = value;
+      this.selectedItems = this.getSelectedItems();
+      this.calciteLookupChange.emit(this.selectedItems);
+      this.resetText();
+      this.textInput.focus();
+      this.filterItems("");
+    } else {
+      this.items.forEach((el) => {
+        el.toggleSelected(false);
+      });
+      item.toggleSelected(true);
+      this.selectedItem = item;
+      this.textInput.value = item.textLabel;
+      this.active = false;
+      this.updateActiveItemIndex(-1);
+      this.resetText();
+      this.filterItems("");
+    }
   }
 
   getVisibleItems(): HTMLCalciteComboboxItemElement[] {
@@ -437,6 +465,11 @@ export class CalciteCombobox {
     this.data = this.getData();
     this.selectedItems = this.getSelectedItems();
     this.visibleItems = this.getVisibleItems();
+    this.needsIcon = this.getNeedsIcon();
+    if (this.selectionMode === "single" && this.selectedItems.length) {
+      const item = this.selectedItems[0];
+      this.selectedItem = item;
+    }
   };
 
   getData(): ItemData[] {
@@ -445,6 +478,10 @@ export class CalciteCombobox {
       label: item.textLabel,
       guid: item.guid
     }));
+  }
+
+  getNeedsIcon(): boolean {
+    return this.selectionMode === "single" && this.items.some((item) => item.icon);
   }
 
   resetText(): void {
@@ -553,6 +590,7 @@ export class CalciteCombobox {
 
   comboboxFocusHandler = (): void => {
     this.active = true;
+    this.textInput.focus();
   };
 
   comboboxBlurHandler = (event: FocusEvent): void => {
@@ -575,6 +613,7 @@ export class CalciteCombobox {
           class={chipClasses}
           dismissLabel={"remove tag"}
           dismissible
+          icon={item.icon}
           id={`chip-${item.guid}`}
           key={item.value}
           scale={scale}
@@ -586,10 +625,59 @@ export class CalciteCombobox {
     });
   }
 
+  renderInput(): VNode {
+    const { active, disabled, placeholder, selectionMode, needsIcon } = this;
+    const single = selectionMode === "single";
+    const showLabel = !active && single && !!this.selectedItem;
+    return (
+      <span
+        class={{
+          "input-wrap": true,
+          "input-wrap--single": single
+        }}
+      >
+        {showLabel && (
+          <span
+            class={{
+              label: true,
+              "label--spaced": needsIcon
+            }}
+            key="label"
+            onFocus={this.comboboxFocusHandler}
+            tabindex="0"
+          >
+            {this.selectedItem.textLabel}
+          </span>
+        )}
+        <input
+          aria-activedescendant={this.activeDescendant}
+          aria-autocomplete="list"
+          aria-controls={guid}
+          class={{
+            input: true,
+            "input--transparent": this.activeChipIndex > -1,
+            "input--single": single,
+            "input--hidden": showLabel,
+            "input--icon": single && needsIcon
+          }}
+          disabled={disabled}
+          id={`${guid}-input`}
+          key="input"
+          onBlur={this.comboboxBlurHandler}
+          onFocus={this.comboboxFocusHandler}
+          onInput={this.inputHandler}
+          placeholder={placeholder}
+          ref={(el) => (this.textInput = el as HTMLInputElement)}
+          type="text"
+        />
+      </span>
+    );
+  }
+
   renderListBoxOptions(): VNode[] {
     return this.visibleItems.map((item) => (
       <li aria-selected={(!!item.selected).toString()} id={item.guid} role="option" tabindex="-1">
-        {item.value}
+        {item.textLabel || item.value}
       </li>
     ));
   }
@@ -615,8 +703,35 @@ export class CalciteCombobox {
     );
   }
 
+  renderIconStart(): VNode {
+    const { selectionMode, needsIcon, selectedItem } = this;
+    const scale = this.scale === "l" ? "m" : "s";
+    return (
+      selectionMode === "single" &&
+      needsIcon && (
+        <span class="icon-start">
+          {selectedItem?.icon && (
+            <calcite-icon class="selected-icon" icon={selectedItem?.icon} scale={scale} />
+          )}
+        </span>
+      )
+    );
+  }
+
+  renderIconEnd(): VNode {
+    const scale = this.scale === "l" ? "m" : "s";
+    return (
+      this.selectionMode === "single" && (
+        <span class="icon-end">
+          <calcite-icon icon="chevron-down" scale={scale} />
+        </span>
+      )
+    );
+  }
+
   render(): VNode {
-    const { guid, active, disabled, el, label, placeholder } = this;
+    const { guid, active, el, label } = this;
+    const single = this.selectionMode === "single";
     const dir = getElementDir(el);
     const labelId = `${guid}-label`;
     return (
@@ -627,29 +742,22 @@ export class CalciteCombobox {
           aria-haspopup="listbox"
           aria-labelledby={labelId}
           aria-owns={guid}
-          class={{ wrapper: true, "wrapper--active": active }}
+          class={{
+            wrapper: true,
+            "wrapper--active": active,
+            "wrapper--single": single
+          }}
           onClick={() => this.setFocus()}
           ref={this.setReferenceEl}
           role="combobox"
         >
-          {this.renderChips()}
+          {this.renderIconStart()}
+          {!single && this.renderChips()}
           <label class="screen-readers-only" htmlFor={`${guid}-input`} id={labelId}>
             {label}
           </label>
-          <input
-            aria-activedescendant={this.activeDescendant}
-            aria-autocomplete="list"
-            aria-controls={guid}
-            class={{ input: true, "input--hidden": this.activeChipIndex > -1 }}
-            disabled={disabled}
-            id={`${guid}-input`}
-            onBlur={this.comboboxBlurHandler}
-            onFocus={this.comboboxFocusHandler}
-            onInput={this.inputHandler}
-            placeholder={placeholder}
-            ref={(el) => (this.textInput = el as HTMLInputElement)}
-            type="text"
-          />
+          {this.renderInput()}
+          {this.renderIconEnd()}
         </div>
         <ul
           aria-labelledby={labelId}

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -427,9 +427,7 @@ export class CalciteCombobox {
       this.textInput.focus();
       this.filterItems("");
     } else {
-      this.items.forEach((el) => {
-        el.toggleSelected(false);
-      });
+      this.items.forEach((el) => el.toggleSelected(false));
       item.toggleSelected(true);
       this.selectedItem = item;
       this.textInput.value = item.textLabel;
@@ -467,8 +465,7 @@ export class CalciteCombobox {
     this.visibleItems = this.getVisibleItems();
     this.needsIcon = this.getNeedsIcon();
     if (this.selectionMode === "single" && this.selectedItems.length) {
-      const item = this.selectedItems[0];
-      this.selectedItem = item;
+      this.selectedItem = this.selectedItems[0];
     }
   };
 

--- a/src/components/calcite-combobox/interfaces.ts
+++ b/src/components/calcite-combobox/interfaces.ts
@@ -2,3 +2,5 @@ export interface listItem {
   label: string;
   value: string;
 }
+
+export type ComboboxSelectionMode = "single" | "multi";

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -50,9 +50,60 @@
     <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
   </calcite-combobox>
 
+  <h2>Single Select</h2>
+  <calcite-combobox label="test" placeholder="select element" max-items="6" selection-mode="single">
+    <calcite-combobox-item value="Trees" text-label="Trees">
+      <calcite-combobox-item value="Pine" text-label="Pine">
+        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+    </calcite-combobox-item>
+    <calcite-combobox-item value="Flowers" text-label="Flowers">
+      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+      <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+    </calcite-combobox-item>
+    <calcite-combobox-item value="Animals" text-label="Animals">
+      <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+      <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+      <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+    </calcite-combobox-item>
+    <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+    <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+    <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+  </calcite-combobox>
+
+  <h2>Single Select with Custom Icons</h2>
+  <calcite-combobox label="test" placeholder="select folder" max-items="6" selection-mode="single">
+    <calcite-combobox-item value="root" text-label="username" icon="home" selected></calcite-combobox-item>
+    <calcite-combobox-item value="1" text-label="Folder 1" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="2" text-label="Folder 2" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="3" text-label="Folder 3" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="4" text-label="Folder 4" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="5" text-label="Folder 5" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="6" text-label="Folder 6" icon="folder"></calcite-combobox-item>
+  </calcite-combobox>
+
+  <h2>Multi Select with Custom Icons</h2>
+  <calcite-combobox label="test" placeholder="select attribute" max-items="6">
+    <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude"></calcite-combobox-item>
+    <calcite-combobox-item icon="article" value="article" text-label="Article"></calcite-combobox-item>
+    <calcite-combobox-item icon="attachment" value="attachment" text-label="Attachment"></calcite-combobox-item>
+    <calcite-combobox-item icon="banana" value="banana" text-label="Banana"></calcite-combobox-item>
+    <calcite-combobox-item icon="beaker" value="beaker" text-label="Beaker"></calcite-combobox-item>
+    <calcite-combobox-item icon="bell" value="bell" text-label="Bell"></calcite-combobox-item>
+    <calcite-combobox-item icon="bookmark" value="bookmark" text-label="Bookmark"></calcite-combobox-item>
+    <calcite-combobox-item icon="brightness" value="brightness" text-label="Brightness"></calcite-combobox-item>
+    <calcite-combobox-item icon="calendar" value="calendar" text-label="Calendar"></calcite-combobox-item>
+    <calcite-combobox-item icon="camera" value="camera" text-label="Camera"></calcite-combobox-item>
+    <calcite-combobox-item icon="car" value="car" text-label="Car"></calcite-combobox-item>
+    <calcite-combobox-item icon="clock" value="clock" text-label="Clock"></calcite-combobox-item>
+  </calcite-combobox>
+
   <h2>Custom Values</h2>
   <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
-    <calcite-combobox-item value="Trees" text-label="Trees">
+    <calcite-combobox-item value="Trees" text-label="Trees" selected>
       <calcite-combobox-item value="Pine" text-label="Pine">
         <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
       </calcite-combobox-item>


### PR DESCRIPTION
## Summary

Adds the ability to select only one item in a combobox at a time. This allows creating nested, single-select workflows from a hierarchy or a flat list:

![Screen Shot 2021-01-27 at 3 10 43 PM](https://user-images.githubusercontent.com/1031758/106066539-d8572600-60b1-11eb-8150-3c056ef41b97.png)

![Screen Shot 2021-01-27 at 3 11 16 PM](https://user-images.githubusercontent.com/1031758/106066588-eefd7d00-60b1-11eb-8fc5-a6e79d22431f.png)

It's a common use case whenever there is a 1to1 relationship (ex. what family/genus/species/ is this animal in? what region/department  is this employee in? etc). This could also be used in lieu of a datalist (#1143) as it provides a search field with filtered options. Possibly could be used in the use case from #925 as well (known list, with search, allow selection).

Specific need from team is for a folder-selection UI. So I've included examples for that as well.

