### PR TITLE
fix(pick-list, value-list): fix keyboard navigation after filtering

### DIFF
--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -1,5 +1,5 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-filter", () => {
   it("renders", async () => renders("calcite-filter"));
@@ -7,6 +7,8 @@ describe("calcite-filter", () => {
   it("honors hidden attribute", async () => hidden("calcite-filter"));
 
   it("is accessible", async () => accessible("calcite-filter"));
+
+  it("is focusable", async () => focusable("calcite-filter"));
 
   describe("strings", () => {
     it("should update the filter placeholder when a string is provided", async () => {

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -7,12 +7,13 @@ import {
   Prop,
   State,
   h,
-  VNode
+  VNode,
+  Method
 } from "@stencil/core";
 import { debounce, forIn } from "lodash-es";
 import { CSS, ICONS, TEXT } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
-import { getElementDir } from "../../utils/dom";
+import { focusElement, getElementDir } from "../../utils/dom";
 
 const filterDebounceInMs = 250;
 
@@ -71,6 +72,20 @@ export class CalciteFilter {
    * This event fires when the filter text changes.
    */
   @Event() calciteFilterChange: EventEmitter;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Public Methods
+  //
+  // --------------------------------------------------------------------------
+
+  /**
+   * Focuses the filter input.
+   */
+  @Method()
+  async setFocus(): Promise<void> {
+    focusElement(this.textInput);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -241,6 +241,7 @@ let groups: Set<HTMLCalcitePickListGroupElement>;
 export function handleFilter<T extends Lists>(this: List<T>, event: CustomEvent): void {
   const filteredData = event.detail;
   const values = filteredData.map((item) => item.value);
+  let hasSelectedMatch = false;
 
   if (!groups) {
     groups = new Set<HTMLCalcitePickListGroupElement>();
@@ -257,6 +258,10 @@ export function handleFilter<T extends Lists>(this: List<T>, event: CustomEvent)
     const matches = values.includes(item.value);
 
     item.hidden = !matches;
+
+    if (!hasSelectedMatch) {
+      hasSelectedMatch = matches && item.selected;
+    }
 
     return matches;
   });
@@ -283,6 +288,10 @@ export function handleFilter<T extends Lists>(this: List<T>, event: CustomEvent)
   });
 
   groups.clear();
+
+  if (matchedItems.length > 0 && !hasSelectedMatch && !this.multiple) {
+    toggleSingleSelectItemTabbing(matchedItems[0], true);
+  }
 }
 
 export type ItemData = {

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -111,6 +111,43 @@ export function keyboardNavigation(listType: ListType): void {
         expect(await getFocusedItemValue(page)).toEqual("one");
       });
     });
+
+    it("navigating items after filtering", async () => {
+      const page = await newE2EPage({
+        html: `
+        <calcite-${listType}-list filter-enabled>
+          <calcite-${listType}-list-item value="one" label="One" selected></calcite-${listType}-list-item>
+          <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>
+      `
+      });
+      const filter = await page.find(`calcite-${listType}-list >>> calcite-filter`);
+      await filter.callMethod("setFocus");
+
+      await page.keyboard.type("one");
+      await page.waitForEvent("calciteFilterChange");
+
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedItemValue(page)).toEqual("one");
+
+      await filter.callMethod("setFocus");
+      await page.waitForChanges();
+
+      await page.keyboard.press("Backspace");
+      await page.keyboard.press("Backspace");
+      await page.keyboard.press("Backspace");
+      await page.waitForChanges();
+
+      await page.keyboard.type("two");
+      await page.waitForEvent("calciteFilterChange");
+
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedItemValue(page)).toEqual("two");
+    });
   });
 }
 


### PR DESCRIPTION
**Related Issue:** #1527 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes an issue where items after filtering would not be keyboard-navigable (unless result includes selected item).

cc @AdelheidF 