### PR TITLE
fix(modal): render correctly with no footer slots

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -288,4 +288,19 @@ describe("calcite-modal accessibility checks", () => {
     });
     expect(documentClass).toEqual(false);
   });
+
+  it("renders correctly with no footer", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-modal>
+        <calcite-button slot="primary">TEST</calcite-button>
+      </calcite-modal>
+    `);
+    let footer = await page.$eval("calcite-modal", (elm) => elm.shadowRoot.querySelector(".footer"));
+    expect(footer).toBeDefined();
+    await page.$eval("calcite-button", (elm) => elm.parentElement.removeChild(elm));
+    await page.waitForChanges();
+    footer = await page.$eval("calcite-modal", (elm) => elm.shadowRoot.querySelector(".footer"));
+    expect(footer).toBeFalsy();
+  });
 });

--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -112,6 +112,10 @@
   padding: var(--calcite-modal-padding-large);
 }
 
+.content--no-footer {
+  @apply rounded-b;
+}
+
 @include slotted("content", "*") {
   font-size: var(--calcite-modal-content-text);
   line-height: 1.5;

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -1,4 +1,5 @@
 import {
+  Build,
   Component,
   Element,
   Event,
@@ -100,8 +101,19 @@ export class CalciteModal {
     }
   }
 
+  componentDidLoad(): void {
+    this.observer?.observe(this.el, { childList: true, subtree: true });
+  }
+
+  connectedCallback(): void {
+    if (Build.isBrowser) {
+      this.observer = new MutationObserver(this.updateFooterVisibility);
+    }
+  }
+
   disconnectedCallback(): void {
     this.removeOverflowHiddenClass();
+    this.observer?.disconnect();
   }
 
   render(): VNode {
@@ -121,7 +133,8 @@ export class CalciteModal {
           <div
             class={{
               content: true,
-              "content--spaced": !this.noPadding
+              "content--spaced": !this.noPadding,
+              "content--no-footer": !this.hasFooter
             }}
             ref={(el) => (this.modalContent = el)}
           >
@@ -135,7 +148,7 @@ export class CalciteModal {
   }
 
   renderFooter(): VNode {
-    return this.el.querySelector("[slot=back], [slot=secondary], [slot=primary]") ? (
+    return this.hasFooter ? (
       <div class="footer">
         <span class="back">
           <slot name="back" />
@@ -198,6 +211,8 @@ export class CalciteModal {
   //--------------------------------------------------------------------------
   @State() isActive: boolean;
 
+  @State() hasFooter: boolean;
+
   previousActiveElement: HTMLElement;
 
   closeButtonEl: HTMLButtonElement;
@@ -205,6 +220,8 @@ export class CalciteModal {
   modalContent: HTMLDivElement;
 
   focusTimeout: number;
+
+  private observer: MutationObserver = null;
 
   //--------------------------------------------------------------------------
   //
@@ -333,4 +350,8 @@ export class CalciteModal {
   private removeOverflowHiddenClass(): void {
     document.documentElement.classList.remove("overflow-hidden");
   }
+
+  private updateFooterVisibility = (): void => {
+    this.hasFooter = !!this.el.querySelector("[slot=back], [slot=secondary], [slot=primary]");
+  };
 }


### PR DESCRIPTION
## Summary

Working on a design right now where there are actions in the footer in some steps and not in others. The current implementation is not "live". So if you have slotted buttons the footer shows, but when you remove them it still shows the empty footer with border, etc:

<img width="650" alt="Screen Shot 2021-04-22 at 1 09 41 PM" src="https://user-images.githubusercontent.com/1031758/115778779-032cdf80-a36c-11eb-894f-294a8354ddd0.png">

This pr adds a `MutationObserver` which checks if you have slotted content in the footer when your dom changes. That way you can flip back and forth between having a footer and not having a footer.

