### PR TITLE
feat(combobox): add ancestor selection mode (#1590)

### DIFF
--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -126,7 +126,6 @@ export class CalciteComboboxItem {
     if (this.disabled) {
       return;
     }
-
     this.isSelected = !this.isSelected;
     this.calciteComboboxItemChange.emit(this.el);
   };

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -157,6 +157,62 @@ describe("calcite-combobox", () => {
       expect(chip).toBeNull();
     });
 
+    it("should select parent in ancestor selection mode", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-combobox selection-mode="ancestors">
+          <calcite-combobox-item value="one" text-label="one">
+            <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
+          </calcite-combobox-item>
+        </calcite-combobox>`
+      });
+
+      await page.keyboard.press("Tab");
+      await page.waitForChanges();
+
+      const cbox = await page.find("calcite-combobox");
+      const item1 = await cbox.find("calcite-combobox-item[value=child1]");
+      await item1.click();
+
+      const parent = await cbox.find("calcite-combobox-item[value=one]");
+      expect(parent).toBeDefined();
+      expect(parent).toHaveAttribute("selected");
+
+      const chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      expect(chips.length).toBe(1);
+    });
+
+    it("should clear children in ancestor selection mode", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-combobox selection-mode="ancestors">
+          <calcite-combobox-item value="parent" text-label="parent">
+            <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
+            <calcite-combobox-item value="child2" text-label="child2"></calcite-combobox-item>
+          </calcite-combobox-item>
+        </calcite-combobox>`
+      });
+
+      await page.keyboard.press("Tab");
+      await page.waitForChanges();
+
+      const cbox = await page.find("calcite-combobox");
+      const parent = await cbox.find("calcite-combobox-item[value=parent]");
+      const parentItem = await cbox.find("calcite-combobox-item[value=parent] >>> li");
+      const item1 = await cbox.find("calcite-combobox-item[value=child1]");
+      const item2 = await cbox.find("calcite-combobox-item[value=child2]");
+      await item1.click();
+      await item2.click();
+      await page.waitForChanges();
+      let chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      expect(chips.length).toBe(2);
+      expect(parent).toHaveAttribute("selected");
+      await parentItem.click();
+      chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      expect(chips.length).toBe(0);
+      expect(parent).not.toHaveAttribute("selected");
+      expect(item1).not.toHaveAttribute("selected");
+      expect(item2).not.toHaveAttribute("selected");
+    });
+
     it("clicking a chip should remove the selected item", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-combobox>

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -20,7 +20,7 @@ export const Simple = (): string => html`
       label="demo combobox"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["multi", "single"], "multi")}"
+      selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -52,7 +52,7 @@ export const Single = (): string => html`
   <div style="width:400px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["multi", "single"], "single")}"
+      selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "single")}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -80,7 +80,7 @@ export const DarkTheme = (): string => html`
   <div style="width:400px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["multi", "single"], "multi")}"
+      selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
       theme="dark"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
@@ -120,7 +120,7 @@ export const Rtl = (): string => html`
     <calcite-combobox
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["multi", "single"], "multi")}"
+      selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
       dir="rtl"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -693,7 +693,7 @@ export class CalciteCombobox {
 
   renderChips(): VNode[] {
     const { activeChipIndex, scale, selectionMode } = this;
-    return (this.selectedItems || []).map((item, i) => {
+    return this.selectedItems.map((item, i) => {
       const chipClasses = { chip: true, "chip--active": activeChipIndex === i };
       const ancestors = [...getItemAncestors(item)].reverse();
       const pathLabel = [...ancestors, item].map((el) => el.textLabel);

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -29,6 +29,7 @@ import {
   ComboboxDefaultPlacement,
   ComboboxTransitionDuration
 } from "./resources";
+import { getItemAncestors, getItemChildren, hasActiveChildren } from "./utils";
 
 interface ItemData {
   label: string;
@@ -86,7 +87,11 @@ export class CalciteCombobox {
   /** Allow entry of custom values which are not in the original set of items */
   @Prop() allowCustomValues: boolean;
 
-  /** specify the selection mode - multi (allow any number of selected items), single (only one selction), defaults to multi */
+  /** specify the selection mode
+   * - multi: allow any number of selected items (default)
+   * - single: only one selection)
+   * - ancestors: like multi, but show ancestors of selected items as selected, only deepest children shown in chips
+   */
   @Prop({ reflect: true }) selectionMode: ComboboxSelectionMode = "multi";
 
   /** Specify the scale of the combobox, defaults to m */
@@ -175,7 +180,7 @@ export class CalciteCombobox {
       case "Backspace":
         if (this.activeChipIndex > -1) {
           this.removeActiveChip();
-        } else if (!this.text && this.selectionMode === "multi") {
+        } else if (!this.text && this.isMulti()) {
           this.removeLastChip();
         }
         break;
@@ -470,8 +475,9 @@ export class CalciteCombobox {
       return;
     }
 
-    if (this.selectionMode === "multi") {
+    if (this.isMulti()) {
       item.selected = value;
+      this.updateAncestors(item);
       this.selectedItems = this.getSelectedItems();
       this.calciteLookupChange.emit(this.selectedItems);
       this.resetText();
@@ -489,6 +495,26 @@ export class CalciteCombobox {
     }
   }
 
+  updateAncestors(item: HTMLCalciteComboboxItemElement): void {
+    if (this.selectionMode !== "ancestors") {
+      return;
+    }
+    const ancestors = getItemAncestors(item);
+    const children = getItemChildren(item);
+    if (item.selected) {
+      ancestors.forEach((el) => {
+        (el as HTMLCalciteComboboxItemElement).selected = true;
+      });
+    } else {
+      children.forEach((el) => (el.selected = false));
+      [...ancestors].forEach((el) => {
+        if (!hasActiveChildren(el)) {
+          el.selected = false;
+        }
+      });
+    }
+  }
+
   getVisibleItems(): HTMLCalciteComboboxItemElement[] {
     return this.items.filter((item) => !item.hidden);
   }
@@ -496,7 +522,10 @@ export class CalciteCombobox {
   getSelectedItems(): HTMLCalciteComboboxItemElement[] {
     return (
       this.items
-        .filter((item) => item.selected)
+        .filter(
+          (item) =>
+            item.selected && (this.selectionMode !== "ancestors" || !hasActiveChildren(item))
+        )
         /** Preserve order of entered tags */
         .sort((a, b) => {
           const aIdx = this.selectedItems.indexOf(a);
@@ -643,6 +672,10 @@ export class CalciteCombobox {
     }
   }
 
+  isMulti(): boolean {
+    return this.selectionMode === "multi" || this.selectionMode === "ancestors";
+  }
+
   comboboxFocusHandler = (): void => {
     this.active = true;
     this.textInput.focus();
@@ -659,9 +692,12 @@ export class CalciteCombobox {
   //--------------------------------------------------------------------------
 
   renderChips(): VNode[] {
-    const { activeChipIndex, scale } = this;
-    return this.selectedItems.map((item, i) => {
+    const { activeChipIndex, scale, selectionMode } = this;
+    return (this.selectedItems || []).map((item, i) => {
       const chipClasses = { chip: true, "chip--active": activeChipIndex === i };
+      const ancestors = [...getItemAncestors(item)].reverse();
+      const pathLabel = [...ancestors, item].map((el) => el.textLabel);
+      const label = selectionMode !== "ancestors" ? item.textLabel : pathLabel.join(" / ");
       return (
         <calcite-chip
           class={chipClasses}
@@ -673,7 +709,7 @@ export class CalciteCombobox {
           scale={scale}
           value={item.value}
         >
-          {item.textLabel}
+          {label}
         </calcite-chip>
       );
     });

--- a/src/components/calcite-combobox/interfaces.ts
+++ b/src/components/calcite-combobox/interfaces.ts
@@ -3,6 +3,7 @@ export interface listItem {
   value: string;
 }
 
-export type ComboboxSelectionMode = "single" | "multi";
+export type ComboboxSelectionMode = "single" | "multi" | "ancestors";
 
 export type ComboboxChildElement = HTMLCalciteComboboxItemElement | HTMLCalciteComboboxItemGroupElement;
+

--- a/src/components/calcite-combobox/utils.ts
+++ b/src/components/calcite-combobox/utils.ts
@@ -1,3 +1,4 @@
+import { nodeListToArray } from "../../utils/dom";
 import { ComboboxChildElement } from "./interfaces";
 import { ComboboxChildSelector } from "./resources";
 
@@ -5,6 +6,21 @@ export function getAncestors(element: HTMLElement): ComboboxChildElement[] {
   const parent: ComboboxChildElement = element.parentElement?.closest(ComboboxChildSelector);
   const grandparent: ComboboxChildElement = parent?.parentElement?.closest(ComboboxChildSelector);
   return [parent, grandparent].filter((el) => el);
+}
+
+export function getItemAncestors(item: HTMLCalciteComboboxItemElement): HTMLCalciteComboboxItemElement[] {
+  return (
+    (item.ancestors?.filter((el) => el.nodeName === "CALCITE-COMBOBOX-ITEM") as HTMLCalciteComboboxItemElement[]) || []
+  );
+}
+
+export function getItemChildren(item: HTMLCalciteComboboxItemElement): HTMLCalciteComboboxItemElement[] {
+  return nodeListToArray(item.querySelectorAll("calcite-combobox-item"));
+}
+
+export function hasActiveChildren(node: HTMLCalciteComboboxItemElement): boolean {
+  const items = nodeListToArray(node.querySelectorAll("calcite-combobox-item"));
+  return items.filter((item) => item.selected).length > 0;
 }
 
 export function getDepth(element: HTMLElement): number {

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -131,6 +131,29 @@
       <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
     </calcite-combobox>
 
+    <h2>Ancestors Selection Mode</h2>
+    <calcite-combobox label="test" placeholder="placeholder" max-items="8" selection-mode="ancestors">
+      <calcite-combobox-item value="Grand 1" text-label="Grand 1">
+        <calcite-combobox-item value="Parent 1" text-label="Parent 1">
+          <calcite-combobox-item value="Child 1" text-label="Child 1"></calcite-combobox-item>
+          <calcite-combobox-item value="Child 2" text-label="Child 2"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Parent 2" text-label="Parent 2">
+          <calcite-combobox-item value="Child 3" text-label="Child 3"></calcite-combobox-item>
+          <calcite-combobox-item value="Child 4" text-label="Child 4"></calcite-combobox-item>
+        </calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Grand 2" text-label="Grand 2">
+        <calcite-combobox-item value="Parent 3" text-label="Parent 3">
+          <calcite-combobox-item value="Child 5" text-label="Child 5"></calcite-combobox-item>
+          <calcite-combobox-item value="Child 6" text-label="Child 6"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Parent 2" text-label="Parent 2">
+          <calcite-combobox-item value="Child 7" text-label="Child 7"></calcite-combobox-item>
+          <calcite-combobox-item value="Child 8" text-label="Child 8"></calcite-combobox-item>
+        </calcite-combobox-item>
+      </calcite-combobox-item>
+    </calcite-combobox>
     <h2>Scale S</h2>
 
     <calcite-combobox label="test" placeholder="placeholder" scale="s">


### PR DESCRIPTION
**Related Issue:** #1590

## Summary

This adds a new selection mode for selecting in a hierarchical set where selection of a child infers selection of a parent. We need this to cover the content categories UI. I've used `selectionMode` to retain consistency with Tree which is the most obviously similar component in our system. 

Selected elements in this mode show their hierarchy in the chip as well:

<img width="500" alt="Screen Shot 2021-03-08 at 9 34 07 AM" src="https://user-images.githubusercontent.com/1031758/110358601-73b4b280-7ff1-11eb-9f4f-51eed017b315.png">

