### PR TITLE
fix(combobox):  treat entered text as chip in custom-value comboboxes on blur

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -147,9 +147,6 @@ export class CalciteCombobox {
         this.activeChipIndex = -1;
         this.activeItemIndex = -1;
         this.active = false;
-        if (this.allowCustomValues && this.text) {
-          this.addCustomChip(this.text);
-        }
         break;
       case "ArrowLeft":
         this.previousChip();
@@ -735,6 +732,9 @@ export class CalciteCombobox {
 
   comboboxBlurHandler = (event: FocusEvent): void => {
     this.setInactiveIfNotContained(event);
+    if (this.allowCustomValues && this.text) {
+      this.addCustomChip(this.text);
+    }
   };
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION


## Summary

Related to the pr I opened the other day: #2239

Previously we used a tab key event to enter the text, this moves to using a blur event so that the text appears correctly if the user clicks away as well.
