### PR TITLE
fix(date-picker, input-date-picker): fix missing range color, update demos

### DIFF
--- a/src/components/calcite-date-picker-day/calcite-date-picker-day.scss
+++ b/src/components/calcite-date-picker-day/calcite-date-picker-day.scss
@@ -4,6 +4,7 @@
 }
 
 :host {
+  --calcite-ui-foreground-current: #c7eaff;
   display: flex;
   justify-content: center;
   outline: none;

--- a/src/components/calcite-date-picker/calcite-date-picker.scss
+++ b/src/components/calcite-date-picker/calcite-date-picker.scss
@@ -24,15 +24,3 @@
 :host([scale="l"]) {
   max-width: 398px;
 }
-
-:host([scale="s"][range]:not([layout="vertical"])) {
-  max-width: 462px;
-}
-
-:host([scale="m"][range]:not([layout="vertical"])) {
-  max-width: 596px;
-}
-
-:host([scale="l"][range]:not([layout="vertical"])) {
-  max-width: 820px;
-}

--- a/src/demos/calcite-input-date-picker.html
+++ b/src/demos/calcite-input-date-picker.html
@@ -27,7 +27,7 @@
   <h1>Calcite Date Picker</h1>
 
   <h2>Standard</h2>
-  <calcite-input-date-picker id="basic-date-picker" active>-picker</calcite-input-date-picker>
+  <calcite-input-date-picker id="basic-date-picker">-picker</calcite-input-date-picker>
 
   <script>
     var picker = document.getElementById("basic-date-picker");
@@ -46,13 +46,13 @@
   <h2>Scales</h2>
 
   <h3>Small</h3>
-  <calcite-input-date-picker scale="s" value="2000-11-27" active></calcite-input-date-picker>
+  <calcite-input-date-picker scale="s" value="2000-11-27"></calcite-input-date-picker>
 
   <h3>Medium</h3>
-  <calcite-input-date-picker scale="m" value="2000-11-27" active></calcite-input-date-picker>
+  <calcite-input-date-picker scale="m" value="2000-11-27"></calcite-input-date-picker>
 
   <h3>Large</h3>
-  <calcite-input-date-picker scale="l" value="2000-11-27" active></calcite-input-date-picker>
+  <calcite-input-date-picker scale="l" value="2000-11-27"></calcite-input-date-picker>
 
   <h2>Inside Small Container</h2>
   <div style="width: 200px">


### PR DESCRIPTION

## Summary

Several style issues from the date refactor. The demos were all `active` on page load which was causing issues, so removed that as well.

Also replaced a CSS variable that's no longer there (I think it was removed after the style/tailwind refactor?). We will need a more permanent solution as this color will not automatically change if a dev uses a custom theme color for `brand`. We can do that in a follow up pr. This at least gets it working again.

  