### PR TITLE
chore(tests): update unstable-test templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/unstable-test.md
+++ b/.github/ISSUE_TEMPLATE/unstable-test.md
@@ -1,7 +1,7 @@
 ---
 name: Unstable Test
 about: Associate issue for an unstable test that was skipped.
-title: "Unstable: "
+title: "Unstable Test: "
 labels: testing, 0 - new, p - high
 assignees: ""
 ---
@@ -12,7 +12,25 @@ assignees: ""
 
 **Which test(s)?:** <!-- list unstable test(s) or suite -->
 
-**Test error or URL to failed Travis build:** <!-- https://travis-ci.com/github/Esri/calcite-components/builds/<number> -->
+**Test error:**
+
+<!--
+For example:
+
+FAIL src/components/calcite-foo/calcite-foo.e2e.ts (32.825 s)
+  ● calcite-foo a11y check › setFocus › can focus some button
+    expect(received).toBe(expected) // Object.is equality
+    Expected: true
+    Received: false
+      165 |   }
+      166 |
+    > 167 |   expect(await page.evaluate((selector) => document.activeElement.matches(selector), focusTargetSelector)).toBe(true);
+          |                                                                                                            ^
+      168 | }
+      169 |
+      at Object.focusable (src/tests/commonTests.ts:167:108)
+          at runMicrotasks (<anonymous>)
+-->
 
 **PR that skipped the test:** #
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ If this is component-related, please verify that:
 
 If this is skipping an unstable test:
 
-- include the URL to the failing Travis build, if applicable, or add info about the test failure
+- include info about the test failure
 - submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out
 
 -->


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include the URL to the failing Travis build, if applicable, or add info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Minor tweaks to the unstable test templates. Mainly drops the Travis build URL since it may point to a successful one if the build is run again and is successful.