### PR TITLE
fix(calcite-input): disallowing typing any key with shift modifier down inside a number input

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { focusable, HYDRATED_ATTR } from "../../tests/commonTests";
+import { letterKeys, numberKeys } from "../../utils/key";
 import { getDecimalSeparator, locales, localizeNumberString } from "../../utils/locale";
 
 describe("calcite-input", () => {
@@ -695,6 +696,29 @@ describe("calcite-input", () => {
 
     expect(await getInputValidity()).toBe(true);
     expect(await input.getProperty("value")).toBe("123");
+  });
+
+  describe("number type", () => {
+    it("disallows typing any letter or number with shift modifier key down2", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-input type="number"></calcite-input>`
+      });
+      const calciteInput = await page.find("calcite-input");
+      const input = await page.find("input");
+
+      await calciteInput.callMethod("setFocus");
+      await page.keyboard.down("Shift");
+      for (let i = 0; i < numberKeys.length; i++) {
+        await input.type(numberKeys[i]);
+      }
+      for (let i = 0; i < letterKeys.length; i++) {
+        await input.type(numberKeys[i]);
+      }
+      await page.keyboard.up("Shift");
+
+      expect(await calciteInput.getProperty("value")).toBeFalsy();
+      expect(await input.getProperty("value")).toBeFalsy();
+    });
   });
 
   describe("number locale support", () => {

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -707,17 +707,20 @@ describe("calcite-input", () => {
       const input = await page.find("input");
 
       await calciteInput.callMethod("setFocus");
-      await page.keyboard.down("Shift");
       for (let i = 0; i < numberKeys.length; i++) {
-        await input.type(numberKeys[i]);
+        await page.keyboard.down("Shift");
+        await page.keyboard.press(numberKeys[i]);
+        await page.keyboard.up("Shift");
+        expect(await calciteInput.getProperty("value")).toBeFalsy();
+        expect(await input.getProperty("value")).toBeFalsy();
       }
       for (let i = 0; i < letterKeys.length; i++) {
-        await input.type(numberKeys[i]);
+        await page.keyboard.down("Shift");
+        await page.keyboard.press(letterKeys[i]);
+        await page.keyboard.up("Shift");
+        expect(await calciteInput.getProperty("value")).toBeFalsy();
+        expect(await input.getProperty("value")).toBeFalsy();
       }
-      await page.keyboard.up("Shift");
-
-      expect(await calciteInput.getProperty("value")).toBeFalsy();
-      expect(await input.getProperty("value")).toBeFalsy();
     });
   });
 

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -699,7 +699,7 @@ describe("calcite-input", () => {
   });
 
   describe("number type", () => {
-    it("disallows typing any letter or number with shift modifier key down2", async () => {
+    it("disallows typing any letter or number with shift modifier key down", async () => {
       const page = await newE2EPage({
         html: `<calcite-input type="number"></calcite-input>`
       });

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -433,7 +433,7 @@ export class CalciteInput {
       "Tab",
       "-"
     ];
-    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+    if (event.altKey || event.ctrlKey || event.metaKey) {
       return;
     }
     if (supportedKeys.includes(event.key)) {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -436,7 +436,7 @@ export class CalciteInput {
     if (event.altKey || event.ctrlKey || event.metaKey) {
       return;
     }
-    if (supportedKeys.includes(event.key)) {
+    if (supportedKeys.includes(event.key) && !event.shiftKey) {
       if (event.key === "Enter") {
         this.calciteInputChange.emit();
       }

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -25,3 +25,31 @@ export function getKey(key: string, dir?: "rtl" | "ltr"): string {
 }
 
 export const numberKeys = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+export const letterKeys = [
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+  "i",
+  "j",
+  "k",
+  "l",
+  "m",
+  "n",
+  "o",
+  "p",
+  "q",
+  "r",
+  "s",
+  "t",
+  "u",
+  "v",
+  "w",
+  "x",
+  "y",
+  "z"
+];


### PR DESCRIPTION
**Related Issue:** #2127