### PR TITLE
fix(input-date-picker): document events emitted by input date picker

### DIFF
--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -9,7 +9,9 @@ import {
   Build,
   Watch,
   VNode,
-  Method
+  Method,
+  Event,
+  EventEmitter
 } from "@stencil/core";
 import { getLocaleData, DateLocaleData } from "../calcite-date-picker/utils";
 import { getElementDir } from "../../utils/dom";
@@ -116,6 +118,21 @@ export class CalciteInputDatePicker {
   calciteDaySelectHandler(): void {
     this.active = false;
   }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  //--------------------------------------------------------------------------
+  /**
+   * Trigger calcite date change when a user changes the date.
+   */
+  @Event() calciteDatePickerChange: EventEmitter<Date>;
+
+  /**
+   * Trigger calcite date change when a user changes the date range.
+   */
+  @Event() calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
## Summary

While the events for date change were firing (due to propagation from the underlying date-picker component, they were not included in the generated doc or generated preact types. Adding them to the input so that they are documented. 

