### PR TITLE
feat(color-picker): restore previous value when there is no color and input is nudged

### DIFF
--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.e2e.ts
@@ -324,30 +324,38 @@ describe("calcite-color-picker-hex-input", () => {
         await assertTabAndEnterBehavior("", null);
       });
 
-      it("does not allow nudging when no-color is allowed and set", async () => {
+      it("restores previous value when a nudge key is pressed and no-color is allowed and set", async () => {
         const noColorValue = null;
-
+        await input.setProperty("value", noColorValue);
+        await page.waitForChanges();
         await input.callMethod("setFocus");
+
+        await page.keyboard.press("ArrowUp");
+        await page.waitForChanges();
+        expect(await input.getProperty("value")).toBe(startingHex);
+
         await input.setProperty("value", noColorValue);
         await page.waitForChanges();
 
-        await page.keyboard.press("ArrowUp");
-        await page.waitForChanges();
-        expect(await input.getProperty("value")).toBe(noColorValue);
-
         await page.keyboard.press("ArrowDown");
         await page.waitForChanges();
-        expect(await input.getProperty("value")).toBe(noColorValue);
+        expect(await input.getProperty("value")).toBe(startingHex);
+
+        await input.setProperty("value", noColorValue);
+        await page.waitForChanges();
 
         await page.keyboard.down("Shift");
         await page.keyboard.press("ArrowUp");
         await page.keyboard.up("Shift");
-        expect(await input.getProperty("value")).toBe(noColorValue);
+        expect(await input.getProperty("value")).toBe(startingHex);
+
+        await input.setProperty("value", noColorValue);
+        await page.waitForChanges();
 
         await page.keyboard.down("Shift");
         await page.keyboard.press("ArrowDown");
         await page.keyboard.up("Shift");
-        expect(await input.getProperty("value")).toBe(noColorValue);
+        expect(await input.getProperty("value")).toBe(startingHex);
       });
     });
   });

--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
@@ -115,6 +115,7 @@ export class CalciteColorPickerHexInput {
         const { internalColor } = this;
         const changed = !internalColor || normalized !== normalizeHex(internalColor.hex());
         this.internalColor = Color(normalized);
+        this.previousNonNullValue = normalized;
         this.value = normalized;
 
         if (changed) {
@@ -188,9 +189,15 @@ export class CalciteColorPickerHexInput {
     const { altKey, ctrlKey, metaKey, shiftKey } = event;
     const { el, inputNode, internalColor, value } = this;
     const key = getKey(event.key);
-    const nudgeable = value && (key === "ArrowDown" || key === "ArrowUp");
+    const isNudgeKey = key === "ArrowDown" || key === "ArrowUp";
 
-    if (nudgeable) {
+    if (isNudgeKey) {
+      if (!value) {
+        this.value = this.previousNonNullValue;
+        event.preventDefault();
+        return;
+      }
+
       const direction = key === "ArrowUp" ? 1 : -1;
       const bump = shiftKey ? 10 : 1;
 
@@ -230,6 +237,8 @@ export class CalciteColorPickerHexInput {
    * The last valid/selected color. Used as a fallback if an invalid hex code is entered.
    */
   @State() internalColor: Color | null = DEFAULT_COLOR;
+
+  private previousNonNullValue: string = this.value;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -849,34 +849,45 @@ describe("calcite-color-picker", () => {
           });
         });
 
-        it("does not allow nudging values", async () => {
+        it("restores previous color value when a nudge key is pressed", async () => {
+          const consistentRgbHsvChannelValue = "0";
+          const initialValue = "#".padEnd(7, consistentRgbHsvChannelValue);
+
           const assertChannelValueNudge = async (page: E2EPage, calciteInput: E2EElement): Promise<void> => {
             await calciteInput.callMethod("setFocus");
             await page.waitForChanges();
 
+            await clearAndEnterValue(page, calciteInput, "");
+
             await page.keyboard.press("ArrowUp");
             await page.waitForChanges();
-            expect(await calciteInput.getProperty("value")).toBe("");
+            expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
+
+            await clearAndEnterValue(page, calciteInput, "");
 
             await page.keyboard.press("ArrowDown");
             await page.waitForChanges();
-            expect(await calciteInput.getProperty("value")).toBe("");
+            expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
+
+            await clearAndEnterValue(page, calciteInput, "");
 
             await page.keyboard.down("Shift");
             await page.keyboard.press("ArrowUp");
             await page.keyboard.up("Shift");
             await page.waitForChanges();
-            expect(await calciteInput.getProperty("value")).toBe("");
+            expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
+
+            await clearAndEnterValue(page, calciteInput, "");
 
             await page.keyboard.down("Shift");
             await page.keyboard.press("ArrowDown");
             await page.keyboard.up("Shift");
             await page.waitForChanges();
-            expect(await calciteInput.getProperty("value")).toBe("");
+            expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
           };
 
           const page = await newE2EPage({
-            html: "<calcite-color-picker allow-empty value=''></calcite-color-picker>"
+            html: `<calcite-color-picker allow-empty value='${initialValue}'></calcite-color-picker>`
           });
 
           const [rgbModeButton, hsvModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -399,6 +399,7 @@ export class CalciteColorPicker {
     const key = getKey(event.key);
 
     if (!this.color && (key === "ArrowUp" || key === "ArrowDown")) {
+      this.internalColorSet(this.previousColor, true);
       event.preventDefault();
       return;
     }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

The color picker was recently updated to use the previous value when there is none and either the hue or saturation/value thumbs are modified via keyboard. This updates the color picker inputs to be consistent with this behavior. 👍🏼 👍🏼 