### PR TITLE
fix(value-list-item): updates handle colors to match CalciteHandle

### DIFF
--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -26,6 +26,7 @@ calcite-pick-list-item {
     border-none 
     text-color-1
     cursor-move;
+  color: theme("borderColor.color.3");
   &:hover {
     @apply bg-foreground-2 text-color-1;
   }
@@ -35,5 +36,8 @@ calcite-pick-list-item {
   }
   &--activated {
     @apply bg-foreground-3 text-color-1;
+  }
+  calcite-icon {
+    color: inherit;
   }
 }


### PR DESCRIPTION
**Related Issue:** #2098

## Summary
Styles internal "handle" element to match CalciteHandle.

Refactoring ValueListItem to use Handle would be cool.
We are going to have a general ListItem, and when ValueListItem is refactored to use that component, we can take care of this then.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
