### PR TITLE
chore: bump calcite-ui-icons to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2824,9 +2824,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.14.3.tgz",
-      "integrity": "sha512-ldsqGJMJqCdzgeCQtAt5PDLOIhWxHh9U8X24lOWpSiX3jfj736zm7tzhK7+ZjOdVDDYeKxibT4L7wfqo0ehl2Q==",
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.14.8.tgz",
+      "integrity": "sha512-rZs5UUt5+0cKAN+VVxOHzfzyUcNMB+25Ns6Zf3sN8hQBMh6Ng8T5j8D9Y41s5GF4IObFnFKiqwfx5gO1Efi7CQ==",
       "dev": true
     },
     "@fullhuman/postcss-purgecss": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.0",
-    "@esri/calcite-ui-icons": "3.14.3",
+    "@esri/calcite-ui-icons": "3.14.8",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "2.0.0",
     "@stencil/sass": "1.4.1",

--- a/src/components/calcite-tile-select/calcite-tile-select.stories.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.stories.ts
@@ -23,7 +23,7 @@ export const Light = (): string => html`
     ${boolean("focused", false)}
     heading="${text("heading", "Tile heading lorem ipsum")}"
     ${boolean("hidden", false)}
-    icon="${select("icon", iconNames, iconNames[296])}"
+    icon="${select("icon", iconNames, "layer")}"
     name="${text("name", "tile-select-demo")}"
     show-input="${select("show-input", ["left", "right", "none"], "left")}"
     type="${select("type", ["radio", "checkbox"], "radio")}"
@@ -43,7 +43,7 @@ export const Dark = (): string => html`
     ${boolean("focused", false)}
     heading="${text("heading", "Tile heading lorem ipsum")}"
     ${boolean("hidden", false)}
-    icon="${select("icon", iconNames, iconNames[296])}"
+    icon="${select("icon", iconNames, "layer")}"
     name="${text("name", "tile-select-demo")}"
     show-input="${select("show-input", ["left", "right", "none"], "left")}"
     theme="dark"

--- a/src/components/calcite-tile/calcite-tile.stories.ts
+++ b/src/components/calcite-tile/calcite-tile.stories.ts
@@ -23,7 +23,7 @@ export const Light = (): string => html`
     heading="${text("heading", "Tile heading lorem ipsum")}"
     ${boolean("hidden", false)}
     href="${text("href", "#")}"
-    icon="${select("icon", iconNames, iconNames[296])}"
+    icon="${select("icon", iconNames, "layer")}"
   >
   </calcite-tile>
 `;
@@ -39,7 +39,7 @@ export const Dark = (): string => html`
     heading="${text("heading", "Tile heading lorem ipsum")}"
     ${boolean("hidden", false)}
     href="${text("href", "#")}"
-    icon="${select("icon", iconNames, iconNames[296])}"
+    icon="${select("icon", iconNames, "layer")}"
     theme="dark"
   >
   </calcite-tile>


### PR DESCRIPTION
## Summary

We were five versions behind on the icons library.