### PR TITLE
fix(dom): Query whole shadowRoot of elements rootNode instead of just inside of the host.

### DIFF
--- a/src/utils/dom.e2e.ts
+++ b/src/utils/dom.e2e.ts
@@ -5,6 +5,7 @@ interface SetUpTestComponentOptions {
   insideHostHTML: string;
   componentTag: string;
   insideShadowHTML: string;
+  myButtonClass: string;
 }
 
 type TestWindow = typeof window & {
@@ -15,11 +16,13 @@ type TestWindow = typeof window & {
   setUpTestComponent: (options: SetUpTestComponentOptions) => void;
 };
 
+const myButtonClass = "my-class";
 const insideHost = "Inside Host";
-const componentTag = "test-component";
-const insideHostHTML = `<button>${insideHost}</button>`;
-const insideShadowHTML = "<div><button>Not queryable</button></div>";
 const outsideHost = "Outside Host";
+const insideShadow = "Inside Shadow";
+const componentTag = "test-component";
+const insideHostHTML = `<button class="${myButtonClass}">${insideHost}</button>`;
+const insideShadowHTML = `<div><button>${insideShadow}</button></div>`;
 const outsideHostHTML = `<span>Test</span><button>${outsideHost}</button>`;
 
 describe("utils/dom", () => {
@@ -61,20 +64,21 @@ describe("utils/dom", () => {
 
   it("queryElementRoots: should query from inside host element", async () => {
     const text = await page.evaluate(
-      ({ insideHostHTML, componentTag, insideShadowHTML }: SetUpTestComponentOptions): string => {
+      ({ insideHostHTML, componentTag, insideShadowHTML, myButtonClass }: SetUpTestComponentOptions): string => {
         (window as TestWindow).setUpTestComponent({
           insideHostHTML,
           componentTag,
-          insideShadowHTML
+          insideShadowHTML,
+          myButtonClass
         });
 
         const testComponent = document.querySelector("test-component");
         const queryEl = testComponent.shadowRoot.querySelector("div");
-        const resultEl: HTMLElement = (window as TestWindow).queryElementRoots(queryEl, "button");
+        const resultEl: HTMLElement = (window as TestWindow).queryElementRoots(queryEl, `button.${myButtonClass}`);
 
         return resultEl?.textContent;
       },
-      { insideHostHTML, componentTag, insideShadowHTML }
+      { insideHostHTML, componentTag, insideShadowHTML, myButtonClass }
     );
 
     expect(text).toBe(insideHost);
@@ -82,11 +86,12 @@ describe("utils/dom", () => {
 
   it("queryElementRoots: should query from outside host element", async () => {
     const text = await page.evaluate(
-      ({ insideHostHTML, componentTag, insideShadowHTML }: SetUpTestComponentOptions): string => {
+      ({ insideHostHTML, componentTag, insideShadowHTML, myButtonClass }: SetUpTestComponentOptions): string => {
         (window as TestWindow).setUpTestComponent({
           insideHostHTML,
           componentTag,
-          insideShadowHTML
+          insideShadowHTML,
+          myButtonClass
         });
 
         const queryEl = document.body.querySelector("span");
@@ -94,7 +99,7 @@ describe("utils/dom", () => {
 
         return resultEl?.textContent;
       },
-      { insideHostHTML, componentTag, insideShadowHTML }
+      { insideHostHTML, componentTag, insideShadowHTML, myButtonClass }
     );
 
     expect(text).toBe(outsideHost);
@@ -102,11 +107,12 @@ describe("utils/dom", () => {
 
   it("queryElementsRoots: should query multiple elements", async () => {
     const results = await page.evaluate(
-      ({ insideHostHTML, componentTag, insideShadowHTML }: SetUpTestComponentOptions): string[] => {
+      ({ insideHostHTML, componentTag, insideShadowHTML, myButtonClass }: SetUpTestComponentOptions): string[] => {
         (window as TestWindow).setUpTestComponent({
           insideHostHTML,
           componentTag,
-          insideShadowHTML
+          insideShadowHTML,
+          myButtonClass
         });
 
         const testComponent = document.querySelector("test-component");
@@ -115,11 +121,12 @@ describe("utils/dom", () => {
 
         return resultEls.map((el: HTMLElement) => el.textContent);
       },
-      { insideHostHTML, componentTag, insideShadowHTML }
+      { insideHostHTML, componentTag, insideShadowHTML, myButtonClass }
     );
 
-    expect(results).toHaveLength(2);
-    expect(results[0]).toBe(insideHost);
-    expect(results[1]).toBe("Outside Host");
+    expect(results).toHaveLength(3);
+    expect(results[0]).toBe(insideShadow);
+    expect(results[1]).toBe(outsideHost);
+    expect(results[2]).toBe(insideHost);
   });
 });

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -31,7 +31,7 @@ export function getHost(root: HTMLDocument | ShadowRoot): Element | null {
 // Queries an element's rootNode and any ancestor rootNodes.
 // based on https://stackoverflow.com/q/54520554/194216
 export function queryElementsRoots<T extends Element = Element>(element: Element, selector: string): T[] {
-  // Gets the rootNode (shadowRoot or document) of an element and if the rootNode is a shadowRoot, it queries the element's shadowRoot.host and any ancestor rootNodes, else queries the rootNode.
+  // Gets the rootNode and any ancestor rootNodes (shadowRoot or document) of an element and queries them for a selector.
   function queryFromAll<T extends Element = Element>(el: Element, allResults: T[]): T[] {
     if (!el) {
       return allResults;
@@ -42,15 +42,14 @@ export function queryElementsRoots<T extends Element = Element>(element: Element
     }
 
     const rootNode = getRootNode(el);
-    const host = getHost(rootNode);
 
-    const results = host
-      ? (Array.from(host.querySelectorAll(selector)) as T[])
-      : (Array.from(rootNode.querySelectorAll(selector)) as T[]);
+    const results = Array.from(rootNode.querySelectorAll(selector)) as T[];
 
     const uniqueResults = results.filter((result) => !allResults.includes(result));
 
     allResults = [...allResults, ...uniqueResults];
+
+    const host = getHost(rootNode);
 
     return host ? queryFromAll(host, allResults) : allResults;
   }
@@ -61,7 +60,7 @@ export function queryElementsRoots<T extends Element = Element>(element: Element
 // Queries an element's rootNode and any ancestor rootNodes.
 // based on https://stackoverflow.com/q/54520554/194216
 export function queryElementRoots<T extends Element = Element>(element: Element, selector: string): T | null {
-  // Gets the rootNode (shadowRoot or document) of an element and if the rootNode is a shadowRoot, it queries the element's shadowRoot.host and any ancestor rootNodes, else queries the rootNode.
+  // Gets the rootNode and any ancestor rootNodes (shadowRoot or document) of an element and queries them for a selector.
   function queryFrom<T extends Element = Element>(el: Element): T | null {
     if (!el) {
       return null;
@@ -72,9 +71,10 @@ export function queryElementRoots<T extends Element = Element>(element: Element,
     }
 
     const rootNode = getRootNode(el);
-    const host = getHost(rootNode);
 
-    const found = host ? (host.querySelector(selector) as T) : (rootNode.querySelector(selector) as T);
+    const found = rootNode.querySelector(selector) as T;
+
+    const host = getHost(rootNode);
 
     return found ? found : host ? queryFrom(host) : null;
   }


### PR DESCRIPTION
**Related Issue:** #2103

## Summary

fix(dom): Query whole shadowRoot of elements rootNode instead of just inside of the host.