### PR TITLE
feat: add maxlength property to calcite-input

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 <!--
 
-Please make sure the PR title and/or commit message adheres to the https://conventionalcommits.org/ specification.
+Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.
 
 Note: If your PR only has one commit and it is NOT semantic, you will need to either
 

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -86,6 +86,9 @@ export class CalciteInput {
     this.minString = this.min?.toString() || null;
   }
 
+  /** maximum length of text input */
+  @Prop({ reflect: true }) maxlength?: number;
+
   /** specify the placement of the number buttons */
   @Prop({ reflect: true }) numberButtonType?: InputPlacement = "vertical";
 
@@ -258,6 +261,7 @@ export class CalciteInput {
         autofocus={this.autofocus ? true : null}
         disabled={this.disabled ? true : null}
         max={this.maxString}
+        maxlength={this.maxlength}
         min={this.minString}
         onBlur={this.inputBlurHandler}
         onFocus={this.inputFocusHandler}


### PR DESCRIPTION
**Related Issue:** #

## Summary

Allow `maxlength` property to be set on a `calcite-input` item