### PR TITLE
fix(shell): content layout when not content-behind

### DIFF
--- a/src/components/calcite-shell-center-row/calcite-shell-center-row.scss
+++ b/src/components/calcite-shell-center-row/calcite-shell-center-row.scss
@@ -5,8 +5,6 @@
   flex: 1 1 auto;
   overflow: hidden;
   background-color: transparent;
-  border-left: 1px solid var(--calcite-ui-border-3);
-  border-right: 1px solid var(--calcite-ui-border-3);
 
   --calcite-shell-center-row-height-small: 33%;
   --calcite-shell-center-row-height-medium: 70%;

--- a/src/components/calcite-shell-center-row/calcite-shell-center-row.scss
+++ b/src/components/calcite-shell-center-row/calcite-shell-center-row.scss
@@ -2,6 +2,7 @@
   @extend %component-host;
   @extend %component-spacing;
   display: flex;
+  flex: 1 1 auto;
   overflow: hidden;
   background-color: transparent;
   border-left: 1px solid var(--calcite-ui-border-3);

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -19,6 +19,16 @@ describe("calcite-shell", () => {
     expect(header).toBeNull();
   });
 
+  it("content node should always be present", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-shell></calcite-shell>`);
+
+    const content = await page.find(`calcite-shell >>> .${CSS.content}`);
+
+    expect(content).not.toBeNull();
+  });
+
   it("footer should be present when defined", async () => {
     const page = await newE2EPage();
 

--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -32,25 +32,35 @@
 }
 
 .content {
+  border-left: 1px solid var(--calcite-ui-border-3);
+  border-right: 1px solid var(--calcite-ui-border-3);
   height: 100%;
   width: 100%;
+  display: flex;
+  flex-flow: column nowrap;
 }
 
-.content--behind ::slotted(calcite-panel),
-.content--behind ::slotted(calcite-flow) {
-  height: 100%;
-  max-height: unset;
-  max-width: unset;
+.content ::slotted(calcite-shell-center-row),
+.content ::slotted(calcite-panel),
+.content ::slotted(calcite-flow) {
+  flex: 1 1 auto;
   width: 100%;
+  max-height: unset;
 }
 
 .content--behind {
+  border: 0;
+  display: initial;
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   top: 0;
   z-index: 0;
+}
+
+.content.content--behind ::slotted(calcite-shell-center-row) {
+  width: unset;
 }
 
 ::slotted(.header .heading) {

--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -35,6 +35,7 @@
   border-left: 1px solid var(--calcite-ui-border-3);
   border-right: 1px solid var(--calcite-ui-border-3);
   height: 100%;
+  overflow: auto;
   width: 100%;
   display: flex;
   flex-flow: column nowrap;

--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -43,8 +43,8 @@
 .content ::slotted(calcite-shell-center-row),
 .content ::slotted(calcite-panel),
 .content ::slotted(calcite-flow) {
+  align-self: stretch;
   flex: 1 1 auto;
-  width: 100%;
   max-height: unset;
 }
 
@@ -59,7 +59,7 @@
   z-index: 0;
 }
 
-.content.content--behind ::slotted(calcite-shell-center-row) {
+::slotted(calcite-shell-center-row) {
   width: unset;
 }
 
@@ -72,6 +72,11 @@
 ::slotted(calcite-shell-center-row) {
   position: relative;
   z-index: 1;
+}
+
+slot[name="center-row"]::slotted(calcite-shell-center-row:not([detached])) {
+  border-left: 1px solid var(--calcite-ui-border-3);
+  border-right: 1px solid var(--calcite-ui-border-3);
 }
 
 ::slotted(calcite-tip-manager) {

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -62,7 +62,7 @@ export class CalciteShell {
       <div
         class={{
           [CSS.content]: true,
-          [CSS.contentBehind]: true
+          [CSS.contentBehind]: !!this.contentBehind
         }}
       >
         <slot />

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -54,16 +54,35 @@ export class CalciteShell {
   }
 
   renderContent(): VNode {
+    return !!this.contentBehind ? this.renderContentBehind() : this.renderContentInline();
+  }
+
+  renderContentBehind(): VNode {
     return (
       <div
         class={{
           [CSS.content]: true,
-          [CSS.contentBehind]: !!this.contentBehind
+          [CSS.contentBehind]: true
         }}
       >
         <slot />
       </div>
     );
+  }
+
+  renderContentInline(): VNode {
+    return (
+      <div class={CSS.content}>
+        <slot />
+        {this.renderCenterRow()}
+      </div>
+    );
+  }
+
+  renderCenterRow(): VNode {
+    const hasCenterRow = !!getSlotted(this.el, SLOTS.centerRow);
+
+    return hasCenterRow ? <slot name={SLOTS.centerRow} /> : null;
   }
 
   renderFooter(): VNode {
@@ -88,7 +107,7 @@ export class CalciteShell {
       <div class={mainClasses}>
         <slot name={SLOTS.primaryPanel} />
         {this.renderContent()}
-        <slot name={SLOTS.centerRow} />
+        {!!this.contentBehind ? this.renderCenterRow() : null}
         <slot name={SLOTS.contextualPanel} />
       </div>
     );

--- a/src/components/calcite-shell/readme.md
+++ b/src/components/calcite-shell/readme.md
@@ -145,6 +145,7 @@ Renders a single panel with actions in an action bar.
 
 | Property | Attribute | Description                               | Type                | Default     |
 | -------- | --------- | ----------------------------------------- | ------------------- | ----------- |
+| `content-behind` | Used to place the content of the default slot behind other slots. | `boolean` | `false` |
 | `theme`  | `theme`   | Used to set the component's color scheme. | `"dark" \| "light"` | `undefined` |
 
 ## Slots
@@ -157,6 +158,7 @@ Renders a single panel with actions in an action bar.
 | `"primary-panel"`    | A slot for adding the leading `calcite-shell-panel`.                                                                                     |
 | `"shell-footer"`     | A slot for adding footer content. This content will be positioned at the bottom of the shell.                                            |
 | `"shell-header"`     | A slot for adding header content. This content will be positioned at the top of the shell.                                               |
+| `"center-row"`     | A slot for secondary content. This content will be positioned at the bottom of the shell above content. It's supported but not recommended to use this slot when `content-behind` is `false`. |
 
 ---
 


### PR DESCRIPTION
**Related Issue:** (#1637)

## Summary
Updates Shell and CenterRow to fix layout bug when Shell did not have `content-behind`.

@driskull Let me know if the conditionals on the node layout is overly complex.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
