### PR TITLE
fix(combobox): solve issue with using combobox inside shadow DOM

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -462,7 +462,7 @@ describe("calcite-combobox", () => {
 
     const combobox = await page.find("div >>> calcite-combobox");
     const input = await page.find("div >>> calcite-combobox >>> .wrapper");
-    expect(await combobox.getProperty("active")).toBe(false);
+    expect(await combobox.getProperty("active")).toBeFalsy();
     await input.click();
     expect(await combobox.getProperty("active")).toBe(true);
   });

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -441,4 +441,29 @@ describe("calcite-combobox", () => {
       expect(selected).toBeNull();
     });
   });
+
+  it("works correctly inside a shadowRoot", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <div></div>
+      <template>
+        <calcite-combobox selection-mode="single">
+          <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
+          <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+        </calcite-combobox>
+      </template>
+      <script>
+        const shadowRootDiv = document.querySelector("div");
+        const shadowRoot = shadowRootDiv.attachShadow({ mode: "open" });
+        shadowRoot.append(document.querySelector("template").content.cloneNode(true));
+      </script>
+    `);
+
+    const combobox = await page.find("div >>> calcite-combobox");
+    const input = await page.find("div >>> calcite-combobox >>> .wrapper");
+    expect(await combobox.getProperty("active")).toBe(false);
+    await input.click();
+    expect(await combobox.getProperty("active")).toBe(true);
+  });
 });

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -52,7 +52,7 @@ export class CalciteCombobox {
   //--------------------------------------------------------------------------
 
   /** Open and close combobox */
-  @Prop({ reflect: true }) active = false;
+  @Prop({ reflect: true, mutable: true }) active = false;
 
   @Watch("active") activeHandler(): void {
     this.reposition();
@@ -745,7 +745,10 @@ export class CalciteCombobox {
             "wrapper--active": active,
             "wrapper--single": single
           }}
-          onClick={() => this.setFocus()}
+          onClick={(e) => {
+            e.stopPropagation();
+            this.setFocus();
+          }}
           ref={this.setReferenceEl}
           role="combobox"
         >

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -90,8 +90,7 @@ export class CalciteCombobox {
 
   @Listen("click", { target: "document" })
   documentClickHandler(event: Event): void {
-    const target = event.target as HTMLElement;
-    this.setInactiveIfNotContained(target);
+    this.setInactiveIfNotContained(event);
   }
 
   @Listen("calciteComboboxItemChange")
@@ -301,8 +300,8 @@ export class CalciteCombobox {
   //
   // --------------------------------------------------------------------------
 
-  setInactiveIfNotContained = (target: HTMLElement): void => {
-    if (!this.active || this.el.contains(target)) {
+  setInactiveIfNotContained = (event: Event): void => {
+    if (!this.active || event.composedPath().includes(this.el)) {
       return;
     }
 
@@ -591,8 +590,7 @@ export class CalciteCombobox {
   };
 
   comboboxBlurHandler = (event: FocusEvent): void => {
-    const relatedTarget = event.relatedTarget as HTMLElement;
-    this.setInactiveIfNotContained(relatedTarget);
+    this.setInactiveIfNotContained(event);
   };
 
   //--------------------------------------------------------------------------
@@ -745,10 +743,7 @@ export class CalciteCombobox {
             "wrapper--active": active,
             "wrapper--single": single
           }}
-          onClick={(e) => {
-            e.stopPropagation();
-            this.setFocus();
-          }}
+          onClick={() => this.setFocus()}
           ref={this.setReferenceEl}
           role="combobox"
         >


### PR DESCRIPTION
## Summary

When using the combobox inside a shadow dom, clicking the element to open it was bubbling up, causing the `setInactiveIfNotContained` method to run and immediately close it. 

I'm not entirely sure why this problem exists only in shadow dom (maybe document is different, or `el.contains` no longer functions correctly). The fix is to just stop that event from bubbling up to the document (it should have been like this anyways, more efficient). 

I've heard this happens on select menus as well, so I'll look into it next.

@eriklharper thanks for the shadow root test you wrote for radio button, it really helped me know how to test this!