### PR TITLE
fix(select): fix rendering of options for mobile

### DIFF
--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -162,7 +162,7 @@ export class CalciteSelect {
       return;
     }
 
-    this.updateNativeElements(optionOrGroup, nativeEl);
+    this.updateNativeElement(optionOrGroup, nativeEl);
 
     if (isOption(optionOrGroup) && optionOrGroup.selected) {
       this.deselectAllExcept(optionOrGroup);
@@ -186,7 +186,7 @@ export class CalciteSelect {
   //
   //--------------------------------------------------------------------------
 
-  private updateNativeElements(
+  private updateNativeElement(
     optionOrGroup: CalciteOptionOrGroup,
     nativeOptionOrGroup: NativeOptionOrGroup
   ): void {
@@ -197,6 +197,10 @@ export class CalciteSelect {
       const option = nativeOptionOrGroup as HTMLOptionElement;
       option.selected = optionOrGroup.selected;
       option.value = optionOrGroup.value;
+
+      // need to set innerText for mobile
+      // see https://stackoverflow.com/questions/35021620/ios-safari-not-showing-all-options-for-select-menu/41749701
+      option.innerText = optionOrGroup.label;
     }
   }
 
@@ -248,12 +252,7 @@ export class CalciteSelect {
   ): NativeOptionOrGroup {
     if (isOption(optionOrGroup)) {
       const option = document.createElement("option");
-
-      option.disabled = optionOrGroup.disabled;
-      option.label = optionOrGroup.label;
-      option.selected = optionOrGroup.selected;
-      option.value = optionOrGroup.value;
-
+      this.updateNativeElement(optionOrGroup, option);
       this.componentToNativeEl.set(optionOrGroup, option);
 
       return option;
@@ -261,9 +260,7 @@ export class CalciteSelect {
 
     if (isOptionGroup(optionOrGroup)) {
       const group = document.createElement("optgroup");
-
-      group.disabled = optionOrGroup.disabled;
-      group.label = optionOrGroup.label;
+      this.updateNativeElement(optionOrGroup, group);
 
       Array.from(optionOrGroup.children as HTMLCollectionOf<HTMLCalciteOptionElement>).forEach(
         (option) => {


### PR DESCRIPTION
**Related Issue:** #1836

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates `calcite-select` to use `innerText` for its internal `<option>`s to display properly in mobile (see https://stackoverflow.com/questions/35021620/ios-safari-not-showing-all-options-for-select-menu/41749701).

Note that there are no accompanying tests since I'm not sure how we can automatically test for this in our E2E setup.