### PR TITLE
fix(pagination): Remove setting 'dir' attribute in light DOM elements #1831

### DIFF
--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -220,7 +220,7 @@ export class CalcitePagination {
     const prevDisabled = num === 1 ? start <= num : start < num;
     const nextDisabled = num === 1 ? start + num > total : start + num > total;
     return (
-      <Host dir={dir}>
+      <Host>
         <button
           aria-label={this.textLabelPrevious}
           class={{


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(pagination): Remove setting 'dir' attribute in light DOM elements #1831