### PR TITLE
chore(tests): add convention for skipping unstable tests with issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/unstable-test.md
+++ b/.github/ISSUE_TEMPLATE/unstable-test.md
@@ -1,0 +1,17 @@
+---
+name: Unstable Test
+about: Associate issue for an unstable test that was skipped.
+title: "Unstable: "
+labels: testing, 0 - new, p - high
+assignees: ""
+---
+
+## Summary
+
+**Which component?:**
+
+**Which test(s)?:** <!-- list unstable test(s) or suite -->
+
+**PR that skipped the test:** #
+
+## Additional Info <!-- any info that may help track down the issue -->

--- a/.github/ISSUE_TEMPLATE/unstable-test.md
+++ b/.github/ISSUE_TEMPLATE/unstable-test.md
@@ -12,6 +12,8 @@ assignees: ""
 
 **Which test(s)?:** <!-- list unstable test(s) or suite -->
 
+**Test error or URL to failed Travis build:** <!-- https://travis-ci.com/github/Esri/calcite-components/builds/<number> -->
+
 **PR that skipped the test:** #
 
-## Additional Info <!-- any info that may help track down the issue -->
+## Additional Info <!-- any info that may help fix the test -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,11 @@ If this is component-related, please verify that:
 - [ ] feature or fix has a corresponding test
 - [ ] changes have been tested with demo page in Edge
 
+---
+
+If this is skipping an unstable test:
+
+- include the URL to the failing Travis build, if applicable, or add info about the test failure
+- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out
+
 -->

--- a/conventions/README.md
+++ b/conventions/README.md
@@ -21,7 +21,9 @@ This is a living document defining our best practices and reasoning for authorin
 - [Custom Themes](#custom-themes)
 - [Unique IDs for Components](#unique-ids-for-components)
 - [Prerendering/SSR](#prerendering-and-ssr)
-- [Writing Tests](#writing-tests)
+- [Tests](#tests)
+  - [Writing Tests](#writing-tests)
+  - [Unstable Tests](#unstable-tests)
 
 <!-- /TOC -->
 
@@ -505,12 +507,20 @@ const elements = this.el.shadowRoot ? this.el.shadowRoot.querySelector("slot").a
 
 To ensure that all components are compatible for prerendering a prerender build is done as part of `npm test`.
 
-## Writing Tests
+## Tests
 
-### Prevent logging unnecessary messaging in the build
+### Writing Tests
+
+#### Prevent logging unnecessary messaging in the build
 
 **This is only necessary if a component's test will produce a lot of console messages in a test run.**
 
 As a best practice when writing tests, prevent emitting console warnings by stubbing them. Depending on the tested component, this may also apply to other console APIs.
 
 Console warnings can end up polluting the build output messaging that makes it more difficult to identify real issues. By stubbing `console.warn`, you can prevent warning messages from displaying in the build. See [`calcite-color.e2e`](https://github.com/Esri/calcite-components/blob/af0c6cb/src/components/calcite-color/calcite-color.e2e.ts#L9-L17) for an example.
+
+### Unstable Tests
+
+If you notice that a test fails intermittently during local or CI test runs, it is unstable and must be skipped to avoid holding up test runs, builds and deployments.
+
+To skip a test, use the `skip` method that's available on [tests, or suites](https://jestjs.io/docs/en/api#methods) and submit a pull request. Once that's done, please create a follow-up issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out.


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

-->

Adds convention to help track and fix unstable tests.