### PR TITLE
feat(panel, shell-panel): add width base unit at root level

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -19,6 +19,8 @@
   --calcite-border-radius: 3px;
   --calcite-ui-opacity-disabled: 0.5;
 
+  --calcite-ui-panel-width-unit: 1;
+
   @apply font-sans;
 }
 

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -19,7 +19,7 @@
   --calcite-border-radius: 3px;
   --calcite-ui-opacity-disabled: 0.5;
 
-  --calcite-ui-panel-width-unit: 1;
+  --calcite-ui-panel-width-multiplier: 1;
 
   @apply font-sans;
 }

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -41,21 +41,21 @@
 }
 
 :host([width-scale="s"]) {
-  --calcite-panel-width: calc(var(--calcite-ui-panel-width-unit) * 12vw);
-  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 300px);
-  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 150px);
+  --calcite-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 12vw);
+  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 300px);
+  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 150px);
 }
 
 :host([width-scale="m"]) {
-  --calcite-panel-width: calc(var(--calcite-ui-panel-width-unit) * 20vw);
-  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 420px);
-  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 240px);
+  --calcite-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 20vw);
+  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 420px);
+  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 240px);
 }
 
 :host([width-scale="l"]) {
-  --calcite-panel-width: calc(var(--calcite-ui-panel-width-unit) * 45vw);
-  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 680px);
-  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 340px);
+  --calcite-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 45vw);
+  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 680px);
+  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 340px);
 }
 
 .container[hidden] {

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -41,21 +41,21 @@
 }
 
 :host([width-scale="s"]) {
-  --calcite-panel-width: 12vw;
-  --calcite-panel-max-width: 300px;
-  --calcite-panel-min-width: 150px;
+  --calcite-panel-width: calc(var(--calcite-ui-panel-width-unit) * 12vw);
+  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 300px);
+  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 150px);
 }
 
 :host([width-scale="m"]) {
-  --calcite-panel-width: 20vw;
-  --calcite-panel-max-width: 420px;
-  --calcite-panel-min-width: 240px;
+  --calcite-panel-width: calc(var(--calcite-ui-panel-width-unit) * 20vw);
+  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 420px);
+  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 240px);
 }
 
 :host([width-scale="l"]) {
-  --calcite-panel-width: 45vw;
-  --calcite-panel-max-width: 680px;
-  --calcite-panel-min-width: 340px;
+  --calcite-panel-width: calc(var(--calcite-ui-panel-width-unit) * 45vw);
+  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 680px);
+  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 340px);
 }
 
 .container[hidden] {

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -136,13 +136,25 @@
 }
 
 .content-container {
-  @apply items-stretch bg-background flex flex-auto overflow-auto flex;
-  flex-flow: column nowrap;
+  @apply items-stretch 
+  bg-background
+  flex
+  flex-auto
+  overflow-auto
+  flex-no-wrap
+  flex-col;
 }
 
 .footer {
   border-top: 1px solid;
-  @apply bg-foreground-1 border-t-color-3 flex justify-evenly sticky bottom-0 w-full;
+  @apply bg-foreground-1
+  border-t-color-3
+  flex
+  justify-evenly
+  sticky
+  bottom-0
+  w-full;
+  
   flex: 0 0 auto;
   min-height: theme("spacing.12");
   padding: theme("spacing.2");
@@ -164,7 +176,14 @@
 }
 
 .fab-container {
-  @apply inline-block sticky my-0 mx-auto bottom-0 left-0 right-0;
+  @apply inline-block
+  sticky
+  my-0
+  mx-auto
+  p-2
+  bottom-0
+  left-0
+  right-0;
+
   z-index: 1;
-  padding: theme("spacing.2");
 }

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -46,21 +46,21 @@
 }
 
 :host([width-scale="s"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-unit) * 12vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 300px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 150px);
+  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 12vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 300px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 150px);
 }
 
 :host([width-scale="m"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-unit) * 20vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 420px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 240px);
+  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 20vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 420px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 240px);
 }
 
 :host([width-scale="l"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-unit) * 45vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 680px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 340px);
+  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 45vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 680px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 340px);
 }
 
 :host([detached-height-scale="s"]) .content--detached {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -46,21 +46,21 @@
 }
 
 :host([width-scale="s"]) .content {
-  --calcite-shell-panel-width: 12vw;
-  --calcite-shell-panel-max-width: 300px;
-  --calcite-shell-panel-min-width: 150px;
+  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-unit) * 12vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 300px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 150px);
 }
 
 :host([width-scale="m"]) .content {
-  --calcite-shell-panel-width: 20vw;
-  --calcite-shell-panel-max-width: 420px;
-  --calcite-shell-panel-min-width: 240px;
+  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-unit) * 20vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 420px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 240px);
 }
 
 :host([width-scale="l"]) .content {
-  --calcite-shell-panel-width: 45vw;
-  --calcite-shell-panel-max-width: 680px;
-  --calcite-shell-panel-min-width: 340px;
+  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-unit) * 45vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-unit) * 680px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-unit) * 340px);
 }
 
 :host([detached-height-scale="s"]) .content--detached {


### PR DESCRIPTION
**Related Issue:** #1849

## Summary
This adds a base width unit at the :root level that is then used when calculating the width, min-width, and max-width for Panel and ShellPanel at each scale.

It should not affect the UI or any existing usages of Shell and ShellPanel.
The `width-scale` property should still behave as it has been on both components.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
