### PR TITLE
fix(input): solve bug with decimal precision in number input (#936)

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -189,7 +189,7 @@ describe("calcite-input", () => {
   it("correctly increments and decrements value when number buttons are clicked", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input type="number" value="3"></calcite-input>
+    <calcite-input type="number" value="3.123"></calcite-input>
     `);
 
     const element = await page.find("calcite-input");
@@ -199,16 +199,27 @@ describe("calcite-input", () => {
     const numberHorizontalItemUp = await page.find(
       "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
     );
-    expect(element.getAttribute("value")).toBe("3");
+    expect(element.getAttribute("value")).toBe("3.123");
     await numberHorizontalItemDown.click();
     await page.waitForChanges();
-    expect(element.getAttribute("value")).toBe("2");
+    expect(element.getAttribute("value")).toBe("2.123");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(element.getAttribute("value")).toBe("3");
+    expect(element.getAttribute("value")).toBe("3.123");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(element.getAttribute("value")).toBe("4");
+    expect(element.getAttribute("value")).toBe("4.123");
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    expect(element.getAttribute("value")).toBe("14.123");
   });
 
   it("correctly increments and decrements value when number buttons are clicked and step is set", async () => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -472,16 +472,17 @@ export class CalciteInput {
       const inputMin = this.minString ? parseFloat(this.minString) : null;
       const inputStep = Number(this.stepString) > 0 ? parseFloat(this.stepString) : 1;
       let inputVal = this.value && this.value !== "" ? parseFloat(this.value) : 0;
+      const decimals = this.value?.split(".")[1]?.length || 0;
 
       switch (e.target.dataset.adjustment) {
         case "up":
           if ((!inputMax && inputMax !== 0) || inputVal < inputMax) {
-            this.childEl.value = (inputVal += inputStep).toString();
+            this.childEl.value = (inputVal += inputStep).toFixed(decimals).toString();
           }
           break;
         case "down":
           if ((!inputMin && inputMin !== 0) || inputVal > inputMin) {
-            this.childEl.value = (inputVal -= inputStep).toString();
+            this.childEl.value = (inputVal -= inputStep).toFixed(decimals).toString();
           }
           break;
       }

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -169,7 +169,7 @@
             </calcite-label>
             <calcite-label>
               Number input - default type vertical
-              <calcite-input type="number" placeholder="How many apples?"></calcite-input>
+              <calcite-input type="number" placeholder="How many apples?" value="1.123" step="1"></calcite-input>
             </calcite-label>
 
             <calcite-label>


### PR DESCRIPTION
**Related Issue:** #936

## Summary

Fixes bug in input where decimal precision got all wonky if you clicked the input a whole bunch of times. I think this bug is due to javascript being... bad at math. Setting a fixed decimal length which is the same as the current value solves the issue.