### PR TITLE
feat(shell-panel): adds slot for header content

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -1,6 +1,17 @@
-import { Component, Event, EventEmitter, Host, Prop, Watch, h, VNode } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  Watch,
+  h,
+  VNode
+} from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { Position, Scale } from "../interfaces";
+import { getSlotted } from "../../utils/dom";
 
 /**
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
@@ -51,6 +62,13 @@ export class CalciteShellPanel {
 
   // --------------------------------------------------------------------------
   //
+  //  Private Properties
+  //
+  // --------------------------------------------------------------------------
+  @Element() el: HTMLCalciteShellPanelElement;
+
+  // --------------------------------------------------------------------------
+  //
   //  Events
   //
   // --------------------------------------------------------------------------
@@ -67,10 +85,13 @@ export class CalciteShellPanel {
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const { collapsed, detached, position } = this;
+    const { collapsed, detached, el, position } = this;
+
+    const hasHeader = getSlotted(el, SLOTS.header);
 
     const contentNode = (
       <div class={{ [CSS.content]: true, [CSS.contentDetached]: detached }} hidden={collapsed}>
+        {hasHeader ? <slot name={SLOTS.header} /> : null}
         <slot />
       </div>
     );

--- a/src/components/calcite-shell-panel/resources.ts
+++ b/src/components/calcite-shell-panel/resources.ts
@@ -4,5 +4,6 @@ export const CSS = {
 };
 
 export const SLOTS = {
-  actionBar: "action-bar"
+  actionBar: "action-bar",
+  header: "header"
 };


### PR DESCRIPTION
**Related Issue:** #1540 

## Summary
This simply adds a named slot for anything at the top of the content area: `<slot name="header" />`
The named slot is not added if it's empty.

cc @kevindoshier 

![image](https://user-images.githubusercontent.com/12503298/107716862-332e7700-6c87-11eb-8f67-921d381caccc.png)

The dark thing at the top there is using its own "hand-rolled" styles.
For content in the default slot, scrolling appears to be unaffected by content in the `header` slot.
Also, a flow in the default slot will operate as normal.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

@driskull I think we should make a Header component or something that can be reused.
There are some pretty similar blocks of code in Block and Panel, and a Header component would work nicely in this slot.
