### PR TITLE
fix(calcite-shell): Remove padding in the calcite-shell footer slot

### DIFF
--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -65,7 +65,3 @@
   right: var(--calcite-shell-tip-spacing);
   z-index: 2;
 }
-
-.footer {
-  padding: var(--calcite-spacing-half) var(--calcite-spacing);
-}


### PR DESCRIPTION
**Related Issue:** #1502

## Summary
Remove padding
<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
