### PR TITLE
docs: add RTL stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch && npm run util:add-custom-elements-extras:index-mjs",
     "deps:update": "updtr --exclude @types/jest @types/puppeteer husky jest jest-cli puppeteer && git add package*.json && git commit -q -m \"build(deps): bump versions\"",
     "docs": "concurrently --kill-others --raw \"npm:util:build-docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\"  \"ts-node ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",
-    "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/tempDocDirCleaner.ts\"",
+    "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",
     "lint": "concurrently npm:lint:*",
     "lint:md": "prettier --write \"**/*.md\"",
     "lint:styles": "stylelint --fix \"src/**/*.scss\"",

--- a/src/components/calcite-button/calcite-button.stories.ts
+++ b/src/components/calcite-button/calcite-button.stories.ts
@@ -161,3 +161,21 @@ DarkMode.story = {
   name: "Dark mode",
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <calcite-button
+    dir="rtl"
+    theme="dark"
+    appearance="${select("appearance", ["solid", "clear", "outline", "transparent"], "solid")}"
+    color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("round", false)}
+    href="${text("href", "")}"
+    ${boolean("loading", false)}
+    ${boolean("disabled", false)}
+    icon-start="${select("icon-start", iconNames, iconNames[0])}"
+    icon-end="${select("icon-end", iconNames, iconNames[1])}"
+  >
+    ${text("text", "button text here")}
+  </calcite-button>
+`;

--- a/src/components/calcite-card/calcite-card.stories.ts
+++ b/src/components/calcite-card/calcite-card.stories.ts
@@ -330,3 +330,14 @@ DarkThemeFooterButtonsTooltipsDropdown.story = {
   name: "Dark Theme - Footer Buttons, Tooltips, Dropdown",
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <div style="width:260px" dir="rtl">
+    <calcite-card ${boolean("loading", false)} ${boolean("selectable", false)}>
+      <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+      <span slot="subtitle"
+        >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+      >
+    </calcite-card>
+  </div>
+`;

--- a/src/components/calcite-checkbox/calcite-checkbox.stories.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.stories.ts
@@ -23,7 +23,6 @@ export const Simple = (): string => html`
     ${text("label", "Checkbox")}
   </calcite-label>
 `;
-
 export const DarkMode = (): string => html`
   <calcite-label layout="inline" theme="dark">
     <calcite-checkbox
@@ -41,3 +40,15 @@ DarkMode.story = {
   name: "Dark mode",
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <calcite-label layout="inline" dir="rtl">
+    <calcite-checkbox
+      ${boolean("checked", true)}
+      ${boolean("disabled", false)}
+      ${boolean("indeterminate", false)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+    ></calcite-checkbox>
+    ${text("label", "Checkbox")}
+  </calcite-label>
+`;

--- a/src/components/calcite-date-picker/calcite-date-picker.stories.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.stories.ts
@@ -71,3 +71,34 @@ export const Range = (): string => html`
     ></calcite-date-picker>
   </div>
 `;
+
+export const SimpleRTL = (): string => html`
+  <div style="width: 400px" dir="rtl">
+    <calcite-date-picker
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      value="${text("value", "2020-12-12")}"
+      min="${text("min", "2020-12-03")}"
+      max="${text("max", "2023-12-18")}"
+      locale="${select("locale", locales, "en")}"
+      intl-next-month="${text("intl-next-month", "Next month")}"
+      intl-prev-month="${text("intl-prev-month", "Previous month")}"
+    ></calcite-date-picker>
+  </div>
+`;
+
+export const RangeRTL = (): string => html`
+  <div style="width: 400px" dir="rtl">
+    <calcite-date-picker
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      start="${text("start", "2020-12-12")}"
+      end="${text("end", "2020-12-16")}"
+      min="${text("min", "2016-08-09")}"
+      max="${text("max", "2023-12-18")}"
+      locale="${select("locale", locales, "en")}"
+      next-month-label="${text("next-month-label", "Next month")}"
+      prev-month-label="${text("prev-month-label", "Previous month")}"
+      range="${boolean("range", true)}"
+      layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    ></calcite-date-picker>
+  </div>
+`;

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.stories.ts
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.stories.ts
@@ -70,3 +70,20 @@ export const Range = (): string => html`
     ></calcite-input-date-picker>
   </div>
 `;
+
+export const RTL = (): string => html`
+  <div style="width: 400px" dir="rtl">
+    <calcite-label layout="inline">
+      Date
+      <calcite-input-date-picker
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        value="${text("value", "2020-12-12")}"
+        min="${text("min", "2016-08-09")}"
+        max="${text("max", "2023-12-18")}"
+        locale="${select("locale", locales, "en")}"
+        intl-next-month="${text("intl-next-month", "Next month")}"
+        intl-prev-month="${text("intl-prev-month", "Previous month")}"
+      ></calcite-input-date-picker
+    ></calcite-label>
+  </div>
+`;

--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -224,3 +224,45 @@ SimpleDarkMode.story = {
   name: "Simple - Dark mode",
   parameters: { backgrounds: darkBackground }
 };
+
+export const WithLabelAndInputMessageRTL = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;" dir="rtl">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      alignment="${select("alignment", ["start", "center", "end"], "start", "Label")}"
+      scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+      layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+    >
+      ${text("label text", "My great label", "Label")}
+      <calcite-input
+        type="${select(
+          "type",
+          ["text", "textarea", "email", "password", "tel", "number", "search", "file", "time", "date"],
+          "text",
+          "Input"
+        )}"
+        status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
+        alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "", "Input")}"
+        suffix-text="${text("suffix-text", "", "Input")}"
+        ${boolean("loading", false)}
+        ${boolean("autofocus", false)}
+        ${boolean("required", false)}
+        value="${text("value", "", "Input")}"
+        placeholder="${text("placeholder", "Placeholder text", "Input")}"
+      >
+      </calcite-input>
+      <calcite-input-message
+        ${boolean("active", true)}
+        ${boolean("icon", false)}
+        icon="${select("icon", iconNames, "", "Input Message")}"
+        type="${select("type", ["default", "floating"], "default", "Input Message")}"
+        >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;

--- a/src/components/calcite-label/calcite-label.stories.ts
+++ b/src/components/calcite-label/calcite-label.stories.ts
@@ -149,3 +149,73 @@ export const DarkTheme = (): string => html`
 DarkTheme.story = {
   parameters: { backgrounds: darkBackground }
 };
+
+export const WrappingComponentsOtherThanInputRTL = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;" dir="rtl">
+    <calcite-label>
+      Default label wrapping a switch
+      <calcite-switch></calcite-switch>
+    </calcite-label>
+    <calcite-label>
+      Default label wrapping a radio group
+      <calcite-radio-group>
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+    </calcite-label>
+    <calcite-label layout="inline">
+      Text leading inline
+      <calcite-switch></calcite-switch>
+    </calcite-label>
+    <calcite-label layout="inline">
+      <calcite-switch></calcite-switch>
+      Text trailing inline
+    </calcite-label>
+    <calcite-label layout="inline">
+      Off
+      <calcite-switch></calcite-switch>
+      On
+    </calcite-label>
+    <calcite-label layout="inline">
+      Text leading inline
+      <calcite-checkbox></calcite-checkbox>
+    </calcite-label>
+    <calcite-label>
+      Focus slider test
+      <calcite-slider></calcite-slider>
+    </calcite-label>
+    <calcite-label>
+      Focus slider test
+      <calcite-slider min-value="10" max-value="80"></calcite-slider>
+    </calcite-label>
+    <calcite-label layout="inline">
+      <calcite-checkbox></calcite-checkbox>
+      Text trailing inline
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
+      Text leading inline-space-between
+      <calcite-switch></calcite-switch>
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
+      <calcite-switch></calcite-switch>
+      Text trailing inline-space-between
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
+      Text leading inline-space-between
+      <calcite-checkbox></calcite-checkbox>
+    </calcite-label>
+    <calcite-label layout="inline-space-between">
+      <calcite-checkbox></calcite-checkbox>
+      Text trailing inline-space-between
+    </calcite-label>
+    <calcite-label>
+      Default label wrapping a select
+      <calcite-select>
+        <calcite-option>a</calcite-option>
+        <calcite-option>b</calcite-option>
+        <calcite-option>c</calcite-option>
+      </calcite-select>
+    </calcite-label>
+  </div>
+`;

--- a/src/components/calcite-link/calcite-link.stories.ts
+++ b/src/components/calcite-link/calcite-link.stories.ts
@@ -127,3 +127,25 @@ DarkMode.story = {
   name: "Dark mode",
   parameters: { backgrounds: darkBackground }
 };
+
+export const WithIconStartAndIconEndRTL = (): string => html`
+  <div
+    dir="rtl"
+    style="font-size: ${select(
+      "containing font size",
+      ["12", "14", "16", "18", "20", "24", "32"],
+      "16"
+    )}px; font-weight: ${select("containing font weight", ["300", "400", "500", "700"], "400")};"
+  >
+    Some wrapping text
+    <calcite-link
+      href="${text("href", "")}"
+      ${boolean("disabled", false)}
+      icon-start="${select("icon-start", iconNames, iconNames[0])}"
+      icon-end="${select("icon-end", iconNames, iconNames[1])}"
+    >
+      ${text("text", "link text here")}</calcite-link
+    >
+    around the link
+  </div>
+`;

--- a/src/components/calcite-modal/calcite-modal.stories.ts
+++ b/src/components/calcite-modal/calcite-modal.stories.ts
@@ -2,6 +2,7 @@ import { select, text, number } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
 
 export default {
   title: "Components/Modal",
@@ -11,55 +12,49 @@ export default {
   }
 };
 
-export const Simple = (): string => {
-  return `
-      <calcite-modal
-        ${boolean("active", true)}
-        color="${select("color", { blue: "blue", red: "red", none: "" }, "")}"
-        background-color="${select("background-color", ["white", "grey"], "white")}"
-        scale="${select("scale", ["s", "m", "l"], "m")}"
-        width="${select("width", ["s", "m", "l"], "s")}"
-        ${boolean("fullscreen", false)}
-        ${boolean("docked", false)}
-        ${boolean("disable-escape", false)}
-        ${boolean("no-padding", false)}
-        intl-close="${text("intl-close", "Close")}"
-      >
-        <h3 slot="header">Small Modal</h3>
-        <div slot="content">
-          <p>
-            The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
-          </p>
-        </div>
-        <calcite-button slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
-        <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-        <calcite-button slot="primary" width="full">Save</calcite-button>
-      </calcite-modal>
-    `;
-};
+export const Simple = (): string => html`
+  <calcite-modal
+    ${boolean("active", true)}
+    color="${select("color", { blue: "blue", red: "red", none: "" }, "")}"
+    background-color="${select("background-color", ["white", "grey"], "white")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "s")}"
+    ${boolean("fullscreen", false)}
+    ${boolean("docked", false)}
+    ${boolean("disable-escape", false)}
+    ${boolean("no-padding", false)}
+    intl-close="${text("intl-close", "Close")}"
+  >
+    <h3 slot="header">Small Modal</h3>
+    <div slot="content">
+      <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.</p>
+    </div>
+    <calcite-button slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full"
+      >Back</calcite-button
+    >
+    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button slot="primary" width="full">Save</calcite-button>
+  </calcite-modal>
+`;
 
-export const CustomSize = (): string => {
-  return `
-      <calcite-modal
-        active
-        width="${number("width", 500)}"
-      >
-        <h3 slot="header">Custom Size</h3>
-        <div slot="content">
-          <p>
-            By passing a number rather than "small", "medium", "large", or "fullscreen", you can set your own max width for the modal.
-            Below this size, the modal will become fullscreen.
-          </p>
-        </div>
-        <calcite-button slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
-        <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-        <calcite-button slot="primary" width="full">Save</calcite-button>
-      </calcite-modal>
-    `;
-};
+export const CustomSize = (): string => html`
+  <calcite-modal active width="${number("width", 500)}">
+    <h3 slot="header">Custom Size</h3>
+    <div slot="content">
+      <p>
+        By passing a number rather than "small", "medium", "large", or "fullscreen", you can set your own max width for
+        the modal. Below this size, the modal will become fullscreen.
+      </p>
+    </div>
+    <calcite-button slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full"
+      >Back</calcite-button
+    >
+    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button slot="primary" width="full">Save</calcite-button>
+  </calcite-modal>
+`;
 
-export const DarkMode = (): string => {
-  return `
+export const DarkMode = (): string => html`
   <calcite-modal
     theme="dark"
     ${boolean("active", true)}
@@ -75,18 +70,43 @@ export const DarkMode = (): string => {
   >
     <h3 slot="header">Small Modal</h3>
     <div slot="content">
-      <p>
-        The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
-      </p>
+      <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.</p>
     </div>
-    <calcite-button theme="dark" slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full">Back</calcite-button>
+    <calcite-button theme="dark" slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full"
+      >Back</calcite-button
+    >
     <calcite-button theme="dark" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
     <calcite-button theme="dark" slot="primary" width="full">Save</calcite-button>
   </calcite-modal>
 `;
-};
 
 DarkMode.story = {
   name: "Dark mode",
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <calcite-modal
+    dir="rtl"
+    ${boolean("active", true)}
+    color="${select("color", { blue: "blue", red: "red", none: "" }, "")}"
+    background-color="${select("background-color", ["white", "grey"], "white")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["s", "m", "l"], "s")}"
+    ${boolean("fullscreen", false)}
+    ${boolean("docked", false)}
+    ${boolean("disable-escape", false)}
+    ${boolean("no-padding", false)}
+    intl-close="${text("intl-close", "Close")}"
+  >
+    <h3 slot="header">Small Modal</h3>
+    <div slot="content">
+      <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.</p>
+    </div>
+    <calcite-button slot="back" color="neutral" appearance="outline" icon="chevron-left" width="full"
+      >Back</calcite-button
+    >
+    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    <calcite-button slot="primary" width="full">Save</calcite-button>
+  </calcite-modal>
+`;

--- a/src/components/calcite-pagination/calcite-pagination.stories.ts
+++ b/src/components/calcite-pagination/calcite-pagination.stories.ts
@@ -39,3 +39,16 @@ export const DarkMode = (): string => html`
 DarkMode.story = {
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <calcite-pagination
+    dir="rtl"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    start="${number("start", 1)}"
+    total="${number("total", 128)}"
+    num="${number("num", 20)}"
+    dir="${select("dir", ["ltr", "rtl"], "ltr")}"
+    theme="light"
+  >
+  </calcite-pagination>
+`;

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.ts
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.stories.ts
@@ -70,3 +70,31 @@ export const DarkTheme = (): string => html`
 DarkTheme.story = {
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <calcite-radio-button-group
+    dir="rtl"
+    name="simple"
+    ${boolean("disabled", false)}
+    ${boolean("hidden", false)}
+    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+  >
+    <calcite-label layout="inline">
+      <calcite-radio-button value="react"></calcite-radio-button>
+      React
+    </calcite-label>
+    <calcite-label layout="inline">
+      <calcite-radio-button value="ember"></calcite-radio-button>
+      Ember
+    </calcite-label>
+    <calcite-label layout="inline">
+      <calcite-radio-button value="angular"></calcite-radio-button>
+      Angular
+    </calcite-label>
+    <calcite-label layout="inline">
+      <calcite-radio-button value="vue"></calcite-radio-button>
+      Vue
+    </calcite-label>
+  </calcite-radio-button-group>
+`;

--- a/src/components/calcite-radio-button/calcite-radio-button.stories.ts
+++ b/src/components/calcite-radio-button/calcite-radio-button.stories.ts
@@ -47,3 +47,18 @@ export const DarkTheme = (): string => html`
 DarkTheme.story = {
   parameters: { backgrounds: darkBackground }
 };
+
+export const RTL = (): string => html`
+  <calcite-label layout="inline" dir="rtl">
+    <calcite-radio-button
+      ${boolean("checked", false)}
+      ${boolean("disabled", false)}
+      ${boolean("hidden", false)}
+      ${boolean("focused", false)}
+      name="simple"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      value="value"
+    ></calcite-radio-button>
+    ${text("label", "Radio Button")}
+  </calcite-label>
+`;

--- a/src/components/calcite-radio-group/calcite-radio-group.stories.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.stories.ts
@@ -105,3 +105,19 @@ export const FullWidth = (): string => html`
 FullWidth.story = {
   name: "Full width"
 };
+
+export const RTL = (): string => html`
+  <calcite-radio-group
+    dir="rtl"
+    layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
+    appearance="${select("appearance", ["solid", "outline"], "solid")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    width="${select("width", ["auto", "full"], "auto")}"
+    ${boolean("disabled", false)}
+  >
+    <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+    <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+    <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+    <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+  </calcite-radio-group>
+`;

--- a/src/components/calcite-select/calcite-select.stories.ts
+++ b/src/components/calcite-select/calcite-select.stories.ts
@@ -123,3 +123,30 @@ export const grouped = (): string =>
       </calcite-option-group>
     `
   );
+
+export const RTL = (): string =>
+  create(
+    "calcite-select",
+    [
+      ...createSelectAttributes({ except: ["dir"] }),
+      {
+        name: "dir",
+        value: "rtl"
+      }
+    ],
+    html`
+      ${create(
+        "calcite-option-group",
+        createOptionGroupAttributes(),
+        html`
+          ${create("calcite-option", createOptionAttributes())}
+          <calcite-option label="some fixed option (A)" value="some-fixed-value-a"></calcite-option>
+          <calcite-option label="another fixed option (A)" value="another-fixed-value-a"></calcite-option>
+        `
+      )}
+      <calcite-option-group label="group B (fixed)">
+        <calcite-option label="some fixed option (B)" value="some-fixed-value-b"></calcite-option>
+        <calcite-option label="another fixed option (B)" value="another-fixed-value-b"></calcite-option>
+      </calcite-option-group>
+    `
+  );

--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -120,3 +120,23 @@ export const DisabledTabs = (): string => {
 DisabledTabs.story = {
   name: "Disabled tabs"
 };
+
+export const RTL = (): string => html`
+  <calcite-tabs
+    dir="rtl"
+    layout="${select("layout", ["inline", "center"], "inline")}"
+    position="${select("position", ["above", "below"], "above")}"
+  >
+    <calcite-tab-nav slot="tab-nav">
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+    </calcite-tab-nav>
+
+    <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 3 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 4 Content</p></calcite-tab>
+  </calcite-tabs>
+`;


### PR DESCRIPTION
**Related Issue:** #2108 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds RTL stories (based on existing ones) for the following components:

- `calcite-button`
- `calcite-card`
- `calcite-checkbox`
- `calcite-date-picker`
- `calcite-input`
- `calcite-input-date-picker`
- `calcite-label`
- `calcite-link`
- `calcite-modal`
- `calcite-pagination`
- `calcite-radio-button`
- `calcite-radio-button-group`
- `calcite-radio-group`
- `calcite-select`
- `calcite-tabs`

This will help Screener detect visual differences in RTL.

cc @caripizza 