### PR TITLE
docs(storybook): prevent component story key presses from activating storybook shortcuts

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -34,3 +34,16 @@
     margin-top: 1rem;
   }
 </style>
+
+<script>
+  window.addEventListener("load", () => {
+    document.addEventListener("keydown", (event) => {
+      const bubbledFromComponentStory = event.composedPath()
+        .some((element) => element.tagName?.toLowerCase().startsWith("calcite-"));
+
+      if (bubbledFromComponentStory) {
+        event.stopPropagation();
+      }
+    });
+  }, { once: true });
+</script>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR aims to keep the existing shortcuts outside of component previews by blocking keydown events coming from users interacting with a component.