### PR TITLE
fix(panel): retain header node even without content to retain action position

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -72,7 +72,7 @@
   border-bottom: 1px solid;
   @apply items-stretch
     bg-foreground-1
-    justify-start
+    justify-between
     sticky
     top-0
     border-b-color-3

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -254,12 +254,12 @@ export class CalcitePanel {
 
     const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
 
-    return headingNode || summaryNode ? (
+    return (
       <div class={CSS.headerContent} key="header-content">
         {headingNode}
         {summaryNode}
       </div>
-    ) : null;
+    );
   }
 
   /**

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -254,12 +254,12 @@ export class CalcitePanel {
 
     const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
 
-    return (
+    return headingNode || summaryNode ? (
       <div class={CSS.headerContent} key="header-content">
         {headingNode}
         {summaryNode}
       </div>
-    );
+    ) : null;
   }
 
   /**


### PR DESCRIPTION
**Related Issue:** (#1822)

## Summary
Alternatively, I could add conditional styles for there not being a header, but this seemed cleaner.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
