### PR TITLE
fix(custom-elements): ensure root components get a util bundle generated

### DIFF
--- a/conventions/README.md
+++ b/conventions/README.md
@@ -471,6 +471,8 @@ As a best practice we should follow [Ionic's configuration](https://github.com/i
 
 **Note:** This is highly likely to change as we move closer to our first release and as Stencil improves their documentation around their specific methods and build processes.
 
+Each root component should have a corresponding bundle entry in `stencil.config.ts`. It is important that the root component be listed first (the `util:build-custom-elements-output-utils` NPM script depends on this).
+
 ## Unique IDs for Components
 
 Many times it is necessary for components to have a `id="something"` attribute for things like `<label>` and various `aria-*` properties. To safely generate a unique id for a component but to also allow a user supplied `id` attribute to work follow the following pattern:

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -21,9 +21,7 @@ export const create: () => Config = () => ({
     },
     { components: ["calcite-alert"] },
     { components: ["calcite-avatar"] },
-    {
-      components: ["calcite-block", "calcite-block-section"]
-    },
+    { components: ["calcite-block", "calcite-block-section"] },
     { components: ["calcite-button"] },
     { components: ["calcite-card"] },
     { components: ["calcite-checkbox"] },
@@ -32,18 +30,16 @@ export const create: () => Config = () => ({
     { components: ["calcite-combobox", "calcite-combobox-item-group", "calcite-combobox-item"] },
     {
       components: [
-        "calcite-input-date-picker",
         "calcite-date-picker",
         "calcite-date-picker-month",
         "calcite-date-picker-month-header",
         "calcite-date-picker-day"
       ]
     },
-    {
-      components: ["calcite-dropdown", "calcite-dropdown-group", "calcite-dropdown-item"]
-    },
+    { components: ["calcite-dropdown", "calcite-dropdown-group", "calcite-dropdown-item"] },
     { components: ["calcite-icon"] },
     { components: ["calcite-input"] },
+    { components: ["calcite-input-date-picker"] },
     { components: ["calcite-input-message"] },
     { components: ["calcite-label"] },
     { components: ["calcite-link"] },
@@ -52,27 +48,19 @@ export const create: () => Config = () => ({
     { components: ["calcite-notice"] },
     { components: ["calcite-pagination"] },
     { components: ["calcite-fab"] },
-    {
-      components: ["calcite-panel", "calcite-flow"]
-    },
+    { components: ["calcite-panel", "calcite-flow"] },
     { components: ["calcite-popover", "calcite-popover-manager"] },
     { components: ["calcite-progress"] },
     { components: ["calcite-radio-group", "calcite-radio-group-item"] },
     { components: ["calcite-rating"] },
     { components: ["calcite-scrim"] },
     { components: ["calcite-select", "calcite-option", "calcite-option-group"] },
-    {
-      components: ["calcite-shell", "calcite-shell-panel"]
-    },
+    { components: ["calcite-shell", "calcite-shell-panel"] },
     { components: ["calcite-slider"] },
     { components: ["calcite-stepper", "calcite-stepper-item"] },
     { components: ["calcite-switch"] },
-    {
-      components: ["calcite-tab", "calcite-tab-title", "calcite-tab-nav", "calcite-tabs"]
-    },
-    {
-      components: ["calcite-tip", "calcite-tip-group", "calcite-tip-manager"]
-    },
+    { components: ["calcite-tab", "calcite-tab-title", "calcite-tab-nav", "calcite-tabs"] },
+    { components: ["calcite-tip", "calcite-tip-group", "calcite-tip-manager"] },
     { components: ["calcite-tooltip", "calcite-tooltip-manager"] },
     { components: ["calcite-tree", "calcite-tree-item"] }
   ],

--- a/support/output-targets/custom-elements/createBundles.ts
+++ b/support/output-targets/custom-elements/createBundles.ts
@@ -1,22 +1,17 @@
-import { CollectionManifest, JsonDocs } from "@stencil/core/internal";
+import { JsonDocs } from "@stencil/core/internal";
 import { promises as fs } from "fs";
+import { config as componentsConfig } from "../../../stencil.config";
 
 (async () => {
   console.log("generating component bundles");
 
-  let componentsManifest: CollectionManifest;
   let componentsUsageReport: JsonDocs;
 
   try {
     console.log("reading doc");
+
     componentsUsageReport = JSON.parse(
       await fs.readFile(`${__dirname}/../../../dist/extras/docs-json.json`, {
-        encoding: "utf8"
-      })
-    );
-
-    componentsManifest = JSON.parse(
-      await fs.readFile(`${__dirname}/../../../dist/collection/collection-manifest.json`, {
         encoding: "utf8"
       })
     );
@@ -24,7 +19,7 @@ import { promises as fs } from "fs";
     console.log("an error occurred during setup", e);
   }
 
-  if (!componentsManifest || !componentsUsageReport) {
+  if (!componentsUsageReport) {
     console.log("could not generate bundles");
     process.exit(-1);
   }
@@ -37,7 +32,7 @@ import { promises as fs } from "fs";
     console.log("bundle dir already exists");
   }
 
-  for (const { components } of componentsManifest.bundles) {
+  for (const { components } of componentsConfig.bundles) {
     const componentNamespacePrefix = /^calcite/;
     const bundleName = components[0].replace(componentNamespacePrefix, "").replace("-", "");
     const componentDeps = new Set<string>();

--- a/tsconfig-node-scripts.json
+++ b/tsconfig-node-scripts.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
+    "esModuleInterop": true,
     "module": "commonJS"
   }
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

`createBundles.ts` uses `collection-manifest.json` to generate the util bundles for the custom-elements output target (https://github.com/Esri/calcite-components/pull/1499). This would work for most cases except if a bundle in `stencil.config.ts` had component names where sorting them alphabetically moved the 1st item (the Stencil build sorts them when generating the manifest file).

For example, the following would work fine since the root component will remain first after sorting.

```ts
{
  components: [
    "calcite-action",
    "calcite-action-group",
    "calcite-action-menu",
    "calcite-action-bar",
    "calcite-action-pad"
  ]
},
```

By contrast, the following would generate a bundle for `calcite-option` and not `calcite-select` (root) after sorting.

```ts
{
  components: [
    "calcite-select", 
    "calcite-option", 
    "calcite-option-group"
  ]
},
```