### PR TITLE
refactor(tabs): use tailwind

### DIFF
--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -1,21 +1,24 @@
 :host {
-  display: flex;
-  flex-direction: column;
+  @apply flex flex-col;
 }
 
 :host([position="below"]) {
-  flex-direction: column-reverse;
+  @apply flex-col-reverse;
 }
 
 section {
-  display: flex;
-  flex-grow: 1;
-  overflow: hidden;
-  border-top: 1px solid var(--calcite-ui-border-1);
+  @apply flex
+    flex-grow
+    overflow-hidden
+    border-t
+    border-t-solid
+    border-t-color-1;
 }
 
 :host([position="below"]) section {
-  flex-direction: column-reverse;
-  border-top: 0;
-  border-bottom: 1px solid var(--calcite-ui-border-1);
+  @apply flex-col-reverse
+    border-t-0
+    border-b
+    border-b-solid
+    border-b-color-1;
 }


### PR DESCRIPTION
**Related Issue:** #1500

## Summary
Refactor calcite-tabs to use the Tailwind config - Depends on pr #1669 for border-side-style utilities.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
