### PR TITLE
refactor(input): move assigning stepString, minString, maxString props to before component is rendered

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -112,7 +112,7 @@ export class CalciteInput {
 
   @Watch("step")
   stepWatcher(): void {
-    this.stepString = this.step.toString() || null;
+    this.stepString = this.step?.toString() || null;
   }
 
   /** optionally add suffix  **/

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -112,7 +112,7 @@ export class CalciteInput {
 
   @Watch("step")
   stepWatcher(): void {
-    this.maxString = this.max?.toString() || null;
+    this.stepString = this.step.toString() || null;
   }
 
   /** optionally add suffix  **/
@@ -171,12 +171,12 @@ export class CalciteInput {
   componentWillLoad(): void {
     this.childElType = this.type === "textarea" ? "textarea" : "input";
     this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
-  }
-
-  componentDidLoad(): void {
     this.minString = this.min?.toString();
     this.maxString = this.max?.toString();
     this.stepString = this.step?.toString();
+  }
+
+  componentDidLoad(): void {
     this.slottedActionEl = this.el.querySelector("[slot=input-action]");
     if (this.disabled) this.setDisabledAction();
   }


### PR DESCRIPTION
**Related Issue:** #
Did not open issue - can make one if needed
## Summary
Setting the properties in the title in componentDidLoad() can cause the attributes not to be applied to the input in the shadow dom at initial render. Looks like this:
![image](https://user-images.githubusercontent.com/52869490/108439363-fa058200-7205-11eb-9a69-c96a6de7b3b3.png)


In the screen shot, step, min, and max are missing. When the value of the input is changed, the attributes then show up because the component re-renders.

Moving these assignments to componentWillLoad() guarantees they will be assigned at render time.

Also saw a typo in the watch method, it should keep the stepString and step properties in sync, not assign max again. If there is a specific reason for that, let me know 😄 

cc: @driskull @macandcheese 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
