### PR TITLE
feat(color-picker): improve thumb drag interaction

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -385,6 +385,65 @@ describe("calcite-color-picker", () => {
     expect(spy).toHaveReceivedEventTimes(changes);
   });
 
+  it("keeps tracking mouse movement when a thumb is actively dragged", async () => {
+    const page = await newE2EPage({
+      html: "<calcite-color-picker></calcite-color-picker>"
+    });
+    const picker = await page.find(`calcite-color-picker`);
+    const colorFieldAndSlider = await page.find(`calcite-color-picker >>> .${CSS.colorFieldAndSlider}`);
+
+    await colorFieldAndSlider.click(); // click middle color
+
+    let lastColor = await picker.getProperty("value");
+
+    await page.mouse.down();
+    await page.mouse.move(1000, -1000); // top-right
+
+    // note that we move the mouse in this order to guarantee value changes (bottom row is #000)
+
+    let currentColor = await picker.getProperty("value");
+    expect(currentColor).not.toEqual(lastColor);
+    lastColor = currentColor;
+
+    await page.mouse.move(-1000, 1000); // bottom-left
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).not.toEqual(lastColor);
+    lastColor = currentColor;
+
+    await page.mouse.move(-1000, -1000); // top-left
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).not.toEqual(lastColor);
+    lastColor = currentColor;
+
+    await page.mouse.move(1000, 1000); // bottom-right
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).not.toEqual(lastColor);
+    lastColor = currentColor;
+
+    // no longer tracks
+    await page.mouse.up();
+
+    await page.mouse.move(1000, -1000); // top-right
+
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).toEqual(lastColor);
+    lastColor = currentColor;
+
+    await page.mouse.move(-1000, 1000); // bottom-left
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).toEqual(lastColor);
+    lastColor = currentColor;
+
+    await page.mouse.move(-1000, -1000); // top-left
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).toEqual(lastColor);
+    lastColor = currentColor;
+
+    await page.mouse.move(1000, 1000); // bottom-right
+    currentColor = await picker.getProperty("value");
+    expect(currentColor).toEqual(lastColor);
+  });
+
   describe("unsupported value handling", () => {
     let page: E2EPage;
 

--- a/src/utils/math.spec.ts
+++ b/src/utils/math.spec.ts
@@ -1,0 +1,9 @@
+import { clamp } from "./math";
+
+describe("clamp", () => {
+  it("clamps numbers within min/max", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(-1, 0, 10)).toBe(0);
+    expect(clamp(11, 0, 10)).toBe(10);
+  });
+});

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,1 @@
+export const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(value, max));


### PR DESCRIPTION
**Related Issue:** #2122 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates the color picker to keep tracking mouse movements when a thumb is being dragged and the mouse moves outside the canvas.

**Notable changes**

* adds `math` util
* fixes thumb hover/idle rendering
* separates mousemove event handlers to cover
  * thumb state rendering 
  * tracking mouse movement for updating the color
  