### PR TITLE
fix(modal): solve issue with custom widths in prod builds

### DIFF
--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -183,20 +183,20 @@ export class CalciteModal {
       <style>
         {`
         .modal {
-          max-width: ${this.width}px;
+          max-width: ${this.width}px !important;
         }
         @media screen and (max-width: ${this.width}px) {
           .modal {
-            height: 100%;
-            max-height: 100%;
-            width: 100%;
-            max-width: 100%;
-            margin: 0;
-            border-radius: 0;
+            height: 100% !important;
+            max-height: 100% !important;
+            width: 100% !important;
+            max-width: 100% !important;
+            margin: 0 !important;
+            border-radius: 0 !important;
           }
           .content {
-            flex: 1 1 auto;
-            max-height: unset;
+            flex: 1 1 auto !important;
+            max-height: unset !important;
           }
         }
       `}


### PR DESCRIPTION
## Summary

In production builds, stencil uses `new CSSStyleSheet()` with `shadowRoot.adoptedStyleSheets` to style components usign shadow dom when browsers support it. This actually overrides the `<style>` tag we have in the render function. To get around this I've used the `!important` sledgehammer. I tried to construct a stylesheet and add it to adoptedStyleSheets but there is very little visibility into the stencil build process and the normal host styles were still winning. This at least will consistently solve the issue.