### PR TITLE
fix(tooltip): improve tooltip border, tooltip usage in card story, card/link demo html

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -17,7 +17,7 @@ $popper-default-z-index: 900;
     transition-property: transform, visibility, opacity;
     opacity: 0;
     box-shadow: $shadow-2;
-    border-radius: var(--calcite-border-radius);
+    @apply rounded;
   }
 }
 

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -111,7 +111,7 @@ $pointer_offset: -$pointer_size/2;
     position: absolute;
     width: $pointer_size;
     height: $pointer_size;
-    z-index: 1;
+    z-index: -1;
   }
 
   .arrow::before {

--- a/src/components/calcite-card/calcite-card.stories.ts
+++ b/src/components/calcite-card/calcite-card.stories.ts
@@ -63,29 +63,31 @@ export const FooterLinks = (): string => html`
       <span slot="subtitle"
         >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
       >
-      <calcite-link theme="dark" slot="footer-leading">Lead footer</calcite-link>
-      <calcite-link theme="dark" slot="footer-trailing">Trail footer</calcite-link>
+      <calcite-link slot="footer-leading">Lead footer</calcite-link>
+      <calcite-link slot="footer-trailing">Trail footer</calcite-link>
     </calcite-card>
   </div>
 `;
 
 export const FooterTextButtonsTooltips = (): string => html`
   <div style="width:260px">
-    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
-      ${footerThumbnail}
-      <h3 slot="title">My great project that might wrap two lines</h3>
-      <span slot="subtitle">Johnathan Smith</span>
-      <span slot="footer-leading">Nov 25, 2018</span>
-      <div slot="footer-trailing">
-        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="neutral" icon-start="circle">
-        </calcite-button>
-        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="neutral" icon-start="circle">
-        </calcite-button>
-      </div>
-    </calcite-card>
+    <calcite-tooltip-manager>
+      <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
+        ${footerThumbnail}
+        <h3 slot="title">My great project that might wrap two lines</h3>
+        <span slot="subtitle">Johnathan Smith</span>
+        <span slot="footer-leading">Nov 25, 2018</span>
+        <div slot="footer-trailing">
+          <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="neutral" icon-start="circle">
+          </calcite-button>
+          <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="neutral" icon-start="circle">
+          </calcite-button>
+        </div>
+      </calcite-card>
+    </calcite-tooltip-manager>
   </div>
-  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure </calcite-tooltip>
-  <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete </calcite-tooltip>
+  <calcite-tooltip placement="top-start" reference-element="card-icon-test-6">Configure </calcite-tooltip>
+  <calcite-tooltip placement="bottom-start" reference-element="card-icon-test-7">Delete </calcite-tooltip>
 `;
 
 FooterTextButtonsTooltips.story = {
@@ -94,45 +96,49 @@ FooterTextButtonsTooltips.story = {
 
 export const FooterButtonsTooltipsDropdown = (): string => html`
 <div style="width:260px">
-  <calcite-card
-  ${boolean("loading", false)}
-  ${boolean("selectable", false)}
-  >
-    <img alt="" slot="thumbnail" src="${placeholderImage({
-      width: 260,
-      height: 160
-    })}" style="width:260px;height:160px" />
-    <h3 slot="title">Portland Businesses</h3>
-    <span slot="subtitle">by
-      <calcite-link href="">example_user</calcite-button>
-    </span>
-    <div>
-      Created: Apr 22, 2019
-      <br />
-      Updated: Dec 9, 2019
-      <br />
-      View Count: 0
-    </div>
-    <calcite-button slot="footer-leading" color="neutral" scale="s" icon-start='circle'></calcite-button>
-    <div slot="footer-trailing">
-      <calcite-button scale="s" color="neutral" id="card-icon-test-2" icon-start='circle'></calcite-button>
-      <calcite-button scale="s" color="neutral" id="card-icon-test-1" icon-start='circle'></calcite-button>
-      <calcite-dropdown>
-        <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="neutral" icon-start='circle'></calcite-button>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>View details</calcite-dropdown-item>
-          <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-          <calcite-dropdown-item>Delete</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>
-    </div>
-  </calcite-card>
+  <calcite-tooltip-manager>
+    <calcite-card
+    ${boolean("loading", false)}
+    ${boolean("selectable", false)}
+    >
+      <img alt="" slot="thumbnail" src="${placeholderImage({
+        width: 260,
+        height: 160
+      })}" style="width:260px;height:160px" />
+      <h3 slot="title">Portland Businesses</h3>
+      <span slot="subtitle">by
+        <calcite-link href="">example_user</calcite-button>
+      </span>
+      <div>
+        Created: Apr 22, 2019
+        <br />
+        Updated: Dec 9, 2019
+        <br />
+        View Count: 0
+      </div>
+      <calcite-button slot="footer-leading" color="neutral" scale="s"  id="card-icon-test-1" icon-start='circle'></calcite-button>
+      <div slot="footer-trailing">
+        <calcite-button scale="s" color="neutral" id="card-icon-test-2" icon-start='circle'></calcite-button>
+        <calcite-button scale="s" color="neutral" id="card-icon-test-3" icon-start='circle'></calcite-button>
+        <calcite-dropdown type="hover">
+          <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="neutral" icon-start='circle'></calcite-button>
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>View details</calcite-dropdown-item>
+            <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+            <calcite-dropdown-item>Delete</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+      </div>
+    </calcite-card>
+  </calcite-tooltip-manager>
 </div>
-<calcite-tooltip placement="bottom" reference-element="card-icon-test-1">My great tooltip example
+<calcite-tooltip placement="bottom-start" reference-element="card-icon-test-1">My great tooltip example
 </calcite-tooltip>
-<calcite-tooltip placement="bottom" reference-element="card-icon-test-2">Sharing level: 2
+<calcite-tooltip placement="bottom-start" reference-element="card-icon-test-2">Sharing level: 2
 </calcite-tooltip>
-<calcite-tooltip placement="top" reference-element="card-icon-test-5">More options
+<calcite-tooltip placement="top-end" reference-element="card-icon-test-3">More...
+</calcite-tooltip>
+<calcite-tooltip placement="top-start" reference-element="card-icon-test-5">More options
 </calcite-tooltip>
 `;
 
@@ -211,18 +217,20 @@ DarkThemeFooterLinks.story = {
 
 export const DarkThemeFooterTextButtonsTooltips = (): string => html`
   <div style="width:260px">
-    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
-      ${footerThumbnail}
-      <h3 slot="title">My great project that might wrap two lines</h3>
-      <span slot="subtitle">Johnathan Smith</span>
-      <span slot="footer-leading">Nov 25, 2018</span>
-      <div slot="footer-trailing">
-        <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="neutral" icon-start="circle">
-        </calcite-button>
-        <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="neutral" icon-start="circle">
-        </calcite-button>
-      </div>
-    </calcite-card>
+    <calcite-tooltip-manager>
+      <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
+        ${footerThumbnail}
+        <h3 slot="title">My great project that might wrap two lines</h3>
+        <span slot="subtitle">Johnathan Smith</span>
+        <span slot="footer-leading">Nov 25, 2018</span>
+        <div slot="footer-trailing">
+          <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="neutral" icon-start="circle">
+          </calcite-button>
+          <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="neutral" icon-start="circle">
+          </calcite-button>
+        </div>
+      </calcite-card>
+    </calcite-tooltip-manager>
   </div>
   <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure </calcite-tooltip>
   <calcite-tooltip placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete </calcite-tooltip>
@@ -235,62 +243,87 @@ DarkThemeFooterTextButtonsTooltips.story = {
 
 export const DarkThemeFooterButtonsTooltipsDropdown = (): string => html`
   <div style="width:260px">
-    <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
-      <img
-        alt=""
-        slot="thumbnail"
-        src="${placeholderImage({ width: 260, height: 160 })}"
-        style="width: 260px; height: 160px;"
-      />
-      <h3 slot="title">Portland Businesses</h3>
-      <span slot="subtitle"
-        >by
-        <calcite-link theme="dark" href="">example_user</calcite-link>
-      </span>
-      <div>
-        Created: Apr 22, 2019
-        <br />
-        Updated: Dec 9, 2019
-        <br />
-        View Count: 0
-      </div>
-      <calcite-button slot="footer-leading" color="neutral" scale="s" icon-start="circle"></calcite-button>
-      <div slot="footer-trailing">
+    <calcite-tooltip-manager>
+      <calcite-card theme="dark" ${boolean("loading", false)} ${boolean("selectable", false)}>
+        <img
+          alt=""
+          slot="thumbnail"
+          src="${placeholderImage({ width: 260, height: 160 })}"
+          style="width: 260px; height: 160px;"
+        />
+        <h3 slot="title">Portland Businesses</h3>
+        <span slot="subtitle"
+          >by
+          <calcite-link theme="dark" href="">example_user</calcite-link>
+        </span>
+        <div>
+          Created: Apr 22, 2019
+          <br />
+          Updated: Dec 9, 2019
+          <br />
+          View Count: 0
+        </div>
         <calcite-button
-          theme="dark"
-          color="neutral"
-          scale="s"
-          id="card-icon-test-2"
-          icon-start="circle"
-        ></calcite-button>
-        <calcite-button
-          theme="dark"
+          slot="footer-leading"
           color="neutral"
           scale="s"
           id="card-icon-test-1"
           icon-start="circle"
         ></calcite-button>
-        <calcite-dropdown>
+        <div slot="footer-trailing">
           <calcite-button
             theme="dark"
             color="neutral"
-            id="card-icon-test-5"
-            slot="dropdown-trigger"
             scale="s"
+            id="card-icon-test-2"
             icon-start="circle"
           ></calcite-button>
-          <calcite-dropdown-group selection-mode="none">
-            <calcite-dropdown-item>View details</calcite-dropdown-item>
-            <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-            <calcite-dropdown-item>Delete</calcite-dropdown-item>
-          </calcite-dropdown-group>
-        </calcite-dropdown>
-      </div>
-    </calcite-card>
+          <calcite-button
+            theme="dark"
+            color="neutral"
+            scale="s"
+            id="card-icon-test-3"
+            icon-start="circle"
+          ></calcite-button>
+          <calcite-dropdown type="hover">
+            <calcite-button
+              theme="dark"
+              color="neutral"
+              id="card-icon-test-5"
+              slot="dropdown-trigger"
+              scale="s"
+              icon-start="circle"
+            ></calcite-button>
+            <calcite-dropdown-group selection-mode="none">
+              <calcite-dropdown-item>View details</calcite-dropdown-item>
+              <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+              <calcite-dropdown-item>Delete</calcite-dropdown-item>
+            </calcite-dropdown-group>
+          </calcite-dropdown>
+        </div>
+      </calcite-card>
+    </calcite-tooltip-manager>
   </div>
-  <calcite-tooltip placement="bottom" reference-element="card-icon-test-1">My great tooltip example </calcite-tooltip>
-  <calcite-tooltip placement="bottom" reference-element="card-icon-test-2">Sharing level: 2 </calcite-tooltip>
-  <calcite-tooltip placement="top" reference-element="card-icon-test-5">More options </calcite-tooltip>
+  <calcite-tooltip
+    theme="dark"
+    label="bottom placed tooltip"
+    placement="bottom-start"
+    reference-element="card-icon-test-1"
+    >My great tooltip example
+  </calcite-tooltip>
+  <calcite-tooltip
+    theme="dark"
+    label="bottom placed tooltip"
+    placement="bottom-start"
+    reference-element="card-icon-test-2"
+    >Sharing level: 2
+  </calcite-tooltip>
+  <calcite-tooltip theme="dark" label="top end placed tooltip" placement="top-end" reference-element="card-icon-test-3"
+    >More...
+  </calcite-tooltip>
+  <calcite-tooltip theme="dark" placement="top-start" reference-element="card-icon-test-5"
+    >More options
+  </calcite-tooltip>
 `;
 
 DarkThemeFooterButtonsTooltipsDropdown.story = {

--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -10,7 +10,15 @@
 }
 
 .calcite-popper-anim {
-  @apply h-full;
+  @apply bg-foreground-1
+    border
+    border-solid
+    border-color-3
+    rounded;
+}
+
+.arrow::before {
+  outline: 1px solid var(--calcite-ui-border-3);
 }
 
 .container {
@@ -21,7 +29,8 @@
     flex-no-wrap 
     flex-row 
     h-full
-    text-color-1;
+    text-color-1
+    rounded;
 }
 
 .content {
@@ -35,19 +44,24 @@
 .close-button {
   @apply focus-base;
   &:focus {
-    @apply focus-inset;
+    @apply focus-inset
+      border-2
+      border-solid
+      border-color-brand;
+    border-radius: 0 0.25rem 0.25rem 0;
   }
 }
 
 .close-button {
-  @apply block 
-    p-3 
-    border-none 
+  @apply flex
+    items-center
+    p-3
     text-color-1 
-    cursor-pointer 
-    bg-foreground-1;
-  flex: 0 0 auto;
-  border-radius: 0 var(--calcite-border-radius) 0 0;
+    cursor-pointer
+    bg-foreground-1
+    border-2
+    border-solid
+    border-color-transparent;
   z-index: 1;
   &:hover {
     @apply bg-foreground-2;
@@ -59,7 +73,7 @@
 
 .calcite--rtl {
   .close-button {
-    border-radius: var(--calcite-border-radius) 0 0 0;
+    border-radius: 0.25rem 0 0 0.25rem;
   }
 }
 

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -3,17 +3,17 @@
 
 .container {
   @apply relative
-    bg-foreground-1
-    flex
-    justify-start
-    flex-col
-    font-medium
-    text-color-1
-    py-3
-    px-4
-    overflow-hidden
-    text--2-wrap
-    rounded;
+     bg-foreground-1
+     flex
+     justify-start
+     flex-col
+     font-medium
+     text-color-1
+     py-3
+     px-4
+     overflow-hidden
+     text--2-wrap
+     rounded;
   max-width: 20rem;
   max-height: 20rem;
 }
@@ -22,12 +22,10 @@
   @apply bg-foreground-1
     border
     border-solid
-    border-color-3;
+    border-color-3
+    rounded;
 }
 
-.arrow:before {
-  @apply bg-foreground-1
-  border
-  border-solid
-  border-color-3;
+.arrow::before {
+  outline: 1px solid var(--calcite-ui-border-3);
 }

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -3,17 +3,17 @@
 
 .container {
   @apply relative
-     bg-foreground-1
-     flex
-     justify-start
-     flex-col
-     font-medium
-     text-color-1
-     py-3
-     px-4
-     overflow-hidden
-     text--2-wrap
-     rounded;
+    bg-foreground-1
+    flex
+    justify-start
+    flex-col
+    font-medium
+    text-color-1
+    py-3
+    px-4
+    overflow-hidden
+    text--2-wrap
+    rounded;
   max-width: 20rem;
   max-height: 20rem;
 }

--- a/src/components/calcite-tooltip/calcite-tooltip.scss
+++ b/src/components/calcite-tooltip/calcite-tooltip.scss
@@ -13,10 +13,21 @@
     px-4
     overflow-hidden
     text--2-wrap
-    border
-    border-solid
-    border-color-3
     rounded;
   max-width: 20rem;
   max-height: 20rem;
+}
+
+.calcite-popper-anim {
+  @apply bg-foreground-1
+    border
+    border-solid
+    border-color-3;
+}
+
+.arrow:before {
+  @apply bg-foreground-1
+  border
+  border-solid
+  border-color-3;
 }

--- a/src/demos/_assets/toggleBodyTheme.ts
+++ b/src/demos/_assets/toggleBodyTheme.ts
@@ -1,0 +1,11 @@
+function toggleBodyTheme(body: HTMLBodyElement): void {
+  if (!body.hasAttribute("theme")) {
+    body.setAttribute("theme", "dark");
+  } else {
+    if (body.getAttribute("theme") === "dark") {
+      body.setAttribute("theme", "light");
+    } else {
+      body.setAttribute("theme", "dark");
+    }
+  }
+}

--- a/src/demos/calcite-card.html
+++ b/src/demos/calcite-card.html
@@ -60,59 +60,64 @@
       </calcite-card>
     </div>
     <div class="example-grid-item">
-      <calcite-card>
-        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
-        <h3 slot="title">Portland Businesses</h3>
-        <span slot="subtitle">by
-          <calcite-link href="">example_user</calcite-link>
-        </span>
-        <div>
-          Created: Apr 22, 2019
-          <br />
-          Updated: Dec 9, 2019
-          <br />
-          View Count: 0
-        </div>
-        <calcite-button slot="footer-leading" color="neutral" scale="s" icon-start='circle'></calcite-button>
-        <div slot="footer-trailing">
-          <calcite-button scale="s" color="neutral" id="card-icon-test-2" icon-start='circle'></calcite-button>
-          <calcite-button scale="s" color="neutral" id="card-icon-test-1" icon-start='circle'></calcite-button>
-          <calcite-dropdown>
-            <calcite-button id="card-icon-test-5" slot="dropdown-trigger" scale="s" color="neutral" icon-start='circle'>
-            </calcite-button>
-            <calcite-dropdown-group selection-mode="none">
-              <calcite-dropdown-item>View details</calcite-dropdown-item>
-              <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-              <calcite-dropdown-item>Delete</calcite-dropdown-item>
-            </calcite-dropdown-group>
-          </calcite-dropdown>
-        </div>
-      </calcite-card>
+      <calcite-tooltip-manager>
+        <calcite-card>
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <h3 slot="title">Portland Businesses</h3>
+          <span slot="subtitle">by
+            <calcite-link href="">example_user</calcite-link>
+          </span>
+          <div>
+            Created: Apr 22, 2019
+            <br />
+            Updated: Dec 9, 2019
+            <br />
+            View Count: 0
+          </div>
+          <calcite-button type="button" slot="footer-leading" color="neutral" scale="s"  id="card-icon-test-1" icon-start='circle'></calcite-button>
+          <div slot="footer-trailing">
+            <calcite-button type="button" scale="s" color="neutral" id="card-icon-test-2" icon-start='circle'></calcite-button>
+            <calcite-button type="button" scale="s" color="neutral" id="card-icon-test-3" icon-start='circle'></calcite-button>
+            <calcite-dropdown type="hover">
+              <calcite-button id="card-icon-test-4" slot="dropdown-trigger" scale="s" color="neutral" icon-start='circle'>
+              </calcite-button>
+              <calcite-dropdown-group selection-mode="none">
+                <calcite-dropdown-item>View details</calcite-dropdown-item>
+                <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+                <calcite-dropdown-item>Delete</calcite-dropdown-item>
+              </calcite-dropdown-group>
+            </calcite-dropdown>
+          </div>
+        </calcite-card>
+      </calcite-tooltip-manager>
     </div>
-    <calcite-tooltip label="bottom placed tooltip" placement="bottom" reference-element="card-icon-test-1">My great tooltip example
+    <calcite-tooltip label="bottom placed tooltip" placement="bottom-start" reference-element="card-icon-test-1">My great tooltip example
     </calcite-tooltip>
-    <calcite-tooltip label="bottom placed tooltip" placement="bottom" reference-element="card-icon-test-2">Sharing level: 2
+    <calcite-tooltip label="bottom placed tooltip" placement="bottom-start" reference-element="card-icon-test-2">Sharing level: 2
     </calcite-tooltip>
-    <calcite-tooltip label="top placed tooltip" placement="top" reference-element="card-icon-test-5">More options
+    <calcite-tooltip label="top end placed tooltip" placement="top-end" reference-element="card-icon-test-3">More...
+    </calcite-tooltip>
+    <calcite-tooltip label="top placed tooltip" placement="top-start" reference-element="card-icon-test-4">More options
     </calcite-tooltip>
     <div class="example-grid-item">
-
-      <calcite-card>
-        <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
-        <h3 slot="title">My great Workforce project that might wrap two lines</h3>
-        <span slot="subtitle">Johnathan Smith</span>
-        <span slot="footer-leading">Nov 25, 2018</span>
-        <div slot="footer-trailing">
-          <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="neutral" icon-start='circle'>
-          </calcite-button>
-          <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="neutral" icon-start='circle'>
-          </calcite-button>
-        </div>
-      </calcite-card>
+      <calcite-tooltip-manager>
+        <calcite-card>
+          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+          <h3 slot="title">My great Workforce project that might wrap two lines</h3>
+          <span slot="subtitle">Johnathan Smith</span>
+          <span slot="footer-leading">Nov 25, 2018</span>
+          <div slot="footer-trailing">
+            <calcite-button id="card-icon-test-6" scale="s" appearance="transparent" color="neutral" icon-start='circle'>
+            </calcite-button>
+            <calcite-button id="card-icon-test-7" scale="s" appearance="transparent" color="neutral" icon-start='circle'>
+            </calcite-button>
+          </div>
+        </calcite-card>
+      </calcite-tooltip-manager>
     </div>
-    <calcite-tooltip label="bottom placed tooltip" placement="bottom" theme="dark" reference-element="card-icon-test-6">Configure
+    <calcite-tooltip label="bottom placed tooltip" placement="bottom-start" reference-element="card-icon-test-6">Configure
     </calcite-tooltip>
-    <calcite-tooltip label="bottom placed tooltip" placement="bottom" theme="dark" reference-element="card-icon-test-7">Delete
+    <calcite-tooltip label="bottom placed tooltip" placement="bottom-start" reference-element="card-icon-test-7">Delete
     </calcite-tooltip>
 
     <div class="example-grid-item">
@@ -234,43 +239,44 @@
         </calcite-card>
       </div>
       <div class="example-grid-item">
-
-
-        <calcite-card theme="dark">
-          <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
-          <h3 slot="title">Portland Businesses</h3>
-          <span slot="subtitle">by
-            <calcite-link theme="dark" href="">example_user</calcite-link>
-          </span>
-          <div>
-            Created: Apr 22, 2019
-            <br />
-            Updated: Dec 9, 2019
-            <br />
-            View Count: 0
-          </div>
-          <calcite-button theme="dark" slot="footer-leading" color="neutral" scale="s" icon-start='circle'></calcite-button>
-          <div slot="footer-trailing">
-            <calcite-button theme="dark" scale="s" color="neutral" id="card-icon-test-3" icon-start='circle'></calcite-button>
-            <calcite-button theme="dark" scale="s" color="neutral" id="card-icon-test-4" icon-start='circle'></calcite-button>
-            <calcite-dropdown theme="dark">
-              <calcite-button slot="dropdown-trigger" theme="dark" scale="s" color="neutral" icon-start='circle'>
-              </calcite-button>
-              <calcite-dropdown-group selection-mode="none">
-                <calcite-dropdown-item>View details</calcite-dropdown-item>
-                <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-                <calcite-dropdown-item>Delete</calcite-dropdown-item>
-              </calcite-dropdown-group>
-            </calcite-dropdown>
-          </div>
-        </calcite-card>
+        <calcite-tooltip-manager>
+          <calcite-card theme="dark">
+            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <h3 slot="title">Portland Businesses</h3>
+            <span slot="subtitle">by
+              <calcite-link theme="dark" href="">example_user</calcite-link>
+            </span>
+            <div>
+              Created: Apr 22, 2019
+              <br />
+              Updated: Dec 9, 2019
+              <br />
+              View Count: 0
+            </div>
+            <calcite-button theme="dark" slot="footer-leading" color="neutral" scale="s"  id="card-icon-test-a" icon-start='circle'></calcite-button>
+            <div slot="footer-trailing">
+              <calcite-button theme="dark" scale="s" color="neutral" id="card-icon-test-b" icon-start='circle'></calcite-button>
+              <calcite-button theme="dark" scale="s" color="neutral" id="card-icon-test-c" icon-start='circle'></calcite-button>
+              <calcite-dropdown theme="dark" type="hover">
+                <calcite-button id="card-icon-test-d" slot="dropdown-trigger" scale="s" color="neutral" icon-start='circle'>
+                </calcite-button>
+                <calcite-dropdown-group selection-mode="none">
+                  <calcite-dropdown-item>View details</calcite-dropdown-item>
+                  <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+                  <calcite-dropdown-item>Delete</calcite-dropdown-item>
+                </calcite-dropdown-group>
+              </calcite-dropdown>
+            </div>
+          </calcite-card>
+        </calcite-tooltip-manager>
       </div>
-      <calcite-tooltip label="bottom placed tooltip" placement="bottom" theme="dark" theme="dark" reference-element="card-icon-test-3">My great
-        tooltip
-        example
+      <calcite-tooltip label="bottom placed tooltip" placement="bottom-start" theme="dark" reference-element="card-icon-test-a">My great tooltip example
       </calcite-tooltip>
-      <calcite-tooltip label="bottom placed tooltip" placement="bottom" theme="dark" theme="dark" reference-element="card-icon-test-4">Sharing level:
-        2
+      <calcite-tooltip label="bottom placed tooltip" placement="bottom-start" theme="dark" reference-element="card-icon-test-b">Sharing level: 2
+      </calcite-tooltip>
+      <calcite-tooltip label="top placed tooltip" placement="top-end" theme="dark" reference-element="card-icon-test-c">More...
+      </calcite-tooltip>
+      <calcite-tooltip label="top placed tooltip" placement="top-start" theme="dark" reference-element="card-icon-test-d">More options
       </calcite-tooltip>
       <div class="example-grid-item">
 

--- a/src/demos/calcite-link.html
+++ b/src/demos/calcite-link.html
@@ -46,7 +46,9 @@
   <br />
 
   <h3>Tooltip trigger</h3>
-  <calcite-link icon-start="information" id="tooltip-example">span to gain focus</calcite-link>
+  <calcite-tooltip-manager>
+    <calcite-link icon-start="information" id="tooltip-example">span to gain focus</calcite-link>
+  </calcite-tooltip-manager>
   <calcite-tooltip label="top placed tooltip" placement="top" reference-element="tooltip-example">Lorem Ipsum is simply
     of the printing and typesetting industry. Lorem Ipsum has been the industry's standard printer of type and
     scrambled it to make a type specimen book.</calcite-tooltip>

--- a/src/demos/calcite-popover.html
+++ b/src/demos/calcite-popover.html
@@ -48,9 +48,11 @@
 
   <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-five" placement="bottom" id="popover-five"
      close-button>
-    <img slot="image" src="https://placem.at/places?w=200&txt=0" />
     <div style="padding:12px 16px;">Here kitty kitty!
     </div>
+  </calcite-popover>
+  <calcite-popover label="dark theme popover" theme="dark" dir="rtl" reference-element="popover-button-rtl" placement="left" id="popover-rtl" close-button>
+    <div style="padding:12px 16px;">مرحبا بالعالم!</div>
   </calcite-popover>
 
   <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-six" placement="top" id="popover-six"
@@ -115,7 +117,7 @@
     <li>
       <calcite-button id="popover-button-two" icon="plus">
         Clickable popover</calcite-button>
-
+    </li>
     <li>
       <calcite-button id="popover-button-four" icon="plus">
         With close button</calcite-button>
@@ -170,12 +172,11 @@
     </p>
     <calcite-popover label="top start popover" placement="top-start" reference-element="popover-button"
     id="popover" close-button>
-    <img slot="image" src="https://placem.at/places?w=200&txt=0" />
     <div style="padding:12px 16px;">Here kitty kitty!
     </div>
   </calcite-popover>
     <calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-      Popover with picture</calcite-button>
+      Popover 🐱</calcite-button>
     <p>
       Nec, dictum egestas odio in integer dictum eros. Euismod vitae vestibulum tempor sit adipiscing sed dolor
       habitant per congue sit condimentum? Nisi nisl ornare ac semper imperdiet eu nascetur quisque ullamcorper a
@@ -229,8 +230,13 @@
     </li>
     <li>
       <calcite-button id="popover-button-five" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-        Popover with picture</calcite-button>
+        Popover 🐱</calcite-button>
     </li>
+    <div dir="rtl">
+      <calcite-button id="popover-button-rtl" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+        Popover RTL
+      </calcite-button>
+    </div>
   </ul>
 
 </calcite-popover-manager>

--- a/src/demos/calcite-tooltip.html
+++ b/src/demos/calcite-tooltip.html
@@ -11,6 +11,15 @@
         color: white;
         padding: 1rem;
       }
+      ol {
+        text-align: center;
+        list-style: none;
+        padding: 0;
+        margin: 0 25%;
+      }
+      li {
+        margin: 2rem;
+      }
     </style>
     <link
       rel="stylesheet"
@@ -26,7 +35,7 @@
     <h1>Calcite Tooltip</h1>
 
     <calcite-tooltip-manager>
-      <calcite-tooltip label="auto placed tooltip" placement="auto" id="tooltip" reference-element="tooltip-button-nine"
+      <calcite-tooltip label="auto placed tooltip" placement="auto" reference-element="tooltip-button"
         >This is the message of the tooltip</calcite-tooltip
       >
 
@@ -105,11 +114,115 @@
         </calcite-button>
         mollit anim id est laborum.
       </p>
+
+      <h2>Placements:</h2>
+      <ol>
+        <li><calcite-button appearance="outline" id="tooltip-auto-ref">auto</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-auto-start-ref">auto-start</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-auto-end-ref">auto-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-top-ref">top</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-top-start-ref">top-start</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-top-end-ref">top-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-bottom-ref">bottom</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-bottom-start-ref">bottom-start</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-bottom-end-ref">bottom-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-right-ref">right</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-right-start-ref">right-start</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-right-end-ref">right-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-left-ref">left</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-left-start-ref">left-start</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-left-end-ref">left-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-leading-start-ref">leading-start</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-leading-ref">leading</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-leading-end-ref">leading-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-trailing-end-ref">trailing-end</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-trailing-ref">trailing</calcite-button></li>
+        <li><calcite-button appearance="outline" id="tooltip-trailing-start-ref">trailing-start</calcite-button></li>
+      </ol>
     </calcite-tooltip-manager>
-    <script>
-      var tooltip = document.getElementById("tooltip");
-      var tooltipButton = document.getElementById("tooltip-button");
-      tooltip.referenceElement = tooltipButton;
-    </script>
+    <calcite-tooltip label="tooltip - auto" placement="auto" reference-element="tooltip-auto-ref">
+      <p>placement: auto</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - auto-start" placement="auto-start" reference-element="tooltip-auto-start-ref">
+      <p>placement: auto-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - auto-end" placement="auto-end" reference-element="tooltip-auto-end-ref">
+      <p>placement: auto-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - top" placement="top" reference-element="tooltip-top-ref">
+      <p>placement: top</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - bottom" placement="bottom" reference-element="tooltip-bottom-ref">
+      <p>placement: bottom</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - right" placement="right" reference-element="tooltip-right-ref">
+      <p>placement: right</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - left" placement="left" reference-element="tooltip-left-ref">
+      <p>placement: left</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - top-start" placement="top-start" reference-element="tooltip-top-start-ref">
+      <p>placement: top-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - top-end" placement="top-end" reference-element="tooltip-top-end-ref">
+      <p>placement: top-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - bottom-start" placement="bottom-start" reference-element="tooltip-bottom-start-ref">
+      <p>placement: bottom-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - bottom-end" placement="bottom-end" reference-element="tooltip-bottom-end-ref">
+      <p>placement: bottom-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - right-start" placement="right-start" reference-element="tooltip-right-start-ref">
+      <p>placement: right-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - right-end" placement="right-end" reference-element="tooltip-right-end-ref">
+      <p>placement: right-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - left-start" placement="left-start" reference-element="tooltip-left-start-ref">
+      <p>placement: left-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - left-end" placement="left-end" reference-element="tooltip-left-end-ref">
+      <p>placement: left-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - leading-start" placement="leading-start" reference-element="tooltip-leading-start-ref">
+      <p>placement: leading-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - leading" placement="leading" reference-element="tooltip-leading-ref">
+      <p>placement: leading</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - leading-end" placement="leading-end" reference-element="tooltip-leading-end-ref">
+      <p>placement: leading-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - trailing-end" placement="trailing-end" reference-element="tooltip-trailing-end-ref">
+      <p>placement: trailing-end</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - trailing" placement="trailing" reference-element="tooltip-trailing-ref">
+      <p>placement: trailing</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
+    <calcite-tooltip label="tooltip - trailing-start" placement="trailing-start" reference-element="tooltip-trailing-start-ref">
+      <p>placement: trailing-start</p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </calcite-tooltip>
   </body>
 </html>

--- a/src/demos/calcite-tooltip.html
+++ b/src/demos/calcite-tooltip.html
@@ -6,16 +6,25 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Calcite Tooltip</title>
     <style>
+      body {
+        background-color: var(--calcite-ui-background);
+        color: var(--calcite-ui-text-1);
+      }
       .demo-background-dark {
         background: #202020;
         color: white;
         padding: 1rem;
       }
+      .placements-container {
+        width: 500px;
+        margin: auto;
+      }
       ol {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
         text-align: center;
         list-style: none;
         padding: 0;
-        margin: 0 25%;
       }
       li {
         margin: 2rem;
@@ -28,6 +37,7 @@
     <link rel="stylesheet" href="../build/calcite.css" />
     <script type="module" src="../build/calcite.esm.js"></script>
     <script nomodule src="../build/calcite.js"></script>
+    <script src="./_assets/toggleBodyTheme.js"></script>
   </head>
 
   <body>
@@ -99,7 +109,7 @@
         mollit anim id est laborum.
       </p>
 
-      <p class="demo-background-dark">
+      <p class="demo-background-dark" theme="dark">
         Lorem <a id="tooltip-button-five" href="#">ipsum</a> dolor sit amet,
         consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
         et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -115,114 +125,117 @@
         mollit anim id est laborum.
       </p>
 
-      <h2>Placements:</h2>
-      <ol>
-        <li><calcite-button appearance="outline" id="tooltip-auto-ref">auto</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-auto-start-ref">auto-start</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-auto-end-ref">auto-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-top-ref">top</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-top-start-ref">top-start</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-top-end-ref">top-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-bottom-ref">bottom</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-bottom-start-ref">bottom-start</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-bottom-end-ref">bottom-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-right-ref">right</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-right-start-ref">right-start</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-right-end-ref">right-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-left-ref">left</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-left-start-ref">left-start</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-left-end-ref">left-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-leading-start-ref">leading-start</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-leading-ref">leading</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-leading-end-ref">leading-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-trailing-end-ref">trailing-end</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-trailing-ref">trailing</calcite-button></li>
-        <li><calcite-button appearance="outline" id="tooltip-trailing-start-ref">trailing-start</calcite-button></li>
-      </ol>
+      <section class="placements-container">
+        <calcite-button onclick="toggleBodyTheme(document.body);" id="toggle-theme-button">Toggle theme</calcite-button>
+        <h2>Placements:</h2>
+        <ol>
+          <li><calcite-button appearance="outline" id="tooltip-auto-ref">auto</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-auto-start-ref">auto-start</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-auto-end-ref">auto-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-top-ref">top</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-top-start-ref">top-start</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-top-end-ref">top-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-bottom-ref">bottom</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-bottom-start-ref">bottom-start</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-bottom-end-ref">bottom-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-right-ref">right</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-right-start-ref">right-start</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-right-end-ref">right-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-left-ref">left</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-left-start-ref">left-start</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-left-end-ref">left-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-leading-start-ref">leading-start</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-leading-ref">leading</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-leading-end-ref">leading-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-trailing-end-ref">trailing-end</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-trailing-ref">trailing</calcite-button></li>
+          <li><calcite-button appearance="outline" id="tooltip-trailing-start-ref">trailing-start</calcite-button></li>
+        </ol>
+        <calcite-tooltip label="tooltip - auto" placement="auto" reference-element="tooltip-auto-ref">
+          <p>placement: auto</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - auto-start" placement="auto-start" reference-element="tooltip-auto-start-ref">
+          <p>placement: auto-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - auto-end" placement="auto-end" reference-element="tooltip-auto-end-ref">
+          <p>placement: auto-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - top" placement="top" reference-element="tooltip-top-ref">
+          <p>placement: top</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - bottom" placement="bottom" reference-element="tooltip-bottom-ref">
+          <p>placement: bottom</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - right" placement="right" reference-element="tooltip-right-ref">
+          <p>placement: right</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - left" placement="left" reference-element="tooltip-left-ref">
+          <p>placement: left</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - top-start" placement="top-start" reference-element="tooltip-top-start-ref">
+          <p>placement: top-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - top-end" placement="top-end" reference-element="tooltip-top-end-ref">
+          <p>placement: top-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - bottom-start" placement="bottom-start" reference-element="tooltip-bottom-start-ref">
+          <p>placement: bottom-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - bottom-end" placement="bottom-end" reference-element="tooltip-bottom-end-ref">
+          <p>placement: bottom-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - right-start" placement="right-start" reference-element="tooltip-right-start-ref">
+          <p>placement: right-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - right-end" placement="right-end" reference-element="tooltip-right-end-ref">
+          <p>placement: right-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - left-start" placement="left-start" reference-element="tooltip-left-start-ref">
+          <p>placement: left-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - left-end" placement="left-end" reference-element="tooltip-left-end-ref">
+          <p>placement: left-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - leading-start" placement="leading-start" reference-element="tooltip-leading-start-ref">
+          <p>placement: leading-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - leading" placement="leading" reference-element="tooltip-leading-ref">
+          <p>placement: leading</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - leading-end" placement="leading-end" reference-element="tooltip-leading-end-ref">
+          <p>placement: leading-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - trailing-end" placement="trailing-end" reference-element="tooltip-trailing-end-ref">
+          <p>placement: trailing-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - trailing" placement="trailing" reference-element="tooltip-trailing-ref">
+          <p>placement: trailing</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip label="tooltip - trailing-start" placement="trailing-start" reference-element="tooltip-trailing-start-ref">
+          <p>placement: trailing-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </calcite-tooltip>
+      </section>
     </calcite-tooltip-manager>
-    <calcite-tooltip label="tooltip - auto" placement="auto" reference-element="tooltip-auto-ref">
-      <p>placement: auto</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - auto-start" placement="auto-start" reference-element="tooltip-auto-start-ref">
-      <p>placement: auto-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - auto-end" placement="auto-end" reference-element="tooltip-auto-end-ref">
-      <p>placement: auto-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - top" placement="top" reference-element="tooltip-top-ref">
-      <p>placement: top</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - bottom" placement="bottom" reference-element="tooltip-bottom-ref">
-      <p>placement: bottom</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - right" placement="right" reference-element="tooltip-right-ref">
-      <p>placement: right</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - left" placement="left" reference-element="tooltip-left-ref">
-      <p>placement: left</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - top-start" placement="top-start" reference-element="tooltip-top-start-ref">
-      <p>placement: top-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - top-end" placement="top-end" reference-element="tooltip-top-end-ref">
-      <p>placement: top-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - bottom-start" placement="bottom-start" reference-element="tooltip-bottom-start-ref">
-      <p>placement: bottom-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - bottom-end" placement="bottom-end" reference-element="tooltip-bottom-end-ref">
-      <p>placement: bottom-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - right-start" placement="right-start" reference-element="tooltip-right-start-ref">
-      <p>placement: right-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - right-end" placement="right-end" reference-element="tooltip-right-end-ref">
-      <p>placement: right-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - left-start" placement="left-start" reference-element="tooltip-left-start-ref">
-      <p>placement: left-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - left-end" placement="left-end" reference-element="tooltip-left-end-ref">
-      <p>placement: left-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - leading-start" placement="leading-start" reference-element="tooltip-leading-start-ref">
-      <p>placement: leading-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - leading" placement="leading" reference-element="tooltip-leading-ref">
-      <p>placement: leading</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - leading-end" placement="leading-end" reference-element="tooltip-leading-end-ref">
-      <p>placement: leading-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - trailing-end" placement="trailing-end" reference-element="tooltip-trailing-end-ref">
-      <p>placement: trailing-end</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - trailing" placement="trailing" reference-element="tooltip-trailing-ref">
-      <p>placement: trailing</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
-    <calcite-tooltip label="tooltip - trailing-start" placement="trailing-start" reference-element="tooltip-trailing-start-ref">
-      <p>placement: trailing-start</p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    </calcite-tooltip>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
This pr aims to fix a few style issues with `calcite-tooltip`'s Tailwind refactors (pr #1738, pr #1765).

The goal here is to a). ensure the tooltip tail doesn't appear **over** the content area, and b). ensure the tooltip's new border styles are visible.

I also noticed the tooltip wasn't working in a few places (card stories, card/link demo html), so I tried to fix those as well.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
