### PR TITLE
docs(modal): fix 'none' option values for modal color attribute

### DIFF
--- a/src/components/calcite-modal/calcite-modal.stories.ts
+++ b/src/components/calcite-modal/calcite-modal.stories.ts
@@ -15,7 +15,7 @@ export const Simple = (): string => {
   return `
       <calcite-modal
         ${boolean("active", true)}
-        color="${select("color", { blue: "blue", red: "red", none: null }, null)}"
+        color="${select("color", { blue: "blue", red: "red", none: "" }, "")}"
         background-color="${select("background-color", ["white", "grey"], "white")}"
         scale="${select("scale", ["s", "m", "l"], "m")}"
         width="${select("width", ["s", "m", "l"], "s")}"
@@ -63,7 +63,7 @@ export const DarkMode = (): string => {
   <calcite-modal
     theme="dark"
     ${boolean("active", true)}
-    color="${select("color", { blue: "blue", red: "red", none: null }, null)}"
+    color="${select("color", { blue: "blue", red: "red", none: "" }, "")}"
     background-color="${select("background-color", ["white", "grey"], "white")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["s", "m", "l"], "s")}"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Uses attribute value to unset the color attribute. Stories use attributes instead of props, so `null` would get stringified when rendered:

```html
<calcite-modal
  active=""
  color="null"
  background-color="white"
  scale="m"
  width="s"
  intl-close="Close"
>/*...*/</calcite-modal>
```