### PR TITLE
feat(shell-panel): adds utility class for properly setting the height of external elements and adds related demo apps

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -45,13 +45,6 @@
   overflow: hidden;
 }
 
-.calcite-match-height {
-  @apply flex
-  flex-auto
-  flex-col
-  overflow-hidden;
-}
-
 [calcite-hydrated-hidden] {
   visibility: hidden;
   pointer-events: none;

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -45,6 +45,13 @@
   overflow: hidden;
 }
 
+.calcite-match-height {
+  @apply flex
+  flex-auto
+  flex-col
+  overflow-hidden;
+}
+
 [calcite-hydrated-hidden] {
   visibility: hidden;
   pointer-events: none;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -14,6 +14,13 @@
   max-width: unset;
 }
 
+::slotted(.calcite-match-height) {
+  @apply flex
+  flex-auto
+  flex-col
+  overflow-hidden;
+}
+
 .content {
   @apply items-stretch 
     self-stretch 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -17,7 +17,6 @@
 ::slotted(.calcite-match-height) {
   @apply flex
   flex-auto
-  flex-col
   overflow-hidden;
 }
 

--- a/src/components/calcite-shell-panel/readme.md
+++ b/src/components/calcite-shell-panel/readme.md
@@ -55,6 +55,11 @@ Renders a panel with an action bar.
 |                | A slot for adding content to the shell panel.          |
 | `"action-bar"` | A slot for adding a `calcite-action-bar` to the panel. |
 
+## Utility class
+| Class                  | Description                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `calcite-match-height` | Provides correct height and scrolling behavior for non-Calcite elements in the generic slot. |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-shell-panel/usage/basic.md
+++ b/src/components/calcite-shell-panel/usage/basic.md
@@ -21,3 +21,55 @@ Renders a panel with an action bar.
   </calcite-action-bar>
 </calcite-shell-panel>
 ```
+
+#### With a CalcitePanel.
+
+```html
+<calcite-shell-panel>
+  <calcite-action-bar slot="action-bar">
+    <calcite-action text="Add" icon="plus"></calcite-action>
+    <calcite-action text="Save" icon="save"></calcite-action>
+    <calcite-action text="Layers" icon="layers"></calcite-action>
+  </calcite-action-bar>
+  <calcite-panel>
+    ...
+  </calcite-panel>
+</calcite-shell-panel>
+```
+#### With a CalciteFlow.
+
+```html
+<calcite-shell-panel>
+  <calcite-action-bar slot="action-bar">
+    <calcite-action text="Add" icon="plus"></calcite-action>
+    <calcite-action text="Save" icon="save"></calcite-action>
+    <calcite-action text="Layers" icon="layers"></calcite-action>
+  </calcite-action-bar>
+  <calcite-flow>
+    <calcite-panel>
+      ...
+    </calcite-panel>
+    <calcite-panel>
+      ...
+    </calcite-panel>
+  </calcite-flow>
+</calcite-shell-panel>
+```
+#### With a custom element wrapping a CalcitePanel.
+
+Add `calcite-match-height` to ensure proper height, scrolling, and sticky behavior (header, footer, fab).
+
+```html
+<calcite-shell-panel>
+  <calcite-action-bar slot="action-bar">
+    <calcite-action text="Add" icon="plus"></calcite-action>
+    <calcite-action text="Save" icon="save"></calcite-action>
+    <calcite-action text="Layers" icon="layers"></calcite-action>
+  </calcite-action-bar>
+  <your-custom-element class="calcite-match-height">
+    <calcite-panel>
+      ...
+    </calcite-panel>
+  </your-custom-element>
+</calcite-shell-panel>
+```

--- a/src/demos/shell/demo-app-advanced-2-shell-header.html
+++ b/src/demos/shell/demo-app-advanced-2-shell-header.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+
+    <title>Calcite Components: calcite-shell</title>
+
+    <script src="../_assets/head.js"></script>
+
+    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.15/"></script>
+    <style>
+      html,
+      body,
+      main,
+      .shell-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <style>
+      #viewDiv {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList"], function (WebMap, MapView, LayerList) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
+        });
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap
+        });
+        view.when(function () {
+          var layerList = new LayerList({
+            view: view,
+            selectionEnabled: true,
+            container: "layerlist-container"
+          });
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <main>
+      <div class="shell-container">
+        <calcite-shell content-behind>
+          <calcite-shell-panel slot="primary-panel" position="start" detached>
+            <calcite-panel
+              id="shell-floating-panel"
+              slot="shell-floating-panel"
+              heading="Anchored Shell Floating Panel"
+              placement="anchor"
+              hidden
+              ><span> Shell Floating Panel Content </span>
+            </calcite-panel>
+            <calcite-panel
+              id="shell-floating-panel-over"
+              slot="shell-floating-panel"
+              heading="Over Shell Floating Panel"
+              placement="over"
+              hidden
+              ><span> Shell Floating Panel Content </span>
+            </calcite-panel>
+
+            <calcite-action-bar slot="action-bar" theme="dark">
+              <calcite-action-group>
+                <calcite-action text="Add">
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
+                </calcite-action>
+                <calcite-action text="Save" disabled>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
+                </calcite-action>
+                <calcite-action text="Layers" active>
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action text="An unbelievably long title">
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
+                </calcite-action>
+                <calcite-action text="Save" disabled>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
+                </calcite-action>
+                <calcite-action text="Layers">
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-panel heading="Layers" height-scale="l">
+              <div id="layerlist-container"></div>
+            </calcite-panel>
+          </calcite-shell-panel>
+
+          <calcite-shell-panel slot="contextual-panel" position="end">
+            <calcite-action-bar slot="action-bar">
+              <calcite-action-group>
+                <calcite-tooltip slot="menu-tooltip">Bits and bobs.</calcite-tooltip>
+                <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
+                <calcite-action text="Styles" icon="shapes"> </calcite-action>
+                <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
+                <calcite-action text="Configure pop-ups" icon="popup"> </calcite-action>
+                <calcite-action text="Configure attributes" icon="feature-details"> </calcite-action>
+                <calcite-action text="Labels" icon="label" active> </calcite-action>
+                <calcite-action text="Table" icon="table"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action text="Save" disabled>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
+                </calcite-action>
+                <calcite-action text="Layers">
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Tips" id="tip-manager-button">
+                  <calcite-icon icon="lightbulb" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-button
+              slot="header"
+              color="inverse"
+              alignment="icon-end-space-between"
+              icon-end="caret-down"
+              width="full"
+            >
+              It's a header button with really long text that should wrap, you know?
+            </calcite-button>
+            <something class="calcite-match-height">
+              <calcite-panel
+                heading="Panel with Header"
+                summary="Popular Demographics in the United States (Beta) - County"
+              >
+                <calcite-action slot="menu-actions" text="Switch layer" icon="caret-down"></calcite-action>
+
+                <section class="enable-label">
+                  <span class="enable-label__text">Enable labels</span>
+                  <calcite-switch scale="s" switched></calcite-switch>
+                </section>
+                <calcite-block heading="2018 Total Population (Esri)" summary="County - Town" open collapsible>
+                  <calcite-icon icon="label" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="s"></calcite-action>
+                  <section class="form-section">
+                    <calcite-label scale="s" for="">
+                      Label attribute
+                      <calcite-input type="text" value="2018 Total Population (Esri)" />
+                    </calcite-label>
+                  </section>
+                  <section class="form-section">
+                    <calcite-button
+                      width="full"
+                      scale="s"
+                      appearance="clear"
+                      color="inverse"
+                      class="combo-button__main"
+                      text="Edit label style"
+                      icon-end="pencil"
+                    >
+                      Edit label
+                    </calcite-button>
+                  </section>
+                </calcite-block>
+                <calcite-block heading="NAME" summary="Continent - State province" open collapsible>
+                  <calcite-icon icon="label" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="s"></calcite-action>
+                  <section class="form-section">
+                    <section class="form-section">
+                      <calcite-label scale="s" for="">
+                        Label attribute
+                        <calcite-input type="text" value="NAME" />
+                      </calcite-label>
+                    </section>
+                    <section class="form-section">
+                      <calcite-button
+                        width="full"
+                        scale="s"
+                        appearance="clear"
+                        color="inverse"
+                        class="combo-button__main"
+                        text="Edit label style"
+                        icon-end="pencil"
+                      >
+                        Edit label
+                      </calcite-button>
+                    </section>
+                  </section>
+                </calcite-block>
+                <calcite-block
+                  heading="2018 Total Households (Esri)"
+                  summary="Streets - Small building"
+                  open
+                  collapsible
+                >
+                  <calcite-icon icon="label" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="s"></calcite-action>
+                  <section class="form-section">
+                    <section class="form-section">
+                      <calcite-label scale="s" for="">
+                        Label attribute
+                        <calcite-input type="text" value="2018 Total Households (Esri)" />
+                      </calcite-label>
+                    </section>
+                    <section class="form-section">
+                      <calcite-button
+                        width="full"
+                        scale="s"
+                        appearance="clear"
+                        color="inverse"
+                        class="combo-button__main"
+                        text="Edit label style"
+                        icon-end="pencil"
+                      >
+                        Edit label
+                      </calcite-button>
+                    </section>
+                  </section>
+                </calcite-block>
+                <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
+                <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
+                  Add label class
+                </calcite-tooltip>
+                <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
+                <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+              </calcite-panel>
+            </something>
+          </calcite-shell-panel>
+          <div slot="shell-header">
+            <header class="header">
+              <h2 class="heading">My App</h2>
+            </header>
+          </div>
+          
+          <div id="viewDiv"></div>
+
+          <footer slot="shell-footer">Footer</footer>
+        </calcite-shell>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/demos/shell/nesting-testing-flow.html
+++ b/src/demos/shell/nesting-testing-flow.html
@@ -114,183 +114,157 @@
             >
               It's a header button with really long text that should wrap, you know?
             </calcite-button>
-            <div class="calcite-match-height">
-              <something class="calcite-match-height">
-                <div class="calcite-match-height">
-                  <div class="calcite-match-height">
-                    <calcite-flow>
-                      <calcite-panel heading="first panel"> Test </calcite-panel>
-                      <calcite-panel heading="Flow & DIVs" summary="Extra nested divs" dismissible>
-                        <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
-                          <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
-                            <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
-                              <calcite-action
-                                slot="actions-end"
-                                text="click-me"
-                                onClick="console.log('clicked');"
-                                icon="x"
-                              >
-                              </calcite-action>
-                            </calcite-value-list-item>
-                            <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
-                              <calcite-action
-                                slot="actions-end"
-                                text="click-me"
-                                onClick="console.log('clicked');"
-                                icon="x"
-                              >
-                              </calcite-action>
-                            </calcite-value-list-item>
-                            <calcite-value-list-item
-                              label="Fish. But not just any fish."
-                              description="Easy to care for."
-                              value="fish"
-                            >
-                              <calcite-action
-                                slot="actions-end"
-                                text="click-me"
-                                onClick="console.log('clicked');"
-                                icon="x"
-                              >
-                              </calcite-action>
-                            </calcite-value-list-item>
-                          </calcite-value-list>
+            <some-custom-element class="calcite-match-height">
+              <calcite-flow>
+                <calcite-panel heading="first panel"> Test </calcite-panel>
+                <calcite-panel heading="Flow & DIVs" summary="Extra nested divs" dismissible>
+                  <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
+                    <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
+                      <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
+                        <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                        </calcite-action>
+                      </calcite-value-list-item>
+                      <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
+                        <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                        </calcite-action>
+                      </calcite-value-list-item>
+                      <calcite-value-list-item
+                        label="Fish. But not just any fish."
+                        description="Easy to care for."
+                        value="fish"
+                      >
+                        <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                        </calcite-action>
+                      </calcite-value-list-item>
+                    </calcite-value-list>
 
-                          <!-- Using Button -->
-                          <calcite-label scale="s">
-                            It's a label (btn).
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-button
-                                slot="input-action"
-                                appearance="transparent"
-                                color="neutral"
-                                icon-start="brackets-curly"
-                                scale="s"
-                              ></calcite-button>
-                            </calcite-input>
-                          </calcite-label>
-                          <!-- Using Action -->
-                          <calcite-label scale="s">
-                            It's a label (action).
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="pencil"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
+                    <!-- Using Button -->
+                    <calcite-label scale="s">
+                      It's a label (btn).
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-button
+                          slot="input-action"
+                          appearance="transparent"
+                          color="neutral"
+                          icon-start="brackets-curly"
+                          scale="s"
+                        ></calcite-button>
+                      </calcite-input>
+                    </calcite-label>
+                    <!-- Using Action -->
+                    <calcite-label scale="s">
+                      It's a label (action).
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action text="cool action" icon="pencil" slot="input-action" scale="s"></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
 
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                          <calcite-block-section text="Section is cool">
-                            <calcite-label scale="s">
-                              It's a label.
-                              <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
-                            </calcite-label>
-                          </calcite-block-section>
-                          <calcite-block-section text="Switch section" toggle-display="switch">
-                            <calcite-label scale="s">
-                              It's a label.
-                              <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
-                            </calcite-label>
-                          </calcite-block-section>
-                        </calcite-block>
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                    <calcite-block-section text="Section is cool">
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                      </calcite-label>
+                    </calcite-block-section>
+                    <calcite-block-section text="Switch section" toggle-display="switch">
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                      </calcite-label>
+                    </calcite-block-section>
+                  </calcite-block>
 
-                        <calcite-block heading="With control" summary="Collapsible" collapsible>
-                          <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                        </calcite-block>
-                        <calcite-block heading="Basic" summary="Not collapsible">
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s">
-                              <calcite-action
-                                text="cool action"
-                                icon="brackets-curly"
-                                slot="input-action"
-                                scale="s"
-                              ></calcite-action>
-                            </calcite-input>
-                          </calcite-label>
-                        </calcite-block>
+                  <calcite-block heading="With control" summary="Collapsible" collapsible>
+                    <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                  </calcite-block>
+                  <calcite-block heading="Basic" summary="Not collapsible">
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s">
+                        <calcite-action
+                          text="cool action"
+                          icon="brackets-curly"
+                          slot="input-action"
+                          scale="s"
+                        ></calcite-action>
+                      </calcite-input>
+                    </calcite-label>
+                  </calcite-block>
 
-                        <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
-                        <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
-                          Add label class
-                        </calcite-tooltip>
-                        <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                        <calcite-button slot="footer-actions" width="half">Done</calcite-button>
-                      </calcite-panel>
-                    </calcite-flow>
-                  </div>
-                </div>
-              </something>
-            </div>
+                  <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
+                  <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
+                    Add label class
+                  </calcite-tooltip>
+                  <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
+                  <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                </calcite-panel>
+              </calcite-flow>
+            </some-custom-element>
           </calcite-shell-panel>
           <div class="gnav" slot="shell-header">
             <h2>Cool app</h2>

--- a/src/demos/shell/nesting-testing-flow.html
+++ b/src/demos/shell/nesting-testing-flow.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+
+    <title>Nesting Testing with a Flow</title>
+
+    <script src="../_assets/head.js"></script>
+
+    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.15/"></script>
+    <style>
+      html,
+      body,
+      main,
+      .shell-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <style>
+      #viewDiv {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
+        });
+
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap
+        });
+        view.when(function () {
+          view.ui.move("zoom", "bottom-right");
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <main>
+      <div class="shell-container">
+        <calcite-shell content-behind>
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
+            <calcite-action-bar slot="action-bar" theme="dark">
+              <calcite-action-group>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action icon="map" text="New"> </calcite-action>
+                <calcite-action icon="collection" text="Open"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers"> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action text="Share" icon="share"></calcite-action>
+                <calcite-action text="Print" icon="print"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Feedback" icon="speech-bubble-plus"></calcite-action>
+                <calcite-action text="What's next" icon="mega-phone"></calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+          </calcite-shell-panel>
+
+          <calcite-shell-panel slot="contextual-panel" position="end">
+            <calcite-action-bar slot="action-bar">
+              <calcite-action-group>
+                <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
+                <calcite-action text="Styles" icon="shapes"> </calcite-action>
+                <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
+                <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
+                <calcite-action text="Configure attributes" icon="feature-details"> </calcite-action>
+                <calcite-action text="Labels" icon="label"> </calcite-action>
+                <calcite-action text="Tablew" icon="table"> </calcite-action>
+                <calcite-action icon="search" text="Search"></calcite-action>
+                <calcite-action icon="measure" text="Measure"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="road-sign" text="Directions"></calcite-action>
+                <calcite-action icon="point" text="Location"></calcite-action>
+                <calcite-action icon="pencil-square" text="Edit" disabled></calcite-action>
+                <calcite-action icon="clock" text="Time" disabled></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Tips" id="tip-manager-button">
+                  <calcite-icon icon="lightbulb" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-button
+              slot="header"
+              color="inverse"
+              alignment="icon-end-space-between"
+              icon-end="caret-down"
+              width="full"
+            >
+              It's a header button with really long text that should wrap, you know?
+            </calcite-button>
+            <div class="calcite-match-height">
+              <something class="calcite-match-height">
+                <div class="calcite-match-height">
+                  <div class="calcite-match-height">
+                    <calcite-flow>
+                      <calcite-panel heading="first panel"> Test </calcite-panel>
+                      <calcite-panel heading="Flow & DIVs" summary="Extra nested divs" dismissible>
+                        <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
+                          <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
+                            <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
+                              <calcite-action
+                                slot="actions-end"
+                                text="click-me"
+                                onClick="console.log('clicked');"
+                                icon="x"
+                              >
+                              </calcite-action>
+                            </calcite-value-list-item>
+                            <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
+                              <calcite-action
+                                slot="actions-end"
+                                text="click-me"
+                                onClick="console.log('clicked');"
+                                icon="x"
+                              >
+                              </calcite-action>
+                            </calcite-value-list-item>
+                            <calcite-value-list-item
+                              label="Fish. But not just any fish."
+                              description="Easy to care for."
+                              value="fish"
+                            >
+                              <calcite-action
+                                slot="actions-end"
+                                text="click-me"
+                                onClick="console.log('clicked');"
+                                icon="x"
+                              >
+                              </calcite-action>
+                            </calcite-value-list-item>
+                          </calcite-value-list>
+
+                          <!-- Using Button -->
+                          <calcite-label scale="s">
+                            It's a label (btn).
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-button
+                                slot="input-action"
+                                appearance="transparent"
+                                color="neutral"
+                                icon-start="brackets-curly"
+                                scale="s"
+                              ></calcite-button>
+                            </calcite-input>
+                          </calcite-label>
+                          <!-- Using Action -->
+                          <calcite-label scale="s">
+                            It's a label (action).
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="pencil"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                          <calcite-block-section text="Section is cool">
+                            <calcite-label scale="s">
+                              It's a label.
+                              <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                            </calcite-label>
+                          </calcite-block-section>
+                          <calcite-block-section text="Switch section" toggle-display="switch">
+                            <calcite-label scale="s">
+                              It's a label.
+                              <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                            </calcite-label>
+                          </calcite-block-section>
+                        </calcite-block>
+
+                        <calcite-block heading="With control" summary="Collapsible" collapsible>
+                          <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                        </calcite-block>
+                        <calcite-block heading="Basic" summary="Not collapsible">
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s">
+                              <calcite-action
+                                text="cool action"
+                                icon="brackets-curly"
+                                slot="input-action"
+                                scale="s"
+                              ></calcite-action>
+                            </calcite-input>
+                          </calcite-label>
+                        </calcite-block>
+
+                        <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
+                        <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
+                          Add label class
+                        </calcite-tooltip>
+                        <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
+                        <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                      </calcite-panel>
+                    </calcite-flow>
+                  </div>
+                </div>
+              </something>
+            </div>
+          </calcite-shell-panel>
+          <div class="gnav" slot="shell-header">
+            <h2>Cool app</h2>
+          </div>
+          <div id="viewDiv"></div>
+
+          <footer slot="shell-footer">Footer</footer>
+        </calcite-shell>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/demos/shell/nesting-testing.html
+++ b/src/demos/shell/nesting-testing.html
@@ -114,180 +114,154 @@
             >
               It's a header button with really long text that should wrap, you know?
             </calcite-button>
-            <div class="calcite-match-height">
-              <something class="calcite-match-height">
-                <div class="calcite-match-height">
-                  <div class="calcite-match-height">
-                    <calcite-panel heading="Panel & DIVs" summary="Extra nested divs" dismissible>
-                      <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
-                        <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
-                          <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
-                            <calcite-action
-                              slot="actions-end"
-                              text="click-me"
-                              onClick="console.log('clicked');"
-                              icon="x"
-                            >
-                            </calcite-action>
-                          </calcite-value-list-item>
-                          <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
-                            <calcite-action
-                              slot="actions-end"
-                              text="click-me"
-                              onClick="console.log('clicked');"
-                              icon="x"
-                            >
-                            </calcite-action>
-                          </calcite-value-list-item>
-                          <calcite-value-list-item
-                            label="Fish. But not just any fish."
-                            description="Easy to care for."
-                            value="fish"
-                          >
-                            <calcite-action
-                              slot="actions-end"
-                              text="click-me"
-                              onClick="console.log('clicked');"
-                              icon="x"
-                            >
-                            </calcite-action>
-                          </calcite-value-list-item>
-                        </calcite-value-list>
+            <some-custom-element class="calcite-match-height">
+              <calcite-panel heading="Panel & DIVs" summary="Extra nested divs" dismissible>
+                <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
+                  <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
+                    <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
+                      <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                      </calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
+                      <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                      </calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item
+                      label="Fish. But not just any fish."
+                      description="Easy to care for."
+                      value="fish"
+                    >
+                      <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                      </calcite-action>
+                    </calcite-value-list-item>
+                  </calcite-value-list>
 
-                        <!-- Using Button -->
-                        <calcite-label scale="s">
-                          It's a label (btn).
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-button
-                              slot="input-action"
-                              appearance="transparent"
-                              color="neutral"
-                              icon-start="brackets-curly"
-                              scale="s"
-                            ></calcite-button>
-                          </calcite-input>
-                        </calcite-label>
-                        <!-- Using Action -->
-                        <calcite-label scale="s">
-                          It's a label (action).
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="pencil"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
+                  <!-- Using Button -->
+                  <calcite-label scale="s">
+                    It's a label (btn).
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-button
+                        slot="input-action"
+                        appearance="transparent"
+                        color="neutral"
+                        icon-start="brackets-curly"
+                        scale="s"
+                      ></calcite-button>
+                    </calcite-input>
+                  </calcite-label>
+                  <!-- Using Action -->
+                  <calcite-label scale="s">
+                    It's a label (action).
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action text="cool action" icon="pencil" slot="input-action" scale="s"></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
 
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                        <calcite-block-section text="Section is cool">
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
-                          </calcite-label>
-                        </calcite-block-section>
-                        <calcite-block-section text="Switch section" toggle-display="switch">
-                          <calcite-label scale="s">
-                            It's a label.
-                            <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
-                          </calcite-label>
-                        </calcite-block-section>
-                      </calcite-block>
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <calcite-block-section text="Section is cool">
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                    </calcite-label>
+                  </calcite-block-section>
+                  <calcite-block-section text="Switch section" toggle-display="switch">
+                    <calcite-label scale="s">
+                      It's a label.
+                      <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                    </calcite-label>
+                  </calcite-block-section>
+                </calcite-block>
 
-                      <calcite-block heading="With control" summary="Collapsible" collapsible>
-                        <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                      </calcite-block>
-                      <calcite-block heading="Basic" summary="Not collapsible">
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                        <calcite-label scale="s">
-                          It's a label.
-                          <calcite-input type="text" placeholder="This is stuff." scale="s">
-                            <calcite-action
-                              text="cool action"
-                              icon="brackets-curly"
-                              slot="input-action"
-                              scale="s"
-                            ></calcite-action>
-                          </calcite-input>
-                        </calcite-label>
-                      </calcite-block>
+                <calcite-block heading="With control" summary="Collapsible" collapsible>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                </calcite-block>
+                <calcite-block heading="Basic" summary="Not collapsible">
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <calcite-label scale="s">
+                    It's a label.
+                    <calcite-input type="text" placeholder="This is stuff." scale="s">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                </calcite-block>
 
-                      <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
-                      <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
-                        Add label class
-                      </calcite-tooltip>
-                      <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                      <calcite-button slot="footer-actions" width="half">Done</calcite-button>
-                    </calcite-panel>
-                  </div>
-                </div>
-              </something>
-            </div>
+                <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
+                <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
+                  Add label class
+                </calcite-tooltip>
+                <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
+                <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+              </calcite-panel>
+            </some-custom-element>
           </calcite-shell-panel>
           <div class="gnav" slot="shell-header">
             <h2>Cool app</h2>
@@ -296,7 +270,7 @@
 
           <footer slot="shell-footer">Footer</footer>
         </calcite-shell>
-      </div> 
+      </div>
     </main>
   </body>
 </html>

--- a/src/demos/shell/nesting-testing.html
+++ b/src/demos/shell/nesting-testing.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+
+    <title>Nesting Testing with a Panel</title>
+
+    <script src="../_assets/head.js"></script>
+
+    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.15/"></script>
+    <style>
+      html,
+      body,
+      main,
+      .shell-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <style>
+      #viewDiv {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
+        });
+
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap
+        });
+        view.when(function () {
+          view.ui.move("zoom", "bottom-right");
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <main>
+      <div class="shell-container">
+        <calcite-shell content-behind>
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
+            <calcite-action-bar slot="action-bar" theme="dark">
+              <calcite-action-group>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action icon="map" text="New"> </calcite-action>
+                <calcite-action icon="collection" text="Open"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers"> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action text="Share" icon="share"></calcite-action>
+                <calcite-action text="Print" icon="print"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Feedback" icon="speech-bubble-plus"></calcite-action>
+                <calcite-action text="What's next" icon="mega-phone"></calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+          </calcite-shell-panel>
+
+          <calcite-shell-panel slot="contextual-panel" position="end">
+            <calcite-action-bar slot="action-bar">
+              <calcite-action-group>
+                <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
+                <calcite-action text="Styles" icon="shapes"> </calcite-action>
+                <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
+                <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
+                <calcite-action text="Configure attributes" icon="feature-details"> </calcite-action>
+                <calcite-action text="Labels" icon="label"> </calcite-action>
+                <calcite-action text="Tablew" icon="table"> </calcite-action>
+                <calcite-action icon="search" text="Search"></calcite-action>
+                <calcite-action icon="measure" text="Measure"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="road-sign" text="Directions"></calcite-action>
+                <calcite-action icon="point" text="Location"></calcite-action>
+                <calcite-action icon="pencil-square" text="Edit" disabled></calcite-action>
+                <calcite-action icon="clock" text="Time" disabled></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Tips" id="tip-manager-button">
+                  <calcite-icon icon="lightbulb" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-button
+              slot="header"
+              color="inverse"
+              alignment="icon-end-space-between"
+              icon-end="caret-down"
+              width="full"
+            >
+              It's a header button with really long text that should wrap, you know?
+            </calcite-button>
+            <div class="calcite-match-height">
+              <something class="calcite-match-height">
+                <div class="calcite-match-height">
+                  <div class="calcite-match-height">
+                    <calcite-panel heading="Panel & DIVs" summary="Extra nested divs" dismissible>
+                      <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
+                        <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
+                          <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
+                            <calcite-action
+                              slot="actions-end"
+                              text="click-me"
+                              onClick="console.log('clicked');"
+                              icon="x"
+                            >
+                            </calcite-action>
+                          </calcite-value-list-item>
+                          <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
+                            <calcite-action
+                              slot="actions-end"
+                              text="click-me"
+                              onClick="console.log('clicked');"
+                              icon="x"
+                            >
+                            </calcite-action>
+                          </calcite-value-list-item>
+                          <calcite-value-list-item
+                            label="Fish. But not just any fish."
+                            description="Easy to care for."
+                            value="fish"
+                          >
+                            <calcite-action
+                              slot="actions-end"
+                              text="click-me"
+                              onClick="console.log('clicked');"
+                              icon="x"
+                            >
+                            </calcite-action>
+                          </calcite-value-list-item>
+                        </calcite-value-list>
+
+                        <!-- Using Button -->
+                        <calcite-label scale="s">
+                          It's a label (btn).
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-button
+                              slot="input-action"
+                              appearance="transparent"
+                              color="neutral"
+                              icon-start="brackets-curly"
+                              scale="s"
+                            ></calcite-button>
+                          </calcite-input>
+                        </calcite-label>
+                        <!-- Using Action -->
+                        <calcite-label scale="s">
+                          It's a label (action).
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="pencil"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                        <calcite-block-section text="Section is cool">
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                          </calcite-label>
+                        </calcite-block-section>
+                        <calcite-block-section text="Switch section" toggle-display="switch">
+                          <calcite-label scale="s">
+                            It's a label.
+                            <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                          </calcite-label>
+                        </calcite-block-section>
+                      </calcite-block>
+
+                      <calcite-block heading="With control" summary="Collapsible" collapsible>
+                        <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                      </calcite-block>
+                      <calcite-block heading="Basic" summary="Not collapsible">
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s">
+                            <calcite-action
+                              text="cool action"
+                              icon="brackets-curly"
+                              slot="input-action"
+                              scale="s"
+                            ></calcite-action>
+                          </calcite-input>
+                        </calcite-label>
+                      </calcite-block>
+
+                      <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
+                      <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
+                        Add label class
+                      </calcite-tooltip>
+                      <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
+                      <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                    </calcite-panel>
+                  </div>
+                </div>
+              </something>
+            </div>
+          </calcite-shell-panel>
+          <div class="gnav" slot="shell-header">
+            <h2>Cool app</h2>
+          </div>
+          <div id="viewDiv"></div>
+
+          <footer slot="shell-footer">Footer</footer>
+        </calcite-shell>
+      </div> 
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
**Related Issue:** #1927

## Summary
Adds a utility class **to ShellPanel** for setting proper heights and scrolling for content that is not an internal component.
This is an opt-in class.

It should help with multiple levels of nested nodes.
See the nesting-testing demos.

cc @AdelheidF @kevindoshier 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
