### PR TITLE
fix(deps): move runtime deps to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21397,8 +21397,7 @@
     "lodash-es": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
-      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==",
-      "dev": true
+      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@stencil/core": "2.4.0",
     "@types/color": "3.0.1",
     "color": "3.1.3",
+    "lodash-es": "4.17.20",
     "sortablejs": "1.13.0"
   },
   "devDependencies": {
@@ -115,7 +116,6 @@
     "jest-axe": "4.1.0",
     "jest-cli": "26.6.3",
     "lint-staged": "10.5.3",
-    "lodash-es": "4.17.20",
     "pify": "5.0.0",
     "posthtml": "0.15.1",
     "prettier": "2.2.1",


### PR DESCRIPTION
**Related Issue:** #1479 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Moves missed dependency from https://github.com/Esri/calcite-components/pull/1492. This would cause other Stencil builds to fail as they couldn't resolve the dependencies and would force users to install these themselves.

cc @subgan82

Thanks, @ffaubry!