### PR TITLE
chore(linting): enable no-unneeded-ternary rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
     "jest/no-export": "warn",
     "lines-between-class-members": ["error", "always"],
     "no-multiple-empty-lines": ["error", { "max": 1 }],
+    "no-unneeded-ternary": "error",
     "react/jsx-sort-props": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -90,7 +90,7 @@ export class CalciteSlider {
   @Prop() histogram?: DataSeries;
 
   @Watch("histogram") histogramWatcher(newHistogram: DataSeries): void {
-    this.hasHistogram = newHistogram ? true : false;
+    this.hasHistogram = !!newHistogram;
   }
 
   /** Indicates if a histogram is present */

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -65,7 +65,7 @@ export class CalciteTree {
     this.scale = parent ? parent.scale : this.scale;
     this.inputEnabled = parent ? parent.inputEnabled : this.inputEnabled;
     this.selectionMode = parent ? parent.selectionMode : this.selectionMode;
-    this.root = parent ? false : true;
+    this.root = !parent;
   }
 
   render(): VNode {

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,7 +1,7 @@
 import { numberKeys } from "./key";
 
 export function isValidNumber(numberString: string): boolean {
-  return !numberString || isNaN(Number(numberString)) ? false : true;
+  return !(!numberString || isNaN(Number(numberString)));
 }
 
 export function parseNumberString(numberString?: string): string {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Enables https://eslint.org/docs/rules/no-unneeded-ternary (auto-fixable) to simplify code.