### PR TITLE
fix(tip): Hide tip when dismissed.

### DIFF
--- a/src/components/calcite-tip/calcite-tip.e2e.ts
+++ b/src/components/calcite-tip/calcite-tip.e2e.ts
@@ -17,15 +17,6 @@ describe("calcite-tip", () => {
 
   it("is accessible", async () => accessible(`<calcite-tip heading="sample"><p>not dismissible</p></calcite-tip>`));
 
-  it("should remove the closeButton when dismissed", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`<calcite-tip dismissed><p>dismissible</p></calcite-tip>`);
-
-    const closeButton = await page.find(`calcite-tip >>> .${CSS.close}`);
-    expect(closeButton).toBeNull();
-  });
-
   it("should remove the closeButton if nonDismissible prop is true", async () => {
     const page = await newE2EPage();
 
@@ -44,7 +35,7 @@ describe("calcite-tip", () => {
 
     await closeButton.click();
 
-    const tip = await page.find(`calcite-tip >>> .${CSS.container}`);
+    const tip = await page.find(`calcite-tip`);
 
     const isVisible = await tip.isVisible();
 

--- a/src/components/calcite-tip/calcite-tip.e2e.ts
+++ b/src/components/calcite-tip/calcite-tip.e2e.ts
@@ -17,6 +17,15 @@ describe("calcite-tip", () => {
 
   it("is accessible", async () => accessible(`<calcite-tip heading="sample"><p>not dismissible</p></calcite-tip>`));
 
+  it("should remove the closeButton when dismissed", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-tip dismissed><p>dismissible</p></calcite-tip>`);
+
+    const closeButton = await page.find(`calcite-tip >>> .${CSS.close}`);
+    expect(closeButton).toBeNull();
+  });
+
   it("should remove the closeButton if nonDismissible prop is true", async () => {
     const page = await newE2EPage();
 

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -9,6 +9,10 @@
     border-color-2;
 }
 
+:host([dismissed]) {
+  @apply hidden;
+}
+
 .container {
   @apply p-4;
 }

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -9,12 +9,13 @@
     border-color-2;
 }
 
-:host([dismissed]) {
-  @apply hidden;
-}
-
 .container {
   @apply p-4;
+}
+
+:host([dismissed]),
+:host([dismissed]) .container {
+  @apply hidden;
 }
 
 :host([selected]) .container {

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -103,11 +103,11 @@ export class CalciteTip {
   }
 
   renderDismissButton(): VNode {
-    const { nonDismissible, hideTip, intlClose } = this;
+    const { nonDismissible, dismissed, hideTip, intlClose } = this;
 
     const text = intlClose || TEXT.close;
 
-    return !nonDismissible ? (
+    return !nonDismissible && !dismissed ? (
       <calcite-action
         class={CSS.close}
         icon={ICONS.close}

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -103,11 +103,11 @@ export class CalciteTip {
   }
 
   renderDismissButton(): VNode {
-    const { nonDismissible, dismissed, hideTip, intlClose } = this;
+    const { nonDismissible, hideTip, intlClose } = this;
 
     const text = intlClose || TEXT.close;
 
-    return !nonDismissible && !dismissed ? (
+    return !nonDismissible ? (
       <calcite-action
         class={CSS.close}
         icon={ICONS.close}
@@ -148,7 +148,7 @@ export class CalciteTip {
   render(): VNode {
     return (
       <Host>
-        <article class={CSS.container} hidden={this.dismissed}>
+        <article class={CSS.container}>
           {this.renderHeader()}
           {this.renderContent()}
         </article>

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -21,7 +21,7 @@ export class CalciteTip {
   /**
    * No longer displays the tip.
    */
-  @Prop({ mutable: true }) dismissed = false;
+  @Prop({ reflect: true, mutable: true }) dismissed = false;
 
   /**
    * Indicates whether the tip can be dismissed.


### PR DESCRIPTION
**Related Issue:** None

## Summary

fix(tip): Hide tip when dismissed.

Currently, closing the tip still shows the close button and border.

https://esri.github.io/calcite-components/?path=/story/components-app-tip--basic
