### PR TITLE
fix(date-picker): Remove setting 'dir' attribute in light DOM elements. #1831

### DIFF
--- a/src/components/calcite-date-picker/calcite-date-picker.tsx
+++ b/src/components/calcite-date-picker/calcite-date-picker.tsx
@@ -217,7 +217,7 @@ export class CalciteDatePicker {
     const dir = getElementDir(this.el);
 
     return (
-      <Host dir={dir} onBlur={this.reset} onKeyUp={this.keyUpHandler} role="application">
+      <Host onBlur={this.reset} onKeyUp={this.keyUpHandler} role="application">
         {this.renderCalendar(activeDate, dir, maxDate, minDate, date, endDate)}
       </Host>
     );


### PR DESCRIPTION
**Related Issue:** #1831

## Summary

fix(date-picker): Remove setting 'dir' attribute in light DOM elements. #1831