### PR TITLE
fix(notice)!: remove open and close methods

### DIFF
--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -78,6 +78,7 @@ export class CalciteNotice {
   updateRequestedIcon(): void {
     this.requestedIcon = setRequestedIcon(StatusIcons, this.icon, this.color);
   }
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -98,7 +99,10 @@ export class CalciteNotice {
       <button
         aria-label={this.intlClose}
         class="notice-close"
-        onClick={() => this.close()}
+        onClick={() => {
+          this.active = false;
+          this.calciteNoticeClose.emit();
+        }}
         ref={() => this.closeButton}
       >
         <calcite-icon icon="x" scale="m" />
@@ -139,19 +143,6 @@ export class CalciteNotice {
   //  Public Methods
   //
   //--------------------------------------------------------------------------
-
-  /** close the notice emit the `calciteNoticeClose` event - <calcite-notice> listens for this */
-  @Method() async close(): Promise<void> {
-    this.active = false;
-    this.calciteNoticeClose.emit();
-  }
-
-  /** open the notice and emit the `calciteNoticeOpen` event - <calcite-notice> listens for this  */
-  @Method() async open(): Promise<void> {
-    this.active = true;
-    this.calciteNoticeOpen.emit();
-  }
-
   /** focus the close button, if present and requested */
   @Method()
   async setFocus(): Promise<void> {

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -99,10 +99,7 @@ export class CalciteNotice {
       <button
         aria-label={this.intlClose}
         class="notice-close"
-        onClick={() => {
-          this.active = false;
-          this.calciteNoticeClose.emit();
-        }}
+        onClick={this.close}
         ref={() => this.closeButton}
       >
         <calcite-icon icon="x" scale="m" />
@@ -154,6 +151,16 @@ export class CalciteNotice {
       this.closeButton.focus();
     }
   }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+  private close = (): void => {
+    this.active = false;
+    this.calciteNoticeClose.emit();
+  };
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #744

## Summary

Showing/hiding the notice is now controlled exclusively via the `active` prop. This brings the component closer to how other components like modal work.

