### PR TITLE
feat(calcite-tile-select): add calciteTileSelectGroupChange event #2020

### DIFF
--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.e2e.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.e2e.ts
@@ -23,15 +23,18 @@ describe("calcite-tile-select-group", () => {
     });
     const internalEventSpy = await page.spyOnEvent("calciteCheckboxChange");
     const eventSpy = await page.spyOnEvent("calciteTileSelectGroupChange");
+    const group = await page.find("calcite-tile-select-group");
     const items = await page.findAll("calcite-tile-select");
     await items[0].click();
     expect(eventSpy).toHaveReceivedEventTimes(1);
     expect(internalEventSpy).toHaveReceivedEventTimes(0);
-    expect(await eventSpy.lastEvent.detail.length).toBe(1);
+    let selected = await group.getProperty("selectedItems");
+    expect(selected.length).toBe(1);
     await items[1].click();
     expect(eventSpy).toHaveReceivedEventTimes(2);
     expect(internalEventSpy).toHaveReceivedEventTimes(0);
-    expect(await eventSpy.lastEvent.detail.length).toBe(2);
+    selected = await group.getProperty("selectedItems");
+    expect(selected.length).toBe(2);
   });
 
   it("correctly emits on change event for radio tiles", async () => {
@@ -45,14 +48,14 @@ describe("calcite-tile-select-group", () => {
     });
     const internalEventSpy = await page.spyOnEvent("calciteRadioButtonChange");
     const eventSpy = await page.spyOnEvent("calciteTileSelectGroupChange");
+    const group = await page.find("calcite-tile-select-group");
     const items = await page.findAll("calcite-tile-select");
+    let selected = await group.getProperty("selectedItem");
+    expect(selected).toBeFalsy();
     await items[0].click();
     expect(eventSpy).toHaveReceivedEventTimes(1);
     expect(internalEventSpy).toHaveReceivedEventTimes(0);
-    expect(await eventSpy.lastEvent.detail.length).toBe(1);
-    await items[1].click();
-    expect(eventSpy).toHaveReceivedEventTimes(2);
-    expect(internalEventSpy).toHaveReceivedEventTimes(0);
-    expect(await eventSpy.lastEvent.detail.length).toBe(1);
+    selected = await group.getProperty("selectedItem");
+    expect(selected.value).toBe("one");
   });
 });

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.e2e.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.e2e.ts
@@ -1,4 +1,6 @@
+import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, reflects, renders } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 
 describe("calcite-tile-select-group", () => {
   it("renders", async () => renders("calcite-tile-select-group"));
@@ -9,4 +11,48 @@ describe("calcite-tile-select-group", () => {
     defaults("calcite-tile-select-group", [{ propertyName: "layout", defaultValue: "horizontal" }]));
 
   it("reflects", async () => reflects("calcite-tile-select-group", [{ propertyName: "layout", value: "horizontal" }]));
+
+  it("correctly emits on change event for checkbox tiles", async () => {
+    const page = await newE2EPage({
+      html: html`
+        <calcite-tile-select-group>
+          <calcite-tile-select name="check" type="checkbox" value="one" heading="One"></calcite-tile-select>
+          <calcite-tile-select name="check" type="checkbox" value="two" heading="Two"></calcite-tile-select>
+        </calcite-tile-select-group>
+      `
+    });
+    const internalEventSpy = await page.spyOnEvent("calciteCheckboxChange");
+    const eventSpy = await page.spyOnEvent("calciteTileSelectGroupChange");
+    const items = await page.findAll("calcite-tile-select");
+    await items[0].click();
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+    expect(internalEventSpy).toHaveReceivedEventTimes(0);
+    expect(await eventSpy.lastEvent.detail.length).toBe(1);
+    await items[1].click();
+    expect(eventSpy).toHaveReceivedEventTimes(2);
+    expect(internalEventSpy).toHaveReceivedEventTimes(0);
+    expect(await eventSpy.lastEvent.detail.length).toBe(2);
+  });
+
+  it("correctly emits on change event for radio tiles", async () => {
+    const page = await newE2EPage({
+      html: html`
+        <calcite-tile-select-group>
+          <calcite-tile-select name="check" type="radio" value="one" heading="One"></calcite-tile-select>
+          <calcite-tile-select name="check" type="radio" value="two" heading="Two"></calcite-tile-select>
+        </calcite-tile-select-group>
+      `
+    });
+    const internalEventSpy = await page.spyOnEvent("calciteRadioButtonChange");
+    const eventSpy = await page.spyOnEvent("calciteTileSelectGroupChange");
+    const items = await page.findAll("calcite-tile-select");
+    await items[0].click();
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+    expect(internalEventSpy).toHaveReceivedEventTimes(0);
+    expect(await eventSpy.lastEvent.detail.length).toBe(1);
+    await items[1].click();
+    expect(eventSpy).toHaveReceivedEventTimes(2);
+    expect(internalEventSpy).toHaveReceivedEventTimes(0);
+    expect(await eventSpy.lastEvent.detail.length).toBe(1);
+  });
 });

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.stories.ts
@@ -13,7 +13,7 @@ export default {
 };
 
 export const Light = (): string => html`
-  <calcite-tile-select-group>
+  <calcite-tile-select-group layout="${select("layout", ["horizontal", "vertical"], "horizontal")}">
     <calcite-tile-select
       checked
       description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.  Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
@@ -9,7 +9,6 @@ import {
   EventEmitter,
   Event
 } from "@stencil/core";
-import { nodeListToArray } from "../../utils/dom";
 import { TileSelectGroupLayout } from "./interfaces";
 
 @Component({
@@ -29,27 +28,40 @@ export class CalciteTileSelectGroup {
   @Prop({ reflect: true }) layout?: TileSelectGroupLayout = "horizontal";
 
   /**
-   * Fired when tiles are selected/deselected
-   * all checked tiles are passed in the event detail
+   * Curretly selected tile for single select (radio) tile groups
+   * @readonly
    */
-  @Event() calciteTileSelectGroupChange: EventEmitter<HTMLCalciteTileSelectElement[]>;
+  @Prop({ mutable: true }) selectedTile: HTMLCalciteTileSelectElement;
+
+  /**
+   * Curretly selected tiles for multi-select (checkbox) tile groups
+   * @readonly
+   */
+  @Prop({ mutable: true }) selectedTiles: HTMLCalciteTileSelectElement[];
+
+  /**
+   * Fired when tiles are selected/deselected
+   */
+  @Event() calciteTileSelectGroupChange: EventEmitter;
 
   @Listen("calciteRadioButtonChange")
   radioButtonChangeHandler(event: CustomEvent): void {
-    this.emitChange(event);
+    event.stopPropagation();
+    this.selectedTile = this.getSelectedTiles()?.[0];
+    this.calciteTileSelectGroupChange.emit();
   }
 
   @Listen("calciteCheckboxChange")
   checkboxChangeHandler(event: CustomEvent): void {
-    this.emitChange(event);
+    event.stopPropagation();
+    this.selectedTiles = this.getSelectedTiles();
+    this.calciteTileSelectGroupChange.emit();
   }
 
-  private emitChange(event: CustomEvent): void {
-    event.stopPropagation();
-    const selected = nodeListToArray(this.el.querySelectorAll("calcite-tile-select")).filter(
+  private getSelectedTiles(): HTMLCalciteTileSelectElement[] {
+    return Array.from(this.el.querySelectorAll("calcite-tile-select")).filter(
       (el: HTMLCalciteTileSelectElement) => el.checked
     );
-    this.calciteTileSelectGroupChange.emit(selected);
   }
 
   render(): VNode {

--- a/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
+++ b/src/components/calcite-tile-select-group/calcite-tile-select-group.tsx
@@ -1,4 +1,15 @@
-import { Component, Host, h, VNode, Prop } from "@stencil/core";
+import {
+  Component,
+  Host,
+  h,
+  VNode,
+  Prop,
+  Listen,
+  Element,
+  EventEmitter,
+  Event
+} from "@stencil/core";
+import { nodeListToArray } from "../../utils/dom";
 import { TileSelectGroupLayout } from "./interfaces";
 
 @Component({
@@ -7,6 +18,8 @@ import { TileSelectGroupLayout } from "./interfaces";
   shadow: true
 })
 export class CalciteTileSelectGroup {
+  @Element() el: HTMLCalciteTileSelectGroupElement;
+
   //--------------------------------------------------------------------------
   //
   //  Properties
@@ -14,6 +27,30 @@ export class CalciteTileSelectGroup {
   //--------------------------------------------------------------------------
   /** Tiles by default move horizontally, stacking with each row, vertical allows single-column layouts */
   @Prop({ reflect: true }) layout?: TileSelectGroupLayout = "horizontal";
+
+  /**
+   * Fired when tiles are selected/deselected
+   * all checked tiles are passed in the event detail
+   */
+  @Event() calciteTileSelectGroupChange: EventEmitter<HTMLCalciteTileSelectElement[]>;
+
+  @Listen("calciteRadioButtonChange")
+  radioButtonChangeHandler(event: CustomEvent): void {
+    this.emitChange(event);
+  }
+
+  @Listen("calciteCheckboxChange")
+  checkboxChangeHandler(event: CustomEvent): void {
+    this.emitChange(event);
+  }
+
+  private emitChange(event: CustomEvent): void {
+    event.stopPropagation();
+    const selected = nodeListToArray(this.el.querySelectorAll("calcite-tile-select")).filter(
+      (el: HTMLCalciteTileSelectElement) => el.checked
+    );
+    this.calciteTileSelectGroupChange.emit(selected);
+  }
 
   render(): VNode {
     return (

--- a/src/components/calcite-tile-select-group/readme.md
+++ b/src/components/calcite-tile-select-group/readme.md
@@ -8,6 +8,12 @@
 | -------- | --------- | ------------------------------------------------------------------------------------------------- | ---------------------------- | -------------- |
 | `layout` | `layout`  | Tiles by default move horizontally, stacking with each row, vertical allows single-column layouts | `"horizontal" \| "vertical"` | `"horizontal"` |
 
+## Events
+
+| Event                          | Description                                                                               | Type                                          |
+| ------------------------------ | ----------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `calciteTileSelectGroupChange` | Fired when tiles are selected/deselected all checked tiles are passed in the event detail | `CustomEvent<HTMLCalciteTileSelectElement[]>` |
+
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -52,7 +52,7 @@
                   <demo-spacer gap="25px">
 
                     <h3>Input-enabled Start Radio</h3>
-                    <calcite-tile-select-group>
+                    <calcite-tile-select-group class="js-radio-select">
                       <calcite-tile-select input-enabled checked icon="layers" name="start-radio" value="one"
                         heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
@@ -83,6 +83,12 @@
                         description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
                       </calcite-tile-select>
                     </calcite-tile-select-group>
+
+                    <script>
+                      document.querySelector(".js-radio-select").addEventListener("calciteTileSelectGroupChange", (e) => {
+                        console.log(e);
+                      } )
+                    </script>
 
                     <h3>Input-enabled Start Radio Large Visual</h3>
                     <calcite-tile-select-group>
@@ -430,7 +436,7 @@
                     </calcite-tile-select-group>
 
                     <h3>Input-enabled Start Checkbox Large Visual</h3>
-                    <calcite-tile-select-group>
+                    <calcite-tile-select-group class="js-checkbox-select">
                       <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-one" type="checkbox"
                         heading="Tile title lorem ipsum">
                       </calcite-tile-select>
@@ -456,6 +462,13 @@
                         heading="Tile title lorem ipsum">
                       </calcite-tile-select>
                     </calcite-tile-select-group>
+
+
+                    <script>
+                      document.querySelector(".js-checkbox-select").addEventListener("calciteTileSelectGroupChange", (e) => {
+                        console.log(e);
+                      } )
+                    </script>
 
                     <h3>Input-enabled Start Checkbox Heading Only</h3>
                     <calcite-tile-select-group>


### PR DESCRIPTION
**Related Issue:** #2020

## Summary

Creates a new `calciteTileSelectGroupChange` event. This allows devs to listen for changes to tiles directly on the group. Previously, we used the `calciteRadioButtonChange` and `calciteCheckboxChange` events from the internal input components. Stopping propagation of those events, and documenting this new event.

Also resolves #1020 documenting full width tile select groups by adding knob to the group story. 