### PR TITLE
feat(combobox): apply entered text on tab for custom values combobox

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -408,6 +408,28 @@ describe("calcite-combobox", () => {
       expect(chips.length).toBe(1);
     });
 
+    it("should allow enter unknown tag when tabbing away", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox allow-custom-values>
+            <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
+            <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          </calcite-combobox>
+        `
+      );
+      const chip = await page.find("calcite-combobox >>> calcite-chip");
+      expect(chip).toBeNull();
+
+      const input = await page.find("calcite-combobox >>> input");
+      await input.click();
+      await input.press("J");
+      await input.press("Tab");
+      const chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      expect(chips.length).toBe(1);
+    });
+
     it("should select known tag when input", async () => {
       const page = await newE2EPage();
       await page.setContent(

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -147,6 +147,9 @@ export class CalciteCombobox {
         this.activeChipIndex = -1;
         this.activeItemIndex = -1;
         this.active = false;
+        if (this.allowCustomValues && this.text) {
+          this.addCustomChip(this.text);
+        }
         break;
       case "ArrowLeft":
         this.previousChip();
@@ -181,7 +184,7 @@ export class CalciteCombobox {
         } else if (this.activeChipIndex > -1) {
           this.removeActiveChip();
         } else if (this.allowCustomValues && this.text) {
-          this.addCustomChip(this.text);
+          this.addCustomChip(this.text, true);
         }
         break;
       case "Delete":
@@ -625,7 +628,7 @@ export class CalciteCombobox {
     return Array.from(this.el.querySelectorAll(ComboboxItemGroup));
   }
 
-  addCustomChip(value: string): void {
+  addCustomChip(value: string, focus?: boolean): void {
     const existingItem = this.items.find((el) => el.textLabel === value);
     if (existingItem) {
       this.toggleSelection(existingItem, true);
@@ -637,7 +640,9 @@ export class CalciteCombobox {
       item.selected = true;
       this.el.appendChild(item);
       this.resetText();
-      this.setFocus();
+      if (focus) {
+        this.setFocus();
+      }
       this.updateItems();
       this.filterItems("");
     }


### PR DESCRIPTION


## Summary
 
We had people typing into a custom values combobox and tabbing away. Because they didn't "enter" the text (and create a chip) their value was thrown away, which was the source of a lot of confusion. One user said "that's weird it's not styled like a tag" and tabbed away anyways.

This change essentially adds a chip for them if they've entered text when they tab away.