### PR TITLE
fix(color-picker): update color swatch border to follow spec

### DIFF
--- a/src/components/calcite-color-picker-swatch/calcite-color-picker-swatch.tsx
+++ b/src/components/calcite-color-picker-swatch/calcite-color-picker-swatch.tsx
@@ -1,7 +1,8 @@
-import { Component, h, Host, Prop, VNode, Watch } from "@stencil/core";
+import { Component, Element, h, Host, Prop, VNode, Watch } from "@stencil/core";
 import Color from "color";
 import { COLORS, CSS } from "./resources";
 import { Scale, Theme } from "../interfaces";
+import { getElementProp } from "../../utils/dom";
 
 @Component({
   tag: "calcite-color-picker-swatch",
@@ -58,6 +59,9 @@ export class CalciteColorPickerSwatch {
   //
   //--------------------------------------------------------------------------
 
+  @Element()
+  el: HTMLCalciteColorPickerSwatchElement;
+
   private internalColor: Color;
 
   //--------------------------------------------------------------------------
@@ -71,17 +75,27 @@ export class CalciteColorPickerSwatch {
   }
 
   render(): VNode {
-    const { active, internalColor, theme } = this;
+    const { active, el, internalColor } = this;
     const borderRadius = active ? "100%" : "0";
     const hex = internalColor.hex();
-    const borderColor = active
-      ? COLORS.activeBorder
-      : internalColor[theme === "light" ? "darken" : "whiten"](0.25).hex();
+    const theme = getElementProp(el, "theme", "light", true);
+    const borderColor = theme === "light" ? COLORS.borderLight : COLORS.borderDark;
 
     return (
       <Host aria-label={hex} title={hex}>
         <svg class={CSS.swatch} xmlns="http://www.w3.org/2000/svg">
-          <rect fill={hex} height="100%" rx={borderRadius} stroke={borderColor} width="100%" />
+          <rect
+            fill={hex}
+            height="100%"
+            id="swatch"
+            rx={borderRadius}
+            stroke={borderColor}
+            // stroke-width and clip-path are needed to hide overflowing portion of stroke
+            // see https://stackoverflow.com/a/7273346/194216
+            stroke-width="2"
+            style={{ "clip-path": `inset(0 round ${borderRadius})` }}
+            width="100%"
+          />
         </svg>
       </Host>
     );

--- a/src/components/calcite-color-picker-swatch/resources.ts
+++ b/src/components/calcite-color-picker-swatch/resources.ts
@@ -4,6 +4,6 @@ export const CSS = {
 };
 
 export const COLORS = {
-  emptyFill: "rgba(0, 0, 0, 0)",
-  activeBorder: "rgba(0, 0, 0, 0.15)"
+  borderLight: "rgba(0, 0, 0, 0.15)",
+  borderDark: "rgba(255, 255, 255, 0.15)"
 };


### PR DESCRIPTION
**Related Issue:** #1886 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates swatch borders to be spec-compliant.

### Preview

**light theme**
![Screen Shot 2021-04-01 at 5 30 44 PM](https://user-images.githubusercontent.com/197440/113367288-76fd3e80-9310-11eb-8740-f2230a373bdc.png)

**dark theme**
![Screen Shot 2021-04-01 at 5 30 55 PM](https://user-images.githubusercontent.com/197440/113367290-7795d500-9310-11eb-9c8a-8c56fa809878.png)



cc @julio8a 
