### PR TITLE
chore: fix auto-doc action step

### DIFF
--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -10,9 +10,10 @@ jobs:
       - uses: actions/setup-node@v1
 
       - name: generate doc
-      - run: npm install
-      - run: npx stencil build --docs
-      - run: npm run lint:md
+        run:  |
+          npm install
+          npx stencil build --docs
+          npm run lint:md
 
       - name: commit readme files
         uses: test-room-7/action-update-file@v1


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes a step in the update-doc action.