### PR TITLE
feat(tree): add ancestor selection mode, input-enabled prop for selectable trees

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -118,6 +118,7 @@
   line-height: 0;
   padding-left: var(--calcite-tree-checkbox-padding-start);
   padding-right: var(--calcite-tree-checkbox-padding-end);
+  outline: none;
 }
 
 .calcite-tree-label {
@@ -199,7 +200,7 @@
   }
 }
 
-:host([checkboxes]) .calcite-tree-node:before {
+:host([input-enabled]) .calcite-tree-node:before {
   display: none;
 }
 

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -27,6 +27,8 @@
   --calcite-tree-children-indent-end: 0;
   --calcite-tree-children-padding-start: 1rem;
   --calcite-tree-children-padding-end: 0;
+  --calcite-tree-checkbox-padding-start: 0;
+  --calcite-tree-checkbox-padding-end: 0.5rem;
   --calcite-tree-line-position-start: 0.05rem;
   --calcite-tree-line-position-end: 0;
   --calcite-tree-parent-line-position-start: -0.95rem;
@@ -71,6 +73,8 @@
   --calcite-tree-children-indent-end: 0.25rem;
   --calcite-tree-children-padding-start: 0;
   --calcite-tree-children-padding-end: 1rem;
+  --calcite-tree-checkbox-padding-start: 0.5rem;
+  --calcite-tree-checkbox-padding-end: 0;
   --calcite-tree-line-position-start: 0;
   --calcite-tree-line-position-end: 0.05rem;
   --calcite-tree-parent-line-position-start: 0;
@@ -108,6 +112,17 @@
 }
 :host(:focus) {
   @include focus-style-inset();
+}
+
+.calcite-tree-checkbox {
+  line-height: 0;
+  padding-left: var(--calcite-tree-checkbox-padding-start);
+  padding-right: var(--calcite-tree-checkbox-padding-end);
+}
+
+.calcite-tree-label {
+  display: flex;
+  align-items: center;
 }
 
 .calcite-tree-children {
@@ -151,6 +166,7 @@
 
 .calcite-tree-node {
   display: flex;
+  align-items: center;
   padding: var(--calcite-tree-vertical-padding) 0;
   padding-left: var(--calcite-tree-indent-start);
   padding-right: var(--calcite-tree-indent-end);
@@ -181,6 +197,10 @@
       display: none;
     }
   }
+}
+
+:host([checkboxes]) .calcite-tree-node:before {
+  display: none;
 }
 
 :host([has-children]) > .calcite-tree-node {

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -65,8 +65,18 @@ export class CalciteTreeItem {
   /** @internal Draw lines (set on parent) */
   @Prop({ reflect: true, mutable: true }) lines: boolean;
 
+  /** @internal Display checkboxes (set on parent) */
+  @Prop({ reflect: true, mutable: true }) checkboxes: boolean;
+
   /** @internal Scale of the parent tree, defaults to m */
   @Prop({ reflect: true, mutable: true }) scale: "s" | "m";
+
+  /**
+   * @internal
+   * In ancestor selection mode using checkboxes,
+   * show as indeterminate when only some children are selected
+   **/
+  @Prop({ reflect: true }) indeterminate: boolean;
 
   //--------------------------------------------------------------------------
   //
@@ -88,6 +98,7 @@ export class CalciteTreeItem {
     this.selectionMode = parentTree.selectionMode;
     this.scale = parentTree.scale || "m";
     this.lines = parentTree.lines;
+    this.checkboxes = parentTree.checkboxes;
 
     let nextParentTree;
     while (parentTree) {
@@ -111,6 +122,20 @@ export class CalciteTreeItem {
         scale="s"
       />
     ) : null;
+    const checkbox = this.checkboxes ? (
+      <label class="calcite-tree-label">
+        <calcite-checkbox
+          checked={this.selected}
+          class="calcite-tree-checkbox"
+          data-test-id="checkbox"
+          indeterminate={this.hasChildren && this.indeterminate}
+          onClick={this.checkboxClickHandler}
+          scale={this.scale}
+          tabIndex={-1}
+        />
+        <slot />
+      </label>
+    ) : null;
 
     const hidden = !(this.parentExpanded || this.depth === 1);
 
@@ -132,7 +157,7 @@ export class CalciteTreeItem {
       >
         <div class="calcite-tree-node" ref={(el) => (this.defaultSlotWrapper = el as HTMLElement)}>
           {icon}
-          <slot />
+          {checkbox ? checkbox : <slot />}
         </div>
         <div
           class="calcite-tree-children"
@@ -171,20 +196,33 @@ export class CalciteTreeItem {
   iconClickHandler = (event: Event): void => {
     event.stopPropagation();
     this.expanded = !this.expanded;
+    if (!this.checkboxes) {
+      this.calciteTreeItemSelect.emit({
+        modifyCurrentSelection: (event as any).shiftKey,
+        forceToggle: true
+      });
+    }
+  };
+
+  childrenClickHandler = (event: MouseEvent): void => event.stopPropagation();
+
+  checkboxClickHandler = (event: Event): void => {
+    event.stopPropagation();
     this.calciteTreeItemSelect.emit({
       modifyCurrentSelection: (event as any).shiftKey,
       forceToggle: true
     });
   };
 
-  childrenClickHandler = (event: MouseEvent): void => event.stopPropagation();
-
   @Listen("keydown") keyDownHandler(e: KeyboardEvent): void {
     let root;
 
     switch (getKey(e.key)) {
       case " ":
-        this.selected = !this.selected;
+        this.calciteTreeItemSelect.emit({
+          modifyCurrentSelection: e.shiftKey,
+          forceToggle: true
+        });
 
         e.preventDefault();
         e.stopPropagation();
@@ -199,7 +237,10 @@ export class CalciteTreeItem {
           link.click();
           this.selected = true;
         } else {
-          this.selected = !this.selected;
+          this.calciteTreeItemSelect.emit({
+            modifyCurrentSelection: e.shiftKey,
+            forceToggle: true
+          });
         }
 
         e.preventDefault();

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -193,12 +193,12 @@ export class CalciteTreeItem {
     });
   }
 
-  iconClickHandler = (event: Event): void => {
+  iconClickHandler = (event: MouseEvent): void => {
     event.stopPropagation();
     this.expanded = !this.expanded;
     if (!this.inputEnabled) {
       this.calciteTreeItemSelect.emit({
-        modifyCurrentSelection: (event as any).shiftKey,
+        modifyCurrentSelection: event.shiftKey,
         forceToggle: true
       });
     }

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -66,14 +66,14 @@ export class CalciteTreeItem {
   @Prop({ reflect: true, mutable: true }) lines: boolean;
 
   /** @internal Display checkboxes (set on parent) */
-  @Prop({ reflect: true, mutable: true }) checkboxes: boolean;
+  @Prop({ reflect: true, mutable: true }) inputEnabled: boolean;
 
   /** @internal Scale of the parent tree, defaults to m */
   @Prop({ reflect: true, mutable: true }) scale: "s" | "m";
 
   /**
    * @internal
-   * In ancestor selection mode using checkboxes,
+   * In ancestor selection mode using inputEnabled,
    * show as indeterminate when only some children are selected
    **/
   @Prop({ reflect: true }) indeterminate: boolean;
@@ -98,7 +98,7 @@ export class CalciteTreeItem {
     this.selectionMode = parentTree.selectionMode;
     this.scale = parentTree.scale || "m";
     this.lines = parentTree.lines;
-    this.checkboxes = parentTree.checkboxes;
+    this.inputEnabled = parentTree.inputEnabled;
 
     let nextParentTree;
     while (parentTree) {
@@ -122,7 +122,7 @@ export class CalciteTreeItem {
         scale="s"
       />
     ) : null;
-    const checkbox = this.checkboxes ? (
+    const checkbox = this.inputEnabled ? (
       <label class="calcite-tree-label">
         <calcite-checkbox
           checked={this.selected}
@@ -196,7 +196,7 @@ export class CalciteTreeItem {
   iconClickHandler = (event: Event): void => {
     event.stopPropagation();
     this.expanded = !this.expanded;
-    if (!this.checkboxes) {
+    if (!this.inputEnabled) {
       this.calciteTreeItemSelect.emit({
         modifyCurrentSelection: (event as any).shiftKey,
         forceToggle: true
@@ -212,6 +212,7 @@ export class CalciteTreeItem {
       modifyCurrentSelection: (event as any).shiftKey,
       forceToggle: true
     });
+    this.el.focus();
   };
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent): void {

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -29,7 +29,7 @@ describe("calcite-tree", () => {
   it("should correctly select tree in ancestors selection mode", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-      <calcite-tree checkboxes selection-mode="ancestors">
+      <calcite-tree input-enabled selection-mode="ancestors">
         <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
         <calcite-tree-item id="two">
           <span>Two</span>

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -25,4 +25,65 @@ describe("calcite-tree", () => {
     </calcite-tree-item>
 </calcite-tree>
   `));
+
+  it("should correctly select tree in ancestors selection mode", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-tree checkboxes selection-mode="ancestors">
+        <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
+        <calcite-tree-item id="two">
+          <span>Two</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item id="child-one">
+              <span>Child 1</span>
+              <calcite-tree slot="children">
+                <calcite-tree-item id="grandchild-one">
+                  <span>Grandchild 1</span>
+                </calcite-tree-item>
+                <calcite-tree-item id="grandchild-two">
+                  <span>Grandchild 2</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+            <calcite-tree-item id="child-two"><span>Child 2</span></calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    `);
+    await page.waitForChanges();
+
+    const one = await page.find("#one");
+    const two = await page.find("#two");
+    const childOne = await page.find("#child-one");
+    const childTwo = await page.find("#child-two");
+    const grandchildOne = await page.find("#grandchild-one");
+    const grandchildTwo = await page.find("#grandchild-two");
+
+    expect(one).not.toHaveAttribute("indeterminate");
+    expect(one).not.toHaveAttribute("selected");
+    expect(childOne).not.toHaveAttribute("indeterminate");
+    expect(childOne).not.toHaveAttribute("selected");
+    expect(childOne).not.toHaveAttribute("indeterminate");
+    expect(childOne).not.toHaveAttribute("selected");
+    expect(grandchildOne).not.toHaveAttribute("selected");
+    expect(grandchildTwo).not.toHaveAttribute("selected");
+
+    await two.click();
+
+    expect(one).not.toHaveAttribute("selected");
+    expect(two).toHaveAttribute("selected");
+    expect(childOne).toHaveAttribute("selected");
+    expect(childTwo).toHaveAttribute("selected");
+    expect(grandchildOne).toHaveAttribute("selected");
+    expect(grandchildTwo).toHaveAttribute("selected");
+
+    await childOne.click();
+
+    expect(childOne).not.toHaveAttribute("selected");
+    expect(childTwo).toHaveAttribute("selected");
+    expect(grandchildOne).not.toHaveAttribute("selected");
+    expect(grandchildTwo).not.toHaveAttribute("selected");
+    expect(two).not.toHaveAttribute("selected");
+    expect(two).toHaveAttribute("indeterminate");
+  });
 });

--- a/src/components/calcite-tree/calcite-tree.stories.ts
+++ b/src/components/calcite-tree/calcite-tree.stories.ts
@@ -53,6 +53,7 @@ export const Simple = (): string => html`
     ${boolean("lines", false)}
     selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
     size="${select("size", ["s", "m"], "m")}"
+    ${boolean("input-enabled", false)}
   >
     ${treeItems}
   </calcite-tree>
@@ -64,6 +65,7 @@ export const DarkMode = (): string => html`
     ${boolean("lines", false)}
     selection-mode="${select("selection-mode", ["single", "multi", "children", "multi-children"], "single")}"
     size="${select("size", ["s", "m"], "m")}"
+    ${boolean("input-enabled", false)}
   >
     ${treeItems}
   </calcite-tree>

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -37,8 +37,8 @@ export class CalciteTree {
   /** Display indentation guide lines */
   @Prop({ mutable: true, reflect: true }) lines = false;
 
-  /** Display checkboxes */
-  @Prop({ mutable: true }) checkboxes = false;
+  /** Display input */
+  @Prop({ mutable: true }) inputEnabled = false;
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -63,7 +63,7 @@ export class CalciteTree {
     const parent: HTMLCalciteTreeElement = this.el.parentElement.closest("calcite-tree");
     this.lines = parent ? parent.lines : this.lines;
     this.scale = parent ? parent.scale : this.scale;
-    this.checkboxes = parent ? parent.checkboxes : this.checkboxes;
+    this.inputEnabled = parent ? parent.inputEnabled : this.inputEnabled;
     this.selectionMode = parent ? parent.selectionMode : this.selectionMode;
     this.root = parent ? false : true;
   }

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -37,6 +37,9 @@ export class CalciteTree {
   /** Display indentation guide lines */
   @Prop({ mutable: true, reflect: true }) lines = false;
 
+  /** Display checkboxes */
+  @Prop({ mutable: true }) checkboxes = false;
+
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
 
@@ -60,6 +63,7 @@ export class CalciteTree {
     const parent: HTMLCalciteTreeElement = this.el.parentElement.closest("calcite-tree");
     this.lines = parent ? parent.lines : this.lines;
     this.scale = parent ? parent.scale : this.scale;
+    this.checkboxes = parent ? parent.checkboxes : this.checkboxes;
     this.selectionMode = parent ? parent.selectionMode : this.selectionMode;
     this.root = parent ? false : true;
   }
@@ -102,6 +106,16 @@ export class CalciteTree {
     const childItems = nodeListToArray(
       target.querySelectorAll("calcite-tree-item")
     ) as HTMLCalciteTreeItemElement[];
+
+    if (this.root) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    if (this.selectionMode === TreeSelectionMode.Ancestors && this.root) {
+      this.updateAncestorTree(e);
+      return;
+    }
 
     const shouldSelect =
       this.selectionMode !== null &&
@@ -178,9 +192,45 @@ export class CalciteTree {
       }
     }
 
-    if (this.root) {
-      e.preventDefault();
-      e.stopPropagation();
+    this.calciteTreeSelect.emit({
+      selected: (nodeListToArray(
+        this.el.querySelectorAll("calcite-tree-item")
+      ) as HTMLCalciteTreeItemElement[]).filter((i) => i.selected)
+    });
+  }
+
+  updateAncestorTree(e: CustomEvent<TreeItemSelectDetail>): void {
+    const item = e.target as HTMLCalciteTreeItemElement;
+    const children = item.querySelectorAll("calcite-tree-item");
+    const ancestors: HTMLCalciteTreeItemElement[] = [];
+    let parent = item.parentElement.closest("calcite-tree-item");
+    while (parent) {
+      ancestors.push(parent);
+      parent = parent.parentElement.closest("calcite-tree-item");
+    }
+
+    item.selected = !item.selected;
+    item.indeterminate = false;
+    if (children?.length) {
+      children.forEach((el) => {
+        el.selected = item.selected;
+        el.indeterminate = false;
+      });
+    }
+
+    if (ancestors) {
+      ancestors.forEach((ancestor) => {
+        const descendants = nodeListToArray(ancestor.querySelectorAll("calcite-tree-item"));
+        const activeDescendants = descendants.filter((el) => el.selected);
+        if (activeDescendants.length === 0) {
+          ancestor.selected = false;
+          ancestor.indeterminate = false;
+          return;
+        }
+        const indeterminate = activeDescendants.length < descendants.length;
+        ancestor.indeterminate = indeterminate;
+        ancestor.selected = !indeterminate;
+      });
     }
 
     this.calciteTreeSelect.emit({
@@ -189,7 +239,6 @@ export class CalciteTree {
       ) as HTMLCalciteTreeItemElement[]).filter((i) => i.selected)
     });
   }
-
   //--------------------------------------------------------------------------
   //
   //  Events

--- a/src/components/calcite-tree/interfaces.ts
+++ b/src/components/calcite-tree/interfaces.ts
@@ -6,5 +6,6 @@ export enum TreeSelectionMode {
   Single = "single",
   Multi = "multi",
   Children = "children",
-  MultiChildren = "multi-children"
+  MultiChildren = "multi-children",
+  Ancestors = "ancestors"
 }

--- a/src/demos/calcite-tree.html
+++ b/src/demos/calcite-tree.html
@@ -239,6 +239,47 @@
       </calcite-tree-item>
     </calcite-tree>
 
+    <h2>Checkboxes in ancestor selection mode</h2>
+    <calcite-tree checkboxes selection-mode="ancestors">
+      <calcite-tree-item>
+        <span>Child 1</span>
+      </calcite-tree-item>
+
+      <calcite-tree-item>
+        <span>Child 2</span>
+
+        <calcite-tree slot="children">
+          <calcite-tree-item>
+            <span>Grandchild 1</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item>
+                <span>Great Grandchild 1</span>
+              </calcite-tree-item>
+              <calcite-tree-item>
+                <span>Great Grandchild 2</span>
+              </calcite-tree-item>
+              <calcite-tree-item>
+                <span>Great Grandchild 3</span>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+          <calcite-tree-item>
+            <span>Grandchild 2</span>
+          </calcite-tree-item>
+          <calcite-tree-item>
+            <span>Grandchild 3</span>
+          </calcite-tree-item>
+        </calcite-tree>
+      </calcite-tree-item>
+
+      <calcite-tree-item>
+        <span>Child 3</span>
+      </calcite-tree-item>
+      <calcite-tree-item>
+        <span>Child 4</span>
+      </calcite-tree-item>
+    </calcite-tree>
+
     <h3>Dark Theme</h3>
     <div class="demo-background-dark">
       <calcite-tree theme="dark">

--- a/src/demos/calcite-tree.html
+++ b/src/demos/calcite-tree.html
@@ -239,8 +239,8 @@
       </calcite-tree-item>
     </calcite-tree>
 
-    <h2>Checkboxes in ancestor selection mode</h2>
-    <calcite-tree checkboxes selection-mode="ancestors">
+    <h2>Input enabled in ancestor selection mode</h2>
+    <calcite-tree input-enabled selection-mode="ancestors">
       <calcite-tree-item>
         <span>Child 1</span>
       </calcite-tree-item>


### PR DESCRIPTION
## Summary

We have several UI's which are hierarchical structures where every level can be selected. Here are some examples:

<img width="335" alt="Screen Shot 2021-03-16 at 6 18 31 PM" src="https://user-images.githubusercontent.com/1031758/111400553-c727a000-8684-11eb-9955-9b987470fd13.png">

<img width="231" alt="Screen Shot 2021-03-16 at 6 20 23 PM" src="https://user-images.githubusercontent.com/1031758/111400560-cabb2700-8684-11eb-8485-77663a223648.png">

I've added this functionality as a mode to the Tree component. `selection-mode="ancestors"` will select all children  of an object when select, and deselect all children when deselected. This selection mode is very similar to the `ancestors` selection mode that is now available in `combobox`.

I've also added a `checkboxes` prop. This works much like `lines`. It's a more form-like way to render tree options for selecting, rather than just navigating. When you have checkboxes and you're in ancestors selection mode, the tree will manage setting indeterminate states for you as well.

I've added a tests for the selection mode. I didn't convert `tree` to tailwind or write tests for the other tree functionality (tests are currently very limited on tree). Can try to take on more of the tree stuff in a follow up.

---

cc @bstifle for design 👀 