### PR TITLE
fix: stop @apply rule from getting into dist CSS

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -27,7 +27,7 @@
 }
 
 .overflow-hidden {
-  @apply overflow-hidden;
+  overflow: hidden;
 }
 
 [calcite-hydrated-hidden] {


### PR DESCRIPTION
## Summary

Currently the global CSS file has an `@apply` rule in it. Stencil is _supposed_ to run your global css through the same plugins as your component css, but for some reason it's leaving it. This is causing problems for people who are using the CSS file over the wire (causing errors as `@apply` is not natively supported). 

For now I'm removing it. Until we work with the stencil devs to fix this we should avoid using `@apply` in the global section.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
