### PR TITLE
fix(modal): aleft align back button with title/content of modal

### DIFF
--- a/src/components/calcite-modal/calcite-modal.scss
+++ b/src/components/calcite-modal/calcite-modal.scss
@@ -133,7 +133,7 @@
 .footer {
   @apply flex justify-between mt-auto box-border rounded-b w-full bg-foreground-1;
   flex: 0 0 auto;
-  padding: var(--calcite-modal-padding);
+  padding: var(--calcite-modal-padding) var(--calcite-modal-padding-large);
   border-top: 1px solid var(--calcite-ui-border-3);
   z-index: 2;
 }


### PR DESCRIPTION

## Summary

<img width="1059" alt="Screen Shot 2021-04-23 at 3 33 02 PM" src="https://user-images.githubusercontent.com/1031758/115936333-ce8f5580-a449-11eb-8cbb-084c7b70e642.png">


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
