### PR TITLE
fix(deps): move runtime deps to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,7 @@
     "@a11y/focus-trap": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
-      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==",
-      "dev": true
+      "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -12014,7 +12013,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
       "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.4"
@@ -12024,7 +12022,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -12032,14 +12029,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
       "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -27321,7 +27316,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -27329,8 +27323,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -27579,8 +27572,7 @@
     "sortablejs": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.13.0.tgz",
-      "integrity": "sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg==",
-      "dev": true
+      "integrity": "sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg=="
     },
     "source-list-map": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -56,12 +56,14 @@
     "url": "git+https://github.com/Esri/calcite-components.git"
   },
   "dependencies": {
+    "@a11y/focus-trap": "1.0.5",
     "@popperjs/core": "2.6.0",
     "@stencil/core": "2.4.0",
-    "@types/color": "3.0.1"
+    "@types/color": "3.0.1",
+    "color": "3.1.3",
+    "sortablejs": "1.13.0"
   },
   "devDependencies": {
-    "@a11y/focus-trap": "1.0.5",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "5.0.0",
     "@esri/calcite-ui-icons": "3.14.3",
@@ -98,7 +100,6 @@
     "babel-loader": "8.2.2",
     "chalk": "4.1.0",
     "chokidar": "3.5.1",
-    "color": "3.1.3",
     "concurrently": "5.3.0",
     "cpy-cli": "^3.1.1",
     "dedent": "0.7.0",
@@ -122,7 +123,6 @@
     "rimraf": "3.0.2",
     "screener-storybook": "0.21.0",
     "semver": "7.3.4",
-    "sortablejs": "1.13.0",
     "standard-version": "9.1.0",
     "storybook": "6.1.15",
     "stylelint": "13.9.0",


### PR DESCRIPTION
**Related Issue:** #1479

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This moves runtime deps installed as devDependencies as dependencies. This would cause other Stencil builds to fail as they couldn't resolve the dependencies and would force users to install these themselves.

cc @subgan82