### PR TITLE
fix(tile-select): Remove setting 'dir' attribute in light DOM elements. #1831

### DIFF
--- a/src/components/calcite-tile-select/calcite-tile-select.scss
+++ b/src/components/calcite-tile-select/calcite-tile-select.scss
@@ -100,7 +100,7 @@ $spacing: $baseline/2;
   }
 }
 
-:host([dir="rtl"][input-enabled][input-alignment="start"][icon][heading]:not([description])) {
+:host([input-enabled][input-alignment="start"][icon][heading]:not([description])) .calcite--rtl {
   ::slotted(calcite-checkbox),
   ::slotted(calcite-radio-button) {
     right: $spacing;
@@ -117,7 +117,7 @@ $spacing: $baseline/2;
   }
 }
 
-:host([dir="rtl"][input-enabled][input-alignment="end"][icon][heading]) {
+:host([input-enabled][input-alignment="end"][icon][heading]) .calcite--rtl {
   ::slotted(calcite-checkbox),
   ::slotted(calcite-radio-button) {
     right: unset;

--- a/src/components/calcite-tile-select/calcite-tile-select.tsx
+++ b/src/components/calcite-tile-select/calcite-tile-select.tsx
@@ -13,6 +13,7 @@ import {
 import { Alignment, Theme, Width } from "../interfaces";
 import { TileSelectType } from "./interfaces";
 import { getElementDir } from "../../utils/dom";
+import { CSS_UTILITY } from "../../utils/resources";
 
 @Component({
   tag: "calcite-tile-select",
@@ -221,8 +222,8 @@ export class CalciteTileSelect {
     const dir = getElementDir(this.el);
 
     return (
-      <Host dir={dir}>
-        <div class={{ focused: this.focused, root: true }}>
+      <Host>
+        <div class={{ focused: this.focused, root: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
           <calcite-tile
             active={this.checked}
             description={this.description}


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(tile-select): Remove setting 'dir' attribute in light DOM elements. #1831