### PR TITLE
refactor(flow): change text from wrap to heading

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -103,13 +103,13 @@
     text-overflow: ellipsis;
   }
   .heading {
-    @apply font-medium mt-0 mx-0 mb-1 text-0-wrap;
+    @apply font-medium mt-0 mx-0 mb-1 text-0h;
     &:only-child {
       @apply mb-0;
     }
   }
   .summary {
-    @apply text-color-2 text--1-wrap;
+    @apply text-color-2 text--1h;
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #1500

## Summary


Updated the heading and sub heading to use `h` and not `wrap` for text. Per feedback from Bryan on Figma/Tailwind refactor project (below).

Working from the [Figma/Tailwind components refactor project](https://github.com/Esri/calcite-components/projects/14)

https://github.com/Esri/calcite-components/projects/14#card-60668063

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
