### PR TITLE
test(shell-panel, panel): adds test to ensure panel height matches shell-panel content node

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -175,4 +175,34 @@ describe("calcite-shell-panel", () => {
     expect(width2).toEqual(widthDefault * multipier);
 
   });
+
+  it("calcite-panel should render at the same height as the content__body.", async () => {
+    const page = await newE2EPage();
+
+    await page.setViewport({width: 1600, height: 1200});
+    await page.setContent(`
+      <div style="width: 100%; height: 100%;">
+        <calcite-shell>
+          <calcite-shell-panel slot="primary-panel">
+            <calcite-button slot="headder">Header test</calcite-button>
+            <calcite-panel>
+              Content test
+            </calcite-panel>
+          </calcite-shell-panel>
+        </calcite-shell>
+      </div>
+    `);
+
+    await page.waitForChanges();
+
+    const shellContent = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
+    const shellHeightStyle = await shellContent.getComputedStyle('height');
+    const shellHeight = parseFloat(shellHeightStyle['height']);
+
+    const panel = await page.find(`calcite-panel`);
+    const panelHeightStyle = await panel.getComputedStyle('height');
+    const panelHeight = parseFloat(panelHeightStyle['height']);
+
+    expect(panelHeight).toEqual(shellHeight);
+  });
 });


### PR DESCRIPTION
**Related Issue:**  (#1919)

## Summary
Adds test to ensure Panel height matches the content node of ShellPanel.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
