### PR TITLE
docs(custom-theme): update to latest CSS color vars

### DIFF
--- a/src/6-custom-theme.stories.mdx
+++ b/src/6-custom-theme.stories.mdx
@@ -13,6 +13,12 @@ export const Template = () =>
       --calcite-ui-brand: ${color("--calcite-ui-brand", "#007ac2")};
       --calcite-ui-brand-hover: ${color("--calcite-ui-brand-hover", "#00619b")};
       --calcite-ui-brand-press: ${color("--calcite-ui-brand-press", "#004874")};
+      --calcite-ui-info: ${color("--calcite-ui-info", "#00619b")};
+      --calcite-ui-success: ${color("--calcite-ui-success", "#35ac46")};
+      --calcite-ui-warning: ${color("--calcite-ui-warning", "#edd317")};
+      --calcite-ui-danger: ${color("--calcite-ui-danger", "#d83020")};
+      --calcite-ui-danger-hover: ${color("--calcite-ui-danger-hover", "#a82b1e")};
+      --calcite-ui-danger-press: ${color("--calcite-ui-danger-press", "#7c1d13")};
       --calcite-ui-background: ${color("--calcite-ui-background", "#f8f8f8")};
       --calcite-ui-foreground-1: ${color("--calcite-ui-foreground-1", "#ffffff")};
       --calcite-ui-foreground-2: ${color("--calcite-ui-foreground-2", "#f3f3f3")};
@@ -26,12 +32,6 @@ export const Template = () =>
       --calcite-ui-border-2: ${color("--calcite-ui-border-2", "#dfdfdf")};
       --calcite-ui-border-3: ${color("--calcite-ui-border-3", "#eaeaea")};
       --calcite-ui-border-input: ${color("--calcite-ui-border-input", "#949494")};
-      --calcite-ui-info: ${color("--calcite-ui-info", "#00619b")};
-      --calcite-ui-success: ${color("--calcite-ui-success", "#35ac46")};
-      --calcite-ui-warning: ${color("--calcite-ui-warning", "#edd317")};
-      --calcite-ui-danger: ${color("--calcite-ui-danger", "#d83020")};
-      --calcite-ui-danger-hover: ${color("--calcite-ui-danger-hover", "#a82b1e")};
-      --calcite-ui-danger-press: ${color("--calcite-ui-danger-press", "#7c1d13")};
     "
   >
     <style>

--- a/src/6-custom-theme.stories.mdx
+++ b/src/6-custom-theme.stories.mdx
@@ -11,13 +11,8 @@ export const Template = () =>
   `<div
     style="
       --calcite-ui-brand: ${color("--calcite-ui-brand", "#007ac2")};
-      --calcite-ui-brand-hover: ${color("--calcite-ui-brand-hover", "#2890ce")};
-      --calcite-ui-brand-press: ${color("--calcite-ui-brand-press", "#00619b")};
-      --calcite-ui-success: ${color("--calcite-ui-success", "#35ac46")};
-      --calcite-ui-warning: ${color("--calcite-ui-warning", "#edd317")};
-      --calcite-ui-danger: ${color("--calcite-ui-danger", "#d83020")};
-      --calcite-ui-danger-hover: ${color("--calcite-ui-danger-hover", "#e65240")};
-      --calcite-ui-danger-press: ${color("--calcite-ui-danger-press", "#a82b1e")};
+      --calcite-ui-brand-hover: ${color("--calcite-ui-brand-hover", "#00619b")};
+      --calcite-ui-brand-press: ${color("--calcite-ui-brand-press", "#004874")};
       --calcite-ui-background: ${color("--calcite-ui-background", "#f8f8f8")};
       --calcite-ui-foreground-1: ${color("--calcite-ui-foreground-1", "#ffffff")};
       --calcite-ui-foreground-2: ${color("--calcite-ui-foreground-2", "#f3f3f3")};
@@ -25,11 +20,18 @@ export const Template = () =>
       --calcite-ui-text-1: ${color("--calcite-ui-text-1", "#151515")};
       --calcite-ui-text-2: ${color("--calcite-ui-text-2", "#4a4a4a")};
       --calcite-ui-text-3: ${color("--calcite-ui-text-3", "#6a6a6a")};
+      --calcite-ui-text-inverse: ${color("--calcite-ui-text-inverse", "#ffffff")};
+      --calcite-ui-text-link: ${color("--calcite-ui-text-link", "#00619b")};
       --calcite-ui-border-1: ${color("--calcite-ui-border-1", "#cacaca")};
       --calcite-ui-border-2: ${color("--calcite-ui-border-2", "#dfdfdf")};
       --calcite-ui-border-3: ${color("--calcite-ui-border-3", "#eaeaea")};
-      --calcite-ui-border-4: ${color("--calcite-ui-border-4", "#9f9f9f")};
-      --calcite-ui-border-5: ${color("--calcite-ui-border-5", "#757575")};
+      --calcite-ui-border-input: ${color("--calcite-ui-border-input", "#949494")};
+      --calcite-ui-info: ${color("--calcite-ui-info", "#00619b")};
+      --calcite-ui-success: ${color("--calcite-ui-success", "#35ac46")};
+      --calcite-ui-warning: ${color("--calcite-ui-warning", "#edd317")};
+      --calcite-ui-danger: ${color("--calcite-ui-danger", "#d83020")};
+      --calcite-ui-danger-hover: ${color("--calcite-ui-danger-hover", "#a82b1e")};
+      --calcite-ui-danger-press: ${color("--calcite-ui-danger-press", "#7c1d13")};
     "
   >
     <style>


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
I noticed the custom-theme story shows some outdated CSS properties so this pr updates them according to global.scss.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
