### PR TITLE
chore(avatar, block, card, chip, shell, tip-manager): use svg placeholder in stories

### DIFF
--- a/src/components/calcite-avatar/calcite-avatar.stories.ts
+++ b/src/components/calcite-avatar/calcite-avatar.stories.ts
@@ -1,7 +1,7 @@
 import { select, text } from "@storybook/addon-knobs";
 
 import { darkBackground } from "../../../.storybook/utils";
-import { html } from "../../tests/utils";
+import { html, placeholderImage } from "../../tests/utils";
 import readme from "./readme.md";
 
 export default {
@@ -18,7 +18,7 @@ export const Simple = (): string => html`
     full-name="${text("full-name", "John Doe")}"
     username="${text("username", "jdoe")}"
     user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
-    thumbnail="${text("thumbnail", "http://placekitten.com/120/120")}"
+    thumbnail="${text("thumbnail", placeholderImage({ width: 120, height: 120 }))}"
   >
   </calcite-avatar>
 `;

--- a/src/components/calcite-block/calcite-block.stories.ts
+++ b/src/components/calcite-block/calcite-block.stories.ts
@@ -3,7 +3,7 @@ import { Attribute, Attributes, createComponentHTML as create, darkBackground } 
 import blockReadme from "./readme.md";
 import sectionReadme from "../calcite-block-section/readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import { html } from "../../tests/utils";
+import { html, placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/App/Block",
@@ -147,11 +147,11 @@ export const basic = (): string =>
       ${create(
         "calcite-block-section",
         createSectionAttributes(),
-        `<img alt="demo" src="https://placeimg.com/320/240/animals" />`
+        `<img alt="demo" src="${placeholderImage({ width: 320, height: 240 })}" />`
       )}
 
       <calcite-block-section text="Nature" open>
-        <img alt="demo" src="https://placeimg.com/320/240/nature" />
+        <img alt="demo" src="${placeholderImage({ width: 320, height: 240 })}" />
       </calcite-block-section>
     `
   );

--- a/src/components/calcite-card/calcite-card.stories.ts
+++ b/src/components/calcite-card/calcite-card.stories.ts
@@ -240,7 +240,7 @@ export const DarkThemeFooterButtonsTooltipsDropdown = (): string => html`
         alt=""
         slot="thumbnail"
         src="${placeholderImage({ width: 260, height: 160 })}"
-        style="width:260px;height:160px"
+        style="width: 260px; height: 160px;"
       />
       <h3 slot="title">Portland Businesses</h3>
       <span slot="subtitle"

--- a/src/components/calcite-card/calcite-card.stories.ts
+++ b/src/components/calcite-card/calcite-card.stories.ts
@@ -1,6 +1,6 @@
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
-import { html } from "../../tests/utils";
+import { html, placeholderImage } from "../../tests/utils";
 import readme from "./readme.md";
 
 export default {
@@ -39,10 +39,15 @@ SimpleWithLinks.story = {
   name: "Simple with Links"
 };
 
+const footerThumbnail = `<img alt="footer thumbnail" slot="thumbnail" src="${placeholderImage({
+  width: 380,
+  height: 180
+})}" style="width: 380px;" />`;
+
 export const FooterButton = (): string => html`
   <div style="width:260px">
     <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" style="width: 380px;" />
+      ${footerThumbnail}
       <h3 slot="title">Untitled experience</h3>
       <span slot="subtitle">Subtext</span>
       <calcite-button slot="footer-leading" width="full">Go</calcite-button>
@@ -53,7 +58,7 @@ export const FooterButton = (): string => html`
 export const FooterLinks = (): string => html`
   <div style="width:260px">
     <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" style="width: 380px;" />
+      ${footerThumbnail}
       <h3 slot="title">My perhaps multiline card title</h3>
       <span slot="subtitle"
         >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
@@ -67,7 +72,7 @@ export const FooterLinks = (): string => html`
 export const FooterTextButtonsTooltips = (): string => html`
   <div style="width:260px">
     <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" style="width: 380px;" />
+      ${footerThumbnail}
       <h3 slot="title">My great project that might wrap two lines</h3>
       <span slot="subtitle">Johnathan Smith</span>
       <span slot="footer-leading">Nov 25, 2018</span>
@@ -93,7 +98,10 @@ export const FooterButtonsTooltipsDropdown = (): string => html`
   ${boolean("loading", false)}
   ${boolean("selectable", false)}
   >
-    <img alt="" slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" style="width:260px;height:160px" />
+    <img alt="" slot="thumbnail" src="${placeholderImage({
+      width: 260,
+      height: 160
+    })}" style="width:260px;height:160px" />
     <h3 slot="title">Portland Businesses</h3>
     <span slot="subtitle">by
       <calcite-link href="">example_user</calcite-button>
@@ -169,7 +177,7 @@ DarkThemeSimpleWithLinks.story = {
 export const DarkThemeFooterButton = (): string => html`
   <div style="width:260px">
     <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" style="width: 380px;" />
+      ${footerThumbnail}
       <h3 slot="title">Untitled experience</h3>
       <span slot="subtitle">Subtext</span>
       <calcite-button theme="dark" slot="footer-leading" width="full">Go</calcite-button>
@@ -185,7 +193,7 @@ DarkThemeFooterButton.story = {
 export const DarkThemeFooterLinks = (): string => html`
   <div style="width:260px">
     <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" style="width: 380px;" />
+      ${footerThumbnail}
       <h3 slot="title">My perhaps multiline card title</h3>
       <span slot="subtitle"
         >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
@@ -204,7 +212,7 @@ DarkThemeFooterLinks.story = {
 export const DarkThemeFooterTextButtonsTooltips = (): string => html`
   <div style="width:260px">
     <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img alt="" slot="thumbnail" src="https://placem.at/places?w=380&h=180&txt=0" style="width: 380px;" />
+      ${footerThumbnail}
       <h3 slot="title">My great project that might wrap two lines</h3>
       <span slot="subtitle">Johnathan Smith</span>
       <span slot="footer-leading">Nov 25, 2018</span>
@@ -231,8 +239,8 @@ export const DarkThemeFooterButtonsTooltipsDropdown = (): string => html`
       <img
         alt=""
         slot="thumbnail"
-        src="https://placem.at/places?w=260&h=160&txt=0"
-        style="width: 260px; height: 160px;"
+        src="${placeholderImage({ width: 260, height: 160 })}"
+        style="width:260px;height:160px"
       />
       <h3 slot="title">Portland Businesses</h3>
       <span slot="subtitle"

--- a/src/components/calcite-chip/calcite-chip.stories.ts
+++ b/src/components/calcite-chip/calcite-chip.stories.ts
@@ -2,7 +2,7 @@ import { select } from "@storybook/addon-knobs";
 import { iconNames, boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
-import { html } from "../../tests/utils";
+import { html, placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/Chip",
@@ -46,7 +46,7 @@ export const WithImage = (): string => html`
       color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
       ${boolean("dismissible", false)}
     >
-      <img alt="" slot="chip-image" src="https://placekitten.com/50/50" />
+      <img alt="" slot="chip-image" src="${placeholderImage({ width: 50, height: 50 })}" />
       My great chip</calcite-chip
     >
   </div>

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -4,7 +4,7 @@ import { ATTRIBUTES } from "../../../.storybook/resources";
 const { dir, position, scale, theme } = ATTRIBUTES;
 import readme from "./readme.md";
 import panelReadme from "../calcite-shell-panel/readme.md";
-import { html } from "../../tests/utils";
+import { html, placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/App/Shell",
@@ -154,7 +154,7 @@ const centerRowAdvancedHTML = html`
   <calcite-tip-manager slot="center-row">
     <calcite-tip-group group-title="Astronomy">
       <calcite-tip heading="The Red Rocks and Blue Water">
-        <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
+        <img slot="thumbnail" src="${placeholderImage({ width: 1000, height: 600 })}" alt="This is an image." />
         <p>
           This tip is how a tip should really look. It has a landscape or square image and a small amount of text
           content. This paragraph is in an "info" slot.
@@ -168,14 +168,14 @@ const centerRowAdvancedHTML = html`
         <a href="http://www.esri.com">This is the "link" slot.</a>
       </calcite-tip>
       <calcite-tip heading="The Long Trees">
-        <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
+        <img slot="thumbnail" src="${placeholderImage({ width: 1000, height: 600 })}" alt="This is an image." />
         <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
         <p>In astronomy, the terms object and body are often used interchangeably.</p>
         <a href="http://www.esri.com">View Esri</a>
       </calcite-tip>
     </calcite-tip-group>
     <calcite-tip heading="Square Nature">
-      <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
+      <img slot="thumbnail" src="${placeholderImage({ width: 1000, height: 1000 })}" alt="This is an image." />
       <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
       <p>In astronomy, the terms object and body are often used interchangeably.</p>
       <p>
@@ -250,7 +250,7 @@ const advancedTrailingPanelHTMl = html`
       <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
       <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
         <calcite-block-content>
-          <img alt="demo" src="https://placeimg.com/640/480/any" width="100%" />
+          <img alt="demo" src="${placeholderImage({ width: 640, height: 480 })}" width="100%" />
           <calcite-block-section text="Cool things">
             <calcite-action text="Cool thing" text-enabled></calcite-action>
             <calcite-action text="Cool thing" text-enabled></calcite-action>
@@ -274,7 +274,7 @@ const advancedTrailingPanelHTMl = html`
             <calcite-action text="Cool thing" text-enabled></calcite-action>
             <calcite-action text="Cool thing" text-enabled></calcite-action>
           </calcite-block-section>
-          <img alt="demo" src="https://placeimg.com/640/480/any" width="100%" />
+          <img alt="demo" src="${placeholderImage({ width: 640, height: 480 })}" width="100%" />
           <calcite-block-section text="Neat things">
             <calcite-action text="Cool thing" text-enabled></calcite-action>
             <calcite-action text="Cool thing" text-enabled></calcite-action>
@@ -289,7 +289,7 @@ const advancedTrailingPanelHTMl = html`
             <calcite-action text="Cool thing" text-enabled></calcite-action>
             <calcite-action text="Cool thing" text-enabled></calcite-action>
           </calcite-block-section>
-          <img alt="demo" src="https://placeimg.com/640/480/nature" width="100%" />
+          <img alt="demo" src="${placeholderImage({ width: 640, height: 480 })}" width="100%" />
           <calcite-block-section text="Neat things">
             <calcite-action text="Cool thing" text-enabled></calcite-action>
             <calcite-action text="Cool thing" text-enabled></calcite-action>

--- a/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.stories.ts
@@ -3,7 +3,7 @@ import { Attributes, createComponentHTML as create, darkBackground } from "../..
 import readme from "./readme.md";
 import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import { html } from "../../tests/utils";
+import { html, placeholderImage } from "../../tests/utils";
 const { dir, theme } = ATTRIBUTES;
 
 export default {
@@ -56,7 +56,7 @@ export const basic = (): string =>
     html`
       <calcite-tip-group group-title="Astronomy">
         <calcite-tip heading="The Red Rocks and Blue Water">
-          <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
+          <img slot="thumbnail" src="${placeholderImage({ width: 1000, height: 600 })}" alt="This is an image." />
           <p>
             This tip is how a tip should really look. It has a landscape or square image and a small amount of text
             content. This paragraph is in an "info" slot.
@@ -70,14 +70,14 @@ export const basic = (): string =>
           <a href="http://www.esri.com">This is the "link" slot.</a>
         </calcite-tip>
         <calcite-tip heading="The Long Trees">
-          <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
+          <img slot="thumbnail" src="${placeholderImage({ width: 1000, height: 600 })}" alt="This is an image." />
           <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
           <p>In astronomy, the terms object and body are often used interchangeably.</p>
           <a href="http://www.esri.com">View Esri</a>
         </calcite-tip>
       </calcite-tip-group>
       <calcite-tip heading="Square Nature">
-        <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
+        <img slot="thumbnail" src="${placeholderImage({ width: 1000, height: 1000 })}" alt="This is an image." />
         <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
         <p>In astronomy, the terms object and body are often used interchangeably.</p>
         <p>

--- a/src/components/calcite-tip/calcite-tip.stories.ts
+++ b/src/components/calcite-tip/calcite-tip.stories.ts
@@ -3,6 +3,7 @@ import { Attributes, createComponentHTML as create, darkBackground } from "../..
 import readme from "./readme.md";
 import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
+import { placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/App/Tip",
@@ -41,6 +42,9 @@ const createAttributes: () => Attributes = () => [
   }
 ];
 
-const html = `<img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non. Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti consectetur. Non porttitor tempor orci dictumst magna porta vitae.</div><a href="http://www.esri.com">This is a "link".</a>`;
+const html = `<img slot="thumbnail" src="${placeholderImage({
+  width: 1000,
+  height: 600
+})}" alt="This is an image." />Enim nascetur erat faucibus ornare varius arcu fames bibendum habitant felis elit ante. Nibh morbi massa curae; leo semper diam aenean congue taciti eu porta. Varius faucibus ridiculus donec. Montes sit ligula purus porta ante lacus habitasse libero cubilia purus! In quis congue arcu maecenas felis cursus pellentesque nascetur porta donec non. Quisque, rutrum ligula pharetra justo habitasse facilisis rutrum neque. Magnis nostra nec nulla dictumst taciti consectetur. Non porttitor tempor orci dictumst magna porta vitae.</div><a href="http://www.esri.com">This is a "link".</a>`;
 
 export const basic = (): string => create("calcite-tip", createAttributes(), html);


### PR DESCRIPTION
**Related Issue:** #1584 

## Summary
This pr replaces network calls to fetch images in avatar, block, card, chip, shell, and tip-manager stories with the new svg placeholder utility.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->
