### PR TITLE
fix(date-picker): Don't emit range change events on outside prop edits (#1484)

### DIFF
--- a/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
@@ -55,6 +55,16 @@ describe("calcite-date-picker", () => {
     expect(changedEvent).toHaveReceivedEventTimes(0);
   });
 
+  it("doesn't fire calciteDatePickerRangeChange on outside changes to start/end", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-date-picker range start='2000-11-27' start='2000-11-29'></calcite-date-picker>");
+    const date = await page.find("calcite-date-picker");
+    const changedEvent = await page.spyOnEvent("calciteDatePickerRangeChange");
+    expect(changedEvent).toHaveReceivedEventTimes(0);
+    await date.setProperty("start", "2001-10-28");
+    expect(changedEvent).toHaveReceivedEventTimes(0);
+  });
+
   it("fires calciteDatePickerRangeChange event on change", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-date-picker range start="2020-09-08" end="2020-09-23"></calcite-date-picker>`);
@@ -80,7 +90,7 @@ describe("calcite-date-picker", () => {
     await page.waitForChanges();
     await page.keyboard.press("Space");
     await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(2);
+    expect(changedEvent).toHaveReceivedEventTimes(1);
   });
 
   describe("when the locale is set to Slovak calendar", () => {

--- a/src/components/calcite-date-picker/calcite-date-picker.tsx
+++ b/src/components/calcite-date-picker/calcite-date-picker.tsx
@@ -68,11 +68,6 @@ export class CalciteDatePicker {
 
     this.activeEndDate = endDate;
     this.activeStartDate = startDate;
-
-    this.calciteDatePickerRangeChange.emit({
-      startDate,
-      endDate
-    });
   }
 
   /** Earliest allowed date ("yyyy-mm-dd") */
@@ -383,17 +378,29 @@ export class CalciteDatePicker {
   /**
    * Update date instance of start if valid
    */
-  private setStartAsDate(startDate: Date): void {
+  private setStartAsDate(startDate: Date, emit?: boolean): void {
     this.startAsDate = startDate;
     this.mostRecentRangeValue = this.startAsDate;
+    if (emit) {
+      this.calciteDatePickerRangeChange.emit({
+        startDate,
+        endDate: this.endAsDate
+      });
+    }
   }
 
   /**
    * Update date instance of end if valid
    */
-  private setEndAsDate(endDate: Date): void {
+  private setEndAsDate(endDate: Date, emit?: boolean): void {
     this.endAsDate = endDate;
     this.mostRecentRangeValue = this.endAsDate;
+    if (emit) {
+      this.calciteDatePickerRangeChange.emit({
+        startDate: this.startAsDate,
+        endDate
+      });
+    }
   }
 
   /**
@@ -426,15 +433,15 @@ export class CalciteDatePicker {
       if (this.startAsDate) {
         const newEndDate = new Date(this.startAsDate);
         this.end = dateToISO(newEndDate);
-        this.setEndAsDate(newEndDate);
+        this.setEndAsDate(newEndDate, true);
         this.activeEndDate = newEndDate;
       }
       this.start = dateToISO(date);
-      this.setStartAsDate(date);
+      this.setStartAsDate(date, true);
       this.activeStartDate = date;
     } else if (!this.endAsDate) {
       this.end = dateToISO(date);
-      this.setEndAsDate(date);
+      this.setEndAsDate(date, true);
       this.activeEndDate = date;
     } else {
       if (!this.proximitySelectionDisabled) {
@@ -442,16 +449,16 @@ export class CalciteDatePicker {
         const endDiff = getDaysDiff(date, this.endAsDate);
         if (startDiff < endDiff) {
           this.start = dateToISO(date);
-          this.setStartAsDate(date);
+          this.setStartAsDate(date, true);
           this.activeStartDate = date;
         } else {
           this.end = dateToISO(date);
-          this.setEndAsDate(date);
+          this.setEndAsDate(date, true);
           this.activeEndDate = date;
         }
       } else {
         this.start = dateToISO(date);
-        this.setStartAsDate(date);
+        this.setStartAsDate(date, true);
         this.activeStartDate = date;
         this.endAsDate = this.activeEndDate = this.end = undefined;
       }

--- a/src/demos/calcite-date-picker.html
+++ b/src/demos/calcite-date-picker.html
@@ -152,10 +152,10 @@
 <h2>Date Range with Event</h2>
 <calcite-date-picker id="dateRangeSample" range start="2020-09-08" end="2020-09-23"></calcite-date-picker>
 <div>
-  Start: <span id="startDisplay"></span>
+  Start: <span id="startDisplay">Unchanged</span>
 </div>
 <div>
-  End: <span id="endDisplay"></span>
+  End: <span id="endDisplay">Unchanged</span>
 </div>
 <script>
   var dateRangeSample = document.getElementById("dateRangeSample");


### PR DESCRIPTION


**Related Issue:** #1484

## Summary

We were emitting an a range change event in the date anytime the start or end changed. On the surface this makes sense, but in react/preact/vue this can cause really unpredictable bugs. Consider the following fake react code:

```jsx
<calcite-date-picker range start={state.start} end={state.end} onCalciteDateRangeChange={this.setStartEnd} />
```

When the component is controlled like this, you could cause a render loop because:

```txt
                        your event handler updates state 
                       ⇗                                ⇘
prop change fires event handler           ⟸            state updates props

```

Events should only be fired on changes that happen from user interaction, not prop changes ("props down events up"). 

