### PR TITLE
feat(tailwind): add percentage based text utils for "text that wraps"

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -80,6 +80,18 @@ module.exports = {
       "6h": [ "var(--calcite-font-size-6)", { lineHeight: '4rem' } ],      // 48px (3rem)
       "7h": [ "var(--calcite-font-size-7)", { lineHeight: '4rem' } ],      // 56px (3.5rem)
       "8h": [ "var(--calcite-font-size-8)", { lineHeight: '5rem' } ],      // 64px (4rem)
+      "-3-snug": [ "var(--calcite-font-size--3)", { lineHeight: '1.375' } ],
+      "-2-snug": [ "var(--calcite-font-size--2)", { lineHeight: '1.375' } ],
+      "-1-snug": [ "var(--calcite-font-size--1)", { lineHeight: '1.375' } ],
+      "0-snug": [ "var(--calcite-font-size-0)", { lineHeight: '1.375' } ],
+      "1-snug": [ "var(--calcite-font-size-1)", { lineHeight: '1.375' } ],
+      "2-snug": [ "var(--calcite-font-size-2)", { lineHeight: '1.375' } ],
+      "3-tight": [ "var(--calcite-font-size-3)", { lineHeight: '1.25' } ],
+      "4-tight": [ "var(--calcite-font-size-4)", { lineHeight: '1.25' } ],
+      "5-tight": [ "var(--calcite-font-size-5)", { lineHeight: '1.25' } ],
+      "6-tight": [ "var(--calcite-font-size-6)", { lineHeight: '1.25' } ],
+      "7-tight": [ "var(--calcite-font-size-7)", { lineHeight: '1.25' } ],
+      "8-tight": [ "var(--calcite-font-size-8)", { lineHeight: '1.25' } ],
     },
     fontWeight: {
       // assets/styles/_type


### PR DESCRIPTION
Supports #1500 

## Summary

This changeset adds a set of convenience utilities for text that wraps.  These utilities combine `text-*` + `leading-*` e.g. `text-2-snug` is equivalent to `text-2 leading-snug`.**
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
