### PR TITLE
docs(readme): drop nomodule script snippets

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -14,7 +14,6 @@ This will load all the dependencies for the project.
 
 ```html
 <script type="module" src="<path-to-calcite-components-package>/dist/calcite/calcite.esm.js"></script>
-<script nomodule="" src="<path-to-calcite-components-package>/dist/calcite/calcite.js"></script>
 ```
 
 Browsers that support modules will load the first, while older browsers will load the second, bundled version. It's worth noting that only components that are actually used will be loaded.

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,6 @@ Calcite components can be loaded via two `<script>` tags in the head of your HTM
 
 ```html
 <script type="module" src="https://unpkg.com/@esri/calcite-components/dist/calcite/calcite.esm.js"></script>
-<script nomodule="" src="https://unpkg.com/@esri/calcite-components/dist/calcite/calcite.js"></script>
 ```
 
 Browsers that support modules will load the first, while older browsers will load the second, bundled version.


### PR DESCRIPTION
**Related Issue:** #1986

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Based on our current [browser support](https://github.com/Esri/calcite-components#browser-support), we should no longer include the `nomodule` script in the doc. 

We can still keep it in our test pages until we no longer need to support it (end of 2021?).

cc @julio8a