### PR TITLE
refactor(tabs, tab-title, tab-nav, tailwind): testing Screener changes all together

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -79,9 +79,11 @@
 }
 
 :host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
-  @apply border-r border-r-solid border-r-color-3;
+  @apply border-r border-r-color-3;
+  border-right-style: solid;
 }
 
 :host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
-  @apply border-l border-l-solid border-l-color-3;
+  @apply border-l border-l-color-3;
+  border-left-style: solid;
 }

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -7,9 +7,10 @@
     w-full
     overflow-auto
     justify-start
-    scrolling-touch
-    p-1
-    -m-1;
+    scrolling-touch;
+  // workaround for outset focus within a scrolling container
+  padding: theme("padding.1");
+  margin: theme("margin.-1");
 }
 
 :host([layout="center"]) .tab-nav {
@@ -23,8 +24,8 @@
     right-0
     bottom-0
     absolute
-    overflow-hidden
-    h-0.5;
+    overflow-hidden;
+  height: theme("height[0.5]");
 }
 
 .tab-nav-active-indicator {
@@ -32,9 +33,9 @@
     bottom-0
     block
     transition-all
-    ease-out
-    bg-brand
-    h-0.5;
+    ease-out;
+  background: theme("colors.brand");
+  height: theme("height[0.5]");
 }
 
 :host([position="below"]) .tab-nav-active-indicator {

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -1,50 +1,48 @@
 :host {
-  z-index: 2;
-  position: relative;
-  display: flex;
+  @apply z-20 relative flex;
 }
 
 .tab-nav {
-  display: flex;
-  width: 100%;
-  overflow: auto;
-  justify-content: flex-start;
-  -webkit-overflow-scrolling: touch;
-  // workaround for outset focus within a scrolling container
-  padding: 4px;
-  margin: -4px;
+  @apply flex
+    w-full
+    overflow-auto
+    justify-start
+    scrolling-touch
+    p-1
+    -m-1;
 }
 
 :host([layout="center"]) .tab-nav {
-  justify-content: center;
+  @apply justify-center;
 }
 
 // prevent indicator overflow in horizontal scrolling situations
 .tab-nav-active-indicator-container {
-  width: 100%;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  @apply w-full
+    left-0
+    right-0
+    bottom-0
+    absolute
+    overflow-hidden;
   height: 3px;
-  position: absolute;
-  overflow: hidden;
 }
 
 .tab-nav-active-indicator {
-  position: absolute;
-  bottom: 0;
+  @apply absolute
+    bottom-0
+    block
+    transition-all
+    ease-out;
   background: var(--calcite-ui-brand);
-  display: block;
   height: 3px;
-  transition: all ease-out;
 }
 
 :host([position="below"]) .tab-nav-active-indicator {
   bottom: unset;
-  top: 0;
+  @apply top-0;
 }
 
 :host([position="below"]) .tab-nav-active-indicator-container {
   bottom: unset;
-  top: 0;
+  @apply top-0;
 }

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -23,8 +23,8 @@
     right-0
     bottom-0
     absolute
-    overflow-hidden;
-  height: 3px;
+    overflow-hidden
+    h-0.5;
 }
 
 .tab-nav-active-indicator {
@@ -32,9 +32,9 @@
     bottom-0
     block
     transition-all
-    ease-out;
-  background: var(--calcite-ui-brand);
-  height: 3px;
+    ease-out
+    bg-brand
+    h-0.5;
 }
 
 :host([position="below"]) .tab-nav-active-indicator {

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -7,10 +7,9 @@
     w-full
     overflow-auto
     justify-start
-    scrolling-touch;
-  // workaround for outset focus within a scrolling container
-  padding: theme("padding.1");
-  margin: theme("margin.-1");
+    scrolling-touch
+    p-1
+    -m-1;
 }
 
 :host([layout="center"]) .tab-nav {
@@ -20,8 +19,7 @@
 // prevent indicator overflow in horizontal scrolling situations
 .tab-nav-active-indicator-container {
   @apply w-full
-    left-0
-    right-0
+    inset-x-0
     bottom-0
     absolute
     overflow-hidden

--- a/src/components/calcite-tab-nav/calcite-tab-nav.scss
+++ b/src/components/calcite-tab-nav/calcite-tab-nav.scss
@@ -24,8 +24,8 @@
     right-0
     bottom-0
     absolute
-    overflow-hidden;
-  height: theme("height[0.5]");
+    overflow-hidden
+    h-0.5;
 }
 
 .tab-nav-active-indicator {
@@ -33,9 +33,9 @@
     bottom-0
     block
     transition-all
-    ease-out;
-  background: theme("colors.brand");
-  height: theme("height[0.5]");
+    ease-out
+    bg-brand
+    h-0.5;
 }
 
 :host([position="below"]) .tab-nav-active-indicator {

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -12,8 +12,8 @@
 :host([position="below"]) a {
   @apply border-b-0
     border-t-2
-    border-t-solid
     border-t-color-transparent;
+  border-top-style: solid;
 }
 
 :host a {
@@ -52,16 +52,16 @@ span {
     truncate
     border-b-2
     border-b-color-transparent
-    border-b-solid
     w-full
     h-full
     flex
     justify-center
     text-color-3
-    text--1
+    text--1h
     transition-default
     px-0
     py-2;
+  border-bottom-style: solid;
 }
 
 span {

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -50,7 +50,7 @@ span {
     appearance-none
     cursor-pointer
     truncate
-    border-b-3
+    border-b-2
     border-b-color-transparent
     border-b-solid
     w-full
@@ -60,9 +60,8 @@ span {
     text-color-3
     text--1
     transition-default
-    text--1h
     px-0
-    py-3;
+    py-2;
 }
 
 span {

--- a/src/components/calcite-tab-title/calcite-tab-title.scss
+++ b/src/components/calcite-tab-title/calcite-tab-title.scss
@@ -1,124 +1,114 @@
-$tab-margin: 1.25rem;
-
 :host {
-  flex: 0 1 auto;
-  outline: none;
-  margin-right: $tab-margin;
-  margin-inline-start: 0;
-  margin-inline-end: $tab-margin;
+  @apply flex-initial outline-none mx-5;
+  margin-inline-start: theme("margin.0");
+  margin-inline-end: theme("margin.5");
 }
 
 :host([layout="center"]) {
+  @apply text-center my-0 mx-5;
   flex-basis: 200px;
-  text-align: center;
-  margin: 0 $tab-margin;
 }
 
 :host([position="below"]) a {
-  border-bottom: 0;
-  border-top: 3px solid transparent;
+  @apply border-b-0
+    border-t-2
+    border-t-solid
+    border-t-color-transparent;
 }
 
 :host a {
-  @include focus-style-base();
+  @apply focus-base;
 }
 
 :host(:focus) a {
-  @include focus-style-outset();
+  @apply focus-outset;
 }
 
 :host(:active),
 :host(:focus),
 :host(:hover) {
   a {
-    text-decoration: none;
-    color: var(--calcite-ui-text-1);
-    border-color: var(--calcite-ui-border-2);
+    @apply no-underline text-color-1 border-color-2;
   }
 }
 
 :host([active]) a {
-  color: var(--calcite-ui-text-1);
-  border-color: transparent;
+  @apply text-color-1 border-color-transparent;
 }
 
 :host([disabled]) {
-  pointer-events: none;
+  @apply pointer-events-none;
   span,
   a {
-    pointer-events: none;
-    opacity: var(--calcite-ui-opacity-disabled);
+    @apply pointer-events-none opacity-50;
   }
 }
 
 a,
 span {
-  box-sizing: border-box;
-  @include font-size(-2);
-  padding: $baseline/2 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  border-bottom: 3px solid transparent;
-  -webkit-appearance: none;
-  cursor: pointer;
-  transition: $transition;
-  color: var(--calcite-ui-text-3);
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
+  @apply box-border
+    appearance-none
+    cursor-pointer
+    truncate
+    border-b-3
+    border-b-color-transparent
+    border-b-solid
+    w-full
+    h-full
+    flex
+    justify-center
+    text-color-3
+    text--1
+    transition-default
+    text--1h
+    px-0
+    py-3;
 }
 
 span {
-  cursor: default;
+  @apply cursor-default;
 }
 
 .calcite-tab-title--icon {
-  display: inline-flex;
-  position: relative;
-  margin: 0;
-  line-height: inherit;
-  align-self: center;
+  @apply inline-flex
+    relative
+    m-0
+    self-center;
   & svg {
-    transition: $transition;
+    @apply transition-default;
   }
 }
 
 :host([hastext]) .calcite-tab-title--icon.icon-start {
-  margin-right: $baseline/3;
+  @apply mr-2;
 }
 
 :host([hastext]) .calcite-tab-title--icon.icon-end {
-  margin-left: $baseline/3;
+  @apply ml-2;
 }
 
 // compensate for spacing when no hastext and two icons
 :host([icon-start][icon-end]) {
   .calcite-tab-title--icon:first-child {
-    margin-right: $baseline/3;
+    @apply mr-2;
   }
 }
 
 // right to left
 :host .rtl {
-  margin-right: 0;
-  margin-left: $tab-margin;
+  @apply mr-0 ml-5;
 }
 
 :host([hastext]) .rtl .calcite-tab-title--icon.icon-end {
-  margin-left: 0;
-  margin-right: $baseline/3;
+  @apply ml-0 mr-2;
 }
 
 :host([hastext]) .rtl .calcite-tab-title--icon.icon-start {
-  margin-right: 0;
-  margin-left: $baseline/3;
+  @apply ml-2 mr-0;
 }
 
 :host([icon-start][icon-end]) .rtl {
   .calcite-tab-title--icon:first-child {
-    margin-right: 0;
-    margin-left: $baseline/3;
+    @apply ml-2 mr-0;
   }
 }

--- a/src/components/calcite-tabs/calcite-tabs.scss
+++ b/src/components/calcite-tabs/calcite-tabs.scss
@@ -11,14 +11,14 @@ section {
     flex-grow
     overflow-hidden
     border-t
-    border-t-solid
     border-t-color-1;
+  border-top-style: solid;
 }
 
 :host([position="below"]) section {
   @apply flex-col-reverse
     border-t-0
     border-b
-    border-b-solid
     border-b-color-1;
+  border-bottom-style: solid;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,14 +21,6 @@ module.exports = {
       "color-danger-hover": theme("colors.danger-hover"),
       "color-danger-press": theme("colors.danger-press"),
     }),
-    borderWidth: {
-      default: '1px',
-      "0": "0px",
-      "2": "2px",
-      "3": "3px",
-      "4": "4px",
-      "8": "8px"
-    },
     colors: {
       "brand": "var(--calcite-ui-brand)",
       "brand-hover": "var(--calcite-ui-brand-hover)",
@@ -259,24 +251,6 @@ module.exports = {
       const utilities = Object.assign({}, ...colorMap);
 
       addUtilities(utilities, variants('borderColor'));
-    },
-    ({ addUtilities, variants }) => {
-      const styles = [
-        'solid',
-        'dashed',
-        'dotted',
-        'double',
-        'none',
-      ];
-      const stylesMap = styles.map(style => ({
-        [`.border-t-${style}`]: {borderTopStyle: style},
-        [`.border-r-${style}`]: {borderRightStyle: style},
-        [`.border-b-${style}`]: {borderBottomStyle: style},
-        [`.border-l-${style}`]: {borderLeftStyle: style},
-      }));
-      const utilities = Object.assign({}, ...stylesMap);
-
-      addUtilities(utilities, variants('borderStyle'));
     },
   ],
   future: {


### PR DESCRIPTION
**Related Issue:** #1500

## Summary
DRAFT PR ONLY: Apologies for the clutter, but I need to see how Screener behaves with all style changes from these open prs: #1746, #1745, #1788.

Hoping to use this one as a comparison for visual clarity. My idea is to:
1). accept Screener changes on #1745 if this one looks good (ie., only accept changes on that pr, not this one)
2). merge the pr's in this progression: a). 1788, b). 1745, c). 1746.
3). close this pr

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
