### PR TITLE
refactor(tab-nav): use tailwind

### DIFF
--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -7,9 +7,10 @@
     w-full
     overflow-auto
     justify-start
-    scrolling-touch
-    p-1
-    -m-1;
+    scrolling-touch;
+  // workaround for outset focus within a scrolling container
+  padding: theme("padding.1");
+  margin: theme("margin.-1");
 }
 
 :host([layout="center"]) .tab-nav {
@@ -23,8 +24,8 @@
     right-0
     bottom-0
     absolute
-    overflow-hidden
-    h-0.5;
+    overflow-hidden;
+  height: theme("height[0.5]");
 }
 
 .tab-nav-active-indicator {
@@ -32,9 +33,9 @@
     bottom-0
     block
     transition-all
-    ease-out
-    bg-brand
-    h-0.5;
+    ease-out;
+  background: theme("colors.brand");
+  height: theme("height[0.5]");
 }
 
 :host([position="below"]) .tab-nav-active-indicator {

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -1,50 +1,48 @@
 :host {
-  z-index: 2;
-  position: relative;
-  display: flex;
+  @apply z-20 relative flex;
 }
 
 .tab-nav {
-  display: flex;
-  width: 100%;
-  overflow: auto;
-  justify-content: flex-start;
-  -webkit-overflow-scrolling: touch;
-  // workaround for outset focus within a scrolling container
-  padding: 4px;
-  margin: -4px;
+  @apply flex
+    w-full
+    overflow-auto
+    justify-start
+    scrolling-touch
+    p-1
+    -m-1;
 }
 
 :host([layout="center"]) .tab-nav {
-  justify-content: center;
+  @apply justify-center;
 }
 
 // prevent indicator overflow in horizontal scrolling situations
 .tab-nav-active-indicator-container {
-  width: 100%;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  @apply w-full
+    left-0
+    right-0
+    bottom-0
+    absolute
+    overflow-hidden;
   height: 3px;
-  position: absolute;
-  overflow: hidden;
 }
 
 .tab-nav-active-indicator {
-  position: absolute;
-  bottom: 0;
+  @apply absolute
+    bottom-0
+    block
+    transition-all
+    ease-out;
   background: var(--calcite-ui-brand);
-  display: block;
   height: 3px;
-  transition: all ease-out;
 }
 
 :host([position="below"]) .tab-nav-active-indicator {
   bottom: unset;
-  top: 0;
+  @apply top-0;
 }
 
 :host([position="below"]) .tab-nav-active-indicator-container {
   bottom: unset;
-  top: 0;
+  @apply top-0;
 }

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -23,8 +23,8 @@
     right-0
     bottom-0
     absolute
-    overflow-hidden;
-  height: 3px;
+    overflow-hidden
+    h-0.5;
 }
 
 .tab-nav-active-indicator {
@@ -32,9 +32,9 @@
     bottom-0
     block
     transition-all
-    ease-out;
-  background: var(--calcite-ui-brand);
-  height: 3px;
+    ease-out
+    bg-brand
+    h-0.5;
 }
 
 :host([position="below"]) .tab-nav-active-indicator {

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -7,10 +7,9 @@
     w-full
     overflow-auto
     justify-start
-    scrolling-touch;
-  // workaround for outset focus within a scrolling container
-  padding: theme("padding.1");
-  margin: theme("margin.-1");
+    scrolling-touch
+    p-1
+    -m-1;
 }
 
 :host([layout="center"]) .tab-nav {
@@ -20,8 +19,7 @@
 // prevent indicator overflow in horizontal scrolling situations
 .tab-nav-active-indicator-container {
   @apply w-full
-    left-0
-    right-0
+    inset-x-0
     bottom-0
     absolute
     overflow-hidden

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -24,8 +24,8 @@
     right-0
     bottom-0
     absolute
-    overflow-hidden;
-  height: theme("height[0.5]");
+    overflow-hidden
+    h-0.5;
 }
 
 .tab-nav-active-indicator {
@@ -33,9 +33,9 @@
     bottom-0
     block
     transition-all
-    ease-out;
-  background: theme("colors.brand");
-  height: theme("height[0.5]");
+    ease-out
+    bg-brand
+    h-0.5;
 }
 
 :host([position="below"]) .tab-nav-active-indicator {


### PR DESCRIPTION
**Related Issue:** #1500

## Summary
Refactors tab-nav styles to use the tailwind config. Changes the 3px active tab indicator height to 2px (to match new calcite-tab-title 2px border width).

** I'm thinking this one should be merged right after pr #1745 - Screener tests are going to fail on this one until the new calcite-tab-title styles are accepted.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
