### PR TITLE
feat(shell-center-row): remove CSS transition for height

### DIFF
--- a/src/components/calcite-shell-center-row/calcite-shell-center-row.scss
+++ b/src/components/calcite-shell-center-row/calcite-shell-center-row.scss
@@ -3,7 +3,6 @@
   @extend %component-spacing;
   display: flex;
   overflow: hidden;
-  transition: height $transition;
   background-color: transparent;
   border-left: 1px solid var(--calcite-ui-border-3);
   border-right: 1px solid var(--calcite-ui-border-3);


### PR DESCRIPTION
**Related Issue:** #1554

## Summary
Removes CSS transition for height.
While it's nice to have, the transition can cause rendering issues with the "micro apps" it contains.

<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
