### PR TITLE
ci: check for latest deployable installs after current commit

### DIFF
--- a/support/deployNextFromTravisBuild.sh
+++ b/support/deployNextFromTravisBuild.sh
@@ -5,7 +5,7 @@
 
 function deployable {
   local LOG_START=${1:-HEAD}
-  local LOG_END="${2:-HEAD}"
+  local LOG_END=${2:-HEAD}
 
   if \
   { git log "${LOG_START}..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -i -E '^feat|fix$' ; } || \

--- a/support/deployNextFromTravisBuild.sh
+++ b/support/deployNextFromTravisBuild.sh
@@ -4,13 +4,13 @@
 # based on https://github.com/conventional-changelog/standard-version/issues/192#issuecomment-610494804
 
 function deployable {
-  local LOG_END="${1:-HEAD}"
-  local LOG_START=${2:-HEAD}
+  local LOG_START=${1:-HEAD}
+  local LOG_END="${2:-HEAD}"
 
   if \
-  { git log "$( git describe --tags --abbrev=0 $LOG_START)..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -i -E '^feat|fix$' ; } || \
-  { git log "$( git describe --tags --abbrev=0 $LOG_START)..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -E '\!$' ; } || \
-  { git log "$( git describe --tags --abbrev=0 $LOG_START)..${LOG_END}" --format='%b' | grep -q -E '^BREAKING CHANGE:' ; }
+  { git log "${LOG_START}..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -i -E '^feat|fix$' ; } || \
+  { git log "${LOG_START}..${LOG_END}" --format='%s' | cut -d: -f1 | sort -u | sed -e 's/([^)]*)//' | grep -q -E '\!$' ; } || \
+  { git log "${LOG_START}..${LOG_END}" --format='%b' | grep -q -E '^BREAKING CHANGE:' ; }
   then
     echo 0 # successful
   fi
@@ -20,15 +20,19 @@ function latestCommit {
   echo $( git rev-parse $1 )
 }
 
+function mostRecentTag {
+  echo $( git describe --tags --abbrev=0 $1)
+}
+
 echo "Determining build deployability 🔍"
 
-if [ ! $( deployable ) ]
+if [ ! $( deployable $( mostRecentTag HEAD ) ) ]
 then
   echo "No changes since the previous release, skipping ⛔"
 else
   git checkout master --quiet && git fetch --quiet >> .npmrc 2> /dev/null
 
-  if [ $( latestCommit master ) != $( latestCommit origin/master) ] && [ $( deployable origin/master origin/master) ]
+  if [ $( latestCommit master ) != $( latestCommit origin/master) ] && [ $( deployable master origin/master) ]
   then
     echo "Deployment build is outdated, aborting ⛔️"
   else


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

https://github.com/Esri/calcite-components/pull/1593/ made some updates to prevent deploying an outdated build. This fixes a bug where the current commit was not excluded from the outdated deployable check. 

This also deletes a local test file that snuck in from ☝️ .