### PR TITLE
chore: hide invalid color warnings shown during test

### DIFF
--- a/src/components/calcite-color/calcite-color.e2e.ts
+++ b/src/components/calcite-color/calcite-color.e2e.ts
@@ -6,6 +6,16 @@ import { ColorValue } from "./interfaces";
 import SpyInstance = jest.SpyInstance;
 
 describe("calcite-color", () => {
+  let consoleSpy: SpyInstance;
+
+  beforeEach(
+    () =>
+      (consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {
+        // hide warning messages during test
+      }))
+  );
+  afterEach(() => consoleSpy.mockClear());
+
   it("is accessible", async () => {
     await accessible("calcite-color");
     await accessible("<calcite-color allow-empty value=''></calcite-color>");
@@ -310,7 +320,6 @@ describe("calcite-color", () => {
 
   describe("unsupported value handling", () => {
     let page: E2EPage;
-    let consoleSpy: SpyInstance;
 
     async function assertUnsupportedValue(page: E2EPage, unsupportedValue: string | null): Promise<void> {
       const picker = await page.find("calcite-color");
@@ -332,7 +341,6 @@ describe("calcite-color", () => {
       page = await newE2EPage({
         html: "<calcite-color></calcite-color>"
       });
-      consoleSpy = jest.spyOn(console, "warn");
     });
 
     afterEach(() => jest.clearAllMocks());


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This hides the many (expected) 'invalid color' messages shown during a local test run.