### PR TITLE
refactor(tailwind, tabs, shell-panel): reverts 3px border width, border-side-style utility, usage

### DIFF
--- a/src/components/calcite-select/calcite-select.scss
+++ b/src/components/calcite-select/calcite-select.scss
@@ -65,8 +65,8 @@
   padding-right: var(--calcite-select-spacing);
   @apply border-0 
     border-r
-    border-r-solid
     border-color-1;
+  border-right-style: solid;
 }
 
 // override user agent stylesheet disabled styling
@@ -95,11 +95,11 @@ select:disabled {
 }
 
 :host([dir="rtl"]) .icon-container {
-  @apply border-l-solid 
-    border-color-1 
+  @apply border-color-1 
     border-r-0 
     left-0;
   right: unset;
+  border-left-style: solid;
 }
 
 .select:focus ~ .icon-container {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -95,9 +95,11 @@
 }
 
 :host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
-  @apply border-r border-r-solid border-r-color-3;
+  @apply border-r border-r-color-3;
+  border-right-style: solid;
 }
 
 :host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
-  @apply border-l border-l-solid border-l-color-3;
+  @apply border-l border-l-color-3;
+  border-left-style: solid;
 }

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -11,14 +11,14 @@ section {
     flex-grow
     overflow-hidden
     border-t
-    border-t-solid
     border-t-color-1;
+  border-top-style: solid;
 }
 
 :host([position="below"]) section {
   @apply flex-col-reverse
     border-t-0
     border-b
-    border-b-solid
     border-b-color-1;
+  border-bottom-style: solid;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,14 +21,6 @@ module.exports = {
       "color-danger-hover": theme("colors.danger-hover"),
       "color-danger-press": theme("colors.danger-press"),
     }),
-    borderWidth: {
-      default: '1px',
-      "0": "0px",
-      "2": "2px",
-      "3": "3px",
-      "4": "4px",
-      "8": "8px"
-    },
     colors: {
       "brand": "var(--calcite-ui-brand)",
       "brand-hover": "var(--calcite-ui-brand-hover)",
@@ -259,24 +251,6 @@ module.exports = {
       const utilities = Object.assign({}, ...colorMap);
 
       addUtilities(utilities, variants('borderColor'));
-    },
-    ({ addUtilities, variants }) => {
-      const styles = [
-        'solid',
-        'dashed',
-        'dotted',
-        'double',
-        'none',
-      ];
-      const stylesMap = styles.map(style => ({
-        [`.border-t-${style}`]: {borderTopStyle: style},
-        [`.border-r-${style}`]: {borderRightStyle: style},
-        [`.border-b-${style}`]: {borderBottomStyle: style},
-        [`.border-l-${style}`]: {borderLeftStyle: style},
-      }));
-      const utilities = Object.assign({}, ...stylesMap);
-
-      addUtilities(utilities, variants('borderStyle'));
     },
   ],
   future: {


### PR DESCRIPTION
**Related Issue:** #1500

## Summary
Removes the 3px border width and border-side-style utility additions introduced in pr #1669 from our Tailwind config. Also removes usage of the border-side-style utility in calcite-tabs and calcite-shell-panel .scss files.

Why?

We don't want to provide 3px border widths in the theme (some border widths - like calcite-notice and calcite-tab-title -  decreased from 3px to 2px in the refactor work, and that's intended).

Additionally, when tailwind base is incorporated down the road, @jrowlingson let me know that the border-side-style utility won't be needed. (As a note, when I looked at this last Friday with Jack, my refactor of calcite-tab-title needed the border-side-style explicitly set for its gray hover effect, which was the reason I had added the utility. Instead of cluttering up the config, I'm just going to set [`border-bottom-style: solid;`](https://github.com/Esri/calcite-components/compare/master...caripizza/1500-revert-border-utility-tab-title-tab-nav#diff-65cbe3a4256e074596efe123527926d26712540a001d0c10bf6c82c46c6f0afeR64) and [`border-top-style: solid;`](https://github.com/Esri/calcite-components/compare/master...caripizza/1500-revert-border-utility-tab-title-tab-nav#diff-65cbe3a4256e074596efe123527926d26712540a001d0c10bf6c82c46c6f0afeR16) and we can revisit/strip out as the refactor work is completed.)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
