### PR TITLE
ci: ensure next builds are the same as production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ deploy:
     branch: master
     condition: $NEXT_RELEASE_ENABLED
   provider: script
-  script: bash support/deployNextFromTravisBuild.sh
+  script: bash support/deployNextFromTravis.sh
   skip_cleanup: true
 language: node_js
 node_js:

--- a/support/deployNextFromTravis.sh
+++ b/support/deployNextFromTravis.sh
@@ -24,19 +24,22 @@ function mostRecentTag {
   echo $( git describe --tags --abbrev=0 $1)
 }
 
-echo "Determining build deployability 🔍"
+echo "Determining @next deployability 🔍"
 
 if [ ! $( deployable $( mostRecentTag HEAD ) ) ]
 then
   echo "No changes since the previous release, skipping ⛔"
 else
+  echo "Building deployable candidate ⚙️"
+  npm run build >/dev/null
+
   git checkout master --quiet && git fetch --quiet >> .npmrc 2> /dev/null
 
   if [ $( latestCommit master ) != $( latestCommit origin/master) ] && [ $( deployable master origin/master) ]
   then
-    echo "Deployment build is outdated, aborting ⛔️"
+    echo "There is a more recent deployable install, aborting ⛔️"
   else
-    echo "Deploying @next from existing build 🚧"
+    echo "Deploying @next 🚧"
 
     if \
       { echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> .npmrc 2> /dev/null ; } && \


### PR DESCRIPTION
**Related Issue:** #1994 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This tweaks the deployment script used by Travis to do a production build instead of reusing a test one, which will lack any configured output targets and extras. 

**Note**: this change will slightly increase the time for a next deployment after tests pass (by ~1 min).