### PR TITLE
fix(popover, panel)!: image slot removed and sizing styles updated

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -2,12 +2,6 @@
   @extend %component-host;
   @apply flex relative;
 
-  max-height: var(--calcite-panel-max-height);
-  width: var(--calcite-panel-width);
-  max-width: var(--calcite-panel-max-width);
-  min-width: var(--calcite-panel-min-width);
-  transition: max-height $transition, width $transition;
-
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
   --calcite-panel-max-height: unset;
   --calcite-panel-width: 100%;
@@ -26,6 +20,12 @@
     w-full
     p-0
     m-0;
+
+  max-height: var(--calcite-panel-max-height);
+  width: var(--calcite-panel-width);
+  max-width: var(--calcite-panel-max-width);
+  min-width: var(--calcite-panel-min-width);
+  transition: max-height $transition, width $transition;
 }
 
 :host([height-scale="s"]) {

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -41,11 +41,6 @@ describe("calcite-popover", () => {
       `<calcite-popover label="test" open close-button reference-element="ref"></calcite-popover><div id="ref">😄</div>`
     ));
 
-  it("is accessible with image", async () =>
-    accessible(
-      `<calcite-popover label="test" placement="auto" reference-element="ref" open><img alt="" slot="image" src="http://placekitten.com/200/300" /></calcite-popover><div id="ref">referenceElement</div>`
-    ));
-
   it("honors hidden attribute", async () => hidden("calcite-popover"));
 
   it("has property defaults", async () =>
@@ -174,18 +169,6 @@ describe("calcite-popover", () => {
     closeButton = await page.find(`calcite-popover >>> .${CSS.closeButton}`);
 
     expect(await closeButton.isVisible()).toBe(true);
-  });
-
-  it("should have image container", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      `<calcite-popover placement="auto" reference-element="ref" open><img slot="image" src="http://placekitten.com/200/300" /></calcite-popover><div id="ref">referenceElement</div>`
-    );
-
-    const imageContainer = await page.find(`calcite-popover >>> .${CSS.imageContainer}`);
-
-    expect(await imageContainer.isVisible()).toBe(true);
   });
 
   it("should honor click interaction", async () => {

--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -1,5 +1,3 @@
-$image_max_height: 200px;
-
 @include popperHost();
 @include popperArrow();
 
@@ -11,23 +9,28 @@ $image_max_height: 200px;
   pointer-events: initial;
 }
 
+.calcite-popper-anim {
+  @apply h-full;
+}
+
 .container {
   @apply bg-foreground-1 
     relative 
     flex 
     overflow-hidden 
     flex-no-wrap 
-    flex-col 
+    flex-row 
+    h-full
     text-color-1;
 }
 
 .content {
-  @apply flex 
-    flex-row 
-    justify-between 
-    justify-start;
-  line-height: theme("spacing.6");
+  @apply flex
+  flex-col
+  flex-no-wrap
+  h-full;
 }
+
 // focus styles
 .close-button {
   @apply focus-base;
@@ -58,20 +61,6 @@ $image_max_height: 200px;
   .close-button {
     border-radius: var(--calcite-border-radius) 0 0 0;
   }
-}
-
-.image-container {
-  @apply overflow-hidden;
-  max-height: $image_max_height;
-  //FIXME: Should this m-1?
-  margin: 5px;
-}
-
-slot[name="image"]::slotted(img) {
-  @apply h-auto w-full object-cover;
-  max-height: $image_max_height;
-  //FIXME: Will this work?
-  object-position: theme("width[1/2]") theme("width[1/2]");
 }
 
 ::slotted(calcite-panel),

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -343,14 +343,6 @@ export class CalcitePopover {
   //
   // --------------------------------------------------------------------------
 
-  renderImage(): VNode {
-    return this.el.querySelector("[slot=image]") ? (
-      <div class={CSS.imageContainer}>
-        <slot name="image" />
-      </div>
-    ) : null;
-  }
-
   renderCloseButton(): VNode {
     const { closeButton, intlClose } = this;
 
@@ -393,11 +385,10 @@ export class CalcitePopover {
         >
           {arrowNode}
           <div class={CSS.container}>
-            {this.renderImage()}
             <div class={CSS.content}>
               <slot />
-              {this.renderCloseButton()}
             </div>
+            {this.renderCloseButton()}
           </div>
         </div>
       </Host>

--- a/src/components/calcite-popover/readme.md
+++ b/src/components/calcite-popover/readme.md
@@ -58,12 +58,6 @@ Type: `Promise<void>`
 
 Type: `Promise<void>`
 
-## Slots
-
-| Slot      | Description                                                                     |
-| --------- | ------------------------------------------------------------------------------- |
-| `"image"` | A slot for adding an image. The image will appear above the other slot content. |
-
 ## Dependencies
 
 ### Used by

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -45,7 +45,7 @@
         const view = new MapView({
           container: "viewDiv",
           map: webmap,
-          padding: { left: 49, right: 385 }
+          // padding: { left: 49, right: 385 }
         });
         view.when(function () {
           view.ui.move("zoom", "bottom-right");
@@ -56,8 +56,11 @@
   <body>
     <main>
       <div class="shell-container">
-        <calcite-shell content-behind>
-          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
+        
+        <calcite-shell>
+          
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start">
+            
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
@@ -92,6 +95,9 @@
                     ></calcite-action>
                   </calcite-input>
                 </calcite-label>
+                <calcite-popover-manager>
+                  <calcite-button id="popover-trigger">Pop it!</calcite-button>
+                </calcite-popover-manager>
               </calcite-panel>
             </calcite-flow>
           </calcite-shell-panel>
@@ -821,13 +827,10 @@
       </div>
       <calcite-popover
         label="right start popover"
-        placement="right-start"
-        reference-element="action-pad-button"
-        add-click-handle
-        class="popover"
+        placement="right"
+        reference-element="popover-trigger"
       >
-        <calcite-panel theme="light">
-          <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
+        <calcite-panel heading="Cool cool">
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" text="options">
               <calcite-icon icon="ellipsis" scale="s"></calcite-icon>
@@ -845,6 +848,11 @@
               value="3"
             ></calcite-pick-list-item>
             <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="END" value="4"></calcite-pick-list-item>
           </calcite-pick-list>
           <calcite-button slot="footer" width="half">Yeah!</calcite-button>
           <calcite-button slot="footer" width="half" appearance="clear">Naw.</calcite-button>

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -44,8 +44,7 @@
 
         const view = new MapView({
           container: "viewDiv",
-          map: webmap,
-          // padding: { left: 49, right: 385 }
+          map: webmap
         });
         view.when(function () {
           view.ui.move("zoom", "bottom-right");

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -83,7 +83,7 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow>
-              <calcite-panel heading="Layers" height-scale="l" width-scale="m">
+              <calcite-panel heading="Layers">
                 <calcite-label>
                   It's a label.
                   <calcite-input type="text" placeholder="This is stuff." scale="s">
@@ -141,7 +141,6 @@
               <calcite-panel
                 heading="cool"
                 summary="Popular Demographics in the United States (Beta) - County"
-                width-scale="m"
               >
                 I'm this panel's content.
               </calcite-panel>
@@ -830,7 +829,7 @@
         placement="right"
         reference-element="popover-trigger"
       >
-        <calcite-panel heading="Cool cool">
+        <calcite-panel heading="Cool cool" height-scale="m">
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" text="options">
               <calcite-icon icon="ellipsis" scale="s"></calcite-icon>
@@ -847,6 +846,11 @@
               label="about starvation and the food that Live Aid bought"
               value="3"
             ></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
             <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
             <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
             <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>


### PR DESCRIPTION
**Related Issue:** #1752

## Summary
Includes some clean-up on Popover as discussed previously with @julio8a .

Also updates demo app for better demo apping.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
