### PR TITLE
feat(combobox): fire event when combobox list is filtered (#1585)

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -33,7 +33,7 @@ describe("calcite-combobox", () => {
       <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
       <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
     </calcite-combobox>`);
-
+    const eventSpy = await page.spyOnEvent("calciteComboboxFilterChange", "window");
     await page.keyboard.press("Tab");
     await page.keyboard.type("one");
 
@@ -51,6 +51,9 @@ describe("calcite-combobox", () => {
 
     expect(item1Visible).toBe(true);
     expect(item2Visible).toBe(false);
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+    expect(await eventSpy.lastEvent.detail.visibleItems.length).toBe(1);
+    expect(await eventSpy.lastEvent.detail.text).toBe("one");
   });
 
   it("should control max items displayed", async () => {

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -218,6 +218,12 @@ export class CalciteCombobox {
   /** Called when the selected items set changes */
   @Event() calciteLookupChange: EventEmitter<HTMLCalciteComboboxItemElement[]>;
 
+  /** Called when the user has entered text to filter the options list */
+  @Event() calciteComboboxFilterChange: EventEmitter<{
+    visibleItems: HTMLCalciteComboboxItemElement[];
+    text: string;
+  }>;
+
   @Event() calciteComboboxChipDismiss: EventEmitter;
 
   // --------------------------------------------------------------------------
@@ -426,6 +432,7 @@ export class CalciteCombobox {
     });
 
     this.visibleItems = this.getVisibleItems();
+    this.calciteComboboxFilterChange.emit({ visibleItems: [...this.visibleItems], text: value });
   }, 100);
 
   toggleSelection(item: HTMLCalciteComboboxItemElement, value = !item.selected): void {


### PR DESCRIPTION
**Related Issue:** #1585

## Summary

New `calciteComboboxFilterChange` event when user filters the combobox list. Detail passed to the event will have the following type:

```ts
{
  visibleItems: HTMLCalciteComboboxItemElement[];
  text: string;
}
```