### PR TITLE
fix(panel, shell-panel, flow): fixes height and scrolling issues with Safari

### DIFF
--- a/src/components/calcite-flow/calcite-flow.scss
+++ b/src/components/calcite-flow/calcite-flow.scss
@@ -1,15 +1,16 @@
 :host {
   @extend %component-host;
   @apply flex 
+    flex-auto
     items-stretch 
     bg-transparent 
-    w-full 
-    h-full 
+    w-full
     overflow-hidden 
     relative;
 
   .frame {
-    @apply flex 
+    @apply flex
+      flex-auto
       items-stretch 
       w-full 
       p-0 

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -1,6 +1,10 @@
 :host {
   @extend %component-host;
-  @apply flex flex-auto relative;
+  @apply flex
+    flex-auto
+    overflow-hidden
+    relative
+    w-full;
 
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
   --calcite-panel-max-height: unset;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -29,22 +29,18 @@
   transition: max-height $transition, max-width $transition;
 }
 
-.content__header,
-.content__body {
+.content__header {
   @apply flex
   flex-col
+  flex-initial
   flex-no-wrap
   items-stretch;
 }
 
-.content__header {
-  @apply flex-initial;
-}
-
 .content__body {
-  @apply flex-auto
+  @apply flex
+  flex-auto
   flex-col
-  flex-no-wrap
   overflow-hidden;
 }
 


### PR DESCRIPTION
… Safari (#1914)

**Related Issue:** #1914 

## Summary
Adds additional styles to play nice with Safari.

Custom elements, i.e. other components inside Panel and Flow will still need these styles applied to them:

```
display: flex;
flex: 1 1 auto;
overflow: hidden;
```

cc @AdelheidF @kevindoshier @dhrumil83 @subgan82
If you know Ganesh and Dhrumil's handles, please mention them here.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
