### PR TITLE
 feat(block, panel, pick-list-group, tip, tip-manager): Add 'headingLevel' property

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -14,6 +14,10 @@ describe("calcite-block", () => {
         defaultValue: false
       },
       {
+        propertyName: "headingLevel",
+        defaultValue: 4
+      },
+      {
         propertyName: "open",
         defaultValue: false
       }

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,9 +1,9 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
-import { CSS, SLOTS, TEXT } from "./resources";
+import { CSS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { Theme } from "../interfaces";
 import { getElementDir, getSlotted, getElementTheme } from "../../utils/dom";
-import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
+import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
  * @slot icon - A slot for adding a trailing header icon.
@@ -45,7 +45,7 @@ export class CalciteBlock {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = 4;
+  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
 
   /**
    * Tooltip used for the toggle when expanded.
@@ -156,9 +156,9 @@ export class CalciteBlock {
           </div>
         ) : null}
         <div class={CSS.title}>
-          <HeadingWizard class={CSS.heading} level={headingLevel}>
+          <CalciteHeading class={CSS.heading} level={headingLevel}>
             {heading}
-          </HeadingWizard>
+          </CalciteHeading>
           {summary ? <div class={CSS.summary}>{summary}</div> : null}
         </div>
       </header>

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -3,6 +3,7 @@ import { CSS, SLOTS, TEXT } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { Theme } from "../interfaces";
 import { getElementDir, getSlotted, getElementTheme } from "../../utils/dom";
+import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
 
 /**
  * @slot icon - A slot for adding a trailing header icon.
@@ -40,6 +41,11 @@ export class CalciteBlock {
    * Block heading.
    */
   @Prop() heading: string;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel = 4;
 
   /**
    * Tooltip used for the toggle when expanded.
@@ -135,7 +141,8 @@ export class CalciteBlock {
       loading,
       open,
       summary,
-      intlLoading
+      intlLoading,
+      headingLevel
     } = this;
 
     const toggleLabel = open ? intlCollapse || TEXT.collapse : intlExpand || TEXT.expand;
@@ -149,7 +156,9 @@ export class CalciteBlock {
           </div>
         ) : null}
         <div class={CSS.title}>
-          <h4 class={CSS.heading}>{heading}</h4>
+          <HeadingWizard class={CSS.heading} level={headingLevel}>
+            {heading}
+          </HeadingWizard>
           {summary ? <div class={CSS.summary}>{summary}</div> : null}
         </div>
       </header>

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -23,3 +23,5 @@ export const SLOTS = {
   icon: "icon",
   control: "control"
 };
+
+export const HEADING_LEVEL = 4;

--- a/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.tsx
+++ b/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.tsx
@@ -22,6 +22,7 @@ import {
 import { getKey } from "../../utils/key";
 import { DateLocaleData } from "../calcite-date-picker/utils";
 import { Scale } from "../interfaces";
+import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 @Component({
   tag: "calcite-date-picker-month-header",
@@ -48,6 +49,11 @@ export class CalciteDatePickerMonthHeader {
 
   /** Focused date with indicator (will become selected date if user proceeds) */
   @Prop() activeDate: Date;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel;
 
   /** Minimum date of the calendar below which is disabled. */
   @Prop() min: Date;
@@ -116,9 +122,9 @@ export class CalciteDatePickerMonthHeader {
             <calcite-icon dir={dir} flip-rtl icon="chevron-left" scale={iconScale} />
           </a>
           <div class={{ text: true, "text--reverse": reverse }}>
-            <span aria-level="2" class="month" role="heading">
+            <CalciteHeading class="month" level={this.headingLevel}>
               {localizedMonth}
-            </span>
+            </CalciteHeading>
             <span class="year-wrap">
               <input
                 class={{

--- a/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
@@ -14,6 +14,10 @@ describe("calcite-date-picker", () => {
         defaultValue: TEXT.prevMonth
       },
       {
+        propertyName: "headingLevel",
+        defaultValue: 2
+      },
+      {
         propertyName: "intlNextMonth",
         defaultValue: TEXT.nextMonth
       },

--- a/src/components/calcite-date-picker/calcite-date-picker.tsx
+++ b/src/components/calcite-date-picker/calcite-date-picker.tsx
@@ -15,11 +15,12 @@ import {
 import { getLocaleData, DateLocaleData } from "./utils";
 import { getElementDir } from "../../utils/dom";
 import { dateFromRange, dateFromISO, dateToISO, getDaysDiff } from "../../utils/date";
-
+import { HeadingLevel } from "../functional/CalciteHeading";
 import { getKey } from "../../utils/key";
 import { TEXT } from "./calcite-date-picker-resources";
 
 import { DateRangeChange } from "./interfaces";
+import { HEADING_LEVEL } from "./resources";
 
 @Component({
   assetsDirs: ["assets"],
@@ -45,6 +46,11 @@ export class CalciteDatePicker {
 
   /** Selected date */
   @Prop() value?: string;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
 
   /** Selected date as full date object*/
   @Prop({ mutable: true }) valueAsDate?: Date;
@@ -346,6 +352,7 @@ export class CalciteDatePicker {
         <calcite-date-picker-month-header
           activeDate={activeDate}
           dir={dir}
+          headingLevel={this.headingLevel}
           intlNextMonth={this.intlNextMonth}
           intlPrevMonth={this.intlPrevMonth}
           localeData={this.localeData}

--- a/src/components/calcite-date-picker/resources.ts
+++ b/src/components/calcite-date-picker/resources.ts
@@ -1,0 +1,1 @@
+export const HEADING_LEVEL = 2;

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -16,7 +16,7 @@ import {
 import { getLocaleData, DateLocaleData } from "../calcite-date-picker/utils";
 import { getElementDir } from "../../utils/dom";
 import { dateFromRange, inRange, dateFromISO, parseDateString, sameDate } from "../../utils/date";
-
+import { HeadingLevel } from "../functional/CalciteHeading";
 import { getKey } from "../../utils/key";
 import { TEXT } from "../calcite-date-picker/calcite-date-picker-resources";
 
@@ -46,6 +46,11 @@ export class CalciteInputDatePicker {
   //--------------------------------------------------------------------------
   /** Selected date */
   @Prop() value?: string;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel;
 
   /** Selected date as full date object*/
   @Prop({ mutable: true }) valueAsDate?: Date;
@@ -230,6 +235,7 @@ export class CalciteInputDatePicker {
                   activeRange={this.focusedInput}
                   dir={dir}
                   endAsDate={this.endAsDate}
+                  headingLevel={this.headingLevel}
                   intlNextMonth={this.intlNextMonth}
                   intlPrevMonth={this.intlPrevMonth}
                   locale={this.locale}

--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -12,6 +12,10 @@ describe("calcite-panel", () => {
       {
         propertyName: "widthScale",
         defaultValue: undefined
+      },
+      {
+        propertyName: "headingLevel",
+        defaultValue: 3
       }
     ]));
 

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -14,6 +14,7 @@ import { CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
 import { Scale, Theme } from "../interfaces";
+import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
 
 /**
  * @slot header-actions-start - a slot for adding actions or content to the start side of the panel header.
@@ -60,6 +61,11 @@ export class CalcitePanel {
    * Displays a close button in the trailing side of the header.
    */
   @Prop({ reflect: true }) dismissible = false;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel = 3;
 
   /**
    * Shows a back button in the header.
@@ -242,8 +248,13 @@ export class CalcitePanel {
   }
 
   renderHeaderContent(): VNode {
-    const { heading, summary } = this;
-    const headingNode = heading ? <h3 class={CSS.heading}>{heading}</h3> : null;
+    const { heading, headingLevel, summary } = this;
+    const headingNode = heading ? (
+      <HeadingWizard class={CSS.heading} level={headingLevel}>
+        {heading}
+      </HeadingWizard>
+    ) : null;
+
     const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
 
     return headingNode || summaryNode ? (

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -10,11 +10,11 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, HEADING_LEVEL, ICONS, SLOTS, TEXT } from "./resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
 import { Scale, Theme } from "../interfaces";
-import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
+import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
  * @slot header-actions-start - a slot for adding actions or content to the start side of the panel header.
@@ -65,7 +65,7 @@ export class CalcitePanel {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = 3;
+  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
 
   /**
    * Shows a back button in the header.
@@ -250,9 +250,9 @@ export class CalcitePanel {
   renderHeaderContent(): VNode {
     const { heading, headingLevel, summary } = this;
     const headingNode = heading ? (
-      <HeadingWizard class={CSS.heading} level={headingLevel}>
+      <CalciteHeading class={CSS.heading} level={headingLevel}>
         {heading}
-      </HeadingWizard>
+      </CalciteHeading>
     ) : null;
 
     const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;

--- a/src/components/calcite-panel/resources.ts
+++ b/src/components/calcite-panel/resources.ts
@@ -40,3 +40,5 @@ export const TEXT = {
   open: "Open",
   options: "Options"
 };
+
+export const HEADING_LEVEL = 3;

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS } from "./resources";
-import { accessible } from "../../tests/commonTests";
+import { accessible, defaults } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
 describe("calcite-pick-list-group", () => {
@@ -15,6 +15,14 @@ describe("calcite-pick-list-group", () => {
       </calcite-pick-list>
     `);
   });
+
+  it("has property defaults", async () =>
+    defaults("calcite-pick-list-group", [
+      {
+        propertyName: "headingLevel",
+        defaultValue: 3
+      }
+    ]));
 
   it("should render", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Host, Prop, h, VNode } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
+import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
@@ -24,6 +25,11 @@ export class CalcitePickListGroup {
    */
   @Prop({ reflect: true }) groupTitle: string;
 
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel = 3;
+
   // --------------------------------------------------------------------------
   //
   //  Private Properties
@@ -39,7 +45,7 @@ export class CalcitePickListGroup {
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const { el, groupTitle } = this;
+    const { el, groupTitle, headingLevel } = this;
     const rtl = getElementDir(el) === "rtl";
     const hasParentItem = getSlotted(el, SLOTS.parentItem) !== null;
     const sectionClasses = {
@@ -52,7 +58,11 @@ export class CalcitePickListGroup {
 
     return (
       <Host>
-        {title ? <h3 class={CSS.heading}>{title}</h3> : null}
+        {title ? (
+          <HeadingWizard class={CSS.heading} level={headingLevel}>
+            {title}
+          </HeadingWizard>
+        ) : null}
         <slot name={SLOTS.parentItem} />
         <section class={sectionClasses}>
           <slot />

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -1,8 +1,9 @@
 import { Component, Element, Host, Prop, h, VNode } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
+import { HEADING_LEVEL } from "./resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
-import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
+import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
@@ -28,7 +29,7 @@ export class CalcitePickListGroup {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = 3;
+  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
 
   // --------------------------------------------------------------------------
   //
@@ -59,9 +60,9 @@ export class CalcitePickListGroup {
     return (
       <Host>
         {title ? (
-          <HeadingWizard class={CSS.heading} level={headingLevel}>
+          <CalciteHeading class={CSS.heading} level={headingLevel}>
             {title}
-          </HeadingWizard>
+          </CalciteHeading>
         ) : null}
         <slot name={SLOTS.parentItem} />
         <section class={sectionClasses}>

--- a/src/components/calcite-pick-list-group/resources.ts
+++ b/src/components/calcite-pick-list-group/resources.ts
@@ -7,3 +7,5 @@ export const CSS = {
 export const SLOTS = {
   parentItem: "parent-item"
 };
+
+export const HEADING_LEVEL = 3;

--- a/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, TEXT } from "./resources";
-import { accessible } from "../../tests/commonTests";
+import { accessible, defaults } from "../../tests/commonTests";
 
 describe("calcite-tip-manager", () => {
   describe("first render", () => {
@@ -18,6 +18,14 @@ describe("calcite-tip-manager", () => {
       const title = await page.find(`calcite-tip-manager >>> .${CSS.heading}`);
       expect(title.innerText).toBe(TEXT.defaultGroupTitle);
     });
+
+    it("has property defaults", async () =>
+      defaults("calcite-tip-manager", [
+        {
+          propertyName: "headingLevel",
+          defaultValue: 2
+        }
+      ]));
 
     it("is accessible", async () =>
       accessible(

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -14,6 +14,7 @@ import {
 import { CSS, ICONS, TEXT } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { Theme } from "../interfaces";
+import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
 
 /**
  * @slot - A slot for adding `calcite-tip`s.
@@ -39,6 +40,11 @@ export class CalciteTipManager {
     this.direction = null;
     this.calciteTipManagerToggle.emit();
   }
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel = 2;
 
   /**
    * Alternate text for closing the tip.
@@ -258,7 +264,7 @@ export class CalciteTipManager {
   }
 
   render(): VNode {
-    const { closed, direction, groupTitle, selectedIndex, intlClose, total } = this;
+    const { closed, direction, headingLevel, groupTitle, selectedIndex, intlClose, total } = this;
 
     const closeLabel = intlClose || TEXT.close;
 
@@ -276,9 +282,9 @@ export class CalciteTipManager {
           tabIndex={0}
         >
           <header class={CSS.header}>
-            <h2 class={CSS.heading} key={selectedIndex}>
+            <HeadingWizard class={CSS.heading} level={headingLevel}>
               {groupTitle}
-            </h2>
+            </HeadingWizard>
             <calcite-action
               class={CSS.close}
               icon={ICONS.close}

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -11,10 +11,10 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CSS, ICONS, TEXT } from "./resources";
+import { CSS, ICONS, TEXT, HEADING_LEVEL } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { Theme } from "../interfaces";
-import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
+import { HeadingLevel, CalciteHeading, ConstrainHeadingLevel } from "../functional/CalciteHeading";
 
 /**
  * @slot - A slot for adding `calcite-tip`s.
@@ -44,7 +44,7 @@ export class CalciteTipManager {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = 2;
+  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
 
   /**
    * Alternate text for closing the tip.
@@ -168,6 +168,7 @@ export class CalciteTipManager {
     this.selectedIndex = selectedTip ? tips.indexOf(selectedTip) : 0;
 
     tips.forEach((tip) => {
+      tip.headingLevel = ConstrainHeadingLevel(this.headingLevel + 1);
       tip.nonDismissible = true;
     });
     this.showSelectedTip();
@@ -282,9 +283,9 @@ export class CalciteTipManager {
           tabIndex={0}
         >
           <header class={CSS.header}>
-            <HeadingWizard class={CSS.heading} level={headingLevel}>
+            <CalciteHeading class={CSS.heading} level={headingLevel}>
               {groupTitle}
-            </HeadingWizard>
+            </CalciteHeading>
             <calcite-action
               class={CSS.close}
               icon={ICONS.close}

--- a/src/components/calcite-tip-manager/resources.ts
+++ b/src/components/calcite-tip-manager/resources.ts
@@ -25,3 +25,5 @@ export const TEXT = {
   previous: "Previous",
   next: "Next"
 };
+
+export const HEADING_LEVEL = 2;

--- a/src/components/calcite-tip/calcite-tip.e2e.ts
+++ b/src/components/calcite-tip/calcite-tip.e2e.ts
@@ -1,11 +1,19 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, hidden, renders, defaults } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-tip", () => {
   it("renders", async () => renders("calcite-tip"));
 
   it("honors hidden attribute", async () => hidden("calcite-tip"));
+
+  it("has property defaults", async () =>
+    defaults("calcite-tip", [
+      {
+        propertyName: "headingLevel",
+        defaultValue: 3
+      }
+    ]));
 
   it("is accessible", async () => accessible(`<calcite-tip heading="sample"><p>not dismissible</p></calcite-tip>`));
 

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -1,8 +1,8 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
 import { Theme } from "../interfaces";
-import { CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, ICONS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
-import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
+import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
  * @slot thumbnail - A slot for adding an HTML image element to the tip.
@@ -36,7 +36,7 @@ export class CalciteTip {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = 3;
+  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
 
   /**
    * The selected state of the tip if it is being used inside a `calcite-tip-manager`.
@@ -95,9 +95,9 @@ export class CalciteTip {
 
     return heading ? (
       <header class={CSS.header}>
-        <HeadingWizard class={CSS.heading} level={headingLevel}>
+        <CalciteHeading class={CSS.heading} level={headingLevel}>
           {heading}
-        </HeadingWizard>
+        </CalciteHeading>
       </header>
     ) : null;
   }

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@
 import { Theme } from "../interfaces";
 import { CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { getSlotted } from "../../utils/dom";
+import { HeadingLevel, HeadingWizard } from "../functional/HeadingWizard";
 
 /**
  * @slot thumbnail - A slot for adding an HTML image element to the tip.
@@ -31,6 +32,11 @@ export class CalciteTip {
    * The heading of the tip.
    */
   @Prop() heading?: string;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel = 3;
 
   /**
    * The selected state of the tip if it is being used inside a `calcite-tip-manager`.
@@ -85,11 +91,13 @@ export class CalciteTip {
   // --------------------------------------------------------------------------
 
   renderHeader(): VNode {
-    const { heading } = this;
+    const { heading, headingLevel } = this;
 
     return heading ? (
       <header class={CSS.header}>
-        <h3 class={CSS.heading}>{heading}</h3>
+        <HeadingWizard class={CSS.heading} level={headingLevel}>
+          {heading}
+        </HeadingWizard>
       </header>
     ) : null;
   }

--- a/src/components/calcite-tip/resources.ts
+++ b/src/components/calcite-tip/resources.ts
@@ -1,3 +1,6 @@
+import { HEADING_LEVEL as PARENT_HEADING_LEVEL } from "../calcite-tip-manager/resources";
+import { HeadingLevel } from "../functional/CalciteHeading";
+
 export const CSS = {
   container: "container",
   header: "header",
@@ -19,3 +22,5 @@ export const SLOTS = {
 export const TEXT = {
   close: "Close"
 };
+
+export const HEADING_LEVEL = (PARENT_HEADING_LEVEL + 1) as HeadingLevel;

--- a/src/components/functional/CalciteHeading.spec.tsx
+++ b/src/components/functional/CalciteHeading.spec.tsx
@@ -1,0 +1,32 @@
+import { h, Component } from "@stencil/core";
+import { newSpecPage } from "@stencil/core/testing";
+import { CalciteHeading, ConstrainHeadingLevel } from "./CalciteHeading";
+
+describe("ConstrainHeadingLevel", () => {
+  it("should constrain heading levels", () => {
+    expect(ConstrainHeadingLevel(10)).toEqual(6);
+    expect(ConstrainHeadingLevel(6)).toEqual(6);
+    expect(ConstrainHeadingLevel(5)).toEqual(5);
+    expect(ConstrainHeadingLevel(1)).toEqual(1);
+    expect(ConstrainHeadingLevel(0)).toEqual(1);
+    expect(ConstrainHeadingLevel(3.14)).toEqual(4);
+  });
+});
+
+@Component({ tag: "dummy-component" })
+class Dummy {}
+
+describe("CalciteHeading", () => {
+  it("should render", async () => {
+    const page = await newSpecPage({
+      components: [Dummy], // Required so we are feeding it a Dummy component
+      template: () => (
+        <CalciteHeading class="test" level={1}>
+          My Heading
+        </CalciteHeading>
+      )
+    });
+
+    expect(page.root).toEqualHtml(`<h1 class="test">My Heading</h1>`);
+  });
+});

--- a/src/components/functional/CalciteHeading.tsx
+++ b/src/components/functional/CalciteHeading.tsx
@@ -3,12 +3,15 @@ import { JSXBase } from "@stencil/core/internal";
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
-interface HeadingWizardProps extends JSXBase.HTMLAttributes {
+interface CalciteHeadingProps extends JSXBase.HTMLAttributes {
   level: HeadingLevel;
 }
 
-// (∩｀-´)⊃━☆ﾟ.*･｡ﾟ
-export const HeadingWizard: FunctionalComponent<HeadingWizardProps> = (props, children) => {
+export function ConstrainHeadingLevel(level: number): HeadingLevel {
+  return Math.min(Math.max(Math.ceil(level), 1), 6) as HeadingLevel;
+}
+
+export const CalciteHeading: FunctionalComponent<CalciteHeadingProps> = (props, children) => {
   const HeadingTag = `h${props.level}`;
 
   delete props.level;

--- a/src/components/functional/HeadingWizard.tsx
+++ b/src/components/functional/HeadingWizard.tsx
@@ -9,9 +9,9 @@ interface HeadingWizardProps extends JSXBase.HTMLAttributes {
 
 // (∩｀-´)⊃━☆ﾟ.*･｡ﾟ
 export const HeadingWizard: FunctionalComponent<HeadingWizardProps> = (props, children) => {
-  const Heading = `h${props.level}`;
+  const HeadingTag = `h${props.level}`;
 
   delete props.level;
 
-  return <Heading {...props}>{children}</Heading>;
+  return <HeadingTag {...props}>{children}</HeadingTag>;
 };

--- a/src/components/functional/HeadingWizard.tsx
+++ b/src/components/functional/HeadingWizard.tsx
@@ -1,0 +1,17 @@
+import { FunctionalComponent, h } from "@stencil/core";
+import { JSXBase } from "@stencil/core/internal";
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+interface HeadingWizardProps extends JSXBase.HTMLAttributes {
+  level: HeadingLevel;
+}
+
+// (∩｀-´)⊃━☆ﾟ.*･｡ﾟ
+export const HeadingWizard: FunctionalComponent<HeadingWizardProps> = (props, children) => {
+  const Heading = `h${props.level}`;
+
+  delete props.level;
+
+  return <Heading {...props}>{children}</Heading>;
+};


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/1531

## Summary

feat(block, panel, pick-list-group, tip, tip-manager): Add 'headingLevel' property to specify a number at which section headings should start for the component.

- Adds a `headingLevel` prop to any components that use a `h1`-`h6`.
- Uses `headingLevel` prop and a functional component to return the correct heading level
- Allows a user to change the level for headings within a component for accessibility and semantics.

## TODO

- ~~@asangma we will need to set sizing for all the heading classes so that changing the level does not change the size of the heading.~~ We can tackle these as the arise or we can create an issue.
- ~~If naming is approved, I will create tests.~~ done
