### PR TITLE
fix(combobox): open combobox in the correct direction

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -131,7 +131,7 @@
 
 @include popperElemAnim(".popper-container");
 
-:host([active]) .popper-container {
+.popper-container--active {
   @include popperWrapperActive();
 }
 
@@ -167,12 +167,12 @@
   @apply mr-0;
 }
 
-:host([dir="rtl"]) .chip {
+.chip--rtl {
   margin-right: unset;
   margin-left: var(--calcite-combobox-item-spacing-unit-m);
 }
 
-:host([dir="rtl"]) .chip:last-child {
+.chip--rtl:last-child {
   @apply ml-0;
 }
 


### PR DESCRIPTION
## Summary

We were running into issues where at first, a combobox would _always_ open down. Any scrolling or recalculation would make it move to the top (correct), but initially it was wrong. 

Digging in, this is because we were setting the height to `0` as part of https://github.com/Esri/calcite-components/pull/1577

So this pr, we first show the items (giving the menu height), then reposition before showing the menu itself. Also removed the `dir` prop on the host component as I think we're getting rid of those. 