### PR TITLE
fix(combobox): prevent hidden options from causing scroll

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -430,6 +430,8 @@ describe("calcite-combobox", () => {
       await element.click();
 
       await items[1].click();
+      await page.waitForChanges();
+
       selected = await page.find("calcite-combobox >>> .selected-icon");
       icon = await selected.getProperty("icon");
       expect(icon).toBe("beaker");

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -154,7 +154,8 @@
 }
 
 .list--hide {
-  display: none;
+  height: 0;
+  overflow: hidden;
 }
 
 .chip {

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -153,6 +153,10 @@
   padding: 0;
 }
 
+.list--hide {
+  display: none;
+}
+
 .chip {
   margin-right: var(--calcite-combobox-item-spacing-unit-s);
   margin-bottom: var(--calcite-combobox-item-spacing-unit-s);

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -54,7 +54,15 @@ export class CalciteCombobox {
   /** Open and close combobox */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  @Watch("active") activeHandler(): void {
+  @Watch("active") activeHandler(newValue: boolean, oldValue: boolean): void {
+    // when closing, wait transition time then hide to prevent overscroll
+    if (oldValue && !newValue) {
+      setTimeout(() => {
+        this.hideList = true;
+      }, 150);
+    } else if (!oldValue && newValue) {
+      this.hideList = false;
+    }
     this.reposition();
   }
 
@@ -259,6 +267,8 @@ export class CalciteCombobox {
   @State() visibleItems: HTMLCalciteComboboxItemElement[] = [];
 
   @State() needsIcon: boolean;
+
+  @State() hideList = !this.active;
 
   @State() activeItemIndex = -1;
 
@@ -679,7 +689,7 @@ export class CalciteCombobox {
   }
 
   renderPopperContainer(): VNode {
-    const { active, maxScrollerHeight, setMenuEl, setListContainerEl } = this;
+    const { active, maxScrollerHeight, setMenuEl, setListContainerEl, hideList } = this;
     const classes = {
       "list-container": true,
       [PopperCSS.animation]: true,
@@ -691,7 +701,7 @@ export class CalciteCombobox {
     return (
       <div aria-hidden="true" class="popper-container" ref={setMenuEl}>
         <div class={classes} ref={setListContainerEl} style={style}>
-          <ul class="list">
+          <ul class={{ list: true, "list--hide": hideList }}>
             <slot />
           </ul>
         </div>

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -385,7 +385,6 @@ export class CalciteCombobox {
         itemsToProcess++;
       }
     });
-
     return maxScrollerHeight;
   }
 

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -27,6 +27,8 @@ const COMBO_BOX_ITEM = "calcite-combobox-item";
 
 const DEFAULT_PLACEMENT = "bottom-start";
 
+const TRANSITION_DURATION = 150;
+
 interface ItemData {
   label: string;
   value: string;
@@ -59,7 +61,7 @@ export class CalciteCombobox {
     if (oldValue && !newValue) {
       setTimeout(() => {
         this.hideList = true;
-      }, 150);
+      }, TRANSITION_DURATION);
     } else if (!oldValue && newValue) {
       this.hideList = false;
     }


### PR DESCRIPTION
## Summary

Inside a container with scroll, the hidden list items are actually taking up room and forcing a scroll of the container even when closed. This sets the items to display none when the combobox is closed so no overscroll is forced

![1-capture](https://user-images.githubusercontent.com/1031758/108426110-329a6100-71f0-11eb-850e-1b351064ddbb.gif)
.

Example code to repro:

```html
<div style="overflow: auto">
  <calcite-combobox>
    ...items, etc
  </calcite-combobox>
</div>
```