### PR TITLE
fix(option): fix mutation observer options used to track content changes

### DIFF
--- a/src/components/calcite-option/calcite-option.e2e.ts
+++ b/src/components/calcite-option/calcite-option.e2e.ts
@@ -49,5 +49,12 @@ describe("calcite-option", () => {
 
     expect(await option.getProperty("label")).toBe(optionText);
     expect(await option.getProperty("value")).toBe(optionText);
+
+    const alternateLabel = "dos";
+    await option.setProperty("innerText", alternateLabel);
+    await page.waitForChanges();
+
+    expect(await option.getProperty("label")).toBe(alternateLabel);
+    expect(await option.getProperty("value")).toBe(alternateLabel);
   });
 });

--- a/src/components/calcite-option/calcite-option.tsx
+++ b/src/components/calcite-option/calcite-option.tsx
@@ -122,8 +122,7 @@ export class CalciteOption {
   connectedCallback(): void {
     this.ensureTextContentDependentProps();
     this.mutationObserver.observe(this.el, {
-      characterData: true,
-      subtree: true,
+      childList: true,
       attributeFilter: ["label", "value"]
     });
   }


### PR DESCRIPTION
**Related Issue:** #1409 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This tweaks the mutation observer options to actually track when its text content changes. `characterData` was not working because of the node being observed was not a text node. Dropped `subtree` since option is not expected to have a subtree as content.