### PR TITLE
chore(avatar, label): drop lingering prop validation checks

### DIFF
--- a/src/components/calcite-avatar/calcite-avatar.tsx
+++ b/src/components/calcite-avatar/calcite-avatar.tsx
@@ -28,7 +28,7 @@ export class CalciteAvatar {
   @Prop({ reflect: true }) theme: Theme;
 
   /** specify the scale of the avatar, defaults to m */
-  @Prop({ mutable: true, reflect: true }) scale: Scale = "m";
+  @Prop({ reflect: true }) scale: Scale = "m";
 
   /** src to an image (remember to add a token if the user is private) */
   @Prop() thumbnail: string;
@@ -47,12 +47,6 @@ export class CalciteAvatar {
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
-
-  connectedCallback() {
-    // prop validations
-    const scale = ["s", "m", "l"];
-    if (!scale.includes(this.scale)) this.scale = "m";
-  }
 
   render() {
     const dir = getElementDir(this.el);

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -38,20 +38,19 @@ export class CalciteLabel {
   @Prop({ reflect: true }) alignment: Alignment = "start";
 
   /** specify the status of the label and any child input / input messages */
-  @Prop({ mutable: true, reflect: true }) status: Status = "idle";
+  @Prop({ reflect: true }) status: Status = "idle";
 
   /** The id of the input associated with the label */
   @Prop({ reflect: true }) for: string;
 
   /** specify the scale of the input, defaults to m */
-  @Prop({ mutable: true, reflect: true }) scale: Scale = "m";
+  @Prop({ reflect: true }) scale: Scale = "m";
 
   /** specify theme of the label and its any child input / input messages */
   @Prop({ reflect: true }) theme: Theme;
 
   /** is the wrapped element positioned inline with the label slotted text */
-  @Prop({ mutable: true, reflect: true }) layout: "inline" | "inline-space-between" | "default" =
-    "default";
+  @Prop({ reflect: true }) layout: "inline" | "inline-space-between" | "default" = "default";
 
   /** eliminates any space around the label */
   @Prop() disableSpacing?: boolean;
@@ -159,17 +158,6 @@ export class CalciteLabel {
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
-
-  connectedCallback(): void {
-    const status = ["invalid", "valid", "idle"];
-    if (!status.includes(this.status)) this.status = "idle";
-
-    const layout = ["inline", "inline-space-between", "default"];
-    if (!layout.includes(this.layout)) this.layout = "default";
-
-    const scale = ["s", "m", "l"];
-    if (!scale.includes(this.scale)) this.scale = "m";
-  }
 
   componentDidLoad(): void {
     if (this.disabled) this.setDisabledControls();


### PR DESCRIPTION
**Related Issue:** #637

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

https://github.com/Esri/calcite-components/pull/954 removed all prop validation checks. This takes care of some remaining ones.
