### PR TITLE
fix(input): only emit input event on user interaction

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -426,16 +426,15 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
-  it("when value changes, event is received", async () => {
+  it("emits input event when value is changed by user interaction", async () => {
     const defaultValue = "John Doe";
-    const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input value="${defaultValue}"></calcite-input>
-    `);
+    const page = await newE2EPage({
+      html: `<calcite-input value="${defaultValue}"></calcite-input>`
+    });
 
     const calciteInputInput = await page.spyOnEvent("calciteInputInput");
     const element = await page.find("calcite-input");
-    expect(element.getAttribute("value")).toBe(defaultValue);
+    expect(await element.getProperty("value")).toBe(defaultValue);
     await element.callMethod("setFocus");
     await page.$eval("calcite-input input", (input: HTMLInputElement): void => {
       input.setSelectionRange(input.value.length, input.value.length);
@@ -443,7 +442,14 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("e");
     await page.waitForChanges();
-    expect(element.getAttribute("value")).toBe(`${defaultValue}e`);
+    expect(await element.getProperty("value")).toBe(`${defaultValue}e`);
+    expect(calciteInputInput).toHaveReceivedEventTimes(1);
+
+    const programmaticSetValue = "should-not-emit";
+    await element.setProperty("value", programmaticSetValue);
+    await page.waitForChanges();
+
+    expect(await element.getProperty("value")).toBe(programmaticSetValue);
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -159,14 +159,6 @@ export class CalciteInput {
   /** input value */
   @Prop({ mutable: true, reflect: true }) value?: string = "";
 
-  @Watch("value")
-  valueWatcher(): void {
-    this.calciteInputInput.emit({
-      element: this.childEl,
-      value: this.value
-    });
-  }
-
   @Watch("icon")
   @Watch("type")
   updateRequestedIcon(): void {
@@ -363,6 +355,7 @@ export class CalciteInput {
   keyDownHandler(e: KeyboardEvent): void {
     if (this.isClearable && getKey(e.key) === "Escape") {
       this.clearInputValue();
+      e.preventDefault();
     }
   }
 
@@ -439,6 +432,14 @@ export class CalciteInput {
 
   private inputInputHandler = (e) => {
     this.value = e.target.value;
+    this.emitInputFromUserInteraction();
+  };
+
+  private emitInputFromUserInteraction = () => {
+    this.calciteInputInput.emit({
+      element: this.childEl,
+      value: this.value
+    });
   };
 
   private inputBlurHandler = () => {
@@ -471,6 +472,7 @@ export class CalciteInput {
 
   private clearInputValue = () => {
     this.value = "";
+    this.emitInputFromUserInteraction();
   };
 
   private updateNumberValue = (e) => {
@@ -498,6 +500,7 @@ export class CalciteInput {
       }
 
       this.value = this.childEl.value.toString();
+      this.emitInputFromUserInteraction();
     }
   };
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This brings `<calcite-input>` closer to `<input>` by only emitting events on user interaction. 

This also helps w/ VDOM integrations where value comes from a state model and is set on the input and not from interaction, so no need to emit in that case. Otherwise, you get two events fired.

cc @AdelheidF 