### PR TITLE
fix(block): place aria-expanded on block toggle button

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -130,6 +130,7 @@ describe("calcite-block", () => {
     const toggle = await page.find(`calcite-block >>> .${CSS.toggle}`);
 
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(toggle.getAttribute("title")).toBe(TEXT.expand);
 
     await toggle.click();
@@ -137,6 +138,7 @@ describe("calcite-block", () => {
     expect(toggleSpy).toHaveReceivedEventTimes(1);
     expect(await element.getProperty("open")).toBe(true);
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(toggle.getAttribute("title")).toBe(TEXT.collapse);
 
     await toggle.click();
@@ -144,6 +146,7 @@ describe("calcite-block", () => {
     expect(toggleSpy).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("open")).toBe(false);
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(toggle.getAttribute("title")).toBe(TEXT.expand);
   });
 

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -168,6 +168,7 @@ export class CalciteBlock {
         {this.dragHandle ? <calcite-handle /> : null}
         {collapsible ? (
           <button
+            aria-expanded={collapsible ? open.toString() : null}
             aria-label={toggleLabel}
             class={CSS.toggle}
             onClick={this.onHeaderClick}
@@ -194,7 +195,6 @@ export class CalciteBlock {
       <Host tabIndex={disabled ? -1 : null}>
         <article
           aria-busy={loading.toString()}
-          aria-expanded={collapsible ? open.toString() : null}
           class={{
             [CSS.article]: true,
             [CSS_UTILITY.rtl]: rtl


### PR DESCRIPTION
**Related Issue:** #1917

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Moves aria attribute to the proper toggling element. 