### PR TITLE
refactor(progress): text heading and medium

### DIFF
--- a/src/components/calcite-progress/calcite-progress.scss
+++ b/src/components/calcite-progress/calcite-progress.scss
@@ -27,7 +27,7 @@
 }
 
 .text {
-  @apply pt-4 pb-0 px-0 text-center text--2-wrap;
+  @apply pt-4 pb-0 px-0 text-center text--2h font-medium;
 }
 
 @keyframes looping-progress-bar-ani {


### PR DESCRIPTION
**Related Issue:** #1500

## Summary

- Changed text to use heading `h`
- Medium font-weight

Working from the [Figma/Tailwind components refactor project](https://github.com/Esri/calcite-components/projects/14)

Card for this PR: https://github.com/Esri/calcite-components/projects/14#card-60667949