### PR TITLE
refactor(radio): tailwindify

### DIFF
--- a/src/components/calcite-radio/calcite-radio.scss
+++ b/src/components/calcite-radio/calcite-radio.scss
@@ -63,9 +63,9 @@
 :host([scale="l"]) {
   .radio {
     //FIXME: Both figma and current code here have 14, but it's not a tailwind value
-    height: 20px;
-    min-width: 20px;
-    max-width: 20px;
+    @apply h-5;
+    min-width: theme("spacing.5");
+    max-width: theme("spacing.5");
   }
 }
 :host([scale="l"][checked]),

--- a/src/components/calcite-radio/calcite-radio.scss
+++ b/src/components/calcite-radio/calcite-radio.scss
@@ -1,8 +1,7 @@
 :host {
   .radio {
-    border-radius: 100%;
-    box-shadow: inset 0 0 0 1px var(--calcite-ui-border-1);
-    cursor: pointer;
+    @apply rounded-full cursor-pointer border;
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
     transition: all 0.15s ease-in-out;
   }
 }
@@ -14,20 +13,19 @@
 }
 :host([disabled]) {
   .radio {
-    cursor: default;
-    opacity: var(--calcite-ui-opacity-disabled);
+    @apply cursor-default opacity-disabled;
   }
 }
 :host([hovered][disabled]) {
   .radio {
-    box-shadow: inset 0 0 0 1px var(--calcite-ui-border-1);
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
   }
 }
 :host([scale="s"]) {
   .radio {
-    height: 12px;
-    min-width: 12px;
-    max-width: 12px;
+    @apply h-3;
+    min-width: theme("spacing.3");
+    max-width: theme("spacing.3");
   }
 }
 :host([scale="s"][checked]),
@@ -44,6 +42,7 @@
 }
 :host([scale="m"]) {
   .radio {
+    //FIXME: Both figma and current code here have 14, but it's not a tailwind value
     height: 14px;
     min-width: 14px;
     max-width: 14px;
@@ -63,6 +62,7 @@
 }
 :host([scale="l"]) {
   .radio {
+    //FIXME: Both figma and current code here have 14, but it's not a tailwind value
     height: 20px;
     min-width: 20px;
     max-width: 20px;
@@ -81,5 +81,5 @@
   }
 }
 :host([hidden]) {
-  display: none;
+  @apply hidden;
 }

--- a/src/components/calcite-radio/calcite-radio.scss
+++ b/src/components/calcite-radio/calcite-radio.scss
@@ -21,13 +21,23 @@
     box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
   }
 }
+
 :host([scale="s"]) {
-  .radio {
-    @apply h-3;
-    min-width: theme("spacing.3");
-    max-width: theme("spacing.3");
-  }
+  --calcite-radio-size: theme("fontSize.-2");
 }
+:host([scale="m"]) {
+  --calcite-radio-size: theme("fontSize.-1");
+}
+:host([scale="l"]) {
+  --calcite-radio-size: theme("fontSize.1");
+}
+
+.radio {
+  height: var(--calcite-radio-size);
+  max-width: var(--calcite-radio-size);
+  min-width: var(--calcite-radio-size);
+}
+
 :host([scale="s"][checked]),
 :host([hovered][scale="s"][checked][disabled]) {
   .radio {
@@ -40,14 +50,6 @@
       0 0 0 4px var(--calcite-ui-brand);
   }
 }
-:host([scale="m"]) {
-  .radio {
-    //FIXME: Both figma and current code here have 14, but it's not a tailwind value
-    height: 14px;
-    min-width: 14px;
-    max-width: 14px;
-  }
-}
 :host([scale="m"][checked]),
 :host([hovered][scale="m"][checked][disabled]) {
   .radio {
@@ -58,14 +60,6 @@
   .radio {
     box-shadow: inset 0 0 0 5px var(--calcite-ui-brand), 0 0 0 2px var(--calcite-ui-foreground-1),
       0 0 0 4px var(--calcite-ui-brand);
-  }
-}
-:host([scale="l"]) {
-  .radio {
-    //FIXME: Both figma and current code here have 14, but it's not a tailwind value
-    @apply h-5;
-    min-width: theme("spacing.5");
-    max-width: theme("spacing.5");
   }
 }
 :host([scale="l"][checked]),

--- a/src/components/calcite-radio/calcite-radio.scss
+++ b/src/components/calcite-radio/calcite-radio.scss
@@ -1,6 +1,6 @@
 :host {
   .radio {
-    @apply rounded-full cursor-pointer border;
+    @apply rounded-full cursor-pointer;
     box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
     transition: all 0.15s ease-in-out;
   }

--- a/src/components/calcite-radio/calcite-radio.scss
+++ b/src/components/calcite-radio/calcite-radio.scss
@@ -1,8 +1,7 @@
 :host {
   .radio {
-    @apply rounded-full cursor-pointer;
+    @apply rounded-full cursor-pointer transition-all duration-150 ease-in-out;
     box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
-    transition: all 0.15s ease-in-out;
   }
 }
 :host([hovered]),


### PR DESCRIPTION
Supports #1694 #1500

Medium: code and design have 14px, however, tailwind doesn't have this vlaue. Tailwind 2.0 does have it, maybe a reason to update? @jrowlingson 

Large: code has 20px, design has 18px (which is not a tailwind value). Used 20px for now.
^^ @bstifle 