### PR TITLE
ci: prevent deployment if outdated

### DIFF
--- a/support/deployNextFromTravisBuild.sh
+++ b/support/deployNextFromTravisBuild.sh
@@ -3,31 +3,53 @@
 # this script is meant to be run Travis deploys and determines if there will release-worthy changes.
 # based on https://github.com/conventional-changelog/standard-version/issues/192#issuecomment-610494804
 
-if \
-  { git log "$( git describe --tags --abbrev=0 )..HEAD" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -i -E '^feat|fix$' ; } || \
-  { git log "$( git describe --tags --abbrev=0 )..HEAD" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -E '\!$' ; } || \
-  { git log "$( git describe --tags --abbrev=0 )..HEAD" --format='%b' | grep -q -E '^BREAKING CHANGE:' ; }
-then
-  echo "Deploying @next from existing build..."
+function deployable {
+  local LOG_END="${1:-HEAD}"
+  local LOG_START=${2:-HEAD}
 
   if \
-    git checkout master --quiet && \
-    { echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> .npmrc 2> /dev/null ; } && \
-    { \
-      echo " - prepping package..." && \
-      npm run util:prep-next-from-existing-build >/dev/null 2>&1 && \
-
-      echo " - pushing tags..." && \
-      npm run util:push-tags -- --quiet https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG master >/dev/null 2>&1 && \
-
-      echo " - publishing @next..." && \
-      npm run util:publish-next >/dev/null 2>&1  \
-    ; }
+  { git log "$( git describe --tags --abbrev=0 $LOG_START)..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -i -E '^feat|fix$' ; } || \
+  { git log "$( git describe --tags --abbrev=0 $LOG_START)..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -E '\!$' ; } || \
+  { git log "$( git describe --tags --abbrev=0 $LOG_START)..${LOG_END}" --format='%b' | grep -q -E '^BREAKING CHANGE:' ; }
   then
-    echo "@next deployed! 🚀"
-  else
-    echo "An error occurred during deployment 🚫"
+    echo 0 # successful
   fi
+}
+
+function latestCommit {
+  echo $( git rev-parse $1 )
+}
+
+echo "Determining build deployability 🔍"
+
+if [ ! $( deployable ) ]
+then
+  echo "No changes since the previous release, skipping ⛔"
 else
-  echo "No changes since the previous release, skipping..."
+  git checkout master --quiet && git fetch --quiet >> .npmrc 2> /dev/null
+
+  if [ $( latestCommit master ) != $( latestCommit origin/master) ] && [ $( deployable origin/master origin/master) ]
+  then
+    echo "Deployment build is outdated, aborting ⛔️"
+  else
+    echo "Deploying @next from existing build 🚧"
+
+    if \
+      { echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> .npmrc 2> /dev/null ; } && \
+      { \
+        echo " - prepping package..." && \
+        npm run util:prep-next-from-existing-build >/dev/null 2>&1 && \
+
+        echo " - pushing tags..." && \
+        npm run util:push-tags -- --quiet https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG master >/dev/null 2>&1 && \
+
+        echo " - publishing @next..." && \
+        npm run util:publish-next >/dev/null 2>&1  \
+      ; }
+    then
+      echo "@next deployed! 🚀"
+    else
+      echo "An error occurred during deployment ❌"
+    fi
+  fi
 fi


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This updates the `@next` deployment script to bail if there is a newer commit that will end up being deployed. This should mitigate a scenario where `@next` releases would halt when multiple deployable PRs are installed consecutively. Basically, the builds from later PRs would be missing commits installed by the `@next` deployment scripts of earlier Travis runs.

cc @subgan82 @asangma 