### PR TITLE
refactor(card): spacing between header and subtitle

### DIFF
--- a/src/components/calcite-card/calcite-card.scss
+++ b/src/components/calcite-card/calcite-card.scss
@@ -84,7 +84,7 @@
   @apply font-normal
     text-color-2
     m-0
-    mt-1
+    mt-2
     text--2-wrap;
 }
 


### PR DESCRIPTION
**Related Issue:** #1500


## Summary
Updated spacing between header and subtitle to match Figma.

Working from the [Figma/Tailwind components refactor project](https://github.com/Esri/calcite-components/projects/14)

https://github.com/Esri/calcite-components/projects/14#card-60668124
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
