### PR TITLE
fix(block, date, panel, pick-list, pick-list-group, tip, tip-manager)!: Remove default 'headingLevel' value.  #1710

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -15,7 +15,7 @@ describe("calcite-block", () => {
       },
       {
         propertyName: "headingLevel",
-        defaultValue: 4
+        defaultValue: undefined
       },
       {
         propertyName: "open",

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -45,7 +45,7 @@ export class CalciteBlock {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
+  @Prop() headingLevel: HeadingLevel;
 
   /**
    * Tooltip used for the toggle when expanded.
@@ -153,7 +153,7 @@ export class CalciteBlock {
           </div>
         ) : null}
         <div class={CSS.title}>
-          <CalciteHeading class={CSS.heading} level={headingLevel}>
+          <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
             {heading}
           </CalciteHeading>
           {summary ? <div class={CSS.summary}>{summary}</div> : null}

--- a/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
@@ -15,7 +15,7 @@ describe("calcite-date-picker", () => {
       },
       {
         propertyName: "headingLevel",
-        defaultValue: 2
+        defaultValue: undefined
       },
       {
         propertyName: "intlNextMonth",

--- a/src/components/calcite-date-picker/calcite-date-picker.tsx
+++ b/src/components/calcite-date-picker/calcite-date-picker.tsx
@@ -50,7 +50,7 @@ export class CalciteDatePicker {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
+  @Prop() headingLevel: HeadingLevel;
 
   /** Selected date as full date object*/
   @Prop({ mutable: true }) valueAsDate?: Date;
@@ -371,7 +371,7 @@ export class CalciteDatePicker {
         <calcite-date-picker-month-header
           activeDate={activeDate}
           dir={dir}
-          headingLevel={this.headingLevel}
+          headingLevel={this.headingLevel || HEADING_LEVEL}
           intlNextMonth={this.intlNextMonth}
           intlPrevMonth={this.intlPrevMonth}
           localeData={this.localeData}

--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -15,7 +15,7 @@ describe("calcite-panel", () => {
       },
       {
         propertyName: "headingLevel",
-        defaultValue: 3
+        defaultValue: undefined
       }
     ]));
 

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -65,7 +65,7 @@ export class CalcitePanel {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
+  @Prop() headingLevel: HeadingLevel;
 
   /**
    * Shows a back button in the header.
@@ -247,7 +247,7 @@ export class CalcitePanel {
   renderHeaderContent(): VNode {
     const { heading, headingLevel, summary } = this;
     const headingNode = heading ? (
-      <CalciteHeading class={CSS.heading} level={headingLevel}>
+      <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
         {heading}
       </CalciteHeading>
     ) : null;

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
@@ -20,7 +20,7 @@ describe("calcite-pick-list-group", () => {
     defaults("calcite-pick-list-group", [
       {
         propertyName: "headingLevel",
-        defaultValue: 3
+        defaultValue: undefined
       }
     ]));
 

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -3,7 +3,7 @@ import { CSS, SLOTS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { HEADING_LEVEL } from "./resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
-import { HeadingLevel, CalciteHeading, ConstrainHeadingLevel } from "../functional/CalciteHeading";
+import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../functional/CalciteHeading";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
@@ -57,7 +57,7 @@ export class CalcitePickListGroup {
 
     const title = groupTitle;
     const parentLevel = el.closest("calcite-pick-list")?.headingLevel;
-    const relativeLevel = parentLevel ? ConstrainHeadingLevel(parentLevel + 1) : null;
+    const relativeLevel = parentLevel ? constrainHeadingLevel(parentLevel + 1) : null;
     const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return (

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -3,7 +3,7 @@ import { CSS, SLOTS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { HEADING_LEVEL } from "./resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
-import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
+import { HeadingLevel, CalciteHeading, ConstrainHeadingLevel } from "../functional/CalciteHeading";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
@@ -29,7 +29,7 @@ export class CalcitePickListGroup {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
+  @Prop() headingLevel: HeadingLevel;
 
   // --------------------------------------------------------------------------
   //
@@ -56,11 +56,14 @@ export class CalcitePickListGroup {
     };
 
     const title = groupTitle;
+    const parentLevel = el.closest("calcite-pick-list")?.headingLevel;
+    const relativeLevel = parentLevel ? ConstrainHeadingLevel(parentLevel + 1) : null;
+    const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return (
       <Host>
         {title ? (
-          <CalciteHeading class={CSS.heading} level={headingLevel}>
+          <CalciteHeading class={CSS.heading} level={level}>
             {title}
           </CalciteHeading>
         ) : null}

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -1,6 +1,6 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { ICON_TYPES } from "./resources";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, hidden, renders, defaults } from "../../tests/commonTests";
 import {
   selectionAndDeselection,
   filterBehavior,
@@ -10,8 +10,17 @@ import {
   focusing
 } from "./shared-list-tests";
 import { html } from "../../tests/utils";
+import { CSS as PICK_LIST_GROUP_CSS } from "../calcite-pick-list-group/resources";
 
 describe("calcite-pick-list", () => {
+  it("has property defaults", async () =>
+    defaults("calcite-pick-list", [
+      {
+        propertyName: "headingLevel",
+        defaultValue: undefined
+      }
+    ]));
+
   it("renders", async () => renders("calcite-pick-list"));
 
   it("honors hidden attribute", async () => hidden("calcite-pick-list"));
@@ -171,4 +180,25 @@ describe("calcite-pick-list", () => {
   describe("disabled states", () => disabledStates("pick"));
 
   describe("setFocus", () => focusing("pick"));
+
+  it("should set headingLevel of tip", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-pick-list heading-level="1">
+      <calcite-pick-list-group group-title="test">
+        <calcite-pick-list-item value="1" label="One" description="uno"></calcite-pick-list-item>
+        <calcite-pick-list-item value="2" label="Two" description="dos"></calcite-pick-list-item>
+      </calcite-pick-list-group>
+    </calcite-pick-list>`
+    });
+
+    await page.waitForChanges();
+
+    const pickList = await page.find("calcite-pick-list");
+
+    expect(await pickList.getProperty("headingLevel")).toEqual(1);
+
+    const heading = await page.find(`calcite-pick-list-group >>> .${PICK_LIST_GROUP_CSS.heading}`);
+
+    expect(heading.tagName).toEqual("H2");
+  });
 });

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -31,6 +31,7 @@ import {
 } from "./shared-list-logic";
 import List from "./shared-list-render";
 import { Theme } from "../interfaces";
+import { HeadingLevel } from "../functional/CalciteHeading";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
@@ -64,6 +65,11 @@ export class CalcitePickList<
    * Placeholder text for the filter input field.
    */
   @Prop({ reflect: true }) filterPlaceholder: string;
+
+  /**
+   * Number at which section headings should start for this component.
+   */
+  @Prop() headingLevel: HeadingLevel;
 
   /**
    * When true, content is waiting to be loaded. This state shows a busy indicator.

--- a/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
@@ -215,4 +215,24 @@ describe("calcite-tip-manager", () => {
       expect(selectedTip.id).toEqual("two");
     });
   });
+
+  it("should set headingLevel of tip", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<calcite-tip-manager heading-level="1">
+        <calcite-tip id="one" heading="test"><p>no pre-selected attribute</p></calcite-tip>
+      </calcite-tip-manager>`
+    );
+
+    await page.waitForChanges();
+
+    const tipManager = await page.find("calcite-tip-manager");
+
+    expect(await tipManager.getProperty("headingLevel")).toEqual(1);
+
+    const heading = await page.find(`calcite-tip >>> .${CSS.heading}`);
+
+    expect(heading.tagName).toEqual("H2");
+  });
 });

--- a/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
@@ -23,7 +23,7 @@ describe("calcite-tip-manager", () => {
       defaults("calcite-tip-manager", [
         {
           propertyName: "headingLevel",
-          defaultValue: 2
+          defaultValue: undefined
         }
       ]));
 

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -14,7 +14,7 @@ import {
 import { CSS, ICONS, TEXT, HEADING_LEVEL } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { Theme } from "../interfaces";
-import { HeadingLevel, CalciteHeading, ConstrainHeadingLevel } from "../functional/CalciteHeading";
+import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
  * @slot - A slot for adding `calcite-tip`s.
@@ -44,7 +44,7 @@ export class CalciteTipManager {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
+  @Prop() headingLevel: HeadingLevel;
 
   /**
    * Alternate text for closing the tip.
@@ -168,7 +168,6 @@ export class CalciteTipManager {
     this.selectedIndex = selectedTip ? tips.indexOf(selectedTip) : 0;
 
     tips.forEach((tip) => {
-      tip.headingLevel = ConstrainHeadingLevel(this.headingLevel + 1);
       tip.nonDismissible = true;
     });
     this.showSelectedTip();
@@ -283,7 +282,7 @@ export class CalciteTipManager {
           tabIndex={0}
         >
           <header class={CSS.header}>
-            <CalciteHeading class={CSS.heading} level={headingLevel}>
+            <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
               {groupTitle}
             </CalciteHeading>
             <calcite-action

--- a/src/components/calcite-tip/calcite-tip.e2e.ts
+++ b/src/components/calcite-tip/calcite-tip.e2e.ts
@@ -11,7 +11,7 @@ describe("calcite-tip", () => {
     defaults("calcite-tip", [
       {
         propertyName: "headingLevel",
-        defaultValue: 3
+        defaultValue: undefined
       }
     ]));
 

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@
 import { Theme } from "../interfaces";
 import { CSS, ICONS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
-import { HeadingLevel, CalciteHeading, ConstrainHeadingLevel } from "../functional/CalciteHeading";
+import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../functional/CalciteHeading";
 
 /**
  * @slot thumbnail - A slot for adding an HTML image element to the tip.
@@ -93,7 +93,7 @@ export class CalciteTip {
   renderHeader(): VNode {
     const { heading, headingLevel, el } = this;
     const parentLevel = el.closest("calcite-tip-manager")?.headingLevel;
-    const relativeLevel = parentLevel ? ConstrainHeadingLevel(parentLevel + 1) : null;
+    const relativeLevel = parentLevel ? constrainHeadingLevel(parentLevel + 1) : null;
     const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return heading ? (

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@
 import { Theme } from "../interfaces";
 import { CSS, ICONS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
-import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
+import { HeadingLevel, CalciteHeading, ConstrainHeadingLevel } from "../functional/CalciteHeading";
 
 /**
  * @slot thumbnail - A slot for adding an HTML image element to the tip.
@@ -36,7 +36,7 @@ export class CalciteTip {
   /**
    * Number at which section headings should start for this component.
    */
-  @Prop() headingLevel: HeadingLevel = HEADING_LEVEL;
+  @Prop() headingLevel: HeadingLevel;
 
   /**
    * The selected state of the tip if it is being used inside a `calcite-tip-manager`.
@@ -91,11 +91,14 @@ export class CalciteTip {
   // --------------------------------------------------------------------------
 
   renderHeader(): VNode {
-    const { heading, headingLevel } = this;
+    const { heading, headingLevel, el } = this;
+    const parentLevel = el.closest("calcite-tip-manager")?.headingLevel;
+    const relativeLevel = parentLevel ? ConstrainHeadingLevel(parentLevel + 1) : null;
+    const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return heading ? (
       <header class={CSS.header}>
-        <CalciteHeading class={CSS.heading} level={headingLevel}>
+        <CalciteHeading class={CSS.heading} level={level}>
           {heading}
         </CalciteHeading>
       </header>

--- a/src/components/functional/CalciteHeading.spec.tsx
+++ b/src/components/functional/CalciteHeading.spec.tsx
@@ -1,15 +1,15 @@
 import { h, Component } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
-import { CalciteHeading, ConstrainHeadingLevel } from "./CalciteHeading";
+import { CalciteHeading, constrainHeadingLevel } from "./CalciteHeading";
 
-describe("ConstrainHeadingLevel", () => {
+describe("constrainHeadingLevel", () => {
   it("should constrain heading levels", () => {
-    expect(ConstrainHeadingLevel(10)).toEqual(6);
-    expect(ConstrainHeadingLevel(6)).toEqual(6);
-    expect(ConstrainHeadingLevel(5)).toEqual(5);
-    expect(ConstrainHeadingLevel(1)).toEqual(1);
-    expect(ConstrainHeadingLevel(0)).toEqual(1);
-    expect(ConstrainHeadingLevel(3.14)).toEqual(4);
+    expect(constrainHeadingLevel(10)).toEqual(6);
+    expect(constrainHeadingLevel(6)).toEqual(6);
+    expect(constrainHeadingLevel(5)).toEqual(5);
+    expect(constrainHeadingLevel(1)).toEqual(1);
+    expect(constrainHeadingLevel(0)).toEqual(1);
+    expect(constrainHeadingLevel(3.14)).toEqual(4);
   });
 });
 

--- a/src/components/functional/CalciteHeading.tsx
+++ b/src/components/functional/CalciteHeading.tsx
@@ -7,7 +7,7 @@ interface CalciteHeadingProps extends JSXBase.HTMLAttributes {
   level: HeadingLevel;
 }
 
-export function ConstrainHeadingLevel(level: number): HeadingLevel {
+export function constrainHeadingLevel(level: number): HeadingLevel {
   return Math.min(Math.max(Math.ceil(level), 1), 6) as HeadingLevel;
 }
 


### PR DESCRIPTION
**Related Issue:** #1710

## Summary

fix(block, date, panel, pick-list, pick-list-group, tip, tip-manager)!: Remove default 'headingLevel' value. 

Removes the default headingLevel value and child elements will calculate the value relative to their parent components.
