### PR TITLE
feat(modal): add setFocus method and deprecate focusElement

### DIFF
--- a/conventions/README.md
+++ b/conventions/README.md
@@ -9,6 +9,7 @@ This is a living document defining our best practices and reasoning for authorin
 - [Light Theme/Dark Theme](#light-themedark-theme)
 - [Form Elements and Custom Inputs](#form-elements-and-custom-inputs)
 - [Component Responsibilities](#component-responsibilities)
+- [Focus support](#focus-support)
 - [Event Names](#event-names)
 - [Private Events](#private-events)
 - [Event Details](#event-details)
@@ -230,6 +231,25 @@ However components are allowed to:
 
 - [Should tabs support syncing and loading from localstorage](https://github.com/ArcGIS/calcite-components/pull/27) . **Yes** because such feature are difficult to implement for **Sites** and would require lots of additional JavaScript work on the part of teams and authors
 - [Should switch support a label](https://github.com/ArcGIS/calcite-components/pull/24#discussion_r289424140). **No** because label place
+
+## Focus support
+
+Components with focusable content, must implement the following pattern:
+
+```ts
+interface FocusableComponent {
+  setFocus(focusId?: FocusId): Promise<void>; // focusId should be supported if there is more than one supported focus target
+}
+
+type FocusId = string;
+```
+
+**Note**: Implementations can use the [`focusElement`](https://github.com/Esri/calcite-components/blob/f2bb61828f3da54b7dcb5fb1dade12b85d82331e/src/utils/dom.ts#L41-L47) helper to handle focusing both native and calcite components.
+
+Examples:
+
+- [`calcite-color`](https://github.com/Esri/calcite-components/blob/78a70a805324689d516130816a69f031e39c5338/src/components/calcite-color/calcite-color.tsx#L409-L413)
+- [`calcite-panel` (supports `focusId`)](https://github.com/Esri/calcite-components/blob/f2bb61828f3da54b7dcb5fb1dade12b85d82331e/src/components/calcite-panel/calcite-panel.tsx#L298-L311)
 
 ## Event Names
 

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { HYDRATED_ATTR } from "../../tests/commonTests";
+import { focusable, HYDRATED_ATTR } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 
 describe("calcite-modal properties", () => {
   it("renders", async () => {
@@ -156,6 +157,34 @@ describe("calcite-modal accessibility checks", () => {
     await modal.setProperty("active", false);
     await page.waitForChanges();
     expect(document.activeElement).toEqual($button);
+  });
+
+  describe("setFocus", () => {
+    const createModalHTML = (contentHTML?: string) => `<calcite-modal active>${contentHTML}</calcite-modal>`;
+
+    const closeButtonFocusId = "close-button";
+    const closeButtonTargetSelector = ".close";
+    const focusableContentTargetClass = "test";
+
+    const focusableContentHTML = html`<h3 slot="header">Title</h3>
+      <p slot="content">This is the content <button class=${focusableContentTargetClass}>test</button></p>`;
+
+    it("focuses focusable content by default", async () =>
+      focusable(createModalHTML(focusableContentHTML), {
+        focusTargetSelector: `.${focusableContentTargetClass}`
+      }));
+
+    it("focuses close button if there is no focusable content", async () =>
+      focusable(createModalHTML(), {
+        focusId: closeButtonFocusId,
+        shadowFocusTargetSelector: closeButtonTargetSelector
+      }));
+
+    it("can focus close button directly", async () =>
+      focusable(createModalHTML(focusableContentHTML), {
+        focusId: closeButtonFocusId,
+        shadowFocusTargetSelector: closeButtonTargetSelector
+      }));
   });
 
   it("has correct aria role/attribute", async () => {

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -1,21 +1,21 @@
 import {
   Component,
   Element,
-  Prop,
-  Host,
   Event,
   EventEmitter,
-  Listen,
   h,
+  Host,
+  Listen,
   Method,
+  Prop,
   State,
-  Watch,
-  VNode
+  VNode,
+  Watch
 } from "@stencil/core";
-import { getElementDir, CalciteFocusableElement, focusElement } from "../../utils/dom";
+import { CalciteFocusableElement, focusElement, getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 import { queryShadowRoot } from "@a11y/focus-trap/shadow";
-import { isHidden, isFocusable } from "@a11y/focus-trap/focusable";
+import { isFocusable, isHidden } from "@a11y/focus-trap/focusable";
 import { Scale, Theme } from "../interfaces";
 import { ModalBackgroundColor } from "./interfaces";
 
@@ -232,19 +232,32 @@ export class CalciteModal {
   //  Public Methods
   //
   //--------------------------------------------------------------------------
-  /** Focus first interactive element */
+  /**
+   * Focus first interactive element
+   * @deprecated use `setFocus` instead.
+   */
   @Method()
   async focusElement(el?: HTMLElement): Promise<void> {
     if (el) {
-      focusElement(el);
-      return;
+      el.focus();
     }
-    const focusableElements = getFocusableElements(this.el);
-    if (focusableElements.length > 0) {
-      focusElement(focusableElements[0]);
-    } else {
-      focusElement(this.closeButtonEl);
-    }
+
+    return this.setFocus();
+  }
+
+  /**
+   * Sets focus on the component.
+   *
+   * By default, will try to focus on any focusable content. If there is none, it will focus on the close button.
+   * If you want to focus on the close button, you can use the `close-button` focus ID.
+   */
+  @Method()
+  async setFocus(focusId?: "close-button"): Promise<void> {
+    const closeButton = this.closeButtonEl;
+
+    return focusElement(
+      focusId === "close-button" ? closeButton : getFocusableElements(this.el)[0] || closeButton
+    );
   }
 
   /** Set the scroll top of the modal content */


### PR DESCRIPTION
**Related Issue:** #1145

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Adds `setFocus` method on modal for consistency:

```ts
interface CalciteModal {
  setFocus(focusId?: "close-button"): Promise<void>;
}
```

Additionally, deprecates `focusElement(el?: HTMLElement): Promise<void>`.
