### PR TITLE
fix(calcite-input): inputInput event now correctly broadcasts the target element's value (event.target.value) to match event.detail.value

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -424,6 +424,10 @@ export class CalciteInput {
     this.setValue(this.defaultValue, event);
   };
 
+  private sanitizeNumberString(value: string) {
+    return value.endsWith(".") ? value.replace(".", "") : value;
+  }
+
   private setChildElRef = (el) => {
     this.childEl = el;
   };
@@ -445,16 +449,19 @@ export class CalciteInput {
 
   private setLocalizedValue = (unlocalizedValue: string): void => {
     this.localizedValue = localizeNumberString(
-      unlocalizedValue.endsWith(".") ? unlocalizedValue.replace(".", "") : unlocalizedValue,
+      this.sanitizeNumberString(unlocalizedValue),
       this.locale
     );
   };
 
   private setValue = (value: string, nativeEvent): void => {
     const previousValue = this.value;
-    this.value = value;
+    this.value = this.type === "number" ? this.sanitizeNumberString(value) : value;
     if (this.shouldFormatNumberByLocale()) {
       this.setLocalizedValue(value);
+    }
+    if (this.type === "number" && value.endsWith(".")) {
+      return;
     }
     const calciteInputInputEvent = this.calciteInputInput.emit({
       element: this.childEl,

--- a/src/demos/calcite-input-number.html
+++ b/src/demos/calcite-input-number.html
@@ -13,11 +13,13 @@
       color: white;
       padding: 1rem;
     }
+
     #locales {
       display: flex;
       flex-wrap: wrap;
       gap: 12px
     }
+
     .locale {
       width: 200px;
     }
@@ -42,7 +44,9 @@
       <input type="number" value="1234" name="native">
       <calcite-input name="calcite-input" placeholder="plain calcite-input"></calcite-input>
       <input name="native-minmax" minLength="2" maxLength="3" placeholder="minlength=2 maxlength=3"></input>
-      <calcite-input name="minmax" minLength="2" maxLength="3" placeholder="minlength=2 maxlength=3" required></calcite-input>
+      <calcite-input name="minmax" minLength="2" maxLength="3" placeholder="minlength=2 maxlength=3" required>
+      </calcite-input>
+      <calcite-input type="number" name="no-locale-number" placeholder="no-locale-number" value="4"></calcite-input>
       <calcite-input type="number" locale="fr" locale-format name="french" value="1234.56" step="0.01"></calcite-input>
       <calcite-input type="number" locale="fr" locale-format name="french-whole" value="1234" step="1"></calcite-input>
       <calcite-input type="number" locale="fr" locale-format name="french-novalue" step="1"></calcite-input>
@@ -82,7 +86,7 @@
       console.log("calciteInputFocus", event.target.getAttribute("name"), event.detail.value);
     });
     document.addEventListener("calciteInputInput", (event) => {
-      console.log("calciteInputInput", event.target.getAttribute("name"), event.detail.value);
+      console.log("calciteInputInput", event.target.getAttribute("name"), event.target.value, event.detail.value);
     });
     document.addEventListener("calciteInputBlur", (event) => {
       console.log("calciteInputBlur", event.target.getAttribute("name"), event.detail.value);


### PR DESCRIPTION
**Related Issue:** #1983 

@driskull This also fixes console.warn messages from appearing in tests and in the browser when entering number values ending in a decimal.  Numbers in the input that end with a decimal are allowed to be typed, but the stored value doesn't update until another number is typed.  The `calciteInputInput` event also won't emit the value if it ends in a decimal, it waits to emit until a number is added to the right of the decimal.