### PR TITLE
fix(calcite-input): setting initial value for number input to "undefined" doesn't display in the input

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -775,5 +775,38 @@ describe("calcite-input", () => {
           expect(await internalLocaleInput.getProperty("value")).toBe(localizeNumberString(assertedValue, locale));
         });
       });
+
+    it(`disallows setting value to "undefined" on initial load.`, async () => {
+      const page = await newE2EPage({
+        html: `<calcite-input type="number" value="undefined"></calcite-input>`
+      });
+      const calciteInput = await page.find("calcite-input");
+      const input = await page.find("input");
+
+      expect(await calciteInput.getProperty("value")).toBeFalsy();
+      expect(await input.getProperty("value")).toBeFalsy();
+    });
+
+    it(`disallows setting value to "null" on initial load.`, async () => {
+      const page = await newE2EPage({
+        html: `<calcite-input type="number" value="null"></calcite-input>`
+      });
+      const calciteInput = await page.find("calcite-input");
+      const input = await page.find("input");
+
+      expect(await calciteInput.getProperty("value")).toBeFalsy();
+      expect(await input.getProperty("value")).toBeFalsy();
+    });
+
+    it(`disallows setting text value on initial load.`, async () => {
+      const page = await newE2EPage({
+        html: `<calcite-input type="number" value="i am a text value"></calcite-input>`
+      });
+      const calciteInput = await page.find("calcite-input");
+      const input = await page.find("input");
+
+      expect(await calciteInput.getProperty("value")).toBeFalsy();
+      expect(await input.getProperty("value")).toBeFalsy();
+    });
   });
 });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../utils/locale";
 import { numberKeys } from "../../utils/key";
 import { hiddenInputStyle } from "../../utils/form";
+import { isValidNumber } from "../../utils/number";
 
 type NumberNudgeDirection = "up" | "down";
 
@@ -257,6 +258,9 @@ export class CalciteInput {
     this.scale = getElementProp(this.el, "scale", this.scale);
     this.status = getElementProp(this.el, "status", this.status);
     this.step = !this.step && this.shouldFormatNumberByLocale() ? "any" : this.step;
+    if (this.type === "number" && !isValidNumber(this.value)) {
+      this.value = undefined;
+    }
   }
 
   disconnectedCallback(): void {
@@ -499,7 +503,7 @@ export class CalciteInput {
     if (this.shouldFormatNumberByLocale()) {
       this.setLocalizedValue(value);
     }
-    if (this.type === "number" && value.endsWith(".")) {
+    if (this.type === "number" && value?.endsWith(".")) {
       return;
     }
     const calciteInputInputEvent = this.calciteInputInput.emit({

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -259,7 +259,7 @@ export class CalciteInput {
     this.status = getElementProp(this.el, "status", this.status);
     this.step = !this.step && this.shouldFormatNumberByLocale() ? "any" : this.step;
     if (this.type === "number" && !isValidNumber(this.value)) {
-      this.value = undefined;
+      this.value = null;
     }
   }
 

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -124,5 +124,5 @@ export function localizeNumberString(numberString: string, locale: string, displ
 }
 
 export function sanitizeDecimalString(decimalString: string): string {
-  return decimalString.endsWith(".") ? decimalString.replace(".", "") : decimalString;
+  return decimalString?.endsWith(".") ? decimalString.replace(".", "") : decimalString;
 }

--- a/src/utils/number.spec.ts
+++ b/src/utils/number.spec.ts
@@ -1,0 +1,19 @@
+import { isValidNumber } from "./number";
+
+describe("isValidNumber", () => {
+  it("returns false for string values that can't compute to a number", () => {
+    expect(isValidNumber("undefined")).toBe(false);
+    expect(isValidNumber(";lkj2323")).toBe(false);
+    expect(isValidNumber("")).toBe(false);
+    expect(isValidNumber(undefined)).toBe(false);
+    expect(isValidNumber(null)).toBe(false);
+    expect(isValidNumber("null")).toBe(false);
+    expect(isValidNumber("not a number")).toBe(false);
+    expect(isValidNumber("1 2345,67")).toBe(false);
+  });
+
+  it("returns true for string values that compute to a valid number", () => {
+    expect(isValidNumber("123345345")).toBe(true);
+    expect(isValidNumber("123123.234234")).toBe(true);
+  });
+});

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,3 @@
+export function isValidNumber(numberString: string): boolean {
+  return !numberString || isNaN(Number(numberString)) ? false : true;
+}


### PR DESCRIPTION
**Related Issue:** #2001 
