### PR TITLE
fix(tile): remove max-width

### DIFF
--- a/src/components/calcite-tile/calcite-tile.scss
+++ b/src/components/calcite-tile/calcite-tile.scss
@@ -10,7 +10,6 @@
 :host(:not([embed])) {
   @apply p-3;
   box-shadow: 0 0 0 1px var(--calcite-ui-border-2);
-  max-width: 20rem;
 }
 :host(:not([embed])[href]:hover) {
   @apply cursor-pointer;


### PR DESCRIPTION
**Related Issue:** #2123

## Summary
Removes max width rule.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
