### PR TITLE
fix(calcite-accordion): updated large accordion to match figma

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -148,7 +148,7 @@
   @apply text-color-2 font-medium;
 }
 :host .accordion-item-subtitle {
-  @apply text-color-3 mt-1 leading-snug;
+  @apply text-color-3 mt-1;
 }
 .calcite--rtl .accordion-item-title {
   @apply mr-0 ml-auto;

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -6,7 +6,7 @@
   --calcite-accordion-item-icon-rotation-rtl: theme("rotate.-90");
   --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.-180");
   --calcite-accordion-item-icon-spacing-start: 0;
-  --calcite-accordion-item-icon-spacing-end: var(--calcite-accordion-item-spacing-unit);
+  --calcite-accordion-item-icon-spacing-end: var(--calcite-accordion-icon-margin);
 }
 
 .icon-position--end {
@@ -15,7 +15,7 @@
   --calcite-accordion-item-active-icon-rotation: theme("rotate.0");
   --calcite-accordion-item-icon-rotation-rtl: theme("rotate.90");
   --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.0");
-  --calcite-accordion-item-icon-spacing-start: var(--calcite-accordion-item-spacing-unit);
+  --calcite-accordion-item-icon-spacing-start: var(--calcite-accordion-icon-margin);
   --calcite-accordion-item-icon-spacing-end: 0;
 }
 

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -82,7 +82,6 @@ export class CalciteAccordionItem {
     this.selectionMode = getElementProp(this.el, "selection-mode", "multi");
     this.iconType = getElementProp(this.el, "icon-type", "chevron");
     this.iconPosition = getElementProp(this.el, "icon-position", this.iconPosition);
-    this.scale = getElementProp(this.el, "scale", "m");
   }
 
   componentDidLoad(): void {
@@ -95,9 +94,8 @@ export class CalciteAccordionItem {
 
   render(): VNode {
     const dir = getElementDir(this.el);
-    const iconScale = this.scale !== "l" ? "s" : "m";
 
-    const iconEl = <calcite-icon class="accordion-item-icon" icon={this.icon} scale={iconScale} />;
+    const iconEl = <calcite-icon class="accordion-item-icon" icon={this.icon} scale="s" />;
 
     return (
       <Host aria-expanded={this.active.toString()} tabindex="0">
@@ -198,9 +196,6 @@ export class CalciteAccordionItem {
 
   /** what icon type does the parent accordion specify */
   private iconType: string;
-
-  /** the scale of the parent accordion */
-  private scale: string;
 
   /** handle clicks on item header */
   private itemHeaderClickHandler = (): void => this.emitRequestedItem();

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -14,7 +14,7 @@
 :host([scale="l"]) {
   --calcite-accordion-item-spacing-unit: theme("spacing.3");
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) theme("spacing.4");
-  @apply text-1h;
+  @apply text-0h;
 }
 
 :host {

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -1,18 +1,21 @@
 // scale variants for child
 :host([scale="s"]) {
   --calcite-accordion-item-spacing-unit: theme("spacing.1");
+  --calcite-accordion-icon-margin: theme("spacing.2");
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) theme("spacing.2");
   @apply text--2h;
 }
 
 :host([scale="m"]) {
   --calcite-accordion-item-spacing-unit: theme("spacing.2");
+  --calcite-accordion-icon-margin: theme("spacing.3");
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) theme("spacing.3");
   @apply text--1h;
 }
 
 :host([scale="l"]) {
   --calcite-accordion-item-spacing-unit: theme("spacing.3");
+  --calcite-accordion-icon-margin: theme("spacing.4");
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) theme("spacing.4");
   @apply text-0h;
 }

--- a/src/demos/calcite-accordion.html
+++ b/src/demos/calcite-accordion.html
@@ -459,7 +459,7 @@
       <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h4>Scale s</h4>
         <calcite-accordion scale="s">
-          <calcite-accordion-item item-title="Accordion Item">
+          <calcite-accordion-item item-title="Accordion Item" icon="map">
             <calcite-radio-group scale="s">
               <calcite-radio-group-item value="Yes" checked>Yes</calcite-radio-group-item>
               <calcite-radio-group-item value="No">No</calcite-radio-group-item>
@@ -496,9 +496,9 @@
             </calcite-tree>
           </calcite-accordion-item>
         </calcite-accordion>
-        <h4>Scale l</h4>
-        <calcite-accordion scale="l">
-          <calcite-accordion-item item-title="Accordion Item"
+        <h4>Scale L</h4>
+        <calcite-accordion scale="l"  icon-position='start'>
+          <calcite-accordion-item item-title="Accordion Item" item-subtitle="Accordion item subtitle" icon="list"
             ><img src="https://placem.at/places?w=200&txt=0" />
           </calcite-accordion-item>
           <calcite-accordion-item item-title="Accordion Item 2" active
@@ -510,7 +510,7 @@
           <calcite-accordion-item item-title="Accordion Item 4"
             ><img src="https://placem.at/places?w=200&txt=0" />
           </calcite-accordion-item>
-          <calcite-accordion-item item-title="Accordion Item 5">
+          <calcite-accordion-item item-title="Accordion Item 5" icon="map">
             <calcite-tree lines>
               <calcite-tree-item> Child 1 </calcite-tree-item>
 

--- a/src/demos/calcite-accordion.html
+++ b/src/demos/calcite-accordion.html
@@ -496,8 +496,44 @@
             </calcite-tree>
           </calcite-accordion-item>
         </calcite-accordion>
-        <h4>Scale L</h4>
+        <h4>Scale L, icon-position: start</h4>
         <calcite-accordion scale="l"  icon-position='start'>
+          <calcite-accordion-item item-title="Accordion Item" item-subtitle="Accordion item subtitle" icon="list"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 2" active
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 3 with a potentially two line title"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 4"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 5" icon="map">
+            <calcite-tree lines>
+              <calcite-tree-item> Child 1 </calcite-tree-item>
+
+              <calcite-tree-item>
+                Child 2
+
+                <calcite-tree slot="children">
+                  <calcite-tree-item> Grandchild 1 </calcite-tree-item>
+
+                  <calcite-tree-item>
+                    Grandchild 2
+                    <calcite-tree slot="children">
+                      <calcite-tree-item> Great-Grandchild 1 </calcite-tree-item>
+                      <calcite-tree-item> Great-Grandchild 2 </calcite-tree-item>
+                    </calcite-tree>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-accordion-item>
+        </calcite-accordion>
+        <h4>Scale L, icon-position: end</h4>
+        <calcite-accordion scale="l"  icon-position='end'>
           <calcite-accordion-item item-title="Accordion Item" item-subtitle="Accordion item subtitle" icon="list"
             ><img src="https://placem.at/places?w=200&txt=0" />
           </calcite-accordion-item>


### PR DESCRIPTION
**Related Issue:** #2041

## Summary
- Updated large accordion header font size to 0 (16px)
- Removed logic for decorative header icon sizing so that all accordion sizes use small icons

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
