### PR TITLE
fix(button): fixes missing text-alignment for alignment prop.

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -159,10 +159,18 @@
   .icon--start {
     margin-right: auto;
   }
+  a,
+  button {
+    text-align: unset;
+  }
 }
 :host([alignment="icon-end-space-between"]:not([width="auto"])) {
   .icon--end {
     margin-left: auto;
+  }
+  a,
+  button {
+    text-align: unset;
   }
 }
 :host([dir="rtl"][alignment="icon-start-space-between"]:not([width="auto"])) {


### PR DESCRIPTION
**Related Issue:** #1562 

## Summary
Especially when using `icon-start-space-between` or `icon-end-space-between`, wrapped text would reveal itself to be centered causing weird looking layout.

This fixes that.

Before
![image](https://user-images.githubusercontent.com/12503298/108131927-e53eb800-7066-11eb-980f-1eaccd90f6d0.png)


After
![image](https://user-images.githubusercontent.com/12503298/108131776-aa3c8480-7066-11eb-8f1b-89ec547dda06.png)


<!--

Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
