### PR TITLE
fix(stepper): Remove setting 'dir' attribute in light DOM elements. #1831

### DIFF
--- a/src/components/calcite-stepper/calcite-stepper.tsx
+++ b/src/components/calcite-stepper/calcite-stepper.tsx
@@ -99,8 +99,10 @@ export class CalciteStepper {
   render(): VNode {
     const dir = getElementDir(this.el);
     return (
-      <Host dir={dir}>
-        <slot />
+      <Host>
+        <div dir={dir}>
+          <slot />
+        </div>
       </Host>
     );
   }

--- a/src/components/calcite-stepper/calcite-stepper.tsx
+++ b/src/components/calcite-stepper/calcite-stepper.tsx
@@ -11,7 +11,6 @@ import {
   VNode,
   Watch
 } from "@stencil/core";
-import { getElementDir } from "../../utils/dom";
 import { IESTYLES } from "./calcite-stepper.resources";
 import { getKey } from "../../utils/key";
 import { Layout, Scale, Theme } from "../interfaces";
@@ -97,12 +96,9 @@ export class CalciteStepper {
   }
 
   render(): VNode {
-    const dir = getElementDir(this.el);
     return (
       <Host>
-        <div dir={dir}>
-          <slot />
-        </div>
+        <slot />
       </Host>
     );
   }


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(stepper): Remove setting 'dir' attribute in light DOM elements. #1831