### PR TITLE
build: exclude irrelevant dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,16 +13,14 @@
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/",
-    "hydrate/",
-    "!.storybook",
-    "!dist/collection/demos"
+    "hydrate/"
   ],
   "scripts": {
     "build": "npm run util:copy-icons && stencil build && npm run util:add-custom-elements-index-mjs && npm run util:build-custom-elements-output-utils",
     "build:watch": "npm run util:copy-icons && stencil build --watch && npm run util:add-custom-elements-index-mjs",
     "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch && npm run util:add-custom-elements-index-mjs",
     "deps:update": "updtr --exclude @types/jest @types/puppeteer husky jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
-    "docs": "concurrently --kill-others --raw \"npm:util:build-docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\"  \"ts-node ./support/tempDocDirCleaner.ts\"",
+    "docs": "concurrently --kill-others --raw \"npm:util:build-docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\"  \"ts-node ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",
     "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/tempDocDirCleaner.ts\"",
     "lint": "concurrently npm:lint:*",
     "lint:styles": "stylelint --fix \"src/**/*.scss\"",
@@ -38,7 +36,7 @@
     "release:next": "npm run util:clean-tested-build && npm run util:deploy-next-from-existing-build",
     "release:prepare": "npm run util:clean-tested-build && ts-node ./support/ensureNonPrereleaseChangelog.ts && git add .",
     "release:publish": "npm run util:push-tags && npm publish && ts-node ./support/releaseToGitHub.ts",
-    "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm:build --dev --watch --serve\"",
+    "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm:build --dev --watch --serve\" \"ts-node ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
     "test": "npm run util:run-tests",
     "test:prerender": "stencil build --no-docs --prerender",
     "test:storybook": "concurrently --raw \"npm:util:build-docs && screener-storybook --conf screener.config.js\"",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/",
-    "hydrate/"
+    "hydrate/",
+    "!.storybook",
+    "!dist/collection/demos"
   ],
   "scripts": {
     "build": "npm run util:copy-icons && stencil build && npm run util:add-custom-elements-index-mjs && npm run util:build-custom-elements-output-utils",

--- a/support/cleanOnProcessExit.ts
+++ b/support/cleanOnProcessExit.ts
@@ -1,4 +1,6 @@
 const rimraf = require("rimraf");
+const { argv } = require("yargs");
+const { resolve } = require("path");
 
 // 👇 based on https://stackoverflow.com/a/14032965
 
@@ -12,9 +14,11 @@ interface ExitOptions {
   exit: boolean;
 }
 
+const { path } = argv;
+
 const exitHandler = (options: CleanupOptions | ExitOptions): void => {
   if ("cleanup" in options) {
-    rimraf.sync(`${__dirname}/../__docs-temp__`);
+    rimraf.sync(resolve(`${process.cwd()}/${path}`));
   }
   if ("exit" in options) {
     process.exit();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig-base",
-  "include": ["src", ".storybook/declarations.d.ts"],
+  "include": ["src"],
   "exclude": ["node_modules", "src/demos/**/*", "src/tests/**/*", "src/**/shared-list-tests.ts", "src/**/*.stories.ts"]
 }


### PR DESCRIPTION
**Related Issue:** #2024

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR will prevent unnecessary files from getting picked up into the dist folder.