### PR TITLE
feat: adds opened and closed status icon to Block and updates UI of related components

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -65,7 +65,7 @@
 }
 
 :host([scale="s"]) .button {
-  @apply p-2;
+  @apply p-3;
 }
 
 :host([scale="m"]) .button {

--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -65,7 +65,7 @@
 }
 
 :host([scale="s"]) .button {
-  @apply p-3;
+  @apply p-2;
 }
 
 :host([scale="m"]) .button {

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -40,7 +40,7 @@
 }
 
 .section-header__text {
-  margin: 0 var(--calcite-spacing-quarter);
+  @apply mx-3 my-0;
 }
 
 .toggle--switch {

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -121,7 +121,9 @@ export class CalciteBlockSection {
           tabIndex={0}
           title={toggleLabel}
         >
-          {text}
+          <span class={CSS.toggleSwitchText}>
+            {text}
+          </span>
           <calcite-switch
             aria-labelledby={labelId}
             onCalciteSwitchChange={this.toggleSection}

--- a/src/components/calcite-block-section/resources.ts
+++ b/src/components/calcite-block-section/resources.ts
@@ -2,6 +2,7 @@ export const CSS = {
   content: "content",
   toggle: "toggle",
   toggleSwitch: "toggle--switch",
+  toggleSwitchText: "toggle--switch__text",
   sectionHeader: "section-header",
   sectionHeaderText: "section-header__text"
 };

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -43,6 +43,7 @@
 .toggle {
   @apply flex
     flex-no-wrap
+    justify-between
     font-inherit
     items-center
     m-0
@@ -99,7 +100,16 @@ calcite-handle {
 }
 
 .toggle-icon {
-  @apply ml-3;
+  @apply mr-4
+  self-center
+  text-color-3
+  transition-color
+  duration-150
+  ease-in-out;
+}
+
+.toggle:hover .toggle-icon {
+  @apply text-color-1;
 }
 
 .content {
@@ -116,7 +126,7 @@ calcite-handle {
 
 .calcite--rtl {
   .toggle-icon {
-    @apply ml-0 mr-3;
+    @apply mr-0 ml-4;
   }
   .icon {
     @apply ml-0 mr-3;
@@ -143,16 +153,10 @@ calcite-handle {
 }
 
 :host([drag-handle]) {
-  .toggle-icon {
-    @apply ml-2;
-  }
 
   .calcite--rtl {
     .title {
       @apply pl-0 pr-1;
-    }
-    .toggle-icon {
-      @apply ml-0 mr-2;
     }
   }
 }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -30,8 +30,8 @@
 
 .header-container {
   @apply grid items-stretch;
-  grid-template: auto / auto 1fr auto;
-  grid-template-areas: "handle header control";
+  grid-template: auto / auto auto 1fr auto;
+  grid-template-areas: "handle toggle-icon header control";
   grid-column: header-start / control-end;
   grid-row: 1 / 2;
 
@@ -97,13 +97,13 @@ calcite-handle {
 }
 
 .toggle-icon {
-  @apply flex-grow-0
-    flex-shrink-0
-    fill-current
-    m-0
-    mr-4;
+  @apply flex
+  flex-initial
+  items-center
+  pl-3
+  pr-1;
 
-  flex-basis: theme("spacing.4");
+  grid-area: toggle-icon;
 }
 
 .content {
@@ -126,10 +126,7 @@ calcite-handle {
 
 :host([open]) {
   @apply my-3;
-  box-shadow: 1px 0 0 var(--calcite-ui-border-1) inset;
-  &.calcite--rtl {
-    box-shadow: -1px 0 0 var(--calcite-ui-border-1) inset;
-  }
+
   .header .title .heading {
     @apply text-color-1;
   }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -30,8 +30,8 @@
 
 .header-container {
   @apply grid items-stretch;
-  grid-template: auto / auto auto 1fr auto;
-  grid-template-areas: "handle toggle-icon header control";
+  grid-template: auto / auto 1fr auto;
+  grid-template-areas: "handle header control";
   grid-column: header-start / control-end;
   grid-row: 1 / 2;
 
@@ -79,7 +79,9 @@ calcite-handle {
   @apply p-0
     text--1
     text-color-3
+    font-medium
     word-break
+    leading-tight
     transition-color
     duration-150
     ease-in-out;
@@ -100,14 +102,7 @@ calcite-handle {
   @apply flex
   flex-initial
   items-center
-  pl-3
-  pr-1;
-
-  grid-area: toggle-icon;
-}
-
-.has-drag-handle .toggle-icon {
-  @apply px-2;
+  pl-3;
 }
 
 .content {
@@ -123,13 +118,16 @@ calcite-handle {
 }
 
 .calcite--rtl {
+  .toggle-icon {
+    @apply pl-0 pr-3;
+  }
   .icon {
     @apply ml-0 mr-3;
   }
 }
 
 :host([open]) {
-  @apply my-3;
+  @apply my-2;
 
   .header .title .heading {
     @apply text-color-1;
@@ -148,12 +146,11 @@ calcite-handle {
 }
 
 :host([drag-handle]) {
-  .title {
-    @apply pl-1;
-  }
-
   .icon {
-    @apply ml-0 mr-2;
+    @apply ml-1;
+  }
+  .toggle-icon {
+    @apply pl-2;
   }
 
   .calcite--rtl {
@@ -161,7 +158,10 @@ calcite-handle {
       @apply pl-0 pr-1;
     }
     .icon {
-      @apply mr-0 ml-1;
+      @apply ml-0 mr-1;
+    }
+    .toggle-icon {
+      @apply pl-0 pr-2;
     }
   }
 }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -143,9 +143,6 @@ calcite-handle {
 }
 
 :host([drag-handle]) {
-  .icon {
-    @apply ml-1;
-  }
   .toggle-icon {
     @apply ml-2;
   }
@@ -153,9 +150,6 @@ calcite-handle {
   .calcite--rtl {
     .title {
       @apply pl-0 pr-1;
-    }
-    .icon {
-      @apply ml-0 mr-1;
     }
     .toggle-icon {
       @apply ml-0 mr-2;

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -99,10 +99,7 @@ calcite-handle {
 }
 
 .toggle-icon {
-  @apply flex
-  flex-initial
-  items-center
-  pl-3;
+  @apply ml-3;
 }
 
 .content {
@@ -119,7 +116,7 @@ calcite-handle {
 
 .calcite--rtl {
   .toggle-icon {
-    @apply pl-0 pr-3;
+    @apply ml-0 mr-3;
   }
   .icon {
     @apply ml-0 mr-3;
@@ -150,7 +147,7 @@ calcite-handle {
     @apply ml-1;
   }
   .toggle-icon {
-    @apply pl-2;
+    @apply ml-2;
   }
 
   .calcite--rtl {
@@ -161,7 +158,7 @@ calcite-handle {
       @apply ml-0 mr-1;
     }
     .toggle-icon {
-      @apply pl-0 pr-2;
+      @apply ml-0 mr-2;
     }
   }
 }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -73,7 +73,7 @@ calcite-handle {
 }
 
 .title {
-  @apply m-0 px-3 py-0;
+  @apply m-0 px-4 py-0;
 }
 
 .header .title .heading {

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -106,6 +106,10 @@ calcite-handle {
   grid-area: toggle-icon;
 }
 
+.has-drag-handle .toggle-icon {
+  @apply px-2;
+}
+
 .content {
   @apply px-3
     py-2

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -149,13 +149,13 @@ export class CalciteBlock {
 
     const headerContent = (
       <header class={CSS.header}>
+        {collapsible ? (
+          <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} aria-hidden="true" />
+        ) : null}
         {hasIcon ? (
           <div class={CSS.icon}>
             <slot name={SLOTS.icon} />
           </div>
-        ) : null}
-        {collapsible ? (
-          <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} aria-hidden="true" />
         ) : null}
         <div class={CSS.title}>
           <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -165,7 +165,10 @@ export class CalciteBlock {
     const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
 
     const headerNode = (
-      <div class={CSS.headerContainer}>
+      <div class={{
+        [CSS.headerContainer]: true,
+        [CSS.hasDragHandle]: this.dragHandle
+        }}>
         {this.dragHandle ? <calcite-handle /> : null}
         {collapsible ? ([
           <div class={CSS.toggleIcon} aria-hidden="true">

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -145,13 +145,9 @@ export class CalciteBlock {
     const toggleLabel = open ? intlCollapse || TEXT.collapse : intlExpand || TEXT.expand;
 
     const hasIcon = getSlotted(el, SLOTS.icon);
-    const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
 
     const headerContent = (
       <header class={CSS.header}>
-        {collapsible ? (
-          <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} aria-hidden="true" />
-        ) : null}
         {hasIcon ? (
           <div class={CSS.icon}>
             <slot name={SLOTS.icon} />
@@ -167,6 +163,7 @@ export class CalciteBlock {
     );
 
     const hasControl = getSlotted(el, SLOTS.control);
+    const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
 
     const headerNode = (
       <div class={CSS.headerContainer}>
@@ -180,6 +177,7 @@ export class CalciteBlock {
             title={toggleLabel}
           >
             {headerContent}
+            <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} aria-hidden="true" />
           </button>
         ) : (
           headerContent

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
-import { CSS, SLOTS, TEXT, HEADING_LEVEL, TOGGLE_ICON } from "./resources";
+import { CSS, SLOTS, TEXT, HEADING_LEVEL, ICONS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { Theme } from "../interfaces";
 import { getElementDir, getSlotted } from "../../utils/dom";
@@ -163,7 +163,7 @@ export class CalciteBlock {
     );
 
     const hasControl = !!getSlotted(el, SLOTS.control);
-    const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
+    const collapseIcon = open ? ICONS.opened : ICONS.closed;
 
     const headerNode = (
       <div class={CSS.headerContainer}>

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -155,7 +155,7 @@ export class CalciteBlock {
           </div>
         ) : null}
         {collapsible ? (
-          <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} />
+          <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} aria-hidden="true" />
         ) : null}
         <div class={CSS.title}>
           <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -162,7 +162,7 @@ export class CalciteBlock {
       </header>
     );
 
-    const hasControl = getSlotted(el, SLOTS.control);
+    const hasControl = !!getSlotted(el, SLOTS.control);
     const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
 
     const headerNode = (
@@ -177,7 +177,14 @@ export class CalciteBlock {
             title={toggleLabel}
           >
             {headerContent}
-            <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} aria-hidden="true" />
+            {!hasControl ? (
+              <calcite-icon
+                icon={collapseIcon}
+                scale="s"
+                class={CSS.toggleIcon}
+                aria-hidden="true"
+              />
+            ) : null}
           </button>
         ) : (
           headerContent

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -145,11 +145,18 @@ export class CalciteBlock {
     const toggleLabel = open ? intlCollapse || TEXT.collapse : intlExpand || TEXT.expand;
 
     const hasIcon = getSlotted(el, SLOTS.icon);
+    const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
+
     const headerContent = (
       <header class={CSS.header}>
         {hasIcon ? (
           <div class={CSS.icon}>
             <slot name={SLOTS.icon} />
+          </div>
+        ) : null}
+        {collapsible ? (
+          <div class={CSS.toggleIcon} aria-hidden="true">
+            <calcite-icon icon={collapseIcon} scale="s" />
           </div>
         ) : null}
         <div class={CSS.title}>
@@ -162,18 +169,13 @@ export class CalciteBlock {
     );
 
     const hasControl = getSlotted(el, SLOTS.control);
-    const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
 
     const headerNode = (
-      <div class={{
-        [CSS.headerContainer]: true,
-        [CSS.hasDragHandle]: this.dragHandle
-        }}>
+      <div
+        class={CSS.headerContainer}
+      >
         {this.dragHandle ? <calcite-handle /> : null}
-        {collapsible ? ([
-          <div class={CSS.toggleIcon} aria-hidden="true">
-            <calcite-icon icon={collapseIcon} scale="s" />
-          </div>,
+        {collapsible ? (
           <button
             aria-expanded={collapsible ? open.toString() : null}
             aria-label={toggleLabel}
@@ -183,7 +185,7 @@ export class CalciteBlock {
           >
             {headerContent}
           </button>
-        ]) : (
+        ) : (
           headerContent
         )}
         {loading ? (

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -155,9 +155,7 @@ export class CalciteBlock {
           </div>
         ) : null}
         {collapsible ? (
-          <div class={CSS.toggleIcon} aria-hidden="true">
-            <calcite-icon icon={collapseIcon} scale="s" />
-          </div>
+          <calcite-icon icon={collapseIcon} scale="s" class={CSS.toggleIcon} />
         ) : null}
         <div class={CSS.title}>
           <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
@@ -171,9 +169,7 @@ export class CalciteBlock {
     const hasControl = getSlotted(el, SLOTS.control);
 
     const headerNode = (
-      <div
-        class={CSS.headerContainer}
-      >
+      <div class={CSS.headerContainer}>
         {this.dragHandle ? <calcite-handle /> : null}
         {collapsible ? (
           <button

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
-import { CSS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
+import { CSS, SLOTS, TEXT, HEADING_LEVEL, TOGGLE_ICON } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { Theme } from "../interfaces";
 import { getElementDir, getSlotted } from "../../utils/dom";
@@ -162,11 +162,15 @@ export class CalciteBlock {
     );
 
     const hasControl = getSlotted(el, SLOTS.control);
+    const collapseIcon = open ? TOGGLE_ICON.opened : TOGGLE_ICON.closed;
 
     const headerNode = (
       <div class={CSS.headerContainer}>
         {this.dragHandle ? <calcite-handle /> : null}
-        {collapsible ? (
+        {collapsible ? ([
+          <div class={CSS.toggleIcon} aria-hidden="true">
+            <calcite-icon icon={collapseIcon} scale="s" />
+          </div>,
           <button
             aria-expanded={collapsible ? open.toString() : null}
             aria-label={toggleLabel}
@@ -176,7 +180,7 @@ export class CalciteBlock {
           >
             {headerContent}
           </button>
-        ) : (
+        ]) : (
           headerContent
         )}
         {loading ? (

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -2,7 +2,6 @@ export const CSS = {
   article: "article",
   content: "content",
   headerContainer: "header-container",
-  hasDragHandle: "has-drag-handle",
   icon: "icon",
   toggle: "toggle",
   toggleIcon: "toggle-icon",

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -24,4 +24,9 @@ export const SLOTS = {
   control: "control"
 };
 
+export const TOGGLE_ICON = {
+  opened: "chevron-up",
+  closed: "chevron-down",
+}
+
 export const HEADING_LEVEL = 4;

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -24,7 +24,7 @@ export const SLOTS = {
   control: "control"
 };
 
-export const TOGGLE_ICON = {
+export const ICONS = {
   opened: "chevron-up",
   closed: "chevron-down",
 }

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -2,6 +2,7 @@ export const CSS = {
   article: "article",
   content: "content",
   headerContainer: "header-container",
+  hasDragHandle: "has-drag-handle",
   icon: "icon",
   toggle: "toggle",
   toggleIcon: "toggle-icon",

--- a/src/components/calcite-handle/calcite-handle.scss
+++ b/src/components/calcite-handle/calcite-handle.scss
@@ -7,20 +7,23 @@
     items-center 
     self-stretch 
     justify-center
-    text-color-2 
     bg-transparent 
     border-none 
     cursor-move
     focus-base;
+  color: theme("borderColor.color.3");
   padding: theme("spacing.3") theme("spacing.1");
   line-height: 0;
   &:hover {
-    @apply bg-foreground-2 text-color-2;
+    @apply bg-foreground-2 text-color-1;
   }
   &:focus {
     @apply text-color-1 focus-inset;
   }
   &--activated {
     @apply bg-foreground-3 text-color-1;
+  }
+  calcite-icon {
+    color: inherit;
   }
 }

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -113,6 +113,19 @@
   }
 }
 
+.back-button {
+  @apply border-color-3
+  border-solid
+  border-l-0
+  border-t-0
+  border-b-0
+  border-r-px;
+}
+
+.calcite--rtl .back-button {
+  @apply border-r-0 border-l-px;
+}
+
 .header-actions {
   @apply flex
   items-stretch

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -116,9 +116,7 @@
 .back-button {
   @apply border-color-3
   border-solid
-  border-l-0
-  border-t-0
-  border-b-0
+  border-0
   border-r-px;
 }
 

--- a/src/demos/shell/popup-config-example.html
+++ b/src/demos/shell/popup-config-example.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+
+    <title>Boomer v Millennial - California</title>
+
+    <script src="../_assets/head.js"></script>
+
+    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/themes/light/main.css" />
+    <script src="https://js.arcgis.com/4.15/"></script>
+    <style>
+      html,
+      body,
+      main,
+      .shell-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <style>
+      #viewDiv {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
+        });
+
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap
+        });
+        view.when(function () {
+          view.ui.move("zoom", "bottom-right");
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <main>
+      <div class="shell-container">
+        <calcite-shell content-behind>
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
+            <calcite-action-bar slot="action-bar" theme="dark">
+              <calcite-action-group>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action icon="map" text="New"> </calcite-action>
+                <calcite-action icon="collection" text="Open"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers" active> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action text="Share" icon="share"></calcite-action>
+                <calcite-action text="Print" icon="print"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Feedback" icon="speech-bubble-plus"></calcite-action>
+                <calcite-action text="What's next" icon="mega-phone"></calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-panel heading="Sketch">
+              <div style="padding: var(--calcite-spacing-half)">
+                <calcite-label scale="s">Draw features</calcite-label>
+                <calcite-action-group layout="grid" style="margin-bottom: var(--calcite-spacing)">
+                  <calcite-action alignment="center" icon="pin" text="Stamp"></calcite-action>
+                  <calcite-action alignment="center" icon="line" text="Line"></calcite-action>
+                  <calcite-action alignment="center" icon="polygon" text="Polygon"></calcite-action>
+                  <calcite-action alignment="center" icon="rectangle" text="Rectangle"></calcite-action>
+                  <calcite-action alignment="center" icon="circle" text="Circle"></calcite-action>
+                  <calcite-action alignment="center" icon="text" text="Text"></calcite-action>
+                </calcite-action-group>
+                <calcite-label scale="s">Select features</calcite-label>
+                <calcite-action-group layout="grid">
+                  <calcite-action alignment="center" icon="cursor" text="Select"></calcite-action>
+                  <calcite-action alignment="center" icon="cursor-marquee" text="Select by rectangle"></calcite-action>
+                  <calcite-action alignment="center" icon="lasso" text="Select by lasso"></calcite-action>
+                </calcite-action-group>
+              </div>
+            </calcite-panel>
+          </calcite-shell-panel>
+
+          <calcite-shell-panel slot="contextual-panel" position="end">
+            <calcite-action-bar slot="action-bar">
+              <calcite-action-group>
+                <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
+                <calcite-action text="Styles" icon="shapes"> </calcite-action>
+                <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
+                <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
+                <calcite-action text="Configure attributes" icon="feature-details"> </calcite-action>
+                <calcite-action text="Labels" icon="label"> </calcite-action>
+                <calcite-action text="Tablew" icon="table"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="search" text="Search"></calcite-action>
+                <calcite-action icon="measure" text="Measure"></calcite-action>
+                <calcite-action icon="road-sign" text="Directions"></calcite-action>
+                <calcite-action icon="point" text="Location"></calcite-action>
+                <calcite-action icon="pencil-square" text="Edit" disabled></calcite-action>
+                <calcite-action icon="clock" text="Time" disabled></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Tips" id="tip-manager-button">
+                  <calcite-icon icon="lightbulb" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-button
+              slot="header"
+              color="inverse"
+              alignment="icon-end-space-between"
+              icon-end="caret-down"
+              width="full"
+            >
+              Ice Cream should be one word.
+            </calcite-button>
+            <!-- <div style="height: 100%;"> -->
+            <calcite-flow id="flow">
+              <style>
+                .demo-heading {
+                  font-weight: 500;
+                  color: var(--calcite-ui-text-2);
+                }
+                .manage-expresssion-container {
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+                  padding: 0.5rem 0;
+                  margin: 1.25rem 0 0.5rem 0;
+                  /* border: 1px solid #e0e0e0; */
+                }
+                .manage-expresssion-text {
+                  flex: 1 0 auto;
+                }
+                .manage-expresssion-container .icon {
+                  flex: 0 0 auto;
+                  padding-right: 0.25rem;
+                }
+              </style>
+              <calcite-panel heading="cool" summary="Popular Demographics in the United States (Beta) - County">
+                I'm this panel's content.
+              </calcite-panel>
+              <calcite-panel heading="Configure popup" dismissible>
+                <!-- <div style="padding: 0.75rem">
+                  <calcite-notice active dismissible scale="s">
+                    <span slot="notice-message"
+                      >The message we've been putting up here. I don't remember what it is.</span
+                    >
+                  </calcite-notice>
+                </div> -->
+                <calcite-block heading="Options" collapsible open>
+                  <calcite-icon icon="sliders" scale="m" slot="icon"></calcite-icon>
+                  <calcite-label layout="inline-space-between">
+                    Enable pop-ups
+                    <calcite-switch switched></calcite-switch>
+                  </calcite-label>
+                  <div class="manage-expresssion-container">
+                    <span class="manage-expresssion-text">Manage expressions</span>
+                    <calcite-icon class="icon" icon="chevron-right" scale="s" />
+                  </div>
+                  <div class="manage-expresssion-container" style="margin-top: 0.25rem">
+                    <span class="manage-expresssion-text">Format fields</span>
+                    <calcite-icon class="icon" icon="chevron-right" scale="s" />
+                  </div>
+                </calcite-block>
+
+                <calcite-block heading="Title" summary="{Cty_NAME}" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <calcite-label scale="s">
+                    Title
+                    <calcite-input type="text" placeholder="My awesome title" value="{Cty_NAME}">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                </calcite-block>
+
+                <h4 class="demo-heading" style="margin: 0.75rem">Contents</h4>
+
+                <!-- <div style="padding: 0.75rem">
+                    <calcite-notice active dismissible scale="s" icon>
+                      <span slot="notice-message">Enable pop-ups to add images, charts, text, and fields.</span>
+                    </calcite-notice>
+                  </div> -->
+                  <!-- <calcite-sortable-list> -->
+                <calcite-block drag-handle heading="Media" summary="Multiple (2)" collapsible >
+                  <calcite-icon icon="images" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <calcite-label scale="s">
+                    Title
+                    <calcite-input type="text" placeholder="My awesome title">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input> </calcite-label
+                  ><calcite-label scale="s">
+                    Description
+                    <calcite-input type="text" placeholder="My awesome description">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <calcite-value-list drag-enabled>
+                    <calcite-value-list-item label="Example of Trend Progress..." description="Image">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="Aggregation of things" description="Bar chart">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                  </calcite-value-list>
+                </calcite-block>
+               
+                <calcite-block drag-handle heading="Fields list" summary="12/13 fields" collapsible  >
+                  <calcite-icon icon="feature-details" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <calcite-label scale="s">
+                    Title
+                    <calcite-input type="text" placeholder="My awesome title">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input> </calcite-label
+                  ><calcite-label scale="s">
+                    Description
+                    <calcite-input type="text" placeholder="My awesome description">
+                      <calcite-action
+                        text="cool action"
+                        icon="brackets-curly"
+                        slot="input-action"
+                        scale="s"
+                      ></calcite-action>
+                    </calcite-input>
+                  </calcite-label>
+                  <h4>Field items</h4>
+                  <calcite-value-list drag-enabled>
+                    <calcite-value-list-item label="# of Trend Changes">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="# of Trend Changes">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="# of Trend Changes">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="# of Trend Changes">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="# of Trend Changes">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                    <calcite-value-list-item label="# of Trend Changes">
+                      <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
+                    </calcite-value-list-item>
+                  </calcite-value-list>
+                </calcite-block> 
+                <calcite-block drag-handle heading="Text" summary="The trending population in this..." collapsible  >
+                    <calcite-icon icon="text" scale="m" slot="icon"></calcite-icon>
+                    <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                </calcite-block>
+            <!-- </calcite-sortable-list> -->
+
+                <calcite-fab
+                  slot="fab"
+                  id="label-fab"
+                  text="Add content"
+                  text-enabled
+                  scale="s"
+                  style="margin-top: 1rem"
+                ></calcite-fab>
+              </calcite-panel>
+            </calcite-flow>
+            <!-- </div> -->
+          </calcite-shell-panel>
+          <div class="gnav" slot="shell-header">
+            <h2>Cool app</h2>
+          </div>
+          <calcite-tip-manager slot="center-row" id="tip-manager" hidden>
+            <calcite-tip-group group-title="Astronomy">
+              <calcite-tip heading="The Red Rocks and Blue Water">
+                <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
+                <p>
+                  This tip is how a tip should really look. It has a landscape or square image and a small amount of
+                  text content. This paragraph is in an "info" slot.
+                </p>
+                <p>
+                  This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum
+                  is a placeholder text commonly used to demonstrate the visual form of a document without relying on
+                  meaningful content (also called greeking). Replacing the actual content with placeholder text allows
+                  designers to design the form of the content before the content itself has been produced.
+                </p>
+                <a href="http://www.esri.com">This is the "link" slot.</a>
+              </calcite-tip>
+              <calcite-tip heading="The Long Trees">
+                <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
+                <p>
+                  This tip has an image that is a pretty tall. And the text will run out before the end of the image.
+                </p>
+                <p>In astronomy, the terms object and body are often used interchangeably.</p>
+                <a href="http://www.esri.com">View Esri</a>
+              </calcite-tip>
+            </calcite-tip-group>
+            <calcite-tip heading="Square Nature">
+              <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
+              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
+              <p>In astronomy, the terms object and body are often used interchangeably.</p>
+              <p>
+                In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
+                visual form of a document without relying on meaningful content (also called greeking). Replacing the
+                actual content with placeholder text allows designers to design the form of the content before the
+                content itself has been produced.
+              </p>
+              <a href="http://www.esri.com">View Esri</a>
+            </calcite-tip>
+            <calcite-tip heading="The lack of imagery">
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
+              <p>
+                This is the next paragraph and should show how wide the content area is now. Of course, the width of the
+                overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
+              </p>
+              <a href="http://www.esri.com">View Esri</a>
+            </calcite-tip>
+          </calcite-tip-manager>
+          <div id="viewDiv"></div>
+
+          <footer slot="shell-footer">Footer</footer>
+        </calcite-shell>
+      </div>
+      <calcite-popover label="right start popover" placement="right" reference-element="popover-trigger">
+        <calcite-panel heading="Cool cool" height-scale="m">
+          <calcite-pick-list filter-enabled filter-sticky>
+            <calcite-action slot="menu-actions" text="options">
+              <calcite-icon icon="ellipsis" scale="s"></calcite-icon>
+            </calcite-action>
+            <calcite-pick-list-item
+              label="about disasters, fires, floods and killer bees"
+              value="1"
+            ></calcite-pick-list-item>
+            <calcite-pick-list-item
+              label="about the NASA shuttle falling in the sea"
+              value="2"
+            ></calcite-pick-list-item>
+            <calcite-pick-list-item
+              label="about starvation and the food that Live Aid bought"
+              value="3"
+            ></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
+            <calcite-pick-list-item label="END" value="4"></calcite-pick-list-item>
+          </calcite-pick-list>
+          <calcite-button slot="footer" width="half">Yeah!</calcite-button>
+          <calcite-button slot="footer" width="half" appearance="clear">Naw.</calcite-button>
+        </calcite-panel>
+      </calcite-popover>
+      <script>
+        const tipManagerButton = document.getElementById("tip-manager-button");
+        const tipManager = document.getElementById("tip-manager");
+        tipManagerButton.addEventListener("click", function () {
+          tipManager.hasAttribute("hidden")
+            ? tipManager.removeAttribute("hidden")
+            : tipManager.setAttribute("hidden", "");
+        });
+        const flowNode = document.getElementById("flow");
+      </script>
+    </main>
+  </body>
+</html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -136,6 +136,9 @@ module.exports = {
       borderRadius: {
         half: "50%"
       },
+      borderWidth: {
+        px: "1px"
+      },
       boxShadow: {
         0: "0 4px 8px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.04)",
         1: "0 4px 8px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.04)",


### PR DESCRIPTION
**Related Issue:** #1542 

## Summary
Adds an icon that indicates opened or closed status of the Block.
Only adds the icon if the Block is collapsible.

Also updates the UI of other components to both increase alignment and distinguish functionality.

@mitc7862 @bstifle Could use your UI review as well.

View demos/shell/block-configurations.html to see permutations of the Block header and how it relates to Panel's back button and BlockSection.

cc @AdelheidF 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

