### PR TITLE
refactor(calcite-input): making locale-format false by default

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -731,7 +731,6 @@ export class CalciteColorPicker {
       aria-label={ariaLabel}
       class={CSS.channel}
       data-channel-index={index}
-      localeFormat={false}
       numberButtonType="none"
       onChange={this.handleChannelChange}
       onInput={this.handleChannelInput}

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -661,7 +661,7 @@ describe("calcite-input", () => {
         it(`formats number on initial load for ${locale} locale`, async () => {
           const value = "1234.56";
           const page = await newE2EPage({
-            html: `<calcite-input locale="${locale}" type="number" value="${value}"></calcite-input>`
+            html: `<calcite-input locale="${locale}" locale-format type="number" value="${value}"></calcite-input>`
           });
           const calciteInput = await page.find("calcite-input");
           const input = await page.find("input");
@@ -672,7 +672,7 @@ describe("calcite-input", () => {
 
         it(`allows typing valid decimal characters for ${locale} locale`, async () => {
           const page = await newE2EPage({
-            html: `<calcite-input locale="${locale}" type="number"></calcite-input>`
+            html: `<calcite-input locale="${locale}" locale-format type="number"></calcite-input>`
           });
           const calciteInput = await page.find("calcite-input");
           const input = await page.find("input");

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -84,8 +84,8 @@ export class CalciteInput {
   /** BCP 47 language tag for desired language and country format */
   @Prop() locale?: string = document.documentElement.lang || "en";
 
-  /** Specifies whether to format by locale or not.  This prop can be updated in the future to accept a formatting string. */
-  @Prop() localeFormat = true;
+  /** Specifies whether to format by locale or not. */
+  @Prop() localeFormat = false;
 
   /** input max */
   @Prop({ reflect: true }) max?: number;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -84,7 +84,10 @@ export class CalciteInput {
   /** BCP 47 language tag for desired language and country format */
   @Prop() locale?: string = document.documentElement.lang || "en";
 
-  /** Specifies whether to format by locale or not. */
+  /**
+   * Toggles locale formatting for numbers.
+   * @internal
+   */
   @Prop() localeFormat = false;
 
   /** input max */

--- a/src/demos/calcite-input-number.html
+++ b/src/demos/calcite-input-number.html
@@ -43,9 +43,9 @@
       <calcite-input name="calcite-input" placeholder="plain calcite-input"></calcite-input>
       <input name="native-minmax" minLength="2" maxLength="3" placeholder="minlength=2 maxlength=3"></input>
       <calcite-input name="minmax" minLength="2" maxLength="3" placeholder="minlength=2 maxlength=3" required></calcite-input>
-      <calcite-input type="number" locale="fr" name="french" value="1234.56" step="0.01"></calcite-input>
-      <calcite-input type="number" locale="fr" name="french-whole" value="1234" step="1"></calcite-input>
-      <calcite-input type="number" locale="fr" name="french-novalue" step="1"></calcite-input>
+      <calcite-input type="number" locale="fr" locale-format name="french" value="1234.56" step="0.01"></calcite-input>
+      <calcite-input type="number" locale="fr" locale-format name="french-whole" value="1234" step="1"></calcite-input>
+      <calcite-input type="number" locale="fr" locale-format name="french-novalue" step="1"></calcite-input>
       <demo-spacer>
         <button type="submit">Submit</button>
         <button type="reset">Reset</button>
@@ -68,6 +68,7 @@
       (locale === "ar" || locale === "he") && input.setAttribute("dir", "rtl");
       input.setAttribute("id", locale);
       input.setAttribute("locale", locale);
+      input.setAttribute("locale-format", true);
       input.setAttribute("name", locale);
       input.setAttribute("scale", "s");
       input.setAttribute("type", "number");


### PR DESCRIPTION
**Related Issue:** #1810

This changes `localeFormat` prop to be off by default.