### PR TITLE
fix(color-picker): fix color field thumb nudging when saturation change does not change the color's RGB value

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -1117,6 +1117,28 @@ describe("calcite-color-picker", () => {
       await scope.press("ArrowLeft");
       expect(await picker.getProperty("value")).toBe("#ededed");
     });
+
+    it("allows nudging color's saturation even if it does not change RGB value", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-color-picker value="#000"></calcite-color-picker>`
+      });
+      const scope = await page.find(`calcite-color-picker >>> .${CSS.scope}`);
+
+      const initialStyle = await scope.getComputedStyle();
+      expect(initialStyle.left).toBe("0px");
+
+      await scope.click();
+
+      let nudgesToTheEdge = 25;
+
+      while (nudgesToTheEdge--) {
+        await scope.press("ArrowRight");
+      }
+
+      const finalStyle = await scope.getComputedStyle();
+      expect(finalStyle.left).toBe(`${DIMENSIONS.m.colorField.width}px`);
+    });
+
     it("allows editing hue slider via keyboard", async () => {
       const page = await newE2EPage({
         html: `<calcite-color-picker allow-empty value=""></calcite-color-picker>`

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -316,11 +316,12 @@ export class CalciteColorPicker {
 
     if (Object.keys(arrowKeyToXYOffset).includes(key)) {
       event.preventDefault();
-      this.captureColor(
-        this.colorFieldScopeLeft + arrowKeyToXYOffset[key].x || 0,
-        this.colorFieldScopeTop + arrowKeyToXYOffset[key].y || 0
-      );
       this.scopeOrientation = key === "ArrowDown" || key === "ArrowUp" ? "vertical" : "horizontal";
+      this.captureColorFieldColor(
+        this.colorFieldScopeLeft + arrowKeyToXYOffset[key].x || 0,
+        this.colorFieldScopeTop + arrowKeyToXYOffset[key].y || 0,
+        false
+      );
       return;
     }
   };
@@ -888,7 +889,7 @@ export class CalciteColorPicker {
     context.scale(devicePixelRatio, devicePixelRatio);
   }
 
-  private captureColor = (x: number, y: number): void => {
+  private captureColorFieldColor = (x: number, y: number, skipEqual = true): void => {
     const {
       dimensions: {
         colorField: { height, width }
@@ -897,7 +898,10 @@ export class CalciteColorPicker {
     const saturation = Math.round((HSV_LIMITS.s / width) * x);
     const value = Math.round((HSV_LIMITS.v / height) * (height - y));
 
-    this.internalColorSet(this.baseColorFieldColor.hsv().saturationv(saturation).value(value));
+    this.internalColorSet(
+      this.baseColorFieldColor.hsv().saturationv(saturation).value(value),
+      skipEqual
+    );
   };
 
   private initColorFieldAndSlider = (canvas: HTMLCanvasElement): void => {
@@ -936,10 +940,10 @@ export class CalciteColorPicker {
 
       if (region === "color-field") {
         this.hueThumbState = "drag";
-        this.captureColor(offsetX, offsetY);
+        this.captureColorFieldColor(offsetX, offsetY);
       } else if (region === "slider") {
         this.sliderThumbState = "drag";
-        captureSliderColor(offsetX);
+        captureHueSliderColor(offsetX);
       }
     });
 
@@ -994,7 +998,7 @@ export class CalciteColorPicker {
           return;
         }
 
-        this.captureColor(offsetX, offsetY);
+        this.captureColorFieldColor(offsetX, offsetY);
       } else if (region === "slider") {
         const {
           dimensions: {
@@ -1035,11 +1039,11 @@ export class CalciteColorPicker {
           return;
         }
 
-        captureSliderColor(offsetX);
+        captureHueSliderColor(offsetX);
       }
     });
 
-    const captureSliderColor = (x: number): void => {
+    const captureHueSliderColor = (x: number): void => {
       const {
         dimensions: {
           slider: { width }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue saturation/value cannot be nudged if it would produce the same RGB value. This is reproducible by setting the color picker to 000 and then trying to modify saturation/value with the keyboard.