### PR TITLE
fix(calcite-input): setting name explicitly on internal input

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -650,6 +650,7 @@ export class CalciteInput {
         maxLength={this.maxLength}
         min={this.minString}
         minLength={this.minLength}
+        name={this.name}
         onBlur={this.inputBlurHandler}
         onFocus={this.inputFocusHandler}
         onInput={this.inputInputHandler}


### PR DESCRIPTION
**Related Issue:** #2071

I couldn't reproduce this locally, but this fix is still something we want to do not just with the `name` attribute, but with all others that we're currently spreading onto the internal input.