### PR TITLE
fix(color-picker): prevent invalid chars from being entered when hex input text is selected

### DIFF
--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
@@ -169,6 +169,28 @@ describe("calcite-color-picker-hex-input", () => {
     expect(spy).toHaveReceivedEventTimes(1);
   });
 
+  it("prevents entering chars if invalid hex chars or it exceeds max hex length", async () => {
+    const page = await newE2EPage({
+      html: "<calcite-color-picker-hex-input value='#b33f33'></calcite-color-picker-hex-input>"
+    });
+    const input = await page.find("calcite-color-picker-hex-input");
+    const selectAllText = async (): Promise<void> => await input.click({ clickCount: 3 });
+
+    await selectAllText();
+    await page.keyboard.type("zaaaz");
+    await page.keyboard.press("Enter");
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("#aaaaaa");
+
+    await selectAllText();
+    await page.keyboard.type("bbbbbbc");
+    await page.keyboard.press("Enter");
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("#bbbbbb");
+  });
+
   describe("keyboard interaction", () => {
     async function assertTabAndEnterBehavior(
       hexInputChars: string,
@@ -247,8 +269,7 @@ describe("calcite-color-picker-hex-input", () => {
         await assertTabAndEnterBehavior("", startingHex);
       });
 
-      it("prevents committing invalid hex chars", async () => {
-        await assertTabAndEnterBehavior("loooooooooooool", startingHex);
+      it("prevents committing invalid hex values", async () => {
         await assertTabAndEnterBehavior("aabbc", startingHex);
         await assertTabAndEnterBehavior("aabb", startingHex);
         await assertTabAndEnterBehavior("aa", startingHex);
@@ -295,8 +316,7 @@ describe("calcite-color-picker-hex-input", () => {
         await assertTabAndEnterBehavior("", null);
       });
 
-      it("prevents committing invalid hex chars", async () => {
-        await assertTabAndEnterBehavior("loooooooooooool", null);
+      it("prevents committing invalid hex values", async () => {
         await assertTabAndEnterBehavior("aabbc", startingHex);
         await assertTabAndEnterBehavior("aabb", startingHex);
         await assertTabAndEnterBehavior("aa", startingHex);

--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
@@ -206,12 +206,13 @@ export class CalciteColorPickerHexInput {
     const hasTextSelection =
       // can't use window.getSelection() because of FF bug: https://bugzilla.mozilla.org/show_bug.cgi?id=85686
       focusedElement.selectionStart != focusedElement.selectionEnd;
+    const singleChar = key.length === 1;
+    const validHexChar = hexChar.test(key);
 
     if (
-      key.length === 1 &&
+      singleChar &&
       !withModifiers &&
-      !hasTextSelection &&
-      (!hexChar.test(key) || exceededHexLength)
+      (!validHexChar || (!hasTextSelection && exceededHexLength))
     ) {
       event.preventDefault();
     }

--- a/src/components/calcite-color-picker/utils.ts
+++ b/src/components/calcite-color-picker/utils.ts
@@ -9,7 +9,7 @@ export function rgbToHex(color: RGB): string {
     .padStart(2, "0")}`.toLowerCase();
 }
 
-export const hexChar = /^[0-9A-F]{1}$/i;
+export const hexChar = /^[0-9A-F]$/i;
 const shortHandHex = /^#[0-9A-F]{3}$/i;
 const longhandHex = /^#[0-9A-F]{6}$/i;
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This tweaks up the input processing logic to prevent users from entering invalid characters when the the input has a selection. 

![invalid-hex-input-char](https://user-images.githubusercontent.com/197440/113173882-b20f4d00-91fe-11eb-856a-eb17cacd4b88.gif)
