### PR TITLE
fix(radio-group): ensure group's outline is included in new total heights

### DIFF
--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -14,6 +14,7 @@
   @apply flex bg-foreground-1;
   width: fit-content;
   outline: 1px solid var(--calcite-ui-border-input);
+  outline-offset: -1px;
 }
 
 :host([layout="vertical"]) {

--- a/src/demos/calcite-radio-group.html
+++ b/src/demos/calcite-radio-group.html
@@ -55,26 +55,6 @@
       </calcite-radio-group>
     </calcite-label>
 
-    <calcite-label scale="l">
-      Inherit L scale from parent label
-      <calcite-radio-group appearance="outline">
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-
-    <calcite-label scale="s">
-      Inherit S scale from parent label
-      <calcite-radio-group appearance="outline">
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-
     <calcite-label>
       My Great Radio Layout Vertical
       <calcite-radio-group layout="vertical">
@@ -129,6 +109,50 @@
     </calcite-label>
 
     <h3 class="leader-1">Width full</h3>
+
+    <div style="width:33vw;margin:2rem;">
+      <calcite-radio-group
+        appearance="solid"
+        width="full"
+      >
+        <calcite-radio-group-item
+          checked
+          appearance="solid"
+          aria-checked="true"
+          layout="horizontal"
+          icon-position="start"
+        >
+          React
+        </calcite-radio-group-item>
+        <calcite-radio-group-item
+          value="ember"
+          appearance="solid"
+          aria-checked="false"
+          layout="horizontal"
+          icon-position="start"
+        >
+          Ember
+        </calcite-radio-group-item>
+        <calcite-radio-group-item
+          value="long-text-1"
+          appearance="solid"
+          aria-checked="false"
+          layout="horizontal"
+          icon-position="start"
+        >
+          Longer text wraps.
+        </calcite-radio-group-item>
+        <calcite-radio-group-item
+          value="long-text-2"
+          appearance="solid"
+          aria-checked="false"
+          layout="horizontal"
+          icon-position="start"
+        >
+          Longer text wraps.
+        </calcite-radio-group-item>
+      </calcite-radio-group>
+    </div>
 
     <calcite-radio-group width="full">
       <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>

--- a/src/demos/calcite-radio-group.html
+++ b/src/demos/calcite-radio-group.html
@@ -112,44 +112,28 @@
 
     <div style="width:33vw;margin:2rem;">
       <calcite-radio-group
-        appearance="solid"
         width="full"
       >
         <calcite-radio-group-item
           checked
-          appearance="solid"
-          aria-checked="true"
-          layout="horizontal"
-          icon-position="start"
+          value="React"
         >
           React
         </calcite-radio-group-item>
         <calcite-radio-group-item
-          value="ember"
-          appearance="solid"
-          aria-checked="false"
-          layout="horizontal"
-          icon-position="start"
+          value="Ember"
         >
           Ember
         </calcite-radio-group-item>
         <calcite-radio-group-item
-          value="long-text-1"
-          appearance="solid"
-          aria-checked="false"
-          layout="horizontal"
-          icon-position="start"
+          value="Longer text wraps."
         >
           Longer text wraps.
         </calcite-radio-group-item>
         <calcite-radio-group-item
-          value="long-text-2"
-          appearance="solid"
-          aria-checked="false"
-          layout="horizontal"
-          icon-position="start"
+          value="Longer text wraps yep"
         >
-          Longer text wraps.
+          Longer text wraps yep
         </calcite-radio-group-item>
       </calcite-radio-group>
     </div>
@@ -297,12 +281,13 @@
       </calcite-radio-group>
     </div>
     <h3 class="leader-1">RTL</h3>
-
-    <calcite-radio-group dir="rtl">
-      <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
-    </calcite-radio-group>
+    <div dir="rtl">
+      <calcite-radio-group>
+        <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
+        <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+        <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
+      </calcite-radio-group>
+    </div>
 
     <h3 class="leader-1">External inputs</h3>
 
@@ -318,12 +303,19 @@
       <label>
         Choose wisely
         <calcite-radio-group name="within-form">
-          <calcite-radio-group-item value="1"></calcite-radio-group-item>
+          <calcite-radio-group-item checked value="1"></calcite-radio-group-item>
           <calcite-radio-group-item value="2"></calcite-radio-group-item>
           <calcite-radio-group-item value="3"></calcite-radio-group-item>
         </calcite-radio-group>
       </label>
+      <button type="submit">Submit</button>
     </form>
+    <script>
+      document.querySelector("form").addEventListener("submit", (e) => {
+        e.preventDefault();
+        window.alert(`You selected ${e.target[0].value}`);
+      });
+    </script>
   </div>
 </body>
 


### PR DESCRIPTION
**Related Issue:** n/a - relates to Tailwind refactor from pr #1711, issue #1500

cc @julio8a @bstifle 

## Summary
Ensures the gray outline around `calcite-radio-group` stays inside the new total heights for each scale. Also freshens up its demo html a bit.


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
