### PR TITLE
feat(pick-list, value-list): improve keyboard interaction for single-item selection

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -19,6 +19,7 @@ import {
   deselectSiblingItems,
   getItemData,
   handleFilter,
+  calciteListFocusOutHandler,
   initialize,
   initializeObserver,
   mutationObserverCallback,
@@ -154,6 +155,11 @@ export class CalcitePickList<
   @Listen("calciteListItemValueChange")
   calciteListItemValueChangeHandler(event: CustomEvent): void {
     calciteListItemValueChangeHandler.call(this, event);
+  }
+
+  @Listen("focusout")
+  calciteListFocusOutHandler(event: FocusEvent): void {
+    calciteListFocusOutHandler.call(this, event);
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -48,12 +48,12 @@ export function calciteListItemChangeHandler<T extends Lists>(this: List<T>, eve
   const { item, value, selected, shiftPressed } = event.detail;
 
   if (selected) {
-    if (!this.multiple) {
-      this.deselectSiblingItems(item);
-    }
-
     if (this.multiple && shiftPressed) {
       this.selectSiblings(item);
+    }
+
+    if (!this.multiple) {
+      this.deselectSiblingItems(item);
     }
 
     selectedValues.set(value, item);
@@ -67,6 +67,10 @@ export function calciteListItemChangeHandler<T extends Lists>(this: List<T>, eve
 
   if (!this.multiple) {
     toggleSingleSelectItemTabbing(item, selected);
+
+    if (selected) {
+      focusElement(item);
+    }
   }
 
   this.lastSelectedItem = item;
@@ -95,6 +99,25 @@ function isValidNavigationKey(key: string): boolean {
   return !!SUPPORTED_ARROW_KEYS.find((k) => k === key);
 }
 
+export function calciteListFocusOutHandler<T extends Lists>(this: List<T>, event: FocusEvent): void {
+  const { el, items, multiple, selectedValues } = this;
+
+  if (multiple) {
+    return;
+  }
+
+  const focusedInside = !!el.contains(event.relatedTarget as Node | null);
+
+  if (focusedInside) {
+    toggleSingleSelectItemTabbing(event.target as ListItemElement<T>, false);
+    return;
+  }
+
+  items.forEach((item) =>
+    toggleSingleSelectItemTabbing(item, selectedValues.size === 0 ? event.target === item : item.selected)
+  );
+}
+
 export function keyDownHandler<T extends Lists>(this: List<T>, event: KeyboardEvent): void {
   const { key, target } = event;
 
@@ -102,7 +125,7 @@ export function keyDownHandler<T extends Lists>(this: List<T>, event: KeyboardEv
     return;
   }
 
-  const { items, multiple } = this;
+  const { items } = this;
   const { length: totalItems } = items;
   const currentIndex = (items as ListItemElement<T>[]).indexOf(target as ListItemElement<T>);
 
@@ -117,10 +140,6 @@ export function keyDownHandler<T extends Lists>(this: List<T>, event: KeyboardEv
 
   toggleSingleSelectItemTabbing(item, true);
   focusElement(item);
-
-  if (!multiple) {
-    item.selected = true;
-  }
 }
 
 export function internalCalciteListChangeEvent<T extends Lists>(this: List<T>): void {

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -13,8 +13,14 @@ export function keyboardNavigation(listType: ListType): void {
       () => (document.activeElement as HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement).value
     );
 
+  async function getSelectedItemValues(list: E2EElement, listType: string): Promise<string[]> {
+    return Promise.all(
+      (await list.findAll(`calcite-${listType}-list-item[selected]`)).map((el) => el.getProperty("value"))
+    );
+  }
+
   describe("multi selection", () => {
-    it("can be navigated with up/down arrow keys", async () => {
+    it("keyboard interaction", async () => {
       const page = await newE2EPage({
         html: `
         <calcite-${listType}-list multiple>
@@ -27,61 +33,42 @@ export function keyboardNavigation(listType: ListType): void {
       await list.callMethod("setFocus");
 
       expect(await getFocusedItemValue(page)).toEqual("one");
+      expect(await getSelectedItemValues(list, listType)).toEqual([]);
 
       await list.press("ArrowDown");
 
       expect(await getFocusedItemValue(page)).toEqual("two");
 
+      await list.press(" ");
+
+      expect(await getSelectedItemValues(list, listType)).toEqual(["two"]);
+
       await list.press("ArrowDown");
 
       expect(await getFocusedItemValue(page)).toEqual("one");
+
+      await list.press(" ");
+      expect(await getSelectedItemValues(list, listType)).toEqual(["one", "two"]);
 
       await list.press("ArrowUp");
 
       expect(await getFocusedItemValue(page)).toEqual("two");
 
+      await list.press(" ");
+      expect(await getSelectedItemValues(list, listType)).toEqual(["one"]);
+
       await list.press("ArrowUp");
 
       expect(await getFocusedItemValue(page)).toEqual("one");
+
+      await list.press(" ");
+      expect(await getSelectedItemValues(list, listType)).toEqual([]);
     });
   });
 
   describe("single selection", () => {
     describe("with selected item", () => {
-      it("can be navigated with up/down arrow keys", async () => {
-        const page = await newE2EPage({
-          html: `
-        <calcite-${listType}-list>
-          <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
-          <calcite-${listType}-list-item value="two" label="Two" selected></calcite-${listType}-list-item>
-        </calcite-${listType}-list>
-      `
-        });
-        const list = await page.find(`calcite-${listType}-list`);
-        await list.callMethod("setFocus");
-
-        expect(await getFocusedItemValue(page)).toEqual("two");
-
-        await list.press("ArrowDown");
-
-        expect(await getFocusedItemValue(page)).toEqual("one");
-
-        await list.press("ArrowDown");
-
-        expect(await getFocusedItemValue(page)).toEqual("two");
-
-        await list.press("ArrowUp");
-
-        expect(await getFocusedItemValue(page)).toEqual("one");
-
-        await list.press("ArrowUp");
-
-        expect(await getFocusedItemValue(page)).toEqual("two");
-      });
-    });
-
-    describe("no selected item", () => {
-      it("can be navigated with up/down arrow keys", async () => {
+      it("keyboard interaction", async () => {
         const page = await newE2EPage({
           html: `
         <calcite-${listType}-list>
@@ -93,23 +80,38 @@ export function keyboardNavigation(listType: ListType): void {
         const list = await page.find(`calcite-${listType}-list`);
         await list.callMethod("setFocus");
 
+        expect(await getSelectedItemValues(list, listType)).toEqual([]);
+
         expect(await getFocusedItemValue(page)).toEqual("one");
+        expect(await getSelectedItemValues(list, listType)).toEqual([]);
 
         await list.press("ArrowDown");
 
         expect(await getFocusedItemValue(page)).toEqual("two");
 
+        await list.press(" ");
+        expect(await getSelectedItemValues(list, listType)).toEqual(["two"]);
+
         await list.press("ArrowDown");
 
         expect(await getFocusedItemValue(page)).toEqual("one");
+
+        await list.press(" ");
+        expect(await getSelectedItemValues(list, listType)).toEqual(["one"]);
 
         await list.press("ArrowUp");
 
         expect(await getFocusedItemValue(page)).toEqual("two");
 
+        await list.press(" ");
+        expect(await getSelectedItemValues(list, listType)).toEqual(["two"]);
+
         await list.press("ArrowUp");
 
         expect(await getFocusedItemValue(page)).toEqual("one");
+
+        await list.press(" ");
+        expect(await getSelectedItemValues(list, listType)).toEqual(["one"]);
       });
     });
 
@@ -153,7 +155,7 @@ export function keyboardNavigation(listType: ListType): void {
 }
 
 export function selectionAndDeselection(listType: ListType): void {
-  describe("when multiple is false and a item is clicked", () => {
+  describe("when multiple is false and an item is clicked", () => {
     it("should emit an event with the last selected item data", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-${listType}-list>


### PR DESCRIPTION
**Related Issue:** #1734 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This tweaks pick list's keyboard interaction to allow an item to be selected with the spacebar and allow items to be navigated via up/down arrows (before it would alter the selection when navigating through items).

This makes it consistent to when the pick list has the `multiple` mode enabled.

![pick-list-keyboard](https://user-images.githubusercontent.com/197440/119058477-5140fd00-b983-11eb-956e-c9f6ecd43d10.gif)
