### PR TITLE
fix(panel, shell-panel): flex grow, shrink, basis definitions 

### DIFF
--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -282,10 +282,10 @@ describe("calcite-panel", () => {
   });
 
   it("should update width based on the multipier CSS variable", async () => {
-
     const multipier = 2;
 
     const page = await newE2EPage();
+    page.setViewport({ width: 1600, height: 1200 });
 
     await page.setContent(`
       <calcite-panel width-scale="m">
@@ -296,10 +296,11 @@ describe("calcite-panel", () => {
     await page.waitForChanges();
 
     const content = await page.find(`calcite-panel >>> .${CSS.container}`);
-    const style = await content.getComputedStyle('width');
-    const widthDefault = parseFloat(style['width']);
+    const style = await content.getComputedStyle("width");
+    const widthDefault = parseFloat(style["width"]);
 
     const page2 = await newE2EPage();
+    page2.setViewport({ width: 1600, height: 1200 });
 
     await page2.setContent(`
       <style>
@@ -315,10 +316,9 @@ describe("calcite-panel", () => {
     await page2.waitForChanges();
 
     const content2 = await page2.find(`calcite-panel >>> .${CSS.container}`);
-    const style2 = await content2.getComputedStyle('width');
-    const width2 = parseFloat(style2['width']);
+    const style2 = await content2.getComputedStyle("width");
+    const width2 = parseFloat(style2["width"]);
 
     expect(width2).toEqual(widthDefault * multipier);
-
   });
 });

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -1,6 +1,6 @@
 :host {
   @extend %component-host;
-  @apply flex relative;
+  @apply flex flex-auto relative;
 
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
   --calcite-panel-max-height: unset;
@@ -13,10 +13,10 @@
 
 .container {
   @apply flex
+    flex-auto
     flex-col
     items-stretch
     bg-background
-    h-full
     w-full
     p-0
     m-0;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -9,7 +9,7 @@
 
 ::slotted(calcite-panel),
 ::slotted(calcite-flow) {
-  @apply h-full w-full;
+  @apply flex-auto h-full w-full;
   max-height: unset;
   max-width: unset;
 }
@@ -42,7 +42,10 @@
 }
 
 .content__body {
-  @apply flex-auto overflow-hidden;
+  @apply flex-auto
+  flex-col
+  flex-no-wrap
+  overflow-hidden;
 }
 
 :host([width-scale="s"]) .content {


### PR DESCRIPTION
**Related Issue:** (#1914)

## Summary
Adds explicit flex grow, shrink, and basis definitions to make Safari play nice.

cc @AdelheidF 
Also added to Panel at the :host level to ease integration.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
