### PR TITLE
chore(input, slider): add change events and deprecate update ones

### DIFF
--- a/conventions/README.md
+++ b/conventions/README.md
@@ -241,6 +241,7 @@ Event names should be treated like global variables since they can collide with 
   - Bad: `change`
   - Good: `calciteTabChange`
 - If an existing event can be listened to, don't create a new custom event. For example, there is no need to create a `calciteButtonClick` event because a standard `click` event will still be fired from the element.
+- For consistency, use `calcite<ComponentName>Change` for value change events.
 
 **Discussed In:**
 

--- a/src/components/calcite-pagination/calcite-pagination.e2e.ts
+++ b/src/components/calcite-pagination/calcite-pagination.e2e.ts
@@ -50,7 +50,7 @@ describe("calcite-pagination", () => {
       pagination = await page.find("calcite-pagination");
     });
     it("next button should increase selected page by 1 when clicked", async () => {
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const nextButton = await page.find(`calcite-pagination >>> .${CSS.next}`);
       await nextButton.click();
       await page.waitForChanges();
@@ -60,7 +60,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(1);
     });
     it("previous button should be disabled when selected page equals the starting page", async () => {
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const previousButton = await page.find(`calcite-pagination >>> .${CSS.previous}`);
       await previousButton.click();
       await page.waitForChanges();
@@ -71,7 +71,7 @@ describe("calcite-pagination", () => {
       await pagination.setAttribute("start", "21");
       await page.waitForChanges();
 
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const previousButton = await page.find(`calcite-pagination >>> .${CSS.previous}`);
       await previousButton.click();
       await page.waitForChanges();
@@ -84,7 +84,7 @@ describe("calcite-pagination", () => {
       await pagination.setAttribute("start", "121");
       await page.waitForChanges();
 
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const nextButton = await page.find(`calcite-pagination >>> .${CSS.next}`);
       await nextButton.click();
       await page.waitForChanges();
@@ -97,7 +97,7 @@ describe("calcite-pagination", () => {
       await pagination.setAttribute("start", "1");
       await page.waitForChanges();
 
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const nextButton = await page.find(`calcite-pagination >>> .${CSS.next}`);
       await nextButton.click();
       await page.waitForChanges();
@@ -109,10 +109,10 @@ describe("calcite-pagination", () => {
     it("should switch selected page to the page that's clicked", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-pagination start="1" total="36" num="10"></calcite-pagination>`);
-      const toggleSpy = await page.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await page.spyOnEvent("calcitePaginationChange");
 
       await page.evaluate(() => {
-        document.addEventListener("calcitePaginationUpdate", (event: CustomEvent): void => {
+        document.addEventListener("calcitePaginationChange", (event: CustomEvent): void => {
           (window as any).eventDetail = event.detail;
         });
       });
@@ -160,7 +160,7 @@ describe("calcite-pagination", () => {
       expect(selectedPage.innerText).toBe("1");
     });
     it("previous button should be disabled when selected page equals the starting page", async () => {
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const previousButton = await page.find(`calcite-pagination >>> .${CSS.previous}`);
       await previousButton.click();
       await page.waitForChanges();
@@ -171,7 +171,7 @@ describe("calcite-pagination", () => {
       await pagination.setAttribute("start", "5");
       await page.waitForChanges();
 
-      const toggleSpy = await pagination.spyOnEvent("calcitePaginationUpdate");
+      const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
       const nextButton = await page.find(`calcite-pagination >>> .${CSS.next}`);
       await nextButton.click();
       await page.waitForChanges();

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -66,10 +66,16 @@ export class CalcitePagination {
   //
   //--------------------------------------------------------------------------
 
-  /** Emitted whenever the selected page changes.
-   * @event calcitePaginationUpdate
+  /**
+   * Emitted whenever the selected page changes.
+   * @deprecated use calcitePaginationChange instead
    */
   @Event() calcitePaginationUpdate: EventEmitter<CalcitePaginationDetail>;
+
+  /**
+   * Emitted whenever the selected page changes.
+   */
+  @Event() calcitePaginationChange: EventEmitter<CalcitePaginationDetail>;
 
   // --------------------------------------------------------------------------
   //
@@ -118,11 +124,14 @@ export class CalcitePagination {
   }
 
   private emitUpdate() {
-    this.calcitePaginationUpdate.emit({
+    const changePayload = {
       start: this.start,
       total: this.total,
       num: this.num
-    });
+    };
+
+    this.calcitePaginationChange.emit(changePayload);
+    this.calcitePaginationUpdate.emit(changePayload);
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -138,7 +138,7 @@ describe("calcite-slider", () => {
     expect(ticks.length).toBe(11);
   });
 
-  it("fires calciteSliderUpdate event on changes", async () => {
+  it("fires calciteSliderChange event on changes", async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-slider
@@ -152,7 +152,7 @@ describe("calcite-slider", () => {
     `);
     const slider = await page.find("calcite-slider");
     const handle = await page.find("calcite-slider >>> .thumb");
-    const changeEvent = await slider.spyOnEvent("calciteSliderUpdate");
+    const changeEvent = await slider.spyOnEvent("calciteSliderChange");
     expect(changeEvent).toHaveReceivedEventTimes(0);
     await handle.press("ArrowRight");
     expect(changeEvent).toHaveReceivedEventTimes(1);

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -111,7 +111,7 @@ export class CalciteSlider {
     if (this.histogram) {
       this.hasHistogram = true;
     }
-    this.calciteSliderUpdate.emit();
+    this.emitChange();
   }
 
   componentDidRender(): void {
@@ -672,37 +672,37 @@ export class CalciteSlider {
       case "ArrowRight":
         e.preventDefault();
         this[this.activeProp] = this.bound(value + this.step, this.activeProp);
-        this.calciteSliderUpdate.emit();
+        this.emitChange();
         break;
       case "ArrowDown":
       case "ArrowLeft":
         e.preventDefault();
         this[this.activeProp] = this.bound(value - this.step, this.activeProp);
-        this.calciteSliderUpdate.emit();
+        this.emitChange();
         break;
       case "PageUp":
         if (this.pageStep) {
           e.preventDefault();
           this[this.activeProp] = this.bound(value + this.pageStep, this.activeProp);
-          this.calciteSliderUpdate.emit();
+          this.emitChange();
         }
         break;
       case "PageDown":
         if (this.pageStep) {
           e.preventDefault();
           this[this.activeProp] = this.bound(value - this.pageStep, this.activeProp);
-          this.calciteSliderUpdate.emit();
+          this.emitChange();
         }
         break;
       case "Home":
         e.preventDefault();
         this[this.activeProp] = this.bound(this.min, this.activeProp);
-        this.calciteSliderUpdate.emit();
+        this.emitChange();
         break;
       case "End":
         e.preventDefault();
         this[this.activeProp] = this.bound(this.max, this.activeProp);
-        this.calciteSliderUpdate.emit();
+        this.emitChange();
         break;
     }
   }
@@ -720,7 +720,7 @@ export class CalciteSlider {
       }
     }
     this[prop] = this.bound(num, prop);
-    this.calciteSliderUpdate.emit();
+    this.emitChange();
     switch (prop) {
       default:
       case "maxValue":
@@ -744,6 +744,15 @@ export class CalciteSlider {
    * :warning: Will be fired frequently during drag. If you are performing any
    * expensive operations consider using a debounce or throttle to avoid
    * locking up the main thread.
+   */
+  @Event() calciteSliderChange: EventEmitter;
+
+  /**
+   * Fires on all updates to the slider.
+   * :warning: Will be fired frequently during drag. If you are performing any
+   * expensive operations consider using a debounce or throttle to avoid
+   * locking up the main thread.
+   * @deprecated use calciteSliderChange instead
    */
   @Event() calciteSliderUpdate: EventEmitter;
 
@@ -859,8 +868,14 @@ export class CalciteSlider {
       } else {
         this[this.dragProp] = this.bound(value, this.dragProp);
       }
-      this.calciteSliderUpdate.emit();
+
+      this.emitChange();
     }
+  }
+
+  private emitChange(): void {
+    this.calciteSliderChange.emit();
+    this.calciteSliderUpdate.emit();
   }
 
   private dragEnd(): void {


### PR DESCRIPTION
**Related Issue:** #1145

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

For consistency, this deprecates `<*Update>` events in favor of `<*Change>` ones.
