### PR TITLE
chore(icons): update icons to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3146,9 +3146,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.14.8",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.14.8.tgz",
-      "integrity": "sha512-rZs5UUt5+0cKAN+VVxOHzfzyUcNMB+25Ns6Zf3sN8hQBMh6Ng8T5j8D9Y41s5GF4IObFnFKiqwfx5gO1Efi7CQ==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.15.1.tgz",
+      "integrity": "sha512-NsgYGaXxLjzPn7Z6UvhLrrlE67jodoZBXG+6ddF7mY+rxo3g6ZBL9eyvZeFvfGbuQ+N/V17eQJWLmuxuErvkIg==",
       "dev": true
     },
     "@fullhuman/postcss-purgecss": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.0",
-    "@esri/calcite-ui-icons": "3.14.8",
+    "@esri/calcite-ui-icons": "3.15.1",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "2.0.0",
     "@stencil/sass": "1.4.1",


### PR DESCRIPTION
**Related Issue:** #

## Summary
Update the icons.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
