### PR TITLE
feat(combobox): add constant prop to combobox item

### DIFF
--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -58,6 +58,9 @@ export class CalciteComboboxItem {
   /** A unique value used to identify this item - similar to the value attribute on an <input>. */
   @Prop({ reflect: true }) value!: string;
 
+  /** Don't filter this item based on the search text */
+  @Prop({ reflect: true }) alwaysVisible: boolean;
+
   // --------------------------------------------------------------------------
   //
   //  Private Properties

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -59,7 +59,7 @@ export class CalciteComboboxItem {
   @Prop({ reflect: true }) value!: string;
 
   /** Don't filter this item based on the search text */
-  @Prop({ reflect: true }) alwaysVisible: boolean;
+  @Prop({ reflect: true }) constant: boolean;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -547,6 +547,28 @@ describe("calcite-combobox", () => {
     });
   });
 
+  it("respects the always-visible item property", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-combobox selection-mode="single">
+        <calcite-combobox-item id="one" always-visible value="one" text-label="One"></calcite-combobox-item>
+        <calcite-combobox-item id="two" value="two" text-label="Two"></calcite-combobox-item>
+        <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+      </calcite-combobox>
+    `);
+
+    await page.waitForChanges();
+    const input = await page.find("calcite-combobox >>> .wrapper");
+    await input.click();
+    await page.keyboard.type("two");
+    const one = await (await page.find("#one")).isVisible();
+    const two = await (await page.find("#two")).isVisible();
+    const three = await (await page.find("#three")).isVisible();
+    expect(one).toBeTruthy();
+    expect(two).toBeTruthy();
+    expect(three).toBeTruthy();
+  });
+
   it("works correctly inside a shadowRoot", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -547,11 +547,11 @@ describe("calcite-combobox", () => {
     });
   });
 
-  it("respects the always-visible item property", async () => {
+  it("respects the constant item property", async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-combobox selection-mode="single">
-        <calcite-combobox-item id="one" always-visible value="one" text-label="One"></calcite-combobox-item>
+        <calcite-combobox-item id="one" constant value="one" text-label="One"></calcite-combobox-item>
         <calcite-combobox-item id="two" value="two" text-label="Two"></calcite-combobox-item>
         <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
       </calcite-combobox>

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -561,12 +561,13 @@ describe("calcite-combobox", () => {
     const input = await page.find("calcite-combobox >>> .wrapper");
     await input.click();
     await page.keyboard.type("two");
+    await page.waitForChanges();
     const one = await (await page.find("#one")).isVisible();
     const two = await (await page.find("#two")).isVisible();
     const three = await (await page.find("#three")).isVisible();
     expect(one).toBeTruthy();
     expect(two).toBeTruthy();
-    expect(three).toBeTruthy();
+    expect(three).toBeFalsy();
   });
 
   it("works correctly inside a shadowRoot", async () => {

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -555,6 +555,7 @@ export class CalciteCombobox {
 
   getData(): ItemData[] {
     return this.items.map((item) => ({
+      alwaysVisible: item.alwaysVisible,
       value: item.value,
       label: item.textLabel,
       guid: item.guid

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -555,7 +555,7 @@ export class CalciteCombobox {
 
   getData(): ItemData[] {
     return this.items.map((item) => ({
-      alwaysVisible: item.alwaysVisible,
+      constant: item.constant,
       value: item.value,
       label: item.textLabel,
       guid: item.guid

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -80,6 +80,32 @@
       <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
     </calcite-combobox>
 
+
+    <h2>Single Select, certain items always visible</h2>
+    <calcite-combobox label="test" placeholder="select element" max-items="6" selection-mode="single">
+      <calcite-combobox-item value="New Item" always-visible text-label="Add new plant" icon="plus"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" text-label="Trees">
+        <calcite-combobox-item value="Pine" text-label="Pine">
+          <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" text-label="Flowers">
+        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Animals" text-label="Animals">
+        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+    </calcite-combobox>
+
     <h2>Single Select with Custom Icons</h2>
     <calcite-combobox label="test" placeholder="select folder" max-items="6" selection-mode="single">
       <calcite-combobox-item value="root" text-label="username" icon="home" selected></calcite-combobox-item>

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -81,9 +81,9 @@
     </calcite-combobox>
 
 
-    <h2>Single Select, certain items always visible</h2>
+    <h2>Single Select, certain items constant</h2>
     <calcite-combobox label="test" placeholder="select element" max-items="6" selection-mode="single">
-      <calcite-combobox-item value="New Item" always-visible text-label="Add new plant" icon="plus"></calcite-combobox-item>
+      <calcite-combobox-item value="New Item" constant text-label="Add new plant" icon="plus"></calcite-combobox-item>
       <calcite-combobox-item value="Trees" text-label="Trees">
         <calcite-combobox-item value="Pine" text-label="Pine">
           <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -10,6 +10,9 @@ export const filter = (data: Array<object>, value: string): Array<any> => {
   }
 
   const find = (input: object, RE: RegExp) => {
+    if ((input as any)?.alwaysVisible) {
+      return true;
+    }
     let found = false;
     forIn(input, (val) => {
       if (typeof val === "function") {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -10,7 +10,7 @@ export const filter = (data: Array<object>, value: string): Array<any> => {
   }
 
   const find = (input: object, RE: RegExp) => {
-    if ((input as any)?.alwaysVisible) {
+    if ((input as any)?.constant) {
       return true;
     }
     let found = false;


### PR DESCRIPTION
## Summary

This allows devs to keep certain combobox items visible even when filtering. The use case here is some sort of "new" option:

<img width="796" alt="Screen Shot 2021-03-17 at 11 52 00 AM" src="https://user-images.githubusercontent.com/1031758/111522446-8af14f80-8717-11eb-98df-851dc6637b71.png">

However, this could also be used to put together an async combobox UI. Imagine you want to have a selection UI for members, but you have to hit a paginated API. You could use the filter event from the box, hit the API, and render the results. If you use this prop on all of them, you'll be able to show them even though text is entered. Basically it allows devs to take care of list filtering themselves if they want to as an opt-in.

I haven't added a storybook entry for this. The combobox storybook needs a rewrite to work more like accordions where there are multiple pages of knobs that are grouped for combobox, combobox-item.


