### PR TITLE
feat(accordion)!: Update Accordion event detail

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -62,11 +62,6 @@ export class CalciteAccordionItem {
   /**
    * @internal
    */
-  @Event() calciteAccordionItemClose: EventEmitter;
-
-  /**
-   * @internal
-   */
   @Event() calciteAccordionItemRegister: EventEmitter;
 
   //--------------------------------------------------------------------------
@@ -94,7 +89,6 @@ export class CalciteAccordionItem {
   render(): VNode {
     const dir = getElementDir(this.el);
     const iconScale = this.scale !== "l" ? "s" : "m";
-
     const iconEl = <calcite-icon class="accordion-item-icon" icon={this.icon} scale={iconScale} />;
 
     return (
@@ -161,8 +155,7 @@ export class CalciteAccordionItem {
 
   @Listen("calciteAccordionChange", { target: "body" })
   updateActiveItemOnChange(event: CustomEvent): void {
-    this.requestedAccordionItem = event.detail
-      .requestedAccordionItem as HTMLCalciteAccordionItemElement;
+    this.requestedAccordionItem = event.detail as HTMLCalciteAccordionItemElement;
     this.determineActiveItem();
   }
 
@@ -219,9 +212,7 @@ export class CalciteAccordionItem {
   }
 
   private emitRequestedItem(): void {
-    this.calciteAccordionItemSelect.emit({
-      requestedAccordionItem: this.el as HTMLCalciteAccordionItemElement
-    });
+    this.calciteAccordionItemSelect.emit(this.el as HTMLCalciteAccordionItemElement);
   }
 
   private getItemPosition(): number {

--- a/src/components/calcite-accordion/calcite-accordion.e2e.ts
+++ b/src/components/calcite-accordion/calcite-accordion.e2e.ts
@@ -154,4 +154,26 @@ describe("calcite-accordion", () => {
     expect(await item2Content.isVisible()).toBe(true);
     expect(await item3Content.isVisible()).toBe(false);
   });
+
+  it("should emit the change event", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-accordion>
+    ${accordionContent}
+    </calcite-accordion>`);
+    const element = await page.find("calcite-accordion");
+    const eventSpy = await page.spyOnEvent("calciteAccordionChange", "window");
+    const item1 = await element.find("calcite-accordion-item[id='1']");
+    const item2 = await element.find("calcite-accordion-item[id='2']");
+    const item3 = await element.find("calcite-accordion-item[id='3']");
+    await item3.click();
+    await page.waitForChanges();
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+    await item2.click();
+    await page.waitForChanges();
+    expect(eventSpy).toHaveReceivedEventTimes(2);
+    await item1.click();
+    await page.waitForChanges();
+    expect(eventSpy).toHaveReceivedEventTimes(3);
+  });
 });

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -127,10 +127,8 @@ export class CalciteAccordion {
   }
 
   @Listen("calciteAccordionItemSelect") updateActiveItemOnChange(event: CustomEvent): void {
-    this.requestedAccordionItem = event.detail.requestedAccordionItem;
-    this.calciteAccordionChange.emit({
-      requestedAccordionItem: this.requestedAccordionItem
-    });
+    this.requestedAccordionItem = event.detail;
+    this.calciteAccordionChange.emit(this.requestedAccordionItem);
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
calciteAccordionChange event now directly returns the active calcite-accordion-item element instead of as “requestedAccordionItem”

**Related Issue:** #1705


- Removes unused calciteAccordionItemClose event
- Keeps calciteAccordionItemSelect internal and simplifies the event output. 
- (could be made public if deemed useful, not sure)
- Adds test

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
