### PR TITLE
fix(color-picker): add keyboard support to color field and hue slider

### DIFF
--- a/src/components/calcite-action-group/resources.ts
+++ b/src/components/calcite-action-group/resources.ts
@@ -6,7 +6,3 @@ export const SLOTS = {
 export const TEXT = {
   more: "More"
 };
-
-export const TEXT = {
-  more: "More"
-};

--- a/src/components/calcite-card/calcite-card.e2e.ts
+++ b/src/components/calcite-card/calcite-card.e2e.ts
@@ -1,6 +1,11 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, renders } from "../../tests/commonTests";
+import { placeholderImage } from "../../tests/utils";
 import { CSS } from "./resources";
+const placeholder = placeholderImage({
+  width: 350,
+  height: 150
+});
 
 describe("calcite-card", () => {
   it("renders", async () => renders("calcite-card"));
@@ -10,14 +15,14 @@ describe("calcite-card", () => {
   it("is accessible when selectable", async () =>
     accessible(`
       <calcite-card selectable>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
+        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>`));
 
   it("renders with default props if none are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
+        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>`);
 
     const element = await page.find("calcite-card");
@@ -31,7 +36,7 @@ describe("calcite-card", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card loading selectable selected disabled>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
+        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>`);
 
     const element = await page.find("calcite-card");
@@ -45,7 +50,7 @@ describe("calcite-card", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card>
-        <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
+        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>
     `);
 
@@ -58,7 +63,7 @@ describe("calcite-card", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-card selectable>
-      <img slot="thumbnail" src="https://via.placeholder.com/350x150.png" alt="Test image" />
+      <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>
     `);
 

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -1082,28 +1082,51 @@ describe("calcite-color-picker", () => {
     await assertHiddenSection([]);
   });
 
-  it("allows editing handles via keyboard", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-color-picker value="#beefee"></calcite-color-picker>`
+  describe("scope keyboard interaction", () => {
+    it("allows editing color field via keyboard", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-color-picker allow-empty value=""></calcite-color-picker>`
+      });
+
+      const picker = await page.find("calcite-color-picker");
+      const scope = await page.find(`calcite-color-picker >>> .${CSS.scope}`);
+
+      await scope.press("Tab");
+      expect(await picker.getProperty("value")).toBeFalsy();
+      await scope.press("ArrowDown");
+      expect(await picker.getProperty("value")).toBe("#ffffff");
+      await scope.press("ArrowDown");
+      expect(await picker.getProperty("value")).toBe("#ededed");
+      await scope.press("ArrowDown");
+      expect(await picker.getProperty("value")).toBe("#dbdbdb");
+      await scope.press("ArrowUp");
+      expect(await picker.getProperty("value")).toBe("#ededed");
+      await scope.press("ArrowRight");
+      expect(await picker.getProperty("value")).toBe("#e4eaed");
+      await scope.press("ArrowLeft");
+      expect(await picker.getProperty("value")).toBe("#ededed");
     });
+    it("allows editing hue slider via keyboard", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-color-picker allow-empty value=""></calcite-color-picker>`
+      });
 
-    const picker = await page.find("calcite-color-picker");
-    const spy = await picker.spyOnEvent("calciteColorPickerChange");
+      const picker = await page.find("calcite-color-picker");
+      const scopes = await page.findAll(`calcite-color-picker >>> .${CSS.scope}`);
 
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("ArrowUp");
-    expect(spy).toHaveReceivedEventTimes(1);
-    await page.keyboard.press("ArrowDown");
-    expect(spy).toHaveReceivedEventTimes(2);
-    await page.keyboard.press("ArrowLeft");
-    expect(spy).toHaveReceivedEventTimes(3);
-    await page.keyboard.press("ArrowRight");
-    expect(spy).toHaveReceivedEventTimes(4);
+      await scopes[0].press("Tab");
+      await scopes[1].press("ArrowDown");
+      expect(await picker.getProperty("value")).toBe("#007ec2");
+      await scopes[1].press("ArrowRight");
+      expect(await picker.getProperty("value")).toBe("#007bc2");
+      await scopes[1].press("ArrowLeft");
+      expect(await picker.getProperty("value")).toBe("#007ec2");
 
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("ArrowLeft");
-    expect(spy).toHaveReceivedEventTimes(5);
-    await page.keyboard.press("ArrowRight");
-    expect(spy).toHaveReceivedEventTimes(6);
+      await page.keyboard.press("Shift");
+      await scopes[1].press("ArrowDown");
+      expect(await picker.getProperty("value")).toBe("#0081c2");
+      await scopes[1].press("ArrowUp");
+      expect(await picker.getProperty("value")).toBe("#007ec2");
+    });
   });
 });

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -1081,4 +1081,29 @@ describe("calcite-color-picker", () => {
     await assertHiddenSection(["channels"]);
     await assertHiddenSection([]);
   });
+
+  it("allows editing handles via keyboard", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-color-picker value="#beefee"></calcite-color-picker>`
+    });
+
+    const picker = await page.find("calcite-color-picker");
+    const spy = await picker.spyOnEvent("calciteColorPickerChange");
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("ArrowUp");
+    expect(spy).toHaveReceivedEventTimes(1);
+    await page.keyboard.press("ArrowDown");
+    expect(spy).toHaveReceivedEventTimes(2);
+    await page.keyboard.press("ArrowLeft");
+    expect(spy).toHaveReceivedEventTimes(3);
+    await page.keyboard.press("ArrowRight");
+    expect(spy).toHaveReceivedEventTimes(4);
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("ArrowLeft");
+    expect(spy).toHaveReceivedEventTimes(5);
+    await page.keyboard.press("ArrowRight");
+    expect(spy).toHaveReceivedEventTimes(6);
+  });
 });

--- a/src/components/calcite-color-picker/calcite-color-picker.scss
+++ b/src/components/calcite-color-picker/calcite-color-picker.scss
@@ -91,7 +91,32 @@ $gap--large: 12px;
 .container {
   display: inline-block;
   border: 1px solid var(--calcite-ui-border-1);
-  background-color: var(--calcite-ui-foreground-1);
+}
+
+.color-field-and-slider-wrap {
+  position: relative;
+  overflow: hidden;
+}
+
+.scope {
+  @apply text--1
+    p-0
+    mb-0
+    mr-0
+    focus-base
+    w-2
+    h-2
+    absolute
+    pointer-events-none;
+
+  margin-top: -0.25rem;
+  margin-left: -0.25rem;
+  outline-offset: 10px;
+
+  &:focus {
+    @apply focus-outset;
+    outline-offset: 12px;
+  }
 }
 
 .color-field-and-slider {

--- a/src/components/calcite-color-picker/calcite-color-picker.scss
+++ b/src/components/calcite-color-picker/calcite-color-picker.scss
@@ -96,7 +96,6 @@ $gap--large: 12px;
 
 .color-field-and-slider-wrap {
   position: relative;
-  overflow: hidden;
 }
 
 .scope {

--- a/src/components/calcite-color-picker/calcite-color-picker.scss
+++ b/src/components/calcite-color-picker/calcite-color-picker.scss
@@ -89,6 +89,7 @@ $gap--large: 12px;
 }
 
 .container {
+  @apply bg-foreground-1;
   display: inline-block;
   border: 1px solid var(--calcite-ui-border-1);
 }

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -314,11 +314,11 @@ export class CalciteColorPicker {
       ArrowLeft: { x: -10, y: 0 }
     };
 
-    if (this.color && Object.keys(arrowKeyToXYOffset).includes(key)) {
+    if (Object.keys(arrowKeyToXYOffset).includes(key)) {
       event.preventDefault();
       this.captureColor(
-        this.colorFieldScopeLeft + arrowKeyToXYOffset[key].x,
-        this.colorFieldScopeTop + arrowKeyToXYOffset[key].y
+        this.colorFieldScopeLeft + arrowKeyToXYOffset[key].x || 0,
+        this.colorFieldScopeTop + arrowKeyToXYOffset[key].y || 0
       );
       this.scopeOrientation = key === "ArrowDown" || key === "ArrowUp" ? "vertical" : "horizontal";
       return;
@@ -335,13 +335,12 @@ export class CalciteColorPicker {
       ArrowLeft: -1
     };
 
-    if (this.color && Object.keys(arrowKeyToXOffset).includes(key)) {
+    if (Object.keys(arrowKeyToXOffset).includes(key)) {
       event.preventDefault();
-      const hue = this.baseColorFieldColor.hue();
-      this.internalColorSet(
-        this.baseColorFieldColor.hue(hue + arrowKeyToXOffset[key] * modifier),
-        false
-      );
+      const delta = arrowKeyToXOffset[key] * modifier;
+      const hue = this.baseColorFieldColor?.hue();
+      const color = hue ? this.baseColorFieldColor.hue(hue + delta) : Color({ h: 0, s: 0, v: 100 });
+      this.internalColorSet(color, false);
       return;
     }
   };
@@ -519,8 +518,14 @@ export class CalciteColorPicker {
       colorFieldScopeLeft,
       hueScopeLeft,
       hueScopeTop,
-      scopeOrientation
+      scopeOrientation,
+      dimensions: {
+        colorField: { height: colorFieldHeight, width: colorFieldWidth },
+        slider: { height: sliderHeight }
+      }
     } = this;
+    const hueTop = hueScopeTop || sliderHeight / 2 + colorFieldHeight;
+    const hueLeft = hueScopeLeft || (colorFieldWidth * DEFAULT_COLOR.hue()) / HSV_LIMITS.h;
     const elementDir = getElementDir(el);
     const noColor = color === null;
     const vertical = scopeOrientation === "vertical";
@@ -541,22 +546,22 @@ export class CalciteColorPicker {
             aria-label={vertical ? this.intlValue : this.intlSaturation}
             aria-valuemax={vertical ? HSV_LIMITS.v : HSV_LIMITS.s}
             aria-valuemin="0"
-            aria-valuenow={color?.hsv().array()[vertical ? 2 : 1] || "0"}
+            aria-valuenow={(vertical ? color?.saturationv() : color?.value()) || "0"}
             class={CSS.scope}
             onKeyDown={this.handleColorFieldScopeKeyDown}
             role="slider"
-            style={{ top: `${colorFieldScopeTop}px`, left: `${colorFieldScopeLeft}px` }}
+            style={{ top: `${colorFieldScopeTop || 0}px`, left: `${colorFieldScopeLeft || 0}px` }}
             tabindex="0"
           />
           <div
             aria-label={this.intlHue}
             aria-valuemax={HSV_LIMITS.h}
             aria-valuemin="0"
-            aria-valuenow={color?.round().hue() || "0"}
+            aria-valuenow={color?.round().hue() || DEFAULT_COLOR.round().hue()}
             class={CSS.scope}
             onKeyDown={this.handleHueScopeKeyDown}
             role="slider"
-            style={{ top: `${hueScopeTop}px`, left: `${hueScopeLeft}px` }}
+            style={{ top: `${hueTop}px`, left: `${hueLeft}px` }}
             tabindex="0"
           />
         </div>

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -275,9 +275,9 @@ export class CalciteColorPicker {
 
   @State() savedColors: string[] = [];
 
-  @State() scopeTop: number;
+  @State() colorFieldScopeTop: number;
 
-  @State() scopeLeft: number;
+  @State() colorFieldScopeLeft: number;
 
   @State() scopeOrientation: "vertical" | "horizontal";
 
@@ -317,8 +317,8 @@ export class CalciteColorPicker {
     if (this.color && Object.keys(arrowKeyToXYOffset).includes(key)) {
       event.preventDefault();
       this.captureColor(
-        this.scopeLeft + arrowKeyToXYOffset[key].x,
-        this.scopeTop + arrowKeyToXYOffset[key].y
+        this.colorFieldScopeLeft + arrowKeyToXYOffset[key].x,
+        this.colorFieldScopeTop + arrowKeyToXYOffset[key].y
       );
       this.scopeOrientation = key === "ArrowDown" || key === "ArrowUp" ? "vertical" : "horizontal";
       return;
@@ -515,8 +515,8 @@ export class CalciteColorPicker {
     const hexInputScale = scale !== "s" ? "m" : scale;
     const {
       colorFieldAndSliderInteractive,
-      scopeTop,
-      scopeLeft,
+      colorFieldScopeTop,
+      colorFieldScopeLeft,
       hueScopeLeft,
       hueScopeTop,
       scopeOrientation
@@ -545,7 +545,7 @@ export class CalciteColorPicker {
             class={CSS.scope}
             onKeyDown={this.handleColorFieldScopeKeyDown}
             role="slider"
-            style={{ top: `${scopeTop}px`, left: `${scopeLeft}px` }}
+            style={{ top: `${colorFieldScopeTop}px`, left: `${colorFieldScopeLeft}px` }}
             tabindex="0"
           />
           <div
@@ -1078,8 +1078,8 @@ export class CalciteColorPicker {
     const y = height - hsvColor.value() / (HSV_LIMITS.v / height);
 
     requestAnimationFrame(() => {
-      this.scopeLeft = x;
-      this.scopeTop = y;
+      this.colorFieldScopeLeft = x;
+      this.colorFieldScopeTop = y;
     });
 
     this.drawThumb(this.fieldAndSliderRenderingContext, radius, x, y, hsvColor, this.hueThumbState);

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -305,39 +305,41 @@ export class CalciteColorPicker {
     this.updateChannelsFromColor(this.color);
   };
 
-  private handleScopeKeydown = (event: KeyboardEvent): void => {
+  private handleColorFieldScopeKeyDown = (event: KeyboardEvent): void => {
     const key = getKey(event.key);
-    const cardinals = {
+    const arrowKeyToXYOffset = {
       ArrowUp: { x: 0, y: -10 },
       ArrowRight: { x: 10, y: 0 },
       ArrowDown: { x: 0, y: 10 },
       ArrowLeft: { x: -10, y: 0 }
     };
 
-    if (this.color && Object.keys(cardinals).indexOf(key) > -1) {
+    if (this.color && Object.keys(arrowKeyToXYOffset).includes(key)) {
       event.preventDefault();
-      this.captureColor(this.scopeLeft + cardinals[key].x, this.scopeTop + cardinals[key].y);
+      this.captureColor(
+        this.scopeLeft + arrowKeyToXYOffset[key].x,
+        this.scopeTop + arrowKeyToXYOffset[key].y
+      );
       this.scopeOrientation = key === "ArrowDown" || key === "ArrowUp" ? "vertical" : "horizontal";
       return;
     }
   };
 
-  private handleHueScopeKeydown = (event: KeyboardEvent): void => {
-    const { shiftKey } = event;
-    const modifier = shiftKey ? 10 : 1;
+  private handleHueScopeKeyDown = (event: KeyboardEvent): void => {
+    const modifier = event.shiftKey ? 10 : 1;
     const key = getKey(event.key);
-    const cardinals = {
+    const arrowKeyToXOffset = {
       ArrowUp: 1,
       ArrowRight: 1,
       ArrowDown: -1,
       ArrowLeft: -1
     };
 
-    if (this.color && Object.keys(cardinals).indexOf(key) > -1) {
+    if (this.color && Object.keys(arrowKeyToXOffset).includes(key)) {
       event.preventDefault();
-      const current = this.baseColorFieldColor.hue();
+      const hue = this.baseColorFieldColor.hue();
       this.internalColorSet(
-        this.baseColorFieldColor.hue(current + cardinals[key] * modifier),
+        this.baseColorFieldColor.hue(hue + arrowKeyToXOffset[key] * modifier),
         false
       );
       return;
@@ -537,22 +539,22 @@ export class CalciteColorPicker {
           />
           <div
             aria-label={vertical ? this.intlValue : this.intlSaturation}
-            aria-valuemax="100"
+            aria-valuemax={vertical ? HSV_LIMITS.v : HSV_LIMITS.s}
             aria-valuemin="0"
             aria-valuenow={color?.hsv().array()[vertical ? 2 : 1] || "0"}
             class={CSS.scope}
-            onKeyDown={this.handleScopeKeydown}
+            onKeyDown={this.handleColorFieldScopeKeyDown}
             role="slider"
             style={{ top: `${scopeTop}px`, left: `${scopeLeft}px` }}
             tabindex="0"
           />
           <div
             aria-label={this.intlHue}
-            aria-valuemax="360"
+            aria-valuemax={HSV_LIMITS.h}
             aria-valuemin="0"
-            aria-valuenow={color?.hue()?.toFixed(0) || "0"}
+            aria-valuenow={color?.round().hue() || "0"}
             class={CSS.scope}
-            onKeyDown={this.handleHueScopeKeydown}
+            onKeyDown={this.handleHueScopeKeyDown}
             role="slider"
             style={{ top: `${hueScopeTop}px`, left: `${hueScopeLeft}px` }}
             tabindex="0"
@@ -1075,7 +1077,7 @@ export class CalciteColorPicker {
     const x = hsvColor.saturationv() / (HSV_LIMITS.s / width);
     const y = height - hsvColor.value() / (HSV_LIMITS.v / height);
 
-    window.requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
       this.scopeLeft = x;
       this.scopeTop = y;
     });
@@ -1129,7 +1131,7 @@ export class CalciteColorPicker {
     const x = hsvColor.hue() / (360 / width);
     const y = height / 2 + colorFieldHeight;
 
-    window.requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
       this.hueScopeLeft = x;
       this.hueScopeTop = y;
     });

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -323,6 +323,8 @@ export class CalciteColorPicker {
   };
 
   private handleHueScopeKeydown = (event: KeyboardEvent): void => {
+    const { shiftKey } = event;
+    const modifier = shiftKey ? 10 : 1;
     const key = getKey(event.key);
     const cardinals = {
       ArrowUp: 1,
@@ -334,7 +336,10 @@ export class CalciteColorPicker {
     if (this.color && Object.keys(cardinals).indexOf(key) > -1) {
       event.preventDefault();
       const current = this.baseColorFieldColor.hue();
-      this.internalColorSet(this.baseColorFieldColor.hue(current + cardinals[key]), false);
+      this.internalColorSet(
+        this.baseColorFieldColor.hue(current + cardinals[key] * modifier),
+        false
+      );
       return;
     }
   };

--- a/src/components/calcite-color-picker/resources.ts
+++ b/src/components/calcite-color-picker/resources.ts
@@ -21,6 +21,8 @@ export const CSS = {
   headerHex: "header--hex",
   colorFieldAndSlider: "color-field-and-slider",
   colorFieldAndSliderInteractive: "color-field-and-slider--interactive",
+  colorFieldAndSliderWrap: "color-field-and-slider-wrap",
+  scope: "scope",
   savedColor: "saved-color"
 };
 


### PR DESCRIPTION
**Related Issue:** #1406

## Summary

I kept getting issues assigned to me about lacking keyboard support in this component, so thought I'd just take a crack at it. I've chosen to model this as multiple `slider` components in terms of accessibility. Because multi-axis sliders are not supported via the `slider` role, when you are moving in the vertical direction, we treat this as a 0-100 value slider, while when you're moving horizontally we treat it as a 0-100 saturation slider. 


