### PR TITLE
feat(filter): clear text on Escape

### DIFF
--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -38,13 +38,10 @@ describe("calcite-filter", () => {
 
       expect(button).toBeNull();
 
-      await page.evaluate(() => {
-        const filter = document.querySelector("calcite-filter");
-        const filterInput = filter.shadowRoot.querySelector("input");
-        filterInput.value = "developer";
-        filterInput.dispatchEvent(new Event("input"));
-      });
+      const filter = await page.find("calcite-filter");
+      await filter.callMethod("setFocus");
 
+      await page.keyboard.type("developer");
       await page.waitForChanges();
 
       button = await page.find(`calcite-filter >>> button`);
@@ -52,27 +49,45 @@ describe("calcite-filter", () => {
       expect(button).not.toBeNull();
     });
 
-    it("should clear the value in the input when pressed", async () => {
-      await page.evaluate(() => {
-        const filter = document.querySelector("calcite-filter");
-        const filterInput = filter.shadowRoot.querySelector("input");
-        filterInput.value = "developer";
-        filterInput.dispatchEvent(new Event("input"));
+    describe("clearing value", () => {
+      it("should clear the value in the input when pressed", async () => {
+        const filter = await page.find("calcite-filter");
+        await filter.callMethod("setFocus");
+
+        await page.keyboard.type("developer");
+        await page.waitForChanges();
+
+        const button = await page.find(`calcite-filter >>> button`);
+
+        await button.click();
+
+        const value = await page.evaluate(() => {
+          const filter = document.querySelector("calcite-filter");
+          const filterInput = filter.shadowRoot.querySelector("input");
+          return filterInput.value;
+        });
+
+        expect(value).toBe("");
       });
 
-      await page.waitForChanges();
+      it("should clear the value in the input when the Escape key is pressed", async () => {
+        const filter = await page.find("calcite-filter");
+        await filter.callMethod("setFocus");
 
-      const button = await page.find(`calcite-filter >>> button`);
+        await page.keyboard.type("developer");
+        await page.waitForChanges();
 
-      await button.click();
+        await page.keyboard.press("Escape");
+        await page.waitForChanges();
 
-      const value = await page.evaluate(() => {
-        const filter = document.querySelector("calcite-filter");
-        const filterInput = filter.shadowRoot.querySelector("input");
-        return filterInput.value;
+        const value = await page.evaluate(() => {
+          const filter = document.querySelector("calcite-filter");
+          const filterInput = filter.shadowRoot.querySelector("input");
+          return filterInput.value;
+        });
+
+        expect(value).toBe("");
       });
-
-      expect(value).toBe("");
     });
   });
 

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -127,10 +127,16 @@ export class CalciteFilter {
     this.calciteFilterChange.emit(result);
   }, filterDebounceInMs);
 
-  inputHandler = (event: Event): void => {
+  inputHandler = (event: InputEvent): void => {
     const target = event.target as HTMLInputElement;
     this.empty = target.value === "";
     this.filter(target.value);
+  };
+
+  keyDownHandler = ({ key }: KeyboardEvent): void => {
+    if (key === "Escape") {
+      this.clear();
+    }
   };
 
   clear = (): void => {
@@ -154,6 +160,7 @@ export class CalciteFilter {
           <input
             aria-label={this.intlLabel || TEXT.filterLabel}
             onInput={this.inputHandler}
+            onKeyDown={this.keyDownHandler}
             placeholder={this.placeholder}
             ref={(el): void => {
               this.textInput = el;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Allows the filter text term to be cleared by pressing the Escape key.