### PR TITLE
fix(tab-title): Remove setting 'dir' attribute in light DOM elements #1831

### DIFF
--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -130,7 +130,6 @@ export class CalciteTabTitle {
       <Host
         aria-controls={this.controls}
         aria-expanded={this.active.toString()}
-        dir={dir}
         hasText={this.hasText}
         id={id}
         role="tab"


### PR DESCRIPTION

**Related Issue:** #1831

## Summary

fix(tab-title): Remove setting 'dir' attribute in light DOM elements #1831