### PR TITLE
fix(input-date-picker): removes max-widths

### DIFF
--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.scss
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.scss
@@ -17,18 +17,6 @@
   line-height: 0; // fixes height in ie11
 }
 
-:host([scale="s"]) {
-  max-width: 216px;
-}
-
-:host([scale="m"]) {
-  max-width: 286px;
-}
-
-:host([scale="l"]) {
-  max-width: 398px;
-}
-
 .input-wrapper {
   position: relative;
 }
@@ -82,7 +70,6 @@
 }
 
 :host([scale="s"][range]:not([layout="vertical"])) {
-  max-width: 462px;
 
   .calendar-picker-wrapper {
     width: 216px;
@@ -94,7 +81,6 @@
 }
 
 :host([scale="m"][range]:not([layout="vertical"])) {
-  max-width: 596px;
 
   .calendar-picker-wrapper {
     width: 286px;
@@ -102,7 +88,6 @@
 }
 
 :host([scale="l"][range]:not([layout="vertical"])) {
-  max-width: 820px;
 
   .calendar-picker-wrapper {
     width: 398px;
@@ -117,7 +102,6 @@
   @include popperContainer();
   visibility: hidden;
   pointer-events: none;
-  width: 100%;
 }
 :host([active]) .menu-container {
   pointer-events: initial;


### PR DESCRIPTION
**Related Issue:** #1689 

## Summary
Removes max-widths.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
