### PR TITLE
fix(calcite-checkbox): fixing focus outline styling weirdness on Safari

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.stories.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.stories.ts
@@ -13,28 +13,24 @@ export default {
 };
 
 export const Simple = (): string => html`
-  <label>
-    <calcite-checkbox
-      ${boolean("checked", true)}
-      ${boolean("disabled", false)}
-      ${boolean("indeterminate", false)}
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-    ></calcite-checkbox>
-    Text for the checkbox
-  </label>
+  <calcite-checkbox
+    ${boolean("checked", true)}
+    ${boolean("disabled", false)}
+    ${boolean("indeterminate", false)}
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    >Text for the checkbox</calcite-checkbox
+  >
 `;
 
 export const DarkMode = (): string => html`
-  <label>
-    <calcite-checkbox
-      theme="dark"
-      ${boolean("checked", true)}
-      ${boolean("disabled", false)}
-      ${boolean("indeterminate", false)}
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      >Text for the checkbox</calcite-checkbox
-    >
-  </label>
+  <calcite-checkbox
+    theme="dark"
+    ${boolean("checked", true)}
+    ${boolean("disabled", false)}
+    ${boolean("indeterminate", false)}
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    >Text for the checkbox</calcite-checkbox
+  >
 `;
 
 DarkMode.story = {

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -243,7 +243,8 @@ export class CalciteCheckbox {
     this.input.style.setProperty("bottom", "0", "important");
     this.input.style.setProperty("left", "0", "important");
     this.input.style.setProperty("margin", "0", "important");
-    this.input.style.setProperty("opacity", "0.3", "important");
+    this.input.style.setProperty("opacity", "0", "important");
+    this.input.style.setProperty("outline", "none", "important");
     this.input.style.setProperty("padding", "0", "important");
     this.input.style.setProperty("position", "absolute", "important");
     this.input.style.setProperty("right", "0", "important");
@@ -253,6 +254,7 @@ export class CalciteCheckbox {
       "important"
     );
     this.input.style.setProperty("transform", "none", "important");
+    this.input.style.setProperty("-webkit-appearance", "none", "important");
     this.input.style.setProperty("z-index", "-1", "important");
     this.input.type = "checkbox";
     if (this.value) {


### PR DESCRIPTION
**Related Issue:** #1566 