### PR TITLE
refactor(color)!: rename color to color-picker

### DIFF
--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
@@ -145,7 +145,7 @@ describe("calcite-color-picker-hex-input", () => {
     });
 
     const input = await page.find("calcite-color-picker-hex-input");
-    const spy = await input.spyOnEvent("calciteColorHexInputChange");
+    const spy = await input.spyOnEvent("calciteColorPickerHexInputChange");
 
     await input.setProperty("value", "#abcdef");
     await page.waitForChanges();

--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
@@ -118,7 +118,7 @@ export class CalciteColorPickerHexInput {
         this.value = normalized;
 
         if (changed) {
-          this.calciteColorHexInputChange.emit();
+          this.calciteColorPickerHexInputChange.emit();
         }
 
         return;
@@ -126,7 +126,7 @@ export class CalciteColorPickerHexInput {
     } else if (this.allowEmpty) {
       this.internalColor = null;
       this.value = null;
-      this.calciteColorHexInputChange.emit();
+      this.calciteColorPickerHexInputChange.emit();
 
       return;
     }
@@ -143,7 +143,7 @@ export class CalciteColorPickerHexInput {
   /**
    * Emitted when the hex value changes.
    */
-  @Event() calciteColorHexInputChange: EventEmitter;
+  @Event() calciteColorPickerHexInputChange: EventEmitter;
 
   private onCalciteInputBlur = (event: Event): void => {
     const node = event.currentTarget as HTMLCalciteInputElement;
@@ -181,7 +181,7 @@ export class CalciteColorPickerHexInput {
     }
 
     this.value = value;
-    this.calciteColorHexInputChange.emit();
+    this.calciteColorPickerHexInputChange.emit();
   };
 
   private onInputKeyDown = (event: KeyboardEvent): void => {

--- a/src/components/calcite-color-picker-hex-input/readme.md
+++ b/src/components/calcite-color-picker-hex-input/readme.md
@@ -15,9 +15,9 @@
 
 ## Events
 
-| Event                        | Description                         | Type               |
-| ---------------------------- | ----------------------------------- | ------------------ |
-| `calciteColorHexInputChange` | Emitted when the hex value changes. | `CustomEvent<any>` |
+| Event                              | Description                         | Type               |
+| ---------------------------------- | ----------------------------------- | ------------------ |
+| `calciteColorPickerHexInputChange` | Emitted when the hex value changes. | `CustomEvent<any>` |
 
 ## Methods
 

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -152,7 +152,7 @@ describe("calcite-color-picker", () => {
     });
     const picker = await page.find("calcite-color-picker");
 
-    const spy = await picker.spyOnEvent("calciteColorChange");
+    const spy = await picker.spyOnEvent("calciteColorPickerChange");
 
     picker.setProperty("value", "#FF00FF");
     await page.waitForChanges();
@@ -176,7 +176,7 @@ describe("calcite-color-picker", () => {
 
       beforeEach(async () => {
         page = await newE2EPage();
-        spy = await page.spyOnEvent("calciteColorChange");
+        spy = await page.spyOnEvent("calciteColorPickerChange");
       });
 
       function assertNoChangeEvents(): void {
@@ -257,7 +257,7 @@ describe("calcite-color-picker", () => {
       html: "<calcite-color-picker></calcite-color-picker>"
     });
     const picker = await page.find("calcite-color-picker");
-    const spy = await picker.spyOnEvent("calciteColorChange");
+    const spy = await picker.spyOnEvent("calciteColorPickerChange");
 
     const supportedStringFormats = [
       supportedFormatToSampleValue.hex,
@@ -293,7 +293,7 @@ describe("calcite-color-picker", () => {
       html: "<calcite-color-picker value='#000' scale='m'></calcite-color-picker>"
     });
     const picker = await page.find(`calcite-color-picker`);
-    const spy = await picker.spyOnEvent("calciteColorChange");
+    const spy = await picker.spyOnEvent("calciteColorPickerChange");
     let changes = 0;
     const mediumScaleDimensions = DIMENSIONS.m;
     const widthOffset = 0.5;
@@ -394,7 +394,7 @@ describe("calcite-color-picker", () => {
 
     async function assertUnsupportedValue(page: E2EPage, unsupportedValue: string | null): Promise<void> {
       const picker = await page.find("calcite-color-picker");
-      const spy = await picker.spyOnEvent("calciteColorChange");
+      const spy = await picker.spyOnEvent("calciteColorPickerChange");
       const currentValue = await picker.getProperty("value");
       picker.setProperty("value", unsupportedValue);
       await page.waitForChanges();

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -227,7 +227,7 @@ export class CalciteColorPicker {
     }
 
     if (this.colorUpdateLocked) {
-      this.calciteColorChange.emit();
+      this.calciteColorPickerChange.emit();
       return;
     }
 
@@ -236,7 +236,7 @@ export class CalciteColorPicker {
 
     if (modeChanged || colorChanged) {
       this.color = color;
-      this.calciteColorChange.emit();
+      this.calciteColorPickerChange.emit();
     }
   }
   //--------------------------------------------------------------------------
@@ -282,7 +282,7 @@ export class CalciteColorPicker {
   //--------------------------------------------------------------------------
 
   @Event()
-  calciteColorChange: EventEmitter;
+  calciteColorPickerChange: EventEmitter;
 
   private handleTabActivate = (event: Event): void => {
     this.channelMode = (event.currentTarget as HTMLElement).getAttribute(
@@ -492,7 +492,7 @@ export class CalciteColorPicker {
                   allowEmpty={allowEmpty}
                   class={CSS.control}
                   dir={elementDir}
-                  onCalciteColorHexInputChange={this.handleHexInputChange}
+                  onCalciteColorPickerHexInputChange={this.handleHexInputChange}
                   ref={this.storeHexInputRef}
                   scale={hexInputScale}
                   theme={theme}

--- a/src/components/calcite-color-picker/readme.md
+++ b/src/components/calcite-color-picker/readme.md
@@ -38,9 +38,9 @@
 
 ## Events
 
-| Event                | Description | Type               |
-| -------------------- | ----------- | ------------------ |
-| `calciteColorChange` |             | `CustomEvent<any>` |
+| Event                      | Description | Type               |
+| -------------------------- | ----------- | ------------------ |
+| `calciteColorPickerChange` |             | `CustomEvent<any>` |
 
 ## Methods
 


### PR DESCRIPTION
**Related Issue:** #1437 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include the URL to the failing Travis build, if applicable, or add info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This renames the following events that were missing from https://github.com/Esri/calcite-components/pull/1613:

* `calciteColorChange` -> `calciteColorPickerChange`
* `calciteColorHexInputChange` -> `calciteColorPickerHexInputChange` (internal)