### PR TITLE
refactor(rating): Unselected star ui-border-input

### DIFF
--- a/src/components/calcite-rating/calcite-rating.scss
+++ b/src/components/calcite-rating/calcite-rating.scss
@@ -1,11 +1,14 @@
 :host {
-  --calcite-rating-spacing-unit: theme("spacing.2");
   @apply flex items-center relative;
   width: fit-content;
 }
 
 :host([scale="s"]) {
   --calcite-rating-spacing-unit: theme("spacing.1");
+}
+
+:host([scale="m"]) {
+  --calcite-rating-spacing-unit: theme("spacing.2");
 }
 
 :host([scale="l"]) {
@@ -25,7 +28,7 @@
 }
 
 .wrapper {
-  display: inline-block;
+  @apply inline-block;
   margin-right: var(--calcite-rating-spacing-unit);
 }
 
@@ -35,9 +38,11 @@
 }
 
 .star {
-  @include focus-style-base();
-  @apply relative inline-block cursor-pointer;
-  color: theme("borderColor.color.1");
+  @apply relative
+    inline-block
+    cursor-pointer
+    focus-base;
+  color: theme("borderColor.color.input");
   transition: $transition;
   transform: scale(1);
   &:active {
@@ -46,7 +51,7 @@
 }
 
 .focused {
-  @include focus-style-outset();
+  @apply focus-base;
 }
 
 .average,
@@ -66,7 +71,11 @@
 }
 
 :host .fraction {
-  @apply absolute overflow-hidden pointer-events-none top-0 left-0;
+  @apply absolute
+    overflow-hidden
+    pointer-events-none
+    top-0
+    left-0;
   transition: $transition;
 }
 


### PR DESCRIPTION
**Related Issue:** #1500

## Summary

- unselected star: updated to use ui-border-input
- This has an action item to use chip at 16px font and 44px height, but this should be done at the chip component, not star. 

Working from the [Figma/Tailwind components refactor project](https://github.com/Esri/calcite-components/projects/14)

Card for this PR: https://github.com/Esri/calcite-components/projects/14#card-60667925