### PR TITLE
fix(tooltip-manager): Don't show tooltip on click of referenceElement

### DIFF
--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -117,9 +117,10 @@ describe("calcite-tooltip-manager", () => {
 
     expect(await tooltip.getProperty("open")).toBe(false);
 
-    const referenceElement = await page.find("#ref");
-
-    await referenceElement.click();
+    await page.evaluate(() => {
+      const ref = document.getElementById("ref");
+      ref.click();
+    });
 
     await page.waitForChanges();
 

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -98,6 +98,34 @@ describe("calcite-tooltip-manager", () => {
     expect(await tooltip.getProperty("open")).toBe(false);
   });
 
+  it("should not open tooltip when clicked", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `
+      <button id="test">test</button>
+      <calcite-tooltip-manager>
+        <calcite-tooltip id="tooltip" reference-element="ref">Content</calcite-tooltip>
+        <div tabindex="0" id="ref">Button</div>
+      <calcite-tooltip-manager>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const tooltip = await page.find("calcite-tooltip");
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+
+    await referenceElement.click();
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+  });
+
   it("should honor focused tooltip closing with ESC key", async () => {
     const page = await newE2EPage();
 

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -155,6 +155,7 @@ export class CalciteTooltipManager {
     const tooltip = this.queryTooltip(event.target as HTMLElement);
 
     if (!tooltip || tooltip === this.clickedTooltip) {
+      this.clickedTooltip = null;
       return;
     }
 

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -22,7 +22,7 @@ export class CalciteTooltipManager {
 
   hoverTimeouts: WeakMap<HTMLCalciteTooltipElement, number> = new WeakMap();
 
-  clickedFlag: boolean;
+  clickedTooltip: HTMLCalciteTooltipElement;
 
   // --------------------------------------------------------------------------
   //
@@ -154,7 +154,7 @@ export class CalciteTooltipManager {
   focusEvent = (event: FocusEvent, value: boolean): void => {
     const tooltip = this.queryTooltip(event.target as HTMLElement);
 
-    if (!tooltip) {
+    if (!tooltip || tooltip === this.clickedTooltip) {
       return;
     }
 
@@ -205,18 +205,12 @@ export class CalciteTooltipManager {
 
   @Listen("click", { capture: true })
   clickHandler(event: MouseEvent): void {
-    if (this.queryTooltip(event.target as HTMLElement)) {
-      this.clickedFlag = true;
-    }
+    this.clickedTooltip = this.queryTooltip(event.target as HTMLElement);
   }
 
   @Listen("focus", { capture: true })
   focusShow(event: FocusEvent): void {
-    if (!this.clickedFlag) {
-      this.focusEvent(event, true);
-    }
-
-    this.clickedFlag = false;
+    this.focusEvent(event, true);
   }
 
   @Listen("blur", { capture: true })

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -22,6 +22,8 @@ export class CalciteTooltipManager {
 
   hoverTimeouts: WeakMap<HTMLCalciteTooltipElement, number> = new WeakMap();
 
+  clickedFlag: boolean;
+
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -201,9 +203,20 @@ export class CalciteTooltipManager {
     this.hoverEvent(event, false);
   }
 
+  @Listen("click", { capture: true })
+  clickHandler(event: MouseEvent): void {
+    if (this.queryTooltip(event.target as HTMLElement)) {
+      this.clickedFlag = true;
+    }
+  }
+
   @Listen("focus", { capture: true })
   focusShow(event: FocusEvent): void {
-    this.focusEvent(event, true);
+    if (!this.clickedFlag) {
+      this.focusEvent(event, true);
+    }
+
+    this.clickedFlag = false;
   }
 
   @Listen("blur", { capture: true })


### PR DESCRIPTION
**Related Issue:** #2171

## Summary

fix(tooltip-manager): Don't show tooltip on click of referenceElement. #2171
