### PR TITLE
fix(filter): keep focus on filter after clearing text via mouse

### DIFF
--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -50,6 +50,9 @@ describe("calcite-filter", () => {
     });
 
     describe("clearing value", () => {
+      const filterIsFocused = async (): Promise<boolean> =>
+        page.evaluate(() => document.querySelector("calcite-filter") === document.activeElement);
+
       it("should clear the value in the input when pressed", async () => {
         const filter = await page.find("calcite-filter");
         await filter.callMethod("setFocus");
@@ -60,6 +63,7 @@ describe("calcite-filter", () => {
         const button = await page.find(`calcite-filter >>> button`);
 
         await button.click();
+        await page.waitForChanges();
 
         const value = await page.evaluate(() => {
           const filter = document.querySelector("calcite-filter");
@@ -68,6 +72,7 @@ describe("calcite-filter", () => {
         });
 
         expect(value).toBe("");
+        expect(await filterIsFocused()).toBe(true);
       });
 
       it("should clear the value in the input when the Escape key is pressed", async () => {
@@ -87,6 +92,7 @@ describe("calcite-filter", () => {
         });
 
         expect(value).toBe("");
+        expect(await filterIsFocused()).toBe(true);
       });
     });
   });

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -148,6 +148,7 @@ export class CalciteFilter {
     this.textInput.value = "";
     this.empty = true;
     this.calciteFilterChange.emit(this.data);
+    this.setFocus();
   };
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #1527

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This addresses lost focus for anyone clearing the filter text by clicking the clear button.

cc @AdelheidF 