### PR TITLE
chore: fine-tune codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*         @esri/calcite-components
-
-# docs:
-/docs/**  @esri/all-esri-members
-
-# Template and assets
-*.md      @esri/all-esri-members
+*     @esri/calcite-components-reviewers


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates codeowners file to use reviewer group as catch-all.

### Questions

Do we want to also set up granular ownership? Something like this would work:

```
# component-specific owners
calcite-block/                    @jcfranco
calcite-block-section/            @jcfranco
calcite-color-picker/             @jcfranco
calcite-color-picker-hex-input/   @jcfranco
calcite-color-picker-swatch/      @jcfranco
calcite-icon/                     @jcfranco
calcite-option/                   @jcfranco
calcite-option-group/             @jcfranco
calcite-pick-list/                @jcfranco
calcite-select/                   @jcfranco
calcite-value-list/               @jcfranco
```

Anything not specified above would be owned by the reviewers group (see [codeowners syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)).