### PR TITLE
refactor(radio-group): updated height of large (icon and font)

### DIFF
--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -43,7 +43,7 @@
 }
 
 .label--scale-l {
-  @apply text-1h px-4 py-2;
+  @apply text-0h px-4 py-2;
 }
 
 :host(:hover) label {

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -43,9 +43,7 @@
 }
 
 .label--scale-l {
-  @apply text-1h px-4;
-  padding-top: 0.625rem;
-  padding-bottom: 0.625rem;
+  @apply text-1h px-4 py-2;
 }
 
 :host(:hover) label {

--- a/src/components/calcite-radio-group/calcite-radio-group.scss
+++ b/src/components/calcite-radio-group/calcite-radio-group.scss
@@ -7,7 +7,7 @@
 }
 
 :host([scale="l"]) {
-  min-height: theme("spacing.12");
+  min-height: theme("spacing.10");
 }
 
 :host {


### PR DESCRIPTION
**Related Issue:** #1500

## Summary

- Large updates:
    - Updated height of large to 44
    - font is 16px
    - icon is 16px

Working from the [Figma/Tailwind components refactor project](https://github.com/Esri/calcite-components/projects/14)

Radio group (and radio group item) for this PR: https://github.com/Esri/calcite-components/projects/14#card-60667936