### PR TITLE
fix(modal): improve modal a11y

### DIFF
--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -13,7 +13,13 @@ import {
   VNode,
   Watch
 } from "@stencil/core";
-import { CalciteFocusableElement, focusElement, getElementDir } from "../../utils/dom";
+import {
+  CalciteFocusableElement,
+  ensureId,
+  focusElement,
+  getElementDir,
+  getSlotted
+} from "../../utils/dom";
 import { getKey } from "../../utils/key";
 import { queryShadowRoot } from "@a11y/focus-trap/shadow";
 import { isFocusable, isHidden } from "@a11y/focus-trap/focusable";
@@ -117,8 +123,14 @@ export class CalciteModal {
 
   render(): VNode {
     const dir = getElementDir(this.el);
+
     return (
-      <Host aria-modal="true" role="dialog">
+      <Host
+        aria-describedby={this.contentId}
+        aria-labelledby={this.titleId}
+        aria-modal="true"
+        role="dialog"
+      >
         <calcite-scrim class="scrim" />
         {this.renderStyle()}
         <div class={{ modal: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
@@ -210,15 +222,19 @@ export class CalciteModal {
   //--------------------------------------------------------------------------
   @State() hasFooter = true;
 
-  previousActiveElement: HTMLElement;
-
   closeButtonEl: HTMLButtonElement;
 
-  modalContent: HTMLDivElement;
+  contentId: string;
 
   focusTimeout: number;
 
+  modalContent: HTMLDivElement;
+
   private observer: MutationObserver = null;
+
+  previousActiveElement: HTMLElement;
+
+  titleId: string;
 
   //--------------------------------------------------------------------------
   //
@@ -309,6 +325,13 @@ export class CalciteModal {
   private open() {
     this.previousActiveElement = document.activeElement as HTMLElement;
     this.active = true;
+
+    const titleEl = getSlotted(this.el, "header");
+    const contentEl = getSlotted(this.el, "content");
+
+    this.titleId = ensureId(titleEl);
+    this.contentId = ensureId(contentEl);
+
     clearTimeout(this.focusTimeout);
     // wait for the modal to open, then handle focus.
     this.focusTimeout = window.setTimeout(() => {

--- a/src/utils/dom.spec.ts
+++ b/src/utils/dom.spec.ts
@@ -1,4 +1,5 @@
-import { getElementProp, getSlotted, setRequestedIcon } from "./dom";
+import { getElementProp, getSlotted, setRequestedIcon, ensureId } from "./dom";
+import { guidPattern } from "./guid.spec";
 
 describe("dom", () => {
   describe("getElementProp()", () => {
@@ -258,5 +259,22 @@ describe("dom", () => {
       expect(setRequestedIcon({ exampleValue: "exampleReturnedValue" }, "", "exampleValue")).toBe(
         "exampleReturnedValue"
       ));
+  });
+
+  describe("uniqueId", () => {
+    it("generates unique ID on an element", () => {
+      const input = document.createElement("input");
+      expect(ensureId(input)).toMatch(new RegExp(`input-${guidPattern.source}`));
+    });
+
+    it("returns the element's ID if it exists", () => {
+      const input = document.createElement("input");
+      input.id = "test";
+      expect(ensureId(input)).toBe("test");
+    });
+
+    it("returns empty string if invoked without element", () => {
+      expect(ensureId(null)).toBe("");
+    });
   });
 });

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,5 +1,21 @@
 import { Theme } from "../components/interfaces";
 import { CSS_UTILITY } from "./resources";
+import { guid } from "./guid";
+
+/**
+ * This helper will guarantee an ID on the provided element.
+ *
+ * If it already has an ID, it will be preserved, otherwise a unique one will be generated and assigned.
+ *
+ * @returns {string} The element's ID.
+ */
+export function ensureId(el: Element): string {
+  if (!el) {
+    return "";
+  }
+
+  return (el.id = el.id || `${el.tagName.toLowerCase()}-${guid()}`);
+}
 
 export function nodeListToArray<T extends Element>(nodeList: HTMLCollectionOf<T> | NodeListOf<T> | T[]): T[] {
   return Array.isArray(nodeList) ? nodeList : Array.from(nodeList);

--- a/src/utils/guid.spec.ts
+++ b/src/utils/guid.spec.ts
@@ -1,7 +1,9 @@
 import { guid } from "./guid";
 
+export const guidPattern = /\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/;
+
 describe("guid", () => {
   it("returns a 36 character guid", () => {
-    expect(guid().length).toEqual(36);
+    expect(guid()).toMatch(guidPattern);
   });
 });


### PR DESCRIPTION
**Related Issue:** #1756 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates `calcite-modal` to use ARIA roles for title and content.

**Note**: This adds a DOM util to ensure elements have a unique ID associated (`ensureId`).

Tested with:

**Safari + VoiceOver**

![Screen Shot 2021-05-27 at 10 57 40 AM](https://user-images.githubusercontent.com/197440/119906473-26b2ef00-bf03-11eb-9170-2105b9ca63b6.png)
![Screen Shot 2021-05-27 at 10 57 33 AM](https://user-images.githubusercontent.com/197440/119906471-261a5880-bf03-11eb-940b-08498d872d2c.png)

**FireFox/Edge + NVDA**

![Screen Shot 2021-05-27 at 3 51 53 PM](https://user-images.githubusercontent.com/197440/119906677-85786880-bf03-11eb-9a1a-96461322b19e.png)


