### PR TITLE
fix(split-button): Remove setting 'dir' attribute in light DOM elements. #1831

### DIFF
--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -60,8 +60,8 @@ export class CalciteSplitButton {
   render(): VNode {
     const dir = getElementDir(this.el);
     return (
-      <Host dir={dir}>
-        <div class="split-button__container">
+      <Host>
+        <div class="split-button__container" dir={dir}>
           <calcite-button
             appearance={this.appearance}
             aria-label={this.primaryLabel}


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(split-button): Remove setting 'dir' attribute in light DOM elements. #1831