### PR TITLE
refactor(panel, shell-panel): rename CSS var to remove -ui- and add testing

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -19,7 +19,7 @@
   --calcite-border-radius: 3px;
   --calcite-ui-opacity-disabled: 0.5;
 
-  --calcite-ui-panel-width-multiplier: 1;
+  --calcite-panel-width-multiplier: 1;
 
   @apply font-sans;
 }

--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -280,4 +280,45 @@ describe("calcite-panel", () => {
 
     expect(footer).toBeNull();
   });
+
+  it("should update width based on the multipier CSS variable", async () => {
+
+    const multipier = 2;
+
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <calcite-panel width-scale="m">
+        test
+      </calcite-panel>
+    `);
+
+    await page.waitForChanges();
+
+    const content = await page.find(`calcite-panel >>> .${CSS.container}`);
+    const style = await content.getComputedStyle('width');
+    const widthDefault = parseFloat(style['width']);
+
+    const page2 = await newE2EPage();
+
+    await page2.setContent(`
+      <style>
+        :root {
+          --calcite-panel-width-multiplier: ${multipier};
+        }
+      </style>
+      <calcite-panel width-scale="m">
+        test multiplied
+      </calcite-panel>
+    `);
+
+    await page2.waitForChanges();
+
+    const content2 = await page2.find(`calcite-panel >>> .${CSS.container}`);
+    const style2 = await content2.getComputedStyle('width');
+    const width2 = parseFloat(style2['width']);
+
+    expect(width2).toEqual(widthDefault * multipier);
+
+  });
 });

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -41,21 +41,21 @@
 }
 
 :host([width-scale="s"]) {
-  --calcite-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 12vw);
-  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 300px);
-  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 150px);
+  --calcite-panel-width: calc(var(--calcite-panel-width-multiplier) * 12vw);
+  --calcite-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 300px);
+  --calcite-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 150px);
 }
 
 :host([width-scale="m"]) {
-  --calcite-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 20vw);
-  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 420px);
-  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 240px);
+  --calcite-panel-width: calc(var(--calcite-panel-width-multiplier) * 20vw);
+  --calcite-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 420px);
+  --calcite-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 240px);
 }
 
 :host([width-scale="l"]) {
-  --calcite-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 45vw);
-  --calcite-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 680px);
-  --calcite-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 340px);
+  --calcite-panel-width: calc(var(--calcite-panel-width-multiplier) * 45vw);
+  --calcite-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 680px);
+  --calcite-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 340px);
 }
 
 .container[hidden] {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -135,4 +135,44 @@ describe("calcite-shell-panel", () => {
 
     expect(detachedElement).not.toBeNull();
   });
+
+  it("should update width based on the multipier CSS variable", async () => {
+
+    const multipier = 2;
+
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <calcite-shell-panel>
+        test
+      </calcite-shell-panel>
+    `);
+
+    await page.waitForChanges();
+
+    const content = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
+    const style = await content.getComputedStyle('width');
+    const widthDefault = parseFloat(style['width']);
+
+    const page2 = await newE2EPage();
+    await page2.setContent(`
+      <style>
+        :root {
+          --calcite-panel-width-multiplier: ${multipier};
+        }
+      </style>
+      <calcite-shell-panel>
+        test multiplied
+      </calcite-shell-panel>
+    `);
+
+    await page2.waitForChanges();
+
+    const content2 = await page2.find(`calcite-shell-panel >>> .${CSS.content}`);
+    const style2 = await content2.getComputedStyle('width');
+    const width2 = parseFloat(style2['width']);
+
+    expect(width2).toEqual(widthDefault * multipier);
+
+  });
 });

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -46,21 +46,21 @@
 }
 
 :host([width-scale="s"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 12vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 300px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 150px);
+  --calcite-shell-panel-width: calc(var(--calcite-panel-width-multiplier) * 12vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 300px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 150px);
 }
 
 :host([width-scale="m"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 20vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 420px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 240px);
+  --calcite-shell-panel-width: calc(var(--calcite-panel-width-multiplier) * 20vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 420px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 240px);
 }
 
 :host([width-scale="l"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-ui-panel-width-multiplier) * 45vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-ui-panel-width-multiplier) * 680px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-ui-panel-width-multiplier) * 340px);
+  --calcite-shell-panel-width: calc(var(--calcite-panel-width-multiplier) * 45vw);
+  --calcite-shell-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 680px);
+  --calcite-shell-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 340px);
 }
 
 :host([detached-height-scale="s"]) .content--detached {


### PR DESCRIPTION
**Related Issue:** #

## Summary
Remove "ui" from var name.

cc @kevindoshier 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
