### PR TITLE
feat(action-menu, combobox, dropdown, input-date-picker, popover, tooltip): Add 'overlayPositioning' property. #2069

### DIFF
--- a/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
+++ b/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
@@ -48,6 +48,10 @@ describe("calcite-action-menu", () => {
       {
         propertyName: "scale",
         defaultValue: "m"
+      },
+      {
+        propertyName: "strategy",
+        defaultValue: "absolute"
       }
     ]));
 

--- a/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
+++ b/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
@@ -50,7 +50,7 @@ describe("calcite-action-menu", () => {
         defaultValue: "m"
       },
       {
-        propertyName: "strategy",
+        propertyName: "positionStrategy",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
+++ b/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
@@ -50,7 +50,7 @@ describe("calcite-action-menu", () => {
         defaultValue: "m"
       },
       {
-        propertyName: "positionStrategy",
+        propertyName: "overlayPositioning",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -15,7 +15,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
 import { focusElement, getSlotted } from "../../utils/dom";
 import { forceUpdate, VNode } from "@stencil/core/internal";
 import { getRoundRobinIndex } from "../../utils/array";
-import { PopperPlacement } from "../../utils/popper";
+import { PopperPlacement, PopperStrategy } from "../../utils/popper";
 import { Placement } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
@@ -96,6 +96,9 @@ export class CalciteActionMenu {
    * Specifies the size of the action.
    */
   @Prop({ reflect: true }) scale: Scale = "m";
+
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() strategy: PopperStrategy = "absolute";
 
   // --------------------------------------------------------------------------
   //
@@ -206,7 +209,8 @@ export class CalciteActionMenu {
       menuId,
       menuButtonEl,
       label,
-      placement
+      placement,
+      strategy
     } = this;
 
     const activeAction = actionElements[activeMenuItemIndex];
@@ -218,6 +222,7 @@ export class CalciteActionMenu {
         open={open}
         placement={placement}
         referenceElement={menuButtonEl}
+        strategy={strategy}
       >
         <div
           aria-activedescendant={activeDescendantId}

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -15,7 +15,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
 import { focusElement, getSlotted } from "../../utils/dom";
 import { forceUpdate, VNode } from "@stencil/core/internal";
 import { getRoundRobinIndex } from "../../utils/array";
-import { PopperPlacement, PopperStrategy } from "../../utils/popper";
+import { PopperPlacement, PopperPositionStrategy } from "../../utils/popper";
 import { Placement } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
@@ -92,13 +92,13 @@ export class CalciteActionMenu {
    */
   @Prop({ reflect: true }) placement: PopperPlacement = "auto";
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+
   /**
    * Specifies the size of the action.
    */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() strategy: PopperStrategy = "absolute";
 
   // --------------------------------------------------------------------------
   //
@@ -210,7 +210,7 @@ export class CalciteActionMenu {
       menuButtonEl,
       label,
       placement,
-      strategy
+      positionStrategy
     } = this;
 
     const activeAction = actionElements[activeMenuItemIndex];
@@ -221,8 +221,8 @@ export class CalciteActionMenu {
         label={label}
         open={open}
         placement={placement}
+        positionStrategy={positionStrategy}
         referenceElement={menuButtonEl}
-        strategy={strategy}
       >
         <div
           aria-activedescendant={activeDescendantId}

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -87,7 +87,7 @@ export class CalciteActionMenu {
     this.calciteActionMenuOpenChange.emit(open);
   }
 
-  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
+  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -87,7 +87,7 @@ export class CalciteActionMenu {
     this.calciteActionMenuOpenChange.emit(open);
   }
 
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -15,7 +15,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
 import { focusElement, getSlotted } from "../../utils/dom";
 import { forceUpdate, VNode } from "@stencil/core/internal";
 import { getRoundRobinIndex } from "../../utils/array";
-import { PopperPlacement, PopperPositionStrategy } from "../../utils/popper";
+import { PopperPlacement, OverlayPositioning } from "../../utils/popper";
 import { Placement } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
@@ -87,13 +87,13 @@ export class CalciteActionMenu {
     this.calciteActionMenuOpenChange.emit(open);
   }
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() overlayPositioning: OverlayPositioning = "absolute";
+
   /**
    * Determines where the component will be positioned relative to the referenceElement.
    */
   @Prop({ reflect: true }) placement: PopperPlacement = "auto";
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
 
   /**
    * Specifies the size of the action.
@@ -210,7 +210,7 @@ export class CalciteActionMenu {
       menuButtonEl,
       label,
       placement,
-      positionStrategy
+      overlayPositioning
     } = this;
 
     const activeAction = actionElements[activeMenuItemIndex];
@@ -220,8 +220,8 @@ export class CalciteActionMenu {
       <calcite-popover
         label={label}
         open={open}
+        overlayPositioning={overlayPositioning}
         placement={placement}
-        positionStrategy={positionStrategy}
         referenceElement={menuButtonEl}
       >
         <div

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-combobox", () => {
   it("defaults", async () =>
     defaults("calcite-combobox", [
       {
-        propertyName: "strategy",
+        propertyName: "positionStrategy",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -1,9 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { renders, hidden, accessible } from "../../tests/commonTests";
+import { renders, hidden, accessible, defaults } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
 describe("calcite-combobox", () => {
   it("renders", async () => renders("calcite-combobox"));
+  it("defaults", async () =>
+    defaults("calcite-combobox", [
+      {
+        propertyName: "strategy",
+        defaultValue: "absolute"
+      }
+    ]));
   it("honors hidden attribute", async () => hidden("calcite-combobox"));
   it("is accessible", async () =>
     accessible(`

--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-combobox", () => {
   it("defaults", async () =>
     defaults("calcite-combobox", [
       {
-        propertyName: "positionStrategy",
+        propertyName: "overlayPositioning",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -17,7 +17,7 @@ import { filter } from "../../utils/filter";
 import { getElementDir } from "../../utils/dom";
 import { debounce } from "lodash-es";
 import { getKey } from "../../utils/key";
-import { createPopper, updatePopper, CSS as PopperCSS } from "../../utils/popper";
+import { createPopper, updatePopper, CSS as PopperCSS, PopperStrategy } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale, Theme } from "../interfaces";
@@ -109,6 +109,9 @@ export class CalciteCombobox {
 
   /** Specify the scale of the combobox, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
+
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() strategy: PopperStrategy = "absolute";
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -406,12 +409,13 @@ export class CalciteCombobox {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl } = this;
+    const { menuEl, referenceEl, strategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
+      strategy,
       placement: ComboboxDefaultPlacement,
       referenceEl
     });

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -105,7 +105,7 @@ export class CalciteCombobox {
   /** Allow entry of custom values which are not in the original set of items */
   @Prop() allowCustomValues: boolean;
 
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** specify the selection mode

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -17,7 +17,12 @@ import { filter } from "../../utils/filter";
 import { getElementDir } from "../../utils/dom";
 import { debounce } from "lodash-es";
 import { getKey } from "../../utils/key";
-import { createPopper, updatePopper, CSS as PopperCSS, PopperStrategy } from "../../utils/popper";
+import {
+  createPopper,
+  updatePopper,
+  CSS as PopperCSS,
+  PopperPositionStrategy
+} from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale, Theme } from "../interfaces";
@@ -100,6 +105,9 @@ export class CalciteCombobox {
   /** Allow entry of custom values which are not in the original set of items */
   @Prop() allowCustomValues: boolean;
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+
   /** specify the selection mode
    * - multi: allow any number of selected items (default)
    * - single: only one selection)
@@ -109,9 +117,6 @@ export class CalciteCombobox {
 
   /** Specify the scale of the combobox, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() strategy: PopperStrategy = "absolute";
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -409,13 +414,13 @@ export class CalciteCombobox {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, strategy } = this;
+    const { menuEl, referenceEl, positionStrategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      strategy,
+      positionStrategy,
       placement: ComboboxDefaultPlacement,
       referenceEl
     });

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -105,7 +105,7 @@ export class CalciteCombobox {
   /** Allow entry of custom values which are not in the original set of items */
   @Prop() allowCustomValues: boolean;
 
-  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
+  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** specify the selection mode

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -21,7 +21,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperPositionStrategy
+  OverlayPositioning
 } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
@@ -106,7 +106,7 @@ export class CalciteCombobox {
   @Prop() allowCustomValues: boolean;
 
   /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+  @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** specify the selection mode
    * - multi: allow any number of selected items (default)
@@ -414,13 +414,13 @@ export class CalciteCombobox {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, positionStrategy } = this;
+    const { menuEl, referenceEl, overlayPositioning } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      positionStrategy,
+      overlayPositioning,
       placement: ComboboxDefaultPlacement,
       referenceEl
     });

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -6,7 +6,7 @@ describe("calcite-dropdown", () => {
   it("defaults", async () =>
     defaults("calcite-dropdown", [
       {
-        propertyName: "strategy",
+        propertyName: "positionStrategy",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,8 +1,15 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
-import { HYDRATED_ATTR, accessible } from "../../tests/commonTests";
+import { HYDRATED_ATTR, accessible, defaults } from "../../tests/commonTests";
 import dedent from "dedent";
 
 describe("calcite-dropdown", () => {
+  it("defaults", async () =>
+    defaults("calcite-dropdown", [
+      {
+        propertyName: "strategy",
+        defaultValue: "absolute"
+      }
+    ]));
   /**
    * Test helper for selected calcite-dropdown items. Expects items to have IDs to test against.
    */

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -6,7 +6,7 @@ describe("calcite-dropdown", () => {
   it("defaults", async () =>
     defaults("calcite-dropdown", [
       {
-        propertyName: "positionStrategy",
+        propertyName: "overlayPositioning",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -67,7 +67,7 @@ export class CalciteDropdown {
   */
   @Prop() maxItems = 0;
 
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -14,7 +14,12 @@ import {
 import { DropdownPlacement, GroupRegistration, ItemKeyboardEvent } from "./interfaces";
 import { getKey } from "../../utils/key";
 import { focusElement, getElementDir } from "../../utils/dom";
-import { createPopper, updatePopper, CSS as PopperCSS, PopperStrategy } from "../../utils/popper";
+import {
+  createPopper,
+  updatePopper,
+  CSS as PopperCSS,
+  PopperPositionStrategy
+} from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { Scale, Theme } from "../interfaces";
 import { DefaultDropdownPlacement } from "./resources";
@@ -72,6 +77,9 @@ export class CalciteDropdown {
     this.reposition();
   }
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+
   /** specify the scale of dropdown, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
 
@@ -81,9 +89,6 @@ export class CalciteDropdown {
    * @readonly
    */
   @Prop({ mutable: true }) selectedItems: HTMLCalciteDropdownItemElement[] = [];
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() strategy: PopperStrategy = "absolute";
 
   /** specify the theme of the dropdown, defaults to light */
   @Prop({ reflect: true }) theme: Theme;
@@ -360,13 +365,13 @@ export class CalciteDropdown {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, placement, strategy } = this;
+    const { menuEl, referenceEl, placement, positionStrategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      strategy,
+      positionStrategy,
       placement,
       referenceEl
     });

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -18,7 +18,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperPositionStrategy
+  OverlayPositioning
 } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { Scale, Theme } from "../interfaces";
@@ -67,6 +67,9 @@ export class CalciteDropdown {
   */
   @Prop() maxItems = 0;
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() overlayPositioning: OverlayPositioning = "absolute";
+
   /**
    * Determines where the dropdown will be positioned relative to the button.
    */
@@ -76,9 +79,6 @@ export class CalciteDropdown {
   placementHandler(): void {
     this.reposition();
   }
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
 
   /** specify the scale of dropdown, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -365,13 +365,13 @@ export class CalciteDropdown {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, placement, positionStrategy } = this;
+    const { menuEl, referenceEl, placement, overlayPositioning } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      positionStrategy,
+      overlayPositioning,
       placement,
       referenceEl
     });

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -67,7 +67,7 @@ export class CalciteDropdown {
   */
   @Prop() maxItems = 0;
 
-  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
+  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -14,7 +14,7 @@ import {
 import { DropdownPlacement, GroupRegistration, ItemKeyboardEvent } from "./interfaces";
 import { getKey } from "../../utils/key";
 import { focusElement, getElementDir } from "../../utils/dom";
-import { createPopper, updatePopper, CSS as PopperCSS } from "../../utils/popper";
+import { createPopper, updatePopper, CSS as PopperCSS, PopperStrategy } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { Scale, Theme } from "../interfaces";
 import { DefaultDropdownPlacement } from "./resources";
@@ -81,6 +81,9 @@ export class CalciteDropdown {
    * @readonly
    */
   @Prop({ mutable: true }) selectedItems: HTMLCalciteDropdownItemElement[] = [];
+
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() strategy: PopperStrategy = "absolute";
 
   /** specify the theme of the dropdown, defaults to light */
   @Prop({ reflect: true }) theme: Theme;
@@ -357,12 +360,13 @@ export class CalciteDropdown {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, placement } = this;
+    const { menuEl, referenceEl, placement, strategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el: menuEl,
       modifiers,
+      strategy,
       placement,
       referenceEl
     });

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
@@ -1,8 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { defaults } from "../../tests/commonTests";
 
 const animationDurationInMs = 200;
 
 describe("calcite-input-date-picker", () => {
+  it("defaults", async () =>
+    defaults("calcite-input-date-picker", [
+      {
+        propertyName: "strategy",
+        defaultValue: "absolute"
+      }
+    ]));
   it("fires a calciteDatePickerChange event on change", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-input-date-picker></calcite-input-date-picker>");

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-input-date-picker", () => {
   it("defaults", async () =>
     defaults("calcite-input-date-picker", [
       {
-        propertyName: "positionStrategy",
+        propertyName: "overlayPositioning",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-input-date-picker", () => {
   it("defaults", async () =>
     defaults("calcite-input-date-picker", [
       {
-        propertyName: "strategy",
+        propertyName: "positionStrategy",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -107,7 +107,7 @@ export class CalciteInputDatePicker {
   /** Selected end date */
   @Prop() end?: string;
 
-  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
+  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** Disables the default behaviour on the third click of narrowing or extending the range and instead starts a new range. */

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -107,7 +107,7 @@ export class CalciteInputDatePicker {
   /** Selected end date */
   @Prop() end?: string;
 
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** Disables the default behaviour on the third click of narrowing or extending the range and instead starts a new range. */

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -20,7 +20,7 @@ import { HeadingLevel } from "../functional/CalciteHeading";
 import { getKey } from "../../utils/key";
 import { TEXT } from "../calcite-date-picker/calcite-date-picker-resources";
 
-import { createPopper, updatePopper, CSS as PopperCSS } from "../../utils/popper";
+import { createPopper, updatePopper, CSS as PopperCSS, PopperStrategy } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { DateRangeChange } from "../calcite-date-picker/interfaces";
 
@@ -107,6 +107,9 @@ export class CalciteInputDatePicker {
 
   /** Layout */
   @Prop({ reflect: true }) layout: "horizontal" | "vertical" = "horizontal";
+
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() strategy: PopperStrategy = "absolute";
 
   //--------------------------------------------------------------------------
   //
@@ -420,7 +423,7 @@ export class CalciteInputDatePicker {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl } = this;
+    const { menuEl, referenceEl, strategy } = this;
 
     if (!menuEl || !referenceEl) {
       return;
@@ -431,6 +434,7 @@ export class CalciteInputDatePicker {
     this.popper = createPopper({
       el: menuEl,
       modifiers,
+      strategy,
       placement: DEFAULT_PLACEMENT,
       referenceEl
     });

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -20,7 +20,12 @@ import { HeadingLevel } from "../functional/CalciteHeading";
 import { getKey } from "../../utils/key";
 import { TEXT } from "../calcite-date-picker/calcite-date-picker-resources";
 
-import { createPopper, updatePopper, CSS as PopperCSS, PopperStrategy } from "../../utils/popper";
+import {
+  createPopper,
+  updatePopper,
+  CSS as PopperCSS,
+  PopperPositionStrategy
+} from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { DateRangeChange } from "../calcite-date-picker/interfaces";
 
@@ -102,14 +107,14 @@ export class CalciteInputDatePicker {
   /** Selected end date */
   @Prop() end?: string;
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+
   /** Disables the default behaviour on the third click of narrowing or extending the range and instead starts a new range. */
   @Prop() proximitySelectionDisabled?: boolean = false;
 
   /** Layout */
   @Prop({ reflect: true }) layout: "horizontal" | "vertical" = "horizontal";
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() strategy: PopperStrategy = "absolute";
 
   //--------------------------------------------------------------------------
   //
@@ -423,7 +428,7 @@ export class CalciteInputDatePicker {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, strategy } = this;
+    const { menuEl, referenceEl, positionStrategy } = this;
 
     if (!menuEl || !referenceEl) {
       return;
@@ -434,7 +439,7 @@ export class CalciteInputDatePicker {
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      strategy,
+      positionStrategy,
       placement: DEFAULT_PLACEMENT,
       referenceEl
     });

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -24,7 +24,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperPositionStrategy
+  OverlayPositioning
 } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { DateRangeChange } from "../calcite-date-picker/interfaces";
@@ -108,7 +108,7 @@ export class CalciteInputDatePicker {
   @Prop() end?: string;
 
   /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+  @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** Disables the default behaviour on the third click of narrowing or extending the range and instead starts a new range. */
   @Prop() proximitySelectionDisabled?: boolean = false;
@@ -428,7 +428,7 @@ export class CalciteInputDatePicker {
 
   createPopper(): void {
     this.destroyPopper();
-    const { menuEl, referenceEl, positionStrategy } = this;
+    const { menuEl, referenceEl, overlayPositioning } = this;
 
     if (!menuEl || !referenceEl) {
       return;
@@ -439,7 +439,7 @@ export class CalciteInputDatePicker {
     this.popper = createPopper({
       el: menuEl,
       modifiers,
-      positionStrategy,
+      overlayPositioning,
       placement: DEFAULT_PLACEMENT,
       referenceEl
     });

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -78,7 +78,7 @@ describe("calcite-popover", () => {
         defaultValue: false
       },
       {
-        propertyName: "strategy",
+        propertyName: "positionStrategy",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -76,6 +76,10 @@ describe("calcite-popover", () => {
       {
         propertyName: "disablePointer",
         defaultValue: false
+      },
+      {
+        propertyName: "strategy",
+        defaultValue: "absolute"
       }
     ]));
 

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -78,7 +78,7 @@ describe("calcite-popover", () => {
         defaultValue: false
       },
       {
-        propertyName: "positionStrategy",
+        propertyName: "overlayPositioning",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -18,7 +18,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperStrategy
+  PopperPositionStrategy
 } from "../../utils/popper";
 import { StrictModifiers, Placement, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
@@ -113,6 +113,9 @@ export class CalcitePopover {
     this.reposition();
   }
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+
   /**
    * Reference HTMLElement used to position this component according to the placement property.
    */
@@ -128,9 +131,6 @@ export class CalcitePopover {
 
   /** Text for close button. */
   @Prop() intlClose = TEXT.close;
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() strategy: PopperStrategy = "absolute";
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -317,13 +317,13 @@ export class CalcitePopover {
 
   createPopper(): void {
     this.destroyPopper();
-    const { el, placement, _referenceElement: referenceEl, strategy } = this;
+    const { el, placement, _referenceElement: referenceEl, positionStrategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
-      strategy,
+      positionStrategy,
       placement,
       referenceEl
     });

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -103,7 +103,7 @@ export class CalcitePopover {
     }
   }
 
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -18,7 +18,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperPositionStrategy
+  OverlayPositioning
 } from "../../utils/popper";
 import { StrictModifiers, Placement, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
@@ -103,6 +103,9 @@ export class CalcitePopover {
     }
   }
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() overlayPositioning: OverlayPositioning = "absolute";
+
   /**
    * Determines where the component will be positioned relative to the referenceElement.
    */
@@ -112,9 +115,6 @@ export class CalcitePopover {
   placementHandler(): void {
     this.reposition();
   }
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
 
   /**
    * Reference HTMLElement used to position this component according to the placement property.
@@ -317,13 +317,13 @@ export class CalcitePopover {
 
   createPopper(): void {
     this.destroyPopper();
-    const { el, placement, _referenceElement: referenceEl, positionStrategy } = this;
+    const { el, placement, _referenceElement: referenceEl, overlayPositioning } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
-      positionStrategy,
+      overlayPositioning,
       placement,
       referenceEl
     });

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -103,7 +103,7 @@ export class CalcitePopover {
     }
   }
 
-  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
+  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -17,7 +17,8 @@ import {
   defaultOffsetDistance,
   createPopper,
   updatePopper,
-  CSS as PopperCSS
+  CSS as PopperCSS,
+  PopperStrategy
 } from "../../utils/popper";
 import { StrictModifiers, Placement, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
@@ -127,6 +128,9 @@ export class CalcitePopover {
 
   /** Text for close button. */
   @Prop() intlClose = TEXT.close;
+
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() strategy: PopperStrategy = "absolute";
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -313,12 +317,13 @@ export class CalcitePopover {
 
   createPopper(): void {
     this.destroyPopper();
-    const { el, placement, _referenceElement: referenceEl } = this;
+    const { el, placement, _referenceElement: referenceEl, strategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
+      strategy,
       placement,
       referenceEl
     });

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -39,7 +39,7 @@ describe("calcite-tooltip", () => {
         defaultValue: undefined
       },
       {
-        propertyName: "strategy",
+        propertyName: "positionStrategy",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -37,6 +37,10 @@ describe("calcite-tooltip", () => {
       {
         propertyName: "referenceElement",
         defaultValue: undefined
+      },
+      {
+        propertyName: "strategy",
+        defaultValue: "absolute"
       }
     ]));
 

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -39,7 +39,7 @@ describe("calcite-tooltip", () => {
         defaultValue: undefined
       },
       {
-        propertyName: "positionStrategy",
+        propertyName: "overlayPositioning",
         defaultValue: "absolute"
       }
     ]));

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -8,7 +8,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperPositionStrategy
+  OverlayPositioning
 } from "../../utils/popper";
 import { Theme } from "../interfaces";
 import { getElementById, getRootNode } from "../../utils/dom";
@@ -58,6 +58,9 @@ export class CalciteTooltip {
     this.reposition();
   }
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() overlayPositioning: OverlayPositioning = "absolute";
+
   /**
    * Determines where the component will be positioned relative to the referenceElement.
    */
@@ -67,9 +70,6 @@ export class CalciteTooltip {
   placementHandler(): void {
     this.reposition();
   }
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
 
   /**
    * Reference HTMLElement used to position this component.
@@ -218,14 +218,14 @@ export class CalciteTooltip {
   createPopper(): void {
     this.destroyPopper();
 
-    const { el, placement, _referenceElement: referenceEl, positionStrategy } = this;
+    const { el, placement, _referenceElement: referenceEl, overlayPositioning } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
       placement,
-      positionStrategy,
+      overlayPositioning,
       referenceEl
     });
   }

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -58,7 +58,7 @@ export class CalciteTooltip {
     this.reposition();
   }
 
-  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
+  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -58,7 +58,7 @@ export class CalciteTooltip {
     this.reposition();
   }
 
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  /** Describes the type of positioning to use for the overlayed content. If your element is in a fixed container, use the 'fixed' value. */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -7,7 +7,8 @@ import {
   defaultOffsetDistance,
   createPopper,
   updatePopper,
-  CSS as PopperCSS
+  CSS as PopperCSS,
+  PopperStrategy
 } from "../../utils/popper";
 import { Theme } from "../interfaces";
 import { getElementById, getRootNode } from "../../utils/dom";
@@ -79,6 +80,9 @@ export class CalciteTooltip {
     this.addReferences();
     this.createPopper();
   }
+
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() strategy: PopperStrategy = "absolute";
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -214,13 +218,14 @@ export class CalciteTooltip {
   createPopper(): void {
     this.destroyPopper();
 
-    const { el, placement, _referenceElement: referenceEl } = this;
+    const { el, placement, _referenceElement: referenceEl, strategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
       placement,
+      strategy,
       referenceEl
     });
   }

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -8,7 +8,7 @@ import {
   createPopper,
   updatePopper,
   CSS as PopperCSS,
-  PopperStrategy
+  PopperPositionStrategy
 } from "../../utils/popper";
 import { Theme } from "../interfaces";
 import { getElementById, getRootNode } from "../../utils/dom";
@@ -68,6 +68,9 @@ export class CalciteTooltip {
     this.reposition();
   }
 
+  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
+  @Prop() positionStrategy: PopperPositionStrategy = "absolute";
+
   /**
    * Reference HTMLElement used to position this component.
    */
@@ -80,9 +83,6 @@ export class CalciteTooltip {
     this.addReferences();
     this.createPopper();
   }
-
-  /** Describes the positioning strategy to use. If your reference element is in a fixed container, use the fixed strategy. */
-  @Prop() strategy: PopperStrategy = "absolute";
 
   /** Select theme (light or dark) */
   @Prop({ reflect: true }) theme: Theme;
@@ -218,14 +218,14 @@ export class CalciteTooltip {
   createPopper(): void {
     this.destroyPopper();
 
-    const { el, placement, _referenceElement: referenceEl, strategy } = this;
+    const { el, placement, _referenceElement: referenceEl, positionStrategy } = this;
     const modifiers = this.getModifiers();
 
     this.popper = createPopper({
       el,
       modifiers,
       placement,
-      strategy,
+      positionStrategy,
       referenceEl
     });
   }

--- a/src/utils/popper.ts
+++ b/src/utils/popper.ts
@@ -24,7 +24,7 @@ type VariationRtl =
 
 export type PopperPlacement = Placement | PlacementRtl | VariationRtl;
 
-export type PopperPositionStrategy = PositioningStrategy;
+export type OverlayPositioning = PositioningStrategy;
 
 export const CSS = {
   animation: "calcite-popper-anim",
@@ -51,12 +51,12 @@ export function createPopper({
   referenceEl,
   el,
   placement,
-  positionStrategy = "absolute",
+  overlayPositioning = "absolute",
   modifiers
 }: {
   el: HTMLElement;
   modifiers: Partial<StrictModifiers>[];
-  positionStrategy: PositioningStrategy;
+  overlayPositioning: PositioningStrategy;
   placement: PopperPlacement;
   referenceEl: HTMLElement;
 }): Popper | null {
@@ -65,7 +65,7 @@ export function createPopper({
   }
 
   return setupPopper(referenceEl, el, {
-    strategy: positionStrategy,
+    strategy: overlayPositioning,
     placement: getPlacement(el, placement),
     modifiers
   });

--- a/src/utils/popper.ts
+++ b/src/utils/popper.ts
@@ -24,7 +24,7 @@ type VariationRtl =
 
 export type PopperPlacement = Placement | PlacementRtl | VariationRtl;
 
-export type PopperStrategy = PositioningStrategy;
+export type PopperPositionStrategy = PositioningStrategy;
 
 export const CSS = {
   animation: "calcite-popper-anim",
@@ -51,12 +51,12 @@ export function createPopper({
   referenceEl,
   el,
   placement,
-  strategy = "absolute",
+  positionStrategy = "absolute",
   modifiers
 }: {
   el: HTMLElement;
   modifiers: Partial<StrictModifiers>[];
-  strategy: PositioningStrategy;
+  positionStrategy: PositioningStrategy;
   placement: PopperPlacement;
   referenceEl: HTMLElement;
 }): Popper | null {
@@ -65,7 +65,7 @@ export function createPopper({
   }
 
   return setupPopper(referenceEl, el, {
-    strategy,
+    strategy: positionStrategy,
     placement: getPlacement(el, placement),
     modifiers
   });

--- a/src/utils/popper.ts
+++ b/src/utils/popper.ts
@@ -1,4 +1,10 @@
-import { Placement, Instance as Popper, createPopper as setupPopper, StrictModifiers } from "@popperjs/core";
+import {
+  Placement,
+  Instance as Popper,
+  createPopper as setupPopper,
+  StrictModifiers,
+  PositioningStrategy
+} from "@popperjs/core";
 import { getElementDir } from "./dom";
 
 type PlacementRtl = "leading-start" | "leading" | "leading-end" | "trailing-end" | "trailing" | "trailing-start";
@@ -17,6 +23,8 @@ type VariationRtl =
   | "left-trailing";
 
 export type PopperPlacement = Placement | PlacementRtl | VariationRtl;
+
+export type PopperStrategy = PositioningStrategy;
 
 export const CSS = {
   animation: "calcite-popper-anim",
@@ -43,10 +51,12 @@ export function createPopper({
   referenceEl,
   el,
   placement,
+  strategy = "absolute",
   modifiers
 }: {
   el: HTMLElement;
   modifiers: Partial<StrictModifiers>[];
+  strategy: PositioningStrategy;
   placement: PopperPlacement;
   referenceEl: HTMLElement;
 }): Popper | null {
@@ -55,6 +65,7 @@ export function createPopper({
   }
 
   return setupPopper(referenceEl, el, {
+    strategy,
     placement: getPlacement(el, placement),
     modifiers
   });


### PR DESCRIPTION
**Related Issue:** #2069 #1913

## Summary

feat(action-menu, combobox, dropdown, input-date-picker, popover, tooltip): Add 'overlayPositioning' property. #2069

Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value.