### PR TITLE
feat(input): add minLength/maxLength props

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -605,4 +605,33 @@ describe("calcite-input", () => {
     await page.waitForChanges();
     expect(calciteInputInput).toHaveReceivedEventTimes(3);
   });
+
+  it("allows restricting input length", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-input minLength="2" maxLength="3"></calcite-input>`
+    });
+
+    const getInputValidity = async () =>
+      page.$eval("calcite-input input", (input: HTMLInputElement) => input.validity.valid);
+
+    const input = await page.find("calcite-input");
+    await input.callMethod("setFocus");
+
+    await page.keyboard.type("1");
+
+    expect(await getInputValidity()).toBe(false);
+
+    await page.keyboard.type("2");
+
+    expect(await getInputValidity()).toBe(true);
+
+    await page.keyboard.type("3");
+
+    expect(await getInputValidity()).toBe(true);
+
+    await page.keyboard.type("4");
+
+    expect(await getInputValidity()).toBe(true);
+    expect(await input.getProperty("value")).toBe("123");
+  });
 });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -89,8 +89,17 @@ export class CalciteInput {
     this.minString = this.min?.toString() || null;
   }
 
-  /** maximum length of text input */
+  /**
+   * Maximum length of text input.
+   * @deprecated use maxLength instead
+   */
   @Prop({ reflect: true }) maxlength?: number;
+
+  /** Maximum length of the input value */
+  @Prop({ reflect: true }) maxLength?: number;
+
+  /** Minimum length of the text input */
+  @Prop({ reflect: true }) minLength?: number;
 
   /** specify the placement of the number buttons */
   @Prop({ reflect: true }) numberButtonType?: InputPlacement = "vertical";
@@ -293,8 +302,9 @@ export class CalciteInput {
         defaultValue={this.defaultValue}
         disabled={this.disabled ? true : null}
         max={this.maxString}
-        maxlength={this.maxlength}
+        maxLength={this.maxLength}
         min={this.minString}
+        minLength={this.minLength}
         onBlur={this.inputBlurHandler}
         onFocus={this.inputFocusHandler}
         onInput={this.inputInputHandler}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds `minLength`/`maxLength` props to `<calcite-input>` and deprecates `minlength` because it does not follow prop casing.