### PR TITLE
fix(date-picker-month-header): Remove setting 'dir' attribute in light DOM elements. #1831

### DIFF
--- a/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.tsx
+++ b/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.tsx
@@ -107,8 +107,8 @@ export class CalciteDatePickerMonthHeader {
     const reverse = order.indexOf("y") < order.indexOf("m");
     const suffix = this.localeData.year?.suffix;
     return (
-      <Host dir={dir}>
-        <div class="header">
+      <Host>
+        <div class="header" dir={dir}>
           <a
             aria-disabled={(this.prevMonthDate.getMonth() === activeMonth).toString()}
             aria-label={this.intlPrevMonth}


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(date-picker-month-header): Remove setting 'dir' attribute in light DOM elements. #1831