### PR TITLE
test(modal): skip unstable test

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -180,7 +180,7 @@ describe("calcite-modal accessibility checks", () => {
         shadowFocusTargetSelector: closeButtonTargetSelector
       }));
 
-    it("can focus close button directly", async () =>
+    it.skip("can focus close button directly", async () =>
       focusable(createModalHTML(focusableContentHTML), {
         focusId: closeButtonFocusId,
         shadowFocusTargetSelector: closeButtonTargetSelector


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include the URL to the failing Travis build, if applicable, or add info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

https://travis-ci.org/github/Esri/calcite-components/builds/760523989

```
FAIL src/components/calcite-modal/calcite-modal.e2e.ts (32.825 s)
  ● calcite-modal accessibility checks › setFocus › can focus close button directly
    expect(received).toBe(expected) // Object.is equality
    Expected: true
    Received: false
      165 |   }
      166 | 
    > 167 |   expect(await page.evaluate((selector) => document.activeElement.matches(selector), focusTargetSelector)).toBe(true);
          |                                                                                                            ^
      168 | }
      169 | 
      at Object.focusable (src/tests/commonTests.ts:167:108)
          at runMicrotasks (<anonymous>)
```