### PR TITLE
fix(color): ensure hue slider always updates internal color regardless of value being equal

### DIFF
--- a/src/components/calcite-color/calcite-color.tsx
+++ b/src/components/calcite-color/calcite-color.tsx
@@ -657,8 +657,8 @@ export class CalciteColor {
   //
   //--------------------------------------------------------------------------
 
-  private internalColorSet(color: Color | null): void {
-    if (colorEqual(color, this.color)) {
+  private internalColorSet(color: Color | null, skipEqual = true): void {
+    if (skipEqual && colorEqual(color, this.color)) {
       return;
     }
 
@@ -956,7 +956,7 @@ export class CalciteColor {
       } = this;
       const hue = (360 / width) * x;
 
-      this.internalColorSet(this.baseColorFieldColor.hue(hue));
+      this.internalColorSet(this.baseColorFieldColor.hue(hue), false);
     };
   };
 


### PR DESCRIPTION
**Related Issue:** #1474 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [x] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

This fixes an issue where the hue slider would not work if the selected color would produce the same RGB value after modifying the hue.

![modifying-hue-of-black](https://user-images.githubusercontent.com/197440/109042426-09ad1c80-7685-11eb-90f5-16b3cf2054bd.gif)
