### PR TITLE
fix(chip): stop setting dir on component, use class

### DIFF
--- a/src/components/calcite-chip/calcite-chip.scss
+++ b/src/components/calcite-chip/calcite-chip.scss
@@ -40,11 +40,11 @@
   }
 }
 
-:host([dir="rtl"][scale="m"]) slot[name="chip-image"]::slotted(*) {
+:host([scale="m"] .calcite--rtl) slot[name="chip-image"]::slotted(*) {
   @apply pl-0 pr-1;
 }
 
-:host([dir="rtl"][scale="l"]) slot[name="chip-image"]::slotted(*) {
+:host([scale="l"] .calcite--rtl) slot[name="chip-image"]::slotted(*) {
   @apply pl-0 pr-1;
 }
 
@@ -70,7 +70,7 @@
   }
 }
 
-:host([dir="rtl"]) {
+:host(.calcite--rtl) {
   @apply text-right;
   --calcite-chip-button-border-radius: 50px 0 0 50px;
 }
@@ -84,7 +84,7 @@
     var(--calcite-chip-spacing-unit-l);
 }
 
-:host([dir="rtl"][dismissible]) span {
+:host([dismissible] .calcite--rtl) span {
   padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s)
     var(--calcite-chip-spacing-unit-s);
 }
@@ -94,7 +94,7 @@
     var(--calcite-chip-spacing-unit-s);
 }
 
-:host([dir="rtl"][icon]:not([dismissible])) span {
+:host([icon]:not([dismissible]) .calcite--rtl) span {
   padding: var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s) var(--calcite-chip-spacing-unit-s)
     var(--calcite-chip-spacing-unit-l);
 }
@@ -140,7 +140,7 @@
   border-radius: var(--calcite-chip-button-border-radius);
 }
 
-:host([dir="rtl"]) .calcite-chip--icon {
+:host(.calcite--rtl) .calcite-chip--icon {
   @apply my-0 ml-0;
   margin-right: var(--calcite-chip-spacing-unit-l);
 }

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -11,6 +11,7 @@ import {
 } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
 import { guid } from "../../utils/guid";
+import { CSS_UTILITY } from "../../utils/resources";
 import { CSS, TEXT } from "./resources";
 import { ChipColor } from "./interfaces";
 import { Appearance, Scale, Theme } from "../interfaces";
@@ -104,12 +105,12 @@ export class CalciteChip {
 
   render(): VNode {
     const dir = getElementDir(this.el);
+    const rtl = dir === "rtl";
     const iconScale = this.scale !== "l" ? "s" : "m";
 
     const iconEl = (
       <calcite-icon
-        class="calcite-chip--icon"
-        dir={dir}
+        class={`calcite-chip--icon ${rtl && CSS_UTILITY.rtl}`}
         flipRtl={this.iconFlipRtl}
         icon={this.icon}
         scale={iconScale}
@@ -129,7 +130,7 @@ export class CalciteChip {
     );
 
     return (
-      <Host dir={dir}>
+      <Host class={{ [CSS_UTILITY.rtl]: rtl }}>
         <slot name="chip-image" />
         {this.icon ? iconEl : null}
         <span id={this.guid}>

--- a/src/demos/calcite-chip.html
+++ b/src/demos/calcite-chip.html
@@ -21,32 +21,35 @@
 
 <body>
   <script>
-    const one = document.querySelector("#one");
-    one.addEventListener("calciteChipDismiss", () => {
-      console.log('dismissed chip');
-    });
+    setTimeout(() => {
+      document.querySelectorAll("calcite-chip[dismissible]").forEach(chip => {
+        chip.addEventListener("calciteChipDismiss", () => {
+          console.log('dismissed chip');
+        })
+      })
+    }, 300)
   </script>
   <calcite-button href="/">Home</calcite-button>
   <h1>Calcite Chip</h1>
   <h2>Basic</h2>
-  <calcite-chip value="calcite chip" id="one" dismissible>Apple</calcite-chip>
+  <calcite-chip value="calcite chip" dismissible>Apple</calcite-chip>
   <h2>Slotted "chip-image"</h2>
-  <calcite-chip value="calcite chip" active>
+  <calcite-chip value="calcite chip">
     <img slot="chip-image" src="https://placekitten.com/50/50" />
     Siamese Cat
   </calcite-chip>
-  <calcite-chip value="calcite chip" active>
+  <calcite-chip value="calcite chip">
     <img slot="chip-image" src="https://placekitten.com/50/50" />
     Siamese Cat
   </calcite-chip>
   <h2>Slotted avatar</h2>
-  <calcite-chip value="calcite chip" active scale="s">
+  <calcite-chip value="calcite chip" scale="s">
     <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
   </calcite-chip>
-  <calcite-chip value="calcite chip" active scale="m">
+  <calcite-chip value="calcite chip" scale="m">
     <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
   </calcite-chip>
-  <calcite-chip value="calcite chip" active scale="l">
+  <calcite-chip value="calcite chip" scale="l">
     <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
   </calcite-chip>
   <h2>With icon attribute</h2>
@@ -168,29 +171,31 @@
     Blue
   </calcite-chip>
 
-  <h2>RTL</h2>
-  <calcite-chip value="calcite chip" dir="rtl">Apple</calcite-chip>
-  <calcite-chip value="calcite chip" dir="rtl">
-    <img slot="chip-image" src="https://placekitten.com/50/50" />
-    Siamese Cat
-  </calcite-chip>
-  <calcite-chip value="calcite chip" icon="camera-flash-on" dir="rtl">
-    Camera Flash On
-  </calcite-chip>
-  <calcite-chip value="calcite chip" dismissible icon="camera-flash-on" appearance="clear" color="blue" dir="rtl">
-    Blue
-  </calcite-chip>
+  <section dir="rtl">
+    <h2>RTL</h2>
+    <calcite-chip value="calcite chip">Apple</calcite-chip>
+    <calcite-chip value="calcite chip">
+      <img slot="chip-image" src="https://placekitten.com/50/50" />
+      Siamese Cat
+    </calcite-chip>
+    <calcite-chip value="calcite chip" icon="camera-flash-on">
+      Camera Flash On
+    </calcite-chip>
+    <calcite-chip value="calcite chip" dismissible icon="camera-flash-on" appearance="clear" color="blue">
+      Blue
+    </calcite-chip>
+  </section>
   <br />
   <br />
   <div class="demo-background-dark" theme="dark">
     <h2>Basic</h2>
-    <calcite-chip value="calcite chip" theme="dark" id="one">Apple</calcite-chip>
+    <calcite-chip value="calcite chip" theme="dark" dismissible>Apple</calcite-chip>
     <h2>Slotted "chip-image"</h2>
-    <calcite-chip value="calcite chip" theme="dark" active>
+    <calcite-chip value="calcite chip" theme="dark">
       <img slot="chip-image" src="https://placekitten.com/50/50" />
       Siamese Cat
     </calcite-chip>
-    <calcite-chip value="calcite chip" theme="dark" active>
+    <calcite-chip value="calcite chip" theme="dark">
       <img slot="chip-image" src="https://placekitten.com/50/50" />
       Siamese Cat
     </calcite-chip>
@@ -311,36 +316,38 @@
       Blue
     </calcite-chip>
     <h2>Slotted avatar</h2>
-    <calcite-chip value="calcite chip" active scale="s">
+    <calcite-chip value="calcite chip" scale="s">
       <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
     </calcite-chip>
-    <calcite-chip value="calcite chip" active scale="m">
+    <calcite-chip value="calcite chip" scale="m">
       <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
     </calcite-chip>
-    <calcite-chip value="calcite chip" active scale="l">
+    <calcite-chip value="calcite chip" scale="l">
       <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
     </calcite-chip>
-    <h2>RTL</h2>
-    <calcite-chip value="calcite chip" theme="dark" dir="rtl">Apple</calcite-chip>
-    <calcite-chip value="calcite chip" theme="dark" dir="rtl">
-      <img slot="chip-image" src="https://placekitten.com/50/50" />
-      Siamese Cat
-    </calcite-chip>
-    <calcite-chip value="calcite chip" active scale="s" dir="rtl">
-      <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
-    </calcite-chip>
-    <calcite-chip value="calcite chip" active scale="m" dir="rtl">
-      <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
-    </calcite-chip>
-    <calcite-chip value="calcite chip" active scale="l" dir="rtl">
-      <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
-    </calcite-chip>
-    <calcite-chip value="calcite chip" theme="dark" icon="camera-flash-on" dir="rtl">
-      Camera Flash On
-    </calcite-chip>
-    <calcite-chip value="calcite chip" theme="dark" dismissible icon="camera-flash-on" appearance="clear" color="blue" dir="rtl">
-      Blue
-    </calcite-chip>
+    <section dir="rtl">
+      <h2>RTL</h2>
+      <calcite-chip value="calcite chip" theme="dark">Apple</calcite-chip>
+      <calcite-chip value="calcite chip" theme="dark">
+        <img slot="chip-image" src="https://placekitten.com/50/50" />
+        Siamese Cat
+      </calcite-chip>
+      <calcite-chip value="calcite chip" scale="s">
+        <calcite-avatar slot="chip-image" scale="s" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>Another User
+      </calcite-chip>
+      <calcite-chip value="calcite chip" scale="m">
+        <calcite-avatar slot="chip-image" scale="m" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="bv"></calcite-avatar>Ben Viceroy
+      </calcite-chip>
+      <calcite-chip value="calcite chip" scale="l">
+        <calcite-avatar slot="chip-image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>Carol Whitten
+      </calcite-chip>
+      <calcite-chip value="calcite chip" theme="dark" icon="camera-flash-on">
+        Camera Flash On
+      </calcite-chip>
+      <calcite-chip value="calcite chip" theme="dark" dismissible icon="camera-flash-on" appearance="clear" color="blue">
+        Blue
+      </calcite-chip>
+    </section>
   </div>
 
 </body>


### PR DESCRIPTION
**Related Issue:** #1831 

## Summary
This pr removes the dir attribute from `calcite-chip`, and refactors its styles to use the rtl class instead.

Also fixes the demo html's:
- dismissible event listener script
- removes erroneous `active` attribute
- puts the rtl demo chips inside a parent `section` element (which has `dir="rtl"` applied)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
