### PR TITLE
fix(modal): restore footer slotted content

### DIFF
--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -108,6 +108,7 @@ export class CalciteModal {
   connectedCallback(): void {
     if (Build.isBrowser) {
       this.observer = new MutationObserver(this.updateFooterVisibility);
+      this.updateFooterVisibility();
     }
   }
 
@@ -211,7 +212,7 @@ export class CalciteModal {
   //--------------------------------------------------------------------------
   @State() isActive: boolean;
 
-  @State() hasFooter: boolean;
+  @State() hasFooter = true;
 
   previousActiveElement: HTMLElement;
 


### PR DESCRIPTION
## Summary

Earlier pr today incorrectly removed slotted content from the footer of modals. This restores it and corrects the footer display with no slotted content. 

I'm not totally sure why screener didn't pick the regression up? Seems like out modal visual testing is probably not very good...