### PR TITLE
fix(action): reset line-height

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -46,7 +46,7 @@
   }
 
   .text-container {
-    @apply leading-none
+    @apply leading-4
       truncate
       m-0
       w-0


### PR DESCRIPTION
## Summary
Resets line-height back to pre-refactor.
Update was causing descenders to get clipped.

cc @driskull 

Fixes this.
![Screen Shot 2021-03-24 at 1 38 25 PM](https://user-images.githubusercontent.com/12503298/112380172-4ed56600-8ca6-11eb-8cd7-eae6374668d6.png)


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
