### PR TITLE
fix(combobox-item): Remove setting 'dir' attribute in light DOM elements. #1831

### DIFF
--- a/src/components/calcite-combobox-item/calcite-combobox-item.scss
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.scss
@@ -29,7 +29,7 @@
   --calcite-combobox-item-indent-end-2: unset;
 }
 
-:host([dir="rtl"]) {
+.calcite--rtl {
   --calcite-combobox-item-indent-start-1: unset;
   --calcite-combobox-item-indent-end-1: var(--calcite-combobox-item-spacing-indent-1);
   --calcite-combobox-item-indent-start-2: unset;
@@ -46,13 +46,13 @@ ul {
 }
 
 .label {
-  @apply flex 
-    box-border 
-    w-full 
-    min-w-full 
-    items-center 
-    text-color-3 
-    cursor-pointer 
+  @apply flex
+    box-border
+    w-full
+    min-w-full
+    items-center
+    text-color-3
+    cursor-pointer
     relative
     duration-150
     ease-in-out
@@ -122,7 +122,7 @@ ul {
   content: "\2022";
 }
 
-:host([dir="rtl"]) .icon--dot:before {
+.calcite--rtl .icon--dot:before {
   @apply text-right;
 }
 

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -16,6 +16,7 @@ import { CSS } from "./resources";
 import { guid } from "../../utils/guid";
 import { ComboboxChildElement } from "../calcite-combobox/interfaces";
 import { getAncestors, getDepth } from "../calcite-combobox/utils";
+import { CSS_UTILITY } from "../../utils/resources";
 
 @Component({
   tag: "calcite-combobox-item",
@@ -180,7 +181,9 @@ export class CalciteComboboxItem {
 
   render(): VNode {
     const isSingleSelect = getElementProp(this.el, "selection-mode", "multi") === "single";
+    const dir = getElementDir(this.el);
     const classes = {
+      [CSS_UTILITY.rtl]: dir === "rtl",
       [CSS.label]: true,
       [CSS.selected]: this.isSelected,
       [CSS.active]: this.active,
@@ -188,10 +191,8 @@ export class CalciteComboboxItem {
     };
     const scale = getElementProp(this.el, "scale", "m");
 
-    const dir = getElementDir(this.el);
-
     return (
-      <Host aria-hidden dir={dir} disabled={this.disabled} scale={scale} tabIndex={-1}>
+      <Host aria-hidden disabled={this.disabled} scale={scale} tabIndex={-1}>
         <li
           class={classes}
           id={this.guid}


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(combobox-item): Remove setting 'dir' attribute in light DOM elements. #1831