### PR TITLE
refactor(tab-title): use tailwind

### DIFF
--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -12,8 +12,8 @@
 :host([position="below"]) a {
   @apply border-b-0
     border-t-2
-    border-t-solid
     border-t-color-transparent;
+  border-top-style: solid;
 }
 
 :host a {
@@ -50,19 +50,18 @@ span {
     appearance-none
     cursor-pointer
     truncate
-    border-b-3
+    border-b-2
     border-b-color-transparent
-    border-b-solid
     w-full
     h-full
     flex
     justify-center
     text-color-3
-    text--1
-    transition-default
     text--1h
+    transition-default
     px-0
-    py-3;
+    py-2;
+  border-bottom-style: solid;
 }
 
 span {

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -1,12 +1,12 @@
 :host {
-  @apply flex-initial outline-none mx-5;
+  @apply flex-initial outline-none mr-5;
   margin-inline-start: theme("margin.0");
   margin-inline-end: theme("margin.5");
 }
 
 :host([layout="center"]) {
   @apply text-center my-0 mx-5;
-  flex-basis: 200px;
+  flex-basis: theme("spacing.48");
 }
 
 :host([position="below"]) a {

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -1,124 +1,114 @@
-$tab-margin: 1.25rem;
-
 :host {
-  flex: 0 1 auto;
-  outline: none;
-  margin-right: $tab-margin;
-  margin-inline-start: 0;
-  margin-inline-end: $tab-margin;
+  @apply flex-initial outline-none mx-5;
+  margin-inline-start: theme("margin.0");
+  margin-inline-end: theme("margin.5");
 }
 
 :host([layout="center"]) {
+  @apply text-center my-0 mx-5;
   flex-basis: 200px;
-  text-align: center;
-  margin: 0 $tab-margin;
 }
 
 :host([position="below"]) a {
-  border-bottom: 0;
-  border-top: 3px solid transparent;
+  @apply border-b-0
+    border-t-2
+    border-t-solid
+    border-t-color-transparent;
 }
 
 :host a {
-  @include focus-style-base();
+  @apply focus-base;
 }
 
 :host(:focus) a {
-  @include focus-style-outset();
+  @apply focus-outset;
 }
 
 :host(:active),
 :host(:focus),
 :host(:hover) {
   a {
-    text-decoration: none;
-    color: var(--calcite-ui-text-1);
-    border-color: var(--calcite-ui-border-2);
+    @apply no-underline text-color-1 border-color-2;
   }
 }
 
 :host([active]) a {
-  color: var(--calcite-ui-text-1);
-  border-color: transparent;
+  @apply text-color-1 border-color-transparent;
 }
 
 :host([disabled]) {
-  pointer-events: none;
+  @apply pointer-events-none;
   span,
   a {
-    pointer-events: none;
-    opacity: var(--calcite-ui-opacity-disabled);
+    @apply pointer-events-none opacity-50;
   }
 }
 
 a,
 span {
-  box-sizing: border-box;
-  @include font-size(-2);
-  padding: $baseline/2 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  border-bottom: 3px solid transparent;
-  -webkit-appearance: none;
-  cursor: pointer;
-  transition: $transition;
-  color: var(--calcite-ui-text-3);
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
+  @apply box-border
+    appearance-none
+    cursor-pointer
+    truncate
+    border-b-3
+    border-b-color-transparent
+    border-b-solid
+    w-full
+    h-full
+    flex
+    justify-center
+    text-color-3
+    text--1
+    transition-default
+    text--1h
+    px-0
+    py-3;
 }
 
 span {
-  cursor: default;
+  @apply cursor-default;
 }
 
 .calcite-tab-title--icon {
-  display: inline-flex;
-  position: relative;
-  margin: 0;
-  line-height: inherit;
-  align-self: center;
+  @apply inline-flex
+    relative
+    m-0
+    self-center;
   & svg {
-    transition: $transition;
+    @apply transition-default;
   }
 }
 
 :host([hastext]) .calcite-tab-title--icon.icon-start {
-  margin-right: $baseline/3;
+  @apply mr-2;
 }
 
 :host([hastext]) .calcite-tab-title--icon.icon-end {
-  margin-left: $baseline/3;
+  @apply ml-2;
 }
 
 // compensate for spacing when no hastext and two icons
 :host([icon-start][icon-end]) {
   .calcite-tab-title--icon:first-child {
-    margin-right: $baseline/3;
+    @apply mr-2;
   }
 }
 
 // right to left
 :host .rtl {
-  margin-right: 0;
-  margin-left: $tab-margin;
+  @apply mr-0 ml-5;
 }
 
 :host([hastext]) .rtl .calcite-tab-title--icon.icon-end {
-  margin-left: 0;
-  margin-right: $baseline/3;
+  @apply ml-0 mr-2;
 }
 
 :host([hastext]) .rtl .calcite-tab-title--icon.icon-start {
-  margin-right: 0;
-  margin-left: $baseline/3;
+  @apply ml-2 mr-0;
 }
 
 :host([icon-start][icon-end]) .rtl {
   .calcite-tab-title--icon:first-child {
-    margin-right: 0;
-    margin-left: $baseline/3;
+    @apply ml-2 mr-0;
   }
 }


### PR DESCRIPTION
**Related Issue:** #1500

## Summary
Refactors tab-title styles to use the tailwind config. Changes 3px border widths to 2px (match calcite-notice).
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
