### PR TITLE
refactor!: Remove 'theme' props from components

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -12,6 +12,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  --calcite-theme-name: "light";
+
   --calcite-ui-foreground-current: #c7eaff;
   --calcite-ui-inverse: #{$blk-180};
   --calcite-ui-inverse-hover: #{$blk-170};
@@ -32,6 +34,7 @@
 
 [theme="dark"] {
   @include calcite-theme-dark();
+  --calcite-theme-name: "dark";
   --calcite-ui-foreground-current: #214155;
   --calcite-ui-inverse: #{$blk-180};
   --calcite-ui-inverse-hover: #{$blk-190};
@@ -46,6 +49,7 @@
 
 [theme="light"] {
   @include calcite-theme-light();
+  --calcite-theme-name: "light";
   --calcite-ui-foreground-current: #c7eaff;
   --calcite-ui-inverse: #{$blk-180};
   --calcite-ui-inverse-hover: #{$blk-170};

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -13,7 +13,6 @@
   -moz-osx-font-smoothing: grayscale;
 
   --calcite-theme-name: "light";
-
   --calcite-ui-foreground-current: #c7eaff;
   --calcite-ui-inverse: #{$blk-180};
   --calcite-ui-inverse-hover: #{$blk-170};

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -32,6 +32,7 @@
   @apply font-sans;
 }
 
+.calcite-theme--dark,
 [theme="dark"] {
   @include calcite-theme-dark();
   --calcite-theme-name: "dark";
@@ -47,6 +48,7 @@
   --calcite-scrim-background: #{rgba($blk-240, 0.75)};
 }
 
+.calcite-theme--light,
 [theme="light"] {
   @include calcite-theme-light();
   --calcite-theme-name: "light";

--- a/src/components/calcite-accordion/calcite-accordion.e2e.ts
+++ b/src/components/calcite-accordion/calcite-accordion.e2e.ts
@@ -31,7 +31,7 @@ describe("calcite-accordion", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-accordion appearance="minimal" icon-position="start"  scale="l" selection-mode="single-persist" theme="dark" icon-type="caret">
+    <calcite-accordion appearance="minimal" icon-position="start"  scale="l" selection-mode="single-persist" icon-type="caret">
     ${accordionContent}
     </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
@@ -39,14 +39,13 @@ describe("calcite-accordion", () => {
     expect(element).toEqualAttribute("icon-position", "start");
     expect(element).toEqualAttribute("scale", "l");
     expect(element).toEqualAttribute("selection-mode", "single-persist");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("icon-type", "caret");
   });
 
   it("renders icon if requested", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-accordion appearance="minimal" icon-position="start"  scale="l" selection-mode="single-persist" theme="dark" icon-type="caret">
+    <calcite-accordion appearance="minimal" icon-position="start"  scale="l" selection-mode="single-persist" icon-type="caret">
     <calcite-accordion-item item-title="Accordion Title 1" icon="car" id="1">Accordion Item Content
     </calcite-accordion-item>
     <calcite-accordion-item item-title="Accordion Title 1" id="2" active>Accordion Item Content

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Prop, VNode } from "@stencil/core";
 import { getKey } from "../../utils/key";
 import { AccordionAppearance } from "./interfaces";
-import { Position, Scale, Theme } from "../interfaces";
+import { Position, Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-accordion",
@@ -38,9 +38,6 @@ export class CalciteAccordion {
   /** specify the selection mode - multi (allow any number of open items), single (allow one open item),
    * or single-persist (allow and require one open item), defaults to multi */
   @Prop({ reflect: true }) selectionMode: "multi" | "single" | "single-persist" = "multi";
-
-  /** specify the theme of accordion, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -10,7 +10,7 @@ import {
   VNode,
   Method
 } from "@stencil/core";
-import { Position, Theme } from "../interfaces";
+import { Position } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../functional/CalciteExpandToggle";
 import { CSS, SLOTS, TEXT } from "./resources";
 import { getSlotted, focusElement } from "../../utils/dom";
@@ -87,11 +87,6 @@ export class CalciteActionBar {
    * Arranges the component depending on the elements 'dir' property.
    */
   @Prop({ reflect: true }) position: Position;
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -10,7 +10,7 @@ import {
   VNode,
   Method
 } from "@stencil/core";
-import { Layout, Position, Theme } from "../interfaces";
+import { Layout, Position } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../functional/CalciteExpandToggle";
 import { getElementDir, focusElement, getSlotted } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -77,11 +77,6 @@ export class CalciteActionPad {
    * Arranges the component depending on the elements 'dir' property.
    */
   @Prop({ reflect: true }) position: Position;
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -11,7 +11,7 @@ import {
   VNode
 } from "@stencil/core";
 
-import { Alignment, Appearance, Scale, Theme } from "../interfaces";
+import { Alignment, Appearance, Scale } from "../interfaces";
 
 import { CSS, TEXT } from "./resources";
 
@@ -93,11 +93,6 @@ export class CalciteAction {
    * Indicates whether the text is displayed.
    */
   @Prop({ reflect: true }) textEnabled = false;
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-alert/calcite-alert.e2e.ts
+++ b/src/components/calcite-alert/calcite-alert.e2e.ts
@@ -41,7 +41,7 @@ describe("calcite-alert", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-alert theme="dark" color="yellow" auto-dismiss-duration="fast" auto-dismiss>
+    <calcite-alert color="yellow" auto-dismiss-duration="fast" auto-dismiss>
     ${alertContent}
     </calcite-alert>`);
 
@@ -51,7 +51,6 @@ describe("calcite-alert", () => {
 
     expect(element).toEqualAttribute("color", "yellow");
     expect(element).toEqualAttribute("auto-dismiss-duration", "fast");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(close).toBeNull();
     expect(icon).toBeNull();
   });

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -14,7 +14,7 @@ import {
 } from "@stencil/core";
 import { getElementDir, setRequestedIcon } from "../../utils/dom";
 import { DURATIONS, SLOTS, TEXT } from "./calcite-alert.resources";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { StatusColor, AlertDuration, StatusIcons } from "./interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
@@ -83,9 +83,6 @@ export class CalciteAlert {
 
   /** specify the scale of the button, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   @Watch("icon")
   @Watch("color")

--- a/src/components/calcite-avatar/calcite-avatar.tsx
+++ b/src/components/calcite-avatar/calcite-avatar.tsx
@@ -1,8 +1,9 @@
 import { Component, Element, h, Prop, State } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
 import { isValidHex } from "../calcite-color-picker/utils";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { hexToHue, stringToHex } from "./utils";
+import { getThemeName } from "../../utils/dom";
 
 @Component({
   tag: "calcite-avatar",
@@ -23,9 +24,6 @@ export class CalciteAvatar {
   //  Properties
   //
   //--------------------------------------------------------------------------
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** specify the scale of the avatar, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -90,7 +88,7 @@ export class CalciteAvatar {
             {initials}
           </span>
         ) : (
-          <calcite-icon class="icon" icon="user" scale={this.scale} theme={this.theme} />
+          <calcite-icon class="icon" icon="user" scale={this.scale} />
         )}
       </span>
     );
@@ -100,7 +98,8 @@ export class CalciteAvatar {
    * Generate a valid background color that is consistent and unique to this user
    */
   private generateFillColor() {
-    const { userId, username, fullName, theme } = this;
+    const { userId, username, fullName, el } = this;
+    const theme = getThemeName(el);
     const id = userId && `#${userId.substr(userId.length - 6)}`;
     const name = username || fullName || "";
     const hex = id && isValidHex(id) ? id : stringToHex(name);

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,7 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
 import { CSS, SLOTS, TEXT, HEADING_LEVEL, ICONS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
-import { Theme } from "../interfaces";
 import { getElementDir, getSlotted } from "../../utils/dom";
 import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
@@ -75,11 +74,6 @@ export class CalciteBlock {
    */
   @Prop() summary: string;
 
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
-
   // --------------------------------------------------------------------------
   //
   //  Private Properties
@@ -117,14 +111,11 @@ export class CalciteBlock {
   // --------------------------------------------------------------------------
 
   renderScrim(): VNode[] {
-    const { disabled, loading, theme } = this;
+    const { disabled, loading } = this;
 
     const defaultSlot = <slot />;
 
-    return [
-      loading || disabled ? <calcite-scrim loading={loading} theme={theme} /> : null,
-      defaultSlot
-    ];
+    return [loading || disabled ? <calcite-scrim loading={loading} /> : null, defaultSlot];
   }
 
   render(): VNode {

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Method, Prop, Build, State, VNode } from "@stenc
 import { CSS, TEXT } from "./resources";
 import { getAttributes, getElementDir } from "../../utils/dom";
 import { ButtonAlignment, ButtonAppearance, ButtonColor } from "./interfaces";
-import { FlipContext, Scale, Theme, Width } from "../interfaces";
+import { FlipContext, Scale, Width } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
 @Component({
@@ -70,9 +70,6 @@ export class CalciteButton {
   /** is the button a child of a calcite-split-button */
   @Prop({ reflect: true }) splitChild?: "primary" | "secondary" | false = false;
 
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
-
   /** specify the width of the button, defaults to auto */
   @Prop({ reflect: true }) width: Width = "auto";
 
@@ -115,8 +112,7 @@ export class CalciteButton {
       "loading",
       "scale",
       "slot",
-      "width",
-      "theme"
+      "width"
     ]);
     const Tag = this.childElType;
 

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -2,7 +2,6 @@ import { Component, Element, Event, EventEmitter, h, Prop, VNode } from "@stenci
 import { CSS, SLOTS, TEXT } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-import { Theme } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
 /**
@@ -46,9 +45,6 @@ export class CalciteCard {
 
   /** Indicates whether the card is selectable. */
   @Prop({ reflect: true }) selectable = false;
-
-  /**  The theme of the card.*/
-  @Prop({ reflect: true }) theme: Theme;
 
   /** string to override English loading text */
   @Prop() intlLoading?: string = TEXT.loading;
@@ -146,7 +142,7 @@ export class CalciteCard {
         onKeyDown={this.cardSelectKeyDown}
         title={checkboxLabel}
       >
-        <calcite-checkbox checked={this.selected} theme={this.theme} />
+        <calcite-checkbox checked={this.selected} />
       </label>
     );
   }

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -13,7 +13,7 @@ import {
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
 import { focusElement } from "../../utils/dom";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { hiddenInputStyle } from "../../utils/form";
 
 @Component({
@@ -78,9 +78,6 @@ export class CalciteCheckbox {
 
   /** specify the scale of the checkbox, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Determines what theme to use */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** The value of the checkbox input */
   @Prop() value?: any;

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -3,7 +3,7 @@ import { getElementDir, getSlotted } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import { CSS, TEXT } from "./resources";
 import { ChipColor } from "./interfaces";
-import { Appearance, Scale, Theme } from "../interfaces";
+import { Appearance, Scale } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
 @Component({
@@ -38,9 +38,6 @@ export class CalciteChip {
 
   /** specify the scale of the chip, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   @Prop() value!: any;
 

--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
@@ -21,7 +21,7 @@ import {
 } from "../calcite-color-picker/utils";
 import Color from "color";
 import { CSS } from "./resources";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { RGB } from "../calcite-color-picker/interfaces";
 import { focusElement, getElementDir } from "../../utils/dom";
 import { TEXT } from "../calcite-color-picker/resources";
@@ -96,11 +96,6 @@ export class CalciteColorPickerHexInput {
    * The component's scale.
    */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /**
-   * The component's theme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   /**
    * The hex value.

--- a/src/components/calcite-color-picker-swatch/calcite-color-picker-swatch.tsx
+++ b/src/components/calcite-color-picker-swatch/calcite-color-picker-swatch.tsx
@@ -1,8 +1,8 @@
 import { Component, Element, h, Prop, VNode, Watch } from "@stencil/core";
 import Color from "color";
 import { COLORS, CSS } from "./resources";
-import { Scale, Theme } from "../interfaces";
-import { getElementProp } from "../../utils/dom";
+import { Scale } from "../interfaces";
+import { getThemeName } from "../../utils/dom";
 
 @Component({
   tag: "calcite-color-picker-swatch",
@@ -45,14 +45,6 @@ export class CalciteColorPickerSwatch {
   })
   scale: Scale = "m";
 
-  /**
-   * The component's theme.
-   */
-  @Prop({
-    reflect: true
-  })
-  theme: Theme;
-
   //--------------------------------------------------------------------------
   //
   //  Private State/Props
@@ -78,7 +70,7 @@ export class CalciteColorPickerSwatch {
     const { active, el, internalColor } = this;
     const borderRadius = active ? "100%" : "0";
     const hex = internalColor.hex();
-    const theme = getElementProp(el, "theme", "light", true);
+    const theme = getThemeName(el);
     const borderColor = theme === "light" ? COLORS.borderLight : COLORS.borderDark;
 
     return (

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -34,10 +34,6 @@ describe("calcite-color-picker", () => {
       {
         propertyName: "scale",
         value: "m"
-      },
-      {
-        propertyName: "theme",
-        value: "light"
       }
     ]));
 

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -14,7 +14,7 @@ import {
 
 import Color from "color";
 import { ColorAppearance, ColorMode, ColorValue, InternalColor } from "./interfaces";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import {
   CSS,
   DEFAULT_COLOR,
@@ -186,14 +186,6 @@ export class CalciteColorPicker {
    * Storage ID for colors.
    */
   @Prop() storageId: string;
-
-  /**
-   * The component's theme.
-   */
-  @Prop({
-    reflect: true
-  })
-  theme: Theme;
 
   /**
    * The color value.
@@ -522,8 +514,7 @@ export class CalciteColorPicker {
       intlSaved,
       intlSaveColor,
       savedColors,
-      scale,
-      theme
+      scale
     } = this;
     const selectedColorInHex = color ? color.hex() : null;
     const hexInputScale = scale !== "s" ? "m" : scale;
@@ -600,7 +591,6 @@ export class CalciteColorPicker {
                   onCalciteColorPickerHexInputChange={this.handleHexInputChange}
                   ref={this.storeHexInputRef}
                   scale={hexInputScale}
-                  theme={theme}
                   value={selectedColorInHex}
                 />
               </div>
@@ -637,7 +627,6 @@ export class CalciteColorPicker {
                   iconStart="minus"
                   onClick={this.deleteColor}
                   scale={scale}
-                  theme={theme}
                 />
                 <calcite-button
                   appearance="transparent"
@@ -648,7 +637,6 @@ export class CalciteColorPicker {
                   iconStart="plus"
                   onClick={this.saveColor}
                   scale={scale}
-                  theme={theme}
                 />
               </div>
             </div>
@@ -665,7 +653,6 @@ export class CalciteColorPicker {
                       onKeyDown={this.handleSavedColorKeyDown}
                       scale={scale}
                       tabIndex={0}
-                      theme={theme}
                     />
                   ))
                 ]}

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { ComboboxSelectionMode, ComboboxChildElement } from "./interfaces";
 import {
   ComboboxChildSelector,
@@ -120,9 +120,6 @@ export class CalciteCombobox {
 
   /** Specify the scale of the combobox, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -111,8 +111,7 @@ export class CalciteDropdownItem {
       "has-text",
       "is-link",
       "dir",
-      "id",
-      "theme"
+      "id"
     ]);
     const dir = getElementDir(this.el);
     const scale = getElementProp(this.el, "scale", "m");

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -108,7 +108,7 @@ describe("calcite-dropdown", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-dropdown placement="bottom-trailing" scale="l" width="l" theme="dark">
+    <calcite-dropdown placement="bottom-trailing" scale="l" width="l">
     <calcite-button slot="dropdown-trigger">Open dropdown</calcite-button>
     <calcite-dropdown-group id="group-1" selection-mode="multi">
     <calcite-dropdown-item id="item-1">
@@ -127,7 +127,6 @@ describe("calcite-dropdown", () => {
     const group1 = await element.find("calcite-dropdown-group[id='group-1']");
     expect(element).toEqualAttribute("scale", "l");
     expect(element).toEqualAttribute("width", "l");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("placement", "bottom-trailing");
     expect(group1).toEqualAttribute("selection-mode", "multi");
   });

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -21,7 +21,7 @@ import {
   OverlayPositioning
 } from "../../utils/popper";
 import { StrictModifiers, Instance as Popper } from "@popperjs/core";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { DefaultDropdownPlacement } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 
@@ -89,9 +89,6 @@ export class CalciteDropdown {
    * @readonly
    */
   @Prop({ mutable: true }) selectedItems: HTMLCalciteDropdownItemElement[] = [];
-
-  /** specify the theme of the dropdown, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** specify whether the dropdown is opened by hover or click of a trigger element */
   @Prop({ reflect: true }) type: "hover" | "click" = "click";

--- a/src/components/calcite-fab/calcite-fab.tsx
+++ b/src/components/calcite-fab/calcite-fab.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Method, Prop, h, VNode } from "@stencil/core";
-import { Appearance, Scale, Theme } from "../interfaces";
+import { Appearance, Scale } from "../interfaces";
 import { ButtonColor } from "../calcite-button/interfaces";
 import { CSS, ICONS } from "./resources";
 import { focusElement, getElementDir } from "../../utils/dom";
@@ -61,11 +61,6 @@ export class CalciteFab {
    */
   @Prop({ reflect: true }) textEnabled = false;
 
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
-
   // --------------------------------------------------------------------------
   //
   //  Private Properties
@@ -94,19 +89,8 @@ export class CalciteFab {
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const {
-      appearance,
-      color,
-      disabled,
-      el,
-      loading,
-      scale,
-      theme,
-      textEnabled,
-      icon,
-      label,
-      text
-    } = this;
+    const { appearance, color, disabled, el, loading, scale, textEnabled, icon, label, text } =
+      this;
     const title = !textEnabled ? label || text || null : null;
     const dir = getElementDir(el);
 
@@ -125,7 +109,6 @@ export class CalciteFab {
         }}
         round={true}
         scale={scale}
-        theme={theme}
         title={title}
         width="auto"
       >

--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -1,8 +1,6 @@
-import { Component, Element, Listen, Method, Prop, State, h, VNode } from "@stencil/core";
+import { Component, Element, Listen, Method, State, h, VNode } from "@stencil/core";
 
 import { CSS } from "./resources";
-
-import { Theme } from "../interfaces";
 
 import { FlowDirection } from "./interfaces";
 
@@ -15,17 +13,6 @@ import { FlowDirection } from "./interfaces";
   shadow: true
 })
 export class CalciteFlow {
-  // --------------------------------------------------------------------------
-  //
-  //  Properties
-  //
-  // --------------------------------------------------------------------------
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
-
   // --------------------------------------------------------------------------
   //
   //  Public Methods

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -2,7 +2,7 @@ import { Build, Component, Element, h, Host, Prop, State, VNode, Watch } from "@
 import { CSS } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { fetchIcon, scaleToPx } from "./utils";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { CalciteIconPath, CalciteMultiPathEntry } from "@esri/calcite-ui-icons";
 
 @Component({
@@ -58,14 +58,6 @@ export class CalciteIcon {
    */
   @Prop()
   textLabel: string;
-
-  /**
-   * Icon theme. Can be "light" or "dark".
-   */
-  @Prop({
-    reflect: true
-  })
-  theme: Theme;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -58,14 +58,13 @@ describe("calcite-inline-editable", () => {
     it("renders requested props when valid props are provided", async () => {
       page = await newE2EPage();
       await page.setContent(`
-      <calcite-inline-editable controls editing-enabled loading disabled scale="l" theme="dark">
+      <calcite-inline-editable controls editing-enabled loading disabled scale="l" >
         <calcite-input/>
       </calcite-inline-editable>
       `);
       await page.waitForChanges();
       const element = await page.find("calcite-inline-editable");
       expect(element).toEqualAttribute("scale", "l");
-      expect(element).toEqualAttribute("theme", "dark");
       expect(element).toHaveAttribute("controls");
       expect(element).toHaveAttribute("editing-enabled");
       expect(element).toHaveAttribute("loading");

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -10,7 +10,7 @@ import {
   Watch
 } from "@stencil/core";
 import { getElementProp } from "../../utils/dom";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { TEXT } from "./resources";
 
 /**
@@ -65,9 +65,6 @@ export class CalciteInlineEditable {
   /** specify the scale of the inline-editable component, defaults to the scale of the wrapped calcite-input or the scale of the closest wrapping component with a set scale */
   @Prop({ reflect: true, mutable: true }) scale?: Scale;
 
-  /** specify the theme of the inline-editable component, defaults to the theme of the wrapped calcite-input or the theme of the closest wrapping component with a set theme */
-  @Prop({ reflect: true }) theme?: Theme;
-
   /** when controls, specify a callback to be executed prior to disabling editing. when provided, loading state will be handled automatically. */
   @Prop() afterConfirm?: () => Promise<void>;
 
@@ -113,7 +110,6 @@ export class CalciteInlineEditable {
               onClick={this.enableEditingHandler}
               ref={(el) => (this.enableEditingButton = el)}
               scale={this.scale}
-              theme={this.theme}
             />
           )}
           {this.shouldShowControls && [
@@ -127,7 +123,6 @@ export class CalciteInlineEditable {
                 iconStart="x"
                 onClick={this.cancelEditingHandler}
                 scale={this.scale}
-                theme={this.theme}
               />
             </div>,
             <calcite-button
@@ -140,7 +135,6 @@ export class CalciteInlineEditable {
               loading={this.loading}
               onClick={this.confirmChangesHandler}
               scale={this.scale}
-              theme={this.theme}
             />
           ]}
         </div>

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -22,19 +22,18 @@ describe("calcite-input-message", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input-message status="valid" theme="dark" type="floating">Text</calcite-input-message>
+    <calcite-input-message status="valid" type="floating">Text</calcite-input-message>
     `);
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "valid");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("type", "floating");
   });
 
   it("inherits requested props when from wrapping calcite-label when props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-label status="invalid" theme="dark">
+    <calcite-label status="invalid">
     Label text
     <calcite-input-message>Text</calcite-input-message>
     </calcite-label>

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, h, Prop, VNode, Watch } from "@stencil/core";
 import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
-import { Scale, Status, Theme } from "../interfaces";
+import { Scale, Status } from "../interfaces";
 import { InputMessageType, StatusIconDefaults } from "./interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
@@ -35,9 +35,6 @@ export class CalciteInputMessage {
 
   /** specify the status of the input field, determines message and icons */
   @Prop({ reflect: true, mutable: true }) status: Status = "idle";
-
-  /** specify the theme, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input) */
   @Prop({ reflect: true }) type: InputMessageType = "default";

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -60,12 +60,11 @@ describe("calcite-input", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input status="invalid" theme="dark" alignment="end" number-button-type="none" type="number" scale="s"></calcite-input>
+    <calcite-input status="invalid" alignment="end" number-button-type="none" type="number" scale="s"></calcite-input>
     `);
 
     const element = await page.find("calcite-input");
     expect(element).toEqualAttribute("status", "invalid");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("alignment", "end");
     expect(element).toEqualAttribute("number-button-type", "none");
     expect(element).toEqualAttribute("type", "number");
@@ -75,7 +74,7 @@ describe("calcite-input", () => {
   it("inherits requested props when from wrapping calcite-label when props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-label status="invalid" theme="dark" scale="s">
+    <calcite-label status="invalid" scale="s">
     Label text
     <calcite-input></calcite-input>
     </calcite-label>

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -1,4 +1,4 @@
-import { Scale, Status, Theme } from "../interfaces";
+import { Scale, Status } from "../interfaces";
 import {
   Component,
   Element,
@@ -151,9 +151,6 @@ export class CalciteInput {
 
   /** optionally add suffix  **/
   @Prop() suffixText?: string;
-
-  /** specify the theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   /**
    * specify the input type
@@ -561,7 +558,6 @@ export class CalciteInput {
       "scale",
       "status",
       "suffix-text",
-      "theme",
       "number-button-type",
       "locale",
       "group-separator"
@@ -581,7 +577,7 @@ export class CalciteInput {
         disabled={this.loading}
         onClick={this.clearInputValue}
       >
-        <calcite-icon icon="x" scale={iconScale} theme={this.theme} />
+        <calcite-icon icon="x" scale={iconScale} />
       </button>
     );
     const iconEl = (
@@ -591,7 +587,6 @@ export class CalciteInput {
         flipRtl={this.iconFlipRtl}
         icon={this.requestedIcon}
         scale={iconScale}
-        theme={this.theme}
       />
     );
 
@@ -604,7 +599,7 @@ export class CalciteInput {
         data-adjustment="up"
         onMouseDown={this.numberButtonMouseDownHandler}
       >
-        <calcite-icon icon="chevron-up" scale={iconScale} theme={this.theme} />
+        <calcite-icon icon="chevron-up" scale={iconScale} />
       </div>
     );
 
@@ -614,7 +609,7 @@ export class CalciteInput {
         data-adjustment="down"
         onMouseDown={this.numberButtonMouseDownHandler}
       >
-        <calcite-icon icon="chevron-down" scale={iconScale} theme={this.theme} />
+        <calcite-icon icon="chevron-down" scale={iconScale} />
       </div>
     );
 

--- a/src/components/calcite-label/calcite-label.e2e.ts
+++ b/src/components/calcite-label/calcite-label.e2e.ts
@@ -26,7 +26,7 @@ describe("calcite-label", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-label status="invalid" theme="dark" layout="inline-space-between">
+    <calcite-label status="invalid" layout="inline-space-between">
     Label text
     <calcite-input></calcite-input>
     </calcite-label>
@@ -34,7 +34,6 @@ describe("calcite-label", () => {
 
     const element = await page.find("calcite-label");
     expect(element).toEqualAttribute("status", "invalid");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("layout", "inline-space-between");
   });
 
@@ -134,7 +133,7 @@ describe("calcite-label", () => {
   it("does not pass id to child label element", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-label id="dont-duplicate-me" status="invalid" theme="dark" layout="inline-space-between">
+    <calcite-label id="dont-duplicate-me" status="invalid" layout="inline-space-between">
     Label text
     <calcite-input></calcite-input>
     </calcite-label>
@@ -145,7 +144,6 @@ describe("calcite-label", () => {
     expect(element).toEqualAttribute("id", "dont-duplicate-me");
     expect(childElement).not.toHaveAttribute("id");
     expect(element).toEqualAttribute("status", "invalid");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("layout", "inline-space-between");
   });
 

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, Listen, h, Prop, EventEmitter, VNode } from "@stencil/core";
 import { getAttributes, getElementDir, queryElementRoots } from "../../utils/dom";
 import { FocusRequest } from "./interfaces";
-import { Alignment, Scale, Status, Theme } from "../interfaces";
+import { Alignment, Scale, Status } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
 @Component({
@@ -35,9 +35,6 @@ export class CalciteLabel {
 
   /** specify the scale of the input, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** specify theme of the label and its any child input / input messages */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** is the wrapped element positioned inline with the label slotted text */
   @Prop({ reflect: true }) layout: "inline" | "inline-space-between" | "default" = "default";
@@ -159,8 +156,7 @@ export class CalciteLabel {
       "dir",
       "layout",
       "scale",
-      "status",
-      "theme"
+      "status"
     ]);
     const dir = getElementDir(this.el);
     return (

--- a/src/components/calcite-link/calcite-link.tsx
+++ b/src/components/calcite-link/calcite-link.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, h, Host, Method, Prop, VNode } from "@stencil/core";
 import { getAttributes, focusElement, getElementDir } from "../../utils/dom";
-import { FlipContext, Theme } from "../interfaces";
+import { FlipContext } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
 /** @slot default text slot for link text */
@@ -44,9 +44,6 @@ export class CalciteLink {
   /** optionally pass an icon to display at the start of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconStart?: string;
 
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
-
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -78,7 +75,7 @@ export class CalciteLink {
       />
     );
 
-    const attributes = getAttributes(this.el, ["dir", "icon-end", "icon-start", "id", "theme"]);
+    const attributes = getAttributes(this.el, ["dir", "icon-end", "icon-start", "id"]);
     const Tag = this.childElType;
     const role = this.childElType === "span" ? "link" : null;
     const tabIndex = this.disabled ? -1 : this.childElType === "span" ? 0 : null;

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -304,7 +304,7 @@ describe("calcite-modal accessibility checks", () => {
     expect(footer).toBeFalsy();
   });
 
-  it("should render calcite-scrim with dark theme background color", async () => {
+  it("should render calcite-scrim with dark background color", async () => {
     const page = await newE2EPage({
       html: `
       <calcite-modal aria-labelledby="modal-title" is-active>

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -17,7 +17,7 @@ import { CalciteFocusableElement, focusElement, getElementDir } from "../../util
 import { getKey } from "../../utils/key";
 import { queryShadowRoot } from "@a11y/focus-trap/shadow";
 import { isFocusable, isHidden } from "@a11y/focus-trap/focusable";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { ModalBackgroundColor } from "./interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
@@ -81,9 +81,6 @@ export class CalciteModal {
    * Use color to add importance to destructive/workflow dialogs. */
   @Prop({ reflect: true }) color?: "red" | "blue";
 
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
-
   /** Background color of modal content */
   @Prop({ reflect: true }) backgroundColor: ModalBackgroundColor = "white";
 
@@ -122,7 +119,7 @@ export class CalciteModal {
     const dir = getElementDir(this.el);
     return (
       <Host aria-modal="true" role="dialog">
-        <calcite-scrim class="scrim" theme="dark" />
+        <calcite-scrim class="scrim" />
         {this.renderStyle()}
         <div class={{ modal: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
           <div data-focus-fence onFocus={this.focusLastElement} tabindex="0" />

--- a/src/components/calcite-notice/calcite-notice.e2e.ts
+++ b/src/components/calcite-notice/calcite-notice.e2e.ts
@@ -36,7 +36,7 @@ describe("calcite-notice", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-notice theme="dark" color="yellow" dismissible>
+    <calcite-notice color="yellow" dismissible>
     ${noticeContent}
     </calcite-notice>`);
 
@@ -45,7 +45,6 @@ describe("calcite-notice", () => {
     const icon = await page.find("calcite-notice >>> .notice-icon");
 
     expect(element).toEqualAttribute("color", "yellow");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(close).not.toBeNull();
     expect(icon).toBeNull();
   });

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -11,7 +11,7 @@ import {
 } from "@stencil/core";
 
 import { SLOTS, TEXT } from "./calcite-notice.resources";
-import { Scale, Theme, Width } from "../interfaces";
+import { Scale, Width } from "../interfaces";
 import { StatusColor, StatusIcons } from "../calcite-alert/interfaces";
 import { getElementDir, setRequestedIcon } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -66,9 +66,6 @@ export class CalciteNotice {
 
   /** specify the scale of the notice, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** specify the width of the notice, defaults to auto */
   @Prop({ reflect: true }) width: Width = "auto";

--- a/src/components/calcite-pagination/calcite-pagination.tsx
+++ b/src/components/calcite-pagination/calcite-pagination.tsx
@@ -10,7 +10,7 @@ import {
   Fragment
 } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 
 import { CSS, TEXT } from "./resources";
 
@@ -46,9 +46,6 @@ export class CalcitePagination {
 
   /** title of the previous button */
   @Prop() textLabelPrevious: string = TEXT.previousLabel;
-
-  /** specify the theme of accordion, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** The scale of the pagination */
   @Prop({ reflect: true }) scale: Scale = "m";

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -13,7 +13,7 @@ import {
 import { CSS, HEADING_LEVEL, ICONS, SLOTS, TEXT } from "./resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
@@ -101,12 +101,6 @@ export class CalcitePanel {
    * 'Options' text string for the actions menu.
    */
   @Prop() intlOptions?: string;
-
-  /**
-   * Used to set the component's color scheme.
-   */
-
-  @Prop({ reflect: true }) theme: Theme;
 
   /**
    * Heading text.

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -30,7 +30,6 @@ import {
   removeItem
 } from "./shared-list-logic";
 import List from "./shared-list-render";
-import { Theme } from "../interfaces";
 import { HeadingLevel } from "../functional/CalciteHeading";
 
 /**
@@ -83,9 +82,6 @@ export class CalcitePickList<
    * and selecting a new item will deselect any other selected items.
    */
   @Prop({ reflect: true }) multiple = false;
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list/shared-list-render.tsx
+++ b/src/components/calcite-pick-list/shared-list-render.tsx
@@ -4,7 +4,6 @@ import { CSS } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { handleFilter } from "./shared-list-logic";
 import DOMAttributes = JSXBase.DOMAttributes;
-import { Theme } from "../interfaces";
 
 interface ListProps extends DOMAttributes {
   disabled: boolean;
@@ -13,7 +12,6 @@ interface ListProps extends DOMAttributes {
   dataForFilter: any;
   handleFilter: typeof handleFilter;
   filterPlaceholder: string;
-  theme: Theme;
   el: HTMLCalcitePickListElement | HTMLCalciteValueListElement;
   setFilterEl: (el: HTMLCalciteFilterElement) => void;
 }
@@ -27,8 +25,7 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
     handleFilter,
     filterPlaceholder,
     el,
-    setFilterEl,
-    theme
+    setFilterEl
   },
   ...rest
 }): VNode => {
@@ -50,7 +47,7 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
           ) : null}
           <slot name="menu-actions" />
         </header>
-        {loading || disabled ? <calcite-scrim loading={loading} theme={theme} /> : null}
+        {loading || disabled ? <calcite-scrim loading={loading} /> : null}
         {defaultSlot}
       </section>
     </Host>

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -22,7 +22,6 @@ import {
 } from "../../utils/popper";
 import { StrictModifiers, Placement, Instance as Popper } from "@popperjs/core";
 import { guid } from "../../utils/guid";
-import { Theme } from "../interfaces";
 import { getElementDir, queryElementRoots } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
 import { PopoverFocusId } from "./resources";
@@ -130,9 +129,6 @@ export class CalcitePopover {
 
   /** Text for close button. */
   @Prop() intlClose = TEXT.close;
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-progress/calcite-progress.tsx
+++ b/src/components/calcite-progress/calcite-progress.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, Fragment, h, Prop, VNode } from "@stencil/core";
-import { Theme } from "../interfaces";
 @Component({
   tag: "calcite-progress",
   styleUrl: "calcite-progress.scss",
@@ -19,9 +18,6 @@ export class CalciteProgress {
 
   /** For indeterminate progress bars, reverse the animation direction */
   @Prop() reversed = false;
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   render(): VNode {
     const isDeterminate = this.type === "determinate";

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.e2e.ts
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.e2e.ts
@@ -56,8 +56,7 @@ describe("calcite-radio-button-group", () => {
       { propertyName: "layout", value: "horizontal" },
       { propertyName: "name", value: "reflects-name" },
       { propertyName: "required", value: true },
-      { propertyName: "scale", value: "m" },
-      { propertyName: "theme", value: "light" }
+      { propertyName: "scale", value: "m" }
     ]));
 
   it("has a radio input for form compatibility", async () => {

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.tsx
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.tsx
@@ -10,7 +10,7 @@ import {
   EventEmitter,
   Listen
 } from "@stencil/core";
-import { Layout, Scale, Theme } from "../interfaces";
+import { Layout, Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-radio-button-group",
@@ -70,14 +70,6 @@ export class CalciteRadioButtonGroup {
     this.passPropsToRadioButtons();
   }
 
-  /** The color theme of the radio button group. */
-  @Prop({ reflect: true }) theme: Theme;
-
-  @Watch("theme")
-  onThemeChange(): void {
-    this.passPropsToRadioButtons();
-  }
-
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -103,7 +95,6 @@ export class CalciteRadioButtonGroup {
         radioButton.name = this.name;
         radioButton.required = this.required;
         radioButton.scale = this.scale;
-        radioButton.theme = this.theme;
       });
     }
   };

--- a/src/components/calcite-radio-button/calcite-radio-button.e2e.ts
+++ b/src/components/calcite-radio-button/calcite-radio-button.e2e.ts
@@ -45,8 +45,7 @@ describe("calcite-radio-button", () => {
       { propertyName: "hidden", value: true },
       { propertyName: "name", value: "reflects-name" },
       { propertyName: "required", value: true },
-      { propertyName: "scale", value: "m" },
-      { propertyName: "theme", value: "light" }
+      { propertyName: "scale", value: "m" }
     ]));
 
   it("has a radio input for form compatibility", async () => {

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -12,7 +12,7 @@ import {
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
 import { focusElement } from "../../utils/dom";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { hiddenInputStyle } from "../../utils/form";
 
 @Component({
@@ -122,9 +122,6 @@ export class CalciteRadioButton {
 
   /** The scale (size) of the radio button.  <code>scale</code> is passed as a property automatically from <code>calcite-radio-button-group</code>. */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** The color theme of the radio button, <code>theme</code> is passed as a property automatically from <code>calcite-radio-button-group</code>. */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** The value of the radio button. */
   @Prop() value!: any;
@@ -358,7 +355,6 @@ export class CalciteRadioButton {
           hovered={this.hovered}
           ref={(el) => (this.radio = el)}
           scale={this.scale}
-          theme={this.theme}
         />
       </div>
     );

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -197,10 +197,9 @@ describe("calcite-radio-group", () => {
   it("renders requested props", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      "<calcite-radio-group theme='dark' scale='l' layout='vertical' appearance='outline' width='full'></calcite-radio-group>"
+      "<calcite-radio-group scale='l' layout='vertical' appearance='outline' width='full'></calcite-radio-group>"
     );
     const element = await page.find("calcite-radio-group");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("scale", "l");
     expect(element).toEqualAttribute("layout", "vertical");
     expect(element).toEqualAttribute("appearance", "outline");

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -15,7 +15,7 @@ import {
 
 import { getElementDir, hasLabel } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-import { Layout, Scale, Theme, Width } from "../interfaces";
+import { Layout, Scale, Width } from "../interfaces";
 import { RadioAppearance } from "./interfaces";
 
 @Component({
@@ -85,9 +85,6 @@ export class CalciteRadioGroup {
       items[0].tabIndex = 0;
     }
   }
-
-  /** The component's theme. */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** specify the width of the group, defaults to auto */
   @Prop({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";

--- a/src/components/calcite-radio/calcite-radio.e2e.ts
+++ b/src/components/calcite-radio/calcite-radio.e2e.ts
@@ -15,7 +15,6 @@ describe("calcite-radio", () => {
       { propertyName: "disabled", value: true },
       { propertyName: "focused", value: true },
       { propertyName: "hidden", value: true },
-      { propertyName: "scale", value: "m" },
-      { propertyName: "theme", value: "light" }
+      { propertyName: "scale", value: "m" }
     ]));
 });

--- a/src/components/calcite-radio/calcite-radio.tsx
+++ b/src/components/calcite-radio/calcite-radio.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from "@stencil/core";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-radio",
@@ -36,9 +36,6 @@ export class CalciteRadio {
 
   /** The scale (size) of the radio. */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** The color theme of the radio, */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -13,7 +13,7 @@ import {
 } from "@stencil/core";
 import { getElementDir, hasLabel } from "../../utils/dom";
 import { guid } from "../../utils/guid";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 import { TEXT } from "./calcite-rating-resources";
 import { CSS_UTILITY } from "../../utils/resources";
 
@@ -36,9 +36,6 @@ export class CalciteRating {
   //  Properties
   //
   // --------------------------------------------------------------------------
-
-  /** specify the theme of scrim, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** specify the scale of the component, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -129,7 +126,7 @@ export class CalciteRating {
             />
             {partial && (
               <div class="fraction" style={{ width: `${fraction * 100}%` }}>
-                <calcite-icon icon="star-f" scale={this.scale} theme={this.theme} />
+                <calcite-icon icon="star-f" scale={this.scale} />
               </div>
             )}
             <span class="visually-hidden">{this.intlStars.replace("${num}", `${i}`)}</span>
@@ -157,7 +154,7 @@ export class CalciteRating {
   }
 
   render() {
-    const { intlRating, showChip, scale, theme, count, average } = this;
+    const { intlRating, showChip, scale, count, average } = this;
     const dir = getElementDir(this.el);
     return (
       <Fragment>
@@ -175,7 +172,6 @@ export class CalciteRating {
             class={{ [CSS_UTILITY.rtl]: dir === "rtl" }}
             dir={dir}
             scale={scale}
-            theme={theme}
             value={count?.toString()}
           >
             {!!average && <span class="number--average">{average.toString()}</span>}

--- a/src/components/calcite-scrim/calcite-scrim.tsx
+++ b/src/components/calcite-scrim/calcite-scrim.tsx
@@ -1,5 +1,4 @@
 import { Component, Prop, h, VNode } from "@stencil/core";
-import { Theme } from "../interfaces";
 
 import { CSS, TEXT } from "./resources";
 
@@ -23,9 +22,6 @@ export class CalciteScrim {
    * Otherwise, will render opaque disabled state.
    */
   @Prop({ reflect: true }) loading = false;
-
-  /** specify the theme of scrim, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -27,10 +27,6 @@ describe("calcite-select", () => {
       {
         propertyName: "scale",
         value: "m"
-      },
-      {
-        propertyName: "theme",
-        value: "light"
       }
     ]));
 

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -11,7 +11,7 @@ import {
   VNode
 } from "@stencil/core";
 import { Direction, focusElement, getElementDir } from "../../utils/dom";
-import { Scale, Theme, Width } from "../interfaces";
+import { Scale, Width } from "../interfaces";
 import { CSS } from "./resources";
 import { FocusRequest } from "../calcite-label/interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -71,14 +71,6 @@ export class CalciteSelect {
    */
   @Prop({ mutable: true })
   selectedOption: HTMLCalciteOptionElement;
-
-  /**
-   * The component theme.
-   */
-  @Prop({
-    reflect: true
-  })
-  theme: Theme;
 
   /**
    * The component width.

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, Prop, h, VNode, Fragment } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
-import { Theme } from "../interfaces";
 import { getSlotted } from "../../utils/dom";
 
 /**
@@ -22,11 +21,6 @@ export class CalciteShell {
   //  Properties
   //
   // --------------------------------------------------------------------------
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   /**
    * Positions the center content behind any calcite-shell-panels.

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -16,7 +16,6 @@ import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
 import { DataSeries } from "../calcite-graph/interfaces";
 import { hasLabel } from "../../utils/dom";
-import { Theme } from "../interfaces";
 
 type activeSliderProperty = "minValue" | "maxValue" | "value" | "minMaxValue";
 
@@ -38,8 +37,6 @@ export class CalciteSlider {
   //  Properties
   //
   //--------------------------------------------------------------------------
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** Disable and gray out the slider */
   @Prop({ reflect: true }) disabled = false;

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -66,7 +66,6 @@ describe("calcite-split-button", () => {
       <calcite-split-button
           scale="s"
           color="red"
-          theme="dark"
           dropdown-icon-type="caret"
           loading
           disabled
@@ -78,7 +77,6 @@ describe("calcite-split-button", () => {
     const dropdownButton = await page.find("calcite-split-button >>> calcite-dropdown calcite-button");
     expect(element).toEqualAttribute("scale", "s");
     expect(element).toEqualAttribute("color", "red");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("dropdown-icon-type", "caret");
     expect(element).toHaveAttribute("loading");
     expect(element).toHaveAttribute("disabled");

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Prop, VNode } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
 import { ButtonAppearance, ButtonColor, DropdownIconType } from "../calcite-button/interfaces";
-import { FlipContext, Scale, Theme } from "../interfaces";
+import { FlipContext, Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-split-button",
@@ -48,9 +48,6 @@ export class CalciteSplitButton {
   /** specify the scale of the control, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** select theme (light or dark), defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
-
   /** fired when the primary button is clicked */
   @Event() calciteSplitButtonPrimaryClick: EventEmitter;
 
@@ -74,7 +71,6 @@ export class CalciteSplitButton {
           onClick={this.calciteSplitButtonPrimaryClickHandler}
           scale={this.scale}
           splitChild={"primary"}
-          theme={this.theme}
         >
           {this.primaryText}
         </calcite-button>
@@ -86,7 +82,6 @@ export class CalciteSplitButton {
           onClick={this.calciteSplitButtonSecondaryClickHandler}
           placement="bottom-trailing"
           scale={this.scale}
-          theme={this.theme}
           width={this.scale}
         >
           <calcite-button
@@ -99,7 +94,6 @@ export class CalciteSplitButton {
             scale={this.scale}
             slot="dropdown-trigger"
             splitChild={"secondary"}
-            theme={this.theme}
           />
           <slot />
         </calcite-dropdown>

--- a/src/components/calcite-stepper/calcite-stepper.e2e.ts
+++ b/src/components/calcite-stepper/calcite-stepper.e2e.ts
@@ -51,7 +51,7 @@ describe("calcite-stepper", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-stepper layout="vertical" scale="l" theme="dark" numbered icon>
+    <calcite-stepper layout="vertical" scale="l" numbered icon>
       <calcite-stepper-item item-title="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
@@ -68,7 +68,6 @@ describe("calcite-stepper", () => {
     const element = await page.find("calcite-stepper");
     expect(element).toEqualAttribute("layout", "vertical");
     expect(element).toEqualAttribute("scale", "l");
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toHaveAttribute("numbered");
     expect(element).toHaveAttribute("icon");
   });
@@ -76,7 +75,7 @@ describe("calcite-stepper", () => {
   it("adds active attribute to requested item", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-stepper layout="vertical" scale="l" theme="dark" numbered icon>
+    <calcite-stepper layout="vertical" scale="l" numbered icon>
       <calcite-stepper-item item-title="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
@@ -103,7 +102,7 @@ describe("calcite-stepper", () => {
   it("adds active attribute to first item if none are requested", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-stepper layout="vertical" scale="l" theme="dark" numbered icon>
+    <calcite-stepper layout="vertical" scale="l" numbered icon>
       <calcite-stepper-item item-title="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>

--- a/src/components/calcite-stepper/calcite-stepper.tsx
+++ b/src/components/calcite-stepper/calcite-stepper.tsx
@@ -12,7 +12,7 @@ import {
 } from "@stencil/core";
 import { IESTYLES } from "./calcite-stepper.resources";
 import { getKey } from "../../utils/key";
-import { Layout, Scale, Theme } from "../interfaces";
+import { Layout, Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-stepper",
@@ -45,9 +45,6 @@ export class CalciteStepper {
 
   /** specify the scale of stepper, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
-
-  /** specify the theme of stepper, defaults to light */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** @internal */
   @Prop({ mutable: true }) requestedContent: HTMLElement[] | NodeListOf<any>;

--- a/src/components/calcite-switch/calcite-switch.e2e.ts
+++ b/src/components/calcite-switch/calcite-switch.e2e.ts
@@ -131,10 +131,9 @@ describe("calcite-switch", () => {
 
   it("renders requested props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-switch theme="dark" scale="l" ></calcite-switch>`);
+    await page.setContent(`<calcite-switch scale="l" ></calcite-switch>`);
     const element = await page.find("calcite-switch");
 
-    expect(element).toEqualAttribute("theme", "dark");
     expect(element).toEqualAttribute("scale", "l");
   });
 

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -17,7 +17,7 @@ import { hiddenInputStyle } from "../../utils/form";
 import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
 import { CSS_UTILITY } from "../../utils/resources";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-switch",
@@ -66,9 +66,6 @@ export class CalciteSwitch {
   switchedWatcher(newSwitched: boolean): void {
     this.inputEl.checked = newSwitched;
   }
-
-  /** The component's theme. */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** The value of the switch input */
   @Prop({ reflect: true }) value?: any;

--- a/src/components/calcite-tabs/calcite-tabs.tsx
+++ b/src/components/calcite-tabs/calcite-tabs.tsx
@@ -1,5 +1,4 @@
 import { Component, Prop, h, Element, Listen, State, VNode, Fragment } from "@stencil/core";
-import { Theme } from "../interfaces";
 import { TabLayout, TabPosition } from "./interfaces";
 
 @Component({
@@ -21,11 +20,6 @@ export class CalciteTabs {
   //  Public Properties
   //
   //--------------------------------------------------------------------------
-
-  /**
-   * Select theme (light or dark)
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   /**
    * Align tab titles to the edge or fully justify them across the tab nav ("center")

--- a/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
@@ -36,7 +36,6 @@ describe("calcite-tile-select", () => {
       { propertyName: "inputAlignment", value: "start" },
       { propertyName: "name", value: "my-tile-select" },
       { propertyName: "inputEnabled", value: true },
-      { propertyName: "theme", value: "light" },
       { propertyName: "type", value: "radio" },
       { propertyName: "width", value: "auto" }
     ]));

--- a/src/components/calcite-tile-select/calcite-tile-select.tsx
+++ b/src/components/calcite-tile-select/calcite-tile-select.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Prop, Listen, VNode, Watch, State, Method } from "@stencil/core";
-import { Alignment, Theme, Width } from "../interfaces";
+import { Alignment, Width } from "../interfaces";
 import { TileSelectType } from "./interfaces";
 import { getElementDir } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -60,9 +60,6 @@ export class CalciteTileSelect {
 
   /** The side of the tile that the radio or checkbox appears on when inputEnabled is true. */
   @Prop({ reflect: true }) inputAlignment: Extract<"end" | "start", Alignment> = "start";
-
-  /** The theme of the tile select. */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** The selection mode of the tile select: radio (single) or checkbox (multiple). */
   @Prop({ reflect: true }) type: TileSelectType = "radio";
@@ -200,7 +197,6 @@ export class CalciteTileSelect {
     if (this.name) {
       this.input.name = this.name;
     }
-    this.input.theme = this.theme;
     if (this.value) {
       this.input.value = this.value != null ? this.value.toString() : "";
     }

--- a/src/components/calcite-tile/calcite-tile.e2e.ts
+++ b/src/components/calcite-tile/calcite-tile.e2e.ts
@@ -27,8 +27,7 @@ describe("calcite-tile", () => {
       { propertyName: "embed", value: true },
       { propertyName: "focused", value: true },
       { propertyName: "href", value: "http://www.esri.com" },
-      { propertyName: "icon", value: "layers" },
-      { propertyName: "theme", value: "light" }
+      { propertyName: "icon", value: "layers" }
     ]));
 
   it("honors hidden attribute", async () => hidden("calcite-tile"));

--- a/src/components/calcite-tile/calcite-tile.tsx
+++ b/src/components/calcite-tile/calcite-tile.tsx
@@ -1,5 +1,4 @@
 import { Component, h, Prop, VNode, Fragment } from "@stencil/core";
-import { Theme } from "../interfaces";
 
 @Component({
   tag: "calcite-tile",
@@ -40,9 +39,6 @@ export class CalciteTile {
   /** The icon that appears at the top of the tile. */
   @Prop({ reflect: true }) icon?: string;
 
-  /** The theme of the tile. */
-  @Prop({ reflect: true }) theme: Theme;
-
   // --------------------------------------------------------------------------
   //
   //  Render Methods
@@ -74,9 +70,7 @@ export class CalciteTile {
     return (
       <Fragment>
         {this.href ? (
-          <calcite-link href={this.href} theme={this.theme}>
-            {this.renderTile()}
-          </calcite-link>
+          <calcite-link href={this.href}>{this.renderTile()}</calcite-link>
         ) : (
           this.renderTile()
         )}

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -12,7 +12,6 @@ import {
 } from "@stencil/core";
 import { CSS, ICONS, TEXT, HEADING_LEVEL } from "./resources";
 import { getElementDir } from "../../utils/dom";
-import { Theme } from "../interfaces";
 import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 
 /**
@@ -69,11 +68,6 @@ export class CalciteTipManager {
    * Alternate text for navigating to the previous tip.
    */
   @Prop() intlPrevious?: string;
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, Event, EventEmitter, Prop, h, VNode, Fragment } from "@stencil/core";
-import { Theme } from "../interfaces";
 import { CSS, ICONS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
 import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../functional/CalciteHeading";
@@ -47,11 +46,6 @@ export class CalciteTip {
    * Alternate text for closing the tip.
    */
   @Prop() intlClose?: string;
-
-  /**
-   * Used to set the component's color scheme.
-   */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -10,7 +10,6 @@ import {
   CSS as PopperCSS,
   OverlayPositioning
 } from "../../utils/popper";
-import { Theme } from "../interfaces";
 import { queryElementRoots } from "../../utils/dom";
 
 @Component({
@@ -83,9 +82,6 @@ export class CalciteTooltip {
     this.addReferences();
     this.createPopper();
   }
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -12,7 +12,7 @@ import {
 import { nodeListToArray } from "../../utils/dom";
 import { TreeItemSelectDetail } from "../calcite-tree-item/interfaces";
 import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
-import { Scale, Theme } from "../interfaces";
+import { Scale } from "../interfaces";
 
 @Component({
   tag: "calcite-tree",
@@ -39,9 +39,6 @@ export class CalciteTree {
 
   /** Display input */
   @Prop({ mutable: true }) inputEnabled = false;
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   /** @internal If this tree is nested within another tree, set to false */
   @Prop({ reflect: true, mutable: true }) child: boolean;

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -32,7 +32,6 @@ import {
 } from "../calcite-pick-list/shared-list-logic";
 import List from "../calcite-pick-list/shared-list-render";
 import { getRoundRobinIndex } from "../../utils/array";
-import { Theme } from "../interfaces";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
@@ -89,9 +88,6 @@ export class CalciteValueList<
    * and selecting a new item will deselect any other selected items.
    */
   @Prop({ reflect: true }) multiple = false;
-
-  /** Select theme (light or dark) */
-  @Prop({ reflect: true }) theme: Theme;
 
   // --------------------------------------------------------------------------
   //

--- a/src/demos/_assets/validateInput.ts
+++ b/src/demos/_assets/validateInput.ts
@@ -48,7 +48,6 @@ function validatePasswordExampleFocusMessage(event): void {
   if (!existingMessage) {
     const message = document.createElement("calcite-input-message");
     message.active = true;
-    message.theme = "dark";
     message.id = "pw-status-1";
     message.type = "floating";
     message.innerHTML = `This should be at least 6 characters long`;

--- a/src/utils/dom.e2e.ts
+++ b/src/utils/dom.e2e.ts
@@ -28,64 +28,6 @@ const insideHostHTML = `<button class="${myButtonClass}">${insideHost}</button>`
 const insideShadowHTML = `<div><button>${insideShadow}</button></div>`;
 const outsideHostHTML = `<span>Test</span><button>${outsideHost}</button>`;
 
-describe("getThemeName()", () => {
-  let page: E2EPage;
-
-  beforeEach(async () => {
-    page = await newE2EPage({
-      html: "<div>test</div>"
-    });
-
-    const content = `
-    const exports = {};
-    exports.themeNameCSSVariable = "${themeNameCSSVariable}";
-    ${getThemeName}
-    `;
-
-    await page.addScriptTag({
-      content
-    });
-
-    await page.waitForFunction(() => (window as TestThemeWindow).getThemeName);
-  });
-
-  it("getThemeName(): light", async () => {
-    const theme = await page.evaluate((themeNameCSSVariable: string) => {
-      document.body.style.setProperty(themeNameCSSVariable, "light");
-      return (window as TestThemeWindow).getThemeName(document.body);
-    }, themeNameCSSVariable);
-
-    expect(theme).toBe("light");
-  });
-
-  it("getThemeName(): light double quoted and padded", async () => {
-    const theme = await page.evaluate((themeNameCSSVariable: string) => {
-      document.body.style.setProperty(themeNameCSSVariable, '    "light"    ');
-      return (window as TestThemeWindow).getThemeName(document.body);
-    }, themeNameCSSVariable);
-
-    expect(theme).toBe("light");
-  });
-
-  it("getThemeName(): light single quoted and padded", async () => {
-    const theme = await page.evaluate((themeNameCSSVariable: string) => {
-      document.body.style.setProperty(themeNameCSSVariable, "   'light'    ");
-      return (window as TestThemeWindow).getThemeName(document.body);
-    }, themeNameCSSVariable);
-
-    expect(theme).toBe("light");
-  });
-
-  it("getThemeName(): dark", async () => {
-    const theme = await page.evaluate((themeNameCSSVariable: string) => {
-      document.body.style.setProperty(themeNameCSSVariable, "dark");
-      return (window as TestThemeWindow).getThemeName(document.body);
-    }, themeNameCSSVariable);
-
-    expect(theme).toBe("dark");
-  });
-});
-
 describe("queries", () => {
   let page: E2EPage;
 

--- a/src/utils/dom.spec.ts
+++ b/src/utils/dom.spec.ts
@@ -1,28 +1,6 @@
-import { getElementProp, getSlotted, setRequestedIcon, themeNameCSSVariable, getThemeName } from "./dom";
+import { getElementProp, getSlotted, setRequestedIcon } from "./dom";
 
 describe("dom", () => {
-  describe("getThemeName()", () => {
-    it("getThemeName(): light", () => {
-      document.body.style.setProperty(themeNameCSSVariable, "light");
-      expect(getThemeName(document.body)).toBe("light");
-    });
-
-    it("getThemeName(): light double quoted and padded", () => {
-      document.body.style.setProperty(themeNameCSSVariable, '    "light"    ');
-      expect(getThemeName(document.body)).toBe("light");
-    });
-
-    it("getThemeName(): light single quoted and padded", () => {
-      document.body.style.setProperty(themeNameCSSVariable, "   'light'    ");
-      expect(getThemeName(document.body)).toBe("light");
-    });
-
-    it("getThemeName(): dark", () => {
-      document.body.style.setProperty(themeNameCSSVariable, "dark");
-      expect(getThemeName(document.body)).toBe("dark");
-    });
-  });
-
   describe("getElementProp()", () => {
     describe("light DOM", () => {
       it("returns match if found on self", async () => {

--- a/src/utils/dom.spec.ts
+++ b/src/utils/dom.spec.ts
@@ -1,6 +1,28 @@
-import { getElementProp, getSlotted, setRequestedIcon } from "./dom";
+import { getElementProp, getSlotted, setRequestedIcon, themeNameCSSVariable, getThemeName } from "./dom";
 
 describe("dom", () => {
+  describe("getThemeName()", () => {
+    it("getThemeName(): light", () => {
+      document.body.style.setProperty(themeNameCSSVariable, "light");
+      expect(getThemeName(document.body)).toBe("light");
+    });
+
+    it("getThemeName(): light double quoted and padded", () => {
+      document.body.style.setProperty(themeNameCSSVariable, '    "light"    ');
+      expect(getThemeName(document.body)).toBe("light");
+    });
+
+    it("getThemeName(): light single quoted and padded", () => {
+      document.body.style.setProperty(themeNameCSSVariable, "   'light'    ");
+      expect(getThemeName(document.body)).toBe("light");
+    });
+
+    it("getThemeName(): dark", () => {
+      document.body.style.setProperty(themeNameCSSVariable, "dark");
+      expect(getThemeName(document.body)).toBe("dark");
+    });
+  });
+
   describe("getElementProp()", () => {
     describe("light DOM", () => {
       it("returns match if found on self", async () => {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,4 +1,5 @@
 import { Theme } from "../components/interfaces";
+import { CSS_UTILITY } from "./resources";
 
 export const themeNameCSSVariable = "--calcite-theme-name";
 
@@ -15,7 +16,7 @@ export function getAttributes(el: HTMLElement, blockList: string[]): Record<stri
 }
 
 export function getThemeName(el: HTMLElement): Theme {
-  return getElementProp(el, "theme", "light", true) as Theme;
+  return closestElementCrossShadowBoundary(`.${CSS_UTILITY.darkTheme}, [theme=dark]`, el) ? "dark" : "light";
 }
 
 export function getElementDir(el: HTMLElement): Direction {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,8 +1,6 @@
 import { Theme } from "../components/interfaces";
 import { CSS_UTILITY } from "./resources";
 
-export const themeNameCSSVariable = "--calcite-theme-name";
-
 export function nodeListToArray<T extends Element>(nodeList: HTMLCollectionOf<T> | NodeListOf<T> | T[]): T[] {
   return Array.isArray(nodeList) ? nodeList : Array.from(nodeList);
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -15,9 +15,7 @@ export function getAttributes(el: HTMLElement, blockList: string[]): Record<stri
 }
 
 export function getThemeName(el: HTMLElement): Theme {
-  return getComputedStyle(el)
-    .getPropertyValue(themeNameCSSVariable)
-    .replace(/\s|'|"/g, "") as Theme;
+  return getElementProp(el, "theme", "light", true) as Theme;
 }
 
 export function getElementDir(el: HTMLElement): Direction {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,3 +1,7 @@
+import { Theme } from "../components/interfaces";
+
+export const themeNameCSSVariable = "--calcite-theme-name";
+
 export function nodeListToArray<T extends Element>(nodeList: HTMLCollectionOf<T> | NodeListOf<T> | T[]): T[] {
   return Array.isArray(nodeList) ? nodeList : Array.from(nodeList);
 }
@@ -8,6 +12,12 @@ export function getAttributes(el: HTMLElement, blockList: string[]): Record<stri
   return Array.from(el.attributes)
     .filter((a) => a && !blockList.includes(a.name))
     .reduce((acc, { name, value }) => ({ ...acc, [name]: value }), {});
+}
+
+export function getThemeName(el: HTMLElement): Theme {
+  return getComputedStyle(el)
+    .getPropertyValue(themeNameCSSVariable)
+    .replace(/\s|'|"/g, "") as Theme;
 }
 
 export function getElementDir(el: HTMLElement): Direction {

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -1,3 +1,5 @@
 export const CSS_UTILITY = {
+  themeLight: "calcite-theme--light",
+  themeDark: "calcite-theme--dark",
   rtl: "calcite--rtl"
 };

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -1,5 +1,5 @@
 export const CSS_UTILITY = {
-  themeLight: "calcite-theme--light",
-  themeDark: "calcite-theme--dark",
+  darkTheme: "calcite-theme--light",
+  lightTheme: "calcite-theme--dark",
   rtl: "calcite--rtl"
 };


### PR DESCRIPTION
**Related Issue:** #2189

## Summary

This PR is the first step of removing the use of the theme attribute selector.

- Removes all 'theme' properties from components
- Removes all use of the theme properties in tests
- Adds css class selectors for light/dark themes

The next steps would be to

- Replace theme attribute selector with classes
- Update stories to replace 'theme' properties with classes.
- Update test apps to replace 'theme' properties with classes.
- Document the theme classes somehow

Please review

