### PR TITLE
 fix(calcite-input): allowing ctrl+v (and other modifier keys) for pasting numbers on windows machines

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -405,7 +405,7 @@ export class CalciteInput {
       "Tab",
       "-"
     ];
-    if (event.metaKey || event.ctrlKey) {
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return;
     }
     if (supportedKeys.includes(event.key)) {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -405,7 +405,7 @@ export class CalciteInput {
       "Tab",
       "-"
     ];
-    if (event.metaKey) {
+    if (event.metaKey || event.ctrlKey) {
       return;
     }
     if (supportedKeys.includes(event.key)) {


### PR DESCRIPTION
**Related Issue:** #1999 
