### PR TITLE
fix(color-picker): ensure consistent handling of hex input text selection

### DIFF
--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
@@ -74,6 +74,22 @@ describe("calcite-color-picker-hex-input", () => {
     expect(await input.getProperty("value")).toBe("#ffffff");
   });
 
+  it("allows entering text if it has a selection", async () => {
+    const page = await newE2EPage({
+      html: "<calcite-color-picker-hex-input value='#ffffff'></calcite-color-picker-hex-input>"
+    });
+    const input = await page.find(`calcite-color-picker-hex-input`);
+
+    // workaround for selecting text based on https://github.com/puppeteer/puppeteer/issues/1313#issuecomment-436932478
+    await input.click({ clickCount: 3 });
+
+    await page.keyboard.type("000");
+    await page.keyboard.press("Enter");
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("#000000");
+  });
+
   it("accepts longhand hex", async () => {
     const page = await newE2EPage({
       html: "<calcite-color-picker-hex-input></calcite-color-picker-hex-input>"

--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
@@ -186,7 +186,7 @@ export class CalciteColorPickerHexInput {
 
   private onInputKeyDown = (event: KeyboardEvent): void => {
     const { altKey, ctrlKey, metaKey, shiftKey } = event;
-    const { inputNode, internalColor, value } = this;
+    const { el, inputNode, internalColor, value } = this;
     const key = getKey(event.key);
     const nudgeable = value && (key === "ArrowDown" || key === "ArrowUp");
 
@@ -202,7 +202,10 @@ export class CalciteColorPickerHexInput {
 
     const withModifiers = altKey || ctrlKey || metaKey;
     const exceededHexLength = inputNode.value.length >= 6;
-    const hasTextSelection = getSelection().type === "Range";
+    const focusedElement = el.shadowRoot.activeElement as HTMLInputElement;
+    const hasTextSelection =
+      // can't use window.getSelection() because of FF bug: https://bugzilla.mozilla.org/show_bug.cgi?id=85686
+      focusedElement.selectionStart != focusedElement.selectionEnd;
 
     if (
       key.length === 1 &&


### PR DESCRIPTION
**Related Issue:** #1852 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This refactors hex-input's character input logic to avoid `window.getSelection`, which doesn't work on Firefox when text selection is on a form control: https://bugzilla.mozilla.org/show_bug.cgi?id=85686