### PR TITLE
fix(tile-select): fix full width tile selects with icons, inputs

### DIFF
--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
@@ -22,6 +22,7 @@ export const Light = (): string => html`
       name="light"
       ${boolean("input-enabled", false)}
       input-alignment="${select("input-alignment", ["start", "end"], "start")}"
+      width="${select("width", ["full", "auto"], "auto")}"
       type="${select("type", ["radio", "checkbox"], "radio")}"
       value="one"
     >
@@ -33,6 +34,7 @@ export const Light = (): string => html`
       name="light"
       ${boolean("input-enabled", false)}
       input-alignment="${select("input-alignment", ["start", "end"], "start")}"
+      width="${select("width", ["full", "auto"], "auto")}"
       type="${select("type", ["radio", "checkbox"], "radio")}"
       value="two"
     >
@@ -44,6 +46,7 @@ export const Light = (): string => html`
       name="light"
       ${boolean("input-enabled", false)}
       input-alignment="${select("input-alignment", ["start", "end"], "start")}"
+      width="${select("width", ["full", "auto"], "auto")}"
       type="${select("type", ["radio", "checkbox"], "radio")}"
       value="three"
     >
@@ -56,6 +59,7 @@ export const Light = (): string => html`
       name="light"
       ${boolean("input-enabled", false)}
       input-alignment="${select("input-alignment", ["start", "end"], "start")}"
+      width="${select("width", ["full", "auto"], "auto")}"
       type="${select("type", ["radio", "checkbox"], "radio")}"
       value="four"
     >

--- a/src/components/calcite-tile-select/calcite-tile-select.scss
+++ b/src/components/calcite-tile-select/calcite-tile-select.scss
@@ -48,8 +48,17 @@ $spacing: $baseline/2;
 
 :host([width="full"]) {
   .root {
-    max-width: none;
-    display: block;
+    @apply max-w-none flex;
+  }
+  calcite-tile {
+    @apply flex-auto;
+  }
+}
+
+:host([input-alignment="start"][width="full"]) {
+  calcite-tile {
+    @apply order-1;
+    margin-inline-start: theme("spacing.3");
   }
 }
 
@@ -66,8 +75,8 @@ $spacing: $baseline/2;
   }
 }
 
-:host([input-enabled][input-alignment="start"][icon][heading][description]),
-:host([input-enabled][input-alignment="start"]:not([icon])[heading]:not([description])) {
+:host([width="auto"][input-enabled][input-alignment="start"][icon][heading][description]),
+:host([width="auto"][input-enabled][input-alignment="start"]:not([icon])[heading]:not([description])) {
   .root {
     display: inline-grid;
     grid-gap: $spacing;

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -229,6 +229,50 @@
                       </calcite-tile-select>
                     </calcite-tile-select-group>
 
+                    <h3>Vertical Layout, Full, No Icon, Input Enabled, Start</h3>
+                    <calcite-tile-select-group layout="vertical">
+                      <calcite-tile-select checked
+                        width="full"
+                        input-enabled
+                        input-alignment="start"
+                        name="start-radio-vertical-dark"
+                        value="one"
+                        heading="Tile title lorem ipsum"
+                        description="test small description"
+                      >
+                      </calcite-tile-select>
+                      <calcite-tile-select
+                        width="full"
+                        input-enabled
+                        input-alignment="start"
+                        name="start-radio-vertical-dark"
+                        value="two"
+                        heading="Tile title lorem ipsum"
+                        description="test small description"
+                      >
+                      </calcite-tile-select>
+                      <calcite-tile-select
+                        width="full"
+                        input-enabled
+                        input-alignment="start"
+                        name="start-radio-vertical-dark"
+                        value="three"
+                        heading="Tile title lorem ipsum"
+                        description="test small description"
+                      >
+                      </calcite-tile-select>
+                      <calcite-tile-select
+                        width="full"
+                        input-enabled
+                        input-alignment="start"
+                        name="start-radio-vertical-dark"
+                        value="four"
+                        heading="Tile title lorem ipsum"
+                        description="test small description"
+                      >
+                      </calcite-tile-select>
+                    </calcite-tile-select-group>
+
                     <h3>Basic Radio</h3>
                     <calcite-tile-select-group>
                       <calcite-tile-select checked icon="layers" name="basic-radio" value="one"


### PR DESCRIPTION
**Related Issue:** #1020

## Summary

There was a CSS issue when you used `width=full` without an icon and with inputs enabled. Example of broken state:

<img width="700" alt="Screen Shot 2021-04-14 at 10 50 20 AM" src="https://user-images.githubusercontent.com/1031758/114756564-bd3e9e80-9d0f-11eb-9fe1-e7eefeceeddd.png">

Notice how in the non-icon example the input alignment is incorrect (should be start) and in the icon example `width=full` is not applying correctly. 

This pr makes the example render correctly. I also added a knob for `width` to satisfy https://github.com/Esri/calcite-components/issues/1020 so devs even know this kind of layout is possible.

@julio8a I can help you update your tile select tailwind pr if this goes in before yours.
