### PR TITLE
fix(rating): focus typo fix - outset

### DIFF
--- a/src/components/calcite-rating/calcite-rating.scss
+++ b/src/components/calcite-rating/calcite-rating.scss
@@ -51,7 +51,7 @@
 }
 
 .focused {
-  @apply focus-base;
+  @apply focus-outset;
 }
 
 .average,


### PR DESCRIPTION
## Summary

A bug caused by the refactor. This brings back the focus animation. 
