### PR TITLE
fix(input-date-picker): Menu position should change depending on dir.

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -11,7 +11,7 @@ export function getAttributes(el: HTMLElement, blockList: string[]): Record<stri
 }
 
 export function getElementDir(el: HTMLElement): Direction {
-  return getElementProp(el, "dir", "ltr") as Direction;
+  return getElementProp(el, "dir", "ltr", true) as Direction;
 }
 
 export function getElementProp(el: Element, prop: string, fallbackValue: any, crossShadowBoundary = false): any {


### PR DESCRIPTION
Updates dom util getElementDir to go beyond shadow dom.

**Related Issue:** #1826

## Summary

fix(input-date-picker): Menu position should change depending on dir.
Updates dom util getElementDir to go beyond shadow dom.