### PR TITLE
docs: remove theme attribute from demo html

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prettier": "concurrently npm:prettier:*",
     "prettier:styles": "prettier --write \"src/**/*.scss\"",
     "prettier:ts": "prettier --write \"src/**/*.ts?(x)\"",
+    "prettier:html": "prettier --write \"src/**/*.html\"",
     "preview-changelog": "ts-node ./support/ensureNonPrereleaseChangelog.ts --standard-version-options=\"--skip.commit --skip.tag\" && cat CHANGELOG.md && git reset --hard --quiet",
     "preview-changelog:latest": "npx touch __CHANGELOG-PREVIEW-TEMP__ && ts-node ./support/ensureNonPrereleaseChangelog.ts --standard-version-options=\"--skip.commit --skip.tag --release-count 1 --infile __CHANGELOG-PREVIEW-TEMP__ --same-file\" && cat __CHANGELOG-PREVIEW-TEMP__ && rimraf __CHANGELOG-PREVIEW-TEMP__ && git reset --hard --quiet",
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",

--- a/src/demos/action-pad/basic.html
+++ b/src/demos/action-pad/basic.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-action-pad</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>

--- a/src/demos/action/basic.html
+++ b/src/demos/action/basic.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-action</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>
@@ -22,7 +21,7 @@
           </calcite-action>
 
           <calcite-action
-            style="position: -webkit-sticky; position: sticky; top: 0;"
+            style="position: -webkit-sticky; position: sticky; top: 0"
             text="Sticky"
             text-enabled
             icon="configure-popup"

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -26,13 +26,13 @@
         <h2>Header + control</h2>
 
         <calcite-block heading="With control" summary="has inline input">
-          <label slot="control">test <input placeholder="I'm a header control"/></label>
+          <label slot="control">test <input placeholder="I'm a header control" /></label>
         </calcite-block>
 
         <h2>Header + control + content (collapsible)</h2>
 
         <calcite-block heading="With control + collapsible content" open collapsible>
-          <label slot="control">test <input placeholder="I'm a header control"/></label>
+          <label slot="control">test <input placeholder="I'm a header control" /></label>
           <calcite-block-section text="Animals" open>
             <img alt="demo" src="https://placeimg.com/640/480/animals" />
           </calcite-block-section>

--- a/src/demos/block/with-value-list.html
+++ b/src/demos/block/with-value-list.html
@@ -6,7 +6,6 @@
     <title>Calcite Components: calcite-block</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>
@@ -45,11 +44,7 @@
               >
               </calcite-action>
             </calcite-value-list-item>
-            <calcite-value-list-item
-              label="2018 Total Households (Esri)"
-              description="{TOTHH_CY}"
-              value="TOTHH_CY"
-            >
+            <calcite-value-list-item label="2018 Total Households (Esri)" description="{TOTHH_CY}" value="TOTHH_CY">
               <calcite-action
                 slot="actions-end"
                 id="action-test"

--- a/src/demos/calcite-accordion.html
+++ b/src/demos/calcite-accordion.html
@@ -497,7 +497,7 @@
           </calcite-accordion-item>
         </calcite-accordion>
         <h4>Scale L, icon-position: start</h4>
-        <calcite-accordion scale="l"  icon-position='start'>
+        <calcite-accordion scale="l" icon-position="start">
           <calcite-accordion-item item-title="Accordion Item" item-subtitle="Accordion item subtitle" icon="list"
             ><img src="https://placem.at/places?w=200&txt=0" />
           </calcite-accordion-item>
@@ -533,7 +533,7 @@
           </calcite-accordion-item>
         </calcite-accordion>
         <h4>Scale L, icon-position: end</h4>
-        <calcite-accordion scale="l"  icon-position='end'>
+        <calcite-accordion scale="l" icon-position="end">
           <calcite-accordion-item item-title="Accordion Item" item-subtitle="Accordion item subtitle" icon="list"
             ><img src="https://placem.at/places?w=200&txt=0" />
           </calcite-accordion-item>
@@ -570,7 +570,7 @@
         </calcite-accordion>
         <div class="demo-background-dark">
           <h4>Dark default</h4>
-          <calcite-accordion theme="dark">
+          <calcite-accordion class="calcite-theme-dark">
             <calcite-accordion-item item-title="Accordion Item"
               ><img src="https://placem.at/places?w=200&txt=0" />
             </calcite-accordion-item>
@@ -606,7 +606,7 @@
             </calcite-accordion-item>
           </calcite-accordion>
           <h4>Dark minimal</h4>
-          <calcite-accordion appearance="minimal" theme="dark">
+          <calcite-accordion appearance="minimal" class="calcite-theme-dark">
             <calcite-accordion-item item-title="Accordion Item"
               ><img src="https://placem.at/places?w=200&txt=0" />
             </calcite-accordion-item>

--- a/src/demos/calcite-alert.html
+++ b/src/demos/calcite-alert.html
@@ -134,12 +134,12 @@
     </calcite-alert>
 
     <!-- test prop validation theme -->
-    <calcite-alert label="this is an alert" color="green" id="alert-two" icon theme="bleme">
+    <calcite-alert label="this is an alert" color="green" id="alert-two" icon>
       <div slot="message">2 Successfully updated <em>Portland Restaurants</em> feature layer</div>
       <calcite-link slot="link" title="my action">Do thing</calcite-link>
     </calcite-alert>
 
-    <calcite-alert label="this is an alert" id="alert-three" icon theme="dark">
+    <calcite-alert label="this is an alert" id="alert-three" icon class="calcite-theme-dark">
       <div slot="message">3 A general piece of information</div>
     </calcite-alert>
 
@@ -160,7 +160,7 @@
       <calcite-link slot="link" title="my action">Take action</calcite-link>
     </calcite-alert>
 
-    <calcite-alert label="this is an alert" color="green" id="alert-seven" theme="dark">
+    <calcite-alert label="this is an alert" color="green" id="alert-seven" class="calcite-theme-dark">
       <div slot="title">Layer duplicated</div>
       <div slot="message">7 Successfully duplicated <em>Portland Restaurants</em> feature layer</div>
       <calcite-link slot="link" title="my action">View layer </calcite-link>
@@ -172,9 +172,15 @@
     </calcite-alert>
 
     <!-- test prop validation duration -->
-    <calcite-alert label="this is an alert" id="alert-nine" theme="dark" auto-dismiss auto-dismiss-duration="blast">
+    <calcite-alert
+      label="this is an alert"
+      id="alert-nine"
+      class="calcite-theme-dark"
+      auto-dismiss
+      auto-dismiss-duration="blast"
+    >
       <div slot="message">9 A general piece of information</div>
-      <calcite-link slot="link" theme="dark" title="my action">Take action </calcite-link>
+      <calcite-link slot="link" class="calcite-theme-dark" title="my action">Take action </calcite-link>
     </calcite-alert>
 
     <calcite-alert label="this is an alert" id="alert-ten" auto-dismiss auto-dismiss-duration="medium">

--- a/src/demos/calcite-avatar.html
+++ b/src/demos/calcite-avatar.html
@@ -66,34 +66,117 @@
     <calcite-avatar user-id="e85f7f72aa51b34f81660a0f4c6a4d80" username="tn"></calcite-avatar>
     <div class="demo-background-dark">
       <h3>Provided Image</h3>
-      <calcite-avatar theme="dark" thumbnail="http://placekitten.com/105/105" scale="s"></calcite-avatar><br /><br />
-      <calcite-avatar theme="dark" thumbnail="http://placekitten.com/40/40" scale="m"></calcite-avatar><br /><br />
-      <calcite-avatar theme="dark" thumbnail="http://placekitten.com/120/120" scale="l"></calcite-avatar><br /><br />
+      <calcite-avatar class="calcite-theme-dark" thumbnail="http://placekitten.com/105/105" scale="s"></calcite-avatar
+      ><br /><br />
+      <calcite-avatar class="calcite-theme-dark" thumbnail="http://placekitten.com/40/40" scale="m"></calcite-avatar
+      ><br /><br />
+      <calcite-avatar class="calcite-theme-dark" thumbnail="http://placekitten.com/120/120" scale="l"></calcite-avatar
+      ><br /><br />
       <h3>Initials from first and last name</h3>
-      <calcite-avatar theme="dark" full-name="Ron Swanson" scale="s"></calcite-avatar><br /><br />
-      <calcite-avatar theme="dark" full-name="Ron" scale="m"></calcite-avatar><br /><br />
-      <calcite-avatar theme="dark" full-name="swanson" scale="l"></calcite-avatar><br /><br />
+      <calcite-avatar class="calcite-theme-dark" full-name="Ron Swanson" scale="s"></calcite-avatar><br /><br />
+      <calcite-avatar class="calcite-theme-dark" full-name="Ron" scale="m"></calcite-avatar><br /><br />
+      <calcite-avatar class="calcite-theme-dark" full-name="swanson" scale="l"></calcite-avatar><br /><br />
       <h4>ID color test</h4>
-      <calcite-avatar theme="dark" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="1c863a764d6de370e220e7d3aeddd8a9" username="bv"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="9a7c50e6b3ce4b859f7b31e302437164" username="dx"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="7938de70b5d04956b098eedce1e3ba47" username="exy"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="98f64d6d4e124c6290d092a7998e96cb" username="fz"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="c977c075f3ad4dc2a840f3d2fff3d978" username="ga"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="25684463a00c449585dbb32a065f6b74" username="hb"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="770b011f40ba22321f686b04b803d325" username="ic"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="eea642e2a6f5a0b6c2e302cc664905c3" username="jd"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="19813ce4b4704b6e9fe2e79c34909ae4" username="ke"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="ad61de73b6d79446416bde1a18da87a7" username="lf"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="8a6fda51f21d40d588d07f1cf52b4890" username="mg"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="bd353ce54a5b40e7b3544d0cb454d465" username="nh"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="dfb1d98e54a244dca345dd85062e227c" username="oi"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="bcce092ebb474a369c9730f52106700c" username="pj"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="8542b186e5a64a90910486de32bced72" username="qk"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="8587853c1f544de6ae4133224db29736" username="rl"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="9de33a713bd84690bbc618e98ecf7567" username="sm"></calcite-avatar>
-      <calcite-avatar theme="dark" user-id="e85f7f72aa51b34f81660a0f4c6a4d80" username="tn"></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="52e44e112b1f429182515dba79b71eb8"
+        username="au"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="1c863a764d6de370e220e7d3aeddd8a9"
+        username="bv"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="a81470986eaeee1833b74b7d8abcd5b2"
+        username="cw"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="9a7c50e6b3ce4b859f7b31e302437164"
+        username="dx"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="7938de70b5d04956b098eedce1e3ba47"
+        username="exy"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="98f64d6d4e124c6290d092a7998e96cb"
+        username="fz"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="c977c075f3ad4dc2a840f3d2fff3d978"
+        username="ga"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="25684463a00c449585dbb32a065f6b74"
+        username="hb"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="770b011f40ba22321f686b04b803d325"
+        username="ic"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="eea642e2a6f5a0b6c2e302cc664905c3"
+        username="jd"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="19813ce4b4704b6e9fe2e79c34909ae4"
+        username="ke"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="ad61de73b6d79446416bde1a18da87a7"
+        username="lf"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="8a6fda51f21d40d588d07f1cf52b4890"
+        username="mg"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="bd353ce54a5b40e7b3544d0cb454d465"
+        username="nh"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="dfb1d98e54a244dca345dd85062e227c"
+        username="oi"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="bcce092ebb474a369c9730f52106700c"
+        username="pj"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="8542b186e5a64a90910486de32bced72"
+        username="qk"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="8587853c1f544de6ae4133224db29736"
+        username="rl"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="9de33a713bd84690bbc618e98ecf7567"
+        username="sm"
+      ></calcite-avatar>
+      <calcite-avatar
+        class="calcite-theme-dark"
+        user-id="e85f7f72aa51b34f81660a0f4c6a4d80"
+        username="tn"
+      ></calcite-avatar>
     </div>
   </body>
 </html>

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -1,88 +1,80 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Button</title>
+    <style>
+      section {
+        padding: 0 2rem;
+        margin-bottom: 3rem;
+      }
+      h1,
+      h3,
+      h4,
+      h5 {
+        color: var(--calcite-ui-text-1);
+      }
+      .demo-background-dark {
+        background: #2b2b2b;
+        color: white;
+        padding: 1rem;
+      }
+      .custom-button-size {
+        height: 44px;
+        width: 44px;
+      }
+    </style>
+    <script src="_assets/head.js"></script>
+    <script src="_assets/loadingButton.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Button</title>
-  <style>
-    section {
-      padding: 0 2rem;
-      margin-bottom: 3rem;
-    }
-    h1,h3,h4,h5 {
-      color: var(--calcite-ui-text-1);
-    }
-    .demo-background-dark {
-      background: #2b2b2b;
-      color: white;
-      padding: 1rem;
-    }
-    .custom-button-size {
-      height: 44px;
-      width: 44px;
-    }
-  </style>
-  <script src="_assets/head.js"></script>
-  <script src="_assets/loadingButton.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Button</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Button</h1>
+    <section>
+      <!-- src/components/calcite-button/usage/.md -->
+      <div>
+        <h3>Basic</h3>
+        <calcite-button icon-start="plus" color="red">Go!</calcite-button>
+      </div>
+      <div>
+        <h3>Within a form</h3>
+        <form name="sign-up">
+          <calcite-label>
+            First name
+            <calcite-input name="first-name" required></calcite-input>
+          </calcite-label>
+          <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
+          <calcite-button type="button">I should not submit the form (type button)</calcite-button>
+          <calcite-button>Submit</calcite-button>
+        </form>
+      </div>
+      <div>
+        <h3>With icons</h3>
+        <calcite-button appearance="solid" icon-start="arrow-left">Back</calcite-button>
+        <calcite-button icon-end="map" color="red">Map Options</calcite-button>
+        <calcite-button icon-end="plus" appearance="outline" color="inverse">Add to favorites</calcite-button>
+      </div>
+      <div>
+        <h3>With loading and disabled states</h3>
+        <calcite-button loading color="neutral">Fetching data...</calcite-button>
+        <calcite-button disabled>Can't touch this</calcite-button>
+      </div>
+    </section>
 
-  <section>
-    <!-- src/components/calcite-button/usage/.md -->
-    <div>
-      <h3>Basic</h3>
-      <calcite-button icon-start="plus" color="red">Go!</calcite-button>
-    </div>
-    <div>
-      <h3>Within a form</h3>
-      <form name="sign-up">
-        <calcite-label>
-          First name
-          <calcite-input name="first-name" required></calcite-input>
-        </calcite-label>
-        <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
-        <calcite-button type="button">I should not submit the form (type button)</calcite-button>
-        <calcite-button>Submit</calcite-button>
-      </form>
-    </div>
-    <div>
-      <h3>With icons</h3>
-      <calcite-button appearance="solid" icon-start="arrow-left">Back</calcite-button>
-      <calcite-button icon-end="map" color="red">Map Options</calcite-button>
-      <calcite-button icon-end="plus" appearance="outline" color="inverse">Add to favorites</calcite-button>
-    </div>
-    <div>
-      <h3>With loading and disabled states</h3>
-      <calcite-button loading color="neutral">Fetching data...</calcite-button>
-      <calcite-button disabled>Can't touch this</calcite-button>
-    </div>
-  </section>
+    <section>
+      <h3>Side by Side test</h3>
+      <div style="width: 300px; position: relative; display: flex">
+        <calcite-button icon-start="plus" appearance="transparent" width="half">Field</calcite-button>
+        <calcite-button icon-start="plus" appearance="transparent" width="half">Long Expression</calcite-button>
+      </div>
+    </section>
 
-  <section>
-    <h3>Side by Side test</h3>
-    <div style="width:300px;position:relative;display:flex;">
-      <calcite-button icon-start="plus" appearance="transparent" width="half">Field</calcite-button>
-      <calcite-button icon-start="plus" appearance="transparent" width="half">Long Expression</calcite-button>
-    </div>
-  </section>
-
-  <section>
-    <h3>Icons</h3>
-    <calcite-button icon-start="plus" aria-label="Add layer"></calcite-button>
-    <calcite-button icon-end="plus">Long Expression</calcite-button>
-    <calcite-button icon-start="layer" icon-end="chevron-down">Long Expression</calcite-button>
-    <calcite-button icon-start="layer" icon-end="chevron-down" loading>Loading</calcite-button>
-    <calcite-button icon-start="layer" icon-end="chevron-down" color="red" loading>Loading</calcite-button>
-    <calcite-button icon-start="layer" icon-end="chevron-down" aria-label="View layer"></calcite-button>
-    <calcite-button icon-start="layer" icon-end="chevron-down" loading aria-label="Get layer"></calcite-button>
-    <calcite-button icon-start="plus" icon-end="plus" aria-label="Add layer"></calcite-button>
-    <h3>Icons RTL</h3>
-    <div dir="rtl">
+    <section>
+      <h3>Icons</h3>
       <calcite-button icon-start="plus" aria-label="Add layer"></calcite-button>
       <calcite-button icon-end="plus">Long Expression</calcite-button>
       <calcite-button icon-start="layer" icon-end="chevron-down">Long Expression</calcite-button>
@@ -91,242 +83,403 @@
       <calcite-button icon-start="layer" icon-end="chevron-down" aria-label="View layer"></calcite-button>
       <calcite-button icon-start="layer" icon-end="chevron-down" loading aria-label="Get layer"></calcite-button>
       <calcite-button icon-start="plus" icon-end="plus" aria-label="Add layer"></calcite-button>
-    </div>
-  </section>
+      <h3>Icons RTL</h3>
+      <div dir="rtl">
+        <calcite-button icon-start="plus" aria-label="Add layer"></calcite-button>
+        <calcite-button icon-end="plus">Long Expression</calcite-button>
+        <calcite-button icon-start="layer" icon-end="chevron-down">Long Expression</calcite-button>
+        <calcite-button icon-start="layer" icon-end="chevron-down" loading>Loading</calcite-button>
+        <calcite-button icon-start="layer" icon-end="chevron-down" color="red" loading>Loading</calcite-button>
+        <calcite-button icon-start="layer" icon-end="chevron-down" aria-label="View layer"></calcite-button>
+        <calcite-button icon-start="layer" icon-end="chevron-down" loading aria-label="Get layer"></calcite-button>
+        <calcite-button icon-start="plus" icon-end="plus" aria-label="Add layer"></calcite-button>
+      </div>
+    </section>
 
-  <section>
-    <h3>Alignment</h3>
-    <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="center">Alignment center (default)</calcite-button>
-    <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="start">Alignment start</calcite-button>
-    <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="end">Alignment end</calcite-button>
-    <calcite-button icon-end="chevron-down" appearance="outline" width="half" alignment="space-between">Alignment space-between</calcite-button>
-    <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="icon-start-space-between">Alignment icon-start-space-between</calcite-button>
-    <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="icon-end-space-between">Alignment icon-end-space-between</calcite-button>
-    <h4>Alignment RTL</h4>
-    <calcite-button dir="rtl" icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="center">Alignment center (default)</calcite-button>
-    <calcite-button dir="rtl" icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="start">Alignment start</calcite-button>
-    <calcite-button dir="rtl" icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="end">Alignment end</calcite-button>
-    <calcite-button dir="rtl" icon-end="chevron-down" appearance="outline" width="half" alignment="space-between">Alignment space-between</calcite-button>
-    <calcite-button dir="rtl" icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="icon-start-space-between">Alignment icon-start-space-between</calcite-button>
-    <calcite-button dir="rtl" icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="icon-end-space-between">Alignment icon-end-space-between</calcite-button>
-  </section>
+    <section>
+      <h3>Alignment</h3>
+      <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="center"
+        >Alignment center (default)</calcite-button
+      >
+      <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="start"
+        >Alignment start</calcite-button
+      >
+      <calcite-button icon-start="banana" icon-end="chevron-down" appearance="outline" width="half" alignment="end"
+        >Alignment end</calcite-button
+      >
+      <calcite-button icon-end="chevron-down" appearance="outline" width="half" alignment="space-between"
+        >Alignment space-between</calcite-button
+      >
+      <calcite-button
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="icon-start-space-between"
+        >Alignment icon-start-space-between</calcite-button
+      >
+      <calcite-button
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="icon-end-space-between"
+        >Alignment icon-end-space-between</calcite-button
+      >
+      <h4>Alignment RTL</h4>
+      <calcite-button
+        dir="rtl"
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="center"
+        >Alignment center (default)</calcite-button
+      >
+      <calcite-button
+        dir="rtl"
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="start"
+        >Alignment start</calcite-button
+      >
+      <calcite-button
+        dir="rtl"
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="end"
+        >Alignment end</calcite-button
+      >
+      <calcite-button dir="rtl" icon-end="chevron-down" appearance="outline" width="half" alignment="space-between"
+        >Alignment space-between</calcite-button
+      >
+      <calcite-button
+        dir="rtl"
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="icon-start-space-between"
+        >Alignment icon-start-space-between</calcite-button
+      >
+      <calcite-button
+        dir="rtl"
+        icon-start="banana"
+        icon-end="chevron-down"
+        appearance="outline"
+        width="half"
+        alignment="icon-end-space-between"
+        >Alignment icon-end-space-between</calcite-button
+      >
+    </section>
 
-  <section>
-    <h3>Normal Lockup</h3>
-    <calcite-button color="neutral" appearance="outline" icon-start="chevronLeft">Back</calcite-button>
-    <calcite-button appearance="outline">Cancel</calcite-button>
-    <calcite-button>Submit</calcite-button>
-    <calcite-button round>round button</calcite-button>
-  </section>
-
-  <section>
-    <h3>Set focus</h3>
-    <calcite-button onclick="document.querySelector('#button-focus-example-1').setFocus()">focus button</calcite-button>
-    <calcite-button onclick="document.querySelector('#button-focus-example-2').setFocus()">focus a</calcite-button>
-    <h4>Receive focus</h4>
-    <calcite-button id="button-focus-example-1">Button to gain focus</calcite-button>
-    <calcite-button href="http://google.com" target="_blank" id="button-focus-example-2">A to gain focus</calcite-button>
-  </section>
-
-  <section>
-    <h5>calcite button inside form with no custom onsubmit</h5>
-    <form name="sign-up-1">
-      <calcite-label>
-        First name
-        <calcite-input name="first-name" required></calcite-input>
-      </calcite-label>
-      <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
-      <calcite-button type="button">I should not submit the form (type button)</calcite-button>
+    <section>
+      <h3>Normal Lockup</h3>
+      <calcite-button color="neutral" appearance="outline" icon-start="chevronLeft">Back</calcite-button>
+      <calcite-button appearance="outline">Cancel</calcite-button>
       <calcite-button>Submit</calcite-button>
-    </form>
-    <h5>with a custom defined onsubmit on form</h5>
-    <form name="sign-up-2" onsubmit="alert('form submitted!');">
-      <calcite-label>
-        First name
-        <calcite-input name="first-name" required></calcite-input>
-      </calcite-label>
-      <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
-      <calcite-button type="button">I should not submit the form (type button)</calcite-button>
-      <calcite-button>Submit</calcite-button>
-    </form>
-  </section>
+      <calcite-button round>round button</calcite-button>
+    </section>
 
-  <section>
-    <h5>multiple calcite buttons outside form</h5>
-    <form name="form2" id="form2">
-      <label>form 2 (no custom onsubmit)
-        <input type="text" name="name2" required />
-      </label>
-    </form>
-    <form name="form3" id="form3" onsubmit="alert('submitted')">
-      <label>form 3 (has custom onsubmit)
-        <input type="text" name="name3" required />
-      </label>
-    </form>
-    <calcite-button form="form2" id="submit-button2">Submit form 2</calcite-button>
-    <calcite-button form="form2" type="button" id="button-button2">no action (form 2)</calcite-button>
-    <calcite-button form="form2" type="reset" id="reset-button2">reset form 2</calcite-button>
-    <br />
-    <calcite-button form="form3" id="submit-button3">Submit form 3 (custom fn)</calcite-button>
-    <calcite-button form="form3" type="button" id="button-button3">no action (form 3)</calcite-button>
-    <calcite-button form="form3" type="reset" id="reset-button3">reset form 3</calcite-button>
-  </section>
+    <section>
+      <h3>Set focus</h3>
+      <calcite-button onclick="document.querySelector('#button-focus-example-1').setFocus()"
+        >focus button</calcite-button
+      >
+      <calcite-button onclick="document.querySelector('#button-focus-example-2').setFocus()">focus a</calcite-button>
+      <h4>Receive focus</h4>
+      <calcite-button id="button-focus-example-1">Button to gain focus</calcite-button>
+      <calcite-button href="http://google.com" target="_blank" id="button-focus-example-2"
+        >A to gain focus</calcite-button
+      >
+    </section>
 
-  <br />
-  <br />
+    <section>
+      <h5>calcite button inside form with no custom onsubmit</h5>
+      <form name="sign-up-1">
+        <calcite-label>
+          First name
+          <calcite-input name="first-name" required></calcite-input>
+        </calcite-label>
+        <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
+        <calcite-button type="button">I should not submit the form (type button)</calcite-button>
+        <calcite-button>Submit</calcite-button>
+      </form>
+      <h5>with a custom defined onsubmit on form</h5>
+      <form name="sign-up-2" onsubmit="alert('form submitted!');">
+        <calcite-label>
+          First name
+          <calcite-input name="first-name" required></calcite-input>
+        </calcite-label>
+        <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
+        <calcite-button type="button">I should not submit the form (type button)</calcite-button>
+        <calcite-button>Submit</calcite-button>
+      </form>
+    </section>
 
-  <section>
-    <h3>Appearance: Solid (default)</h3>
-    <calcite-button title="blue solid button">blue solid button</calcite-button>
-    <calcite-button title="red solid button" color="red">red solid button</calcite-button>
-    <calcite-button title="neutral solid button" color="neutral">neutral solid button</calcite-button>
-    <calcite-button title="inverse solid button" color="inverse">inverse solid button</calcite-button>
+    <section>
+      <h5>multiple calcite buttons outside form</h5>
+      <form name="form2" id="form2">
+        <label
+          >form 2 (no custom onsubmit)
+          <input type="text" name="name2" required />
+        </label>
+      </form>
+      <form name="form3" id="form3" onsubmit="alert('submitted')">
+        <label
+          >form 3 (has custom onsubmit)
+          <input type="text" name="name3" required />
+        </label>
+      </form>
+      <calcite-button form="form2" id="submit-button2">Submit form 2</calcite-button>
+      <calcite-button form="form2" type="button" id="button-button2">no action (form 2)</calcite-button>
+      <calcite-button form="form2" type="reset" id="reset-button2">reset form 2</calcite-button>
+      <br />
+      <calcite-button form="form3" id="submit-button3">Submit form 3 (custom fn)</calcite-button>
+      <calcite-button form="form3" type="button" id="button-button3">no action (form 3)</calcite-button>
+      <calcite-button form="form3" type="reset" id="reset-button3">reset form 3</calcite-button>
+    </section>
+
     <br />
     <br />
-    <h5>Theme="dark" on blue /red</h5>
-    <div theme="dark" class="demo-background-dark">
+
+    <section>
+      <h3>Appearance: Solid (default)</h3>
       <calcite-button title="blue solid button">blue solid button</calcite-button>
       <calcite-button title="red solid button" color="red">red solid button</calcite-button>
       <calcite-button title="neutral solid button" color="neutral">neutral solid button</calcite-button>
       <calcite-button title="inverse solid button" color="inverse">inverse solid button</calcite-button>
-    </div>
+      <br />
+      <br />
+      <h5>Dark on blue /red</h5>
+      <div class="demo-background-dark calcite-theme-dark">
+        <calcite-button title="blue solid button">blue solid button</calcite-button>
+        <calcite-button title="red solid button" color="red">red solid button</calcite-button>
+        <calcite-button title="neutral solid button" color="neutral">neutral solid button</calcite-button>
+        <calcite-button title="inverse solid button" color="inverse">inverse solid button</calcite-button>
+      </div>
 
-    <h3>Appearance: Outline</h3>
-    <calcite-button title="blue outline button" appearance="outline">blue outline button</calcite-button>
-    <calcite-button title="red outline button" appearance="outline" color="red">red outline button</calcite-button>
-    <calcite-button title="neutral outline button" appearance="outline" color="neutral">neutral outline button</calcite-button>
-    <calcite-button title="inverse outline button" appearance="outline" color="inverse">inverse outline button</calcite-button>
-    <br />
-    <br />
-    <h5>Theme="dark" on blue /red</h5>
-    <div theme="dark" class="demo-background-dark">
+      <h3>Appearance: Outline</h3>
       <calcite-button title="blue outline button" appearance="outline">blue outline button</calcite-button>
       <calcite-button title="red outline button" appearance="outline" color="red">red outline button</calcite-button>
-      <calcite-button title="neutral outline button" appearance="outline" color="neutral">neutral outline button</calcite-button>
-      <calcite-button title="inverse outline button" appearance="outline" color="inverse">inverse outline button</calcite-button>
-    </div>
+      <calcite-button title="neutral outline button" appearance="outline" color="neutral"
+        >neutral outline button</calcite-button
+      >
+      <calcite-button title="inverse outline button" appearance="outline" color="inverse"
+        >inverse outline button</calcite-button
+      >
+      <br />
+      <br />
+      <h5>Dark on blue /red</h5>
+      <div class="demo-background-dark calcite-theme-dark">
+        <calcite-button title="blue outline button" appearance="outline">blue outline button</calcite-button>
+        <calcite-button title="red outline button" appearance="outline" color="red">red outline button</calcite-button>
+        <calcite-button title="neutral outline button" appearance="outline" color="neutral"
+          >neutral outline button</calcite-button
+        >
+        <calcite-button title="inverse outline button" appearance="outline" color="inverse"
+          >inverse outline button</calcite-button
+        >
+      </div>
 
-    <div>
-      <h3>Appearance: Clear</h3>
-      <calcite-button title="blue clear button" appearance="clear">blue clear button</calcite-button>
-      <calcite-button title="red clear button" appearance="clear" color="red">red clear button</calcite-button>
-      <calcite-button title="neutral clear button" appearance="clear" color="neutral">neutral clear button</calcite-button>
-      <calcite-button title="inverse clear button" appearance="clear" color="inverse">inverse clear button</calcite-button>
-    </div>
-    <br />
-    <br />
-    <h5>Theme="dark" on blue /red</h5>
-    <div theme="dark" class="demo-background-dark">
-      <calcite-button title="blue clear button" appearance="clear">blue clear button</calcite-button>
-      <calcite-button title="red clear button" appearance="clear" color="red">red clear button</calcite-button>
-      <calcite-button title="neutral clear button" appearance="clear" color="neutral">neutral clear button</calcite-button>
-      <calcite-button title="inverse clear button" appearance="clear" color="inverse">inverse clear button</calcite-button>
-    </div>
+      <div>
+        <h3>Appearance: Clear</h3>
+        <calcite-button title="blue clear button" appearance="clear">blue clear button</calcite-button>
+        <calcite-button title="red clear button" appearance="clear" color="red">red clear button</calcite-button>
+        <calcite-button title="neutral clear button" appearance="clear" color="neutral"
+          >neutral clear button</calcite-button
+        >
+        <calcite-button title="inverse clear button" appearance="clear" color="inverse"
+          >inverse clear button</calcite-button
+        >
+      </div>
+      <br />
+      <br />
+      <h5>Dark on blue /red</h5>
+      <div class="demo-background-dark calcite-theme-dark">
+        <calcite-button title="blue clear button" appearance="clear">blue clear button</calcite-button>
+        <calcite-button title="red clear button" appearance="clear" color="red">red clear button</calcite-button>
+        <calcite-button title="neutral clear button" appearance="clear" color="neutral"
+          >neutral clear button</calcite-button
+        >
+        <calcite-button title="inverse clear button" appearance="clear" color="inverse"
+          >inverse clear button</calcite-button
+        >
+      </div>
 
-    <div>
-      <h3>Appearance: Transparent</h3>
-      <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers">transparent and icon</calcite-button>
-      <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers">transparent and end icon</calcite-button>
-      <calcite-button title="blue transparent button" appearance="transparent">blue transparent button</calcite-button>
-      <calcite-button title="red transparent button" appearance="transparent" color="red">red transparent button</calcite-button>
-      <calcite-button title="neutral transparent button" appearance="transparent" color="neutral">neutral transparent button</calcite-button>
-      <calcite-button title="inverse transparent button" appearance="transparent" color="inverse">inverse transparent button</calcite-button>
-    </div>
-    <br />
-    <br />
-    <h5>Theme="dark" on blue /red</h5>
-    <div theme="dark" class="demo-background-dark">
-      <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers">transparent and icon</calcite-button>
-      <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers">transparent and end icon</calcite-button>
-      <calcite-button title="blue transparent button" appearance="transparent">blue transparent button</calcite-button>
-      <calcite-button title="red transparent button" appearance="transparent" color="red">red transparent button</calcite-button>
-      <calcite-button title="neutral transparent button" appearance="transparent" color="neutral">neutral transparent button</calcite-button>
-      <calcite-button title="inverse transparent button" appearance="transparent" color="inverse">inverse transparent button</calcite-button>
-    </div>
-  </section>
+      <div>
+        <h3>Appearance: Transparent</h3>
+        <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers"
+          >transparent and icon</calcite-button
+        >
+        <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers"
+          >transparent and end icon</calcite-button
+        >
+        <calcite-button title="blue transparent button" appearance="transparent"
+          >blue transparent button</calcite-button
+        >
+        <calcite-button title="red transparent button" appearance="transparent" color="red"
+          >red transparent button</calcite-button
+        >
+        <calcite-button title="neutral transparent button" appearance="transparent" color="neutral"
+          >neutral transparent button</calcite-button
+        >
+        <calcite-button title="inverse transparent button" appearance="transparent" color="inverse"
+          >inverse transparent button</calcite-button
+        >
+      </div>
+      <br />
+      <br />
+      <h5>Dark on blue /red</h5>
+      <div class="demo-background-dark calcite-theme-dark">
+        <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers"
+          >transparent and icon</calcite-button
+        >
+        <calcite-button title="blue transparent button" appearance="transparent" icon-start="layers"
+          >transparent and end icon</calcite-button
+        >
+        <calcite-button title="blue transparent button" appearance="transparent"
+          >blue transparent button</calcite-button
+        >
+        <calcite-button title="red transparent button" appearance="transparent" color="red"
+          >red transparent button</calcite-button
+        >
+        <calcite-button title="neutral transparent button" appearance="transparent" color="neutral"
+          >neutral transparent button</calcite-button
+        >
+        <calcite-button title="inverse transparent button" appearance="transparent" color="inverse"
+          >inverse transparent button</calcite-button
+        >
+      </div>
+    </section>
 
-  <section>
-    <h3>Disabled</h3>
-    <calcite-button title="blue solid button" disabled>blue solid button</calcite-button>
-    <calcite-button icon-start="launch" title="inverse solid button" color="inverse" disabled>inverse solid button</calcite-button>
-    <calcite-button title="blue clear button" appearance="clear" disabled>blue clear button</calcite-button>
-    <calcite-button title="blue clear button" appearance="transparent" disabled>blue clear button</calcite-button>
-    <br />
-    <br />
-    <div theme="dark" class="demo-background-dark">
+    <section>
+      <h3>Disabled</h3>
       <calcite-button title="blue solid button" disabled>blue solid button</calcite-button>
-      <calcite-button icon-start="launch" title="inverse solid button" color="inverse" disabled>inverse solid button</calcite-button>
+      <calcite-button icon-start="launch" title="inverse solid button" color="inverse" disabled
+        >inverse solid button</calcite-button
+      >
       <calcite-button title="blue clear button" appearance="clear" disabled>blue clear button</calcite-button>
       <calcite-button title="blue clear button" appearance="transparent" disabled>blue clear button</calcite-button>
-    </div>
-  </section>
+      <br />
+      <br />
+      <div class="demo-background-dark calcite-theme-dark">
+        <calcite-button title="blue solid button" disabled>blue solid button</calcite-button>
+        <calcite-button icon-start="launch" title="inverse solid button" color="inverse" disabled
+          >inverse solid button</calcite-button
+        >
+        <calcite-button title="blue clear button" appearance="clear" disabled>blue clear button</calcite-button>
+        <calcite-button title="blue clear button" appearance="transparent" disabled>blue clear button</calcite-button>
+      </div>
+    </section>
 
-  <section>
-    <h3>Scales</h3>
-    <calcite-button title="l scale button" scale="l">l scale button</calcite-button>
-    <calcite-button title="m / default scale button">m / default scale button</calcite-button>
-    <calcite-button title="s scale button" scale="s">s scale button</calcite-button>
+    <section>
+      <h3>Scales</h3>
+      <calcite-button title="l scale button" scale="l">l scale button</calcite-button>
+      <calcite-button title="m / default scale button">m / default scale button</calcite-button>
+      <calcite-button title="s scale button" scale="s">s scale button</calcite-button>
 
-    <h3>Scales with icons</h3>
-    <calcite-button title="l scale button" icon-start="check-circle" scale="l">l scale button</calcite-button>
-    <calcite-button title="m / default scale button" icon-start="check-circle">m / default scale button</calcite-button>
-    <calcite-button title="s scale button" icon-start="check-circle" scale="s">s scale button</calcite-button>
-  </section>
+      <h3>Scales with icons</h3>
+      <calcite-button title="l scale button" icon-start="check-circle" scale="l">l scale button</calcite-button>
+      <calcite-button title="m / default scale button" icon-start="check-circle"
+        >m / default scale button</calcite-button
+      >
+      <calcite-button title="s scale button" icon-start="check-circle" scale="s">s scale button</calcite-button>
+    </section>
 
-  <section>
-    <h3>Widths</h3>
-    <calcite-button title="Auto / default width button">Auto / default width button</calcite-button>
-    <br />
-    <calcite-button title="half width button" width="half">half width button</calcite-button>
-    <br />
-    <calcite-button title="full width button" width="full">full width button</calcite-button>
-    <calcite-button title="full width button" icon-start="check-circle" width="full">full width button with icon</calcite-button>
-    <calcite-button title="full width button" icon-start="check-circle" width="full">full width button with icon </calcite-button>
-  </section>
+    <section>
+      <h3>Widths</h3>
+      <calcite-button title="Auto / default width button">Auto / default width button</calcite-button>
+      <br />
+      <calcite-button title="half width button" width="half">half width button</calcite-button>
+      <br />
+      <calcite-button title="full width button" width="full">full width button</calcite-button>
+      <calcite-button title="full width button" icon-start="check-circle" width="full"
+        >full width button with icon</calcite-button
+      >
+      <calcite-button title="full width button" icon-start="check-circle" width="full"
+        >full width button with icon
+      </calcite-button>
+    </section>
 
-  <section>
-    <h3>Anchor links</h3>
-    <h5>Passing a href will render the component as an anchor.</h5>
-    <calcite-button href="#content">Internal anchor</calcite-button>
-    <calcite-button href="https://www.esri.com" rel="noopener noreferrer" target="_blank">External anchor</calcite-button>
-    <calcite-button href="https://www.esri.com" appearance="outline" icon-start="launch" rel="noopener noreferrer" target="_blank">External anchor with icon</calcite-button>
-  </section>
+    <section>
+      <h3>Anchor links</h3>
+      <h5>Passing a href will render the component as an anchor.</h5>
+      <calcite-button href="#content">Internal anchor</calcite-button>
+      <calcite-button href="https://www.esri.com" rel="noopener noreferrer" target="_blank"
+        >External anchor</calcite-button
+      >
+      <calcite-button
+        href="https://www.esri.com"
+        appearance="outline"
+        icon-start="launch"
+        rel="noopener noreferrer"
+        target="_blank"
+        >External anchor with icon</calcite-button
+      >
+    </section>
 
-  <section>
-    <h3>Loader</h3>
-    <h5>These examples remove on the consumer end, the loader attribute when done... We could also present a "done" loader state somehow...</h5>
-    <calcite-button onclick="loadingButton(this, 5000)">Do something</calcite-button>
-    <calcite-button appearance="outline" onclick="loadingButton(this, 5000)">Do something</calcite-button>
-    <calcite-button color="red" onclick="loadingButton(this, 500000000)">Do something</calcite-button>
-    <calcite-button color="red" appearance="outline" onclick="loadingButton(this, 5000)">Do something</calcite-button>
-  </section>
+    <section>
+      <h3>Loader</h3>
+      <h5>
+        These examples remove on the consumer end, the loader attribute when done... We could also present a "done"
+        loader state somehow...
+      </h5>
+      <calcite-button onclick="loadingButton(this, 5000)">Do something</calcite-button>
+      <calcite-button appearance="outline" onclick="loadingButton(this, 5000)">Do something</calcite-button>
+      <calcite-button color="red" onclick="loadingButton(this, 500000000)">Do something</calcite-button>
+      <calcite-button color="red" appearance="outline" onclick="loadingButton(this, 5000)">Do something</calcite-button>
+    </section>
 
-  <section>
-    <h3>Icons, and icons in combination with loader</h3>
-    <h5>pass path data - recommend using Calcite UI Icon Filled variants @ 24.</h5>
-    <calcite-button appearance="outline" color="neutral" icon-start="check-circle" aria-label="Upload status"></calcite-button>
-    <calcite-button onclick="loadingButton(this, 3000)" icon-start="check-circle" aria-label="Upload status"></calcite-button>
-    <calcite-button appearance="outline" color="inverse" icon-start="check-circle">Download icon end</calcite-button>
-    <calcite-button scale="l" appearance="outline" icon-start="download-to">Download</calcite-button>
-    <calcite-button icon-start="download-to"><em>Download</em></calcite-button>
-    <calcite-button color="red" icon-start="trash">Delete this</calcite-button>
-    <calcite-button color="red" appearance="outline" onclick="loadingButton(this, 3000)" icon-start="trash">Delete this (loader)</calcite-button>
-    <calcite-button color="red" scale="l" appearance="outline" onclick="loadingButton(this, 3000)" icon-start="trash">Delete this (loader)</calcite-button>
-  </section>
+    <section>
+      <h3>Icons, and icons in combination with loader</h3>
+      <h5>pass path data - recommend using Calcite UI Icon Filled variants @ 24.</h5>
+      <calcite-button
+        appearance="outline"
+        color="neutral"
+        icon-start="check-circle"
+        aria-label="Upload status"
+      ></calcite-button>
+      <calcite-button
+        onclick="loadingButton(this, 3000)"
+        icon-start="check-circle"
+        aria-label="Upload status"
+      ></calcite-button>
+      <calcite-button appearance="outline" color="inverse" icon-start="check-circle">Download icon end</calcite-button>
+      <calcite-button scale="l" appearance="outline" icon-start="download-to">Download</calcite-button>
+      <calcite-button icon-start="download-to"><em>Download</em></calcite-button>
+      <calcite-button color="red" icon-start="trash">Delete this</calcite-button>
+      <calcite-button color="red" appearance="outline" onclick="loadingButton(this, 3000)" icon-start="trash"
+        >Delete this (loader)</calcite-button
+      >
+      <calcite-button color="red" scale="l" appearance="outline" onclick="loadingButton(this, 3000)" icon-start="trash"
+        >Delete this (loader)</calcite-button
+      >
+    </section>
 
-  <section>
-    <h3>Icons placed inside slot: plain svg (height constrained), calcite-icons (height constrained), using icon-start</h3>
-    <calcite-button class="custom-button-size" aria-label="Share layer">
-      <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
-        <path
-          fill="#fff"
-          d="M22.117 7H7.883A.883.883 0 0 0 7 7.883v14.234c0 .487.396.883.883.883H15v-7h-3v-2h3v-.992c0-2.066 1.277-3.192 3.121-3.192.883 0 1.879.066 1.879.096V12h-1.764c-1.002 0-1.236.148-1.236.848V14h2.73l-.911 2H17v7h5.117a.884.884 0 0 0 .883-.883V7.883A.883.883 0 0 0 22.117 7z"
-        />
-      </svg>
-    </calcite-button>
-    <calcite-button class="custom-button-size" color="inverse" aria-label="Add layer"><calcite-icon scale="m" icon="layer"></calcite-icon></calcite-button>
-    <calcite-button class="custom-button-size" aria-label="Add layer"><calcite-icon scale="l" icon="layer"></calcite-icon></calcite-button>
-    <calcite-button icon-start="layer" aria-label="View layer"></calcite-button>
-  </section>
-</body>
+    <section>
+      <h3>
+        Icons placed inside slot: plain svg (height constrained), calcite-icons (height constrained), using icon-start
+      </h3>
+      <calcite-button class="custom-button-size" aria-label="Share layer">
+        <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
+          <path
+            fill="#fff"
+            d="M22.117 7H7.883A.883.883 0 0 0 7 7.883v14.234c0 .487.396.883.883.883H15v-7h-3v-2h3v-.992c0-2.066 1.277-3.192 3.121-3.192.883 0 1.879.066 1.879.096V12h-1.764c-1.002 0-1.236.148-1.236.848V14h2.73l-.911 2H17v7h5.117a.884.884 0 0 0 .883-.883V7.883A.883.883 0 0 0 22.117 7z"
+          />
+        </svg>
+      </calcite-button>
+      <calcite-button class="custom-button-size" color="inverse" aria-label="Add layer"
+        ><calcite-icon scale="m" icon="layer"></calcite-icon
+      ></calcite-button>
+      <calcite-button class="custom-button-size" aria-label="Add layer"
+        ><calcite-icon scale="l" icon="layer"></calcite-icon
+      ></calcite-button>
+      <calcite-button icon-start="layer" aria-label="View layer"></calcite-button>
+    </section>
+  </body>
 </html>

--- a/src/demos/calcite-card.html
+++ b/src/demos/calcite-card.html
@@ -259,32 +259,32 @@
       <h3>Cards: Dark</h3>
       <div class="example-grid">
         <div class="example-grid-item">
-          <calcite-card theme="dark">
+          <calcite-card class="calcite-theme-dark">
             <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
             <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
-            <calcite-link theme="dark" slot="footer-leading">Lead füt</calcite-link>
-            <calcite-link theme="dark" slot="footer-trailing">Trail füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-trailing">Trail füt</calcite-link>
           </calcite-card>
         </div>
         <div class="example-grid-item">
-          <calcite-card theme="dark">
+          <calcite-card class="calcite-theme-dark">
             <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
             <h3 slot="title">ArcGIS Pro Editing Workflows</h3>
             <span slot="subtitle"
               >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
             >
-            <calcite-link theme="dark" slot="footer-leading">Lead füt</calcite-link>
-            <calcite-link theme="dark" slot="footer-trailing">Trail füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-trailing">Trail füt</calcite-link>
           </calcite-card>
         </div>
         <div class="example-grid-item">
           <calcite-tooltip-manager>
-            <calcite-card theme="dark">
+            <calcite-card class="calcite-theme-dark">
               <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
               <h3 slot="title">Portland Businesses</h3>
               <span slot="subtitle"
                 >by
-                <calcite-link theme="dark" href="">example_user</calcite-link>
+                <calcite-link class="calcite-theme-dark" href="">example_user</calcite-link>
               </span>
               <div>
                 Created: Apr 22, 2019
@@ -294,7 +294,7 @@
                 View Count: 0
               </div>
               <calcite-button
-                theme="dark"
+                class="calcite-theme-dark"
                 slot="footer-leading"
                 color="neutral"
                 scale="s"
@@ -303,20 +303,20 @@
               ></calcite-button>
               <div slot="footer-trailing">
                 <calcite-button
-                  theme="dark"
+                  class="calcite-theme-dark"
                   scale="s"
                   color="neutral"
                   id="card-icon-test-b"
                   icon-start="circle"
                 ></calcite-button>
                 <calcite-button
-                  theme="dark"
+                  class="calcite-theme-dark"
                   scale="s"
                   color="neutral"
                   id="card-icon-test-c"
                   icon-start="circle"
                 ></calcite-button>
-                <calcite-dropdown theme="dark" type="hover">
+                <calcite-dropdown class="calcite-theme-dark" type="hover">
                   <calcite-button
                     id="card-icon-test-d"
                     slot="dropdown-trigger"
@@ -338,42 +338,42 @@
         <calcite-tooltip
           label="bottom placed tooltip"
           placement="bottom-start"
-          theme="dark"
+          class="calcite-theme-dark"
           reference-element="card-icon-test-a"
           >My great tooltip example
         </calcite-tooltip>
         <calcite-tooltip
           label="bottom placed tooltip"
           placement="bottom-start"
-          theme="dark"
+          class="calcite-theme-dark"
           reference-element="card-icon-test-b"
           >Sharing level: 2
         </calcite-tooltip>
         <calcite-tooltip
           label="top placed tooltip"
           placement="top-end"
-          theme="dark"
+          class="calcite-theme-dark"
           reference-element="card-icon-test-c"
           >More...
         </calcite-tooltip>
         <calcite-tooltip
           label="top placed tooltip"
           placement="top-start"
-          theme="dark"
+          class="calcite-theme-dark"
           reference-element="card-icon-test-d"
           >More options
         </calcite-tooltip>
         <div class="example-grid-item">
-          <calcite-card theme="dark" selected>
+          <calcite-card class="calcite-theme-dark" selected>
             <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
             <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
 
-            <calcite-link theme="dark" slot="footer-leading">Lead füt</calcite-link>
-            <calcite-link theme="dark" slot="footer-trailing">Trail füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-trailing">Trail füt</calcite-link>
           </calcite-card>
         </div>
         <div class="example-grid-item">
-          <calcite-card theme="dark" selected selectable>
+          <calcite-card class="calcite-theme-dark" selected selectable>
             <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
             <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
             <span slot="subtitle"
@@ -382,13 +382,13 @@
           </calcite-card>
         </div>
         <div class="example-grid-item">
-          <calcite-card theme="dark" selected>
+          <calcite-card class="calcite-theme-dark" selected>
             <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
             <span slot="subtitle"
               >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
             >
-            <calcite-link theme="dark" slot="footer-leading">Lead füt</calcite-link>
-            <calcite-link theme="dark" slot="footer-trailing">Trail füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link class="calcite-theme-dark" slot="footer-trailing">Trail füt</calcite-link>
           </calcite-card>
         </div>
       </div>

--- a/src/demos/calcite-checkbox.html
+++ b/src/demos/calcite-checkbox.html
@@ -46,7 +46,12 @@
           <h3>Indeterminate and checked with native label</h3>
           <label for="checked-indeterminate">
             Status
-            <calcite-checkbox checked indeterminate id="checked-indeterminate" name="checked-indeterminate"></calcite-checkbox>
+            <calcite-checkbox
+              checked
+              indeterminate
+              id="checked-indeterminate"
+              name="checked-indeterminate"
+            ></calcite-checkbox>
           </label>
         </div>
         <div>
@@ -111,31 +116,69 @@
                     indeterminate unchecked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox hovered indeterminate name="light-s-indeterminate-unchecked-hovered" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      hovered
+                      indeterminate
+                      name="light-s-indeterminate-unchecked-hovered"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate unchecked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox focused indeterminate name="light-s-indeterminate-unchecked-focused" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      focused
+                      indeterminate
+                      name="light-s-indeterminate-unchecked-focused"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate unchecked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox disabled indeterminate name="light-s-indeterminate-unchecked-disabled" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      disabled
+                      indeterminate
+                      name="light-s-indeterminate-unchecked-disabled"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate unchecked disabled
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked indeterminate name="light-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      indeterminate
+                      name="light-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked hovered indeterminate name="light-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      hovered
+                      indeterminate
+                      name="light-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused indeterminate name="light-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      indeterminate
+                      name="light-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked disabled indeterminate name="light-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      disabled
+                      indeterminate
+                      name="light-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
 
@@ -156,17 +199,27 @@
 
                   <calcite-label for="light-wrapped-in-calcite-label-with-for">
                     wrapped in calcite-label with for
-                    <calcite-checkbox id="light-wrapped-in-calcite-label-with-for" name="light-wrapped-in-calcite-label-with-for"></calcite-checkbox>
+                    <calcite-checkbox
+                      id="light-wrapped-in-calcite-label-with-for"
+                      name="light-wrapped-in-calcite-label-with-for"
+                    ></calcite-checkbox>
                   </calcite-label>
 
                   <calcite-label for="light-wrapped-in-calcite-label-span-with-for">
                     <span>wrapped in calcite-label span with for</span>
-                    <calcite-checkbox id="light-wrapped-in-calcite-label-span-with-for" name="light-wrapped-in-calcite-label-span-with-for"></calcite-checkbox>
+                    <calcite-checkbox
+                      id="light-wrapped-in-calcite-label-span-with-for"
+                      name="light-wrapped-in-calcite-label-span-with-for"
+                    ></calcite-checkbox>
                   </calcite-label>
 
                   <div>
-                    <calcite-label for="light-sibling-calcite-label">sibling calcite-label
-                      <calcite-checkbox id="light-sibling-calcite-label" name="sibling-calcite-label"></calcite-checkbox>
+                    <calcite-label for="light-sibling-calcite-label"
+                      >sibling calcite-label
+                      <calcite-checkbox
+                        id="light-sibling-calcite-label"
+                        name="sibling-calcite-label"
+                      ></calcite-checkbox>
                     </calcite-label>
                   </div>
 
@@ -176,11 +229,15 @@
                   </label>
 
                   <label for="light-wrapped-in-label-with-for">
-                    <calcite-checkbox id="light-wrapped-in-label-with-for" name="light-wrapped-in-label-with-for"></calcite-checkbox>
+                    <calcite-checkbox
+                      id="light-wrapped-in-label-with-for"
+                      name="light-wrapped-in-label-with-for"
+                    ></calcite-checkbox>
                     wrapped in native label with for
                   </label>
 
-                  <label for="sibling-label">sibling native label
+                  <label for="sibling-label"
+                    >sibling native label
                     <calcite-checkbox id="sibling-label" name="sibling-label"></calcite-checkbox>
                   </label>
 
@@ -210,7 +267,13 @@
                     checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused hovered name="light-m-checked-focused" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      hovered
+                      name="light-m-checked-focused"
+                      scale="m"
+                    ></calcite-checkbox>
                     checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
@@ -222,31 +285,69 @@
                     indeterminate unchecked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox hovered indeterminate name="light-m-indeterminate-checked-hovered" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      hovered
+                      indeterminate
+                      name="light-m-indeterminate-checked-hovered"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate unchecked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox focused indeterminate name="light-m-indeterminate-unchecked-focused" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      focused
+                      indeterminate
+                      name="light-m-indeterminate-unchecked-focused"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate unchecked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox disabled indeterminate name="light-m-indeterminate-unchecked-disabled" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      disabled
+                      indeterminate
+                      name="light-m-indeterminate-unchecked-disabled"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate unchecked disabled
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked indeterminate name="light-m-indeterminate-checked" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      indeterminate
+                      name="light-m-indeterminate-checked"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked hovered indeterminate name="light-m-indeterminate-checked-hovered" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      hovered
+                      indeterminate
+                      name="light-m-indeterminate-checked-hovered"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused indeterminate name="light-m-indeterminate-checked-focused" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      indeterminate
+                      name="light-m-indeterminate-checked-focused"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked disabled indeterminate name="light-m-indeterminate-checked-disabled" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      disabled
+                      indeterminate
+                      name="light-m-indeterminate-checked-disabled"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked disabled
                   </calcite-label>
                   <calcite-label layout="inline" scale="m">
@@ -296,31 +397,69 @@
                     indeterminate unchecked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox hovered indeterminate name="light-l-indeterminate-unchecked-hovered" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      hovered
+                      indeterminate
+                      name="light-l-indeterminate-unchecked-hovered"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate unchecked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox focused indeterminate name="light-l-indeterminate-unchecked-focused" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      focused
+                      indeterminate
+                      name="light-l-indeterminate-unchecked-focused"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate unchecked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox disabled indeterminate name="light-l-indeterminate-unchecked-disabled" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      disabled
+                      indeterminate
+                      name="light-l-indeterminate-unchecked-disabled"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate unchecked disabled
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked indeterminate name="light-l-indeterminate-checked" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      indeterminate
+                      name="light-l-indeterminate-checked"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked hovered indeterminate name="light-l-indeterminate-checked-hovered" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      hovered
+                      indeterminate
+                      name="light-l-indeterminate-checked-hovered"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused indeterminate name="light-l-indeterminate-checked-focused" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      indeterminate
+                      name="light-l-indeterminate-checked-focused"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked disabled indeterminate name="light-l-indeterminate-checked-disabled" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      disabled
+                      indeterminate
+                      name="light-l-indeterminate-checked-disabled"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked disabled
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
@@ -333,7 +472,7 @@
                   </calcite-label>
                 </demo-spacer>
               </div>
-              <div class="demo-background-dark" theme="dark">
+              <div class="demo-background-dark calcite-theme-dark">
                 <demo-spacer>
                   <h3>Small</h3>
                   <calcite-label layout="inline">
@@ -373,31 +512,69 @@
                     indeterminate unchecked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox hovered indeterminate name="dark-s-indeterminate-unchecked-hovered" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      hovered
+                      indeterminate
+                      name="dark-s-indeterminate-unchecked-hovered"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate unchecked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox focused indeterminate name="dark-s-indeterminate-unchecked-focused" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      focused
+                      indeterminate
+                      name="dark-s-indeterminate-unchecked-focused"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate unchecked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox disabled indeterminate name="dark-s-indeterminate-unchecked-disabled" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      disabled
+                      indeterminate
+                      name="dark-s-indeterminate-unchecked-disabled"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate unchecked disabled
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked indeterminate name="dark-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      indeterminate
+                      name="dark-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked hovered indeterminate name="dark-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      hovered
+                      indeterminate
+                      name="dark-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused indeterminate name="dark-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      indeterminate
+                      name="dark-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked disabled indeterminate name="dark-s-indeterminate-checked" scale="s"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      disabled
+                      indeterminate
+                      name="dark-s-indeterminate-checked"
+                      scale="s"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
 
@@ -418,16 +595,23 @@
 
                   <calcite-label for="dark-wrapped-in-calcite-label-with-for">
                     wrapped in calcite-label with for
-                    <calcite-checkbox id="dark-wrapped-in-calcite-label-with-for" name="wrapped in calcite-label with for"></calcite-checkbox>
+                    <calcite-checkbox
+                      id="dark-wrapped-in-calcite-label-with-for"
+                      name="wrapped in calcite-label with for"
+                    ></calcite-checkbox>
                   </calcite-label>
 
                   <calcite-label for="dark-wrapped-in-calcite-label-span-with-for">
                     <span>wrapped in calcite-label span with for</span>
-                    <calcite-checkbox id="dark-wrapped-in-calcite-label-span-with-for" name="wrapped in calcite-label span with for"></calcite-checkbox>
+                    <calcite-checkbox
+                      id="dark-wrapped-in-calcite-label-span-with-for"
+                      name="wrapped in calcite-label span with for"
+                    ></calcite-checkbox>
                   </calcite-label>
 
                   <div>
-                    <calcite-label for="sibling-calcite-label">sibling calcite-label
+                    <calcite-label for="sibling-calcite-label"
+                      >sibling calcite-label
                       <calcite-checkbox id="sibling-calcite-label" name="sibling-calcite-label"></calcite-checkbox>
                     </calcite-label>
                   </div>
@@ -438,11 +622,15 @@
                   </label>
 
                   <label for="wrapped-in-label-with-for">
-                    <calcite-checkbox id="wrapped-in-label-with-for" name="wrapped-in-label-with-for"></calcite-checkbox>
+                    <calcite-checkbox
+                      id="wrapped-in-label-with-for"
+                      name="wrapped-in-label-with-for"
+                    ></calcite-checkbox>
                     wrapped in native label with for
                   </label>
 
-                  <label for="dark-sibling-label">sibling native label
+                  <label for="dark-sibling-label"
+                    >sibling native label
                     <calcite-checkbox id="dark-sibling-label" name="sibling-label"></calcite-checkbox>
                   </label>
 
@@ -472,7 +660,13 @@
                     checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused hovered name="dark-m-checked-focused" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      hovered
+                      name="dark-m-checked-focused"
+                      scale="m"
+                    ></calcite-checkbox>
                     checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
@@ -484,31 +678,69 @@
                     indeterminate unchecked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox hovered indeterminate name="dark-m-indeterminate-checked-hovered" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      hovered
+                      indeterminate
+                      name="dark-m-indeterminate-checked-hovered"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate unchecked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox focused indeterminate name="dark-m-indeterminate-unchecked-focused" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      focused
+                      indeterminate
+                      name="dark-m-indeterminate-unchecked-focused"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate unchecked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox disabled indeterminate name="dark-m-indeterminate-unchecked-disabled" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      disabled
+                      indeterminate
+                      name="dark-m-indeterminate-unchecked-disabled"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate unchecked disabled
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked indeterminate name="dark-m-indeterminate-checked" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      indeterminate
+                      name="dark-m-indeterminate-checked"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked hovered indeterminate name="dark-m-indeterminate-checked-hovered" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      hovered
+                      indeterminate
+                      name="dark-m-indeterminate-checked-hovered"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused indeterminate name="dark-m-indeterminate-checked-focused" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      indeterminate
+                      name="dark-m-indeterminate-checked-focused"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked disabled indeterminate name="dark-m-indeterminate-checked-disabled" scale="m"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      disabled
+                      indeterminate
+                      name="dark-m-indeterminate-checked-disabled"
+                      scale="m"
+                    ></calcite-checkbox>
                     indeterminate checked disabled
                   </calcite-label>
                   <calcite-label layout="inline" scale="m">
@@ -558,31 +790,69 @@
                     indeterminate unchecked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox hovered indeterminate name="dark-l-indeterminate-unchecked-hovered" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      hovered
+                      indeterminate
+                      name="dark-l-indeterminate-unchecked-hovered"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate unchecked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox focused indeterminate name="dark-l-indeterminate-unchecked-focused" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      focused
+                      indeterminate
+                      name="dark-l-indeterminate-unchecked-focused"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate unchecked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox disabled indeterminate name="dark-l-indeterminate-unchecked-disabled" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      disabled
+                      indeterminate
+                      name="dark-l-indeterminate-unchecked-disabled"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate unchecked disabled
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked indeterminate name="dark-l-indeterminate-checked" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      indeterminate
+                      name="dark-l-indeterminate-checked"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked hovered indeterminate name="dark-l-indeterminate-checked-hovered" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      hovered
+                      indeterminate
+                      name="dark-l-indeterminate-checked-hovered"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked hovered
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked focused indeterminate name="dark-l-indeterminate-checked-focused" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      focused
+                      indeterminate
+                      name="dark-l-indeterminate-checked-focused"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked focused
                   </calcite-label>
                   <calcite-label layout="inline">
-                    <calcite-checkbox checked disabled indeterminate name="dark-l-indeterminate-checked-disabled" scale="l"></calcite-checkbox>
+                    <calcite-checkbox
+                      checked
+                      disabled
+                      indeterminate
+                      name="dark-l-indeterminate-checked-disabled"
+                      scale="l"
+                    ></calcite-checkbox>
                     indeterminate checked disabled
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">

--- a/src/demos/calcite-chip.html
+++ b/src/demos/calcite-chip.html
@@ -22,7 +22,7 @@
         one.addEventListener("calciteChipDismiss", () => {
           console.log("dismissed chip");
         });
-      }
+      };
     </script>
     <calcite-button href="/">Home</calcite-button>
     <h1>Calcite Chip</h1>
@@ -96,21 +96,13 @@
     <calcite-chip value="calcite chip" icon="globe" appearance="clear" color="blue"> Blue </calcite-chip>
     <br />
     <br />
-    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear">
-      Grey (default)
-    </calcite-chip>
-    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="red">
-      Red
-    </calcite-chip>
+    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear"> Grey (default) </calcite-chip>
+    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="red"> Red </calcite-chip>
     <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="yellow">
       Yellow
     </calcite-chip>
-    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="green">
-      Green
-    </calcite-chip>
-    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="blue">
-      Blue
-    </calcite-chip>
+    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="green"> Green </calcite-chip>
+    <calcite-chip value="calcite chip" dismissible icon="globe" appearance="clear" color="blue"> Blue </calcite-chip>
 
     <h2>RTL</h2>
     <calcite-chip value="calcite chip" dir="rtl">Apple</calcite-chip>
@@ -124,92 +116,103 @@
     </calcite-chip>
     <br />
     <br />
-    <div class="demo-background-dark" theme="dark">
+    <div class="demo-background-dark calcite-theme-dark">
       <h2>Basic</h2>
-      <calcite-chip value="calcite chip" theme="dark" id="one">Apple</calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" id="one">Apple</calcite-chip>
       <h2>Slotted "image"</h2>
-      <calcite-chip value="calcite chip" theme="dark" active>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" active>
         <img slot="image" src="https://placekitten.com/50/50" />
         Siamese Cat
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" active>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" active>
         <img slot="image" src="https://placekitten.com/50/50" />
         Siamese Cat
       </calcite-chip>
       <h2>With icon attribute</h2>
-      <calcite-chip value="calcite chip" theme="dark" icon="check-circle"> Siamese Cat </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe"> Camera Flash On </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="check-circle"> Siamese Cat </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe"> Camera Flash On </calcite-chip>
       <h2>With icon attribute dismissible</h2>
-      <calcite-chip value="calcite chip" dismissible theme="dark" icon="check-circle"> Siamese Cat </calcite-chip>
-      <calcite-chip value="calcite chip" dismissible theme="dark" icon="globe">
+      <calcite-chip value="calcite chip" dismissible class="calcite-theme-dark" icon="check-circle">
+        Siamese Cat
+      </calcite-chip>
+      <calcite-chip value="calcite chip" dismissible class="calcite-theme-dark" icon="globe">
         Camera Flash On
       </calcite-chip>
       <h2>Scales</h2>
 
-      <calcite-chip value="calcite chip" theme="dark" scale="s"> Scale S </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" scale="m"> Scale M </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" scale="l"> Scale L </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" scale="s"> Scale S </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" scale="m"> Scale M </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" scale="l"> Scale L </calcite-chip>
 
       <br />
       <br />
-      <calcite-chip value="calcite chip" dismissible theme="dark" scale="s"> Scale S </calcite-chip>
-      <calcite-chip value="calcite chip" dismissible theme="dark" scale="m"> Scale M </calcite-chip>
-      <calcite-chip value="calcite chip" dismissible theme="dark" scale="l"> Scale L </calcite-chip>
+      <calcite-chip value="calcite chip" dismissible class="calcite-theme-dark" scale="s"> Scale S </calcite-chip>
+      <calcite-chip value="calcite chip" dismissible class="calcite-theme-dark" scale="m"> Scale M </calcite-chip>
+      <calcite-chip value="calcite chip" dismissible class="calcite-theme-dark" scale="l"> Scale L </calcite-chip>
 
       <br />
       <br />
 
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" scale="s"> Scale S </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" scale="m"> Scale M </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" scale="l"> Scale L </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" scale="s"> Scale S </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" scale="m"> Scale M </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" scale="l"> Scale L </calcite-chip>
       <h3>Colors - Solid (Default)</h3>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe"> Grey (default) </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" color="red"> Red </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" color="yellow"> Yellow </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" color="green"> Green </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" color="blue"> Blue </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe"> Grey (default) </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" color="red"> Red </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" color="yellow"> Yellow </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" color="green"> Green </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" color="blue"> Blue </calcite-chip>
       <br />
       <br />
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe"> Grey (default) </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe" color="red">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dismissible icon="globe">
+        Grey (default)
+      </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dismissible icon="globe" color="red">
         Red
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe" color="yellow">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dismissible icon="globe" color="yellow">
         Yellow
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe" color="green">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dismissible icon="globe" color="green">
         Green
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe" color="blue">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dismissible icon="globe" color="blue">
         Blue
       </calcite-chip>
       <h3>Colors - clear</h3>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" appearance="clear">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" appearance="clear">
         Grey (default)
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" appearance="clear" color="red">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" appearance="clear" color="red">
         Red
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" appearance="clear" color="yellow">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" appearance="clear" color="yellow">
         Yellow
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" appearance="clear" color="green">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" appearance="clear" color="green">
         Green
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" appearance="clear" color="blue">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" appearance="clear" color="blue">
         Blue
       </calcite-chip>
       <br />
       <br />
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe" appearance="clear">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dismissible icon="globe" appearance="clear">
         Grey (default)
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" dismissible icon="globe" appearance="clear" color="red">
+      <calcite-chip
+        value="calcite chip"
+        class="calcite-theme-dark"
+        dismissible
+        icon="globe"
+        appearance="clear"
+        color="red"
+      >
         Red
       </calcite-chip>
       <calcite-chip
         value="calcite chip"
-        theme="dark"
+        class="calcite-theme-dark"
         dismissible
         icon="globe"
         appearance="clear"
@@ -219,7 +222,7 @@
       </calcite-chip>
       <calcite-chip
         value="calcite chip"
-        theme="dark"
+        class="calcite-theme-dark"
         dismissible
         icon="globe"
         appearance="clear"
@@ -229,7 +232,7 @@
       </calcite-chip>
       <calcite-chip
         value="calcite chip"
-        theme="dark"
+        class="calcite-theme-dark"
         dismissible
         icon="globe"
         appearance="clear"
@@ -251,8 +254,8 @@
         >Carol Whitten
       </calcite-chip>
       <h2>RTL</h2>
-      <calcite-chip value="calcite chip" theme="dark" dir="rtl">Apple</calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" dir="rtl">
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dir="rtl">Apple</calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" dir="rtl">
         <img slot="image" src="https://placekitten.com/50/50" />
         Siamese Cat
       </calcite-chip>
@@ -268,10 +271,12 @@
         <calcite-avatar slot="image" scale="l" user-id="a81470986eaeee1833b74b7d8abcd5b2" username="cw"></calcite-avatar
         >Carol Whitten
       </calcite-chip>
-      <calcite-chip value="calcite chip" theme="dark" icon="globe" dir="rtl"> Camera Flash On </calcite-chip>
+      <calcite-chip value="calcite chip" class="calcite-theme-dark" icon="globe" dir="rtl">
+        Camera Flash On
+      </calcite-chip>
       <calcite-chip
         value="calcite chip"
-        theme="dark"
+        class="calcite-theme-dark"
         dismissible
         icon="globe"
         appearance="clear"

--- a/src/demos/calcite-color-picker.html
+++ b/src/demos/calcite-color-picker.html
@@ -58,7 +58,7 @@
     <div class="demo-background-dark">
       <h3 class="leader-1">Dark theme</h3>
 
-      <calcite-color-picker theme="dark"></calcite-color-picker>
+      <calcite-color-picker class="calcite-theme-dark"></calcite-color-picker>
     </div>
   </body>
 </html>

--- a/src/demos/calcite-combobox.html
+++ b/src/demos/calcite-combobox.html
@@ -77,7 +77,6 @@
       <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
     </calcite-combobox>
 
-
     <h2>Single Select, certain items constant</h2>
     <calcite-combobox label="test" placeholder="select element" max-items="6" selection-mode="single">
       <calcite-combobox-item value="New Item" constant text-label="Add new plant" icon="plus"></calcite-combobox-item>
@@ -249,7 +248,7 @@
     <div class="demo-background-dark">
       <h2>Scale M</h2>
 
-      <calcite-combobox theme="dark" label="test" placeholder="placeholder">
+      <calcite-combobox class="calcite-theme-dark" label="test" placeholder="placeholder">
         <calcite-combobox-item value="Trees" text-label="Trees">
           <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
           <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>

--- a/src/demos/calcite-date-picker.html
+++ b/src/demos/calcite-date-picker.html
@@ -1,222 +1,293 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Date Picker</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem 1rem 3rem 1rem;
+      }
+      h2,
+      h3 {
+        padding-top: 3rem;
+      }
+    </style>
+    <script src="_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Date Picker</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem 1rem 3rem 1rem;
-    }
-    h2, h3 {
-      padding-top: 3rem;
-    }
-  </style>
- <script src="_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Date Picker</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Date Picker</h1>
+    <h2>Standard</h2>
+    <calcite-date-picker id="simple-picker">-picker</calcite-date-picker>
+    <script>
+      var simplePicker = document.getElementById("simple-picker");
+      simplePicker.addEventListener("calciteDatePickerChange", console.log);
+      simplePicker.valueAsDate = new Date();
+      simplePicker.maxAsDate = new Date();
+      simplePicker.min = "2021-01-01";
+    </script>
 
-  <h2>Standard</h2>
-  <calcite-date-picker id="simple-picker">-picker</calcite-date-picker>
-  <script>
-    var simplePicker = document.getElementById("simple-picker");
-    simplePicker.addEventListener("calciteDatePickerChange", console.log);
-    simplePicker.valueAsDate = new Date();
-    simplePicker.maxAsDate = new Date();
-    simplePicker.min = "2021-01-01";
-  </script>
+    <h2>Initial Value (from ISO 8601 string)</h2>
+    <calcite-date-picker value="2020-03-07"></calcite-date-picker>
 
-  <h2>Initial Value (from ISO 8601 string)</h2>
-  <calcite-date-picker value="2020-03-07"></calcite-date-picker>
+    <h2>Min &amp; Max</h2>
+    <calcite-date-picker min="2020-03-07" max="2020-03-15" value="2020-04-01"></calcite-date-picker>
 
-  <h2>Min &amp; Max</h2>
-  <calcite-date-picker min="2020-03-07" max="2020-03-15" value="2020-04-01"></calcite-date-picker>
+    <h2>Start day of locale</h2>
+    <calcite-date-picker locale="es"></calcite-date-picker>
 
-  <h2>Start day of locale</h2>
-  <calcite-date-picker locale="es"></calcite-date-picker>
+    <h2>Scales</h2>
 
-  <h2>Scales</h2>
+    <h3>Small</h3>
+    <calcite-date-picker scale="s" value="2000-11-27" active></calcite-date-picker>
 
-  <h3>Small</h3>
-  <calcite-date-picker scale="s" value="2000-11-27" active></calcite-date-picker>
+    <h3>Medium</h3>
+    <calcite-date-picker scale="m" value="2000-11-27" active></calcite-date-picker>
 
-  <h3>Medium</h3>
-  <calcite-date-picker scale="m" value="2000-11-27" active></calcite-date-picker>
+    <h3>Large</h3>
+    <calcite-date-picker scale="l" value="2000-11-27" active></calcite-date-picker>
 
-  <h3>Large</h3>
-  <calcite-date-picker scale="l" value="2000-11-27" active></calcite-date-picker>
+    <h2>Inside Small Container</h2>
+    <div style="width: 200px">
+      <calcite-date-picker value="2020-03-07" scale="s"></calcite-date-picker>
+    </div>
 
-  <h2>Inside Small Container</h2>
-  <div style="width: 200px">
-    <calcite-date-picker value="2020-03-07" scale="s"></calcite-date-picker>
-  </div>
+    <h2>Locale formatted dates</h2>
+    <calcite-date-picker
+      value="2019-08-23"
+      min="2019-08-09"
+      max="2021-12-18"
+      locale="ja"
+      id="locale"
+    ></calcite-date-picker>
+    <calcite-dropdown id="localePicker">
+      <calcite-button slot="dropdown-trigger">Select Locale</calcite-button>
+      <calcite-dropdown-group>
+        <calcite-dropdown-item data-locale="ar">ar</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="bs">bs</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ca">ca</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="cs">cs</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="da">da</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="de-CH">de-CH</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="de">de</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="el">el</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en-AU">en-AU</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en-CA">en-CA</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en-GB">en-GB</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en">en</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="es-MX">es-MX</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="es">es</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="et">et</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="fi">fi</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="fr-CH">fr-CH</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="fr">fr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="he">he</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="hi">hi</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="hr">hr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="hu">hu</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="id">id</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="it-CH">it-CH</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="it">it</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ja">ja</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ko">ko</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="lt">lt</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="lv">lv</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="mk">mk</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="nb">nb</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="nl">nl</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="pl">pl</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="pt-PT">pt-PT</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="pt">pt</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ro">ro</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ru">ru</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sk">sk</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sl">sl</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sr">sr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sv">sv</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="th">th</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="tr">tr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="uk">uk</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="vi">vi</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="zh-CN">zh-CN</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="zh-HK">zh-HK</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="zh-TW">zh-TW</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+    <script>
+      document.getElementById("localePicker").addEventListener("calciteDropdownSelect", function (e) {
+        document.getElementById("locale").locale = e.target.selectedItems[0].getAttribute("data-locale");
+      });
+    </script>
 
-  <h2>Locale formatted dates</h2>
-  <calcite-date-picker value="2019-08-23" min="2019-08-09" max="2021-12-18" locale="ja" id="locale"></calcite-date-picker>
-  <calcite-dropdown id="localePicker">
-    <calcite-button slot="dropdown-trigger">Select Locale</calcite-button>
-    <calcite-dropdown-group>
-      <calcite-dropdown-item data-locale="ar">ar</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="bs">bs</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ca">ca</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="cs">cs</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="da">da</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="de-CH">de-CH</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="de">de</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="el">el</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en-AU">en-AU</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en-CA">en-CA</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en-GB">en-GB</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en">en</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="es-MX">es-MX</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="es">es</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="et">et</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="fi">fi</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="fr-CH">fr-CH</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="fr">fr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="he">he</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="hi">hi</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="hr">hr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="hu">hu</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="id">id</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="it-CH">it-CH</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="it">it</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ja">ja</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ko">ko</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="lt">lt</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="lv">lv</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="mk">mk</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="nb">nb</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="nl">nl</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="pl">pl</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="pt-PT">pt-PT</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="pt">pt</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ro">ro</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ru">ru</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sk">sk</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sl">sl</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sr">sr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sv">sv</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="th">th</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="tr">tr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="uk">uk</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="vi">vi</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="zh-CN">zh-CN</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="zh-HK">zh-HK</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="zh-TW">zh-TW</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-dropdown>
-  <script>
-    document.getElementById("localePicker").addEventListener("calciteDropdownSelect", function (e) {
-      document.getElementById("locale").locale = e.target.selectedItems[0].getAttribute("data-locale");
-    });
-  </script>
-
-  <div dir="rtl">
-    <h2>Right to left, arabic numerals</h2>
-    <calcite-date-picker value="2000-11-27" locale="ar-EG" dir="rtl"></calcite-date-picker>
-  </div>
-
-  <h2>Always open</h2>
-  <calcite-date-picker value="2000-11-27" active></calcite-date-picker>
-
-  <h2>Set Value</h2>
-  <calcite-button id="dynamic-button">Set value of date input</calcite-button>
-  <calcite-date-picker id="dynamic-value" value="2000-11-27"></calcite-date-picker>
-  <script>
-    var dynamicDate = document.getElementById("dynamic-value");
-    document.getElementById("dynamic-button").addEventListener("click", function () {
-      console.log("setting value");
-      document.getElementById("dynamic-value").value = "2020-10-02";
-    });
-  </script>
-
-  <h2>Events</h2>
-  <calcite-date-picker id="dateSample"></calcite-date-picker>
-  <p>Date selected: <pre><code id="dateDisplay">n/a</code></pre></p>
-  <script>
-    var dateSample = document.getElementById("dateSample");
-    var dateDisplay = document.getElementById("dateDisplay");
-    dateSample.addEventListener("calciteDatePickerChange", function (e) {
-      dateDisplay.innerHTML = e.detail;
-    });
-  </script>
-
-<h2>Date Range with Event</h2>
-<calcite-date-picker id="dateRangeSample" range start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-<div>
-  Start: <span id="startDisplay">Unchanged</span>
-</div>
-<div>
-  End: <span id="endDisplay">Unchanged</span>
-</div>
-<script>
-  var dateRangeSample = document.getElementById("dateRangeSample");
-  var startDisplay = document.getElementById("startDisplay");
-  var endDisplay = document.getElementById("endDisplay");
-  dateRangeSample.addEventListener("calciteDatePickerRangeChange", function (e) {
-    console.log(e);
-    startDisplay.textContent = e.detail.startDate;
-    endDisplay.textContent = e.detail.endDate;
-  });
-</script>
-
-<div>
-  <h2>Small Date Range</h2>
-  <calcite-date-picker scale="s" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-  <div style="margin-top: 16px;">
-    <calcite-date-picker scale="s" layout="vertical" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-  </div>
-</div>
-
-<div>
-  <h2>Medium Date Range</h2>
-  <calcite-date-picker range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-  <div style="margin-top: 16px;">
-    <calcite-date-picker layout="vertical" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-  </div>
-</div>
-
-<div>
-  <h2>Large Date Range</h2>
-  <calcite-date-picker scale="l" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-  <div style="margin-top: 16px;">
-    <calcite-date-picker layout="vertical" scale="l" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-  </div>
-</div>
-
-<div>
-  <h2>Date Range Always Open</h2>
-  <calcite-date-picker range active></calcite-date-picker>
-  <h2>Without Proximity Selection</h2>
-  <calcite-date-picker range active proximity-selection="false"></calcite-date-picker>
-</div>
-
-<div dir="rtl" style="margin-bottom: 16px;">
-  <h2>Date Range RTL</h2>
-  <calcite-date-picker id="dateRangeSampleRtl" locale="ar-EG" dir="rtl" range  min="2020-01-03" max="2020-09-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-</div>
-
-  <div class="demo-background-dark">
-    <h1>Dark theme</h1>
-    <calcite-date-picker theme="dark" value="2019-08-23"></calcite-date-picker>
+    <div dir="rtl">
+      <h2>Right to left, arabic numerals</h2>
+      <calcite-date-picker value="2000-11-27" locale="ar-EG" dir="rtl"></calcite-date-picker>
+    </div>
 
     <h2>Always open</h2>
-    <calcite-date-picker value="2000-11-27" theme="dark" active></calcite-date-picker>
+    <calcite-date-picker value="2000-11-27" active></calcite-date-picker>
 
-    <h2>Range</h2>
-    <calcite-date-picker theme="dark" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
-    <div style="margin-top: 16px;">
-      <calcite-date-picker theme="dark" layout="vertical" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-date-picker>
+    <h2>Set Value</h2>
+    <calcite-button id="dynamic-button">Set value of date input</calcite-button>
+    <calcite-date-picker id="dynamic-value" value="2000-11-27"></calcite-date-picker>
+    <script>
+      var dynamicDate = document.getElementById("dynamic-value");
+      document.getElementById("dynamic-button").addEventListener("click", function () {
+        console.log("setting value");
+        document.getElementById("dynamic-value").value = "2020-10-02";
+      });
+    </script>
+
+    <h2>Events</h2>
+    <calcite-date-picker id="dateSample"></calcite-date-picker>
+    <div>
+      Date selected:
+      <pre><code id="dateDisplay">n/a</code></pre>
     </div>
-  </div>
-</body>
+    <script>
+      var dateSample = document.getElementById("dateSample");
+      var dateDisplay = document.getElementById("dateDisplay");
+      dateSample.addEventListener("calciteDatePickerChange", function (e) {
+        dateDisplay.innerHTML = e.detail;
+      });
+    </script>
 
+    <h2>Date Range with Event</h2>
+    <calcite-date-picker id="dateRangeSample" range start="2020-09-08" end="2020-09-23"></calcite-date-picker>
+    <div>Start: <span id="startDisplay">Unchanged</span></div>
+    <div>End: <span id="endDisplay">Unchanged</span></div>
+    <script>
+      var dateRangeSample = document.getElementById("dateRangeSample");
+      var startDisplay = document.getElementById("startDisplay");
+      var endDisplay = document.getElementById("endDisplay");
+      dateRangeSample.addEventListener("calciteDatePickerRangeChange", function (e) {
+        console.log(e);
+        startDisplay.textContent = e.detail.startDate;
+        endDisplay.textContent = e.detail.endDate;
+      });
+    </script>
+
+    <div>
+      <h2>Small Date Range</h2>
+      <calcite-date-picker
+        scale="s"
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-date-picker
+          scale="s"
+          layout="vertical"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-date-picker>
+      </div>
+    </div>
+
+    <div>
+      <h2>Medium Date Range</h2>
+      <calcite-date-picker
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-date-picker
+          layout="vertical"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-date-picker>
+      </div>
+    </div>
+
+    <div>
+      <h2>Large Date Range</h2>
+      <calcite-date-picker
+        scale="l"
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-date-picker
+          layout="vertical"
+          scale="l"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-date-picker>
+      </div>
+    </div>
+
+    <div>
+      <h2>Date Range Always Open</h2>
+      <calcite-date-picker range active></calcite-date-picker>
+      <h2>Without Proximity Selection</h2>
+      <calcite-date-picker range active proximity-selection="false"></calcite-date-picker>
+    </div>
+
+    <div dir="rtl" style="margin-bottom: 16px">
+      <h2>Date Range RTL</h2>
+      <calcite-date-picker
+        id="dateRangeSampleRtl"
+        locale="ar-EG"
+        dir="rtl"
+        range
+        min="2020-01-03"
+        max="2020-09-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-date-picker>
+    </div>
+
+    <div class="demo-background-dark">
+      <h1>Dark theme</h1>
+      <calcite-date-picker class="calcite-theme-dark" value="2019-08-23"></calcite-date-picker>
+
+      <h2>Always open</h2>
+      <calcite-date-picker value="2000-11-27" class="calcite-theme-dark" active></calcite-date-picker>
+
+      <h2>Range</h2>
+      <calcite-date-picker
+        class="calcite-theme-dark"
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-date-picker
+          class="calcite-theme-dark"
+          layout="vertical"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-date-picker>
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -292,7 +292,7 @@
       <br />
       <br />
       <h3>Dark mode</h3>
-      <calcite-dropdown theme="dark">
+      <calcite-dropdown class="calcite-theme-dark">
         <calcite-button color="neutral" slot="dropdown-trigger">Open Dropdown dark mode</calcite-button>
         <calcite-dropdown-group>
           <calcite-dropdown-item>Mint</calcite-dropdown-item>
@@ -303,7 +303,7 @@
         </calcite-dropdown-group>
       </calcite-dropdown>
 
-      <calcite-dropdown theme="dark">
+      <calcite-dropdown class="calcite-theme-dark">
         <calcite-button color="neutral" slot="dropdown-trigger">Open Dropdown dark mode with groups</calcite-button>
         <calcite-dropdown-group group-title="Flavors">
           <calcite-dropdown-item>Mint</calcite-dropdown-item>

--- a/src/demos/calcite-graph.html
+++ b/src/demos/calcite-graph.html
@@ -1,53 +1,50 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Graph</title>
+    <style>
+      h3 {
+        margin-top: 4rem;
+      }
+    </style>
+    <script src="_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Graph</title>
-  <style>
-    h3 {
-      margin-top: 4rem;
-    }
-  </style>
-  <script src="_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Graph</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Graph</h1>
+    <h3>Default</h3>
+    <calcite-graph></calcite-graph>
 
-  <h3>Default</h3>
-  <calcite-graph></calcite-graph>
+    <h3>Custom Size</h3>
+    <calcite-graph width="100" height="40"></calcite-graph>
 
-  <h3>Custom Size</h3>
-  <calcite-graph width="100" height="40"></calcite-graph>
+    <h3>Inherit Color</h3>
+    <p style="color: var(--calcite-ui-brand)">
+      <calcite-graph></calcite-graph>
+    </p>
 
-
-  <h3>Inherit Color</h3>
-  <p style="color: var(--calcite-ui-brand)">
-    <calcite-graph ></calcite-graph>
-  </p>
-
-  <script>
-    var data = [
-      [0, 0],
-      [10, 80],
-      [20, 20],
-      [30, 30],
-      [40, 42],
-      [50, 50],
-      [60, 55],
-      [70, 48],
-      [80, 30],
-      [90, 10],
-      [100, 0]
-    ];
-    [].slice.call(document.querySelectorAll("calcite-graph")).forEach(function (graphElement) {
-      graphElement.data = data;
-    });
-  </script>
-</body>
-
+    <script>
+      var data = [
+        [0, 0],
+        [10, 80],
+        [20, 20],
+        [30, 30],
+        [40, 42],
+        [50, 50],
+        [60, 55],
+        [70, 48],
+        [80, 30],
+        [90, 10],
+        [100, 0]
+      ];
+      [].slice.call(document.querySelectorAll("calcite-graph")).forEach(function (graphElement) {
+        graphElement.data = data;
+      });
+    </script>
+  </body>
 </html>

--- a/src/demos/calcite-icon.html
+++ b/src/demos/calcite-icon.html
@@ -52,9 +52,9 @@
 
     <h2>Dark theme</h2>
     <div class="demo-background-dark">
-      <calcite-icon class="my-icon-color-class" icon="aZ" theme="dark"></calcite-icon>
-      <calcite-icon icon="basemap" theme="dark"></calcite-icon>
-      <calcite-icon icon="camera" theme="dark"></calcite-icon>
+      <calcite-icon class="my-icon-color-class calcite-theme-dark" icon="aZ"></calcite-icon>
+      <calcite-icon icon="basemap" class="calcite-theme-dark"></calcite-icon>
+      <calcite-icon icon="camera" class="calcite-theme-dark"></calcite-icon>
     </div>
 
     <h2>Flips icon in RTL when requested with "flip-rtl"</h2>

--- a/src/demos/calcite-input-date-picker.html
+++ b/src/demos/calcite-input-date-picker.html
@@ -1,210 +1,280 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Input Date Picker</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem 1rem 3rem 1rem;
+      }
+      h2,
+      h3 {
+        padding-top: 3rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Input Date Picker</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem 1rem 3rem 1rem;
-    }
-    h2, h3 {
-      padding-top: 3rem;
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Date Picker</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Date Picker</h1>
+    <h2>Standard</h2>
+    <calcite-input-date-picker id="basic-date-picker">-picker</calcite-input-date-picker>
 
-  <h2>Standard</h2>
-  <calcite-input-date-picker id="basic-date-picker">-picker</calcite-input-date-picker>
+    <script>
+      var picker = document.getElementById("basic-date-picker");
+      picker.addEventListener("calciteDatePickerChange", console.log);
+      picker.valueAsDate = new Date();
+      picker.maxAsDate = new Date();
+      picker.min = "2021-01-01";
+    </script>
 
-  <script>
-    var picker = document.getElementById("basic-date-picker");
-    picker.addEventListener("calciteDatePickerChange", console.log);
-    picker.valueAsDate = new Date();
-    picker.maxAsDate = new Date();
-    picker.min = "2021-01-01";
-  </script>
+    <h2>Initial Value (from ISO 8601 string)</h2>
+    <calcite-input-date-picker value="2020-03-07"></calcite-input-date-picker>
 
-  <h2>Initial Value (from ISO 8601 string)</h2>
-  <calcite-input-date-picker value="2020-03-07"></calcite-input-date-picker>
+    <h2>Min &amp; Max</h2>
+    <calcite-input-date-picker min="2020-03-07" max="2020-03-15" value="2020-04-01"></calcite-input-date-picker>
 
-  <h2>Min &amp; Max</h2>
-  <calcite-input-date-picker min="2020-03-07" max="2020-03-15" value="2020-04-01"></calcite-input-date-picker>
+    <h2>Start day of locale</h2>
+    <calcite-input-date-picker locale="es"></calcite-input-date-picker>
 
-  <h2>Start day of locale</h2>
-  <calcite-input-date-picker locale="es"></calcite-input-date-picker>
+    <h2>Scales</h2>
 
-  <h2>Scales</h2>
+    <h3>Small</h3>
+    <calcite-input-date-picker scale="s" value="2000-11-27"></calcite-input-date-picker>
 
-  <h3>Small</h3>
-  <calcite-input-date-picker scale="s" value="2000-11-27"></calcite-input-date-picker>
+    <h3>Medium</h3>
+    <calcite-input-date-picker scale="m" value="2000-11-27"></calcite-input-date-picker>
 
-  <h3>Medium</h3>
-  <calcite-input-date-picker scale="m" value="2000-11-27"></calcite-input-date-picker>
+    <h3>Large</h3>
+    <calcite-input-date-picker scale="l" value="2000-11-27"></calcite-input-date-picker>
 
-  <h3>Large</h3>
-  <calcite-input-date-picker scale="l" value="2000-11-27"></calcite-input-date-picker>
-
-  <h2>Inside Small Container</h2>
-  <div style="width: 200px">
-    <calcite-input-date-picker value="2020-03-07" scale="s"></calcite-input-date-picker>
-  </div>
-
-  <h2>Locale formatted dates</h2>
-  <calcite-input-date-picker value="2019-08-23" min="2019-08-09" max="2021-12-18" locale="ja" id="locale"></calcite-input-date-picker>
-  <calcite-dropdown id="localePicker">
-    <calcite-button slot="dropdown-trigger">Select Locale</calcite-button>
-    <calcite-dropdown-group>
-      <calcite-dropdown-item data-locale="ar">ar</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="bs">bs</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ca">ca</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="cs">cs</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="da">da</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="de-CH">de-CH</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="de">de</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="el">el</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en-AU">en-AU</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en-CA">en-CA</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en-GB">en-GB</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="en">en</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="es-MX">es-MX</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="es">es</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="et">et</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="fi">fi</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="fr-CH">fr-CH</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="fr">fr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="he">he</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="hi">hi</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="hr">hr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="hu">hu</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="id">id</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="it-CH">it-CH</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="it">it</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ja">ja</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ko">ko</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="lt">lt</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="lv">lv</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="mk">mk</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="nb">nb</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="nl">nl</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="pl">pl</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="pt-PT">pt-PT</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="pt">pt</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ro">ro</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="ru">ru</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sk">sk</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sl">sl</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sr">sr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="sv">sv</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="th">th</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="tr">tr</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="uk">uk</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="vi">vi</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="zh-CN">zh-CN</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="zh-HK">zh-HK</calcite-dropdown-item>
-      <calcite-dropdown-item data-locale="zh-TW">zh-TW</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-dropdown>
-  <script>
-    document.getElementById("localePicker").addEventListener("calciteDropdownSelect", function (e) {
-      document.getElementById("locale").locale = e.target.selectedItems[0].getAttribute("data-locale");
-    });
-  </script>
-
-  <div dir="rtl">
-    <h2>Right to left, arabic numerals</h2>
-    <calcite-input-date-picker value="2000-11-27" locale="ar-EG" dir="rtl"></calcite-input-date-picker>
-  </div>
-
-  <h2>Set Value</h2>
-  <calcite-button id="dynamic-button">Set value of date input</calcite-button>
-  <calcite-input-date-picker id="dynamic-value" value="2000-11-27"></calcite-input-date-picker>
-  <script>
-    var dynamicDate = document.getElementById("dynamic-value");
-    document.getElementById("dynamic-button").addEventListener("click", function () {
-      console.log("setting value");
-      document.getElementById("dynamic-value").value = "2020-10-02";
-    });
-  </script>
-
-  <h2>Events</h2>
-  <calcite-input-date-picker id="dateSample"></calcite-input-date-picker>
-  <p>Date selected: <pre><code id="dateDisplay">n/a</code></pre></p>
-  <script>
-    var dateSample = document.getElementById("dateSample");
-    var dateDisplay = document.getElementById("dateDisplay");
-    dateSample.addEventListener("calciteDatePickerChange", function (e) {
-      dateDisplay.innerHTML = e.detail;
-    });
-  </script>
-
-<h2>Date Range with Event</h2>
-<calcite-input-date-picker id="dateRangeSample" range ></calcite-input-date-picker>
-<div>
-  Start: <span id="startDisplay"></span>
-</div>
-<div>
-  End: <span id="endDisplay"></span>
-</div>
-<script>
-  var dateRangeSample = document.getElementById("dateRangeSample");
-  var startDisplay = document.getElementById("startDisplay");
-  var endDisplay = document.getElementById("endDisplay");
-  dateRangeSample.addEventListener("calciteDatePickerRangeChange", function (e) {
-    startDisplay.textContent = e.detail.startDate;
-    endDisplay.textContent = e.detail.endDate;
-  });
-</script>
-
-<div>
-  <h2>Small Date Range</h2>
-  <calcite-input-date-picker scale="s" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-  <div style="margin-top: 16px;">
-    <calcite-input-date-picker scale="s" layout="vertical" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-  </div>
-</div>
-
-<div>
-  <h2>Medium Date Range</h2>
-  <calcite-input-date-picker range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-  <div style="margin-top: 16px;">
-    <calcite-input-date-picker layout="vertical" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-  </div>
-</div>
-
-<div>
-  <h2>Large Date Range</h2>
-  <calcite-input-date-picker scale="l" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-  <div style="margin-top: 16px;">
-    <calcite-input-date-picker layout="vertical" scale="l" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-  </div>
-</div>
-
-
-<div dir="rtl" style="margin-bottom: 16px;">
-  <h2>Date Range RTL</h2>
-  <calcite-input-date-picker id="dateRangeSampleRtl" locale="ar-EG" dir="rtl" range  min="2020-01-03" max="2020-09-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-</div>
-
-  <div class="demo-background-dark">
-    <h1>Dark theme</h1>
-    <calcite-input-date-picker theme="dark" value="2019-08-23"></calcite-input-date-picker>
-
-    <h2>Range</h2>
-    <calcite-input-date-picker theme="dark" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
-    <div style="margin-top: 16px;">
-      <calcite-input-date-picker theme="dark" layout="vertical" range min="2020-01-03" max="2020-12-29" start="2020-09-08" end="2020-09-23"></calcite-input-date-picker>
+    <h2>Inside Small Container</h2>
+    <div style="width: 200px">
+      <calcite-input-date-picker value="2020-03-07" scale="s"></calcite-input-date-picker>
     </div>
-  </div>
-</body>
 
+    <h2>Locale formatted dates</h2>
+    <calcite-input-date-picker
+      value="2019-08-23"
+      min="2019-08-09"
+      max="2021-12-18"
+      locale="ja"
+      id="locale"
+    ></calcite-input-date-picker>
+    <calcite-dropdown id="localePicker">
+      <calcite-button slot="dropdown-trigger">Select Locale</calcite-button>
+      <calcite-dropdown-group>
+        <calcite-dropdown-item data-locale="ar">ar</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="bs">bs</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ca">ca</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="cs">cs</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="da">da</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="de-CH">de-CH</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="de">de</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="el">el</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en-AU">en-AU</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en-CA">en-CA</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en-GB">en-GB</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="en">en</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="es-MX">es-MX</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="es">es</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="et">et</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="fi">fi</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="fr-CH">fr-CH</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="fr">fr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="he">he</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="hi">hi</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="hr">hr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="hu">hu</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="id">id</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="it-CH">it-CH</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="it">it</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ja">ja</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ko">ko</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="lt">lt</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="lv">lv</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="mk">mk</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="nb">nb</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="nl">nl</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="pl">pl</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="pt-PT">pt-PT</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="pt">pt</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ro">ro</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="ru">ru</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sk">sk</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sl">sl</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sr">sr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="sv">sv</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="th">th</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="tr">tr</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="uk">uk</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="vi">vi</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="zh-CN">zh-CN</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="zh-HK">zh-HK</calcite-dropdown-item>
+        <calcite-dropdown-item data-locale="zh-TW">zh-TW</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+    <script>
+      document.getElementById("localePicker").addEventListener("calciteDropdownSelect", function (e) {
+        document.getElementById("locale").locale = e.target.selectedItems[0].getAttribute("data-locale");
+      });
+    </script>
+
+    <div dir="rtl">
+      <h2>Right to left, arabic numerals</h2>
+      <calcite-input-date-picker value="2000-11-27" locale="ar-EG" dir="rtl"></calcite-input-date-picker>
+    </div>
+
+    <h2>Set Value</h2>
+    <calcite-button id="dynamic-button">Set value of date input</calcite-button>
+    <calcite-input-date-picker id="dynamic-value" value="2000-11-27"></calcite-input-date-picker>
+    <script>
+      var dynamicDate = document.getElementById("dynamic-value");
+      document.getElementById("dynamic-button").addEventListener("click", function () {
+        console.log("setting value");
+        document.getElementById("dynamic-value").value = "2020-10-02";
+      });
+    </script>
+
+    <h2>Events</h2>
+    <calcite-input-date-picker id="dateSample"></calcite-input-date-picker>
+    <div>
+      Date selected:
+      <pre><code id="dateDisplay">n/a</code></pre>
+    </div>
+    <script>
+      var dateSample = document.getElementById("dateSample");
+      var dateDisplay = document.getElementById("dateDisplay");
+      dateSample.addEventListener("calciteDatePickerChange", function (e) {
+        dateDisplay.innerHTML = e.detail;
+      });
+    </script>
+
+    <h2>Date Range with Event</h2>
+    <calcite-input-date-picker id="dateRangeSample" range></calcite-input-date-picker>
+    <div>Start: <span id="startDisplay"></span></div>
+    <div>End: <span id="endDisplay"></span></div>
+    <script>
+      var dateRangeSample = document.getElementById("dateRangeSample");
+      var startDisplay = document.getElementById("startDisplay");
+      var endDisplay = document.getElementById("endDisplay");
+      dateRangeSample.addEventListener("calciteDatePickerRangeChange", function (e) {
+        startDisplay.textContent = e.detail.startDate;
+        endDisplay.textContent = e.detail.endDate;
+      });
+    </script>
+
+    <div>
+      <h2>Small Date Range</h2>
+      <calcite-input-date-picker
+        scale="s"
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-input-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-input-date-picker
+          scale="s"
+          layout="vertical"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-input-date-picker>
+      </div>
+    </div>
+
+    <div>
+      <h2>Medium Date Range</h2>
+      <calcite-input-date-picker
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-input-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-input-date-picker
+          layout="vertical"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-input-date-picker>
+      </div>
+    </div>
+
+    <div>
+      <h2>Large Date Range</h2>
+      <calcite-input-date-picker
+        scale="l"
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-input-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-input-date-picker
+          layout="vertical"
+          scale="l"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-input-date-picker>
+      </div>
+    </div>
+
+    <div dir="rtl" style="margin-bottom: 16px">
+      <h2>Date Range RTL</h2>
+      <calcite-input-date-picker
+        id="dateRangeSampleRtl"
+        locale="ar-EG"
+        dir="rtl"
+        range
+        min="2020-01-03"
+        max="2020-09-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-input-date-picker>
+    </div>
+
+    <div class="demo-background-dark">
+      <h1>Dark theme</h1>
+      <calcite-input-date-picker class="calcite-theme-dark" value="2019-08-23"></calcite-input-date-picker>
+
+      <h2>Range</h2>
+      <calcite-input-date-picker
+        class="calcite-theme-dark"
+        range
+        min="2020-01-03"
+        max="2020-12-29"
+        start="2020-09-08"
+        end="2020-09-23"
+      ></calcite-input-date-picker>
+      <div style="margin-top: 16px">
+        <calcite-input-date-picker
+          class="calcite-theme-dark"
+          layout="vertical"
+          range
+          min="2020-01-03"
+          max="2020-12-29"
+          start="2020-09-08"
+          end="2020-09-23"
+        ></calcite-input-date-picker>
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -12,7 +12,10 @@
         padding: 0 2rem;
         margin-bottom: 3rem;
       }
-      h1,h2,h3,h4 {
+      h1,
+      h2,
+      h3,
+      h4 {
         color: var(--calcite-ui-text-1);
       }
       .demo-background-dark {
@@ -21,7 +24,7 @@
         padding: 1rem;
       }
     </style>
-   <script src="./_assets/head.js"></script>
+    <script src="./_assets/head.js"></script>
     <script src="_assets/validateInput.js"></script>
   </head>
 
@@ -43,13 +46,11 @@
         </calcite-label>
       </div>
       <div>
-        <H3>With label status</H3>
+        <h3>With label status</h3>
         <calcite-label status="invalid">
           Invalid input
           <calcite-input placeholder="Filter your files" value="adfo2h2"></calcite-input>
-          <calcite-input-message active icon>
-            Something doesn't look right
-          </calcite-input-message>
+          <calcite-input-message active icon> Something doesn't look right </calcite-input-message>
         </calcite-label>
       </div>
       <div>
@@ -65,8 +66,15 @@
     </section>
 
     <form id="myForm">
-      <input minlength="2" maxlength="3" step="any"/>
-      <input minlength="2" maxlength="3" class="sc-calcite-input-h sc-calcite-input-s sc-calcite-input" value="" placeholder="" type="text" />
+      <input minlength="2" maxlength="3" step="any" />
+      <input
+        minlength="2"
+        maxlength="3"
+        class="sc-calcite-input-h sc-calcite-input-s sc-calcite-input"
+        value=""
+        placeholder=""
+        type="text"
+      />
       <calcite-input minLength="2" maxLength="3"></calcite-input>
       <input value="Initial" />
       <button>Submit</button>
@@ -240,7 +248,14 @@
             </calcite-label>
             <calcite-label>
               Number input clearable kitchen sync
-              <calcite-input value="2" prefix-text="pre" suffix-text="suf" clearable type="number" placeholder="How many apples?">
+              <calcite-input
+                value="2"
+                prefix-text="pre"
+                suffix-text="suf"
+                clearable
+                type="number"
+                placeholder="How many apples?"
+              >
                 <calcite-button slot="action">Go</calcite-button>
               </calcite-input>
             </calcite-label>
@@ -392,11 +407,7 @@
             <calcite-label>
               Readonly with prefix and button
               <calcite-input readonly prefix-text="API Key" value="A123-S5DL-24FA">
-                <calcite-button
-                  slot="action"
-                  onclick="alert('copied')"
-                  icon-start="copy-to-clipboard"
-                ></calcite-button>
+                <calcite-button slot="action" onclick="alert('copied')" icon-start="copy-to-clipboard"></calcite-button>
               </calcite-input>
             </calcite-label>
             <calcite-label>
@@ -525,7 +536,7 @@
               <calcite-input-message icon active status="idle">This is where we'll call you</calcite-input-message>
             </calcite-label>
             <calcite-card>
-              <div style="display:inline-flex; width: 100%; padding:var(--calcite-spacing-half) 0;">
+              <div style="display: inline-flex; width: 100%; padding: var(--calcite-spacing-half) 0">
                 <calcite-input-message icon active id="toggle-status">
                   Input message + status icon
                 </calcite-input-message>
@@ -533,7 +544,7 @@
                   Toggle status
                 </calcite-button>
               </div>
-              <div style="display:inline-flex; width: 100%; padding:var(--calcite-spacing-half) 0;">
+              <div style="display: inline-flex; width: 100%; padding: var(--calcite-spacing-half) 0">
                 <calcite-input-message icon active id="toggle-icon">
                   Input message + custom icon
                 </calcite-input-message>
@@ -554,7 +565,7 @@
                 }
                 function toggleIcon() {
                   let el = document.getElementById("toggle-icon");
-                  const iconOptions = ["banana","layer-basemap","arcgis-online","3d-glasses","add-layer","a-z"];
+                  const iconOptions = ["banana", "layer-basemap", "arcgis-online", "3d-glasses", "add-layer", "a-z"];
                   let num = Math.floor(Math.random() * Math.floor(iconOptions.length));
                   el.icon = iconOptions[num];
                 }
@@ -760,7 +771,14 @@
             </calcite-label>
             <calcite-label disabled>
               Number input clearable kitchen sync
-              <calcite-input value="2" prefix-text="pre" suffix-text="suf" clearable type="number" placeholder="How many apples?">
+              <calcite-input
+                value="2"
+                prefix-text="pre"
+                suffix-text="suf"
+                clearable
+                type="number"
+                placeholder="How many apples?"
+              >
                 <calcite-button slot="action">Go</calcite-button>
               </calcite-input>
             </calcite-label>
@@ -1007,15 +1025,15 @@
         "
       >
         <h3>In use - using custom emitted events and dark mode</h3>
-        <calcite-accordion active icon-position="start" selection-mode="multi" theme="dark">
+        <calcite-accordion active icon-position="start" selection-mode="multi" class="calcite-theme-dark">
           <calcite-accordion-item item-title="Register Event-listener example" active>
             <form name="form-input-example-2" id="form-input-example-2">
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Create username
                 <calcite-input id="validate-input-example-username" placeholder="Enter username" required>
                 </calcite-input>
               </calcite-label>
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Create username
                 <calcite-input
                   suffix-text="@maps.esri.com"
@@ -1025,12 +1043,12 @@
                 >
                 </calcite-input>
               </calcite-label>
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Create password
                 <calcite-input id="validate-input-example-password" type="password" placeholder="•••••">
                 </calcite-input>
               </calcite-label>
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Confirm password
                 <calcite-input id="validate-input-example-password-2" type="password" placeholder="•••••">
                 </calcite-input>
@@ -1053,7 +1071,7 @@
             <calcite-notice width="full" id="validate-input-example-native-function-blur-notice"> </calcite-notice>
             <calcite-notice width="full" id="validate-input-example-native-function-change-notice"> </calcite-notice>
             <form name="form-input-example-3" id="form-input-example-3">
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Create username (autofocus)
                 <calcite-input
                   focusIn="nativeInlineEventFocusIn()"
@@ -1065,12 +1083,12 @@
                 >
                 </calcite-input>
               </calcite-label>
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Create password
                 <calcite-input id="validate-input-example-native-function-password" type="password" placeholder="•••••">
                 </calcite-input>
               </calcite-label>
-              <calcite-label theme="dark">
+              <calcite-label class="calcite-theme-dark">
                 Confirm password
                 <calcite-input
                   id="validate-input-example-native-function-password-2"

--- a/src/demos/calcite-label.html
+++ b/src/demos/calcite-label.html
@@ -1,463 +1,496 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Label</title>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Label</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script src="_assets/validateInput.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+  </head>
 
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
-<script src="./_assets/head.js"></script>
-  <script src="_assets/validateInput.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Label</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Label</h1>
+    <demo-form>
+      <form name="calcite-label-demo-form">
+        <calcite-label layout="inline" disable-spacing>
+          <span style="margin-right: 0.75rem">Manual spacing for browsers that don't support flex gap</span>
+          <calcite-checkbox></calcite-checkbox>
+        </calcite-label>
 
-  <demo-form>
-    <form name="calcite-label-demo-form">
+        <calcite-label>
+          Leading text with default layout
+          <calcite-checkbox></calcite-checkbox>
+        </calcite-label>
 
-      <calcite-label layout="inline" disable-spacing>
-        <span style="margin-right: 0.75rem">Manual spacing for browsers that don't support flex gap</span>
-        <calcite-checkbox></calcite-checkbox>
-      </calcite-label>
+        <calcite-label>
+          <calcite-checkbox></calcite-checkbox>
+          Trailing text with default layout
+        </calcite-label>
 
-      <calcite-label>
-        Leading text with default layout
-        <calcite-checkbox></calcite-checkbox>
-      </calcite-label>
+        <calcite-label layout="inline">
+          Leading text with inline layout
+          <calcite-checkbox></calcite-checkbox>
+        </calcite-label>
 
-      <calcite-label>
-        <calcite-checkbox></calcite-checkbox>
-        Trailing text with default layout
-      </calcite-label>
+        <calcite-label layout="inline">
+          <calcite-checkbox></calcite-checkbox>
+          Trailing text with inline layout
+        </calcite-label>
 
-      <calcite-label layout="inline">
-        Leading text with inline layout
-        <calcite-checkbox></calcite-checkbox>
-      </calcite-label>
+        <calcite-label layout="inline-space-between">
+          Leading text with inline-space-between layout
+          <calcite-checkbox></calcite-checkbox>
+        </calcite-label>
 
-      <calcite-label layout="inline">
-        <calcite-checkbox></calcite-checkbox>
-        Trailing text with inline layout
-      </calcite-label>
+        <calcite-label layout="inline-space-between">
+          <calcite-checkbox></calcite-checkbox>
+          Trailing text with inline-space-between layout
+        </calcite-label>
 
-      <calcite-label layout="inline-space-between">
-        Leading text with inline-space-between layout
-        <calcite-checkbox></calcite-checkbox>
-      </calcite-label>
+        <h2>Wrapping Native Inputs</h2>
 
-      <calcite-label layout="inline-space-between">
-        <calcite-checkbox></calcite-checkbox>
-        Trailing text with inline-space-between layout
-      </calcite-label>
+        <calcite-label>
+          Calcite Label Wrapping Native Input
+          <input id="wrapping-input" name="wrapping-input" value="native input" />
+        </calcite-label>
 
-      <h2>Wrapping Native Inputs</h2>
+        <calcite-label for="wrapping-input-with-for">
+          Calcite Label Wrapping Native Input With For
+          <input id="wrapping-input-with-for" name="wrapping-input-with-for" value="native input" />
+        </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Native Input
-        <input id="wrapping-input" name="wrapping-input" value="native input">
-      </calcite-label>
+        <calcite-label>
+          Calcite Label Wrapping Native Textarea
+          <textarea id="wrapping-textarea" name="wrapping-textarea" value="native textarea"></textarea>
+        </calcite-label>
 
-      <calcite-label for="wrapping-input-with-for">
-        Calcite Label Wrapping Native Input With For
-        <input id="wrapping-input-with-for" name="wrapping-input-with-for" value="native input">
-      </calcite-label>
+        <calcite-label for="wrapping-textarea-with-for">
+          Calcite Label Wrapping Native Textarea With For
+          <textarea
+            id="wrapping-textarea-with-for"
+            name="wrapping-textarea-with-for"
+            value="native textarea"
+          ></textarea>
+        </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Native Textarea
-        <textarea id="wrapping-textarea" name="wrapping-textarea" value="native textarea"></textarea>
-      </calcite-label>
+        <calcite-label>
+          Calcite Label Wrapping Native Checkbox
+          <input id="wrapping-native-checkbox" type="checkbox" name="wrapping-native-checkbox" />
+        </calcite-label>
 
-      <calcite-label for="wrapping-textarea-with-for">
-        Calcite Label Wrapping Native Textarea With For
-        <textarea id="wrapping-textarea-with-for" name="wrapping-textarea-with-for" value="native textarea"></textarea>
-      </calcite-label>
+        <calcite-label for="wrapping-native-checkbox-with-for">
+          Calcite Label Wrapping Native Checkbox With For
+          <input id="wrapping-native-checkbox-with-for" type="checkbox" name="wrapping-native-checkbox-with-for" />
+        </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Native Checkbox
-        <input id="wrapping-native-checkbox" type="checkbox" name="wrapping-native-checkbox">
-      </calcite-label>
+        <calcite-label>
+          Calcite Label Wrapping Native Radio Group
+          <input type="radio" name="wrapping-native-radio" value="one" />
+          <input type="radio" name="wrapping-native-radio" value="two" />
+        </calcite-label>
 
-      <calcite-label for="wrapping-native-checkbox-with-for">
-        Calcite Label Wrapping Native Checkbox With For
-        <input id="wrapping-native-checkbox-with-for" type="checkbox" name="wrapping-native-checkbox-with-for">
-      </calcite-label>
+        <calcite-label for="wrapping-native-radio-with-for">
+          Calcite Label Wrapping Native Radio Group With For
+          <input id="wrapping-native-radio-with-for" type="radio" name="wrapping-native-radio-with-for" value="one" />
+          <input type="radio" name="wrapping-native-radio-with-for" value="two" />
+        </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Native Radio Group
-        <input type="radio" name="wrapping-native-radio" value="one">
-        <input type="radio" name="wrapping-native-radio" value="two">
-      </calcite-label>
+        <calcite-label>
+          Calcite Label Wrapping Native Select
+          <select name="wrapping-native-select">
+            <option value="volvo">Volvo</option>
+            <option value="saab">Saab</option>
+            <option value="mercedes">Mercedes</option>
+            <option value="audi">Audi</option>
+          </select>
+        </calcite-label>
 
-      <calcite-label for="wrapping-native-radio-with-for">
-        Calcite Label Wrapping Native Radio Group With For
-        <input id="wrapping-native-radio-with-for" type="radio" name="wrapping-native-radio-with-for" value="one">
-        <input type="radio" name="wrapping-native-radio-with-for" value="two">
-      </calcite-label>
+        <calcite-label for="wrapping-native-select-with-for">
+          Calcite Label Wrapping Native Select With For
+          <select id="wrapping-native-select-with-for" name="wrapping-native-select-with-for">
+            <option value="volvo">Volvo</option>
+            <option value="saab">Saab</option>
+            <option value="mercedes">Mercedes</option>
+            <option value="audi">Audi</option>
+          </select>
+        </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Native Select
-        <select name="wrapping-native-select">
+        <calcite-label>
+          Calcite Label Wrapping Native Button
+          <button id="wrapping-native-button" type="button">Native Button</button>
+        </calcite-label>
+
+        <calcite-label for="wrapping-native-button-with-for">
+          Calcite Label Wrapping Native Button With For
+          <button id="wrapping-native-button-with-for" type="button">Native Button</button>
+        </calcite-label>
+
+        <h2>Wrapping Calcite Inputs</h2>
+
+        <calcite-label>
+          Calcite Label Wrapping Calcite Button
+          <calcite-button id="wrapping-calcite-button" name="wrapping-calcite-button" type="button"
+            >Calcite Button</calcite-button
+          >
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-button-with-for">
+          Calcite Label Wrapping Calcite Button With For
+          <calcite-button id="wrapping-calcite-button-with-for" name="wrapping-calcite-button-with-for" type="button">
+            Native Button</calcite-button
+          >
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label Wrapping Calcite Checkbox
+          <calcite-checkbox id="wrapping-calcite-checkbox" name="wrapping-calcite-checkbox"> </calcite-checkbox>
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-checkbox-with-for">
+          Calcite Label Wrapping Calcite Checkbox With For
+          <calcite-checkbox id="wrapping-calcite-checkbox-with-for" name="wrapping-calcite-checkbox-with-for">
+          </calcite-checkbox>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label wrapping Calcite Date
+          <calcite-input-date-picker></calcite-input-date-picker>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label wrapping Calcite Inline Editable
+          <calcite-inline-editable>
+            <calcite-input> </calcite-input>
+          </calcite-inline-editable>
+          <calcite-input-message> My great input message </calcite-input-message>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label Wrapping Calcite Input
+          <calcite-input id="wrapping-calcite-input" name="wrapping-calcite-input"> </calcite-input>
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-input-with-for">
+          Calcite Label Wrapping Calcite Input With For
+          <calcite-input id="wrapping-calcite-input-with-for" name="wrapping-calcite-input-with-for"></calcite-input>
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-input-with-for-text-wrapped">
+          <span>Calcite Label Wrapping Calcite Input With For and Label Text is Wrapped in span</span>
+          <calcite-input
+            id="wrapping-calcite-input-with-for-text-wrapped"
+            name="wrapping-calcite-input-with-for-text-wrapped"
+          ></calcite-input>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label Wrapping Calcite Radio Buttons
+          <calcite-radio-button name="wrapping-calcite-radio" value="one"></calcite-radio-button>
+          <calcite-radio-button name="wrapping-calcite-radio" value="two"></calcite-radio-button>
+        </calcite-label>
+
+        <calcite-label>
+          <span>Calcite Label wrapped in span Wrapping Calcite Radio Buttons</span>
+          <calcite-radio-button name="wrapping-calcite-radio-label-in-span" value="one"></calcite-radio-button>
+          <calcite-radio-button name="wrapping-calcite-radio-label-in-span" value="two"></calcite-radio-button>
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-radio-with-for">
+          Calcite Label Wrapping Calcite Radio Buttons With For
+          <calcite-radio-button id="wrapping-calcite-radio-with-for" name="wrapping-calcite-radio-with-for" value="one">
+          </calcite-radio-button>
+          <calcite-radio-button name="wrapping-calcite-radio-with-for" value="two"></calcite-radio-button>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label Wrapping Calcite Radio Button Group
+          <calcite-radio-button-group name="wrapping-calcite-radio-button-group">
+            <calcite-radio-button value="one"></calcite-radio-button>
+            <calcite-radio-button value="two"></calcite-radio-button>
+          </calcite-radio-button-group>
+        </calcite-label>
+
+        <calcite-label>
+          <span>Calcite Label wrapped in span Wrapping Calcite Radio Button Group</span>
+          <calcite-radio-button-group name="wrapping-calcite-radio-button-group-span">
+            <calcite-radio-button value="one"></calcite-radio-button>
+            <calcite-radio-button value="two"></calcite-radio-button>
+          </calcite-radio-button-group>
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-radio-button-group-with-for">
+          Calcite Label Wrapping Calcite Radio Button Group With For
+          <calcite-radio-button-group name="wrapping-calcite-radio-button-group-with-for">
+            <calcite-radio-button id="wrapping-calcite-radio-button-group-with-for" value="one"></calcite-radio-button>
+            <calcite-radio-button value="two"></calcite-radio-button>
+          </calcite-radio-button-group>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label wrapping a Calcite Radio Group
+          <calcite-radio-group>
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label Wrapping Calcite Select
+          <calcite-select label="calcite select" name="wrapping-calcite-select">
+            <calcite-option>high</calcite-option>
+            <calcite-option>medium</calcite-option>
+            <calcite-option>low</calcite-option>
+          </calcite-select>
+        </calcite-label>
+
+        <calcite-label for="wrapping-calcite-select-with-for">
+          Calcite Label Wrapping Calcite Select With For
+          <calcite-select
+            label="calcite select"
+            id="wrapping-calcite-select-with-for"
+            name="wrapping-calcite-select-with-for"
+          >
+            <calcite-option>high</calcite-option>
+            <calcite-option>medium</calcite-option>
+            <calcite-option>low</calcite-option>
+          </calcite-select>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label wrapping a Calcite Slider
+          <calcite-slider></calcite-slider>
+        </calcite-label>
+
+        <calcite-label>
+          Calcite Label wrapping a Calcite Switch
+          <calcite-switch></calcite-switch>
+        </calcite-label>
+
+        <h2>Sibling to Native Inputs</h2>
+
+        <calcite-label for="sibling-native-input">Sibling Calcite Label to Native Input</calcite-label>
+        <input id="sibling-native-input" value="native input" />
+
+        <calcite-label for="sibling-native-input-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Native Input</span></calcite-label
+        >
+        <input id="sibling-native-input-wrapped-in-span" value="native input" />
+
+        <calcite-label for="sibling-native-textarea">Sibling Calcite Label to Native Text Area</calcite-label>
+        <textarea id="sibling-native-textarea" value="native textarea">native textarea</textarea>
+
+        <calcite-label for="sibling-native-textarea-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Native Text Area</span></calcite-label
+        >
+        <textarea id="sibling-native-textarea-wrapped-in-span" value="native textarea">native textarea</textarea>
+
+        <calcite-label for="sibling-native-checkbox">Sibling Calcite Label to Native Checkbox</calcite-label>
+        <input id="sibling-native-checkbox" type="checkbox" name="sibling-native-checkbox" />
+
+        <calcite-label for="sibling-native-checkbox-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Native Checkbox</span></calcite-label
+        >
+        <input
+          id="sibling-native-checkbox-wrapped-in-span"
+          type="checkbox"
+          name="sibling-native-checkbox-wrapped-in-span"
+        />
+
+        <calcite-label for="sibling-native-radio">Sibling Calcite Label to Native Radio Buttons</calcite-label>
+        <input id="sibling-native-radio" type="radio" name="sibling-native-radio" />
+        <input type="radio" name="sibling-native-radio" />
+
+        <calcite-label for="sibling-native-radio-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Native Radio Buttons</span></calcite-label
+        >
+        <input id="sibling-native-radio-wrapped-in-span" type="radio" name="sibling-native-radio-wrapped-in-span" />
+        <input type="radio" name="sibling-native-radio-wrapped-in-span" />
+
+        <calcite-label for="sibling-native-select">Sibling Calcite Label to Native Select</calcite-label>
+        <select id="sibling-native-select" name="sibling-native-select">
           <option value="volvo">Volvo</option>
           <option value="saab">Saab</option>
           <option value="mercedes">Mercedes</option>
           <option value="audi">Audi</option>
         </select>
-      </calcite-label>
 
-      <calcite-label for="wrapping-native-select-with-for">
-        Calcite Label Wrapping Native Select With For
-        <select id="wrapping-native-select-with-for" name="wrapping-native-select-with-for">
+        <calcite-label for="sibling-native-select-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Native Select</span></calcite-label
+        >
+        <select id="sibling-native-select-wrapped-in-span" name="sibling-native-select-wrapped-in-span">
           <option value="volvo">Volvo</option>
           <option value="saab">Saab</option>
           <option value="mercedes">Mercedes</option>
           <option value="audi">Audi</option>
         </select>
-      </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Native Button
-        <button id="wrapping-native-button" type="button">Native Button</button>
-      </calcite-label>
+        <calcite-label for="sibling-native-button">Sibling Calcite Label to Native Button</calcite-label>
+        <button id="sibling-native-button" type="button">Native Button</button>
 
-      <calcite-label for="wrapping-native-button-with-for">
-        Calcite Label Wrapping Native Button With For
-        <button id="wrapping-native-button-with-for" type="button">Native Button</button>
-      </calcite-label>
+        <calcite-label for="sibling-native-button-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Native Button</span></calcite-label
+        >
+        <button id="sibling-native-button-wrapped-in-span" type="button">Native Button</button>
 
-      <h2>Wrapping Calcite Inputs</h2>
+        <h2>Sibling to Calcite Inputs</h2>
 
-      <calcite-label>
-        Calcite Label Wrapping Calcite Button
-        <calcite-button id="wrapping-calcite-button" name="wrapping-calcite-button" type="button">Calcite
-          Button</calcite-button>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-button">Sibling Calcite Label to Calcite Button</calcite-label>
+        <calcite-button id="sibling-calcite-button" type="button">Calcite Button</calcite-button>
 
-      <calcite-label for="wrapping-calcite-button-with-for">
-        Calcite Label Wrapping Calcite Button With For
-        <calcite-button id="wrapping-calcite-button-with-for" name="wrapping-calcite-button-with-for" type="button">
-          Native Button</calcite-button>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-button-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Calcite Button</span></calcite-label
+        >
+        <calcite-button id="sibling-calcite-button-wrapped-in-span" type="button">Calcite Button</calcite-button>
 
-      <calcite-label>
-        Calcite Label Wrapping Calcite Checkbox
-        <calcite-checkbox id="wrapping-calcite-checkbox" name="wrapping-calcite-checkbox">
-        </calcite-checkbox>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-checkbox">Sibling Calcite Label to Calcite Checkbox</calcite-label>
+        <calcite-checkbox id="sibling-calcite-checkbox" name="sibling-calcite-checkbox"></calcite-checkbox>
 
-      <calcite-label for="wrapping-calcite-checkbox-with-for">
-        Calcite Label Wrapping Calcite Checkbox With For
-        <calcite-checkbox id="wrapping-calcite-checkbox-with-for" name="wrapping-calcite-checkbox-with-for">
-        </calcite-checkbox>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-checkbox-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Calcite Checkbox</span></calcite-label
+        >
+        <calcite-checkbox
+          id="sibling-calcite-checkbox-wrapped-in-span"
+          name="sibling-calcite-checkbox-wrapped-in-span"
+        ></calcite-checkbox>
 
-      <calcite-label>
-        Calcite Label wrapping Calcite Date
-        <calcite-input-date-picker></calcite-input-date-picker>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-date"> Sibling Calcite Label to Calcite Date </calcite-label>
+        <calcite-input-date-picker id="sibling-calcite-date"></calcite-input-date-picker>
 
-      <calcite-label>
-        Calcite Label wrapping Calcite Inline Editable
-        <calcite-inline-editable>
-          <calcite-input>
-          </calcite-input>
+        <calcite-label for="sibling-calcite-date-wrapped-in-span">
+          <span>Sibling Calcite Label wrapped in span to Calcite Date</span>
+        </calcite-label>
+        <calcite-input-date-picker id="sibling-calcite-date-wrapped-in-span"></calcite-input-date-picker>
+
+        <calcite-label for="sibling-calcite-inline-editable">
+          Sibling Calcite Label to Calcite Inline Editable
+        </calcite-label>
+        <calcite-inline-editable id="sibling-calcite-inline-editable">
+          <calcite-input></calcite-input>
         </calcite-inline-editable>
-        <calcite-input-message>
-          My great input message
-        </calcite-input-message>
-      </calcite-label>
+        <calcite-input-message> My great input message </calcite-input-message>
 
-      <calcite-label>
-        Calcite Label Wrapping Calcite Input
-        <calcite-input id="wrapping-calcite-input" name="wrapping-calcite-input">
-        </calcite-input>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-inline-editable-wrapped-in-span">
+          <span>Sibling Calcite Label wrapped in span to Calcite Inline Editable</span>
+        </calcite-label>
+        <calcite-inline-editable id="sibling-calcite-inline-editable-wrapped-in-span">
+          <calcite-input></calcite-input>
+        </calcite-inline-editable>
+        <calcite-input-message> My great input message </calcite-input-message>
 
-      <calcite-label for="wrapping-calcite-input-with-for">
-        Calcite Label Wrapping Calcite Input With For
-        <calcite-input id="wrapping-calcite-input-with-for" name="wrapping-calcite-input-with-for"></calcite-input>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-input">Sibling Calcite Label to Calcite Input</calcite-label>
+        <calcite-input id="sibling-calcite-input" value="calcite input"></calcite-input>
 
-      <calcite-label for="wrapping-calcite-input-with-for-text-wrapped">
-        <span>Calcite Label Wrapping Calcite Input With For and Label Text is Wrapped in span</span>
-        <calcite-input id="wrapping-calcite-input-with-for-text-wrapped"
-          name="wrapping-calcite-input-with-for-text-wrapped"></calcite-input>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-input-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Calcite Input</span></calcite-label
+        >
+        <calcite-input id="sibling-calcite-input-wrapped-in-span" value="calcite input"></calcite-input>
 
-      <calcite-label>
-        Calcite Label Wrapping Calcite Radio Buttons
-        <calcite-radio-button name="wrapping-calcite-radio" value="one"></calcite-radio-button>
-        <calcite-radio-button name="wrapping-calcite-radio" value="two"></calcite-radio-button>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-radio">Sibling Calcite Label to Calcite Radio Buttons</calcite-label>
+        <calcite-radio-button
+          value="one"
+          id="sibling-calcite-radio"
+          name="sibling-calcite-radio"
+        ></calcite-radio-button>
+        <calcite-radio-button value="two" name="sibling-calcite-radio"></calcite-radio-button>
 
-      <calcite-label>
-        <span>Calcite Label wrapped in span Wrapping Calcite Radio Buttons</span>
-        <calcite-radio-button name="wrapping-calcite-radio-label-in-span" value="one"></calcite-radio-button>
-        <calcite-radio-button name="wrapping-calcite-radio-label-in-span" value="two"></calcite-radio-button>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-radio-wrapped-in-span"
+          ><span>Sibling Calcite Label wrapped in span to Calcite Radio Buttons</span></calcite-label
+        >
+        <calcite-radio-button
+          value="one"
+          id="sibling-calcite-radio-wrapped-in-span"
+          name="sibling-calcite-radio-wrapped-in-span"
+        ></calcite-radio-button>
+        <calcite-radio-button value="two" name="sibling-calcite-radio-wrapped-in-span"></calcite-radio-button>
 
-      <calcite-label for="wrapping-calcite-radio-with-for">
-        Calcite Label Wrapping Calcite Radio Buttons With For
-        <calcite-radio-button id="wrapping-calcite-radio-with-for" name="wrapping-calcite-radio-with-for" value="one">
-        </calcite-radio-button>
-        <calcite-radio-button name="wrapping-calcite-radio-with-for" value="two"></calcite-radio-button>
-      </calcite-label>
-
-      <calcite-label>
-        Calcite Label Wrapping Calcite Radio Button Group
-        <calcite-radio-button-group name="wrapping-calcite-radio-button-group">
+        <calcite-label for="sibling-calcite-radio-button-group">
+          Sibling Calcite Label to Calcite Radio Button Group
+        </calcite-label>
+        <calcite-radio-button-group id="sibling-calcite-radio-button-group" name="sibling-calcite-radio-button-group">
           <calcite-radio-button value="one"></calcite-radio-button>
           <calcite-radio-button value="two"></calcite-radio-button>
         </calcite-radio-button-group>
-      </calcite-label>
 
-      <calcite-label>
-        <span>Calcite Label wrapped in span Wrapping Calcite Radio Button Group</span>
-        <calcite-radio-button-group name="wrapping-calcite-radio-button-group-span">
+        <calcite-label for="sibling-calcite-radio-button-group-span">
+          <span>Calcite Label wrapped in span sibling Calcite Radio Button Group</span>
+        </calcite-label>
+        <calcite-radio-button-group
+          id="sibling-calcite-radio-button-group-span"
+          name="sibling-calcite-radio-button-group-span"
+        >
           <calcite-radio-button value="one"></calcite-radio-button>
           <calcite-radio-button value="two"></calcite-radio-button>
         </calcite-radio-button-group>
-      </calcite-label>
 
-      <calcite-label for="wrapping-calcite-radio-button-group-with-for">
-        Calcite Label Wrapping Calcite Radio Button Group With For
-        <calcite-radio-button-group name="wrapping-calcite-radio-button-group-with-for">
-          <calcite-radio-button id="wrapping-calcite-radio-button-group-with-for" value="one"></calcite-radio-button>
-          <calcite-radio-button value="two"></calcite-radio-button>
-        </calcite-radio-button-group>
-      </calcite-label>
-
-      <calcite-label>
-        Calcite Label wrapping a Calcite Radio Group
-        <calcite-radio-group>
+        <calcite-label for="sibling-calcite-radio-group"> Sibling Calcite Label to Calcite Radio Group </calcite-label>
+        <calcite-radio-group id="sibling-calcite-radio-group">
           <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
           <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
           <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
         </calcite-radio-group>
-      </calcite-label>
 
-      <calcite-label>
-        Calcite Label Wrapping Calcite Select
-        <calcite-select label="calcite select" name="wrapping-calcite-select">
+        <calcite-label for="sibling-calcite-radio-group-wrapped-in-span">
+          <span>Sibling Calcite Label wrapped in span to Calcite Radio Group</span>
+        </calcite-label>
+        <calcite-radio-group id="sibling-calcite-radio-group-wrapped-in-span">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        </calcite-radio-group>
+
+        <calcite-label for="sibling-calcite-select">Sibling Calcite Label to Calcite Select</calcite-label>
+        <calcite-select label="calcite select" id="sibling-calcite-select" name="sibling-calcite-select">
           <calcite-option>high</calcite-option>
           <calcite-option>medium</calcite-option>
           <calcite-option>low</calcite-option>
         </calcite-select>
-      </calcite-label>
 
-      <calcite-label for="wrapping-calcite-select-with-for">
-        Calcite Label Wrapping Calcite Select With For
-        <calcite-select label="calcite select" id="wrapping-calcite-select-with-for" name="wrapping-calcite-select-with-for">
+        <calcite-label for="sibling-calcite-select-wrapped-in-span">
+          <span>Sibling Calcite Label wrapped in span to Calcite Select</span>
+        </calcite-label>
+        <calcite-select
+          label="calcite select"
+          id="sibling-calcite-select-wrapped-in-span"
+          name="sibling-calcite-select-wrapped-in-span"
+        >
           <calcite-option>high</calcite-option>
           <calcite-option>medium</calcite-option>
           <calcite-option>low</calcite-option>
         </calcite-select>
-      </calcite-label>
 
-      <calcite-label>
-        Calcite Label wrapping a Calcite Slider
-        <calcite-slider></calcite-slider>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-slider"> Sibling Calcite Label to Calcite Slider </calcite-label>
+        <calcite-slider id="sibling-calcite-slider"></calcite-slider>
 
-      <calcite-label>
-        Calcite Label wrapping a Calcite Switch
-        <calcite-switch></calcite-switch>
-      </calcite-label>
+        <calcite-label for="sibling-calcite-slider-wrapped-in-span">
+          <span>Sibling Calcite Label wrapped in span to Calcite Slider</span>
+        </calcite-label>
+        <calcite-slider id="sibling-calcite-slider-wrapped-in-span"></calcite-slider>
 
-      <h2>Sibling to Native Inputs</h2>
+        <calcite-label for="sibling-calcite-switch"> Sibling Calcite Label to Calcite Switch </calcite-label>
+        <calcite-switch id="sibling-calcite-switch"></calcite-switch>
 
-      <calcite-label for="sibling-native-input">Sibling Calcite Label to Native Input</calcite-label>
-      <input id="sibling-native-input" value="native input">
+        <calcite-label for="sibling-calcite-switch-wrapped-in-span">
+          <span>Sibling Calcite Label wrapped in span to Calcite Switch</span>
+        </calcite-label>
+        <calcite-switch id="sibling-calcite-switch-wrapped-in-span"></calcite-switch>
 
-      <calcite-label for="sibling-native-input-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Native Input</span></calcite-label>
-      <input id="sibling-native-input-wrapped-in-span" value="native input">
-
-      <calcite-label for="sibling-native-textarea">Sibling Calcite Label to Native Text Area</calcite-label>
-      <textarea id="sibling-native-textarea" value="native textarea">native textarea</textarea>
-
-      <calcite-label for="sibling-native-textarea-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Native Text Area</span></calcite-label>
-      <textarea id="sibling-native-textarea-wrapped-in-span" value="native textarea">native textarea</textarea>
-
-      <calcite-label for="sibling-native-checkbox">Sibling Calcite Label to Native Checkbox</calcite-label>
-      <input id="sibling-native-checkbox" type="checkbox" name="sibling-native-checkbox">
-
-      <calcite-label for="sibling-native-checkbox-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Native Checkbox</span></calcite-label>
-      <input id="sibling-native-checkbox-wrapped-in-span" type="checkbox" name="sibling-native-checkbox-wrapped-in-span">
-
-      <calcite-label for="sibling-native-radio">Sibling Calcite Label to Native Radio Buttons</calcite-label>
-      <input id="sibling-native-radio" type="radio" name="sibling-native-radio">
-      <input type="radio" name="sibling-native-radio">
-
-      <calcite-label for="sibling-native-radio-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Native Radio Buttons</span></calcite-label>
-      <input id="sibling-native-radio-wrapped-in-span" type="radio" name="sibling-native-radio-wrapped-in-span">
-      <input type="radio" name="sibling-native-radio-wrapped-in-span">
-
-      <calcite-label for="sibling-native-select">Sibling Calcite Label to Native Select</calcite-label>
-      <select id="sibling-native-select" name="sibling-native-select">
-        <option value="volvo">Volvo</option>
-        <option value="saab">Saab</option>
-        <option value="mercedes">Mercedes</option>
-        <option value="audi">Audi</option>
-      </select>
-
-      <calcite-label for="sibling-native-select-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Native Select</span></calcite-label>
-      <select id="sibling-native-select-wrapped-in-span" name="sibling-native-select-wrapped-in-span">
-        <option value="volvo">Volvo</option>
-        <option value="saab">Saab</option>
-        <option value="mercedes">Mercedes</option>
-        <option value="audi">Audi</option>
-      </select>
-
-      <calcite-label for="sibling-native-button">Sibling Calcite Label to Native Button</calcite-label>
-      <button id="sibling-native-button" type="button">Native Button</button>
-
-      <calcite-label for="sibling-native-button-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Native Button</span></calcite-label>
-      <button id="sibling-native-button-wrapped-in-span" type="button">Native Button</button>
-
-      <h2>Sibling to Calcite Inputs</h2>
-
-      <calcite-label for="sibling-calcite-button">Sibling Calcite Label to Calcite Button</calcite-label>
-      <calcite-button id="sibling-calcite-button" type="button">Calcite Button</calcite-button>
-
-      <calcite-label for="sibling-calcite-button-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Calcite Button</span></calcite-label>
-      <calcite-button id="sibling-calcite-button-wrapped-in-span" type="button">Calcite Button</calcite-button>
-
-      <calcite-label for="sibling-calcite-checkbox">Sibling Calcite Label to Calcite Checkbox</calcite-label>
-      <calcite-checkbox id="sibling-calcite-checkbox" name="sibling-calcite-checkbox"></calcite-checkbox>
-
-      <calcite-label for="sibling-calcite-checkbox-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Calcite Checkbox</span></calcite-label>
-      <calcite-checkbox id="sibling-calcite-checkbox-wrapped-in-span" name="sibling-calcite-checkbox-wrapped-in-span"></calcite-checkbox>
-
-      <calcite-label for="sibling-calcite-date">
-        Sibling Calcite Label to Calcite Date
-      </calcite-label>
-      <calcite-input-date-picker id="sibling-calcite-date"></calcite-input-date-picker>
-
-      <calcite-label for="sibling-calcite-date-wrapped-in-span">
-        <span>Sibling Calcite Label wrapped in span to Calcite Date</span>
-      </calcite-label>
-      <calcite-input-date-picker id="sibling-calcite-date-wrapped-in-span"></calcite-input-date-picker>
-
-      <calcite-label for="sibling-calcite-inline-editable">
-        Sibling Calcite Label to Calcite Inline Editable
-      </calcite-label>
-      <calcite-inline-editable id="sibling-calcite-inline-editable">
-        <calcite-input></calcite-input>
-      </calcite-inline-editable>
-      <calcite-input-message>
-        My great input message
-      </calcite-input-message>
-
-      <calcite-label for="sibling-calcite-inline-editable-wrapped-in-span">
-        <span>Sibling Calcite Label wrapped in span to Calcite Inline Editable</span>
-      </calcite-label>
-      <calcite-inline-editable id="sibling-calcite-inline-editable-wrapped-in-span">
-        <calcite-input></calcite-input>
-      </calcite-inline-editable>
-      <calcite-input-message>
-        My great input message
-      </calcite-input-message>
-
-      <calcite-label for="sibling-calcite-input">Sibling Calcite Label to Calcite Input</calcite-label>
-      <calcite-input id="sibling-calcite-input" value="calcite input"></calcite-input>
-
-      <calcite-label for="sibling-calcite-input-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Calcite Input</span></calcite-label>
-      <calcite-input id="sibling-calcite-input-wrapped-in-span" value="calcite input"></calcite-input>
-
-      <calcite-label for="sibling-calcite-radio">Sibling Calcite Label to Calcite Radio Buttons</calcite-label>
-      <calcite-radio-button value="one" id="sibling-calcite-radio" name="sibling-calcite-radio"></calcite-radio-button>
-      <calcite-radio-button value="two" name="sibling-calcite-radio"></calcite-radio-button>
-
-      <calcite-label for="sibling-calcite-radio-wrapped-in-span"><span>Sibling Calcite Label wrapped in span to Calcite Radio Buttons</span></calcite-label>
-      <calcite-radio-button value="one" id="sibling-calcite-radio-wrapped-in-span" name="sibling-calcite-radio-wrapped-in-span"></calcite-radio-button>
-      <calcite-radio-button value="two" name="sibling-calcite-radio-wrapped-in-span"></calcite-radio-button>
-
-      <calcite-label for="sibling-calcite-radio-button-group">
-        Sibling Calcite Label to Calcite Radio Button Group
-      </calcite-label>
-      <calcite-radio-button-group id="sibling-calcite-radio-button-group" name="sibling-calcite-radio-button-group">
-        <calcite-radio-button value="one"></calcite-radio-button>
-        <calcite-radio-button value="two"></calcite-radio-button>
-      </calcite-radio-button-group>
-
-      <calcite-label for="sibling-calcite-radio-button-group-span">
-        <span>Calcite Label wrapped in span sibling Calcite Radio Button Group</span>
-      </calcite-label>
-      <calcite-radio-button-group id="sibling-calcite-radio-button-group-span" name="sibling-calcite-radio-button-group-span">
-        <calcite-radio-button value="one"></calcite-radio-button>
-        <calcite-radio-button value="two"></calcite-radio-button>
-      </calcite-radio-button-group>
-
-      <calcite-label for="sibling-calcite-radio-group">
-        Sibling Calcite Label to Calcite Radio Group
-      </calcite-label>
-      <calcite-radio-group id="sibling-calcite-radio-group">
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      </calcite-radio-group>
-
-      <calcite-label for="sibling-calcite-radio-group-wrapped-in-span">
-        <span>Sibling Calcite Label wrapped in span to Calcite Radio Group</span>
-      </calcite-label>
-      <calcite-radio-group id="sibling-calcite-radio-group-wrapped-in-span">
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      </calcite-radio-group>
-
-      <calcite-label for="sibling-calcite-select">Sibling Calcite Label to Calcite Select</calcite-label>
-      <calcite-select label="calcite select" id="sibling-calcite-select" name="sibling-calcite-select">
-        <calcite-option>high</calcite-option>
-        <calcite-option>medium</calcite-option>
-        <calcite-option>low</calcite-option>
-      </calcite-select>
-
-      <calcite-label for="sibling-calcite-select-wrapped-in-span">
-        <span>Sibling Calcite Label wrapped in span to Calcite Select</span>
-      </calcite-label>
-      <calcite-select label="calcite select" id="sibling-calcite-select-wrapped-in-span" name="sibling-calcite-select-wrapped-in-span">
-        <calcite-option>high</calcite-option>
-        <calcite-option>medium</calcite-option>
-        <calcite-option>low</calcite-option>
-      </calcite-select>
-
-      <calcite-label for="sibling-calcite-slider">
-        Sibling Calcite Label to Calcite Slider
-      </calcite-label>
-      <calcite-slider id="sibling-calcite-slider"></calcite-slider>
-
-      <calcite-label for="sibling-calcite-slider-wrapped-in-span">
-        <span>Sibling Calcite Label wrapped in span to Calcite Slider</span>
-      </calcite-label>
-      <calcite-slider id="sibling-calcite-slider-wrapped-in-span"></calcite-slider>
-
-      <calcite-label for="sibling-calcite-switch">
-        Sibling Calcite Label to Calcite Switch
-      </calcite-label>
-      <calcite-switch id="sibling-calcite-switch"></calcite-switch>
-
-      <calcite-label for="sibling-calcite-switch-wrapped-in-span">
-        <span>Sibling Calcite Label wrapped in span to Calcite Switch</span>
-      </calcite-label>
-      <calcite-switch id="sibling-calcite-switch-wrapped-in-span"></calcite-switch>
-
-      <p>
-        <calcite-button type="submit">Submit</calcite-button>
-      </p>
-
-    </form>
-  </demo-form>
-</body>
-
+        <p>
+          <calcite-button type="submit">Submit</calcite-button>
+        </p>
+      </form>
+    </demo-form>
+  </body>
 </html>

--- a/src/demos/calcite-link.html
+++ b/src/demos/calcite-link.html
@@ -1,85 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Link</title>
+    <style>
+      .sticky-example {
+        position: -webkit-sticky;
+        position: sticky;
+        bottom: 20px;
+        margin: 0 auto;
+      }
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Link</title>
-  <style>
-    .sticky-example {
-      position: -webkit-sticky;
-      position: sticky;
-      bottom: 20px;
-      margin: 0 auto;
-    }
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script src="_assets/loadingButton.js"></script>
+  </head>
 
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
-<script src="./_assets/head.js"></script>
-  <script src="_assets/loadingButton.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Link</h1>
+    <h4>calcite-link has no scale - it inherits font size from its container</h4>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Link</h1>
-  <h4>calcite-link has no scale - it inherits font size from its container</h4>
+    <h3>Set focus</h3>
+    <calcite-button onclick="document.querySelector('#button-focus-example-1').setFocus()">focus span </calcite-button>
+    <calcite-button onclick="document.querySelector('#button-focus-example-2').setFocus()">focus a </calcite-button>
+    <h4>Receive focus</h4>
 
-  <h3>Set focus</h3>
-  <calcite-button onclick="document.querySelector('#button-focus-example-1').setFocus()">focus span
-  </calcite-button>
-  <calcite-button onclick="document.querySelector('#button-focus-example-2').setFocus()">focus a
-  </calcite-button>
-  <h4>Receive focus</h4>
+    <calcite-link id="button-focus-example-1">span to gain focus</calcite-link>
+    <br />
+    <calcite-link id="button-focus-example-2" href="http://google.com">anchor to gain focus</calcite-link>
 
-  <calcite-link id="button-focus-example-1">span to gain focus</calcite-link>
-  <br />
-  <calcite-link id="button-focus-example-2" href="http://google.com">anchor to gain focus</calcite-link>
+    <br />
 
-  <br />
+    <h3>Tooltip trigger</h3>
+    <calcite-tooltip-manager>
+      <calcite-link icon-start="information" id="tooltip-example">span to gain focus</calcite-link>
+    </calcite-tooltip-manager>
+    <calcite-tooltip label="top placed tooltip" placement="top" reference-element="tooltip-example"
+      >Lorem Ipsum is simply of the printing and typesetting industry. Lorem Ipsum has been the industry's standard
+      printer of type and scrambled it to make a type specimen book.</calcite-tooltip
+    >
+    <h3>Icons</h3>
 
-  <h3>Tooltip trigger</h3>
-  <calcite-tooltip-manager>
-    <calcite-link icon-start="information" id="tooltip-example">span to gain focus</calcite-link>
-  </calcite-tooltip-manager>
-  <calcite-tooltip label="top placed tooltip" placement="top" reference-element="tooltip-example">Lorem Ipsum is simply
-    of the printing and typesetting industry. Lorem Ipsum has been the industry's standard printer of type and
-    scrambled it to make a type specimen book.</calcite-tooltip>
-  <h3>Icons</h3>
+    <calcite-link icon-start="information">example text</calcite-link><br /><br />
+    <calcite-link icon-end="information">example text</calcite-link><br /><br />
+    <calcite-link icon-start="information" icon-end="information">example text</calcite-link>
+    <br /><br />
+    <h3>Inline links</h3>
 
+    A <calcite-link title="in the middle">link with no href in the middle</calcite-link> of some text.<br />
+    A <calcite-link title="in the middle" href="/">in the middle</calcite-link> of some text.<br />
+    <div class="demo-background-dark">
+      <br />
 
-  <calcite-link icon-start="information">example text</calcite-link><br /><br />
-  <calcite-link icon-end="information">example text</calcite-link><br /><br />
-  <calcite-link icon-start="information" icon-end="information">example text</calcite-link>
-  <br /><br />
-  <h3>Inline links</h3>
+      A link
+      <calcite-link
+        href="http://google.com"
+        rel="noopener noreferrer"
+        target="_blank"
+        class="calcite-theme-dark"
+        title="in the middle with an icon"
+        icon-start="launch"
+        >to Google with an icon</calcite-link
+      >
+      in some text.<br />
+      A link <calcite-link icon-start="launch" class="calcite-theme-dark">with an icon and no href</calcite-link> in
+      some text.<br />
+      A link
+      <calcite-link
+        href="http://google.com"
+        rel="noopener noreferrer"
+        target="_blank"
+        class="calcite-theme-dark"
+        title="in the middle with an icon"
+        icon-start="launch"
+        >to Google with an icon</calcite-link
+      >
+      in some text.<br />
 
-  A <calcite-link title="in the middle">link with no href in the middle</calcite-link>
-  of
-  some
-  text.<br />
-  A <calcite-link title="in the middle" href="/">in the middle</calcite-link> of
-  some
-  text.<br />
-  <div class="demo-background-dark"><br />
-
-    A link <calcite-link href="http://google.com" rel="noopener noreferrer" target="_blank"
-      theme="dark" title="in the middle with an icon" icon-start='launch'>to
-      Google with an
-      icon</calcite-link> in some text.<br />
-    A link <calcite-link icon-start='launch' theme="dark">with an
-      icon and no href</calcite-link> in some text.<br />
-    A link <calcite-link href="http://google.com" rel="noopener noreferrer" target="_blank"
-      theme="dark" title="in the middle with an icon" icon-start='launch'>to Google with an
-      icon</calcite-link> in some text.<br />
-
-    <h3> A link <calcite-link href="http://google.com" rel="noopener noreferrer" target="_blank"
-        theme="dark" title="in the middle with an icon" icon-start='launch'>to Google with an
-        icon</calcite-link> in some text.</h3> <br />
-</body>
-
+      <h3>
+        A link
+        <calcite-link
+          href="http://google.com"
+          rel="noopener noreferrer"
+          target="_blank"
+          class="calcite-theme-dark"
+          title="in the middle with an icon"
+          icon-start="launch"
+          >to Google with an icon</calcite-link
+        >
+        in some text.
+      </h3>
+      <br />
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-loader.html
+++ b/src/demos/calcite-loader.html
@@ -1,96 +1,101 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Loader</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-
-    h2 {
-      text-align: center;
-      padding-top: 6rem;
-    }
-
-    h2:first-of-type {
-      padding-top: 2rem;
-    }
-  </style>
-<script src="./_assets/head.js"></script>
-</head>
-
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <hr>
-  <calcite-button scale="s" data-scale="s" class="scale-selector">Small</calcite-button>
-  <calcite-button scale="s" data-scale="m" class="scale-selector">Medium</calcite-button>
-  <calcite-button scale="s" data-scale="l" class="scale-selector">Large</calcite-button>
-  <h1>Calcite Loader</h1>
-  <h2>Standard</h2>
-  <calcite-loader label="loading" active></calcite-loader>
-  <h2>Determinate</h2>
-  <calcite-loader label="loading" active type="determinate" value="0" id="loader-determinate" text="Determinate loader">
-  </calcite-loader>
-  <div style="text-align: center">
-    <calcite-button id="replay" appearance="transparent" icon="refresh">Replay</calcite-button>
-  </div>
-  <script>
-    (function () {
-      var determinateLoader = document.querySelector("#loader-determinate");
-      var randoms = [0, 0, 0, 0, 0, 0, 1, 3];
-      function updateLoader() {
-        var random = randoms[Math.floor(Math.random() * randoms.length)];
-        determinateLoader.value = Math.min(determinateLoader.value + random, 100);
-        if (determinateLoader.value !== 100) {
-          requestAnimationFrame(updateLoader);
-        }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Loader</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
       }
 
-      updateLoader();
+      h2 {
+        text-align: center;
+        padding-top: 6rem;
+      }
 
-      document.querySelector("#replay").addEventListener("click", function () {
-        cancelAnimationFrame(updateLoader);
-        determinateLoader.value = 0;
+      h2:first-of-type {
+        padding-top: 2rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
+
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <hr />
+    <calcite-button scale="s" data-scale="s" class="scale-selector">Small</calcite-button>
+    <calcite-button scale="s" data-scale="m" class="scale-selector">Medium</calcite-button>
+    <calcite-button scale="s" data-scale="l" class="scale-selector">Large</calcite-button>
+    <h1>Calcite Loader</h1>
+    <h2>Standard</h2>
+    <calcite-loader label="loading" active></calcite-loader>
+    <h2>Determinate</h2>
+    <calcite-loader
+      label="loading"
+      active
+      type="determinate"
+      value="0"
+      id="loader-determinate"
+      text="Determinate loader"
+    >
+    </calcite-loader>
+    <div style="text-align: center">
+      <calcite-button id="replay" appearance="transparent" icon="refresh">Replay</calcite-button>
+    </div>
+    <script>
+      (function () {
+        var determinateLoader = document.querySelector("#loader-determinate");
+        var randoms = [0, 0, 0, 0, 0, 0, 1, 3];
+        function updateLoader() {
+          var random = randoms[Math.floor(Math.random() * randoms.length)];
+          determinateLoader.value = Math.min(determinateLoader.value + random, 100);
+          if (determinateLoader.value !== 100) {
+            requestAnimationFrame(updateLoader);
+          }
+        }
+
         updateLoader();
-      });
 
-      const scaleSelectors = document.querySelectorAll(".scale-selector");
-      scaleSelectors.forEach((selector) => {
-        selector.addEventListener("click", function (e) {
-          const scale = e.target.getAttribute("data-scale");
-          const loaders = document.querySelectorAll("calcite-loader");
-          loaders.forEach((loader) => {
-            console.log("scale: " + loader.getAttribute("scale"));
-            loader.setAttribute("scale", scale);
-          });
+        document.querySelector("#replay").addEventListener("click", function () {
           cancelAnimationFrame(updateLoader);
           determinateLoader.value = 0;
           updateLoader();
         });
-      });
-    })();
-  </script>
-  <h2>Inline</h2>
-  <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
-    <calcite-loader label="loading" active inline></calcite-loader><span style="margin:0 10px">Inline Loader</span>
-  </div>
-  <h2>Custom theme</h2>
-  <style>
-    calcite-loader.green {
-      --calcite-ui-brand: #50ba5f;
-      --calcite-ui-brand-hover: #1a6324;
-      --calcite-ui-brand-press: #338033;
-    }
-  </style>
-  <calcite-loader label="loading" active class="green"></calcite-loader>
-  <h2>Loading Text</h2>
-  <calcite-loader label="loading" active text="optional loading text&hellip;" type="indeterminate"></calcite-loader>
-</body>
 
+        const scaleSelectors = document.querySelectorAll(".scale-selector");
+        scaleSelectors.forEach((selector) => {
+          selector.addEventListener("click", function (e) {
+            const scale = e.target.getAttribute("data-scale");
+            const loaders = document.querySelectorAll("calcite-loader");
+            loaders.forEach((loader) => {
+              console.log("scale: " + loader.getAttribute("scale"));
+              loader.setAttribute("scale", scale);
+            });
+            cancelAnimationFrame(updateLoader);
+            determinateLoader.value = 0;
+            updateLoader();
+          });
+        });
+      })();
+    </script>
+    <h2>Inline</h2>
+    <div style="display: inline-flex; align-items: center; justify-content: center; width: 100%">
+      <calcite-loader label="loading" active inline></calcite-loader><span style="margin: 0 10px">Inline Loader</span>
+    </div>
+    <h2>Custom theme</h2>
+    <style>
+      calcite-loader.green {
+        --calcite-ui-brand: #50ba5f;
+        --calcite-ui-brand-hover: #1a6324;
+        --calcite-ui-brand-press: #338033;
+      }
+    </style>
+    <calcite-loader label="loading" active class="green"></calcite-loader>
+    <h2>Loading Text</h2>
+    <calcite-loader label="loading" active text="optional loading text&hellip;" type="indeterminate"></calcite-loader>
+  </body>
 </html>

--- a/src/demos/calcite-modal.html
+++ b/src/demos/calcite-modal.html
@@ -1,306 +1,342 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Modal</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+      .flex {
+        display: flex;
+      }
+      calcite-card + calcite-card {
+        margin-left: 2rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Modal</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-    .flex {
-      display: flex;
-    }
-    calcite-card + calcite-card {
-      margin-left: 2rem;
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Modal</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Modal</h1>
-
-  <calcite-modal class="js-modal-1" width="s" scale="s">
-    <h3 slot="header">Small Modal</h3>
-    <div slot="content">
-      <p>
-        The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.
-      </p>
-    </div>
-    <calcite-button slot="back" width="full" scale="s" color="neutral" appearance="outline"
-      icon="chevron-left">Back</calcite-button>
-    <calcite-button slot="secondary" width="full" scale="s" appearance="outline">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full" scale="s">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-2" width="m" scale="m">
-    <h3 slot="header">Medium Modal</h3>
-    <div slot="content">
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <p>The medium modal is large enough to fit a two column layout where both columns will have a
-                readable line-length on
-                most desktop devices.</p>
-            </td>
-            <td>
-              <p>Single column layouts will still be within a readable line length on the medium size.</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <calcite-button slot="back" width="full" scale="m" color="neutral" appearance="outline"
-      icon="chevron-left">Back</calcite-button>
-    <calcite-button slot="secondary" width="full" scale="m" appearance="outline">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full" scale="m">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-3" width="l" scale="l">
-    <h3 slot="header">Large modal</h3>
-    <div slot="content">
-      <p>This modal will be fullscreen until it is as wide as the calcite-web grid's max-width. This enables you
-        to use gridded
-        layouts within the modal and keeps your modal from growing beyond a readable line length.</p>
-    </div>
-    <calcite-button slot="secondary" width="full" scale="l" appearance="outline">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full" scale="l">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-4" fullscreen>
-    <h3 slot="header">Fullscreen modal</h3>
-    <div slot="content">
-      <p>This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your
-        modal
-        need the full screen real estate (maps, etc)</p>
-    </div>
-    <calcite-button slot="back" width="full" color="neutral" appearance="outline"
-      icon="chevron-left">Back</calcite-button>
-    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-5" color="red">
-    <h3 slot="header">Delete</h3>
-    <div slot="content">
-      <p>This will delete things and perform some desctructive action, do you wish to continue?</p>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline" color="red">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full" color="red">Delete</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-6" color="blue">
-    <h3 slot="header">Information</h3>
-    <div slot="content">
-      <p>This dialog should be used when choosing two viable paths.</p>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline">Start with no members</calcite-button>
-    <calcite-button slot="primary" width="full">Add members now</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-7" status="info" docked>
-    <h3 slot="header">Docked</h3>
-    <div slot="content">
-      <p>For devices smaller than a tablet this modal will "dock" to the bottom. This makes action selection more
-        thumb-friendly.</p>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-8" status="info" docked>
-    <h3 slot="header">Tab Fencing</h3>
-    <div slot="content">
-      <p>When you open a modal, the focus should be set to the first focusable element. <calcite-button>LIKE THIS
-        </calcite-button>.</p>
-      <div><a href="#">Anchors</a>, <input type="text" value="inputs">, <calcite-slider></calcite-slider>
+    <calcite-modal class="js-modal-1" width="s" scale="s">
+      <h3 slot="header">Small Modal</h3>
+      <div slot="content">
+        <p>The small modal is perfect for short confirmation dialogs or very compact interfaces with few elements.</p>
       </div>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal theme="dark" class="js-modal-9">
-    <h3 slot="header">Dark Theme</h3>
-    <div slot="content">
-      <p>Example of a modal rendered in dark theme. The text will become light on dark, but notice box shadows are
-        still dark.
-    </div>
-    <calcite-button theme="dark" slot="primary">OK</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-10" disable-escape>
-    <h3 slot="header">Modal title</h3>
-    <div slot="content">
-      <p>This modal has <code>disable-escape</code> set, so pressing the escape key will not dismiss it.</p>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-11" disable-close-button>
-    <h3 slot="header">Modal title</h3>
-    <div slot="content">
-      <p>This modal has no close button.</p>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-12" width="500">
-    <h3 slot="header">Modal title</h3>
-    <div slot="content">
-      <p>This modal will be 500 pixels wide on larger screens and become fullscreen below that.</p>
-    </div>
-    <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-13" width="s" scale="s">
-    <h3 slot="header">Small Scale</h3>
-    <div slot="content">
-      <p>
-        This is the small scale modal. It is meant to work with other components at the small scale (like buttons, etc).
-      </p>
-    </div>
-    <calcite-button scale="s" slot="back" width="full" color="neutral" appearance="outline"
-      icon="chevron-left" width="full">Back</calcite-button>
-    <calcite-button scale="s" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button scale="s" slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-14" width="s" scale="m">
-    <h3 slot="header">Medium Scale</h3>
-    <div slot="content">
-      <p>
-        This is the medium scale modal. It is the default scale and is meant to work with other components at the medium scale.
-      </p>
-    </div>
-    <calcite-button scale="m" slot="back" width="full" color="neutral" appearance="outline"
-      icon="chevron-left" width="full">Back</calcite-button>
-    <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-15" width="s" scale="l">
-    <h3 slot="header">Large Scale</h3>
-    <div slot="content">
-      <p>
-        This is the large scale modal. It is meant to work with other components at the large scale (like buttons, etc).
-      </p>
-    </div>
-    <calcite-button scale="l" slot="back" width="full" color="neutral" appearance="outline"
-      icon="chevron-left" width="full">Back</calcite-button>
-    <calcite-button scale="l" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button scale="l" slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-16" fullscreen background-color="grey">
-    <h3 slot="header">Grey Background</h3>
-    <div slot="content">
-      <p>
-        By using the backgroundColor attribute, you can create a modal with a light grey background rather than white.
-      </p>
-      <p>This allows you to have white components inside the modal with good separation.</p>
-      <h4>Card Example</h4>
-      <div class="flex">
-        <calcite-card selected selectable>
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
-
-          <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
-          <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-            overly verbose.</span>
-          <calcite-link slot="footer-leading">Lead füt</calcite-link>
-          <calcite-link slot="footer-trailing">Trail füt</calcite-link>
-        </calcite-card>
-        <calcite-card selected selectable>
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
-
-          <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
-          <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-            overly verbose.</span>
-          <calcite-link slot="footer-leading">Lead füt</calcite-link>
-          <calcite-link slot="footer-trailing">Trail füt</calcite-link>
-        </calcite-card>
-        <calcite-card selected selectable>
-          <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
-
-          <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
-          <span slot="subtitle">A great example of a study description that might wrap to a line or two, but isn't
-            overly verbose.</span>
-          <calcite-link slot="footer-leading">Lead füt</calcite-link>
-          <calcite-link slot="footer-trailing">Trail füt</calcite-link>
-        </calcite-card>
+      <calcite-button slot="back" width="full" scale="s" color="neutral" appearance="outline" icon="chevron-left"
+        >Back</calcite-button
+      >
+      <calcite-button slot="secondary" width="full" scale="s" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full" scale="s">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-2" width="m" scale="m">
+      <h3 slot="header">Medium Modal</h3>
+      <div slot="content">
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <p>
+                  The medium modal is large enough to fit a two column layout where both columns will have a readable
+                  line-length on most desktop devices.
+                </p>
+              </td>
+              <td>
+                <p>Single column layouts will still be within a readable line length on the medium size.</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    </div>
-    <calcite-button scale="m" slot="back" width="full" color="neutral" appearance="outline"
-      icon="chevron-left" width="full">Back</calcite-button>
-    <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
-    <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
-  </calcite-modal>
-  <calcite-modal class="js-modal-17" width="s">
-    <h3 slot="header">Small Modal</h3>
-    <div slot="content">
-      <calcite-loader label="loading" active/>
-    </div>
-  </calcite-modal>
-  <ul>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-1')">Small Modal</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-2')">Medium Modal</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-3')">Large Modal</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-4')">Fullscreen Modal</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-5')">Destructive Modal</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-6')">Info Modal</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-7')">Docked</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-8')">Tab Fencing</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-9')">Dark Theme</calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-10')">Close on escape press disabled
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-11')">No Close Button
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-12')">Custom Width
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-13')">Scale Small
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-14')">Scale Medium
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-15')">Scale Large
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-16')">Grey Background Color
-      </calcite-link>
-    </li>
-    <li>
-      <calcite-link onClick="openModal('.js-modal-17')">No footer
-      </calcite-link>
-    </li>
-  </ul>
-  <script>
-    function openModal(selector) {
-      document.querySelector(selector).active = true;
-    }
-  </script>
-  </calcite-tab>
+      <calcite-button slot="back" width="full" scale="m" color="neutral" appearance="outline" icon="chevron-left"
+        >Back</calcite-button
+      >
+      <calcite-button slot="secondary" width="full" scale="m" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full" scale="m">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-3" width="l" scale="l">
+      <h3 slot="header">Large modal</h3>
+      <div slot="content">
+        <p>
+          This modal will be fullscreen until it is as wide as the calcite-web grid's max-width. This enables you to use
+          gridded layouts within the modal and keeps your modal from growing beyond a readable line length.
+        </p>
+      </div>
+      <calcite-button slot="secondary" width="full" scale="l" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full" scale="l">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-4" fullscreen>
+      <h3 slot="header">Fullscreen modal</h3>
+      <div slot="content">
+        <p>
+          This modal will <em>always</em> be fullscreen. Use in situations where the elements contained inside your
+          modal need the full screen real estate (maps, etc)
+        </p>
+      </div>
+      <calcite-button slot="back" width="full" color="neutral" appearance="outline" icon="chevron-left"
+        >Back</calcite-button
+      >
+      <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-5" color="red">
+      <h3 slot="header">Delete</h3>
+      <div slot="content">
+        <p>This will delete things and perform some desctructive action, do you wish to continue?</p>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline" color="red">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full" color="red">Delete</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-6" color="blue">
+      <h3 slot="header">Information</h3>
+      <div slot="content">
+        <p>This dialog should be used when choosing two viable paths.</p>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline">Start with no members</calcite-button>
+      <calcite-button slot="primary" width="full">Add members now</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-7" status="info" docked>
+      <h3 slot="header">Docked</h3>
+      <div slot="content">
+        <p>
+          For devices smaller than a tablet this modal will "dock" to the bottom. This makes action selection more
+          thumb-friendly.
+        </p>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-8" status="info" docked>
+      <h3 slot="header">Tab Fencing</h3>
+      <div slot="content">
+        <p>
+          When you open a modal, the focus should be set to the first focusable element.
+          <calcite-button>LIKE THIS </calcite-button>.
+        </p>
+        <div><a href="#">Anchors</a>, <input type="text" value="inputs" />, <calcite-slider></calcite-slider></div>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-9 calcite-theme-dark">
+      <h3 slot="header">Dark Theme</h3>
+      <div slot="content">
+        <p>
+          Example of a modal rendered in dark theme. The text will become light on dark, but notice box shadows are
+          still dark.
+        </p>
+      </div>
 
-</body>
+      <calcite-button class="calcite-theme-dark" slot="primary">OK</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-10" disable-escape>
+      <h3 slot="header">Modal title</h3>
+      <div slot="content">
+        <p>This modal has <code>disable-escape</code> set, so pressing the escape key will not dismiss it.</p>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-11" disable-close-button>
+      <h3 slot="header">Modal title</h3>
+      <div slot="content">
+        <p>This modal has no close button.</p>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-12" width="500">
+      <h3 slot="header">Modal title</h3>
+      <div slot="content">
+        <p>This modal will be 500 pixels wide on larger screens and become fullscreen below that.</p>
+      </div>
+      <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-13" width="s" scale="s">
+      <h3 slot="header">Small Scale</h3>
+      <div slot="content">
+        <p>
+          This is the small scale modal. It is meant to work with other components at the small scale (like buttons,
+          etc).
+        </p>
+      </div>
+      <calcite-button
+        scale="s"
+        slot="back"
+        width="full"
+        color="neutral"
+        appearance="outline"
+        icon="chevron-left"
+        width="full"
+        >Back</calcite-button
+      >
+      <calcite-button scale="s" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button scale="s" slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-14" width="s" scale="m">
+      <h3 slot="header">Medium Scale</h3>
+      <div slot="content">
+        <p>
+          This is the medium scale modal. It is the default scale and is meant to work with other components at the
+          medium scale.
+        </p>
+      </div>
+      <calcite-button
+        scale="m"
+        slot="back"
+        width="full"
+        color="neutral"
+        appearance="outline"
+        icon="chevron-left"
+        width="full"
+        >Back</calcite-button
+      >
+      <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-15" width="s" scale="l">
+      <h3 slot="header">Large Scale</h3>
+      <div slot="content">
+        <p>
+          This is the large scale modal. It is meant to work with other components at the large scale (like buttons,
+          etc).
+        </p>
+      </div>
+      <calcite-button
+        scale="l"
+        slot="back"
+        width="full"
+        color="neutral"
+        appearance="outline"
+        icon="chevron-left"
+        width="full"
+        >Back</calcite-button
+      >
+      <calcite-button scale="l" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button scale="l" slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-16" fullscreen background-color="grey">
+      <h3 slot="header">Grey Background</h3>
+      <div slot="content">
+        <p>
+          By using the backgroundColor attribute, you can create a modal with a light grey background rather than white.
+        </p>
+        <p>This allows you to have white components inside the modal with good separation.</p>
+        <h4>Card Example</h4>
+        <div class="flex">
+          <calcite-card selected selectable>
+            <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
 
+            <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+            <span slot="subtitle"
+              >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+            >
+            <calcite-link slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+          </calcite-card>
+          <calcite-card selected selectable>
+            <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+
+            <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+            <span slot="subtitle"
+              >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+            >
+            <calcite-link slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+          </calcite-card>
+          <calcite-card selected selectable>
+            <img slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" />
+
+            <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
+            <span slot="subtitle"
+              >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+            >
+            <calcite-link slot="footer-leading">Lead füt</calcite-link>
+            <calcite-link slot="footer-trailing">Trail füt</calcite-link>
+          </calcite-card>
+        </div>
+      </div>
+      <calcite-button
+        scale="m"
+        slot="back"
+        width="full"
+        color="neutral"
+        appearance="outline"
+        icon="chevron-left"
+        width="full"
+        >Back</calcite-button
+      >
+      <calcite-button scale="m" slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+      <calcite-button scale="m" slot="primary" width="full">Save</calcite-button>
+    </calcite-modal>
+    <calcite-modal class="js-modal-17" width="s">
+      <h3 slot="header">Small Modal</h3>
+      <div slot="content">
+        <calcite-loader label="loading" active />
+      </div>
+    </calcite-modal>
+    <ul>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-1')">Small Modal</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-2')">Medium Modal</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-3')">Large Modal</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-4')">Fullscreen Modal</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-5')">Destructive Modal</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-6')">Info Modal</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-7')">Docked</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-8')">Tab Fencing</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-9')">Dark Theme</calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-10')">Close on escape press disabled </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-11')">No Close Button </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-12')">Custom Width </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-13')">Scale Small </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-14')">Scale Medium </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-15')">Scale Large </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-16')">Grey Background Color </calcite-link>
+      </li>
+      <li>
+        <calcite-link onClick="openModal('.js-modal-17')">No footer </calcite-link>
+      </li>
+    </ul>
+    <script>
+      function openModal(selector) {
+        document.querySelector(selector).active = true;
+      }
+    </script>
+  </body>
 </html>

--- a/src/demos/calcite-notice.html
+++ b/src/demos/calcite-notice.html
@@ -49,26 +49,53 @@
     <br />
     <br />
     <div class="demo-background-dark">
-      <calcite-notice icon theme="dark" color="yellow" id="notice-two" width="auto" scale="m" active>
+      <calcite-notice icon class="calcite-theme-dark" color="yellow" id="notice-two" width="auto" scale="m" active>
         <div slot="title">Something kind of worked</div>
         <div slot="notice-message">One part of that thing you wanted to do didn't work as expected</div>
-        <calcite-link slot="notice-link" theme="dark" title="my action">View item </calcite-link>
+        <calcite-link slot="notice-link" class="calcite-theme-dark" title="my action">View item </calcite-link>
       </calcite-notice>
       <br />
       <br />
-      <calcite-notice icon color="green" theme="dark" id="notice-six" width="auto" scale="m" active dismissible>
+      <calcite-notice
+        icon
+        color="green"
+        class="calcite-theme-dark"
+        id="notice-six"
+        width="auto"
+        scale="m"
+        active
+        dismissible
+      >
         <div slot="title">Something worked</div>
         <div slot="notice-message">That thing you wanted to do worked as expected</div>
       </calcite-notice>
       <br />
       <br />
-      <calcite-notice icon color="blue" theme="dark" id="notice-six" width="auto" scale="m" active dismissible>
+      <calcite-notice
+        icon
+        color="blue"
+        class="calcite-theme-dark"
+        id="notice-six"
+        width="auto"
+        scale="m"
+        active
+        dismissible
+      >
         <div slot="title">Something worked</div>
         <div slot="notice-message">That thing you wanted to do worked as expected</div>
       </calcite-notice>
       <br />
       <br />
-      <calcite-notice icon color="red" theme="dark" id="notice-six" width="auto" scale="m" active dismissible>
+      <calcite-notice
+        icon
+        color="red"
+        class="calcite-theme-dark"
+        id="notice-six"
+        width="auto"
+        scale="m"
+        active
+        dismissible
+      >
         <div slot="title">Something worked</div>
         <div slot="notice-message">That thing you wanted to do worked as expected</div>
       </calcite-notice>

--- a/src/demos/calcite-pagination.html
+++ b/src/demos/calcite-pagination.html
@@ -1,105 +1,103 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Pagination</title>
+    <script src="./_assets/head.js"></script>
+    <style>
+      .demo-background-dark {
+        background: #2b2b2b;
+        color: white;
+        padding: 1rem;
+      }
+      .demo-spaced {
+        margin: 8px 0;
+      }
+    </style>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Pagination</title>
-  <script src="./_assets/head.js"></script>
-  <style>
-    .demo-background-dark {
-      background: #2b2b2b;
-      color: white;
-      padding: 1rem;
-    }
-    .demo-spaced {
-      margin: 8px 0;
-    }
-  </style>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Pagination</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Pagination</h1>
+    <h2>Basic</h2>
+    <div class="demo-spaced">
+      <calcite-pagination total="46" num="10"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="8" num="10"></calcite-pagination>
+    </div>
 
-  <h2>Basic</h2>
-  <div class="demo-spaced">
-    <calcite-pagination total="46" num="10"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="8" num="10"></calcite-pagination>
-  </div>
+    <div class="demo-background-dark">
+      <h2>Dark Theme</h2>
+      <calcite-pagination total="46" num="10" class="calcite-theme-dark"></calcite-pagination>
+    </div>
 
-  <div class="demo-background-dark">
-    <h2>Dark Theme</h2>
-    <calcite-pagination total="46" num="10" theme="dark"></calcite-pagination>
-  </div>
+    <div>
+      <h2>RTL</h2>
+      <calcite-pagination dir="rtl" total="46" num="10"></calcite-pagination>
+    </div>
 
-  <div>
-    <h2>RTL</h2>
-    <calcite-pagination dir="rtl" total="46" num="10"></calcite-pagination>
-  </div>
+    <h2>Many pages, ellipsis examples</h2>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="101"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="201"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="301"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="401"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="501"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="601"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="701"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="801"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="901"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="1001"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="1101"></calcite-pagination>
+    </div>
 
-  <h2>Many pages, ellipsis examples</h2>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="101"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="201"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="301"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="401"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="501"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="601"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="701"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="801"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="901"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="1001"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="1101"></calcite-pagination>
-  </div>
+    <h2>One per page</h2>
+    <div class="demo-spaced">
+      <calcite-pagination total="5" num="1" start="1"></calcite-pagination>
+    </div>
+    <div class="demo-spaced">
+      <calcite-pagination total="15" num="1" start="1"></calcite-pagination>
+    </div>
 
-  <h2>One per page</h2>
-  <div class="demo-spaced">
-    <calcite-pagination total="5" num="1" start="1"></calcite-pagination>
-  </div>
-  <div class="demo-spaced">
-    <calcite-pagination total="15" num="1" start="1"></calcite-pagination>
-  </div>
-
-  <h2>Scales</h2>
-  <h3>S</h3>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="1001" scale="s"></calcite-pagination>
-  </div>
-  <h3>M (default)</h3>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="1001"></calcite-pagination>
-  </div>
-  <h3>L</h3>
-  <div class="demo-spaced">
-    <calcite-pagination total="1200" num="100" start="1001" scale="l"></calcite-pagination>
-  </div>
-</body>
-
+    <h2>Scales</h2>
+    <h3>S</h3>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="1001" scale="s"></calcite-pagination>
+    </div>
+    <h3>M (default)</h3>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="1001"></calcite-pagination>
+    </div>
+    <h3>L</h3>
+    <div class="demo-spaced">
+      <calcite-pagination total="1200" num="100" start="1001" scale="l"></calcite-pagination>
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-popover.html
+++ b/src/demos/calcite-popover.html
@@ -1,260 +1,325 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Popover</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Popover</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Popover</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Popover</h1>
+    <calcite-popover-manager>
+      <calcite-popover
+        label="right start popover"
+        reference-element="popover-button-two"
+        placement="right-start"
+        id="popover-two"
+      >
+        <div style="padding: 12px 16px">Hello! I am some popover content!</div>
+      </calcite-popover>
 
-  <calcite-popover-manager>
-  <calcite-popover label="right start popover" reference-element="popover-button-two" placement="right-start" id="popover-two" >
-    <div style="padding:12px 16px">Hello! I am some popover content!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="right end popover"
+        reference-element="popover-button-three"
+        placement="right-end"
+        id="popover-three"
+        close-button
+      >
+        <div style="padding: 12px 16px; width: 33vw">
+          <b>I am a title!</b> <br />
+          <p>
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+          </p>
+          <calcite-link title="Inline link">I am an inline link</calcite-link>
+        </div>
+      </calcite-popover>
 
-  <calcite-popover label="right end popover" reference-element="popover-button-three" placement="right-end" id="popover-three"
-    close-button>
-    <div style="padding:12px 16px;width:33vw;">
-      <b>I am a title!</b> <br>
-      <p>
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-        industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
-        scrambled it to make a type specimen book.
-      </p>
-      <calcite-link title="Inline link">I am an inline link</calcite-link>
-    </div>
-  </calcite-popover>
-  
-  <calcite-popover heading="I'm a heading in the header using the 'heading' prop!" label="right end popover" reference-element="popover-button-three-heading" placement="right-end" id="popover-three-heading"
-    close-button style="width:25vw;">
-    <img src="https://www.fillmurray.com/640/360" style="width: 100%;" />
-    <div style="padding: 0.5rem 1rem 0.75rem;">
-      <p style="margin-top: 0;">
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-        industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
-        scrambled it to make a type specimen book.
-      </p>
-      <calcite-link title="Inline link">I am an inline link</calcite-link>
-    </div>
-  </calcite-popover>
+      <calcite-popover
+        heading="I'm a heading in the header using the 'heading' prop!"
+        label="right end popover"
+        reference-element="popover-button-three-heading"
+        placement="right-end"
+        id="popover-three-heading"
+        close-button
+        style="width: 25vw"
+      >
+        <img src="https://www.fillmurray.com/640/360" style="width: 100%" />
+        <div style="padding: 0.5rem 1rem 0.75rem">
+          <p style="margin-top: 0">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+          </p>
+          <calcite-link title="Inline link">I am an inline link</calcite-link>
+        </div>
+      </calcite-popover>
 
-  <calcite-popover label="auto placement popover" reference-element="popover-button-four" placement="auto" id="popover-four"
-    close-button>
-    <div style="padding:12px 16px">I am a popover with a close button!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="auto placement popover"
+        reference-element="popover-button-four"
+        placement="auto"
+        id="popover-four"
+        close-button
+      >
+        <div style="padding: 12px 16px">I am a popover with a close button!</div>
+      </calcite-popover>
 
-  <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-five" placement="bottom" id="popover-five"
-     close-button>
-    <div style="padding:12px 16px;">Here kitty kitty!
-    </div>
-  </calcite-popover>
-  <calcite-popover label="dark theme popover" theme="dark" dir="rtl" reference-element="popover-button-rtl" placement="left" id="popover-rtl" close-button>
-    <div style="padding:12px 16px;">مرحبا بالعالم!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="dark theme popover"
+        class="calcite-theme-dark"
+        reference-element="popover-button-five"
+        placement="bottom"
+        id="popover-five"
+        close-button
+      >
+        <div style="padding: 12px 16px">Here kitty kitty!</div>
+      </calcite-popover>
+      <calcite-popover
+        label="dark theme popover"
+        class="calcite-theme-dark"
+        dir="rtl"
+        reference-element="popover-button-rtl"
+        placement="left"
+        id="popover-rtl"
+        close-button
+      >
+        <div style="padding: 12px 16px">مرحبا بالعالم!</div>
+      </calcite-popover>
 
-  <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-six" placement="top" id="popover-six"
-    >
-    <div style="padding:12px 16px">Hello! I am some popover content!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="dark theme popover"
+        class="calcite-theme-dark"
+        reference-element="popover-button-six"
+        placement="top"
+        id="popover-six"
+      >
+        <div style="padding: 12px 16px">Hello! I am some popover content!</div>
+      </calcite-popover>
 
-  <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-seven" placement="auto" id="popover-seven"
-     close-button>
-    <div style="padding:12px 16px;width:33vw;">
-      <b>I am a title!</b> <br>
-      <p>
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-        industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
-        scrambled it to make a type specimen book.
-      </p>
-      <calcite-link theme="dark" title="Inline button">I am an inline link
-      </calcite-link>
-    </div>
-  </calcite-popover>
+      <calcite-popover
+        label="dark theme popover"
+        class="calcite-theme-dark"
+        reference-element="popover-button-seven"
+        placement="auto"
+        id="popover-seven"
+        close-button
+      >
+        <div style="padding: 12px 16px; width: 33vw">
+          <b>I am a title!</b> <br />
+          <p>
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+            industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+            scrambled it to make a type specimen book.
+          </p>
+          <calcite-link class="calcite-theme-dark" title="Inline button">I am an inline link </calcite-link>
+        </div>
+      </calcite-popover>
 
-  <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-eight" placement="auto" id="popover-eight"
-     close-button>
-    <div style="padding:12px 16px">I am a popover with a close button!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="dark theme popover"
+        class="calcite-theme-dark"
+        reference-element="popover-button-eight"
+        placement="auto"
+        id="popover-eight"
+        close-button
+      >
+        <div style="padding: 12px 16px">I am a popover with a close button!</div>
+      </calcite-popover>
 
-  <calcite-popover label="dark theme popover" theme="dark" reference-element="popover-button-nine" placement="auto" id="popover-nine"
-    >
-    <div style="padding:12px 16px">I am a popover with a close button!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="dark theme popover"
+        class="calcite-theme-dark"
+        reference-element="popover-button-nine"
+        placement="auto"
+        id="popover-nine"
+      >
+        <div style="padding: 12px 16px">I am a popover with a close button!</div>
+      </calcite-popover>
 
-  <calcite-popover label="top placement dark theme popover" reference-element="tooltip-and-popover" placement="top" theme="dark" >
-    <div style="padding:12px 16px">Hello! I am some popover content!</div>
-  </calcite-popover>
+      <calcite-popover
+        label="top placement dark theme popover"
+        reference-element="tooltip-and-popover"
+        placement="top"
+        class="calcite-theme-dark"
+      >
+        <div style="padding: 12px 16px">Hello! I am some popover content!</div>
+      </calcite-popover>
 
-  <calcite-tooltip label="bottom placed tooltip" reference-element="tooltip-and-popover" placement="bottom">Lorem Ipsum is simply of the printing and typesetting industry. Lorem
-    Ipsum has been the industry's standard printer of type and scrambled it
-    to make a type specimen book.</calcite-tooltip>
+      <calcite-tooltip label="bottom placed tooltip" reference-element="tooltip-and-popover" placement="bottom"
+        >Lorem Ipsum is simply of the printing and typesetting industry. Lorem Ipsum has been the industry's standard
+        printer of type and scrambled it to make a type specimen book.</calcite-tooltip
+      >
 
-  <style>
-    .popover-list {
-      list-style: none;
-      margin: 0;
-      padding: 20px 10px;
-      margin: 0 ;
-    }
+      <style>
+        .popover-list {
+          list-style: none;
+          margin: 0;
+          padding: 20px 10px;
+          margin: 0;
+        }
 
-    .popover-list li {
-      margin: 30px 0;
-    }
+        .popover-list li {
+          margin: 30px 0;
+        }
 
-    .popover-scroller {
-      position: relative;
-      margin: 20px 40px;
-      width: 500px;
-      height: 500px;
-      overflow: auto;
-    }
-  </style>
+        .popover-scroller {
+          position: relative;
+          margin: 20px 40px;
+          width: 500px;
+          height: 500px;
+          overflow: auto;
+        }
+      </style>
 
-  <ul class="popover-list">
-    <li>
-      <calcite-button id="popover-button-two" icon="plus">
-        Clickable popover</calcite-button>
-    </li>
-    <li>
-      <calcite-button id="popover-button-four" icon="plus">
-        With close button</calcite-button>
-    </li>
-    <li>
-      <calcite-button id="popover-button-three" icon="plus">
-        Title, content & CTA</calcite-button>
-    </li>
-    <li>
-      <calcite-button id="popover-button-three-heading" icon="plus">
-        Heading (in prop), content & CTA</calcite-button>
-    </li>
-    <li>
-      <calcite-tooltip-manager>
-        <calcite-button id="tooltip-and-popover">Tooltip and popover test</calcite-button>
-    </calcite-tooltip-manager>
-    </li>
-  </ul>
+      <ul class="popover-list">
+        <li>
+          <calcite-button id="popover-button-two" icon="plus"> Clickable popover</calcite-button>
+        </li>
+        <li>
+          <calcite-button id="popover-button-four" icon="plus"> With close button</calcite-button>
+        </li>
+        <li>
+          <calcite-button id="popover-button-three" icon="plus"> Title, content & CTA</calcite-button>
+        </li>
+        <li>
+          <calcite-button id="popover-button-three-heading" icon="plus">
+            Heading (in prop), content & CTA</calcite-button
+          >
+        </li>
+        <li>
+          <calcite-tooltip-manager>
+            <calcite-button id="tooltip-and-popover">Tooltip and popover test</calcite-button>
+          </calcite-tooltip-manager>
+        </li>
+      </ul>
 
-  <div id="popover-boundary" class="popover-scroller">
-    <p>
-      Nec, dictum egestas odio in integer dictum eros. Euismod vitae vestibulum tempor sit adipiscing sed dolor
-      habitant per congue sit condimentum? Nisi nisl ornare ac semper imperdiet eu nascetur quisque ullamcorper a
-      id. Odio pharetra iaculis mattis fusce pharetra fusce. Venenatis suspendisse porta posuere torquent justo
-      arcu. Viverra venenatis nisl mi. Integer laoreet cubilia, lobortis nisi fringilla. Dictum venenatis taciti
-      arcu fringilla fames sociis.
-    </p>
-    <p>
-      Ultricies aliquam hac, commodo ullamcorper. At senectus blandit, magnis accumsan aptent vitae mi dapibus
-      quis sagittis taciti nisi. Et aliquam leo nullam sagittis conubia nascetur? Euismod blandit aptent conubia.
-      Curae; laoreet tortor urna eleifend dui ultrices vestibulum viverra dictumst risus? Vehicula diam vulputate
-      cras volutpat inceptos nostra cras at auctor! Luctus inceptos dis eleifend eleifend tellus molestie.
-      Ridiculus eget laoreet vitae.
-    </p>
-    <p>
-      Viverra mus velit interdum per pellentesque. Rutrum parturient risus feugiat habitasse magnis? Adipiscing
-      vehicula natoque rutrum consectetur dui, euismod ultricies ante quam pulvinar. Taciti mauris nam vehicula
-      sapien a taciti vel vitae cum id aenean! Torquent sapien fusce, class eros lectus. Ut sodales placerat
-      phasellus, nostra platea lobortis cubilia porta elementum viverra. Imperdiet ultrices, rhoncus himenaeos cum
-      risus. Egestas imperdiet velit, dapibus inceptos inceptos torquent. Dolor natoque, non imperdiet dictum
-      eleifend diam. Eget sem, hendrerit vulputate consectetur metus class.
-    </p>
-    <p>
-      Habitant vel penatibus felis sapien integer, imperdiet felis porttitor porta. Nec ad natoque habitasse metus
-      augue consequat sem tortor arcu tempor augue. Facilisi, magna amet cursus pellentesque. Nibh conubia tellus
-      porta torquent sociis mauris laoreet et neque venenatis habitasse! Egestas eu est nunc malesuada justo,
-      fames sociis ullamcorper? Sollicitudin inceptos, ipsum duis ullamcorper.
-    </p>
-    <p>
-      Fermentum mollis metus euismod netus ultricies ad gravida velit molestie integer. Accumsan amet litora
-      ligula ligula metus diam vitae euismod aptent. Nunc eros ridiculus volutpat praesent scelerisque dignissim
-      nunc cras. Ipsum diam dapibus cum sociis, elit adipiscing. Imperdiet vulputate neque elementum varius id,
-      torquent quis. Aliquam pretium sapien primis. Nunc iaculis mi magnis malesuada nascetur. Nostra habitasse
-      dictum dictum rutrum lacus? Tortor sem, taciti pellentesque cubilia! Vulputate at ridiculus hac lacinia
-      risus quisque potenti suscipit orci. Conubia urna tortor mauris ante litora nibh quisque consequat.
-    </p>
-    <calcite-popover label="top start popover" placement="top-start" reference-element="popover-button"
-    id="popover" close-button>
-    <div style="padding:12px 16px;">Here kitty kitty!
-    </div>
-  </calcite-popover>
-    <calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-      Popover 🐱</calcite-button>
-    <p>
-      Nec, dictum egestas odio in integer dictum eros. Euismod vitae vestibulum tempor sit adipiscing sed dolor
-      habitant per congue sit condimentum? Nisi nisl ornare ac semper imperdiet eu nascetur quisque ullamcorper a
-      id. Odio pharetra iaculis mattis fusce pharetra fusce. Venenatis suspendisse porta posuere torquent justo
-      arcu. Viverra venenatis nisl mi. Integer laoreet cubilia, lobortis nisi fringilla. Dictum venenatis taciti
-      arcu fringilla fames sociis.
-    </p>
-    <p>
-      Ultricies aliquam hac, commodo ullamcorper. At senectus blandit, magnis accumsan aptent vitae mi dapibus
-      quis sagittis taciti nisi. Et aliquam leo nullam sagittis conubia nascetur? Euismod blandit aptent conubia.
-      Curae; laoreet tortor urna eleifend dui ultrices vestibulum viverra dictumst risus? Vehicula diam vulputate
-      cras volutpat inceptos nostra cras at auctor! Luctus inceptos dis eleifend eleifend tellus molestie.
-      Ridiculus eget laoreet vitae.
-    </p>
-    <p>
-      Viverra mus velit interdum per pellentesque. Rutrum parturient risus feugiat habitasse magnis? Adipiscing
-      vehicula natoque rutrum consectetur dui, euismod ultricies ante quam pulvinar. Taciti mauris nam vehicula
-      sapien a taciti vel vitae cum id aenean! Torquent sapien fusce, class eros lectus. Ut sodales placerat
-      phasellus, nostra platea lobortis cubilia porta elementum viverra. Imperdiet ultrices, rhoncus himenaeos cum
-      risus. Egestas imperdiet velit, dapibus inceptos inceptos torquent. Dolor natoque, non imperdiet dictum
-      eleifend diam. Eget sem, hendrerit vulputate consectetur metus class.
-    </p>
-    <p>
-      Habitant vel penatibus felis sapien integer, imperdiet felis porttitor porta. Nec ad natoque habitasse metus
-      augue consequat sem tortor arcu tempor augue. Facilisi, magna amet cursus pellentesque. Nibh conubia tellus
-      porta torquent sociis mauris laoreet et neque venenatis habitasse! Egestas eu est nunc malesuada justo,
-      fames sociis ullamcorper? Sollicitudin inceptos, ipsum duis ullamcorper.
-    </p>
-    <p>
-      Fermentum mollis metus euismod netus ultricies ad gravida velit molestie integer. Accumsan amet litora
-      ligula ligula metus diam vitae euismod aptent. Nunc eros ridiculus volutpat praesent scelerisque dignissim
-      nunc cras. Ipsum diam dapibus cum sociis, elit adipiscing. Imperdiet vulputate neque elementum varius id,
-      torquent quis. Aliquam pretium sapien primis. Nunc iaculis mi magnis malesuada nascetur. Nostra habitasse
-      dictum dictum rutrum lacus? Tortor sem, taciti pellentesque cubilia! Vulputate at ridiculus hac lacinia
-      risus quisque potenti suscipit orci. Conubia urna tortor mauris ante litora nibh quisque consequat.
-    </p>
-  </div>
+      <div id="popover-boundary" class="popover-scroller">
+        <p>
+          Nec, dictum egestas odio in integer dictum eros. Euismod vitae vestibulum tempor sit adipiscing sed dolor
+          habitant per congue sit condimentum? Nisi nisl ornare ac semper imperdiet eu nascetur quisque ullamcorper a
+          id. Odio pharetra iaculis mattis fusce pharetra fusce. Venenatis suspendisse porta posuere torquent justo
+          arcu. Viverra venenatis nisl mi. Integer laoreet cubilia, lobortis nisi fringilla. Dictum venenatis taciti
+          arcu fringilla fames sociis.
+        </p>
+        <p>
+          Ultricies aliquam hac, commodo ullamcorper. At senectus blandit, magnis accumsan aptent vitae mi dapibus quis
+          sagittis taciti nisi. Et aliquam leo nullam sagittis conubia nascetur? Euismod blandit aptent conubia. Curae;
+          laoreet tortor urna eleifend dui ultrices vestibulum viverra dictumst risus? Vehicula diam vulputate cras
+          volutpat inceptos nostra cras at auctor! Luctus inceptos dis eleifend eleifend tellus molestie. Ridiculus eget
+          laoreet vitae.
+        </p>
+        <p>
+          Viverra mus velit interdum per pellentesque. Rutrum parturient risus feugiat habitasse magnis? Adipiscing
+          vehicula natoque rutrum consectetur dui, euismod ultricies ante quam pulvinar. Taciti mauris nam vehicula
+          sapien a taciti vel vitae cum id aenean! Torquent sapien fusce, class eros lectus. Ut sodales placerat
+          phasellus, nostra platea lobortis cubilia porta elementum viverra. Imperdiet ultrices, rhoncus himenaeos cum
+          risus. Egestas imperdiet velit, dapibus inceptos inceptos torquent. Dolor natoque, non imperdiet dictum
+          eleifend diam. Eget sem, hendrerit vulputate consectetur metus class.
+        </p>
+        <p>
+          Habitant vel penatibus felis sapien integer, imperdiet felis porttitor porta. Nec ad natoque habitasse metus
+          augue consequat sem tortor arcu tempor augue. Facilisi, magna amet cursus pellentesque. Nibh conubia tellus
+          porta torquent sociis mauris laoreet et neque venenatis habitasse! Egestas eu est nunc malesuada justo, fames
+          sociis ullamcorper? Sollicitudin inceptos, ipsum duis ullamcorper.
+        </p>
+        <p>
+          Fermentum mollis metus euismod netus ultricies ad gravida velit molestie integer. Accumsan amet litora ligula
+          ligula metus diam vitae euismod aptent. Nunc eros ridiculus volutpat praesent scelerisque dignissim nunc cras.
+          Ipsum diam dapibus cum sociis, elit adipiscing. Imperdiet vulputate neque elementum varius id, torquent quis.
+          Aliquam pretium sapien primis. Nunc iaculis mi magnis malesuada nascetur. Nostra habitasse dictum dictum
+          rutrum lacus? Tortor sem, taciti pellentesque cubilia! Vulputate at ridiculus hac lacinia risus quisque
+          potenti suscipit orci. Conubia urna tortor mauris ante litora nibh quisque consequat.
+        </p>
+        <calcite-popover
+          label="top start popover"
+          placement="top-start"
+          reference-element="popover-button"
+          id="popover"
+          close-button
+        >
+          <div style="padding: 12px 16px">Here kitty kitty!</div>
+        </calcite-popover>
+        <calcite-button id="popover-button" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+          Popover 🐱</calcite-button
+        >
+        <p>
+          Nec, dictum egestas odio in integer dictum eros. Euismod vitae vestibulum tempor sit adipiscing sed dolor
+          habitant per congue sit condimentum? Nisi nisl ornare ac semper imperdiet eu nascetur quisque ullamcorper a
+          id. Odio pharetra iaculis mattis fusce pharetra fusce. Venenatis suspendisse porta posuere torquent justo
+          arcu. Viverra venenatis nisl mi. Integer laoreet cubilia, lobortis nisi fringilla. Dictum venenatis taciti
+          arcu fringilla fames sociis.
+        </p>
+        <p>
+          Ultricies aliquam hac, commodo ullamcorper. At senectus blandit, magnis accumsan aptent vitae mi dapibus quis
+          sagittis taciti nisi. Et aliquam leo nullam sagittis conubia nascetur? Euismod blandit aptent conubia. Curae;
+          laoreet tortor urna eleifend dui ultrices vestibulum viverra dictumst risus? Vehicula diam vulputate cras
+          volutpat inceptos nostra cras at auctor! Luctus inceptos dis eleifend eleifend tellus molestie. Ridiculus eget
+          laoreet vitae.
+        </p>
+        <p>
+          Viverra mus velit interdum per pellentesque. Rutrum parturient risus feugiat habitasse magnis? Adipiscing
+          vehicula natoque rutrum consectetur dui, euismod ultricies ante quam pulvinar. Taciti mauris nam vehicula
+          sapien a taciti vel vitae cum id aenean! Torquent sapien fusce, class eros lectus. Ut sodales placerat
+          phasellus, nostra platea lobortis cubilia porta elementum viverra. Imperdiet ultrices, rhoncus himenaeos cum
+          risus. Egestas imperdiet velit, dapibus inceptos inceptos torquent. Dolor natoque, non imperdiet dictum
+          eleifend diam. Eget sem, hendrerit vulputate consectetur metus class.
+        </p>
+        <p>
+          Habitant vel penatibus felis sapien integer, imperdiet felis porttitor porta. Nec ad natoque habitasse metus
+          augue consequat sem tortor arcu tempor augue. Facilisi, magna amet cursus pellentesque. Nibh conubia tellus
+          porta torquent sociis mauris laoreet et neque venenatis habitasse! Egestas eu est nunc malesuada justo, fames
+          sociis ullamcorper? Sollicitudin inceptos, ipsum duis ullamcorper.
+        </p>
+        <p>
+          Fermentum mollis metus euismod netus ultricies ad gravida velit molestie integer. Accumsan amet litora ligula
+          ligula metus diam vitae euismod aptent. Nunc eros ridiculus volutpat praesent scelerisque dignissim nunc cras.
+          Ipsum diam dapibus cum sociis, elit adipiscing. Imperdiet vulputate neque elementum varius id, torquent quis.
+          Aliquam pretium sapien primis. Nunc iaculis mi magnis malesuada nascetur. Nostra habitasse dictum dictum
+          rutrum lacus? Tortor sem, taciti pellentesque cubilia! Vulputate at ridiculus hac lacinia risus quisque
+          potenti suscipit orci. Conubia urna tortor mauris ante litora nibh quisque consequat.
+        </p>
+      </div>
 
-  <ul class="popover-list demo-background-dark">
-    <li>
-      <calcite-button id="popover-button-six" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-        Clickable popover</calcite-button>
-    </li>
-    <li>
-      <calcite-button id="popover-button-eight" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-        With close button</calcite-button>
-    </li>
-    <li>
-      <calcite-button id="popover-button-seven" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-        Title, content & CTA</calcite-button>
-    </li>
-    <li>
-      <calcite-button id="popover-button-five" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-        Popover 🐱</calcite-button>
-    </li>
-    <div dir="rtl">
-      <calcite-button id="popover-button-rtl" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
-        Popover RTL
-      </calcite-button>
-    </div>
-  </ul>
-
-</calcite-popover-manager>
-
-</body>
-
+      <ul class="popover-list demo-background-dark">
+        <li>
+          <calcite-button id="popover-button-six" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+            Clickable popover</calcite-button
+          >
+        </li>
+        <li>
+          <calcite-button id="popover-button-eight" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+            With close button</calcite-button
+          >
+        </li>
+        <li>
+          <calcite-button id="popover-button-seven" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+            Title, content & CTA</calcite-button
+          >
+        </li>
+        <li>
+          <calcite-button id="popover-button-five" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+            Popover 🐱</calcite-button
+          >
+        </li>
+        <div dir="rtl">
+          <calcite-button id="popover-button-rtl" icon="M15.707 20h-1.414l-7.5-7.5 7.5-7.5h1.414l-7.5 7.5z">
+            Popover RTL
+          </calcite-button>
+        </div>
+      </ul>
+    </calcite-popover-manager>
+  </body>
 </html>

--- a/src/demos/calcite-progress.html
+++ b/src/demos/calcite-progress.html
@@ -12,7 +12,7 @@
         padding: 1rem;
       }
     </style>
-  <script src="./_assets/head.js"></script>
+    <script src="./_assets/head.js"></script>
   </head>
 
   <body>
@@ -21,11 +21,7 @@
     <h1>Indeterminate</h1>
     <calcite-progress type="indeterminate"></calcite-progress>
     <h1>Determinate</h1>
-    <calcite-progress
-      type="determinate"
-      value="0.5"
-      text="50% Complete (optional text)"
-    ></calcite-progress>
+    <calcite-progress type="determinate" value="0.5" text="50% Complete (optional text)"></calcite-progress>
     <h1>Reversed</h1>
     <calcite-progress type="indeterminate" reversed></calcite-progress>
     <br />
@@ -33,16 +29,11 @@
     <br />
     <div class="demo-background-dark">
       <h1>Indeterminate</h1>
-      <calcite-progress theme="dark" type="indeterminate"></calcite-progress>
+      <calcite-progress class="calcite-theme-dark" type="indeterminate"></calcite-progress>
       <br />
       <br />
       <h1>Determinate</h1>
-      <calcite-progress
-        theme="dark"
-        type="determinate"
-        value="0.5"
-        text="50% Complete (optional text)"
-      >
+      <calcite-progress class="calcite-theme-dark" type="determinate" value="0.5" text="50% Complete (optional text)">
       </calcite-progress>
     </div>
   </body>

--- a/src/demos/calcite-radio-button-group-rtl.html
+++ b/src/demos/calcite-radio-button-group-rtl.html
@@ -1,82 +1,120 @@
 <!DOCTYPE html>
 <html lang="en" dir="rtl">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-  <title>Calcite Radio Button Group (RTL)</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Radio Button Group (RTL)</title>
 
-  <style>
-    h1,
-    h2,
-    h3 {
-      margin: 0;
-    }
+    <style>
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+      }
 
-    hr {
-      width: 100%;
-      border: 0;
-      height: 0;
-      border-top: 1px solid rgba(0, 0, 0, 0.1);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-      margin: 0;
-    }
+      hr {
+        width: 100%;
+        border: 0;
+        height: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.1);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+        margin: 0;
+      }
 
-    .vertical-grid {
-      display: grid;
-      grid-gap: 25px;
-      grid-template-columns: repeat(3, minmax(0px, max-content));
-    }
+      .vertical-grid {
+        display: grid;
+        grid-gap: 25px;
+        grid-template-columns: repeat(3, minmax(0px, max-content));
+      }
 
-    .dark {
-      background: #2b2b2b;
-      padding: 1rem;
-    }
+      .dark {
+        background: #2b2b2b;
+        padding: 1rem;
+      }
 
-    .dark h2,
-    .dark h3 {
-      color: white;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
-</head>
+      .dark h2,
+      .dark h3 {
+        color: white;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
+  </head>
 
-<body>
-  <demo-spacer>
-    <calcite-button href="/">
-      < Home</calcite-button>
-        <h1>Calcite Radio Button Group</h1>
-        <demo-form>
-          <form name="calcite-radio-button-group-demo-form">
-            <demo-spacer>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
-              <div
-                style="display: grid; grid-template-columns: repeat(auto-fit, minmax(500px, max-content)); grid-gap: 8px;">
-                <div style="border: 1px solid #2B2B2B; padding: 1rem;">
-                  <demo-spacer>
-                    <h3>Scale s</h3>
-                    <calcite-radio-button-group name="s" scale="s">
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="react" checked></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="s-disabled" scale="s" disabled>
+  <body>
+    <demo-spacer>
+      <calcite-button href="/"> < Home</calcite-button>
+      <h1>Calcite Radio Button Group</h1>
+      <demo-form>
+        <form name="calcite-radio-button-group-demo-form">
+          <demo-spacer>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
+            <div
+              style="display: grid; grid-template-columns: repeat(auto-fit, minmax(500px, max-content)); grid-gap: 8px"
+            >
+              <div style="border: 1px solid #2b2b2b; padding: 1rem">
+                <demo-spacer>
+                  <h3>Scale s</h3>
+                  <calcite-radio-button-group name="s" scale="s">
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="react" checked></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="s-disabled" scale="s" disabled>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="s-disabled-single" scale="s">
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="s">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group name="s-label-wrapped" scale="s">
                       <calcite-label layout="inline" scale="s">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -94,7 +132,46 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="s-disabled-single" scale="s">
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="s-vertical" scale="s" layout="vertical">
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="s-disabled-vertical" scale="s" disabled layout="vertical">
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="s-disabled-single-vertical" scale="s" layout="vertical">
                       <calcite-label layout="inline" scale="s">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -114,7 +191,7 @@
                     </calcite-radio-button-group>
                     <calcite-label scale="s">
                       wrapped in calcite-label
-                      <calcite-radio-button-group name="s-label-wrapped" scale="s">
+                      <calcite-radio-button-group name="s-vertical-label-wrapped" scale="s" layout="vertical">
                         <calcite-label layout="inline" scale="s">
                           <calcite-radio-button value="stencil" checked></calcite-radio-button>
                           Stencil
@@ -133,87 +210,66 @@
                         </calcite-label>
                       </calcite-radio-button-group>
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="s-vertical" scale="s" layout="vertical">
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="s-disabled-vertical" scale="s" disabled layout="vertical">
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="s-disabled-single-vertical" scale="s" layout="vertical">
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="s">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group name="s-vertical-label-wrapped" scale="s" layout="vertical">
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </div>
 
-                    <h3>Scale m (default)</h3>
-                    <calcite-radio-button-group name="m">
+                  <h3>Scale m (default)</h3>
+                  <calcite-radio-button-group name="m">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="m-disabled" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="m-disabled-single">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="m">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group name="m-label-wrapped">
                       <calcite-label layout="inline">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -231,7 +287,10 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="m-disabled" disabled>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="m-vertical" layout="vertical">
                       <calcite-label layout="inline">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -249,7 +308,25 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="m-disabled-single">
+                    <calcite-radio-button-group name="m-disabled-vertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="m-disabled-single-vertical" layout="vertical">
                       <calcite-label layout="inline">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -269,7 +346,7 @@
                     </calcite-radio-button-group>
                     <calcite-label scale="m">
                       wrapped in calcite-label
-                      <calcite-radio-button-group name="m-label-wrapped">
+                      <calcite-radio-button-group name="m-vertical-label-wrapped" layout="vertical">
                         <calcite-label layout="inline">
                           <calcite-radio-button value="stencil" checked></calcite-radio-button>
                           Stencil
@@ -288,87 +365,66 @@
                         </calcite-label>
                       </calcite-radio-button-group>
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="m-vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="m-disabled-vertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="m-disabled-single-vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="m">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group name="m-vertical-label-wrapped" layout="vertical">
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </div>
 
-                    <h3>Scale l</h3>
-                    <calcite-radio-button-group name="l" scale="l">
+                  <h3>Scale l</h3>
+                  <calcite-radio-button-group name="l" scale="l">
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="l-disabled" scale="l" disabled>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="l-disabled-single" scale="l">
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="l">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group name="l-label-wrapped" scale="l">
                       <calcite-label layout="inline" scale="l">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -386,7 +442,10 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="l-disabled" scale="l" disabled>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="l-vertical" scale="l" layout="vertical">
                       <calcite-label layout="inline" scale="l">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -404,7 +463,25 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="l-disabled-single" scale="l">
+                    <calcite-radio-button-group name="l-disabled-vertical" scale="l" disabled layout="vertical">
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="l-disabled-single-vertical" scale="l" layout="vertical">
                       <calcite-label layout="inline" scale="l">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -424,7 +501,7 @@
                     </calcite-radio-button-group>
                     <calcite-label scale="l">
                       wrapped in calcite-label
-                      <calcite-radio-button-group name="l-label-wrapped" scale="l">
+                      <calcite-radio-button-group name="l-vertical-label-wrapped" scale="l" layout="vertical">
                         <calcite-label layout="inline" scale="l">
                           <calcite-radio-button value="stencil" checked></calcite-radio-button>
                           Stencil
@@ -443,136 +520,14 @@
                         </calcite-label>
                       </calcite-radio-button-group>
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="l-vertical" scale="l" layout="vertical">
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="l-disabled-vertical" scale="l" disabled layout="vertical">
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="l-disabled-single-vertical" scale="l" layout="vertical">
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="l">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group name="l-vertical-label-wrapped" scale="l" layout="vertical">
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </div>
 
-                    <hr>
+                  <hr />
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="valueAsLabelVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="valueAsLabelDisabledVertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="valueAsLabelDisabledSingleVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>None checked</h3>
-                    <calcite-radio-button-group name="noneChecked">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="valueAsLabelVertical" layout="vertical">
                       <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
                       <calcite-label layout="inline">
@@ -584,9 +539,9 @@
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="noneCheckedDisabled" disabled>
+                    <calcite-radio-button-group name="valueAsLabelDisabledVertical" disabled layout="vertical">
                       <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
                       <calcite-label layout="inline">
@@ -598,9 +553,9 @@
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="noneCheckedDisabledSingle">
+                    <calcite-radio-button-group name="valueAsLabelDisabledSingleVertical" layout="vertical">
                       <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
                       <calcite-label layout="inline">
@@ -612,1423 +567,1600 @@
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="noneCheckedVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="noneCheckedDisabledVertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="noneCheckedDisabledSingleVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, first two checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsFirst2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3"></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3"></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3"></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsFirst2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2Vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, second two checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsSecond2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSecond2" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsSecond2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSecond2Vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, first and last checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsFirstLast">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2"></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledFirstLast" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2"></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLast">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsFirstLastVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledFirstLastVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLastVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, all checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsAll">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsAllDisabled" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingle">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsAllVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsAllDisabledVertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingleVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-                  </demo-spacer>
-                </div>
-                <div class="dark">
-                  <demo-spacer>
-                    <h3>Scale s</h3>
-                    <calcite-radio-button-group theme="dark" name="s-dark" scale="s">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="s-dark-disabled" scale="s" disabled>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="s-dark-disabled-single" scale="s">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react" disabled></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-label scale="s" theme="dark">
-                      wrapped in calcite-label
-                      <calcite-radio-button-group theme="dark" name="s-dark-label-wrapped" scale="s">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
+                  <h3>None checked</h3>
+                  <calcite-radio-button-group name="noneChecked">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="s-dark-vertical" scale="s" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="s-dark-disabled-vertical" scale="s" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="s-dark-disabled-single-vertical" scale="s"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="s" theme="dark">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group theme="dark" name="s-dark-vertical-label-wrapped" scale="s"
-                          layout="vertical">
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
-
-                    <h3>Scale m (default)</h3>
-                    <calcite-radio-button-group theme="dark" name="m-dark">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="m-dark-disabled" disabled>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="m-dark-disabled-single">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react" disabled></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-label scale="m" theme="dark">
-                      wrapped in calcite-label
-                      <calcite-radio-button-group theme="dark" name="m-dark-label-wrapped">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="m-dark-vertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="m-dark-disabled-vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="m-dark-disabled-single-vertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="m" theme="dark">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group theme="dark" name="m-dark-vertical-label-wrapped" layout="vertical">
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
-
-                    <h3>Scale l</h3>
-                    <calcite-radio-button-group theme="dark" name="l-dark" scale="l">
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="l-dark-disabled" scale="l" disabled>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="l-dark-disabled-single" scale="l">
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="react" disabled></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-label scale="l" theme="dark">
-                      wrapped in calcite-label
-                      <calcite-radio-button-group theme="dark" name="l-dark-label-wrapped" scale="l">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="l-dark-vertical" scale="l" layout="vertical">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="l-dark-disabled-vertical" scale="l" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="l-dark-disabled-single-vertical" scale="l"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="l" theme="dark">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group theme="dark" name="l-dark-vertical-label-wrapped" scale="l"
-                          layout="vertical">
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="noneCheckedDisabled" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="noneCheckedDisabledSingle">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <hr>
+                  <hr />
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="valueAsLabelDarkVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="valueAsLabelDarkDisabledVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="valueAsLabelDarkDisabledSingleVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>None checked</h3>
-                    <calcite-radio-button-group theme="dark" name="noneCheckedDark">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="noneCheckedVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabled" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="noneCheckedDisabledVertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabledSingle">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="noneCheckedDisabledSingleVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, first two checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsFirst2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="noneCheckedDarkVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabledVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabledSingleVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, first two checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirst2">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsFirst2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirst2" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2Vertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, second two checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsSecond2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSecond2" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirst2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirst2Vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, second two checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkSecond2">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsSecond2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSecond2" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group
+                      name="lastCheckedWinsDisabledSecond2Vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, first and last checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsFirstLast">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledFirstLast" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLast">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkSecond2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSecond2Vertical"
-                        disabled layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, first and last checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirstLast">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsFirstLastVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirstLast" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group
+                      name="lastCheckedWinsDisabledFirstLastVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLastVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, all checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsAll">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsAllDisabled" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingle">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirstLastVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirstLastVertical"
-                        disabled layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLastVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, all checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAll">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsAllVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabled" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsAllDisabledVertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabledSingle">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingleVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabledVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabledSingleVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-                  </demo-spacer>
-                </div>
+                  </div>
+                </demo-spacer>
               </div>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
-              <button type="submit" style="display: none">Submit</button>
-            </demo-spacer>
-          </form>
-        </demo-form>
-  </demo-spacer>
-</body>
+              <div class="dark">
+                <demo-spacer>
+                  <h3>Scale s</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="s-dark" scale="s">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="s-dark-disabled" scale="s" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="s-dark-disabled-single" scale="s">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="s" class="calcite-theme-dark">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group class="calcite-theme-dark" name="s-dark-label-wrapped" scale="s">
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="s-dark-vertical"
+                      scale="s"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="s-dark-disabled-vertical"
+                      scale="s"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="s-dark-disabled-single-vertical"
+                      scale="s"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react" disabled></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-label scale="s" class="calcite-theme-dark">
+                      wrapped in calcite-label
+                      <calcite-radio-button-group
+                        class="calcite-theme-dark"
+                        name="s-dark-vertical-label-wrapped"
+                        scale="s"
+                        layout="vertical"
+                      >
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                          Stencil
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="react"></calcite-radio-button>
+                          React
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="ember"></calcite-radio-button>
+                          Ember
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="angular"></calcite-radio-button>
+                          Angular
+                        </calcite-label>
+                      </calcite-radio-button-group>
+                    </calcite-label>
+                  </div>
 
+                  <h3>Scale m (default)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="m-dark">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-disabled" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-disabled-single">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="m" class="calcite-theme-dark">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-label-wrapped">
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-vertical" layout="vertical">
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="m-dark-disabled-vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="m-dark-disabled-single-vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react" disabled></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-label scale="m" class="calcite-theme-dark">
+                      wrapped in calcite-label
+                      <calcite-radio-button-group
+                        class="calcite-theme-dark"
+                        name="m-dark-vertical-label-wrapped"
+                        layout="vertical"
+                      >
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                          Stencil
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="react"></calcite-radio-button>
+                          React
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="ember"></calcite-radio-button>
+                          Ember
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="angular"></calcite-radio-button>
+                          Angular
+                        </calcite-label>
+                      </calcite-radio-button-group>
+                    </calcite-label>
+                  </div>
+
+                  <h3>Scale l</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="l-dark" scale="l">
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="l-dark-disabled" scale="l" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="l-dark-disabled-single" scale="l">
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="l" class="calcite-theme-dark">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group class="calcite-theme-dark" name="l-dark-label-wrapped" scale="l">
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="l-dark-vertical"
+                      scale="l"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="l-dark-disabled-vertical"
+                      scale="l"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="l-dark-disabled-single-vertical"
+                      scale="l"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react" disabled></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-label scale="l" class="calcite-theme-dark">
+                      wrapped in calcite-label
+                      <calcite-radio-button-group
+                        class="calcite-theme-dark"
+                        name="l-dark-vertical-label-wrapped"
+                        scale="l"
+                        layout="vertical"
+                      >
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                          Stencil
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="react"></calcite-radio-button>
+                          React
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="ember"></calcite-radio-button>
+                          Ember
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="angular"></calcite-radio-button>
+                          Angular
+                        </calcite-label>
+                      </calcite-radio-button-group>
+                    </calcite-label>
+                  </div>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="valueAsLabelDarkVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="valueAsLabelDarkDisabledVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="valueAsLabelDarkDisabledSingleVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>None checked</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="noneCheckedDark">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="noneCheckedDarkDisabled" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="noneCheckedDarkDisabledSingle">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="noneCheckedDarkVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="noneCheckedDarkDisabledVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="noneCheckedDarkDisabledSingleVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, first two checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkFirst2">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledFirst2"
+                    disabled
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkDisabledSingleFirst2">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkFirst2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledFirst2Vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSingleFirst2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, second two checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkSecond2">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSecond2"
+                    disabled
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkSecond2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSecond2Vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSingleSecond2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, first and last checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkFirstLast">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledFirstLast"
+                    disabled
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkFirstLastVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledFirstLastVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSingleFirstLastVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, all checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkAll">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkAllDisabled" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkAllDisabledSingle">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkAllVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkAllDisabledVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkAllDisabledSingleVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+                </demo-spacer>
+              </div>
+            </div>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
+            <button type="submit" style="display: none">Submit</button>
+          </demo-spacer>
+        </form>
+      </demo-form>
+    </demo-spacer>
+  </body>
 </html>

--- a/src/demos/calcite-radio-button-group.html
+++ b/src/demos/calcite-radio-button-group.html
@@ -1,151 +1,188 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Radio Button Group</title>
+    <style>
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        color: var(--calcite-ui-text-1);
+      }
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Radio Button Group</title>
-  <style>
-    h1,
-    h2,
-    h3 {
-      margin: 0;
-      color: var(--calcite-ui-text-1);
-    }
+      hr {
+        width: 100%;
+        border: 0;
+        height: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.1);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+        margin: 0;
+      }
 
-    hr {
-      width: 100%;
-      border: 0;
-      height: 0;
-      border-top: 1px solid rgba(0, 0, 0, 0.1);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-      margin: 0;
-    }
+      section {
+        padding: 1rem 2rem;
+      }
 
-    section {
-      padding: 1rem 2rem;
-    }
+      .vertical-grid {
+        display: grid;
+        grid-gap: 25px;
+        grid-template-columns: repeat(4, minmax(0px, max-content));
+      }
 
-    .vertical-grid {
-      display: grid;
-      grid-gap: 25px;
-      grid-template-columns: repeat(4, minmax(0px, max-content));
-    }
+      .dark {
+        background: #2b2b2b;
+        padding: 1rem;
+      }
 
-    .dark {
-      background: #2B2B2B;
-      padding: 1rem;
-    }
+      .dark h2,
+      .dark h3 {
+        color: white;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
+  </head>
 
-    .dark h2,
-    .dark h3 {
-      color: white;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
-</head>
+  <body>
+    <demo-spacer>
+      <calcite-button href="/"> < Home</calcite-button>
+      <h1>Calcite Radio Button Group</h1>
 
-<body>
-  <demo-spacer>
-    <calcite-button href="/">
-      < Home</calcite-button>
-        <h1>Calcite Radio Button Group</h1>
+      <section>
+        <!-- src/components/calcite-radio-button-group/usage/.md -->
+        <div>
+          <h3>Basic</h3>
+          <calcite-radio-button-group name="basic-group">
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Maps
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Layers
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Data
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Geography
+            </calcite-label>
+          </calcite-radio-button-group>
+        </div>
+        <div>
+          <h3>With vertical layout</h3>
+          <calcite-radio-button-group name="vertical-group" layout="vertical">
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Maps
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Layers
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Data
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              Geography
+            </calcite-label>
+          </calcite-radio-button-group>
+        </div>
+        <div>
+          <h3>With all radio button inputs disabled, first one checked</h3>
+          <calcite-radio-button-group name="disabled-group" disabled>
+            <calcite-label layout="inline">
+              <calcite-radio-button checked></calcite-radio-button>
+              A
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              B
+            </calcite-label>
+            <calcite-label layout="inline">
+              <calcite-radio-button></calcite-radio-button>
+              C
+            </calcite-label>
+          </calcite-radio-button-group>
+        </div>
+      </section>
 
-        <section>
-          <!-- src/components/calcite-radio-button-group/usage/.md -->
-          <div>
-            <h3>Basic</h3>
-            <calcite-radio-button-group name="basic-group">
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Maps
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Layers
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Data
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Geography
-              </calcite-label>
-            </calcite-radio-button-group>
-          </div>
-          <div>
-            <h3>With vertical layout</h3>
-            <calcite-radio-button-group name="vertical-group" layout="vertical">
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Maps
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Layers
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Data
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                Geography
-              </calcite-label>
-            </calcite-radio-button-group>
-          </div>
-          <div>
-            <h3>With all radio button inputs disabled, first one checked</h3>
-            <calcite-radio-button-group name="disabled-group" disabled>
-              <calcite-label layout="inline">
-                <calcite-radio-button checked></calcite-radio-button>
-                A
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                B
-              </calcite-label>
-              <calcite-label layout="inline">
-                <calcite-radio-button></calcite-radio-button>
-                C
-              </calcite-label>
-            </calcite-radio-button-group>
-          </div>
-        </section>
-
-        <demo-form>
-          <form name="calcite-radio-button-group-demo-form">
-            <demo-spacer>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
-              <div
-                style="display: grid; grid-template-columns: repeat(auto-fit, minmax(500px, max-content)); grid-gap: 8px;">
-                <div style="border: 1px solid #2B2B2B; padding: 1rem;">
-                  <demo-spacer>
-                    <h3>Scale s</h3>
-                    <calcite-radio-button-group name="s" scale="s">
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="react" checked></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" scale="s">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="s-disabled" scale="s" disabled>
+      <demo-form>
+        <form name="calcite-radio-button-group-demo-form">
+          <demo-spacer>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
+            <div
+              style="display: grid; grid-template-columns: repeat(auto-fit, minmax(500px, max-content)); grid-gap: 8px"
+            >
+              <div style="border: 1px solid #2b2b2b; padding: 1rem">
+                <demo-spacer>
+                  <h3>Scale s</h3>
+                  <calcite-radio-button-group name="s" scale="s">
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="react" checked></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="s-disabled" scale="s" disabled>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="s-disabled-single" scale="s">
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="s">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="s">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group name="s-label-wrapped" scale="s">
                       <calcite-label layout="inline" scale="s">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -163,7 +200,46 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="s-disabled-single" scale="s">
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="s-vertical" scale="s" layout="vertical">
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="s-disabled-vertical" scale="s" disabled layout="vertical">
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="s">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="s-disabled-single-vertical" scale="s" layout="vertical">
                       <calcite-label layout="inline" scale="s">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -183,7 +259,7 @@
                     </calcite-radio-button-group>
                     <calcite-label scale="s">
                       wrapped in calcite-label
-                      <calcite-radio-button-group name="s-label-wrapped" scale="s">
+                      <calcite-radio-button-group name="s-vertical-label-wrapped" scale="s" layout="vertical">
                         <calcite-label layout="inline" scale="s">
                           <calcite-radio-button value="stencil" checked></calcite-radio-button>
                           Stencil
@@ -202,87 +278,66 @@
                         </calcite-label>
                       </calcite-radio-button-group>
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="s-vertical" scale="s" layout="vertical">
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="s-disabled-vertical" scale="s" disabled layout="vertical">
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="s-disabled-single-vertical" scale="s" layout="vertical">
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="s">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="s">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group name="s-vertical-label-wrapped" scale="s" layout="vertical">
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="s">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </div>
 
-                    <h3>Scale m (default)</h3>
-                    <calcite-radio-button-group name="m">
+                  <h3>Scale m (default)</h3>
+                  <calcite-radio-button-group name="m">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="m-disabled" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="m-disabled-single">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="m">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group name="m-label-wrapped">
                       <calcite-label layout="inline">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -300,7 +355,10 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="m-disabled" disabled>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="m-vertical" layout="vertical">
                       <calcite-label layout="inline">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -318,7 +376,25 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="m-disabled-single">
+                    <calcite-radio-button-group name="m-disabled-vertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="m-disabled-single-vertical" layout="vertical">
                       <calcite-label layout="inline">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -338,7 +414,7 @@
                     </calcite-radio-button-group>
                     <calcite-label scale="m">
                       wrapped in calcite-label
-                      <calcite-radio-button-group name="m-label-wrapped">
+                      <calcite-radio-button-group name="m-vertical-label-wrapped" layout="vertical">
                         <calcite-label layout="inline">
                           <calcite-radio-button value="stencil" checked></calcite-radio-button>
                           Stencil
@@ -357,87 +433,66 @@
                         </calcite-label>
                       </calcite-radio-button-group>
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="m-vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="m-disabled-vertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="m-disabled-single-vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="m">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group name="m-vertical-label-wrapped" layout="vertical">
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </div>
 
-                    <h3>Scale l</h3>
-                    <calcite-radio-button-group name="l" scale="l">
+                  <h3>Scale l</h3>
+                  <calcite-radio-button-group name="l" scale="l">
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="l-disabled" scale="l" disabled>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="l-disabled-single" scale="l">
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="l">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group name="l-label-wrapped" scale="l">
                       <calcite-label layout="inline" scale="l">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -455,7 +510,10 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="l-disabled" scale="l" disabled>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="l-vertical" scale="l" layout="vertical">
                       <calcite-label layout="inline" scale="l">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -473,7 +531,25 @@
                         Angular
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="l-disabled-single" scale="l">
+                    <calcite-radio-button-group name="l-disabled-vertical" scale="l" disabled layout="vertical">
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group name="l-disabled-single-vertical" scale="l" layout="vertical">
                       <calcite-label layout="inline" scale="l">
                         <calcite-radio-button value="stencil" checked></calcite-radio-button>
                         Stencil
@@ -493,7 +569,7 @@
                     </calcite-radio-button-group>
                     <calcite-label scale="l">
                       wrapped in calcite-label
-                      <calcite-radio-button-group name="l-label-wrapped" scale="l">
+                      <calcite-radio-button-group name="l-vertical-label-wrapped" scale="l" layout="vertical">
                         <calcite-label layout="inline" scale="l">
                           <calcite-radio-button value="stencil" checked></calcite-radio-button>
                           Stencil
@@ -512,136 +588,14 @@
                         </calcite-label>
                       </calcite-radio-button-group>
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="l-vertical" scale="l" layout="vertical">
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="l-disabled-vertical" scale="l" disabled layout="vertical">
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="l-disabled-single-vertical" scale="l" layout="vertical">
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="l">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group name="l-vertical-label-wrapped" scale="l" layout="vertical">
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" scale="l">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </div>
 
-                    <hr>
+                  <hr />
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="valueAsLabelVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="valueAsLabelDisabledVertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="valueAsLabelDisabledSingleVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>None checked</h3>
-                    <calcite-radio-button-group name="noneChecked">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="valueAsLabelVertical" layout="vertical">
                       <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
                       <calcite-label layout="inline">
@@ -653,9 +607,9 @@
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="noneCheckedDisabled" disabled>
+                    <calcite-radio-button-group name="valueAsLabelDisabledVertical" disabled layout="vertical">
                       <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
                       <calcite-label layout="inline">
@@ -667,9 +621,9 @@
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group name="noneCheckedDisabledSingle">
+                    <calcite-radio-button-group name="valueAsLabelDisabledSingleVertical" layout="vertical">
                       <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
                       <calcite-label layout="inline">
@@ -681,1422 +635,1600 @@
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="noneCheckedVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="noneCheckedDisabledVertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="noneCheckedDisabledSingleVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, first two checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsFirst2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3"></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3"></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3"></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsFirst2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2Vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, second two checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsSecond2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSecond2" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1"></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsSecond2Vertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSecond2Vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, first and last checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsFirstLast">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2"></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledFirstLast" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2"></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLast">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsFirstLastVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledFirstLastVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLastVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>Only one checked value (last wins, all checked)</h3>
-                    <calcite-radio-button-group name="lastCheckedWinsAll">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsAllDisabled" disabled>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingle">
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="1" checked></calcite-radio-button>
-                        1
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                        2
-                      </calcite-label>
-                      <calcite-label layout="inline">
-                        <calcite-radio-button value="3" checked></calcite-radio-button>
-                        3
-                      </calcite-label>
-                    </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group name="lastCheckedWinsAllVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsAllDisabledVertical" disabled layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingleVertical" layout="vertical">
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-                  </demo-spacer>
-                </div>
-                <div class="dark">
-                  <demo-spacer>
-                    <h3>Scale s</h3>
-                    <calcite-radio-button-group theme="dark" name="s-dark" scale="s">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="s-dark-disabled" scale="s" disabled>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="s-dark-disabled-single" scale="s">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react" disabled></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-label scale="s" theme="dark">
-                      wrapped in calcite-label
-                      <calcite-radio-button-group theme="dark" name="s-dark-label-wrapped" scale="s">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
+                  <h3>None checked</h3>
+                  <calcite-radio-button-group name="noneChecked">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="s-dark-vertical" scale="s" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="s-dark-disabled-vertical" scale="s" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="s-dark-disabled-single-vertical" scale="s"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="s" theme="dark">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group theme="dark" name="s-dark-vertical-label-wrapped" scale="s" layout="vertical">
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
-
-                    <h3>Scale m (default)</h3>
-                    <calcite-radio-button-group theme="dark" name="m-dark">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="m-dark-disabled" disabled>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="m-dark-disabled-single">
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="react" disabled></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-label scale="m" theme="dark">
-                      wrapped in calcite-label
-                      <calcite-radio-button-group theme="dark" name="m-dark-label-wrapped">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="m-dark-vertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="m-dark-disabled-vertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="m-dark-disabled-single-vertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="m" theme="dark">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group theme="dark" name="m-dark-vertical-label-wrapped" layout="vertical">
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
-
-                    <h3>Scale l</h3>
-                    <calcite-radio-button-group theme="dark" name="l-dark" scale="l">
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="l-dark-disabled" scale="l" disabled>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="react"></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="l-dark-disabled-single" scale="l">
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                        Stencil
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="react" disabled></calcite-radio-button>
-                        React
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="ember"></calcite-radio-button>
-                        Ember
-                      </calcite-label>
-                      <calcite-label layout="inline" theme="dark" scale="l">
-                        <calcite-radio-button value="angular"></calcite-radio-button>
-                        Angular
-                      </calcite-label>
-                    </calcite-radio-button-group>
-                    <calcite-label scale="l" theme="dark">
-                      wrapped in calcite-label
-                      <calcite-radio-button-group theme="dark" name="l-dark-label-wrapped" scale="l">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
                     </calcite-label>
-                    <hr>
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="l-dark-vertical" scale="l" layout="vertical">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="l-dark-disabled-vertical" scale="l" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react"></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="l-dark-disabled-single-vertical" scale="l"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                          Stencil
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="react" disabled></calcite-radio-button>
-                          React
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="ember"></calcite-radio-button>
-                          Ember
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark" scale="l">
-                          <calcite-radio-button value="angular"></calcite-radio-button>
-                          Angular
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-label scale="l" theme="dark">
-                        wrapped in calcite-label
-                        <calcite-radio-button-group theme="dark" name="l-dark-vertical-label-wrapped" scale="l" layout="vertical">
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="stencil" checked></calcite-radio-button>
-                            Stencil
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="react"></calcite-radio-button>
-                            React
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="ember"></calcite-radio-button>
-                            Ember
-                          </calcite-label>
-                          <calcite-label layout="inline" theme="dark" scale="l">
-                            <calcite-radio-button value="angular"></calcite-radio-button>
-                            Angular
-                          </calcite-label>
-                        </calcite-radio-button-group>
-                      </calcite-label>
-                    </div>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="noneCheckedDisabled" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="noneCheckedDisabledSingle">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <hr>
+                  <hr />
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="valueAsLabelDarkVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="valueAsLabelDarkDisabledVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="valueAsLabelDarkDisabledSingleVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-
-                    <h3>None checked</h3>
-                    <calcite-radio-button-group theme="dark" name="noneCheckedDark">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="noneCheckedVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabled" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="noneCheckedDisabledVertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabledSingle">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="noneCheckedDisabledSingleVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, first two checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsFirst2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="noneCheckedDarkVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabledVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="noneCheckedDarkDisabledSingleVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, first two checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirst2">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsFirst2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirst2" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledFirst2Vertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirst2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3"></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, second two checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsSecond2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSecond2" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirst2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirst2Vertical"
-                        disabled layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3"></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, second two checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkSecond2">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsSecond2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSecond2" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group
+                      name="lastCheckedWinsDisabledSecond2Vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleSecond2Vertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1"></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, first and last checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsFirstLast">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledFirstLast" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLast">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkSecond2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSecond2Vertical"
-                        disabled layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2Vertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1"></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, first and last checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirstLast">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsFirstLastVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirstLast" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group
+                      name="lastCheckedWinsDisabledFirstLastVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2"></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsDisabledSingleFirstLastVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
+                  </div>
 
-                    <hr>
+                  <h3>Only one checked value (last wins, all checked)</h3>
+                  <calcite-radio-button-group name="lastCheckedWinsAll">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsAllDisabled" disabled>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingle">
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
 
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkFirstLastVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkDisabledFirstLastVertical"
-                        disabled layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2"></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark"
-                        name="lastCheckedWinsDarkDisabledSingleFirstLastVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
+                  <hr />
 
-                    <h3>Only one checked value (last wins, all checked)</h3>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAll">
-                      <calcite-label layout="inline" theme="dark">
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group name="lastCheckedWinsAllVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabled" disabled>
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsAllDisabledVertical" disabled layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-                    <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabledSingle">
-                      <calcite-label layout="inline" theme="dark">
+                    <calcite-radio-button-group name="lastCheckedWinsAllDisabledSingleVertical" layout="vertical">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="1" checked></calcite-radio-button>
                         1
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="2" checked disabled></calcite-radio-button>
                         2
                       </calcite-label>
-                      <calcite-label layout="inline" theme="dark">
+                      <calcite-label layout="inline">
                         <calcite-radio-button value="3" checked></calcite-radio-button>
                         3
                       </calcite-label>
                     </calcite-radio-button-group>
-
-                    <hr>
-
-                    <div class="vertical-grid">
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllVertical" layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabledVertical" disabled
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                      <calcite-radio-button-group theme="dark" name="lastCheckedWinsDarkAllDisabledSingleVertical"
-                        layout="vertical">
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="1" checked></calcite-radio-button>
-                          1
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="2" checked disabled></calcite-radio-button>
-                          2
-                        </calcite-label>
-                        <calcite-label layout="inline" theme="dark">
-                          <calcite-radio-button value="3" checked></calcite-radio-button>
-                          3
-                        </calcite-label>
-                      </calcite-radio-button-group>
-                    </div>
-                  </demo-spacer>
-                </div>
+                  </div>
+                </demo-spacer>
               </div>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
-              <button type="submit" style="display: none">Submit</button>
-            </demo-spacer>
-          </form>
-        </demo-form>
-  </demo-spacer>
-</body>
+              <div class="dark">
+                <demo-spacer>
+                  <h3>Scale s</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="s-dark" scale="s">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="s-dark-disabled" scale="s" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="s-dark-disabled-single" scale="s">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="s" class="calcite-theme-dark">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group class="calcite-theme-dark" name="s-dark-label-wrapped" scale="s">
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="s-dark-vertical"
+                      scale="s"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="s-dark-disabled-vertical"
+                      scale="s"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="s-dark-disabled-single-vertical"
+                      scale="s"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react" disabled></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-label scale="s" class="calcite-theme-dark">
+                      wrapped in calcite-label
+                      <calcite-radio-button-group
+                        class="calcite-theme-dark"
+                        name="s-dark-vertical-label-wrapped"
+                        scale="s"
+                        layout="vertical"
+                      >
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                          Stencil
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="react"></calcite-radio-button>
+                          React
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="ember"></calcite-radio-button>
+                          Ember
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="angular"></calcite-radio-button>
+                          Angular
+                        </calcite-label>
+                      </calcite-radio-button-group>
+                    </calcite-label>
+                  </div>
 
+                  <h3>Scale m (default)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="m-dark">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-disabled" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-disabled-single">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="m" class="calcite-theme-dark">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-label-wrapped">
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group class="calcite-theme-dark" name="m-dark-vertical" layout="vertical">
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="m-dark-disabled-vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="m-dark-disabled-single-vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="react" disabled></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-label scale="m" class="calcite-theme-dark">
+                      wrapped in calcite-label
+                      <calcite-radio-button-group
+                        class="calcite-theme-dark"
+                        name="m-dark-vertical-label-wrapped"
+                        layout="vertical"
+                      >
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                          Stencil
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="react"></calcite-radio-button>
+                          React
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="ember"></calcite-radio-button>
+                          Ember
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark">
+                          <calcite-radio-button value="angular"></calcite-radio-button>
+                          Angular
+                        </calcite-label>
+                      </calcite-radio-button-group>
+                    </calcite-label>
+                  </div>
+
+                  <h3>Scale l</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="l-dark" scale="l">
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="l-dark-disabled" scale="l" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="react"></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="l-dark-disabled-single" scale="l">
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                      Stencil
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="react" disabled></calcite-radio-button>
+                      React
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="ember"></calcite-radio-button>
+                      Ember
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                      <calcite-radio-button value="angular"></calcite-radio-button>
+                      Angular
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-label scale="l" class="calcite-theme-dark">
+                    wrapped in calcite-label
+                    <calcite-radio-button-group class="calcite-theme-dark" name="l-dark-label-wrapped" scale="l">
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </calcite-label>
+                  <hr />
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="l-dark-vertical"
+                      scale="l"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="l-dark-disabled-vertical"
+                      scale="l"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react"></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="l-dark-disabled-single-vertical"
+                      scale="l"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                        Stencil
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="react" disabled></calcite-radio-button>
+                        React
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="ember"></calcite-radio-button>
+                        Ember
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                        <calcite-radio-button value="angular"></calcite-radio-button>
+                        Angular
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-label scale="l" class="calcite-theme-dark">
+                      wrapped in calcite-label
+                      <calcite-radio-button-group
+                        class="calcite-theme-dark"
+                        name="l-dark-vertical-label-wrapped"
+                        scale="l"
+                        layout="vertical"
+                      >
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="stencil" checked></calcite-radio-button>
+                          Stencil
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="react"></calcite-radio-button>
+                          React
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="ember"></calcite-radio-button>
+                          Ember
+                        </calcite-label>
+                        <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                          <calcite-radio-button value="angular"></calcite-radio-button>
+                          Angular
+                        </calcite-label>
+                      </calcite-radio-button-group>
+                    </calcite-label>
+                  </div>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="valueAsLabelDarkVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="valueAsLabelDarkDisabledVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="valueAsLabelDarkDisabledSingleVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>None checked</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="noneCheckedDark">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="noneCheckedDarkDisabled" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="noneCheckedDarkDisabledSingle">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="noneCheckedDarkVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="noneCheckedDarkDisabledVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="noneCheckedDarkDisabledSingleVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, first two checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkFirst2">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledFirst2"
+                    disabled
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkDisabledSingleFirst2">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3"></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkFirst2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledFirst2Vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSingleFirst2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3"></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, second two checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkSecond2">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSecond2"
+                    disabled
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1"></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkSecond2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSecond2Vertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSingleSecond2Vertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1"></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, first and last checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkFirstLast">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledFirstLast"
+                    disabled
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2"></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                  >
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkFirstLastVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledFirstLastVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2"></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkDisabledSingleFirstLastVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+
+                  <h3>Only one checked value (last wins, all checked)</h3>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkAll">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkAllDisabled" disabled>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+                  <calcite-radio-button-group class="calcite-theme-dark" name="lastCheckedWinsDarkAllDisabledSingle">
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="1" checked></calcite-radio-button>
+                      1
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                      2
+                    </calcite-label>
+                    <calcite-label layout="inline" class="calcite-theme-dark">
+                      <calcite-radio-button value="3" checked></calcite-radio-button>
+                      3
+                    </calcite-label>
+                  </calcite-radio-button-group>
+
+                  <hr />
+
+                  <div class="vertical-grid">
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkAllVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkAllDisabledVertical"
+                      disabled
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                    <calcite-radio-button-group
+                      class="calcite-theme-dark"
+                      name="lastCheckedWinsDarkAllDisabledSingleVertical"
+                      layout="vertical"
+                    >
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="1" checked></calcite-radio-button>
+                        1
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="2" checked disabled></calcite-radio-button>
+                        2
+                      </calcite-label>
+                      <calcite-label layout="inline" class="calcite-theme-dark">
+                        <calcite-radio-button value="3" checked></calcite-radio-button>
+                        3
+                      </calcite-label>
+                    </calcite-radio-button-group>
+                  </div>
+                </demo-spacer>
+              </div>
+            </div>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-group-demo-form" type="reset">Reset</calcite-button>
+            <button type="submit" style="display: none">Submit</button>
+          </demo-spacer>
+        </form>
+      </demo-form>
+    </demo-spacer>
+  </body>
 </html>

--- a/src/demos/calcite-radio-button-rtl.html
+++ b/src/demos/calcite-radio-button-rtl.html
@@ -1,970 +1,1289 @@
 <!DOCTYPE html>
 <html lang="en" dir="rtl">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Radio Button (RTL)</title>
-  <style>
-    h1,
-    h2,
-    h3 {
-      margin: 12px 0;
-    }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Radio Button (RTL)</title>
+    <style>
+      h1,
+      h2,
+      h3 {
+        margin: 12px 0;
+      }
 
-    hr {
-      width: 100%;
-      border: 0;
-      height: 0;
-      border-top: 1px solid rgba(0, 0, 0, 0.1);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-      margin: 12px 0;
-    }
+      hr {
+        width: 100%;
+        border: 0;
+        height: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.1);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+        margin: 12px 0;
+      }
 
-    .vertical-grid {
-      display: grid;
-      grid-gap: 25px;
-      grid-template-columns: repeat(3, minmax(0px, max-content));
-    }
+      .vertical-grid {
+        display: grid;
+        grid-gap: 25px;
+        grid-template-columns: repeat(3, minmax(0px, max-content));
+      }
 
-    .dark {
-      background: #2B2B2B;
-      padding: 1rem;
-    }
+      .dark {
+        background: #2b2b2b;
+        padding: 1rem;
+      }
 
-    .dark h2,
-    .dark h3 {
-      color: white;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
+      .dark h2,
+      .dark h3 {
+        color: white;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
 
-  <style>
-    .radio {
-      background-color: orange;
-      box-shadow: none;
-    }
+    <style>
+      .radio {
+        background-color: orange;
+        box-shadow: none;
+      }
 
-    input {
-      margin: unset !important;
-      opacity: unset !important;
-      padding: unset !important;
-      position: unset !important;
-      transform: unset !important;
-      z-index: unset !important;
-    }
-  </style>
-</head>
+      input {
+        margin: unset !important;
+        opacity: unset !important;
+        padding: unset !important;
+        position: unset !important;
+        transform: unset !important;
+        z-index: unset !important;
+      }
+    </style>
+  </head>
 
-<body>
-  <demo-spacer>
-    <calcite-button href="/">
-      < Home</calcite-button>
-        <h1>Calcite Radio Button</h1>
-        <demo-form>
-          <form name="calcite-radio-button-demo-form">
-            <demo-spacer>
-              <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
-              <div style="display: grid; grid-template-columns: repeat(auto-fit, 400px); grid-gap: 8px;">
-                <div style="border: 1px solid #2B2B2B; padding: 1rem;">
-                  <h3>Scale s</h3>
+  <body>
+    <demo-spacer>
+      <calcite-button href="/"> < Home</calcite-button>
+      <h1>Calcite Radio Button</h1>
+      <demo-form>
+        <form name="calcite-radio-button-demo-form">
+          <demo-spacer>
+            <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, 400px); grid-gap: 8px">
+              <div style="border: 1px solid #2b2b2b; padding: 1rem">
+                <h3>Scale s</h3>
 
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="react" checked></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="vue"></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="polymer"></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="litelement"></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="backbone"></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="jquery"></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="mootools"></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="stencil" checked>
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="react" disabled>
+                  </calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="s" layout="inline">
+                  wrapped in calcite-label
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="stencil" checked></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="stencil" checked>
+                    </calcite-radio-button>
                     Stencil
                   </calcite-label>
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="react" checked></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="react"></calcite-radio-button>
                     React
                   </calcite-label>
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="ember"></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="ember"></calcite-radio-button>
                     Ember
                   </calcite-label>
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="angular"></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="angular"></calcite-radio-button>
                     Angular
                   </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="stencil" checked>
+                <h3>Scale m (default)</h3>
+
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="react" checked></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="vue"></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="polymer"></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="litelement"></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="backbone"></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="jquery"></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="mootools"></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="react" disabled></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="m" layout="inline">
+                  wrapped in calcite-label
+                  <calcite-label layout="inline" scale="m">
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="stencil" checked>
                     </calcite-radio-button>
                     Stencil
                   </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="react" disabled>
+                  <calcite-label layout="inline" scale="m">
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="react" checked>
                     </calcite-radio-button>
                     React
                   </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="s" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="stencil" checked>
-                      </calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="react"></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
-
-                  <hr>
-
-                  <h3>Scale m (default)</h3>
-
                   <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="react" checked></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="ember"></calcite-radio-button>
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="ember"></calcite-radio-button>
                     Ember
                   </calcite-label>
                   <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="angular"></calcite-radio-button>
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="angular"></calcite-radio-button>
                     Angular
                   </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="react" disabled></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
+                <h3>Scale l</h3>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="react" checked></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="vue"></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="polymer"></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="litelement"></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="backbone"></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="jquery"></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="mootools"></calcite-radio-button>
+                  MooTools
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label scale="m" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="stencil" checked>
-                      </calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="react" checked>
-                      </calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="stencil" checked>
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="react" disabled>
+                  </calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <h3>Scale l</h3>
+                <calcite-label scale="l">
+                  wrapped in calcite-label
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="react" checked></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="stencil" checked>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="stencil" checked>
                     </calcite-radio-button>
                     Stencil
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="react" disabled>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="react" checked>
                     </calcite-radio-button>
                     React
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="ember"></calcite-radio-button>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="ember"></calcite-radio-button>
                     Ember
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="angular"></calcite-radio-button>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="angular"></calcite-radio-button>
                     Angular
                   </calcite-label>
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label scale="l">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="stencil" checked>
-                      </calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="react" checked>
-                      </calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
+                <h3>None checked</h3>
 
-                  <hr>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneChecked" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneChecked" value="2"></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneChecked" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneCheckedDisabledSingle" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneCheckedDisabledSingle" value="2" disabled></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneCheckedDisabledSingle" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <h3>None checked</h3>
+                <h3>Only one checked value (last wins, first two checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirst2" value="1" checked></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirst2" value="2" checked></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirst2" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="1" checked>
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="2" checked disabled>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneChecked" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneChecked" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneChecked" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneCheckedDisabledSingle" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneCheckedDisabledSingle" value="2" disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneCheckedDisabledSingle" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
+                <h3>Only one checked value (last wins, second two checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsSecond2" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsSecond2" value="2" checked></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsSecond2" value="3" checked></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="2" checked disabled>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="3" checked>
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <h3>Only one checked value (last wins, first two checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirst2" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirst2" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirst2" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="2" checked disabled>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
+                <h3>Only one checked value (last wins, first and last checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirstLast" value="1" checked></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirstLast" value="2"></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirstLast" value="3" checked></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="1" checked>
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="2" disabled>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="3" checked>
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <h3>Only one checked value (last wins, second two checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsSecond2" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsSecond2" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsSecond2" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="2" checked disabled>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first and last checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirstLast" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirstLast" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirstLast" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="2" disabled>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, all checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAll" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAll" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAll" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="2" checked disabled>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                </div>
-                <div class="dark">
-                  <h3>Scale s</h3>
-
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="react"></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="litelement">
-                    </calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="react" disabled>
-                    </calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="ember">
-                    </calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="angular">
-                    </calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="s" theme="dark" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="stencil" checked>
-                      </calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="react">
-                      </calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="ember">
-                      </calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="angular">
-                      </calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
-
-                  <h3>Scale m (default)</h3>
-
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="react"></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="litelement">
-                    </calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="react" disabled>
-                    </calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="ember">
-                    </calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="angular">
-                    </calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="m" theme="dark" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="stencil" checked>
-                      </calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="react">
-                      </calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="ember">
-                      </calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="angular">
-                      </calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
-
-                  <h3>Scale l</h3>
-
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="react"></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="litelement">
-                    </calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="react" disabled>
-                    </calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="ember">
-                    </calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="angular">
-                    </calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="l" theme="dark"">
-                    wrapped in calcite-label
-                    <calcite-label layout=" inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="stencil" checked>
-                    </calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="react">
-                    </calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="ember">
-                    </calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="angular">
-                    </calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="2" disabled>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="3">
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>None checked</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="1">
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="2" disabled>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="3">
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first two checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirst2" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirst2" value="2" checked>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirst2" value="3">
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2" value="2" checked
-                      disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2" value="3">
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, second two checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkSecond2" value="1">
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkSecond2" value="2" checked>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkSecond2" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2" value="1">
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2" value="2" checked
-                      disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2" value="3"
-                      checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first and last checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirstLast" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirstLast" value="2">
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirstLast" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast" value="1"
-                      checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast" value="2"
-                      disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast" value="3"
-                      checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, all checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAll" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAll" value="2" checked>
-                    </calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAll" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAllDisabledSingle" value="1" checked>
-                    </calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAllDisabledSingle" value="2" checked
-                      disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAllDisabledSingle" value="3" checked>
-                    </calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                </div>
+                <h3>Only one checked value (last wins, all checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAll" value="1" checked></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAll" value="2" checked></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAll" value="3" checked></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="1" checked>
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="2" checked disabled>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="3" checked>
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
               </div>
-              <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
-              <button type="submit" style="display: none">Submit</button>
-            </demo-spacer>
-          </form>
-        </demo-form>
-  </demo-spacer>
-</body>
+              <div class="dark">
+                <h3>Scale s</h3>
 
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button class="calcite-theme-dark" name="s-dark" scale="s" value="stencil" checked>
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="react"
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="vue"
+                  ></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="polymer"
+                  ></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button class="calcite-theme-dark" name="s-dark" scale="s" value="litelement">
+                  </calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="backbone"
+                  ></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="jquery"
+                  ></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="mootools"
+                  ></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="stencil"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="react"
+                    disabled
+                  >
+                  </calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="ember"
+                  >
+                  </calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="angular"
+                  >
+                  </calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="s" class="calcite-theme-dark" layout="inline">
+                  wrapped in calcite-label
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="stencil"
+                      checked
+                    >
+                    </calcite-radio-button>
+                    Stencil
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="react"
+                    >
+                    </calcite-radio-button>
+                    React
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="ember"
+                    >
+                    </calcite-radio-button>
+                    Ember
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="angular"
+                    >
+                    </calcite-radio-button>
+                    Angular
+                  </calcite-label>
+                </calcite-label>
+
+                <h3>Scale m (default)</h3>
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button class="calcite-theme-dark" name="m-dark" scale="m" value="stencil" checked>
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="react"
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="vue"
+                  ></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="polymer"
+                  ></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button class="calcite-theme-dark" name="m-dark" scale="m" value="litelement">
+                  </calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="backbone"
+                  ></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="jquery"
+                  ></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="mootools"
+                  ></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark-disabled-single"
+                    value="stencil"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button class="calcite-theme-dark" name="m-dark-disabled-single" value="react" disabled>
+                  </calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button class="calcite-theme-dark" name="m-dark-disabled-single" value="ember">
+                  </calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button class="calcite-theme-dark" name="m-dark-disabled-single" value="angular">
+                  </calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="m" class="calcite-theme-dark" layout="inline">
+                  wrapped in calcite-label
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="stencil"
+                      checked
+                    >
+                    </calcite-radio-button>
+                    Stencil
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="react"
+                    >
+                    </calcite-radio-button>
+                    React
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="ember"
+                    >
+                    </calcite-radio-button>
+                    Ember
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="angular"
+                    >
+                    </calcite-radio-button>
+                    Angular
+                  </calcite-label>
+                </calcite-label>
+
+                <h3>Scale l</h3>
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button class="calcite-theme-dark" name="l-dark" scale="l" value="stencil" checked>
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="react"
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="vue"
+                  ></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="polymer"
+                  ></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button class="calcite-theme-dark" name="l-dark" scale="l" value="litelement">
+                  </calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="backbone"
+                  ></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="jquery"
+                  ></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="mootools"
+                  ></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="stencil"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="react"
+                    disabled
+                  >
+                  </calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="ember"
+                  >
+                  </calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="angular"
+                  >
+                  </calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="l" class="calcite-theme-dark">
+                  wrapped in calcite-label
+                  <calcite-label layout=" inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="stencil"
+                      checked
+                    >
+                    </calcite-radio-button>
+                    Stencil
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="react"
+                    >
+                    </calcite-radio-button>
+                    React
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="ember"
+                    >
+                    </calcite-radio-button>
+                    Ember
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="angular"
+                    >
+                    </calcite-radio-button>
+                    Angular
+                  </calcite-label>
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="valueAsLabelDarkDisabledSingle"
+                    value="1"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="valueAsLabelDarkDisabledSingle"
+                    value="2"
+                    disabled
+                  >
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="valueAsLabelDarkDisabledSingle" value="3">
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>None checked</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDark"
+                    value="1"
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDark"
+                    value="2"
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDark"
+                    value="3"
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="noneCheckedDarkDisabledSingle" value="1">
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDarkDisabledSingle"
+                    value="2"
+                    disabled
+                  >
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="noneCheckedDarkDisabledSingle" value="3">
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, first two checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkFirst2" value="1" checked>
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkFirst2" value="2" checked>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkFirst2" value="3">
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirst2"
+                    value="1"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirst2"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirst2"
+                    value="3"
+                  >
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, second two checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkSecond2" value="1">
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkSecond2" value="2" checked>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkSecond2" value="3" checked>
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                    value="1"
+                  >
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, first and last checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirstLast"
+                    value="1"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkFirstLast" value="2">
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirstLast"
+                    value="3"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                    value="2"
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, all checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkAll" value="1" checked>
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkAll" value="2" checked>
+                  </calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button class="calcite-theme-dark" name="lastCheckedWinsDarkAll" value="3" checked>
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAllDisabledSingle"
+                    value="1"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAllDisabledSingle"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAllDisabledSingle"
+                    value="3"
+                    checked
+                  >
+                  </calcite-radio-button>
+                  3
+                </calcite-label>
+              </div>
+            </div>
+            <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
+            <button type="submit" style="display: none">Submit</button>
+          </demo-spacer>
+        </form>
+      </demo-form>
+    </demo-spacer>
+  </body>
 </html>

--- a/src/demos/calcite-radio-button.html
+++ b/src/demos/calcite-radio-button.html
@@ -1,892 +1,1400 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Radio Button</title>
+    <style>
+      h1,
+      h2,
+      h3 {
+        margin: 12px 0;
+      }
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Radio Button</title>
-  <style>
-    h1,
-    h2,
-    h3 {
-      margin: 12px 0;
-    }
+      hr {
+        width: 100%;
+        border: 0;
+        height: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.1);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+        margin: 12px 0;
+      }
 
-    hr {
-      width: 100%;
-      border: 0;
-      height: 0;
-      border-top: 1px solid rgba(0, 0, 0, 0.1);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-      margin: 12px 0;
-    }
+      .vertical-grid {
+        display: grid;
+        grid-gap: 25px;
+        grid-template-columns: repeat(3, minmax(0px, max-content));
+      }
 
-    .vertical-grid {
-      display: grid;
-      grid-gap: 25px;
-      grid-template-columns: repeat(3, minmax(0px, max-content));
-    }
+      .dark {
+        background: #2b2b2b;
+        padding: 1rem;
+      }
 
-    .dark {
-      background: #2B2B2B;
-      padding: 1rem;
-    }
+      .dark h2,
+      .dark h3 {
+        color: white;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
 
-    .dark h2,
-    .dark h3 {
-      color: white;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
+    <style>
+      .radio {
+        background-color: orange;
+        box-shadow: none;
+      }
 
-  <style>
-    .radio {
-      background-color: orange;
-      box-shadow: none;
-    }
+      input {
+        margin: unset !important;
+        opacity: unset !important;
+        padding: unset !important;
+        position: unset !important;
+        transform: unset !important;
+        z-index: unset !important;
+      }
+    </style>
+  </head>
 
-    input {
-      margin: unset !important;
-      opacity: unset !important;
-      padding: unset !important;
-      position: unset !important;
-      transform: unset !important;
-      z-index: unset !important;
-    }
-  </style>
-</head>
+  <body>
+    <demo-spacer>
+      <calcite-button href="/"> < Home</calcite-button>
+      <h1>Calcite Radio Button</h1>
+      <demo-form>
+        <form name="calcite-radio-button-demo-form">
+          <demo-spacer>
+            <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, 400px); grid-gap: 8px">
+              <div style="border: 1px solid #2b2b2b; padding: 1rem">
+                <h3>Scale s</h3>
 
-<body>
-  <demo-spacer>
-    <calcite-button href="/">
-      < Home</calcite-button>
-        <h1>Calcite Radio Button</h1>
-        <demo-form>
-          <form name="calcite-radio-button-demo-form">
-            <demo-spacer>
-              <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
-              <div style="display: grid; grid-template-columns: repeat(auto-fit, 400px); grid-gap: 8px;">
-                <div style="border: 1px solid #2B2B2B; padding: 1rem;">
-                  <h3>Scale s</h3>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="react" checked></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="vue"></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="polymer"></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="litelement"></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="backbone"></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="jquery"></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s" scale="s" value="mootools"></calcite-radio-button>
+                  MooTools
+                </calcite-label>
 
+                <hr />
+
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button
+                    name="s-disabled-single"
+                    scale="s"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button
+                    name="s-disabled-single"
+                    scale="s"
+                    value="react"
+                    disabled
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="s">
+                  <calcite-radio-button name="s-disabled-single" scale="s" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="s" layout="inline">
+                  wrapped in calcite-label
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="stencil" checked></calcite-radio-button>
+                    <calcite-radio-button
+                      name="s-label-wrapped"
+                      scale="s"
+                      value="stencil"
+                      checked
+                    ></calcite-radio-button>
                     Stencil
                   </calcite-label>
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="react" checked></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="react"></calcite-radio-button>
                     React
                   </calcite-label>
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="ember"></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="ember"></calcite-radio-button>
                     Ember
                   </calcite-label>
                   <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="angular"></calcite-radio-button>
+                    <calcite-radio-button name="s-label-wrapped" scale="s" value="angular"></calcite-radio-button>
                     Angular
                   </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s" scale="s" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="react" disabled></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="s">
-                    <calcite-radio-button name="s-disabled-single" scale="s" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
+                <h3>Scale m (default)</h3>
 
-                  <hr>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="react" checked></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="vue"></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="polymer"></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="litelement"></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="backbone"></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="jquery"></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m" scale="m" value="mootools"></calcite-radio-button>
+                  MooTools
+                </calcite-label>
 
-                  <calcite-label scale="s" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="stencil" checked></calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="react"></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="s">
-                      <calcite-radio-button name="s-label-wrapped" scale="s" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
+                <hr />
 
-                  <hr>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="react" disabled></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="m">
+                  <calcite-radio-button name="m-disabled-single" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
 
-                  <h3>Scale m (default)</h3>
+                <hr />
 
+                <calcite-label scale="m" layout="inline">
+                  wrapped in calcite-label
                   <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="react" checked></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m" scale="m" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="stencil" checked></calcite-radio-button>
+                    <calcite-radio-button
+                      name="m-label-wrapped"
+                      scale="m"
+                      value="stencil"
+                      checked
+                    ></calcite-radio-button>
                     Stencil
                   </calcite-label>
                   <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="react" disabled></calcite-radio-button>
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="react" checked></calcite-radio-button>
                     React
                   </calcite-label>
                   <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="ember"></calcite-radio-button>
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="ember"></calcite-radio-button>
                     Ember
                   </calcite-label>
                   <calcite-label layout="inline" scale="m">
-                    <calcite-radio-button name="m-disabled-single" value="angular"></calcite-radio-button>
+                    <calcite-radio-button name="m-label-wrapped" scale="m" value="angular"></calcite-radio-button>
                     Angular
                   </calcite-label>
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label scale="m" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="stencil" checked></calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="react" checked></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="m">
-                      <calcite-radio-button name="m-label-wrapped" scale="m" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
+                <h3>Scale l</h3>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="stencil" checked></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="react" checked></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="vue"></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="polymer"></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="litelement"></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="backbone"></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="jquery"></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l" scale="l" value="mootools"></calcite-radio-button>
+                  MooTools
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <h3>Scale l</h3>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button
+                    name="l-disabled-single"
+                    scale="l"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button
+                    name="l-disabled-single"
+                    scale="l"
+                    value="react"
+                    disabled
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="ember"></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" scale="l">
+                  <calcite-radio-button name="l-disabled-single" scale="l" value="angular"></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="l">
+                  wrapped in calcite-label
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="stencil" checked></calcite-radio-button>
+                    <calcite-radio-button
+                      name="l-label-wrapped"
+                      scale="l"
+                      value="stencil"
+                      checked
+                    ></calcite-radio-button>
                     Stencil
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="react" checked></calcite-radio-button>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="react" checked></calcite-radio-button>
                     React
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="ember"></calcite-radio-button>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="ember"></calcite-radio-button>
                     Ember
                   </calcite-label>
                   <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="angular"></calcite-radio-button>
+                    <calcite-radio-button name="l-label-wrapped" scale="l" value="angular"></calcite-radio-button>
                     Angular
                   </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l" scale="l" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
+                </calcite-label>
 
-                  <hr>
+                <hr />
 
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="react" disabled></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" scale="l">
-                    <calcite-radio-button name="l-disabled-single" scale="l" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
+                <h3>None checked</h3>
 
-                  <hr>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneChecked" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneChecked" value="2"></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneChecked" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneCheckedDisabledSingle" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneCheckedDisabledSingle" value="2" disabled></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="noneCheckedDisabledSingle" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <calcite-label scale="l">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="stencil" checked></calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="react" checked></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" scale="l">
-                      <calcite-radio-button name="l-label-wrapped" scale="l" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
+                <h3>Only one checked value (last wins, first two checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirst2" value="1" checked></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirst2" value="2" checked></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirst2" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleFirst2"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleFirst2"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="3"></calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <hr>
+                <h3>Only one checked value (last wins, second two checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsSecond2" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsSecond2" value="2" checked></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsSecond2" value="3" checked></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="1"></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleSecond2"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleSecond2"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <h3>None checked</h3>
+                <h3>Only one checked value (last wins, first and last checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirstLast" value="1" checked></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirstLast" value="2"></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsFirstLast" value="3" checked></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleFirstLast"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleFirstLast"
+                    value="2"
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsDisabledSingleFirstLast"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
 
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneChecked" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneChecked" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneChecked" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneCheckedDisabledSingle" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneCheckedDisabledSingle" value="2" disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="noneCheckedDisabledSingle" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first two checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirst2" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirst2" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirst2" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="2" checked disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirst2" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, second two checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsSecond2" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsSecond2" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsSecond2" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="2" checked disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleSecond2" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first and last checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirstLast" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirstLast" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsFirstLast" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="2" disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsDisabledSingleFirstLast" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, all checked)</h3>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAll" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAll" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAll" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-                  <hr>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="2" checked disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline">
-                    <calcite-radio-button name="lastCheckedWinsAllDisabledSingle" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                </div>
-                <div class="dark">
-                  <h3>Scale s</h3>
-
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="react"></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark" scale="s" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="react" disabled></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="s">
-                    <calcite-radio-button theme="dark" name="s-dark-disabled-single" scale="s" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="s" theme="dark" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="stencil" checked></calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="react"></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="s">
-                      <calcite-radio-button theme="dark" name="s-dark-label-wrapped" scale="s" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
-
-                  <h3>Scale m (default)</h3>
-
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="react"></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark" scale="m" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="react" disabled></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="m">
-                    <calcite-radio-button theme="dark" name="m-dark-disabled-single" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="m" theme="dark" layout="inline">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="stencil" checked></calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="react"></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="m">
-                      <calcite-radio-button theme="dark" name="m-dark-label-wrapped" scale="m" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
-
-                  <h3>Scale l</h3>
-
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="react"></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="vue"></calcite-radio-button>
-                    Vue
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="polymer"></calcite-radio-button>
-                    Polymer
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="litelement"></calcite-radio-button>
-                    LitElement
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="backbone"></calcite-radio-button>
-                    Backbone
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="jquery"></calcite-radio-button>
-                    jQuery
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark" scale="l" value="mootools"></calcite-radio-button>
-                    MooTools
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="stencil" checked></calcite-radio-button>
-                    Stencil
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="react" disabled></calcite-radio-button>
-                    React
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="ember"></calcite-radio-button>
-                    Ember
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark" scale="l">
-                    <calcite-radio-button theme="dark" name="l-dark-disabled-single" scale="l" value="angular"></calcite-radio-button>
-                    Angular
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label scale="l" theme="dark"">
-                    wrapped in calcite-label
-                    <calcite-label layout="inline" theme="dark" scale="l">
-                      <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="stencil" checked></calcite-radio-button>
-                      Stencil
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="l">
-                      <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="react"></calcite-radio-button>
-                      React
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="l">
-                      <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="ember"></calcite-radio-button>
-                      Ember
-                    </calcite-label>
-                    <calcite-label layout="inline" theme="dark" scale="l">
-                      <calcite-radio-button theme="dark" name="l-dark-label-wrapped" scale="l" value="angular"></calcite-radio-button>
-                      Angular
-                    </calcite-label>
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="2" disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="valueAsLabelDarkDisabledSingle" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>None checked</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDark" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="2" disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="noneCheckedDarkDisabledSingle" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first two checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirst2" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirst2" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirst2" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2" value="2" checked disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirst2" value="3"></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, second two checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkSecond2" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkSecond2" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkSecond2" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2" value="1"></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2" value="2" checked disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleSecond2" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, first and last checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirstLast" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirstLast" value="2"></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkFirstLast" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast" value="2" disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkDisabledSingleFirstLast" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <h3>Only one checked value (last wins, all checked)</h3>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAll" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAll" value="2" checked></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAll" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                  <hr>
-
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAllDisabledSingle" value="1" checked></calcite-radio-button>
-                    1
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAllDisabledSingle" value="2" checked disabled></calcite-radio-button>
-                    2
-                  </calcite-label>
-                  <calcite-label layout="inline" theme="dark">
-                    <calcite-radio-button theme="dark" name="lastCheckedWinsDarkAllDisabledSingle" value="3" checked></calcite-radio-button>
-                    3
-                  </calcite-label>
-
-                </div>
+                <h3>Only one checked value (last wins, all checked)</h3>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAll" value="1" checked></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAll" value="2" checked></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button name="lastCheckedWinsAll" value="3" checked></calcite-radio-button>
+                  3
+                </calcite-label>
+                <hr />
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsAllDisabledSingle"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsAllDisabledSingle"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline">
+                  <calcite-radio-button
+                    name="lastCheckedWinsAllDisabledSingle"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
               </div>
-              <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
-              <button type="submit" style="display: none">Submit</button>
-            </demo-spacer>
-          </form>
-        </demo-form>
-  </demo-spacer>
-</body>
+              <div class="dark">
+                <h3>Scale s</h3>
 
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="react"
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="vue"
+                  ></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="polymer"
+                  ></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="litelement"
+                  ></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="backbone"
+                  ></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="jquery"
+                  ></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark"
+                    scale="s"
+                    value="mootools"
+                  ></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="react"
+                    disabled
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="s-dark-disabled-single"
+                    scale="s"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="s" class="calcite-theme-dark" layout="inline">
+                  wrapped in calcite-label
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="stencil"
+                      checked
+                    ></calcite-radio-button>
+                    Stencil
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="react"
+                    ></calcite-radio-button>
+                    React
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="ember"
+                    ></calcite-radio-button>
+                    Ember
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="s">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="s-dark-label-wrapped"
+                      scale="s"
+                      value="angular"
+                    ></calcite-radio-button>
+                    Angular
+                  </calcite-label>
+                </calcite-label>
+
+                <h3>Scale m (default)</h3>
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="react"
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="vue"
+                  ></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="polymer"
+                  ></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="litelement"
+                  ></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="backbone"
+                  ></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="jquery"
+                  ></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark"
+                    scale="m"
+                    value="mootools"
+                  ></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark-disabled-single"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark-disabled-single"
+                    value="react"
+                    disabled
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark-disabled-single"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="m-dark-disabled-single"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="m" class="calcite-theme-dark" layout="inline">
+                  wrapped in calcite-label
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="stencil"
+                      checked
+                    ></calcite-radio-button>
+                    Stencil
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="react"
+                    ></calcite-radio-button>
+                    React
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="ember"
+                    ></calcite-radio-button>
+                    Ember
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="m">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="m-dark-label-wrapped"
+                      scale="m"
+                      value="angular"
+                    ></calcite-radio-button>
+                    Angular
+                  </calcite-label>
+                </calcite-label>
+
+                <h3>Scale l</h3>
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="react"
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="vue"
+                  ></calcite-radio-button>
+                  Vue
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="polymer"
+                  ></calcite-radio-button>
+                  Polymer
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="litelement"
+                  ></calcite-radio-button>
+                  LitElement
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="backbone"
+                  ></calcite-radio-button>
+                  Backbone
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="jquery"
+                  ></calcite-radio-button>
+                  jQuery
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark"
+                    scale="l"
+                    value="mootools"
+                  ></calcite-radio-button>
+                  MooTools
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="stencil"
+                    checked
+                  ></calcite-radio-button>
+                  Stencil
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="react"
+                    disabled
+                  ></calcite-radio-button>
+                  React
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="ember"
+                  ></calcite-radio-button>
+                  Ember
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="l-dark-disabled-single"
+                    scale="l"
+                    value="angular"
+                  ></calcite-radio-button>
+                  Angular
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label scale="l" class="calcite-theme-dark">
+                  wrapped in calcite-label
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="stencil"
+                      checked
+                    ></calcite-radio-button>
+                    Stencil
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="react"
+                    ></calcite-radio-button>
+                    React
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="ember"
+                    ></calcite-radio-button>
+                    Ember
+                  </calcite-label>
+                  <calcite-label layout="inline" class="calcite-theme-dark" scale="l">
+                    <calcite-radio-button
+                      class="calcite-theme-dark"
+                      name="l-dark-label-wrapped"
+                      scale="l"
+                      value="angular"
+                    ></calcite-radio-button>
+                    Angular
+                  </calcite-label>
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="valueAsLabelDarkDisabledSingle"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="valueAsLabelDarkDisabledSingle"
+                    value="2"
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="valueAsLabelDarkDisabledSingle"
+                    value="3"
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>None checked</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDark"
+                    value="1"
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDark"
+                    value="2"
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDark"
+                    value="3"
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDarkDisabledSingle"
+                    value="1"
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDarkDisabledSingle"
+                    value="2"
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="noneCheckedDarkDisabledSingle"
+                    value="3"
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, first two checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirst2"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirst2"
+                    value="2"
+                    checked
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirst2"
+                    value="3"
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirst2"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirst2"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirst2"
+                    value="3"
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, second two checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkSecond2"
+                    value="1"
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkSecond2"
+                    value="2"
+                    checked
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkSecond2"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                    value="1"
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleSecond2"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, first and last checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirstLast"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirstLast"
+                    value="2"
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkFirstLast"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                    value="2"
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkDisabledSingleFirstLast"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <h3>Only one checked value (last wins, all checked)</h3>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAll"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAll"
+                    value="2"
+                    checked
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAll"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+
+                <hr />
+
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAllDisabledSingle"
+                    value="1"
+                    checked
+                  ></calcite-radio-button>
+                  1
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAllDisabledSingle"
+                    value="2"
+                    checked
+                    disabled
+                  ></calcite-radio-button>
+                  2
+                </calcite-label>
+                <calcite-label layout="inline" class="calcite-theme-dark">
+                  <calcite-radio-button
+                    class="calcite-theme-dark"
+                    name="lastCheckedWinsDarkAllDisabledSingle"
+                    value="3"
+                    checked
+                  ></calcite-radio-button>
+                  3
+                </calcite-label>
+              </div>
+            </div>
+            <calcite-button form="calcite-radio-button-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-radio-button-demo-form" type="reset">Reset</calcite-button>
+            <button type="submit" style="display: none">Submit</button>
+          </demo-spacer>
+        </form>
+      </demo-form>
+    </demo-spacer>
+  </body>
 </html>

--- a/src/demos/calcite-radio-group.html
+++ b/src/demos/calcite-radio-group.html
@@ -1,319 +1,297 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Radio Group</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Radio Group</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Radio Group</h1>
+    <div style="width: 600px; max-width: 100%">
+      <h3 class="leader-1">Simple</h3>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Radio Group</h1>
-  <div style="width:600px;max-width:100%">
-    <h3 class="leader-1">Simple</h3>
-
-    <calcite-radio-group>
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Wrapped with calcite-label</h3>
-
-    <calcite-label>
-      My Great Radio Group
       <calcite-radio-group>
         <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
         <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
         <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
         <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
       </calcite-radio-group>
-    </calcite-label>
 
+      <h3 class="leader-1">Wrapped with calcite-label</h3>
 
-    <calcite-label>
-      My Great Radio Appearance Outline
-      <calcite-radio-group appearance="outline">
+      <calcite-label>
+        My Great Radio Group
+        <calcite-radio-group>
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+
+      <calcite-label>
+        My Great Radio Appearance Outline
+        <calcite-radio-group appearance="outline">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+
+      <calcite-label>
+        My Great Radio Layout Vertical
+        <calcite-radio-group layout="vertical">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular or another item">Angular or another item</calcite-radio-group-item>
+          <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+
+      <calcite-label>
+        My Great Radio Layout Vertical Outline
+        <calcite-radio-group layout="vertical" appearance="outline">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+
+      <calcite-label>
+        Icons!
+        <calcite-radio-group layout="vertical">
+          <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+          <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+          <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+      <calcite-label>
+        Icons!
+        <calcite-radio-group>
+          <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+          <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+          <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+      <calcite-label>
+        More Icons!
+        <calcite-radio-group layout="vertical" appearance="outline">
+          <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+          <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+          <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+      <calcite-label>
+        More Icons!
+        <calcite-radio-group appearance="outline">
+          <calcite-radio-group-item icon="car" value="car" icon-position="end" checked>Car</calcite-radio-group-item>
+          <calcite-radio-group-item icon="plane" value="plane" icon-position="end">Plane</calcite-radio-group-item>
+          <calcite-radio-group-item icon="biking" value="bicycle" icon-position="end">Bicycle</calcite-radio-group-item>
+        </calcite-radio-group>
+      </calcite-label>
+
+      <h3 class="leader-1">Width full</h3>
+
+      <div style="width: 33vw; margin: 2rem">
+        <calcite-radio-group width="full">
+          <calcite-radio-group-item checked value="React"> React </calcite-radio-group-item>
+          <calcite-radio-group-item value="Ember"> Ember </calcite-radio-group-item>
+          <calcite-radio-group-item value="Longer text wraps."> Longer text wraps. </calcite-radio-group-item>
+          <calcite-radio-group-item value="Longer text wraps yep"> Longer text wraps yep </calcite-radio-group-item>
+        </calcite-radio-group>
+      </div>
+
+      <calcite-radio-group width="full">
         <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
         <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
         <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
         <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-
-    <calcite-label>
-      My Great Radio Layout Vertical
-      <calcite-radio-group layout="vertical">
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="angular or another item">Angular or another item</calcite-radio-group-item>
-        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-
-    <calcite-label>
-      My Great Radio Layout Vertical Outline
-      <calcite-radio-group layout="vertical" appearance="outline">
-        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-        <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-
-    <calcite-label>
-      Icons!
-      <calcite-radio-group layout="vertical">
-        <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
-        <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
-        <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-    <calcite-label>
-      Icons!
-      <calcite-radio-group>
-        <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
-        <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
-        <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-    <calcite-label>
-      More Icons!
-      <calcite-radio-group layout="vertical" appearance="outline">
-        <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
-        <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
-        <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-    <calcite-label>
-      More Icons!
-      <calcite-radio-group appearance="outline">
-        <calcite-radio-group-item icon="car" value="car" icon-position="end" checked>Car</calcite-radio-group-item>
-        <calcite-radio-group-item icon="plane" value="plane" icon-position="end">Plane</calcite-radio-group-item>
-        <calcite-radio-group-item icon="biking" value="bicycle" icon-position="end">Bicycle</calcite-radio-group-item>
-      </calcite-radio-group>
-    </calcite-label>
-
-    <h3 class="leader-1">Width full</h3>
-
-    <div style="width:33vw;margin:2rem;">
-      <calcite-radio-group
-        width="full"
-      >
-        <calcite-radio-group-item
-          checked
-          value="React"
-        >
-          React
-        </calcite-radio-group-item>
-        <calcite-radio-group-item
-          value="Ember"
-        >
-          Ember
-        </calcite-radio-group-item>
-        <calcite-radio-group-item
-          value="Longer text wraps."
-        >
-          Longer text wraps.
-        </calcite-radio-group-item>
-        <calcite-radio-group-item
-          value="Longer text wraps yep"
-        >
-          Longer text wraps yep
-        </calcite-radio-group-item>
-      </calcite-radio-group>
-    </div>
-
-    <calcite-radio-group width="full">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-      <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Scale s</h3>
-
-    <calcite-radio-group scale="s">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <br>
-
-    <calcite-radio-group scale="s" layout="vertical">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Scale m</h3>
-
-    <calcite-radio-group scale="m">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <br>
-
-    <calcite-radio-group scale="m" layout="vertical">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Scale l</h3>
-
-    <calcite-radio-group scale="l">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <br>
-
-    <calcite-radio-group scale="l" layout="vertical">
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Disabled</h3>
-
-    <calcite-radio-group disabled>
-      <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-      <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-      <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-    </calcite-radio-group>
-    <h3 class="leader-1">With labels</h3>
-
-    <calcite-radio-group>
-      <calcite-radio-group-item value="1">Uno</calcite-radio-group-item>
-      <calcite-radio-group-item value="2" checked>Dos</calcite-radio-group-item>
-      <calcite-radio-group-item value="3">Tres</calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Uses value as label if missing</h3>
-
-    <calcite-radio-group>
-      <calcite-radio-group-item value="1"></calcite-radio-group-item>
-      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="3"></calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">None checked</h3>
-
-    <calcite-radio-group>
-      <calcite-radio-group-item value="1"></calcite-radio-group-item>
-      <calcite-radio-group-item value="2"></calcite-radio-group-item>
-      <calcite-radio-group-item value="3"></calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Only one selected value (last wins)</h3>
-
-    <calcite-radio-group>
-      <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-      <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <h3 class="leader-1">Change Event</h3>
-
-    <calcite-radio-group class="js-group">
-      <calcite-radio-group-item value="1"></calcite-radio-group-item>
-      <calcite-radio-group-item value="2"></calcite-radio-group-item>
-      <calcite-radio-group-item value="3"></calcite-radio-group-item>
-    </calcite-radio-group>
-
-    <p>Currently selected value: <span class="js-value">n/a</span></p>
-
-    <script>
-      document.querySelector(".js-group").addEventListener("calciteRadioGroupChange", function (e) {
-        document.querySelector(".js-value").innerHTML = e.detail;
-      });
-    </script>
-
-    <br />
-    <br />
-    <div class="demo-background-dark">
-      <h3 class="leader-1">Dark theme</h3>
-
-      <calcite-radio-group theme="dark">
-        <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
-        <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
-        <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
       </calcite-radio-group>
 
       <h3 class="leader-1">Scale s</h3>
-      <calcite-radio-group theme="dark" scale="s">
+
+      <calcite-radio-group scale="s">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <br />
+
+      <calcite-radio-group scale="s" layout="vertical">
         <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
         <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
         <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       </calcite-radio-group>
 
       <h3 class="leader-1">Scale m</h3>
-      <calcite-radio-group theme="dark" scale="m">
+
+      <calcite-radio-group scale="m">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <br />
+
+      <calcite-radio-group scale="m" layout="vertical">
         <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
         <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
         <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       </calcite-radio-group>
 
       <h3 class="leader-1">Scale l</h3>
-      <calcite-radio-group theme="dark" scale="l">
+
+      <calcite-radio-group scale="l">
         <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
         <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
         <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
       </calcite-radio-group>
-    </div>
-    <h3 class="leader-1">RTL</h3>
-    <div dir="rtl">
+
+      <br />
+
+      <calcite-radio-group scale="l" layout="vertical">
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">Disabled</h3>
+
+      <calcite-radio-group disabled>
+        <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+        <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+        <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+      </calcite-radio-group>
+      <h3 class="leader-1">With labels</h3>
+
+      <calcite-radio-group>
+        <calcite-radio-group-item value="1">Uno</calcite-radio-group-item>
+        <calcite-radio-group-item value="2" checked>Dos</calcite-radio-group-item>
+        <calcite-radio-group-item value="3">Tres</calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">Uses value as label if missing</h3>
+
+      <calcite-radio-group>
+        <calcite-radio-group-item value="1"></calcite-radio-group-item>
+        <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+        <calcite-radio-group-item value="3"></calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">None checked</h3>
+
+      <calcite-radio-group>
+        <calcite-radio-group-item value="1"></calcite-radio-group-item>
+        <calcite-radio-group-item value="2"></calcite-radio-group-item>
+        <calcite-radio-group-item value="3"></calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">Only one selected value (last wins)</h3>
+
       <calcite-radio-group>
         <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
         <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
         <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
       </calcite-radio-group>
-    </div>
 
-    <h3 class="leader-1">External inputs</h3>
+      <h3 class="leader-1">Change Event</h3>
 
-    <calcite-radio-group name="grouped">
-      <calcite-radio-group-item><input type="radio" slot="input" value="1"></calcite-radio-group-item>
-      <calcite-radio-group-item><input type="radio" slot="input" value="2"></calcite-radio-group-item>
-      <calcite-radio-group-item><input type="radio" slot="input" value="3"></calcite-radio-group-item>
-    </calcite-radio-group>
+      <calcite-radio-group class="js-group">
+        <calcite-radio-group-item value="1"></calcite-radio-group-item>
+        <calcite-radio-group-item value="2"></calcite-radio-group-item>
+        <calcite-radio-group-item value="3"></calcite-radio-group-item>
+      </calcite-radio-group>
 
-    <h3 class="leader-1">Within form</h3>
+      <p>Currently selected value: <span class="js-value">n/a</span></p>
 
-    <form>
-      <label>
-        Choose wisely
-        <calcite-radio-group name="within-form">
-          <calcite-radio-group-item checked value="1"></calcite-radio-group-item>
-          <calcite-radio-group-item value="2"></calcite-radio-group-item>
-          <calcite-radio-group-item value="3"></calcite-radio-group-item>
+      <script>
+        document.querySelector(".js-group").addEventListener("calciteRadioGroupChange", function (e) {
+          document.querySelector(".js-value").innerHTML = e.detail;
+        });
+      </script>
+
+      <br />
+      <br />
+      <div class="demo-background-dark">
+        <h3 class="leader-1">Dark theme</h3>
+
+        <calcite-radio-group class="calcite-theme-dark">
+          <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
+          <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+          <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
         </calcite-radio-group>
-      </label>
-      <button type="submit">Submit</button>
-    </form>
-    <script>
-      document.querySelector("form").addEventListener("submit", (e) => {
-        e.preventDefault();
-        window.alert(`You selected ${e.target[0].value}`);
-      });
-    </script>
-  </div>
-</body>
 
+        <h3 class="leader-1">Scale s</h3>
+        <calcite-radio-group class="calcite-theme-dark" scale="s">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        </calcite-radio-group>
+
+        <h3 class="leader-1">Scale m</h3>
+        <calcite-radio-group class="calcite-theme-dark" scale="m">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        </calcite-radio-group>
+
+        <h3 class="leader-1">Scale l</h3>
+        <calcite-radio-group class="calcite-theme-dark" scale="l">
+          <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+          <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+          <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+        </calcite-radio-group>
+      </div>
+      <h3 class="leader-1">RTL</h3>
+      <div dir="rtl">
+        <calcite-radio-group>
+          <calcite-radio-group-item value="1" checked></calcite-radio-group-item>
+          <calcite-radio-group-item value="2" checked></calcite-radio-group-item>
+          <calcite-radio-group-item value="3" checked></calcite-radio-group-item>
+        </calcite-radio-group>
+      </div>
+
+      <h3 class="leader-1">External inputs</h3>
+
+      <calcite-radio-group name="grouped">
+        <calcite-radio-group-item><input type="radio" slot="input" value="1" /></calcite-radio-group-item>
+        <calcite-radio-group-item><input type="radio" slot="input" value="2" /></calcite-radio-group-item>
+        <calcite-radio-group-item><input type="radio" slot="input" value="3" /></calcite-radio-group-item>
+      </calcite-radio-group>
+
+      <h3 class="leader-1">Within form</h3>
+
+      <form>
+        <label>
+          Choose wisely
+          <calcite-radio-group name="within-form">
+            <calcite-radio-group-item checked value="1"></calcite-radio-group-item>
+            <calcite-radio-group-item value="2"></calcite-radio-group-item>
+            <calcite-radio-group-item value="3"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </label>
+        <button type="submit">Submit</button>
+      </form>
+      <script>
+        document.querySelector("form").addEventListener("submit", (e) => {
+          e.preventDefault();
+          window.alert(`You selected ${e.target[0].value}`);
+        });
+      </script>
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-rating.html
+++ b/src/demos/calcite-rating.html
@@ -1,177 +1,171 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Rating</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-  <title>Calcite Rating</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-</head>
-
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Rating</h1>
-  <div style="display:flex;flex-direction:row">
-    <div style="display:flex;width:50%;flex-direction:column;">
-
-      <h2>Default</h2>
-      <h5>Default with average</h5>
-      <calcite-rating average=3.65></calcite-rating>
-      <h5>Default with value</h5>
-      <calcite-rating value=2></calcite-rating>
-      <h5>Default with average and value</h5>
-      <calcite-rating average=3.65 value=2></calcite-rating>
-      <h5>Default without average or value</h5>
-      <calcite-rating></calcite-rating>
-      <h5>Default with average, show chip</h5>
-      <calcite-rating average=3.65 show-chip></calcite-rating>
-      <h5>Default with average, value, and count; show chip</h5>
-      <calcite-rating average=3.65 value=2 count=240 show-chip></calcite-rating>
-
-      <h2>Wrapped in calcite-label</h2>
-      <calcite-label>
-        Rate this item
-        <calcite-rating average=2.35 count=14></calcite-rating>
-      </calcite-label>
-      <calcite-label layout="inline">
-        Rate this item
-        <calcite-rating average=2.35 count=14></calcite-rating>
-      </calcite-label>
-      <calcite-label layout="inline-space-between">
-        Rate this item
-        <calcite-rating average=2.35 count=14></calcite-rating>
-      </calcite-label>
-      <h2>Read only</h2>
-      <h5>Read only with average</h5>
-      <calcite-rating read-only average=3.65></calcite-rating>
-      <h5>Read only with value</h5>
-      <calcite-rating read-only value=3></calcite-rating>
-      <h5>Read only with average and value</h5>
-      <calcite-rating read-only average=3.65 value=2 count=31></calcite-rating>
-      <h5>Read only without average or value</h5>
-      <calcite-rating read-only></calcite-rating>
-
-      <h2>Disabled</h2>
-      <h5>Disabled with average</h5>
-      <calcite-rating disabled average=3.65></calcite-rating>
-      <h5>Disabled with value</h5>
-      <calcite-rating disabled value=3></calcite-rating>
-      <h5>Disabled with average and value</h5>
-      <calcite-rating disabled average=3.65 value=2></calcite-rating>
-      <h5>Disabled without average or value</h5>
-      <calcite-rating disabled></calcite-rating>
-
-      <h2>Icon Types</h2>
-      <h5>Star (Default)</h5>
-      <calcite-rating>
-      </calcite-rating>
-
-      <h2>Scales</h2>
-      <h5>S</h5>
-      <calcite-rating scale="s"></calcite-rating>
-      <calcite-rating average=4.24 count=214 scale="s"></calcite-rating>
-      <h5>M (Default)</h5>
-      <calcite-rating></calcite-rating>
-      <h5>L</h5>
-      <calcite-rating scale="l"></calcite-rating>
-      <calcite-rating average=4.24 count=214 scale="l"></calcite-rating>
-
-      <h2>Chip combinations</h2>
-      <calcite-rating average=2.35 count=14></calcite-rating><br />
-      <calcite-rating average=2.35 value=4></calcite-rating><br />
-      <calcite-rating count=14></calcite-rating>
-      <div dir="rtl">
-        <h2>RTL</h2>
-        <calcite-rating average=2.35 count=14></calcite-rating><br />
-        <calcite-rating average=2.35 value=4></calcite-rating><br />
-        <calcite-rating count=14></calcite-rating>
-      </div>
-    </div>
-    <div style="display:flex;width:50%;flex-direction:column;">
-      <div class="demo-background-dark">
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Rating</h1>
+    <div style="display: flex; flex-direction: row">
+      <div style="display: flex; width: 50%; flex-direction: column">
         <h2>Default</h2>
         <h5>Default with average</h5>
-        <calcite-rating theme="dark" average=3.65></calcite-rating>
+        <calcite-rating average="3.65"></calcite-rating>
         <h5>Default with value</h5>
-        <calcite-rating theme="dark" value=3></calcite-rating>
+        <calcite-rating value="2"></calcite-rating>
         <h5>Default with average and value</h5>
-        <calcite-rating theme="dark" average=3.65 value=2></calcite-rating>
+        <calcite-rating average="3.65" value="2"></calcite-rating>
         <h5>Default without average or value</h5>
-        <calcite-rating theme="dark"></calcite-rating>
+        <calcite-rating></calcite-rating>
         <h5>Default with average, show chip</h5>
-        <calcite-rating theme="dark" average=3.65 show-chip></calcite-rating>
+        <calcite-rating average="3.65" show-chip></calcite-rating>
         <h5>Default with average, value, and count; show chip</h5>
-        <calcite-rating theme="dark" average=3.65 value=2 count=240 show-chip></calcite-rating>
-        <h2>Wrapped in calcite-label</h2>
-        <calcite-label theme="dark">
-          Rate this item
-          <calcite-rating theme="dark" average=2.35 count=14></calcite-rating>
-        </calcite-label>
-        <calcite-label theme="dark" layout="inline">
-          Rate this item
-          <calcite-rating average=2.35 count=14></calcite-rating>
-        </calcite-label>
-        <calcite-label theme="dark" layout="inline-space-between">
-          Rate this item
-          <calcite-rating theme="dark" average=2.35 count=14></calcite-rating>
-        </calcite-label>
+        <calcite-rating average="3.65" value="2" count="240" show-chip></calcite-rating>
 
+        <h2>Wrapped in calcite-label</h2>
+        <calcite-label>
+          Rate this item
+          <calcite-rating average="2.35" count="14"></calcite-rating>
+        </calcite-label>
+        <calcite-label layout="inline">
+          Rate this item
+          <calcite-rating average="2.35" count="14"></calcite-rating>
+        </calcite-label>
+        <calcite-label layout="inline-space-between">
+          Rate this item
+          <calcite-rating average="2.35" count="14"></calcite-rating>
+        </calcite-label>
         <h2>Read only</h2>
         <h5>Read only with average</h5>
-        <calcite-rating theme="dark" read-only average=3.65></calcite-rating>
+        <calcite-rating read-only average="3.65"></calcite-rating>
         <h5>Read only with value</h5>
-        <calcite-rating theme="dark" read-only value=3></calcite-rating>
+        <calcite-rating read-only value="3"></calcite-rating>
         <h5>Read only with average and value</h5>
-        <calcite-rating theme="dark" read-only average=3.65 value=2 count=31></calcite-rating>
+        <calcite-rating read-only average="3.65" value="2" count="31"></calcite-rating>
         <h5>Read only without average or value</h5>
-        <calcite-rating theme="dark" read-only></calcite-rating>
+        <calcite-rating read-only></calcite-rating>
+
         <h2>Disabled</h2>
         <h5>Disabled with average</h5>
-        <calcite-rating theme="dark" disabled average=3.65></calcite-rating>
+        <calcite-rating disabled average="3.65"></calcite-rating>
         <h5>Disabled with value</h5>
-        <calcite-rating theme="dark" disabled value=3></calcite-rating>
+        <calcite-rating disabled value="3"></calcite-rating>
         <h5>Disabled with average and value</h5>
-        <calcite-rating theme="dark" disabled average=3.65 value=2></calcite-rating>
+        <calcite-rating disabled average="3.65" value="2"></calcite-rating>
         <h5>Disabled without average or value</h5>
-        <calcite-rating theme="dark" disabled></calcite-rating>
+        <calcite-rating disabled></calcite-rating>
 
         <h2>Icon Types</h2>
         <h5>Star (Default)</h5>
-        <calcite-rating theme="dark">
-        </calcite-rating>
+        <calcite-rating> </calcite-rating>
 
         <h2>Scales</h2>
         <h5>S</h5>
-        <calcite-rating theme="dark" scale="s"></calcite-rating>
-        <calcite-rating theme="dark" average=4.24 count=214 scale="s"></calcite-rating>
+        <calcite-rating scale="s"></calcite-rating>
+        <calcite-rating average="4.24" count="214" scale="s"></calcite-rating>
         <h5>M (Default)</h5>
         <calcite-rating></calcite-rating>
         <h5>L</h5>
-        <calcite-rating theme="dark" scale="l"></calcite-rating>
-        <calcite-rating theme="dark" average=4.24 count=214 scale="l"></calcite-rating>
+        <calcite-rating scale="l"></calcite-rating>
+        <calcite-rating average="4.24" count="214" scale="l"></calcite-rating>
 
         <h2>Chip combinations</h2>
-        <calcite-rating theme="dark" average=2.35 count=14></calcite-rating><br />
-        <calcite-rating theme="dark" average=2.35 value=4></calcite-rating><br />
-        <calcite-rating theme="dark" count=14></calcite-rating>
+        <calcite-rating average="2.35" count="14"></calcite-rating><br />
+        <calcite-rating average="2.35" value="4"></calcite-rating><br />
+        <calcite-rating count="14"></calcite-rating>
         <div dir="rtl">
           <h2>RTL</h2>
-          <calcite-rating theme="dark" average=2.35 count=14></calcite-rating><br />
-          <calcite-rating theme="dark" average=2.35 value=4></calcite-rating><br />
-          <calcite-rating theme="dark" count=14></calcite-rating>
+          <calcite-rating average="2.35" count="14"></calcite-rating><br />
+          <calcite-rating average="2.35" value="4"></calcite-rating><br />
+          <calcite-rating count="14"></calcite-rating>
+        </div>
+      </div>
+      <div style="display: flex; width: 50%; flex-direction: column">
+        <div class="demo-background-dark">
+          <h2>Default</h2>
+          <h5>Default with average</h5>
+          <calcite-rating class="calcite-theme-dark" average="3.65"></calcite-rating>
+          <h5>Default with value</h5>
+          <calcite-rating class="calcite-theme-dark" value="3"></calcite-rating>
+          <h5>Default with average and value</h5>
+          <calcite-rating class="calcite-theme-dark" average="3.65" value="2"></calcite-rating>
+          <h5>Default without average or value</h5>
+          <calcite-rating class="calcite-theme-dark"></calcite-rating>
+          <h5>Default with average, show chip</h5>
+          <calcite-rating class="calcite-theme-dark" average="3.65" show-chip></calcite-rating>
+          <h5>Default with average, value, and count; show chip</h5>
+          <calcite-rating class="calcite-theme-dark" average="3.65" value="2" count="240" show-chip></calcite-rating>
+          <h2>Wrapped in calcite-label</h2>
+          <calcite-label class="calcite-theme-dark">
+            Rate this item
+            <calcite-rating class="calcite-theme-dark" average="2.35" count="14"></calcite-rating>
+          </calcite-label>
+          <calcite-label class="calcite-theme-dark" layout="inline">
+            Rate this item
+            <calcite-rating average="2.35" count="14"></calcite-rating>
+          </calcite-label>
+          <calcite-label class="calcite-theme-dark" layout="inline-space-between">
+            Rate this item
+            <calcite-rating class="calcite-theme-dark" average="2.35" count="14"></calcite-rating>
+          </calcite-label>
+
+          <h2>Read only</h2>
+          <h5>Read only with average</h5>
+          <calcite-rating class="calcite-theme-dark" read-only average="3.65"></calcite-rating>
+          <h5>Read only with value</h5>
+          <calcite-rating class="calcite-theme-dark" read-only value="3"></calcite-rating>
+          <h5>Read only with average and value</h5>
+          <calcite-rating class="calcite-theme-dark" read-only average="3.65" value="2" count="31"></calcite-rating>
+          <h5>Read only without average or value</h5>
+          <calcite-rating class="calcite-theme-dark" read-only></calcite-rating>
+          <h2>Disabled</h2>
+          <h5>Disabled with average</h5>
+          <calcite-rating class="calcite-theme-dark" disabled average="3.65"></calcite-rating>
+          <h5>Disabled with value</h5>
+          <calcite-rating class="calcite-theme-dark" disabled value="3"></calcite-rating>
+          <h5>Disabled with average and value</h5>
+          <calcite-rating class="calcite-theme-dark" disabled average="3.65" value="2"></calcite-rating>
+          <h5>Disabled without average or value</h5>
+          <calcite-rating class="calcite-theme-dark" disabled></calcite-rating>
+
+          <h2>Icon Types</h2>
+          <h5>Star (Default)</h5>
+          <calcite-rating class="calcite-theme-dark"> </calcite-rating>
+
+          <h2>Scales</h2>
+          <h5>S</h5>
+          <calcite-rating class="calcite-theme-dark" scale="s"></calcite-rating>
+          <calcite-rating class="calcite-theme-dark" average="4.24" count="214" scale="s"></calcite-rating>
+          <h5>M (Default)</h5>
+          <calcite-rating></calcite-rating>
+          <h5>L</h5>
+          <calcite-rating class="calcite-theme-dark" scale="l"></calcite-rating>
+          <calcite-rating class="calcite-theme-dark" average="4.24" count="214" scale="l"></calcite-rating>
+
+          <h2>Chip combinations</h2>
+          <calcite-rating class="calcite-theme-dark" average="2.35" count="14"></calcite-rating><br />
+          <calcite-rating class="calcite-theme-dark" average="2.35" value="4"></calcite-rating><br />
+          <calcite-rating class="calcite-theme-dark" count="14"></calcite-rating>
+          <div dir="rtl">
+            <h2>RTL</h2>
+            <calcite-rating class="calcite-theme-dark" average="2.35" count="14"></calcite-rating><br />
+            <calcite-rating class="calcite-theme-dark" average="2.35" value="4"></calcite-rating><br />
+            <calcite-rating class="calcite-theme-dark" count="14"></calcite-rating>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  </div>
-</body>
-
+  </body>
 </html>

--- a/src/demos/calcite-select.html
+++ b/src/demos/calcite-select.html
@@ -15,7 +15,7 @@
         display: flex;
       }
     </style>
-   <script src="./_assets/head.js"></script>
+    <script src="./_assets/head.js"></script>
   </head>
 
   <body>
@@ -116,7 +116,7 @@
     <h3>Dark Theme</h3>
 
     <div class="demo-background-dark">
-      <calcite-select label="calcite select" theme="dark">
+      <calcite-select label="calcite select" class="calcite-theme-dark">
         <calcite-option>🙂</calcite-option>
         <calcite-option>😃</calcite-option>
         <calcite-option>😂</calcite-option>
@@ -124,7 +124,7 @@
 
       <h3>Wrapped with calcite-label and theme set on label</h3>
 
-      <calcite-label theme="dark">
+      <calcite-label class="calcite-theme-dark">
         Choose uno
         <calcite-select>
           <calcite-option>uno</calcite-option>
@@ -135,7 +135,7 @@
 
       <h3>Wrapped with disabled calcite-label and theme set on label</h3>
 
-      <calcite-label theme="dark" disabled>
+      <calcite-label class="calcite-theme-dark" disabled>
         Choose uno
         <calcite-select>
           <calcite-option>uno</calcite-option>
@@ -146,7 +146,7 @@
 
       <h3>Basic disabled</h3>
 
-      <calcite-select label="calcite select" disabled theme="dark">
+      <calcite-select label="calcite select" disabled class="calcite-theme-dark">
         <calcite-option>uno</calcite-option>
         <calcite-option>dos</calcite-option>
         <calcite-option>Some long content that will probably be enough to extend past the end</calcite-option>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -1,511 +1,1055 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Slider</title>
+    <style>
+      body {
+        margin: 20px;
+      }
+      .demo-background-light {
+        border: 1px solid #202020;
+        padding: 1rem;
+      }
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+      .two-columns {
+        display: grid;
+        grid-template-columns: 350px 350px;
+        grid-gap: 20px;
+      }
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Slider</title>
-  <style>
-    body {
-      margin: 20px;
-    }
-    .demo-background-light {
-      border: 1px solid #202020;
-      padding: 1rem;
-    }
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-    .two-columns {
-      display: grid;
-      grid-template-columns: 350px 350px;
-      grid-gap: 20px;
-    }
+      h3 {
+        margin-top: 24px;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
+  </head>
 
-    h3 {
-      margin-top: 24px;
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Slider</h1>
 
-<body>
+    <div class="two-columns">
+      <div class="demo-background-light">
+        <h2>Single Value</h2>
 
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Slider</h1>
+        <demo-spacer>
+          <h3>Handle</h3>
+          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
 
-  <div class="two-columns">
-    <div class="demo-background-light">
-      <h2>Single Value</h2>
+          <h3>Labeled Handle</h3>
+          <calcite-slider
+            min="100"
+            max="1000"
+            value="1000"
+            step="10"
+            label="Temperature"
+            label-handles
+          ></calcite-slider>
 
-      <demo-spacer>
+          <h3>Precise Handle</h3>
+          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+          </calcite-slider>
 
-        <h3>Handle</h3>
-        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+          <h3>Precise Labeled Handle</h3>
+          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
+          </calcite-slider>
 
-        <h3>Labeled Handle</h3>
-        <calcite-slider min="100" max="1000" value="1000" step="10" label="Temperature" label-handles></calcite-slider>
+          <h3>Ticks</h3>
+          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
 
-        <h3>Precise Handle</h3>
-        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
-        </calcite-slider>
+          <h3>Ticks with Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+          </calcite-slider>
+          <calcite-slider min="-100" max="0" value="0" step="10" ticks="10" label="Temperature" label-handles>
+          </calcite-slider>
 
-        <h3>Precise Labeled Handle</h3>
-        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
-        </calcite-slider>
+          <h3>Ticks with Precise Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="50"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            precise
+          ></calcite-slider>
 
-        <h3>Ticks</h3>
-        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+          <h3>Ticks with Precise Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
+          </calcite-slider>
 
-        <h3>Ticks with Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
-        </calcite-slider>
-        <calcite-slider min="-100" max="0" value="0" step="10" ticks="10" label="Temperature" label-handles>
-        </calcite-slider>
+          <h3>Labeled Ticks</h3>
+          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+          </calcite-slider>
 
-        <h3>Ticks with Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="50" step="10" ticks="10" label="Temperature" precise></calcite-slider>
+          <h3>Labeled Ticks with Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="40"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+            label-ticks
+          >
+          </calcite-slider>
 
-        <h3>Ticks with Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
-        </calcite-slider>
+          <h3>Labeled Ticks with Precise Handle</h3>
+          <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+          </calcite-slider>
 
-        <h3>Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
-        </calcite-slider>
+          <h3>Labeled Ticks with Precise Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="23"
+            step="10"
+            ticks="10"
+            label-handles
+            label-ticks
+            precise
+            label="Temperature"
+          ></calcite-slider>
 
-        <h3>Labeled Ticks with Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles label-ticks>
-        </calcite-slider>
+          <h3>Disabled</h3>
+          <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
 
-        <h3>Labeled Ticks with Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
-        </calcite-slider>
+          <h3>Histogram</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
 
-        <h3>Labeled Ticks with Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise
-          label="Temperature"></calcite-slider>
+          <h3>Histogram with Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
 
-        <h3>Disabled</h3>
-        <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+          <h3>Histogram with Precise Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
 
-        <h3>Histogram</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+          <h3>Histogram with Precise Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+          </calcite-slider>
 
-        <h3>Histogram with Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+          <h3>Histogram with Ticks</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
 
-        <h3>Histogram with Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+          <h3>Histogram with Ticks and Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
+          </calcite-slider>
 
-        <h3>Histogram with Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
-        </calcite-slider>
+          <h3>Histogram with Ticks and Precise Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="60"
+            step="10"
+            class="js-histogram"
+            ticks="10"
+            precise
+          ></calcite-slider>
 
-        <h3>Histogram with Ticks</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+          <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
+          </calcite-slider>
 
-        <h3>Histogram with Ticks and Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+          </calcite-slider>
 
-        <h3>Histogram with Ticks and Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
+          <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="60"
+            step="10"
+            class="js-histogram"
+            ticks="10"
+            label-handles
+            label-ticks
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Ticks and Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+          </calcite-slider>
 
-        <h3>Histogram with Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="60"
+            step="10"
+            class="js-histogram"
+            ticks="10"
+            label-handles
+            label-ticks
+            precise
+          ></calcite-slider>
 
-        <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles
-          label-ticks>
-        </calcite-slider>
+          <h3>Histogram Disabled</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+        </demo-spacer>
 
-        <h3>Histogram with Labeled Ticks and Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
-        </calcite-slider>
+        <h2>Range</h2>
 
-        <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
-          precise></calcite-slider>
+        <demo-spacer>
+          <h3>Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+          ></calcite-slider>
 
-        <h3>Histogram Disabled</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
-      </demo-spacer>
+          <h3>Labeled Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            label-handles
+          ></calcite-slider>
 
-      <h2>Range</h2>
+          <h3>Precise Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            precise
+          ></calcite-slider>
 
-      <demo-spacer>
-        <h3>Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)"></calcite-slider>
+          <h3>Precise Labeled Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            precise
+            label-handles
+          >
+          </calcite-slider>
 
-        <h3>Labeled Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" label-handles></calcite-slider>
+          <h3>Ticks</h3>
+          <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+          </calcite-slider>
 
-        <h3>Precise Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
+          <h3>Ticks with Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+          ></calcite-slider>
 
-        <h3>Precise Labeled Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles>
-        </calcite-slider>
+          <h3>Ticks with Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            precise
+          >
+          </calcite-slider>
 
-        <h3>Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
-        </calcite-slider>
+          <h3>Ticks with Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+            precise
+          >
+          </calcite-slider>
 
-        <h3>Ticks with Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
-          label-handles></calcite-slider>
+          <h3>Labeled Ticks</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-ticks
+          >
+          </calcite-slider>
 
-        <h3>Ticks with Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
-          precise>
-        </calcite-slider>
+          <h3>Labeled Ticks with Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+            label-ticks
+          ></calcite-slider>
 
-        <h3>Ticks with Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
-          label-handles precise>
-        </calcite-slider>
+          <h3>Labeled Ticks with Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            precise
+            label-ticks
+          ></calcite-slider>
 
-        <h3>Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
-          label-ticks>
-        </calcite-slider>
+          <h3>Labeled Ticks with Precise Labeled Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="30000"
+            max-value="80000"
+            step="10000"
+            ticks="10000"
+            label="Temperature"
+            precise
+            label-handles
+            label-ticks
+          ></calcite-slider>
 
-        <h3>Labeled Ticks with Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
-          label-handles label-ticks></calcite-slider>
+          <h3>Histogram</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+          ></calcite-slider>
 
-        <h3>Labeled Ticks with Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
-          label-ticks></calcite-slider>
+          <h3>Histogram with Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+          ></calcite-slider>
+          <calcite-slider
+            min="-100"
+            max="0"
+            min-value="-100"
+            max-value="0"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+          ></calcite-slider>
 
-        <h3>Labeled Ticks with Precise Labeled Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="30000" max-value="80000" step="10000" ticks="10000"
-          label="Temperature" precise label-handles label-ticks></calcite-slider>
+          <h3>Histogram with Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            precise
+          ></calcite-slider>
 
-        <h3>Histogram</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
+          <h3>Histogram with Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            precise
+            label-handles
+          ></calcite-slider>
 
-        <h3>Histogram with Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
-        <calcite-slider min="-100" max="0" min-value="-100" max-value="0" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
+          <h3>Histogram with Ticks</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
+          <h3>Histogram with Ticks and Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
+          <h3>Histogram with Ticks and Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            precise
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram">
-        </calcite-slider>
+          <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+            precise
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Ticks and Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram"
-          label-handles>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-ticks
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Ticks and Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+            label-ticks
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Ticks and Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
-          precise>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-ticks
+            precise
+          >
+          </calcite-slider>
 
-        <h3>Histogram with Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
-        </calcite-slider>
+          <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+            label-ticks
+            precise
+          >
+          </calcite-slider>
+        </demo-spacer>
+      </div>
 
-        <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
-          label-ticks>
-        </calcite-slider>
+      <div class="demo-background-dark calcite-theme-dark">
+        <h2>Single Value</h2>
 
-        <h3>Histogram with Labeled Ticks and Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks
-          precise>
-        </calcite-slider>
+        <demo-spacer>
+          <h3>Handle</h3>
+          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
 
-        <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
-          label-ticks precise>
-        </calcite-slider>
+          <h3>Labeled Handle</h3>
+          <calcite-slider
+            min="100"
+            max="1000"
+            value="1000"
+            step="10"
+            label="Temperature"
+            label-handles
+          ></calcite-slider>
 
-      </demo-spacer>
+          <h3>Precise Handle</h3>
+          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+          </calcite-slider>
+
+          <h3>Precise Labeled Handle</h3>
+          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
+          </calcite-slider>
+
+          <h3>Ticks</h3>
+          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+
+          <h3>Ticks with Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+          </calcite-slider>
+
+          <h3>Ticks with Precise Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="50"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            precise
+          ></calcite-slider>
+
+          <h3>Ticks with Precise Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
+          </calcite-slider>
+
+          <h3>Labeled Ticks</h3>
+          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+          </calcite-slider>
+
+          <h3>Labeled Ticks with Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="40"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+            label-ticks
+          >
+          </calcite-slider>
+
+          <h3>Labeled Ticks with Precise Handle</h3>
+          <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+          </calcite-slider>
+
+          <h3>Labeled Ticks with Precise Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="23"
+            step="10"
+            ticks="10"
+            label-handles
+            label-ticks
+            precise
+            label="Temperature"
+          ></calcite-slider>
+
+          <h3>Disabled</h3>
+          <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+
+          <h3>Histogram</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+
+          <h3>Histogram with Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+
+          <h3>Histogram with Precise Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+
+          <h3>Histogram with Precise Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+          </calcite-slider>
+
+          <h3>Histogram with Ticks</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+
+          <h3>Histogram with Ticks and Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
+          </calcite-slider>
+
+          <h3>Histogram with Ticks and Precise Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="60"
+            step="10"
+            class="js-histogram"
+            ticks="10"
+            precise
+          ></calcite-slider>
+
+          <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="60"
+            step="10"
+            class="js-histogram"
+            ticks="10"
+            label-handles
+            label-ticks
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            value="60"
+            step="10"
+            class="js-histogram"
+            ticks="10"
+            label-handles
+            label-ticks
+            precise
+          ></calcite-slider>
+
+          <h3>Histogram Disabled</h3>
+          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+        </demo-spacer>
+
+        <h2>Range</h2>
+
+        <demo-spacer>
+          <h3>Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+          ></calcite-slider>
+
+          <h3>Labeled Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            label-handles
+          ></calcite-slider>
+
+          <h3>Precise Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            precise
+          ></calcite-slider>
+
+          <h3>Precise Labeled Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="10000"
+            max-value="100000"
+            step="1000"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            precise
+            label-handles
+          >
+          </calcite-slider>
+
+          <h3>Ticks</h3>
+          <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+          </calcite-slider>
+
+          <h3>Ticks with Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+          ></calcite-slider>
+
+          <h3>Ticks with Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            precise
+          >
+          </calcite-slider>
+
+          <h3>Ticks with Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+            precise
+          >
+          </calcite-slider>
+
+          <h3>Labeled Ticks</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-ticks
+          >
+          </calcite-slider>
+
+          <h3>Labeled Ticks with Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            label-handles
+            label-ticks
+          ></calcite-slider>
+
+          <h3>Labeled Ticks with Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="20"
+            max-value="80"
+            step="10"
+            ticks="10"
+            label="Temperature"
+            precise
+            label-ticks
+          ></calcite-slider>
+
+          <h3>Labeled Ticks with Precise Labeled Handles</h3>
+          <calcite-slider
+            min="10000"
+            max="100000"
+            min-value="30000"
+            max-value="80000"
+            step="10000"
+            ticks="10000"
+            label="Temperature"
+            precise
+            label-handles
+            label-ticks
+          ></calcite-slider>
+
+          <h3>Histogram</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+          ></calcite-slider>
+
+          <h3>Histogram with Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+          ></calcite-slider>
+
+          <h3>Histogram with Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            precise
+          ></calcite-slider>
+
+          <h3>Histogram with Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="85"
+            step="1"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            precise
+            label-handles
+          ></calcite-slider>
+
+          <h3>Histogram with Ticks</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Ticks and Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Ticks and Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            precise
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+            precise
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-ticks
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+            label-ticks
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-ticks
+            precise
+          >
+          </calcite-slider>
+
+          <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+          <calcite-slider
+            min="0"
+            max="100"
+            min-value="50"
+            max-value="80"
+            step="10"
+            ticks="10"
+            min-label="Temperature range (lower)"
+            max-label="Temperature range (upper)"
+            class="js-histogram"
+            label-handles
+            label-ticks
+            precise
+          >
+          </calcite-slider>
+        </demo-spacer>
+      </div>
     </div>
 
-    <div class="demo-background-dark" theme="dark">
+    <h3>Event Listener</h3>
+    <calcite-slider id="sliderEvents" min="0" max="100" value="50" step="1" label="Temperature"></calcite-slider>
+    <p>Current slider value is: <span id="sliderEventDisplay"></span></p>
 
-      <h2>Single Value</h2>
-
-      <demo-spacer>
-
-        <h3>Handle</h3>
-        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
-
-        <h3>Labeled Handle</h3>
-        <calcite-slider min="100" max="1000" value="1000" step="10" label="Temperature" label-handles></calcite-slider>
-
-        <h3>Precise Handle</h3>
-        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
-        </calcite-slider>
-
-        <h3>Precise Labeled Handle</h3>
-        <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
-        </calcite-slider>
-
-        <h3>Ticks</h3>
-        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
-
-        <h3>Ticks with Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
-        </calcite-slider>
-
-        <h3>Ticks with Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="50" step="10" ticks="10" label="Temperature" precise></calcite-slider>
-
-        <h3>Ticks with Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
-        </calcite-slider>
-
-        <h3>Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
-        </calcite-slider>
-
-        <h3>Labeled Ticks with Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles label-ticks>
-        </calcite-slider>
-
-        <h3>Labeled Ticks with Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
-        </calcite-slider>
-
-        <h3>Labeled Ticks with Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-handles label-ticks precise
-          label="Temperature"></calcite-slider>
-
-        <h3>Disabled</h3>
-        <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
-
-        <h3>Histogram</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
-
-        <h3>Histogram with Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
-
-        <h3>Histogram with Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
-
-        <h3>Histogram with Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
-        </calcite-slider>
-
-        <h3>Histogram with Ticks</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
-
-        <h3>Histogram with Ticks and Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
-        </calcite-slider>
-
-        <h3>Histogram with Ticks and Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" precise></calcite-slider>
-
-        <h3>Histogram with Ticks and Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks and Precise Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
-        <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles label-ticks
-          precise></calcite-slider>
-
-        <h3>Histogram Disabled</h3>
-        <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
-      </demo-spacer>
-
-      <h2>Range</h2>
-
-      <demo-spacer>
-        <h3>Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)"></calcite-slider>
-
-        <h3>Labeled Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" label-handles></calcite-slider>
-
-        <h3>Precise Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise></calcite-slider>
-
-        <h3>Precise Labeled Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="10000" max-value="100000" step="1000" step="1"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" precise label-handles>
-        </calcite-slider>
-
-        <h3>Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
-        </calcite-slider>
-
-        <h3>Ticks with Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature"
-          label-handles></calcite-slider>
-
-        <h3>Ticks with Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise>
-        </calcite-slider>
-
-        <h3>Ticks with Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles
-          precise>
-        </calcite-slider>
-
-        <h3>Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-ticks>
-        </calcite-slider>
-
-        <h3>Labeled Ticks with Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" label-handles
-          label-ticks></calcite-slider>
-
-        <h3>Labeled Ticks with Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature" precise
-          label-ticks></calcite-slider>
-
-        <h3>Labeled Ticks with Precise Labeled Handles</h3>
-        <calcite-slider min="10000" max="100000" min-value="30000" max-value="80000" step="10000" ticks="10000"
-          label="Temperature" precise label-handles label-ticks></calcite-slider>
-
-        <h3>Histogram</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram"></calcite-slider>
-
-        <h3>Histogram with Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" label-handles></calcite-slider>
-
-        <h3>Histogram with Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" precise></calcite-slider>
-
-        <h3>Histogram with Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="85" step="1" min-label="Temperature range (lower)"
-          max-label="Temperature range (upper)" class="js-histogram" precise label-handles></calcite-slider>
-
-        <h3>Histogram with Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram">
-        </calcite-slider>
-
-        <h3>Histogram with Ticks and Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles>
-        </calcite-slider>
-
-        <h3>Histogram with Ticks and Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" precise>
-        </calcite-slider>
-
-        <h3>Histogram with Ticks and Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
-          precise>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
-          label-ticks>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks and Precise Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-ticks
-          precise>
-        </calcite-slider>
-
-        <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
-        <calcite-slider min="0" max="100" min-value="50" max-value="80" step="10" ticks="10"
-          min-label="Temperature range (lower)" max-label="Temperature range (upper)" class="js-histogram" label-handles
-          label-ticks precise>
-        </calcite-slider>
-
-      </demo-spacer>
-
-    </div>
-  </div>
-
-  <h3>Event Listener</h3>
-  <calcite-slider id="sliderEvents" min="0" max="100" value="50" step="1" label="Temperature"></calcite-slider>
-  <p>Current slider value is: <span id="sliderEventDisplay"></span></p>
-
-  <script>
-    (function () {
-      var label = document.getElementById("sliderEventDisplay");
-      document.getElementById("sliderEvents").addEventListener("calciteSliderUpdate", function (e) {
-        label.innerHTML = e.target.value;
+    <script>
+      (function () {
+        var label = document.getElementById("sliderEventDisplay");
+        document.getElementById("sliderEvents").addEventListener("calciteSliderUpdate", function (e) {
+          label.innerHTML = e.target.value;
+        });
+      })();
+    </script>
+    <script>
+      var histogram = [
+        [0, 0],
+        [20, 12],
+        [40, 25],
+        [60, 55],
+        [80, 10],
+        [100, 0]
+      ];
+      [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
+        graphElement.histogram = histogram;
       });
-    })();
-  </script>
-  <script>
-    var histogram = [
-      [0, 0],
-      [20, 12],
-      [40, 25],
-      [60, 55],
-      [80, 10],
-      [100, 0]
-    ];
-    [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
-      graphElement.histogram = histogram;
-    });
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/src/demos/calcite-split-button.html
+++ b/src/demos/calcite-split-button.html
@@ -1,408 +1,435 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Button with Dropdown</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Button with Dropdown</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-</head>
-
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Split Button</h1>
-  <div style="width:1200px;position:relative;">
-    <h3>Example with Custom Dropdown Content</h3>
-    <calcite-split-button primary-icon-start='save' primary-text="Primary Option">
-      <calcite-dropdown-group selection-mode="none">
-        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-split-button>
-
-    <h3>Example with Custom Dropdown Content (RTL)</h3>
-    <div dir="rtl">
-      <calcite-split-button primary-icon-start='save' primary-text="Primary Option">
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Split Button</h1>
+    <div style="width: 1200px; position: relative">
+      <h3>Example with Custom Dropdown Content</h3>
+      <calcite-split-button primary-icon-start="save" primary-text="Primary Option">
         <calcite-dropdown-group selection-mode="none">
           <calcite-dropdown-item>Option 2</calcite-dropdown-item>
           <calcite-dropdown-item>Option 3</calcite-dropdown-item>
           <calcite-dropdown-item>Option 4</calcite-dropdown-item>
         </calcite-dropdown-group>
       </calcite-split-button>
-      <calcite-split-button primary-icon-end='save' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button primary-icon-start='save' primary-icon-end='layer' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
+
+      <h3>Example with Custom Dropdown Content (RTL)</h3>
+      <div dir="rtl">
+        <calcite-split-button primary-icon-start="save" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button primary-icon-end="save" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button primary-icon-start="save" primary-icon-end="layer" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+
+      <h3>Color</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button primary-text="Primary Option"></calcite-split-button>
+        <calcite-split-button color="red" primary-text="Primary Option"></calcite-split-button>
+        <calcite-split-button color="neutral" primary-text="Primary Option"></calcite-split-button>
+        <calcite-split-button color="inverse" primary-text="Primary Option"></calcite-split-button>
+      </div>
+
+      <h3>Color (Dark Theme)</h3>
+      <div class="demo-background-dark" style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button class="calcite-theme-dark" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button color="red" class="calcite-theme-dark" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button color="neutral" class="calcite-theme-dark" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button color="inverse" class="calcite-theme-dark" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+
+      <h3>Appearance</h3>
+      <div
+        style="display: flex; flex-direction: row; justify-content: space-between; padding: 1em; background: #e3e3e3"
+      >
+        <calcite-split-button primary-text="Default/Solid Appearance"> </calcite-split-button>
+        <calcite-split-button appearance="outline" primary-text="Outline Appearance"> </calcite-split-button>
+        <calcite-split-button appearance="clear" primary-text="Clear Appearance"> </calcite-split-button>
+        <calcite-split-button appearance="transparent" primary-text="Transparent Appearance"> </calcite-split-button>
+      </div>
+
+      <h3>Appearance (Red Color)</h3>
+      <div
+        style="display: flex; flex-direction: row; justify-content: space-between; padding: 1em; background: #e3e3e3"
+      >
+        <calcite-split-button color="red" primary-text="Default/Solid Appearance"> </calcite-split-button>
+        <calcite-split-button color="red" appearance="outline" primary-text="Outline Appearance">
+        </calcite-split-button>
+        <calcite-split-button color="red" appearance="clear" primary-text="Clear Appearance"> </calcite-split-button>
+        <calcite-split-button color="red" appearance="transparent" primary-text="Transparent Appearance">
+        </calcite-split-button>
+      </div>
+
+      <h3>Appearance (Neutral Color)</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button color="neutral" primary-text="Default/Solid Appearance"> </calcite-split-button>
+        <calcite-split-button color="neutral" appearance="outline" primary-text="Outline Appearance">
+        </calcite-split-button>
+        <calcite-split-button color="neutral" appearance="clear" primary-text="Clear Appearance">
+        </calcite-split-button>
+        <calcite-split-button color="neutral" appearance="transparent" primary-text="Transparent Appearance">
+        </calcite-split-button>
+      </div>
+
+      <h3>Appearance (Inverse Color)</h3>
+      <div
+        style="display: flex; flex-direction: row; justify-content: space-between; padding: 1em; background: #e3e3e3"
+      >
+        <calcite-split-button color="inverse" primary-text="Default/Solid Appearance"> </calcite-split-button>
+        <calcite-split-button color="inverse" appearance="outline" primary-text="Outline Appearance">
+        </calcite-split-button>
+        <calcite-split-button color="inverse" appearance="clear" primary-text="Clear Appearance">
+        </calcite-split-button>
+        <calcite-split-button color="inverse" appearance="transparent" primary-text="Transparent Appearance">
+        </calcite-split-button>
+      </div>
+
+      <h3>Appearance (Dark Theme)</h3>
+      <div
+        class="demo-background-dark"
+        style="display: flex; flex-direction: row; justify-content: space-between; padding: 1em"
+      >
+        <calcite-split-button class="calcite-theme-dark" primary-text="Default/Solid Appearance">
+        </calcite-split-button>
+        <calcite-split-button class="calcite-theme-dark" appearance="outline" primary-text="Outline Appearance">
+        </calcite-split-button>
+        <calcite-split-button class="calcite-theme-dark" appearance="clear" primary-text="Clear Appearance">
+        </calcite-split-button>
+        <calcite-split-button class="calcite-theme-dark" appearance="transparent" primary-text="Transparent Appearance">
+        </calcite-split-button>
+      </div>
+
+      <h3>Appearance (Neutral Color, Dark Theme)</h3>
+      <div class="demo-background-dark" style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button class="calcite-theme-dark" color="neutral" primary-text="Default/Solid Appearance">
+        </calcite-split-button>
+        <calcite-split-button
+          class="calcite-theme-dark"
+          color="neutral"
+          appearance="outline"
+          primary-text="Outline Appearance"
+        >
+        </calcite-split-button>
+        <calcite-split-button
+          class="calcite-theme-dark"
+          color="neutral"
+          appearance="clear"
+          primary-text="Clear Appearance"
+        >
+        </calcite-split-button>
+        <calcite-split-button
+          class="calcite-theme-dark"
+          color="neutral"
+          appearance="transparent"
+          primary-text="Transparent Appearance"
+        >
+        </calcite-split-button>
+      </div>
+
+      <h3>Disabled</h3>
+      <calcite-split-button disabled="true" primary-text="Primary Option"></calcite-split-button>
+
+      <h3>Loading</h3>
+      <calcite-split-button loading="true" primary-text="Primary Option"></calcite-split-button>
+
+      <h3>Scale</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <script>
+          document.addEventListener("calciteSplitButtonPrimaryClick", () => alert("primary action"));
+          document.addEventListener("calciteSplitButtonSecondaryClick", () => alert("secondary action"));
+        </script>
+      </div>
+
+      <h3>Scale (two icons)</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button
+          primary-icon-start="plus"
+          primary-icon-end="layer"
+          scale="s"
+          primary-text="Primary Option"
+        >
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button
+          primary-icon-start="plus"
+          primary-icon-end="layer"
+          scale="m"
+          primary-text="Primary Option"
+        >
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button
+          primary-icon-start="plus"
+          primary-icon-end="layer"
+          scale="l"
+          primary-text="Primary Option"
+        >
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <script>
+          document.addEventListener("calciteSplitButtonPrimaryClick", () => alert("primary action"));
+        </script>
+      </div>
+
+      <h3>Scale (when `primary-text` is empty)</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-icon-start="save">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-icon-start="save">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-icon-start="save">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+
+      <h3>Scale (primary-icon-end)(when `primary-text` is empty)</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-icon-end="save">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-icon-end="save">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-icon-end="save">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+
+      <h3>Scale (primary-icon-end and -start)(when `primary-text` is empty)</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-icon-end="save" primary-icon-start="layer">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-icon-end="save" primary-icon-start="layer">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-icon-end="save" primary-icon-start="layer">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+      <h3>Scale (when `dropdown-icon-type` is 'chevron' (default))</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-text="Primary Option">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+      <h3>Scale (when `dropdown-icon-type` is 'caret')</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-text="Primary Option" dropdown-icon-type="caret">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-text="Primary Option" dropdown-icon-type="caret">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-text="Primary Option" dropdown-icon-type="caret">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+      <h3>Scale (when `dropdown-icon-type` is 'ellipsis')</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-text="Primary Option" dropdown-icon-type="ellipsis">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-text="Primary Option" dropdown-icon-type="ellipsis">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-text="Primary Option" dropdown-icon-type="ellipsis">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+      <h3>Scale (when `dropdown-icon-type` is 'overflow')</h3>
+      <div style="display: flex; flex-direction: row; justify-content: space-between">
+        <calcite-split-button scale="s" primary-text="Primary Option" dropdown-icon-type="overflow">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="m" primary-text="Primary Option" dropdown-icon-type="overflow">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+        <calcite-split-button scale="l" primary-text="Primary Option" dropdown-icon-type="overflow">
+          <calcite-dropdown-group selection-mode="none">
+            <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+            <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-split-button>
+      </div>
+      <br />
     </div>
-
-    <h3>Color</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button primary-text="Primary Option"></calcite-split-button>
-      <calcite-split-button color='red' primary-text="Primary Option"></calcite-split-button>
-      <calcite-split-button color='neutral' primary-text="Primary Option"></calcite-split-button>
-      <calcite-split-button color='inverse' primary-text="Primary Option"></calcite-split-button>
-    </div>
-
-    <h3>Color (Dark Theme)</h3>
-    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button theme='dark' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button color='red' theme='dark' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button color='neutral' theme='dark' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button color='inverse' theme='dark' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-
-    <h3>Appearance</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
-      <calcite-split-button primary-text="Default/Solid Appearance">
-      </calcite-split-button>
-      <calcite-split-button appearance='outline' primary-text="Outline Appearance">
-      </calcite-split-button>
-      <calcite-split-button appearance='clear' primary-text="Clear Appearance">
-      </calcite-split-button>
-      <calcite-split-button appearance='transparent' primary-text="Transparent Appearance">
-      </calcite-split-button>
-    </div>
-
-    <h3>Appearance (Red Color)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
-      <calcite-split-button color="red" primary-text="Default/Solid Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="red" appearance='outline' primary-text="Outline Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="red" appearance='clear' primary-text="Clear Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="red" appearance='transparent' primary-text="Transparent Appearance">
-      </calcite-split-button>
-    </div>
-
-    <h3>Appearance (Neutral Color)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between;'>
-      <calcite-split-button color="neutral" primary-text="Default/Solid Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="neutral" appearance='outline' primary-text="Outline Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="neutral" appearance='clear' primary-text="Clear Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="neutral" appearance='transparent' primary-text="Transparent Appearance">
-      </calcite-split-button>
-    </div>
-
-    <h3>Appearance (Inverse Color)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;background:#e3e3e3;'>
-      <calcite-split-button color="inverse" primary-text="Default/Solid Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="inverse" appearance='outline' primary-text="Outline Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="inverse" appearance='clear' primary-text="Clear Appearance">
-      </calcite-split-button>
-      <calcite-split-button color="inverse" appearance='transparent' primary-text="Transparent Appearance">
-      </calcite-split-button>
-    </div>
-
-    <h3>Appearance (Dark Theme)</h3>
-    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between;padding:1em;'>
-      <calcite-split-button theme="dark" primary-text="Default/Solid Appearance">
-      </calcite-split-button>
-      <calcite-split-button theme="dark" appearance='outline' primary-text="Outline Appearance">
-      </calcite-split-button>
-      <calcite-split-button theme="dark" appearance='clear' primary-text="Clear Appearance">
-      </calcite-split-button>
-      <calcite-split-button theme="dark" appearance='transparent' primary-text="Transparent Appearance">
-      </calcite-split-button>
-    </div>
-
-    <h3>Appearance (Neutral Color, Dark Theme)</h3>
-    <div class='demo-background-dark' style='display:flex;flex-direction:row;justify-content:space-between;'>
-      <calcite-split-button theme="dark" color="neutral" primary-text="Default/Solid Appearance">
-      </calcite-split-button>
-      <calcite-split-button theme="dark" color="neutral" appearance='outline' primary-text="Outline Appearance">
-      </calcite-split-button>
-      <calcite-split-button theme="dark" color="neutral" appearance='clear' primary-text="Clear Appearance">
-      </calcite-split-button>
-      <calcite-split-button theme="dark" color="neutral" appearance='transparent' primary-text="Transparent Appearance">
-      </calcite-split-button>
-    </div>
-
-    <h3>Disabled</h3>
-    <calcite-split-button disabled=true primary-text="Primary Option"></calcite-split-button>
-
-    <h3>Loading</h3>
-    <calcite-split-button loading=true primary-text="Primary Option"></calcite-split-button>
-
-    <h3>Scale</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <script>
-        document.addEventListener('calciteSplitButtonPrimaryClick', () => alert('primary action'))
-        document.addEventListener('calciteSplitButtonSecondaryClick', () => alert('secondary action'))
-      </script>
-    </div>
-
-
-    <h3>Scale (two icons)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button primary-icon-start="plus" primary-icon-end="layer" scale='s' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button primary-icon-start="plus" primary-icon-end="layer" scale='m' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button primary-icon-start="plus" primary-icon-end="layer" scale='l' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <script>
-        document.addEventListener('calciteSplitButtonPrimaryClick', () => alert('primary action'))
-      </script>
-    </div>
-
-    <h3>Scale (when `primary-text` is empty)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-icon-start='save'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-icon-start='save'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-icon-start='save'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-
-    <h3>Scale (primary-icon-end)(when `primary-text` is empty)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-icon-end='save'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-icon-end='save'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-icon-end='save'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-
-    <h3>Scale (primary-icon-end and -start)(when `primary-text` is empty)</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-icon-end='save' primary-icon-start="layer">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-icon-end='save' primary-icon-start="layer">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-icon-end='save' primary-icon-start="layer">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-    <h3>Scale (when `dropdown-icon-type` is 'chevron' (default))</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-text="Primary Option">
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-    <h3>Scale (when `dropdown-icon-type` is 'caret')</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-text="Primary Option" dropdown-icon-type='caret'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-text="Primary Option" dropdown-icon-type='caret'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-text="Primary Option" dropdown-icon-type='caret'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-    <h3>Scale (when `dropdown-icon-type` is 'ellipsis')</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-text="Primary Option" dropdown-icon-type='ellipsis'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-text="Primary Option" dropdown-icon-type='ellipsis'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-text="Primary Option" dropdown-icon-type='ellipsis'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-    <h3>Scale (when `dropdown-icon-type` is 'overflow')</h3>
-    <div style='display:flex;flex-direction:row;justify-content:space-between'>
-      <calcite-split-button scale='s' primary-text="Primary Option" dropdown-icon-type='overflow'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='m' primary-text="Primary Option" dropdown-icon-type='overflow'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-      <calcite-split-button scale='l' primary-text="Primary Option" dropdown-icon-type='overflow'>
-        <calcite-dropdown-group selection-mode="none">
-          <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-          <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-split-button>
-    </div>
-    </br>
-    </br>
-  </div>
-</body>
-
+  </body>
 </html>

--- a/src/demos/calcite-stepper.html
+++ b/src/demos/calcite-stepper.html
@@ -1,600 +1,88 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Stepper</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+      .demo-test-style {
+        background: red;
+        padding: 2rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Stepper</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-    .demo-test-style {
-      background: red;
-      padding:2rem;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Stepper</h1>
+    <h4>Invite Members Example</h4>
+    <calcite-modal class="js-modal-1" size="large">
+      <h3 slot="header">Add Members</h3>
+      <div slot="content">
+        <calcite-stepper icon numbered id="my-example-stepper">
+          <calcite-stepper-item item-title="Choose method" complete> Step 1 Content Goes Here </calcite-stepper-item>
+          <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 2 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 3 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 4 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+        </calcite-stepper>
+      </div>
+      <calcite-button
+        slot="back"
+        width="full"
+        color="neutral"
+        appearance="outline"
+        icon="chevronLeft"
+        onclick="document.querySelector('#my-example-stepper').startStep()"
+        >Start Over</calcite-button
+      >
+      <calcite-button
+        slot="secondary"
+        width="full"
+        appearance="outline"
+        onclick="document.querySelector('#my-example-stepper').prevStep()"
+        >Back</calcite-button
+      >
+      <calcite-button slot="primary" width="full" onclick="document.querySelector('#my-example-stepper').nextStep()">
+        Continue</calcite-button
+      >
+      <calcite-button slot="primary" width="full" onclick="document.querySelector('#my-example-stepper').endStep()"
+        >End Step</calcite-button
+      >
+      <calcite-button slot="primary" width="full" onclick="document.querySelector('#my-example-stepper').goToStep(2)"
+        >2
+      </calcite-button>
+    </calcite-modal>
+    <calcite-button onClick="document.querySelector('.js-modal-1').active = true">Invite Members </calcite-button>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Stepper</h1>
-  <h4>Invite Members Example</h4>
-  <calcite-modal class="js-modal-1" size="large">
-    <h3 slot="header">Add Members</h3>
-    <div slot="content">
-      <calcite-stepper icon numbered id="my-example-stepper">
-        <calcite-stepper-item item-title="Choose method" complete>
-          Step 1 Content Goes Here
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" complete>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-
-    </div>
-    <calcite-button slot="back" width="full" color="neutral" appearance="outline" icon="chevronLeft"
-      onclick="document.querySelector('#my-example-stepper').startStep()">Start Over</calcite-button>
-    <calcite-button slot="secondary" width="full" appearance="outline"
-      onclick="document.querySelector('#my-example-stepper').prevStep()">Back</calcite-button>
-    <calcite-button slot="primary" width="full" onclick="document.querySelector('#my-example-stepper').nextStep()">
-      Continue</calcite-button>
-    <calcite-button slot="primary" width="full" onclick="document.querySelector('#my-example-stepper').endStep()">End
-      Step</calcite-button>
-    <calcite-button slot="primary" width="full" onclick="document.querySelector('#my-example-stepper').goToStep(2)">2
-    </calcite-button>
-
-
-  </calcite-modal>
-  <calcite-button onClick="document.querySelector('.js-modal-1').active = true">Invite Members
-  </calcite-button>
-
-  <h4>Horizontal</h4>
-  <calcite-stepper numbered="zom" icon="zar">
-    <calcite-stepper-item item-title="Choose method" complete>
-      Something before a div
+    <h4>Horizontal</h4>
+    <calcite-stepper numbered="zom" icon="zar">
+      <calcite-stepper-item item-title="Choose method" complete>
+        Something before a div
         <calcite-notice active width="full">
           <div slot="notice-message">Step 1 Content Goes Here</div>
         </calcite-notice>
-       <div class="demo-test-style">Something after a div</div>
+        <div class="demo-test-style">Something after a div</div>
         <div>a non calcite element div</div>
         Something else
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-
-  <h4>No content</h4>
-  <calcite-stepper>
-    <calcite-stepper-item item-title="Choose method" complete>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Numbered</h4>
-  <calcite-stepper numbered>
-    <calcite-stepper-item item-title="Choose method" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Error</h4>
-  <calcite-stepper>
-    <calcite-stepper-item item-title="Choose method" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete error>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Icons</h4>
-  <calcite-stepper icon>
-    <calcite-stepper-item item-title="Choose method" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete error>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Icons and Numbered</h4>
-  <calcite-stepper icon numbered>
-    <calcite-stepper-item item-title="Choose method" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete error>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-
-  <h4>Disabled steps</h4>
-  Test programatically setting disabled to update navigable items (disabled steps should not be navigable)
-  <calcite-radio-group>
-    <calcite-radio-group-item value="Disabled" checked
-      onclick="document.querySelector('#demo-make-non-disabled').setAttribute('disabled', true)">Step 4 Disabled
-    </calcite-radio-group-item>
-    <calcite-radio-group-item value="Not Disabled"
-      onclick="document.querySelector('#demo-make-non-disabled').removeAttribute('disabled')">Step 4 Not Disabled
-    </calcite-radio-group-item>
-  </calcite-radio-group>
-  <br />
-  <br />
-  <calcite-stepper>
-    <calcite-stepper-item item-title="Choose method" complete disabled>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" error>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete" disabled>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 5 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Automatically set the first item as active if none are active</h4>
-  <calcite-stepper>
-    <calcite-stepper-item item-title="Choose method">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Scale Small</h4>
-
-  <calcite-stepper scale="s" numbered icon>
-    <calcite-stepper-item item-title="Choose method" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Scale Large</h4>
-
-  <calcite-stepper scale="l" numbered icon>
-    <calcite-stepper-item item-title="Choose method" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 1 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Compile member list" complete>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 2 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 3 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-    <calcite-stepper-item item-title="Confirm and complete">
-      <calcite-notice active width="full">
-        <div slot="notice-message">Step 4 Content Goes Here</div>
-      </calcite-notice>
-    </calcite-stepper-item>
-  </calcite-stepper>
-  <h4>Vertical</h4>
-  <div style=display:flex;width:100%>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Default</h5>
-      <calcite-stepper layout="vertical">
-        <calcite-stepper-item item-title="Choose method" complete>
-          asdfasdfs
-          <calcite-radio-group>
-            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-          </calcite-radio-group>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list">
-          <calcite-radio-group>
-            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-          </calcite-radio-group>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
-          <calcite-radio-group>
-            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-          </calcite-radio-group>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete">
-          <calcite-radio-group>
-            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
-            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
-            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
-            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
-          </calcite-radio-group>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Numbered</h5>
-      <calcite-stepper layout="vertical" numbered>
-        <calcite-stepper-item item-title="Choose method" complete>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Error</h5>
-      <calcite-stepper layout="vertical" numbered>
-        <calcite-stepper-item item-title="Choose method" complete>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-  </div>
-  <div style=display:flex;width:100%>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Icons</h5>
-      <calcite-stepper layout="vertical" icon>
-        <calcite-stepper-item item-title="Choose method" complete>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Icons and Numbered</h5>
-      <calcite-stepper layout="vertical" numbered icon>
-        <calcite-stepper-item item-title="Choose method" complete>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete">
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Disabled steps</h5>
-      <calcite-stepper layout="vertical">
-        <calcite-stepper-item item-title="Choose method" complete disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Another thing!" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 5 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>No Content</h5>
-      <calcite-stepper layout="vertical">
-        <calcite-stepper-item item-title="Choose method" complete>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Another thing!" disabled>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete" disabled>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-  </div>
-  <div style=display:flex;width:100%>
-
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Sale S</h5>
-      <calcite-stepper scale="s" layout="vertical" numbered icon>
-        <calcite-stepper-item item-title="Choose method" complete disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Another thing!" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 5 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Scale M (default)</h5>
-      <calcite-stepper layout="vertical" numbered icon>
-        <calcite-stepper-item item-title="Choose method" complete disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Another thing!" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 5 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-    <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
-      <h5>Scale L</h5>
-      <calcite-stepper scale="l" layout="vertical" numbered icon>
-        <calcite-stepper-item item-title="Choose method" complete disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 1 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Compile member list" error>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 2 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 3 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Another thing!" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 4 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-        <calcite-stepper-item item-title="Confirm and complete" disabled>
-          <calcite-notice active width="full">
-            <div slot="notice-message">Step 5 Content Goes Here</div>
-          </calcite-notice>
-        </calcite-stepper-item>
-      </calcite-stepper>
-    </div>
-  </div>
-  <div class="demo-background-dark">
-    <h4>Horizontal</h4>
-    <calcite-stepper theme="dark">
-      <calcite-stepper-item item-title="Choose method" complete>
-        <calcite-notice active width="full">
-          <div slot="notice-message">Step 1 Content Goes Here</div>
-        </calcite-notice>
       </calcite-stepper-item>
       <calcite-stepper-item item-title="Compile member list" complete>
         <calcite-notice active width="full">
@@ -614,18 +102,15 @@
     </calcite-stepper>
 
     <h4>No content</h4>
-    <calcite-stepper theme="dark">
-      <calcite-stepper-item item-title="Choose method" complete>
-      </calcite-stepper-item>
-      <calcite-stepper-item item-title="Compile member list" complete>
-      </calcite-stepper-item>
+    <calcite-stepper>
+      <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
+      <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
       <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Confirm and complete">
-      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
     </calcite-stepper>
     <h4>Numbered</h4>
-    <calcite-stepper theme="dark" numbered>
+    <calcite-stepper numbered>
       <calcite-stepper-item item-title="Choose method" complete>
         <calcite-notice active width="full">
           <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -648,7 +133,7 @@
       </calcite-stepper-item>
     </calcite-stepper>
     <h4>Error</h4>
-    <calcite-stepper theme="dark">
+    <calcite-stepper>
       <calcite-stepper-item item-title="Choose method" complete>
         <calcite-notice active width="full">
           <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -671,7 +156,7 @@
       </calcite-stepper-item>
     </calcite-stepper>
     <h4>Icons</h4>
-    <calcite-stepper theme="dark" icon>
+    <calcite-stepper icon>
       <calcite-stepper-item item-title="Choose method" complete>
         <calcite-notice active width="full">
           <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -694,7 +179,7 @@
       </calcite-stepper-item>
     </calcite-stepper>
     <h4>Icons and Numbered</h4>
-    <calcite-stepper theme="dark" icon numbered>
+    <calcite-stepper icon numbered>
       <calcite-stepper-item item-title="Choose method" complete>
         <calcite-notice active width="full">
           <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -716,8 +201,25 @@
         </calcite-notice>
       </calcite-stepper-item>
     </calcite-stepper>
+
     <h4>Disabled steps</h4>
-    <calcite-stepper theme="dark">
+    Test programatically setting disabled to update navigable items (disabled steps should not be navigable)
+    <calcite-radio-group>
+      <calcite-radio-group-item
+        value="Disabled"
+        checked
+        onclick="document.querySelector('#demo-make-non-disabled').setAttribute('disabled', true)"
+        >Step 4 Disabled
+      </calcite-radio-group-item>
+      <calcite-radio-group-item
+        value="Not Disabled"
+        onclick="document.querySelector('#demo-make-non-disabled').removeAttribute('disabled')"
+        >Step 4 Not Disabled
+      </calcite-radio-group-item>
+    </calcite-radio-group>
+    <br />
+    <br />
+    <calcite-stepper>
       <calcite-stepper-item item-title="Choose method" complete disabled>
         <calcite-notice active width="full">
           <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -733,7 +235,7 @@
           <div slot="notice-message">Step 3 Content Goes Here</div>
         </calcite-notice>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Another thing!" disabled>
+      <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
         <calcite-notice active width="full">
           <div slot="notice-message">Step 4 Content Goes Here</div>
         </calcite-notice>
@@ -744,36 +246,120 @@
         </calcite-notice>
       </calcite-stepper-item>
     </calcite-stepper>
+    <h4>Automatically set the first item as active if none are active</h4>
+    <calcite-stepper>
+      <calcite-stepper-item item-title="Choose method">
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 1 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Compile member list">
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 2 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 3 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Confirm and complete">
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 4 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+    </calcite-stepper>
+    <h4>Scale Small</h4>
+
+    <calcite-stepper scale="s" numbered icon>
+      <calcite-stepper-item item-title="Choose method" complete>
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 1 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Compile member list" complete>
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 2 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 3 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Confirm and complete">
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 4 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+    </calcite-stepper>
+    <h4>Scale Large</h4>
+
+    <calcite-stepper scale="l" numbered icon>
+      <calcite-stepper-item item-title="Choose method" complete>
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 1 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Compile member list" complete>
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 2 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 3 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item item-title="Confirm and complete">
+        <calcite-notice active width="full">
+          <div slot="notice-message">Step 4 Content Goes Here</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+    </calcite-stepper>
     <h4>Vertical</h4>
-    <div style=display:flex;width:100%>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+    <div style="display: flex; width: 100%">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>Default</h5>
-        <calcite-stepper layout="vertical" theme="dark">
+        <calcite-stepper layout="vertical">
           <calcite-stepper-item item-title="Choose method" complete>
-            <calcite-notice active width="full">
-              <div slot="notice-message">Step 1 Content Goes Here</div>
-            </calcite-notice>
+            asdfasdfs
+            <calcite-radio-group>
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
           </calcite-stepper-item>
           <calcite-stepper-item item-title="Compile member list">
-            <calcite-notice active width="full">
-              <div slot="notice-message">Step 2 Content Goes Here</div>
-            </calcite-notice>
+            <calcite-radio-group>
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
           </calcite-stepper-item>
           <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
-            <calcite-notice active width="full">
-              <div slot="notice-message">Step 3 Content Goes Here</div>
-            </calcite-notice>
+            <calcite-radio-group>
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
           </calcite-stepper-item>
           <calcite-stepper-item item-title="Confirm and complete">
-            <calcite-notice active width="full">
-              <div slot="notice-message">Step 4 Content Goes Here</div>
-            </calcite-notice>
+            <calcite-radio-group>
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
           </calcite-stepper-item>
         </calcite-stepper>
       </div>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>Numbered</h5>
-        <calcite-stepper layout="vertical" numbered theme="dark">
+        <calcite-stepper layout="vertical" numbered>
           <calcite-stepper-item item-title="Choose method" complete>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -796,9 +382,9 @@
           </calcite-stepper-item>
         </calcite-stepper>
       </div>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>Error</h5>
-        <calcite-stepper layout="vertical" numbered theme="dark">
+        <calcite-stepper layout="vertical" numbered>
           <calcite-stepper-item item-title="Choose method" complete>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -822,10 +408,10 @@
         </calcite-stepper>
       </div>
     </div>
-    <div style=display:flex;width:100%>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+    <div style="display: flex; width: 100%">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>Icons</h5>
-        <calcite-stepper layout="vertical" icon theme="dark">
+        <calcite-stepper layout="vertical" icon>
           <calcite-stepper-item item-title="Choose method" complete>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -848,20 +434,20 @@
           </calcite-stepper-item>
         </calcite-stepper>
       </div>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>Icons and Numbered</h5>
-        <calcite-stepper layout="vertical" numbered icon theme="dark">
+        <calcite-stepper layout="vertical" numbered icon>
           <calcite-stepper-item item-title="Choose method" complete>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 1 Content Goes Here</div>
             </calcite-notice>
           </calcite-stepper-item>
-          <calcite-stepper-item item-title="Compile member list" error complete>
+          <calcite-stepper-item item-title="Compile member list" error>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 2 Content Goes Here</div>
             </calcite-notice>
           </calcite-stepper-item>
-          <calcite-stepper-item item-title="Set member properties" active item-subtitle="Some subtext">
+          <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 3 Content Goes Here</div>
             </calcite-notice>
@@ -873,9 +459,9 @@
           </calcite-stepper-item>
         </calcite-stepper>
       </div>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>Disabled steps</h5>
-        <calcite-stepper theme="dark" layout="vertical">
+        <calcite-stepper layout="vertical">
           <calcite-stepper-item item-title="Choose method" complete disabled>
             <calcite-notice active width="full">
               <div slot="notice-message">Step 1 Content Goes Here</div>
@@ -901,26 +487,436 @@
               <div slot="notice-message">Step 5 Content Goes Here</div>
             </calcite-notice>
           </calcite-stepper-item>
+        </calcite-stepper>
       </div>
-      <div style="display:inline-flex;flex-direction:column;width:33%;padding:10px">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
         <h5>No Content</h5>
-        <calcite-stepper theme="dark" layout="vertical">
-          <calcite-stepper-item item-title="Choose method" complete>
-          </calcite-stepper-item>
-          <calcite-stepper-item item-title="Compile member list" error>
-          </calcite-stepper-item>
+        <calcite-stepper layout="vertical">
+          <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
+          <calcite-stepper-item item-title="Compile member list" error> </calcite-stepper-item>
           <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
           </calcite-stepper-item>
+          <calcite-stepper-item item-title="Another thing!" disabled> </calcite-stepper-item>
+          <calcite-stepper-item item-title="Confirm and complete" disabled> </calcite-stepper-item>
+        </calcite-stepper>
+      </div>
+    </div>
+    <div style="display: flex; width: 100%">
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+        <h5>Sale S</h5>
+        <calcite-stepper scale="s" layout="vertical" numbered icon>
+          <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 1 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 2 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 3 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
           <calcite-stepper-item item-title="Another thing!" disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 4 Content Goes Here</div>
+            </calcite-notice>
           </calcite-stepper-item>
           <calcite-stepper-item item-title="Confirm and complete" disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 5 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+        </calcite-stepper>
+      </div>
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+        <h5>Scale M (default)</h5>
+        <calcite-stepper layout="vertical" numbered icon>
+          <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 1 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 2 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 3 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Another thing!" disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 4 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Confirm and complete" disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 5 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+        </calcite-stepper>
+      </div>
+      <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+        <h5>Scale L</h5>
+        <calcite-stepper scale="l" layout="vertical" numbered icon>
+          <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 1 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 2 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 3 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Another thing!" disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 4 Content Goes Here</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="Confirm and complete" disabled>
+            <calcite-notice active width="full">
+              <div slot="notice-message">Step 5 Content Goes Here</div>
+            </calcite-notice>
           </calcite-stepper-item>
         </calcite-stepper>
       </div>
     </div>
-  </div>
-  </div>
-  </div>
-</body>
+    <div class="demo-background-dark">
+      <h4>Horizontal</h4>
+      <calcite-stepper class="calcite-theme-dark">
+        <calcite-stepper-item item-title="Choose method" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 1 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 2 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 3 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete">
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 4 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+      </calcite-stepper>
 
+      <h4>No content</h4>
+      <calcite-stepper class="calcite-theme-dark">
+        <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+      </calcite-stepper>
+      <h4>Numbered</h4>
+      <calcite-stepper class="calcite-theme-dark" numbered>
+        <calcite-stepper-item item-title="Choose method" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 1 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 2 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 3 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete">
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 4 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+      </calcite-stepper>
+      <h4>Error</h4>
+      <calcite-stepper class="calcite-theme-dark">
+        <calcite-stepper-item item-title="Choose method" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 1 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" complete error>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 2 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 3 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete">
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 4 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+      </calcite-stepper>
+      <h4>Icons</h4>
+      <calcite-stepper class="calcite-theme-dark" icon>
+        <calcite-stepper-item item-title="Choose method" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 1 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" complete error>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 2 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 3 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete">
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 4 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+      </calcite-stepper>
+      <h4>Icons and Numbered</h4>
+      <calcite-stepper class="calcite-theme-dark" icon numbered>
+        <calcite-stepper-item item-title="Choose method" complete>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 1 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" complete error>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 2 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 3 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete">
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 4 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+      </calcite-stepper>
+      <h4>Disabled steps</h4>
+      <calcite-stepper class="calcite-theme-dark">
+        <calcite-stepper-item item-title="Choose method" complete disabled>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 1 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Compile member list" error>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 2 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 3 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Another thing!" disabled>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 4 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Confirm and complete" disabled>
+          <calcite-notice active width="full">
+            <div slot="notice-message">Step 5 Content Goes Here</div>
+          </calcite-notice>
+        </calcite-stepper-item>
+      </calcite-stepper>
+      <h4>Vertical</h4>
+      <div style="display: flex; width: 100%">
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>Default</h5>
+          <calcite-stepper layout="vertical" class="calcite-theme-dark">
+            <calcite-stepper-item item-title="Choose method" complete>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 2 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 3 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>Numbered</h5>
+          <calcite-stepper layout="vertical" numbered class="calcite-theme-dark">
+            <calcite-stepper-item item-title="Choose method" complete>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list" active>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 2 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 3 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>Error</h5>
+          <calcite-stepper layout="vertical" numbered class="calcite-theme-dark">
+            <calcite-stepper-item item-title="Choose method" complete>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list" error>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 2 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 3 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+      </div>
+      <div style="display: flex; width: 100%">
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>Icons</h5>
+          <calcite-stepper layout="vertical" icon class="calcite-theme-dark">
+            <calcite-stepper-item item-title="Choose method" complete>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 2 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 3 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>Icons and Numbered</h5>
+          <calcite-stepper layout="vertical" numbered icon class="calcite-theme-dark">
+            <calcite-stepper-item item-title="Choose method" complete>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list" error complete>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 2 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" active item-subtitle="Some subtext">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 3 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete">
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>Disabled steps</h5>
+          <calcite-stepper class="calcite-theme-dark" layout="vertical">
+            <calcite-stepper-item item-title="Choose method" complete disabled>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 1 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list" error>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 2 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 3 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Another thing!" disabled>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete" disabled>
+              <calcite-notice active width="full">
+                <div slot="notice-message">Step 5 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+        <div style="display: inline-flex; flex-direction: column; width: 33%; padding: 10px">
+          <h5>No Content</h5>
+          <calcite-stepper class="calcite-theme-dark" layout="vertical">
+            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item item-title="Compile member list" error> </calcite-stepper-item>
+            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="Another thing!" disabled> </calcite-stepper-item>
+            <calcite-stepper-item item-title="Confirm and complete" disabled> </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-switch.html
+++ b/src/demos/calcite-switch.html
@@ -23,19 +23,19 @@
       Small
       <calcite-switch scale="s"></calcite-switch>
     </calcite-label>
-    <br>
+    <br />
 
     <calcite-label layout="inline">
       Medium
       <calcite-switch scale="m"></calcite-switch>
     </calcite-label>
-    <br>
+    <br />
 
     <calcite-label layout="inline">
       Large
       <calcite-switch scale="l"></calcite-switch>
     </calcite-label>
-    <br>
+    <br />
 
     <calcite-label layout="inline">
       <calcite-switch id="basicSwitch" switched></calcite-switch>
@@ -59,7 +59,7 @@
     <div class="demo-background-dark">
       <div>
         <calcite-label layout="inline">
-          <calcite-switch theme="dark" id="basicSwitch2" switched></calcite-switch>
+          <calcite-switch class="calcite-theme-dark" id="basicSwitch2" switched></calcite-switch>
           Listening for "calciteSwitchChange".
           <script>
             var basicSwitch = document.getElementById("basicSwitch2");
@@ -72,7 +72,7 @@
       </div>
       <br />
       <div>
-        <calcite-switch theme="dark"></calcite-switch>
+        <calcite-switch class="calcite-theme-dark"></calcite-switch>
         Switch with no wrapping <code>label</code>.
       </div>
     </div>
@@ -101,13 +101,13 @@
       <div class="demo-background-dark">
         <div>
           <calcite-label layout="inline">
-            <calcite-switch theme="dark" switched> </calcite-switch>
+            <calcite-switch class="calcite-theme-dark" switched> </calcite-switch>
             inline switch
           </calcite-label>
         </div>
         <br />
         <div>
-          <calcite-switch theme="dark"></calcite-switch>
+          <calcite-switch class="calcite-theme-dark"></calcite-switch>
           Switch with no wrapping <code>label</code>.
         </div>
       </div>

--- a/src/demos/calcite-tabs.html
+++ b/src/demos/calcite-tabs.html
@@ -1,183 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Tabs</title>
+    <style>
+      .demo-background-dark {
+        background: #202020;
+        color: white;
+        padding: 1rem;
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Tabs</title>
-  <style>
-    .demo-background-dark {
-      background: #202020;
-      color: white;
-      padding: 1rem;
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-</head>
+  <body>
+    <calcite-button href="/">Home</calcite-button>
+    <h1>Calcite Tabs</h1>
+    <h1 class="leader-1">Light Theme Tabs</h1>
 
-<body>
-  <calcite-button href="/">Home</calcite-button>
-  <h1>Calcite Tabs</h1>
-  <h1 class="leader-1">Light Theme Tabs</h1>
-
-  <calcite-tabs active>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 7 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 8 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 9 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 10 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 11 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 12 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-  <h3>Content position: above (default)</h3>
-
-  <calcite-tabs active position="above">
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 7 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 8 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 9 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 10 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 11 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 12 Title</calcite-tab-title>
-    </calcite-tab-nav>
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h3>Content position: below</h3>
-  <calcite-tabs active position="below">
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 7 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 8 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 9 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 10 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 11 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 12 Title</calcite-tab-title>
-    </calcite-tab-nav>
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-  <h2>
-    Icons
-  </h2>
-  <h3>Icon start</h3>
-  <calcite-tabs active>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active icon-start="layer">Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="layer">Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="layer">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="layer">Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-  <h3>Icon end</h3>
-  <calcite-tabs active>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active icon-end="layer">Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title icon-end="layer">Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title icon-end="layer">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title icon-end="layer">Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h3>Icon start and end</h3>
-  <calcite-tabs active>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active icon-start="layer" icon-end="layer">Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="layer" icon-end="layer">Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="layer" icon-end="layer">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="layer" icon-end="layer">Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-  <h3>Icon no text</h3>
-  <calcite-tabs active>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active icon-start="layer"></calcite-tab-title>
-      <calcite-tab-title icon-start="layer"></calcite-tab-title>
-      <calcite-tab-title icon-start="layer"></calcite-tab-title>
-      <calcite-tab-title icon-start="layer"></calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h2>Just tab-nav</h2>
-  <calcite-tab-nav>
-    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 5 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 6 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 7 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 8 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 9 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 10 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 11 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 12 Title</calcite-tab-title>
-  </calcite-tab-nav>
-<br/>
-  <calcite-tab-nav position="below">
-    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-  </calcite-tab-nav>
-  <h1 class="leader-1">Dark Theme Tabs</h1>
-
-  <div class="demo-background-dark">
-    <calcite-tabs theme="dark">
+    <calcite-tabs active>
       <calcite-tab-nav slot="tab-nav">
         <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
         <calcite-tab-title>Tab 2 Title</calcite-tab-title>
         <calcite-tab-title>Tab 3 Title</calcite-tab-title>
         <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 12 Title</calcite-tab-title>
       </calcite-tab-nav>
 
       <calcite-tab active>Tab 1 Content</calcite-tab>
@@ -185,7 +41,82 @@
       <calcite-tab>Tab 3 Content</calcite-tab>
       <calcite-tab>Tab 4 Content</calcite-tab>
     </calcite-tabs>
-    <calcite-tabs active theme="dark">
+    <h3>Content position: above (default)</h3>
+
+    <calcite-tabs active position="above">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 12 Title</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h3>Content position: below</h3>
+    <calcite-tabs active position="below">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 12 Title</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+    <h2>Icons</h2>
+    <h3>Icon start</h3>
+    <calcite-tabs active>
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active icon-start="layer">Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="layer">Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="layer">Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="layer">Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+    <h3>Icon end</h3>
+    <calcite-tabs active>
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active icon-end="layer">Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title icon-end="layer">Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title icon-end="layer">Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title icon-end="layer">Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h3>Icon start and end</h3>
+    <calcite-tabs active>
       <calcite-tab-nav slot="tab-nav">
         <calcite-tab-title active icon-start="layer" icon-end="layer">Tab 1 Title</calcite-tab-title>
         <calcite-tab-title icon-start="layer" icon-end="layer">Tab 2 Title</calcite-tab-title>
@@ -198,281 +129,332 @@
       <calcite-tab>Tab 3 Content</calcite-tab>
       <calcite-tab>Tab 4 Content</calcite-tab>
     </calcite-tabs>
-  </div>
+    <h3>Icon no text</h3>
+    <calcite-tabs active>
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active icon-start="layer"></calcite-tab-title>
+        <calcite-tab-title icon-start="layer"></calcite-tab-title>
+        <calcite-tab-title icon-start="layer"></calcite-tab-title>
+        <calcite-tab-title icon-start="layer"></calcite-tab-title>
+      </calcite-tab-nav>
 
-  <h1 class="leader-1">Select First Tab By Default</h1>
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
 
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Disabled Tab</h1>
-
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title disabled>Tab 3 Title (disabled)</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Inaccessible Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Named Tabs</h1>
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab2" active>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab4">Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
-    <calcite-tab tab="tab2" active>Tab 2 Content</calcite-tab>
-    <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
-    <calcite-tab tab="tab4">Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Save Active Tab To Cookie</h1>
-
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav" storage-id="calcite-tabs-cookie-demo">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Named Tabs w/ Cookie</h1>
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav" storage-id="calcite-tabs-named-cookie-demo">
-      <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab2" active>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab4">Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
-    <calcite-tab tab="tab2" active>Tab 2 Content</calcite-tab>
-    <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
-    <calcite-tab tab="tab4">Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Tab Sync Demo</h1>
-
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav" sync-id="sync-demo">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav" sync-id="sync-demo">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Tab Sync + Cookie Demo</h1>
-
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav" sync-id="sync-cookie-demo" storage-id="sync-cookie-demo">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <calcite-tabs>
-    <calcite-tab-nav slot="tab-nav" sync-id="sync-cookie-demo" storage-id="sync-cookie-demo">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Centered Tabs</h1>
-
-  <calcite-tabs layout="center">
-    <calcite-tab-nav slot="tab-nav">
+    <h2>Just tab-nav</h2>
+    <calcite-tab-nav>
       <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
       <calcite-tab-title>Tab 5 Title</calcite-tab-title>
       <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 12 Title</calcite-tab-title>
     </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-    <calcite-tab>Tab 5 Content</calcite-tab>
-    <calcite-tab>Tab 6 Content</calcite-tab>
-  </calcite-tabs>
-
-  <calcite-tabs layout="center">
-    <calcite-tab-nav slot="tab-nav">
+    <br />
+    <calcite-tab-nav position="below">
       <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="plus">Tab 4 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="plus"></calcite-tab-title>
-      <calcite-tab-title icon-end="plus">Tab 6 Title</calcite-tab-title>
-    </calcite-tab-nav>
-
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-    <calcite-tab>Tab 5 Content</calcite-tab>
-    <calcite-tab>Tab 6 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">RTL Tabs</h1>
-
-  <calcite-tabs dir="rtl">
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
+    <h1 class="leader-1">Dark Theme Tabs</h1>
 
-    <calcite-tab>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
-
-  <h1 class="leader-1">Scrollable RTL Tabs in Container</h1>
-  <div dir="rtl" style="width: 100%">
-    <div style="width: 500px">
-      <calcite-tabs >
+    <div class="demo-background-dark">
+      <calcite-tabs class="calcite-theme-dark">
         <calcite-tab-nav slot="tab-nav">
           <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-          <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 2 Title</calcite-tab-title>
-          <calcite-tab-title icon-start="plus" icon-end='plus'>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 3 Title</calcite-tab-title>
           <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 5 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 6 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 7 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 8 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 9 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 10 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 11 Title</calcite-tab-title>
-          <calcite-tab-title>Tab 12 Title</calcite-tab-title>
         </calcite-tab-nav>
 
-        <calcite-tab>Tab 1 Content</calcite-tab>
+        <calcite-tab active>Tab 1 Content</calcite-tab>
         <calcite-tab>Tab 2 Content</calcite-tab>
         <calcite-tab>Tab 3 Content</calcite-tab>
         <calcite-tab>Tab 4 Content</calcite-tab>
-        <calcite-tab>Tab 5 Content</calcite-tab>
-        <calcite-tab>Tab 6 Content</calcite-tab>
-        <calcite-tab>Tab 7 Content</calcite-tab>
-        <calcite-tab>Tab 8 Content</calcite-tab>
-        <calcite-tab>Tab 9 Content</calcite-tab>
-        <calcite-tab>Tab 10 Content</calcite-tab>
-        <calcite-tab>Tab 11 Content</calcite-tab>
-        <calcite-tab>Tab 12 Content</calcite-tab>
+      </calcite-tabs>
+      <calcite-tabs active class="calcite-theme-dark">
+        <calcite-tab-nav slot="tab-nav">
+          <calcite-tab-title active icon-start="layer" icon-end="layer">Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title icon-start="layer" icon-end="layer">Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title icon-start="layer" icon-end="layer">Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title icon-start="layer" icon-end="layer">Tab 4 Title</calcite-tab-title>
+        </calcite-tab-nav>
+
+        <calcite-tab active>Tab 1 Content</calcite-tab>
+        <calcite-tab>Tab 2 Content</calcite-tab>
+        <calcite-tab>Tab 3 Content</calcite-tab>
+        <calcite-tab>Tab 4 Content</calcite-tab>
       </calcite-tabs>
     </div>
-  </div>
-  <h1 class="leader-1">Centered RTL</h1>
 
-  <calcite-tabs layout="center" dir="rtl">
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 5 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 6 Title</calcite-tab-title>
-    </calcite-tab-nav>
+    <h1 class="leader-1">Select First Tab By Default</h1>
 
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-    <calcite-tab>Tab 5 Content</calcite-tab>
-    <calcite-tab>Tab 6 Content</calcite-tab>
-  </calcite-tabs>
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
 
-  <h1 class="leader-1">Custom Colors</h1>
+      <calcite-tab>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
 
-  <style>
-    calcite-tabs.green {
-      --calcite-ui-brand: #338033;
-    }
+    <h1 class="leader-1">Disabled Tab</h1>
 
-    calcite-tabs[theme="dark"].green {
-      --calcite-ui-brand: #5a9359;
-    }
-  </style>
-  <calcite-tabs class="green">
-    <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-    </calcite-tab-nav>
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title disabled>Tab 3 Title (disabled)</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
 
-    <calcite-tab active>Tab 1 Content</calcite-tab>
-    <calcite-tab>Tab 2 Content</calcite-tab>
-    <calcite-tab>Tab 3 Content</calcite-tab>
-    <calcite-tab>Tab 4 Content</calcite-tab>
-  </calcite-tabs>
+      <calcite-tab>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Inaccessible Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
 
-  <div class="demo-background-dark">
-    <calcite-tabs class="green" theme="dark">
+    <h1 class="leader-1">Named Tabs</h1>
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title tab="tab2" active>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title tab="tab4">Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
+      <calcite-tab tab="tab2" active>Tab 2 Content</calcite-tab>
+      <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
+      <calcite-tab tab="tab4">Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Save Active Tab To Cookie</h1>
+
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav" storage-id="calcite-tabs-cookie-demo">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Named Tabs w/ Cookie</h1>
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav" storage-id="calcite-tabs-named-cookie-demo">
+        <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title tab="tab2" active>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title tab="tab4">Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
+      <calcite-tab tab="tab2" active>Tab 2 Content</calcite-tab>
+      <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
+      <calcite-tab tab="tab4">Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Tab Sync Demo</h1>
+
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav" sync-id="sync-demo">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav" sync-id="sync-demo">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Tab Sync + Cookie Demo</h1>
+
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav" sync-id="sync-cookie-demo" storage-id="sync-cookie-demo">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <calcite-tabs>
+      <calcite-tab-nav slot="tab-nav" sync-id="sync-cookie-demo" storage-id="sync-cookie-demo">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Centered Tabs</h1>
+
+    <calcite-tabs layout="center">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+      <calcite-tab>Tab 5 Content</calcite-tab>
+      <calcite-tab>Tab 6 Content</calcite-tab>
+    </calcite-tabs>
+
+    <calcite-tabs layout="center">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="plus">Tab 4 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="plus"></calcite-tab-title>
+        <calcite-tab-title icon-end="plus">Tab 6 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+      <calcite-tab>Tab 5 Content</calcite-tab>
+      <calcite-tab>Tab 6 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">RTL Tabs</h1>
+
+    <calcite-tabs dir="rtl">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="plus" icon-end="plus">Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title icon-start="plus" icon-end="plus">Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Scrollable RTL Tabs in Container</h1>
+    <div dir="rtl" style="width: 100%">
+      <div style="width: 500px">
+        <calcite-tabs>
+          <calcite-tab-nav slot="tab-nav">
+            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title icon-start="plus" icon-end="plus">Tab 2 Title</calcite-tab-title>
+            <calcite-tab-title icon-start="plus" icon-end="plus">Tab 3 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 7 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 8 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 9 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 10 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 11 Title</calcite-tab-title>
+            <calcite-tab-title>Tab 12 Title</calcite-tab-title>
+          </calcite-tab-nav>
+
+          <calcite-tab>Tab 1 Content</calcite-tab>
+          <calcite-tab>Tab 2 Content</calcite-tab>
+          <calcite-tab>Tab 3 Content</calcite-tab>
+          <calcite-tab>Tab 4 Content</calcite-tab>
+          <calcite-tab>Tab 5 Content</calcite-tab>
+          <calcite-tab>Tab 6 Content</calcite-tab>
+          <calcite-tab>Tab 7 Content</calcite-tab>
+          <calcite-tab>Tab 8 Content</calcite-tab>
+          <calcite-tab>Tab 9 Content</calcite-tab>
+          <calcite-tab>Tab 10 Content</calcite-tab>
+          <calcite-tab>Tab 11 Content</calcite-tab>
+          <calcite-tab>Tab 12 Content</calcite-tab>
+        </calcite-tabs>
+      </div>
+    </div>
+    <h1 class="leader-1">Centered RTL</h1>
+
+    <calcite-tabs layout="center" dir="rtl">
+      <calcite-tab-nav slot="tab-nav">
+        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 5 Title</calcite-tab-title>
+        <calcite-tab-title>Tab 6 Title</calcite-tab-title>
+      </calcite-tab-nav>
+
+      <calcite-tab active>Tab 1 Content</calcite-tab>
+      <calcite-tab>Tab 2 Content</calcite-tab>
+      <calcite-tab>Tab 3 Content</calcite-tab>
+      <calcite-tab>Tab 4 Content</calcite-tab>
+      <calcite-tab>Tab 5 Content</calcite-tab>
+      <calcite-tab>Tab 6 Content</calcite-tab>
+    </calcite-tabs>
+
+    <h1 class="leader-1">Custom Colors</h1>
+
+    <style>
+      calcite-tabs.green {
+        --calcite-ui-brand: #338033;
+      }
+
+      calcite-tabs.calcite-theme-dark.green {
+        --calcite-ui-brand: #5a9359;
+      }
+    </style>
+    <calcite-tabs class="green">
       <calcite-tab-nav slot="tab-nav">
         <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
         <calcite-tab-title>Tab 2 Title</calcite-tab-title>
@@ -485,7 +467,21 @@
       <calcite-tab>Tab 3 Content</calcite-tab>
       <calcite-tab>Tab 4 Content</calcite-tab>
     </calcite-tabs>
-  </div>
-</body>
 
+    <div class="demo-background-dark">
+      <calcite-tabs class="green calcite-theme-dark">
+        <calcite-tab-nav slot="tab-nav">
+          <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        </calcite-tab-nav>
+
+        <calcite-tab active>Tab 1 Content</calcite-tab>
+        <calcite-tab>Tab 2 Content</calcite-tab>
+        <calcite-tab>Tab 3 Content</calcite-tab>
+        <calcite-tab>Tab 4 Content</calcite-tab>
+      </calcite-tabs>
+    </div>
+  </body>
 </html>

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -1,1346 +1,2816 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Tile Select</title>
+    <style>
+      .demo-body {
+        margin: 0 2rem;
+      }
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        color: var(--calcite-ui-text-1);
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Tile Select</title>
-  <style>
-    .demo-body {
-      margin: 0 2rem;
-    }
-    h1,
-    h2,
-    h3 {
-      margin: 0;
-      color: var(--calcite-ui-text-1);
-    }
-  </style>
- <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-form.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
+  <body class="demo-body">
+    <demo-spacer>
+      <calcite-button href="/"> < Home</calcite-button>
+      <h1>Calcite Tile Select</h1>
+      <demo-form>
+        <form name="calcite-tile-select-demo-form">
+          <demo-spacer>
+            <calcite-button form="calcite-tile-select-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-tile-select-demo-form" type="reset">Reset</calcite-button>
+            <div>
+              <demo-spacer gap="25px">
+                <section>
+                  <h3>Input-enabled Start Radio: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      disabled
+                      icon="layers"
+                      name="start-radio"
+                      value="four"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      disabled
+                      icon="layers"
+                      name="start-radio"
+                      value="seven"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled Start Radio: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      disabled
+                      icon="layers"
+                      name="start-radio"
+                      value="four"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      disabled
+                      icon="layers"
+                      name="start-radio"
+                      value="seven"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-</head>
+                <section>
+                  <h3>Input-enabled Start Radio Large Visual: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled Start Radio Large Visual: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-radio-large-visual"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-<body class="demo-body">
-  <demo-spacer>
-    <calcite-button href="/">
-      < Home</calcite-button>
-        <h1>Calcite Tile Select</h1>
-        <demo-form>
-          <form name="calcite-tile-select-demo-form">
-            <demo-spacer>
-              <calcite-button form="calcite-tile-select-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-tile-select-demo-form" type="reset">Reset</calcite-button>
-              <div>
-                <demo-spacer gap="25px">
+                <section>
+                  <h3>Input-enabled Start Radio Heading Only: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-radio-heading-only"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-radio-heading-only"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled Start Radio Heading Only: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-radio-heading-only"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-radio-heading-only"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-radio-heading-only"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled Start Radio: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-radio" value="one"
-                        heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-radio" value="two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled disabled icon="layers" name="start-radio" value="four" heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="five" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="six" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled disabled icon="layers" name="start-radio" value="seven"
-                        heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled Start Radio: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-radio" value="one"
-                        heading="Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-radio" value="two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall. Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled disabled icon="layers" name="start-radio" value="four" heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="five" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="six" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled disabled icon="layers" name="start-radio" value="seven"
-                        heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio" value="eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled end Radio: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled end Radio: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio"
+                      input-enabled
+                      input-alignment="end"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled Start Radio Large Visual: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-radio-large-visual" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-radio-large-visual" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled Start Radio Large Visual: RTL</h3>
-                      <calcite-tile-select-group>
-                        <calcite-tile-select input-enabled checked icon="layers" name="start-radio-large-visual" value="one"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled checked icon="layers" name="start-radio-large-visual" value="two"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="three"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="four"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="five"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="six"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="seven"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                        <calcite-tile-select input-enabled icon="layers" name="start-radio-large-visual" value="eight"
-                          heading="Tile title lorem ipsum">
-                        </calcite-tile-select>
-                      </calcite-tile-select-group>
-                    </section>
+                <section>
+                  <h3>Input-enabled end Radio Large Visual: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled end Radio Large Visual: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="end-radio-large-visual"
+                      input-enabled
+                      input-alignment="end"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled Start Radio Heading Only: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked name="start-radio-heading-only" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-radio-heading-only" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="four" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="five" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="six" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled Start Radio Heading Only: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked name="start-radio-heading-only" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-radio-heading-only" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="four" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="five" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="six" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-radio-heading-only" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled end Radio Heading Only: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      checked
+                      name="end-radio-heading-only"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      checked
+                      name="end-radio-heading-only"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled end Radio Heading Only: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      checked
+                      name="end-radio-heading-only"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      checked
+                      name="end-radio-heading-only"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-radio-heading-only"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled end Radio: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="end-radio" input-enabled input-alignment="end" value="one"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="end-radio" input-enabled input-alignment="end" value="two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="four"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="five"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="six"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="seven"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled end Radio: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="end-radio" input-enabled input-alignment="end" value="one"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="end-radio" input-enabled input-alignment="end" value="two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="four"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="five"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="six"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="seven"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio" input-enabled input-alignment="end" value="eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Vertical Layout, Full, No Icon, Input Enabled, Start: LTR</h3>
+                  <calcite-tile-select-group layout="vertical">
+                    <calcite-tile-select
+                      checked
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Vertical Layout, Full, No Icon, Input Enabled, Start: LTR</h3>
+                  <calcite-tile-select-group layout="vertical">
+                    <calcite-tile-select
+                      checked
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      input-enabled
+                      input-alignment="start"
+                      name="start-radio-vertical-dark"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                      description="test small description"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled end Radio Large Visual: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end"
-                        value="three" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end"
-                        value="seven" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end"
-                        value="eight" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled end Radio Large Visual: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end"
-                        value="three" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end"
-                        value="seven" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="end-radio-large-visual" input-enabled input-alignment="end"
-                        value="eight" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Basic Radio: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="basic-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      disabled
+                      icon="layers"
+                      name="basic-radio"
+                      value="four"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="basic-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      disabled
+                      icon="layers"
+                      name="basic-radio"
+                      value="six"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Basic Radio: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="basic-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      disabled
+                      icon="layers"
+                      name="basic-radio"
+                      value="four"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="basic-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      disabled
+                      icon="layers"
+                      name="basic-radio"
+                      value="six"
+                      heading="Disabled - Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="basic-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled end Radio Heading Only: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" checked name="end-radio-heading-only" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" checked name="end-radio-heading-only" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled end Radio Heading Only: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" checked name="end-radio-heading-only" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" checked name="end-radio-heading-only" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-radio-heading-only" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Basic Large Visual Radio: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Basic Large Visual Radio: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      icon="layers"
+                      name="large-visual-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Vertical Layout, Full, No Icon, Input Enabled, Start: LTR</h3>
-                    <calcite-tile-select-group layout="vertical">
-                      <calcite-tile-select checked
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="one"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                      <calcite-tile-select
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="two"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                      <calcite-tile-select
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="three"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                      <calcite-tile-select
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="four"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Vertical Layout, Full, No Icon, Input Enabled, Start: LTR</h3>
-                    <calcite-tile-select-group layout="vertical">
-                      <calcite-tile-select checked
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="one"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                      <calcite-tile-select
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="two"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                      <calcite-tile-select
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="three"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                      <calcite-tile-select
-                        width="full"
-                        input-enabled
-                        input-alignment="start"
-                        name="start-radio-vertical-dark"
-                        value="four"
-                        heading="Tile title lorem ipsum"
-                        description="test small description"
-                      >
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Basic Heading Only Radio: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      name="basic-heading-only-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="two" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="three" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="four" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      name="basic-heading-only-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="six" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="seven" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="eight" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Basic Heading Only Radio: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      name="basic-heading-only-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="two" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="three" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="four" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      name="basic-heading-only-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="six" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="seven" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                    <calcite-tile-select name="basic-heading-only-radio" value="eight" heading="Tile title lorem ipsum">
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Basic Radio: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="basic-radio" value="one"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select disabled icon="layers" name="basic-radio" value="four"
-                        heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="basic-radio" value="five"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select disabled icon="layers" name="basic-radio" value="six"
-                        heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="seven"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Basic Radio: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="basic-radio" value="one"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select disabled icon="layers" name="basic-radio" value="four"
-                        heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="basic-radio" value="five"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select disabled icon="layers" name="basic-radio" value="six"
-                        heading="Disabled - Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="seven"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="basic-radio" value="eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Full Width: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Full Width: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      width="full"
+                      name="basic-heading-only-full-width-radio"
+                      value="eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Basic Large Visual Radio: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="large-visual-radio" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="large-visual-radio" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Basic Large Visual Radio: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked icon="layers" name="large-visual-radio" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked icon="layers" name="large-visual-radio" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select icon="layers" name="large-visual-radio" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled Start Checkbox: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled Start Checkbox: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Basic Heading Only Radio: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked name="basic-heading-only-radio" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked name="basic-heading-only-radio" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Basic Heading Only Radio: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked name="basic-heading-only-radio" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked name="basic-heading-only-radio" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select name="basic-heading-only-radio" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled Start Checkbox Large Visual: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled Start Checkbox Large Visual: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      icon="layers"
+                      name="start-checkbox-large-visual-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      icon="layers"
+                      name="start-checkbox-large-visual-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Full Width: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked width="full" name="basic-heading-only-full-width-radio" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked width="full" name="basic-heading-only-full-width-radio" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Full Width: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked width="full" name="basic-heading-only-full-width-radio" value="one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked width="full" name="basic-heading-only-full-width-radio" value="five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select width="full" name="basic-heading-only-full-width-radio" value="eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled Start Checkbox Heading Only: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled Start Checkbox Heading Only: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      checked
+                      name="start-checkbox-heading-only-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      name="start-checkbox-heading-only-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled Start Checkbox: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-one" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-two" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-three" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-four" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-five" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-six" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-seven" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-eight" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled Start Checkbox: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-one" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-two" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-three" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-four" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-five" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-six" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-seven" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-eight" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled end Checkbox: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled end Checkbox: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled Start Checkbox Large Visual: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-one" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-two" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-three" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-four" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-five" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-six" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-seven" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-eight" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled Start Checkbox Large Visual: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-one" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-two" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-three" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-four" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-five" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked icon="layers" name="start-checkbox-large-visual-six" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-seven" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled icon="layers" name="start-checkbox-large-visual-eight" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled end Checkbox Large Visual: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled end Checkbox Large Visual: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      icon="layers"
+                      name="end-checkbox-large-visual-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled Start Checkbox Heading Only: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-one" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-two" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-three" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-four" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-five" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-six" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-seven" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-eight" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled Start Checkbox Heading Only: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-one" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-two" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-three" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-four" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-five" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled checked name="start-checkbox-heading-only-six" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-seven" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled name="start-checkbox-heading-only-eight" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Input-enabled end Checkbox Heading Only: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Input-enabled end Checkbox Heading Only: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-one"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-two"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-three"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-four"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-five"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-six"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-seven"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      checked
+                      input-enabled
+                      input-alignment="end"
+                      name="end-checkbox-heading-only-eight"
+                      type="checkbox"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled end Checkbox: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-one" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-two" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-three"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-four"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-five" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-six" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-seven"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-eight"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled end Checkbox: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-one" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-two" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-three"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-four"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-five" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-six" type="checkbox"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-seven"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers" name="end-checkbox-eight"
-                        type="checkbox" heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Basic Checkbox: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-one"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-four"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-six"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-seven"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Basic Checkbox: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-one"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-two"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-three"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-four"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-five"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-six"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-seven"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="basic-checkbox-eight"
+                      heading="Tile title lorem ipsum"
+                      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled end Checkbox Large Visual: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-one"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-two"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-three" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-four" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-five"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-six"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-seven" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-eight" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled end Checkbox Large Visual: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-one"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-two"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-three" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-four" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-five"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" icon="layers" name="end-checkbox-large-visual-six"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-seven" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" icon="layers"
-                        name="end-checkbox-large-visual-eight" type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
+                <section>
+                  <h3>Basic Large Visual Checkbox: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Basic Large Visual Checkbox: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      icon="layers"
+                      name="large-visual-checkbox-eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
 
-                  <section>
-                    <h3>Input-enabled end Checkbox Heading Only: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-one" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-two" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-three"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-four"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-five" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-six" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-seven"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-eight"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Input-enabled end Checkbox Heading Only: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-one" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-two" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-three"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-four"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-five" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select input-enabled input-alignment="end" name="end-checkbox-heading-only-six" type="checkbox"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-seven"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select checked input-enabled input-alignment="end" name="end-checkbox-heading-only-eight"
-                        type="checkbox" heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-
-                  <section>
-                    <h3>Basic Checkbox: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked type="checkbox" icon="layers" name="basic-checkbox-one"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-four"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-five"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-six"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-seven"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Basic Checkbox: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked type="checkbox" icon="layers" name="basic-checkbox-one"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-two"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-three"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-four"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-five"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-six"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-seven"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="basic-checkbox-eight"
-                        heading="Tile title lorem ipsum"
-                        description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-
-                  <section>
-                    <h3>Basic Large Visual Checkbox: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked type="checkbox" icon="layers" name="large-visual-checkbox-one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Basic Large Visual Checkbox: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked type="checkbox" icon="layers" name="large-visual-checkbox-one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" icon="layers" name="large-visual-checkbox-eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-
-                  <section>
-                    <h3>Basic Heading Only Checkbox: LTR</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked type="checkbox" name="basic-heading-only-checkbox-one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-                  <section dir="rtl">
-                    <h3>Basic Heading Only Checkbox: RTL</h3>
-                    <calcite-tile-select-group>
-                      <calcite-tile-select checked type="checkbox" name="basic-heading-only-checkbox-one"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-two"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-three"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-four"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-five"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-six"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-seven"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                      <calcite-tile-select type="checkbox" name="basic-heading-only-checkbox-eight"
-                        heading="Tile title lorem ipsum">
-                      </calcite-tile-select>
-                    </calcite-tile-select-group>
-                  </section>
-
-                </demo-spacer>
-              </div>
-              <calcite-button form="calcite-tile-select-demo-form" type="submit">Submit</calcite-button>
-              <calcite-button form="calcite-tile-select-demo-form" type="reset">Reset</calcite-button>
-              <button type="submit" style="display: none">Submit</button>
-            </demo-spacer>
-          </form>
-        </demo-form>
-  </demo-spacer>
-</body>
-
+                <section>
+                  <h3>Basic Heading Only Checkbox: LTR</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+                <section dir="rtl">
+                  <h3>Basic Heading Only Checkbox: RTL</h3>
+                  <calcite-tile-select-group>
+                    <calcite-tile-select
+                      checked
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-one"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-two"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-three"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-four"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-five"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-six"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-seven"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                    <calcite-tile-select
+                      type="checkbox"
+                      name="basic-heading-only-checkbox-eight"
+                      heading="Tile title lorem ipsum"
+                    >
+                    </calcite-tile-select>
+                  </calcite-tile-select-group>
+                </section>
+              </demo-spacer>
+            </div>
+            <calcite-button form="calcite-tile-select-demo-form" type="submit">Submit</calcite-button>
+            <calcite-button form="calcite-tile-select-demo-form" type="reset">Reset</calcite-button>
+            <button type="submit" style="display: none">Submit</button>
+          </demo-spacer>
+        </form>
+      </demo-form>
+    </demo-spacer>
+  </body>
 </html>

--- a/src/demos/calcite-tile.html
+++ b/src/demos/calcite-tile.html
@@ -1,98 +1,108 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Calcite Tile</title>
+    <style>
+      .demo-body {
+        width: 50vw;
+        align-content: center;
+        margin: 0 auto;
+      }
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        color: var(--calcite-ui-text-1);
+      }
+    </style>
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Calcite Tile</title>
-  <style>
-    .demo-body {
-      width: 50vw;
-      align-content: center;
-      margin: 0 auto;
-    }
-    h1,
-    h2,
-    h3 {
-      margin: 0;
-      color: var(--calcite-ui-text-1);
-    }
-  </style>
-  <script src="./_assets/head.js"></script>
-  <script type="module" src="./_assets/demo-spacer.js"></script>
-</head>
+  <body class="demo-body">
+    <demo-spacer>
+      <calcite-button href="/">< Home</calcite-button>
+      <h1>Calcite Tile</h1>
+      <demo-spacer gap="25px">
+        <section>
+          <h3>Basic: LTR</h3>
+          <calcite-tile
+            icon="layers"
+            heading="Tile title lorem ipsum"
+            description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          >
+          </calcite-tile>
+        </section>
+        <section dir="rtl">
+          <h3>Basic: RTL</h3>
+          <calcite-tile
+            icon="layers"
+            heading="Tile title lorem ipsum"
+            description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          >
+          </calcite-tile>
+        </section>
 
-<body class="demo-body">
-  <demo-spacer>
-    <calcite-button href="/">< Home</calcite-button>
-    <h1>Calcite Tile</h1>
-    <demo-spacer gap="25px">
+        <section>
+          <h3>Link: LTR</h3>
+          <calcite-tile
+            href="/"
+            icon="layers"
+            heading="Tile title lorem ipsum"
+            description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          >
+          </calcite-tile>
+        </section>
+        <section dir="rtl">
+          <h3>Link: RTL</h3>
+          <calcite-tile
+            href="/"
+            icon="layers"
+            heading="Tile title lorem ipsum"
+            description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          >
+          </calcite-tile>
+        </section>
 
-      <section>
-        <h3>Basic: LTR</h3>
-        <calcite-tile icon="layers" heading="Tile title lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-        </calcite-tile>
-      </section>
-      <section dir="rtl">
-        <h3>Basic: RTL</h3>
-        <calcite-tile icon="layers" heading="Tile title lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-        </calcite-tile>
-      </section>
+        <section>
+          <h3>Heading Only: LTR</h3>
+          <calcite-tile heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
+        <section dir="rtl">
+          <h3>Heading Only: RTL</h3>
+          <calcite-tile heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
 
-      <section>
-        <h3>Link: LTR</h3>
-        <calcite-tile href="/" icon="layers" heading="Tile title lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-        </calcite-tile>
-      </section>
-      <section dir="rtl">
-        <h3>Link: RTL</h3>
-        <calcite-tile href="/" icon="layers" heading="Tile title lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall.">
-        </calcite-tile>
-      </section>
+        <section>
+          <h3>Heading Only Link: LTR</h3>
+          <calcite-tile href="/" heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
+        <section dir="rtl">
+          <h3>Heading Only Link: RTL</h3>
+          <calcite-tile href="/" heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
 
-      <section>
-        <h3>Heading Only: LTR</h3>
-        <calcite-tile heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-      <section dir="rtl">
-        <h3>Heading Only: RTL</h3>
-        <calcite-tile heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
+        <section>
+          <h3>Large Visual: LTR</h3>
+          <calcite-tile icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
+        <section dir="rtl">
+          <h3>Large Visual: RTL</h3>
+          <calcite-tile icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
 
-      <section>
-        <h3>Heading Only Link: LTR</h3>
-        <calcite-tile href="/" heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-      <section dir="rtl">
-        <h3>Heading Only Link: RTL</h3>
-        <calcite-tile href="/" heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-
-      <section>
-        <h3>Large Visual: LTR</h3>
-        <calcite-tile icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-      <section dir="rtl">
-        <h3>Large Visual: RTL</h3>
-        <calcite-tile icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-
-      <section>
-        <h3>Large Visual Link: LTR</h3>
-        <calcite-tile href="/" icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-      <section dir="rtl">
-        <h3>Large Visual Link: RTL</h3>
-        <calcite-tile href="/" icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
-      </section>
-
+        <section>
+          <h3>Large Visual Link: LTR</h3>
+          <calcite-tile href="/" icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
+        <section dir="rtl">
+          <h3>Large Visual Link: RTL</h3>
+          <calcite-tile href="/" icon="layers" heading="Tile title lorem ipsum"></calcite-tile>
+        </section>
+      </demo-spacer>
     </demo-spacer>
-  </demo-spacer>
-</body>
-
+  </body>
 </html>

--- a/src/demos/calcite-tooltip.html
+++ b/src/demos/calcite-tooltip.html
@@ -59,13 +59,13 @@
         printer of type and scrambled it to make a type specimen book.
       </calcite-tooltip>
 
-      <calcite-tooltip label="auto placed tooltip" theme="dark" reference-element="tooltip-button-five"
+      <calcite-tooltip label="auto placed tooltip" class="calcite-theme-dark" reference-element="tooltip-button-five"
         >This is the message of the tooltip.
       </calcite-tooltip>
 
       <calcite-tooltip
         label="auto placed tooltip"
-        theme="dark"
+        class="calcite-theme-dark"
         placement="auto"
         id="tooltip-six"
         reference-element="tooltip-button-six"
@@ -75,7 +75,7 @@
 
       <calcite-tooltip
         label="auto placed tooltip"
-        theme="dark"
+        class="calcite-theme-dark"
         placement="auto"
         reference-element="tooltip-button-eight"
         >Lorem Ipsum is simply of the printing and typesetting industry. Lorem Ipsum has been the industry's standard
@@ -92,7 +92,7 @@
         mollit anim id est laborum.
       </p>
 
-      <p class="demo-background-dark" theme="dark">
+      <p class="demo-background-dark" class="calcite-theme-dark">
         Lorem <a id="tooltip-button-five" href="#">ipsum</a> dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
         <strong id="tooltip-button-six" tabindex="0">ullamco</strong> laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/demos/calcite-tree.html
+++ b/src/demos/calcite-tree.html
@@ -12,7 +12,7 @@
         padding: 1rem;
       }
     </style>
-   <script src="./_assets/head.js"></script>
+    <script src="./_assets/head.js"></script>
   </head>
 
   <body>
@@ -279,7 +279,7 @@
 
     <h3>Dark Theme</h3>
     <div class="demo-background-dark">
-      <calcite-tree theme="dark">
+      <calcite-tree class="calcite-theme-dark">
         <calcite-tree-item>
           <a href="#">Child 1</a>
         </calcite-tree-item>
@@ -338,7 +338,7 @@
 
     <h3>Dark Theme (Lines)</h3>
     <div class="demo-background-dark">
-      <calcite-tree theme="dark" lines>
+      <calcite-tree class="calcite-theme-dark" lines>
         <calcite-tree-item>
           <a href="#">Child 1</a>
         </calcite-tree-item>

--- a/src/demos/fab/basic.html
+++ b/src/demos/fab/basic.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-fab</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>

--- a/src/demos/flow/basic.html
+++ b/src/demos/flow/basic.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-flow</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>
@@ -35,7 +34,7 @@
             <calcite-fab slot="fab"></calcite-fab>
             <div slot="footer">
               <img src="http://www.fillmurray.com/100/100" alt="placeholder" />
-              <hr>
+              <hr />
               I'm a custom footer.
             </div>
           </calcite-panel>

--- a/src/demos/panel/basic.html
+++ b/src/demos/panel/basic.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-panel</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>
@@ -27,8 +26,14 @@
           <calcite-action label="cool banana" icon="banana" slot="header-actions-end"></calcite-action>
           <calcite-action label="cool banana" icon="banana" slot="header-actions-start"></calcite-action>
           <calcite-action label="cool banana" icon="banana" slot="header-actions-start"></calcite-action>
-          <calcite-action label="cool banana" icon="banana" text="cool banana" text-enabled slot="header-menu-actions"></calcite-action>
-            <calcite-action icon="banana" text="cool banana" text-enabled slot="header-menu-actions"></calcite-action>
+          <calcite-action
+            label="cool banana"
+            icon="banana"
+            text="cool banana"
+            text-enabled
+            slot="header-menu-actions"
+          ></calcite-action>
+          <calcite-action icon="banana" text="cool banana" text-enabled slot="header-menu-actions"></calcite-action>
           <p>I'm using the properties.</p>
           <img src="https://via.placeholder.com/300x400" alt="placeholder" />
           <calcite-fab slot="fab"></calcite-fab>
@@ -43,9 +48,19 @@
 
         <h2>With Header Actions</h2>
         <calcite-panel>
-          <calcite-action label="icon left" icon="left" onclick="console.log('left clicked');" slot="header-actions-start"></calcite-action>
+          <calcite-action
+            label="icon left"
+            icon="left"
+            onclick="console.log('left clicked');"
+            slot="header-actions-start"
+          ></calcite-action>
           <div slot="header-content">panel 3 header</div>
-          <calcite-action label="icon right" icon="right" onclick="console.log('right clicked');" slot="header-actions-end"></calcite-action>
+          <calcite-action
+            label="icon right"
+            icon="right"
+            onclick="console.log('right clicked');"
+            slot="header-actions-end"
+          ></calcite-action>
           <p>Buttons in the top left and right. Mainly for calcite-actions and not plain buttons.</p>
         </calcite-panel>
 
@@ -66,7 +81,7 @@
         </script>
 
         <h2>Scrolling Panel</h2>
-        <calcite-panel style="height: 500px;" id="panel">
+        <calcite-panel style="height: 500px" id="panel">
           <div slot="header-content">panel header</div>
           <p>Slotted content</p>
           <p>Slotted content</p>
@@ -94,7 +109,7 @@
           <p>Slotted content</p>
           <p>Slotted content</p>
           <p>Slotted content</p>
-          <p style="position: relative; z-index: 999;">
+          <p style="position: relative; z-index: 999">
             High zIndex content. High zIndex content. High zIndex content. High zIndex content. High zIndex content.
             High zIndex content. High zIndex content. High zIndex content. High zIndex content. High zIndex content.
             High zIndex content. High zIndex content. High zIndex content. High zIndex content. High zIndex content.
@@ -168,9 +183,19 @@
           </calcite-panel>
 
           <calcite-panel>
-            <calcite-action label="icon left" onclick="console.log('left clicked');" icon="left" slot="header-actions-start"></calcite-action>
+            <calcite-action
+              label="icon left"
+              onclick="console.log('left clicked');"
+              icon="left"
+              slot="header-actions-start"
+            ></calcite-action>
             <div slot="header-content">panel 3 header</div>
-            <calcite-action label="icon right" onclick="console.log('right clicked');" icon="right" slot="header-actions-end"></calcite-action>
+            <calcite-action
+              label="icon right"
+              onclick="console.log('right clicked');"
+              icon="right"
+              slot="header-actions-end"
+            ></calcite-action>
             <p>Button positions are reversed!</p>
           </calcite-panel>
 

--- a/src/demos/pick-list/advanced.html
+++ b/src/demos/pick-list/advanced.html
@@ -24,7 +24,7 @@
       </style>
     </header>
     <main>
-      <section class="example-container" style="width: 28vw; margin-top: 2em;">
+      <section class="example-container" style="width: 28vw; margin-top: 2em">
         <h1>LTR</h1>
         <h2>multi-select w/ filter</h2>
         <calcite-pick-list id="one" multiple filter-enabled>
@@ -62,11 +62,7 @@
               tags: ["square", "mile"]
             };
           </script>
-          <calcite-pick-list-item
-            label="2018 Total Households (Esri)"
-            description="TOTHH_CY"
-            value="TOTHH_CY"
-          >
+          <calcite-pick-list-item label="2018 Total Households (Esri)" description="TOTHH_CY" value="TOTHH_CY">
             <calcite-action
               slot="actions-end"
               id="action-test"
@@ -165,11 +161,7 @@
         <h2>grouped single-select</h2>
         <calcite-pick-list id="three">
           <calcite-pick-list-group group-title="numbers">
-            <calcite-pick-list-item
-              label="2023 Diversity Index (Esri)"
-              description="DIVINDX_FY"
-              value="DIVINDX_FY"
-            >
+            <calcite-pick-list-item label="2023 Diversity Index (Esri)" description="DIVINDX_FY" value="DIVINDX_FY">
               <calcite-action
                 slot="actions-end"
                 id="action-test"
@@ -191,11 +183,7 @@
             </calcite-pick-list-item>
           </calcite-pick-list-group>
           <calcite-pick-list-group group-title="colors">
-            <calcite-pick-list-item
-              label="2018 Total Housing Units (Esri)"
-              description="TOTHU_CY"
-              value="TOTHU_CY"
-            >
+            <calcite-pick-list-item label="2018 Total Housing Units (Esri)" description="TOTHU_CY" value="TOTHU_CY">
               <calcite-action
                 slot="actions-end"
                 id="action-test"
@@ -229,7 +217,7 @@
         </script>
       </section>
       <!-- RTL -->
-      <section class="example-container" style="width: 28vw; margin-top: 2em;" dir="rtl">
+      <section class="example-container" style="width: 28vw; margin-top: 2em" dir="rtl">
         <h1>RTL</h1>
         <h2>multi-select w/ filter</h2>
         <calcite-pick-list id="one_rtl" multiple filter-enabled>
@@ -257,11 +245,7 @@
             >
             </calcite-action>
           </calcite-pick-list-item>
-          <calcite-pick-list-item
-            label="2018 Total Households (Esri)"
-            description="TOTHH_CY"
-            value="TOTHH_CY"
-          >
+          <calcite-pick-list-item label="2018 Total Households (Esri)" description="TOTHH_CY" value="TOTHH_CY">
             <calcite-action
               slot="actions-end"
               id="action-test"
@@ -353,11 +337,7 @@
         <h2>grouped single-select</h2>
         <calcite-pick-list id="three_rtl">
           <calcite-pick-list-group group-title="numbers">
-            <calcite-pick-list-item
-              label="2023 Diversity Index (Esri)"
-              description="DIVINDX_FY"
-              value="DIVINDX_FY"
-            >
+            <calcite-pick-list-item label="2023 Diversity Index (Esri)" description="DIVINDX_FY" value="DIVINDX_FY">
               <calcite-action
                 slot="actions-end"
                 id="action-test"
@@ -379,11 +359,7 @@
             </calcite-pick-list-item>
           </calcite-pick-list-group>
           <calcite-pick-list-group group-title="colors">
-            <calcite-pick-list-item
-              label="2018 Total Housing Units (Esri)"
-              description="TOTHU_CY"
-              value="TOTHU_CY"
-            >
+            <calcite-pick-list-item label="2018 Total Housing Units (Esri)" description="TOTHU_CY" value="TOTHU_CY">
               <calcite-action
                 slot="actions-end"
                 id="action-test"

--- a/src/demos/pick-list/basic.html
+++ b/src/demos/pick-list/basic.html
@@ -44,10 +44,14 @@
 
         <h2>multi-select filter-enabled</h2>
         <calcite-pick-list id="two" multiple filter-enabled>
-          <calcite-action scale="s" text="filters" slot="menu-actions" icon="sliders">
-          </calcite-action>
+          <calcite-action scale="s" text="filters" slot="menu-actions" icon="sliders"> </calcite-action>
           <calcite-pick-list-item label="Chocolate" description="Dark is the best." value="chocolate">
-            <calcite-icon scale="s" icon="title" slot="actions-start" style="align-self: center; padding: 0 var(--calcite-spacing);"></calcite-icon>
+            <calcite-icon
+              scale="s"
+              icon="title"
+              slot="actions-start"
+              style="align-self: center; padding: 0 var(--calcite-spacing)"
+            ></calcite-icon>
             <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="ellipsis">
             </calcite-action>
           </calcite-pick-list-item>
@@ -71,11 +75,7 @@
             };
             document.currentScript.previousElementSibling.selected = true;
           </script>
-          <calcite-pick-list-item
-            label="actions-start"
-            description="no metadata on this one"
-            value="strawberry"
-          >
+          <calcite-pick-list-item label="actions-start" description="no metadata on this one" value="strawberry">
             <calcite-action
               slot="actions-start"
               text="click-me"
@@ -177,12 +177,7 @@
         <calcite-pick-list id="four" filter-enabled multiple>
           <calcite-pick-list-group group-title="Cool group">
             <calcite-pick-list-item label="You can count on numbers." value="numbers"></calcite-pick-list-item>
-            <calcite-pick-list-item
-              label="One item label"
-              value="one"
-              icon="grip"
-              selected
-            ></calcite-pick-list-item>
+            <calcite-pick-list-item label="One item label" value="one" icon="grip" selected></calcite-pick-list-item>
             <calcite-pick-list-item label="Another item label" value="two" icon="grip"></calcite-pick-list-item>
           </calcite-pick-list-group>
           <calcite-pick-list-group group-title="Neat group">

--- a/src/demos/shell-panel/basic.html
+++ b/src/demos/shell-panel/basic.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-shell-panel</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>

--- a/src/demos/shell/basic.html
+++ b/src/demos/shell/basic.html
@@ -8,7 +8,6 @@
 
     <script src="../_assets/head.js"></script>
 
-
     <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/themes/light/main.css" />
     <script src="https://js.arcgis.com/4.12/"></script>
     <style>
@@ -54,13 +53,9 @@
         <h2>Shell with Panels</h2>
         <div class="shell-container">
           <calcite-shell>
-            <calcite-shell-panel slot="primary-panel" position="start">
-              leading panel
-            </calcite-shell-panel>
+            <calcite-shell-panel slot="primary-panel" position="start"> leading panel </calcite-shell-panel>
 
-            <calcite-shell-panel slot="contextual-panel" position="end">
-              trailing panel
-            </calcite-shell-panel>
+            <calcite-shell-panel slot="contextual-panel" position="end"> trailing panel </calcite-shell-panel>
             <div slot="header">
               <header class="header">
                 <h2 class="heading">Shell Header: My App</h2>

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -55,12 +55,9 @@
   <body>
     <main>
       <div class="shell-container">
-
         <calcite-shell content-behind>
-
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
-
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>
@@ -81,25 +78,25 @@
                 <calcite-action text="What's next" icon="mega-phone"></calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
-              <calcite-panel heading="Sketch">
-                <div style="padding:var(--calcite-spacing-half);">
-                  <calcite-label scale="s">Draw features</calcite-label>
-                  <calcite-action-group layout="grid" style="margin-bottom: var(--calcite-spacing);">
-                    <calcite-action alignment="center" icon="pin" text="Stamp"></calcite-action>
-                    <calcite-action alignment="center" icon="line" text="Line"></calcite-action>
-                    <calcite-action alignment="center" icon="polygon" text="Polygon"></calcite-action>
-                    <calcite-action alignment="center" icon="rectangle" text="Rectangle"></calcite-action>
-                    <calcite-action alignment="center" icon="circle" text="Circle"></calcite-action>
-                    <calcite-action alignment="center" icon="text" text="Text"></calcite-action>
-                  </calcite-action-group>
-                  <calcite-label scale="s">Select features</calcite-label>
-                  <calcite-action-group layout="grid">
-                    <calcite-action alignment="center" icon="cursor" text="Select"></calcite-action>
-                    <calcite-action alignment="center" icon="cursor-marquee" text="Select by rectangle"></calcite-action>
-                    <calcite-action alignment="center" icon="lasso" text="Select by lasso"></calcite-action>
-                  </calcite-action-group>
-                </div>
-              </calcite-panel>
+            <calcite-panel heading="Sketch">
+              <div style="padding: var(--calcite-spacing-half)">
+                <calcite-label scale="s">Draw features</calcite-label>
+                <calcite-action-group layout="grid" style="margin-bottom: var(--calcite-spacing)">
+                  <calcite-action alignment="center" icon="pin" text="Stamp"></calcite-action>
+                  <calcite-action alignment="center" icon="line" text="Line"></calcite-action>
+                  <calcite-action alignment="center" icon="polygon" text="Polygon"></calcite-action>
+                  <calcite-action alignment="center" icon="rectangle" text="Rectangle"></calcite-action>
+                  <calcite-action alignment="center" icon="circle" text="Circle"></calcite-action>
+                  <calcite-action alignment="center" icon="text" text="Text"></calcite-action>
+                </calcite-action-group>
+                <calcite-label scale="s">Select features</calcite-label>
+                <calcite-action-group layout="grid">
+                  <calcite-action alignment="center" icon="cursor" text="Select"></calcite-action>
+                  <calcite-action alignment="center" icon="cursor-marquee" text="Select by rectangle"></calcite-action>
+                  <calcite-action alignment="center" icon="lasso" text="Select by lasso"></calcite-action>
+                </calcite-action-group>
+              </div>
+            </calcite-panel>
           </calcite-shell-panel>
 
           <calcite-shell-panel slot="contextual-panel" position="end">
@@ -138,10 +135,7 @@
             </calcite-button>
             <!-- <div style="height: 100%;"> -->
             <calcite-flow id="flow">
-              <calcite-panel
-                heading="cool"
-                summary="Popular Demographics in the United States (Beta) - County"
-              >
+              <calcite-panel heading="cool" summary="Popular Demographics in the United States (Beta) - County">
                 I'm this panel's content.
               </calcite-panel>
               <calcite-panel heading="Configure popup" dismissible>
@@ -189,12 +183,7 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-block-section text="Section is cool">
@@ -216,34 +205,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -251,34 +225,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -287,34 +246,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -323,34 +267,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -359,34 +288,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -396,34 +310,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -433,34 +332,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -469,34 +353,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -504,34 +373,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -545,34 +399,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -581,34 +420,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -617,34 +441,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -653,34 +462,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -691,34 +485,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -728,34 +507,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -824,11 +588,7 @@
           <footer slot="footer">Footer</footer>
         </calcite-shell>
       </div>
-      <calcite-popover
-        label="right start popover"
-        placement="right"
-        reference-element="popover-trigger"
-      >
+      <calcite-popover label="right start popover" placement="right" reference-element="popover-trigger">
         <calcite-panel heading="Cool cool" height-scale="m">
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" text="options">

--- a/src/demos/shell/demo-app-advanced-2-shell-header.html
+++ b/src/demos/shell/demo-app-advanced-2-shell-header.html
@@ -72,7 +72,7 @@
               ><span> Shell Floating Panel Content </span>
             </calcite-panel>
 
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Add">
                   <calcite-icon icon="plus" scale="s"></calcite-icon>

--- a/src/demos/shell/demo-app-advanced-2.html
+++ b/src/demos/shell/demo-app-advanced-2.html
@@ -72,7 +72,7 @@
               ><span> Shell Floating Panel Content </span>
             </calcite-panel>
 
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Add">
                   <calcite-icon icon="plus" scale="s"></calcite-icon>
@@ -276,7 +276,7 @@
         add-click-handle
         class="popover"
       >
-        <calcite-panel theme="light">
+        <calcite-panel class="calcite-theme-light">
           <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" text="options">

--- a/src/demos/shell/demo-app-advanced-3.html
+++ b/src/demos/shell/demo-app-advanced-3.html
@@ -72,12 +72,7 @@
               ><span> Shell Floating Panel Content </span>
             </calcite-panel>
 
-            <calcite-action-bar
-              slot="action-bar"
-              theme="dark"
-              intl-collapse="Collapse"
-              intl-expand="Expand"
-              expand=
+            <calcite-action-bar slot="action-bar" theme="dark" intl-collapse="Collapse" intl-expand="Expand" expand
               ><calcite-action-group class="js-action-group" slot="" calcite-hydrated=""
                 ><calcite-action
                   id="adddata"
@@ -252,10 +247,10 @@
           <calcite-shell-panel slot="contextual-panel" position="end">
             <calcite-action-bar
               slot="action-bar"
-              theme="light"
+              class="calcite-theme-light"
               intl-collapse="Collapse"
               intl-expand="Expand"
-              expand=
+              expand
               ><calcite-action-group class="js-action-group" slot="" calcite-hydrated=""
                 ><calcite-action
                   id="layerproperties"
@@ -561,7 +556,7 @@
         add-click-handle
         class="popover"
       >
-        <calcite-panel theme="light">
+        <calcite-panel class="calcite-theme-light">
           <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" text="options">

--- a/src/demos/shell/demo-app-advanced-center-row-async.html
+++ b/src/demos/shell/demo-app-advanced-center-row-async.html
@@ -54,7 +54,7 @@
       });
       function addCenterRow() {
         const centerRow = document.createElement("calcite-shell-center-row");
-        centerRow.setAttribute('slot', 'center-row');
+        centerRow.setAttribute("slot", "center-row");
         centerRow.setAttribute("detached", "");
         centerRow.setAttribute("hidden", "");
 
@@ -78,7 +78,7 @@
       <div class="shell-container">
         <calcite-shell content-behind id="shell">
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start">
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>

--- a/src/demos/shell/demo-app-advanced-center-row.html
+++ b/src/demos/shell/demo-app-advanced-center-row.html
@@ -58,7 +58,7 @@
       <div class="shell-container">
         <calcite-shell>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start">
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>
@@ -80,9 +80,7 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow>
-              <calcite-panel heading="First flow item" width-scale="l">
-                Default slot of the first panel
-              </calcite-panel>
+              <calcite-panel heading="First flow item" width-scale="l"> Default slot of the first panel </calcite-panel>
               <calcite-panel heading="Second flow item 02" width-scale="m">
                 Default slot of the second panel
               </calcite-panel>
@@ -383,9 +381,7 @@
             </calcite-tip-group>
             <calcite-tip heading="Square Nature">
               <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is square. And the text will run out before the end of the image.
-              </p>
+              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
               <p>
                 In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -396,9 +392,7 @@
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
             <calcite-tip heading="The lack of imagery">
-              <p>
-                This tip has no image. As such, the content area will take up the entire width of the tip.
-              </p>
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
               <p>
                 This is the next paragraph and should show how wide the content area is now. Of course, the width of the
                 overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
@@ -427,7 +421,7 @@
             ? centerRow.setAttribute("height-scale", "m")
             : centerRow.setAttribute("height-scale", "s");
 
-            centerRow.getAttribute("height-scale") == "s"
+          centerRow.getAttribute("height-scale") == "s"
             ? expandTrigger.setAttribute("icon", "chevrons-up")
             : expandTrigger.setAttribute("icon", "chevrons-down");
         });

--- a/src/demos/shell/demo-app-advanced.html
+++ b/src/demos/shell/demo-app-advanced.html
@@ -35,53 +35,51 @@
       }
     </style>
 
-<script>
-    require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList","esri/widgets/Zoom"], function(WebMap, MapView, LayerList, Zoom) {
-      const webmap = new WebMap({
-        portalItem: {
-          id: "cc316ca9e0824970ad29ac558161d42d"
-        }
-      });
-
-      const view = new MapView({
-        container: "viewDiv",
-        map: webmap
-      });
-      view.when(function() {
-        var layerList = new LayerList({
-          view: view,
-          selectionEnabled: true,
-          container: "layerlist-container"
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
         });
 
-        view.ui.move("zoom", "bottom-right");
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap
+        });
+        view.when(function () {
+          var layerList = new LayerList({
+            view: view,
+            selectionEnabled: true,
+            container: "layerlist-container"
+          });
+
+          view.ui.move("zoom", "bottom-right");
+        });
       });
-    });
-  </script>
+    </script>
   </head>
   <body>
     <main>
       <div class="shell-container">
         <calcite-shell>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
-                <calcite-action text="Save" icon="save" indicator>
-                </calcite-action>
-                <calcite-action text-enabled icon="map" text="New" slot="menu-actions">
-                </calcite-action>
-                <calcite-action text-enabled icon="collection" text="Open" slot="menu-actions">
-                </calcite-action>
-            </calcite-action-group>
-            <calcite-action-group>
-                <calcite-action icon="layers" text="Layers" active>
-                </calcite-action>
-                <calcite-action icon="basemap" text="Basemaps">
-                </calcite-action>
-                <calcite-action icon="legend" text="Legend">
-                </calcite-action>
-                <calcite-action icon="bookmark" text="Bookmarks">
-                </calcite-action>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action text-enabled icon="map" text="New" slot="menu-actions"> </calcite-action>
+                <calcite-action text-enabled icon="collection" text="Open" slot="menu-actions"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers" active> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action text="Share" icon="share"></calcite-action>
@@ -92,22 +90,25 @@
                 <calcite-action text="What's next" icon="mega-phone"></calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
-              <calcite-panel heading="Layers" height-scale="l" width-scale="m">
-                  <div id="layerlist-container"></div>
-                  <calcite-fab slot="fab" id="layer-fab" text="Add layers"></calcite-fab>
-                  <calcite-tooltip label="tooltip" reference-element="layer-fab" disable-pointer>Add layers</calcite-tooltip>
-              </calcite-panel>
+            <calcite-panel heading="Layers" height-scale="l" width-scale="m">
+              <div id="layerlist-container"></div>
+              <calcite-fab slot="fab" id="layer-fab" text="Add layers"></calcite-fab>
+              <calcite-tooltip label="tooltip" reference-element="layer-fab" disable-pointer
+                >Add layers</calcite-tooltip
+              >
+            </calcite-panel>
           </calcite-shell-panel>
 
           <calcite-shell-panel slot="contextual-panel" position="end">
             <calcite-action-bar slot="action-bar">
-              <calcite-tooltip slot="expand-tooltip" label="tooltip"  disable-pointer>Add layers</calcite-tooltip>
+              <calcite-tooltip slot="expand-tooltip" label="tooltip" disable-pointer>Add layers</calcite-tooltip>
               <calcite-action-group>
                 <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
                 <calcite-action text="Styles" icon="shapes"> </calcite-action>
                 <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
                 <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
-                <calcite-action text-enabled text="Configure attributes" icon="feature-details" slot="menu-actions"> </calcite-action>
+                <calcite-action text-enabled text="Configure attributes" icon="feature-details" slot="menu-actions">
+                </calcite-action>
                 <calcite-action text-enabled text="Labels" icon="label" slot="menu-actions"> </calcite-action>
                 <calcite-action text-enabled text="Tablew" icon="table" slot="menu-actions"> </calcite-action>
               </calcite-action-group>
@@ -116,7 +117,13 @@
                 <calcite-action icon="measure" text="Measure"></calcite-action>
                 <calcite-action text-enabled icon="road-sign" text="Directions" slot="menu-actions"></calcite-action>
                 <calcite-action text-enabled icon="point" text="Location" slot="menu-actions"></calcite-action>
-                <calcite-action text-enabled icon="pencil-square" text="Edit" disabled slot="menu-actions"></calcite-action>
+                <calcite-action
+                  text-enabled
+                  icon="pencil-square"
+                  text="Edit"
+                  disabled
+                  slot="menu-actions"
+                ></calcite-action>
                 <calcite-action text-enabled icon="clock" text="Time" disabled slot="menu-actions"></calcite-action>
               </calcite-action-group>
               <calcite-action-group slot="bottom-actions">
@@ -131,25 +138,22 @@
                 summary="Popular Demographics in the United States (Beta) - County"
                 width-scale="m"
               >
-              <calcite-action slot="header-actions-end" icon="x" text="Close">
-              </calcite-action>
+                <calcite-action slot="header-actions-end" icon="x" text="Close"> </calcite-action>
 
-                <calcite-block heading="Title"  summary="County: {NAME}" collapsible>
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action label="code icon" class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="Title" summary="County: {NAME}" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">County: {NAME}</button>
+                      <calcite-action label="code icon" class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
                 <calcite-sortable-list>
                   <calcite-block drag-handle heading="Attributes" summary="2/98" collapsible>
                     <calcite-icon icon="feature-details" scale="m" slot="icon"></calcite-icon>
                     <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    </calcite-button>
+
                     <calcite-value-list drag-enabled>
                       <calcite-value-list-item
                         label="2018 Total Households (Esri)"
@@ -163,7 +167,9 @@
                       ></calcite-value-list-item>
                     </calcite-value-list>
                     <div class="row">
-                        <calcite-button id="attribute-add" round icon="plus" scale="s" width="full" color="neutral">Select attributes</calcite-button>
+                      <calcite-button id="attribute-add" round icon="plus" scale="s" width="full" color="neutral"
+                        >Select attributes</calcite-button
+                      >
                     </div>
                   </calcite-block>
                   <calcite-block drag-handle heading="Image" collapsible>
@@ -172,26 +178,26 @@
                     <section class="form-section">
                       <label>
                         URL
-                        <input type="text" value="https://ca-times.brightspotcdn.com/dims4/default/"/>
+                        <input type="text" value="https://ca-times.brightspotcdn.com/dims4/default/" />
                       </label>
                     </section>
                     <calcite-block-section text="Options">
                       <section class="form-section">
                         <label>
                           Title
-                          <input type="text" placeholder="My cool title"/>
+                          <input type="text" placeholder="My cool title" />
                         </label>
                         <label>
                           Caption
-                          <input type="text" placeholder="My cool caption"/>
+                          <input type="text" placeholder="My cool caption" />
                         </label>
                         <label>
                           State
                           <select placeholder="My cool caption">
-                          <option value="Denial">Denial</option>
-                          <option value="Grace">Grace</option>
-                          <option value="Confusion">Confusion</option>
-                        </select>
+                            <option value="Denial">Denial</option>
+                            <option value="Grace">Grace</option>
+                            <option value="Confusion">Confusion</option>
+                          </select>
                         </label>
                       </section>
                     </calcite-block-section>
@@ -199,19 +205,19 @@
                       <section class="form-section">
                         <label>
                           Title
-                          <input type="text" placeholder="My cool title"/>
+                          <input type="text" placeholder="My cool title" />
                         </label>
                         <label>
                           Caption
-                          <input type="text" placeholder="My cool caption"/>
+                          <input type="text" placeholder="My cool caption" />
                         </label>
                         <label>
                           State
                           <select placeholder="My cool caption">
-                          <option value="Denial">Denial</option>
-                          <option value="Grace">Grace</option>
-                          <option value="Confusion">Confusion</option>
-                        </select>
+                            <option value="Denial">Denial</option>
+                            <option value="Grace">Grace</option>
+                            <option value="Confusion">Confusion</option>
+                          </select>
                         </label>
                       </section>
                     </calcite-block-section>
@@ -219,7 +225,9 @@
                   <calcite-block drag-handle heading="Text" summary="Cool. he {expression/..." collapsible>
                     <calcite-icon icon="image" scale="m" slot="icon"></calcite-icon>
                     <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <button class="multiline-button">Cool. he {expression/expr1} population is {expression/expr2}%...</button>
+                    <button class="multiline-button">
+                      Cool. he {expression/expr1} population is {expression/expr2}%...
+                    </button>
                   </calcite-block>
                 </calcite-sortable-list>
                 <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
@@ -230,7 +238,7 @@
             </calcite-flow>
           </calcite-shell-panel>
           <div class="gnav" slot="header">
-              <h2>Boomer v Millennial - California</h2>
+            <h2>Boomer v Millennial - California</h2>
           </div>
           <calcite-tip-manager slot="center-row" id="tip-manager" hidden>
             <calcite-tip-group group-title="Astronomy">
@@ -259,9 +267,7 @@
             </calcite-tip-group>
             <calcite-tip heading="Square Nature">
               <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is square. And the text will run out before the end of the image.
-              </p>
+              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
               <p>
                 In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -272,9 +278,7 @@
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
             <calcite-tip heading="The lack of imagery">
-              <p>
-                This tip has no image. As such, the content area will take up the entire width of the tip.
-              </p>
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
               <p>
                 This is the next paragraph and should show how wide the content area is now. Of course, the width of the
                 overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
@@ -287,8 +291,14 @@
           <footer slot="footer">Footer</footer>
         </calcite-shell>
       </div>
-      <calcite-popover label="right start popover" placement="right-start" reference-element="action-pad-button" add-click-handle class="popover">
-        <calcite-panel theme="light">
+      <calcite-popover
+        label="right start popover"
+        placement="right-start"
+        reference-element="action-pad-button"
+        add-click-handle
+        class="popover"
+      >
+        <calcite-panel class="calcite-theme-light">
           <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" text="options">
@@ -306,10 +316,7 @@
               label="about starvation and the food that Live Aid bought"
               value="3"
             ></calcite-pick-list-item>
-            <calcite-pick-list-item
-              label="about disease, baby rock, Hudson, rock,"
-              value="4"
-            ></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
           </calcite-pick-list>
           <calcite-button slot="footer" width="half">Yeah!</calcite-button>
           <calcite-button slot="footer" width="half" appearance="clear">Naw.</calcite-button>
@@ -318,7 +325,7 @@
       <script>
         const tipManagerButton = document.getElementById("tip-manager-button");
         const tipManager = document.getElementById("tip-manager");
-        tipManagerButton.addEventListener("click", function() {
+        tipManagerButton.addEventListener("click", function () {
           tipManager.hasAttribute("hidden")
             ? tipManager.removeAttribute("hidden")
             : tipManager.setAttribute("hidden", "");

--- a/src/demos/shell/demo-app-center-row-action-bar.html
+++ b/src/demos/shell/demo-app-center-row-action-bar.html
@@ -58,7 +58,7 @@
       <div class="shell-container">
         <calcite-shell>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" id="primary-panel">
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>
@@ -80,13 +80,9 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow>
-              <calcite-panel heading="First flow item" width-scale="m" >
-                Default slot of the first panel
-              </calcite-panel>
-              <calcite-panel heading="Second flow item 02" width-scale="m" >
-                <div style="height: 45vh;">
-                Default slot of the second panel
-              </div>
+              <calcite-panel heading="First flow item" width-scale="m"> Default slot of the first panel </calcite-panel>
+              <calcite-panel heading="Second flow item 02" width-scale="m">
+                <div style="height: 45vh">Default slot of the second panel</div>
               </calcite-panel>
             </calcite-flow>
           </calcite-shell-panel>
@@ -126,247 +122,258 @@
             <h2>Boomer v Millennial - California</h2>
           </div>
           <calcite-shell-center-row slot="center-row" height-scale="s" detached id="center-row">
-              <calcite-panel heading="Table" summary="Table in the center row.">
-                <calcite-action label="this is a label" slot="header-actions-start" icon="caret-down" scale="s"></calcite-action>
-                <calcite-action label="this is a label" slot="header-actions-end" icon="chevrons-up" scale="m" id="expand-trigger"></calcite-action>
-                <calcite-action label="this is a label" slot="header-actions-end" icon="x" scale="m"></calcite-action>
-                <style>
-                  .demo-table th {
-                    background-color: white;
-                    position: sticky;
-                    top: 0;
-                  }
-                  .demo-table,
-                  .demo-table th,
-                  .demo-table td {
-                    font-size: 12px;
-                    text-align: unset;
-                    border: solid 1px var(--calcite-app-border);
-                    border-collapse: collapse;
-                  }
-                  .demo-table th,
-                  .demo-table td {
-                    padding: 4px 8px;
-                  }
-                  .demo-table td {
-                    vertical-align: top;
-                  }
-                  .demo-table th {
-                    min-width: 7rem;
-                  }
-                  .demo-table th.sml {
-                    min-width: 1rem;
-                  }
-                  .demo-table tr:nth-child(even) {
-                    background-color: #f8f8f8;
-                  }
-                  .demo-table calcite-icon {
-                    color: #9e9e9e;
-                  }
-                  .demo-table tr td:first-child {
-                    vertical-align: middle;
-                  }
-                </style>
-                <!-- ShellCenterRow content -->
-                <table class="demo-table">
-                  <tr>
-                    <th class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></th>
-                    <th class="sml">ID</th>
-                    <th>Cool cache</th>
-                    <th>neat-notion</th>
-                    <th>Super Stuff</th>
-                    <th>Awesome article</th>
-                    <th>OBVI_OBJ</th>
-                    <th>reasonable_article</th>
-                    <th>memorable_material</th>
-                    <th>enhanced_element</th>
-                    <th>particular-PIECE</th>
-                    <th>UnderwaterUnit</th>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>Can't keep Johnny down.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                  <tr>
-                    <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
-                    <td>01</td>
-                    <td>This should be last.</td>
-                    <td>You probably get that a lot.</td>
-                    <td>Old Pine Box</td>
-                    <td>Canajoharie</td>
-                    <td>Cloissonné</td>
-                    <td>Let your hair hang down.</td>
-                    <td>Celebration</td>
-                    <td>In Fact</td>
-                    <td>When will you die?</td>
-                    <td>Protagonist</td>
-                  </tr>
-                </table>
-                <!-- / ShellCenterRow content -->
-              </calcite-panel>
+            <calcite-panel heading="Table" summary="Table in the center row.">
+              <calcite-action
+                label="this is a label"
+                slot="header-actions-start"
+                icon="caret-down"
+                scale="s"
+              ></calcite-action>
+              <calcite-action
+                label="this is a label"
+                slot="header-actions-end"
+                icon="chevrons-up"
+                scale="m"
+                id="expand-trigger"
+              ></calcite-action>
+              <calcite-action label="this is a label" slot="header-actions-end" icon="x" scale="m"></calcite-action>
+              <style>
+                .demo-table th {
+                  background-color: white;
+                  position: sticky;
+                  top: 0;
+                }
+                .demo-table,
+                .demo-table th,
+                .demo-table td {
+                  font-size: 12px;
+                  text-align: unset;
+                  border: solid 1px var(--calcite-app-border);
+                  border-collapse: collapse;
+                }
+                .demo-table th,
+                .demo-table td {
+                  padding: 4px 8px;
+                }
+                .demo-table td {
+                  vertical-align: top;
+                }
+                .demo-table th {
+                  min-width: 7rem;
+                }
+                .demo-table th.sml {
+                  min-width: 1rem;
+                }
+                .demo-table tr:nth-child(even) {
+                  background-color: #f8f8f8;
+                }
+                .demo-table calcite-icon {
+                  color: #9e9e9e;
+                }
+                .demo-table tr td:first-child {
+                  vertical-align: middle;
+                }
+              </style>
+              <!-- ShellCenterRow content -->
+              <table class="demo-table">
+                <tr>
+                  <th class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></th>
+                  <th class="sml">ID</th>
+                  <th>Cool cache</th>
+                  <th>neat-notion</th>
+                  <th>Super Stuff</th>
+                  <th>Awesome article</th>
+                  <th>OBVI_OBJ</th>
+                  <th>reasonable_article</th>
+                  <th>memorable_material</th>
+                  <th>enhanced_element</th>
+                  <th>particular-PIECE</th>
+                  <th>UnderwaterUnit</th>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>Can't keep Johnny down.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+                <tr>
+                  <td class="sml"><calcite-icon icon="square" scale="s"></calcite-icon></td>
+                  <td>01</td>
+                  <td>This should be last.</td>
+                  <td>You probably get that a lot.</td>
+                  <td>Old Pine Box</td>
+                  <td>Canajoharie</td>
+                  <td>Cloissonné</td>
+                  <td>Let your hair hang down.</td>
+                  <td>Celebration</td>
+                  <td>In Fact</td>
+                  <td>When will you die?</td>
+                  <td>Protagonist</td>
+                </tr>
+              </table>
+              <!-- / ShellCenterRow content -->
+            </calcite-panel>
 
-              <calcite-action-bar slot="action-bar">
-                <calcite-action-group>
-                  <calcite-action text="It's like you can touch it!" icon="3d-glasses"> </calcite-action>
-                  <calcite-action text="It has appeal." icon="banana"> </calcite-action>
-                  <calcite-action text="Make it a race car." icon="erase"> </calcite-action>
-                  <calcite-action label="add in edit" icon="add-in-edit" text="3 Square?"></calcite-action>
-                </calcite-action-group>
-                <calcite-action-group slot="bottom-actions">
-                  <calcite-action icon="lightbulb" text="Tips" id="tip-manager-button"></calcite-action>
-                  <calcite-action icon="mega-phone" text="What's that?!" id="tip-manager-button"></calcite-action>
-                </calcite-action-group>
-              </calcite-action-bar>
+            <calcite-action-bar slot="action-bar">
+              <calcite-action-group>
+                <calcite-action text="It's like you can touch it!" icon="3d-glasses"> </calcite-action>
+                <calcite-action text="It has appeal." icon="banana"> </calcite-action>
+                <calcite-action text="Make it a race car." icon="erase"> </calcite-action>
+                <calcite-action label="add in edit" icon="add-in-edit" text="3 Square?"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action icon="lightbulb" text="Tips" id="tip-manager-button"></calcite-action>
+                <calcite-action icon="mega-phone" text="What's that?!" id="tip-manager-button"></calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
           </calcite-shell-center-row>
           <calcite-tip-manager slot="center-row" id="tip-manager" hidden detached>
             <calcite-tip-group group-title="Astronomy">
@@ -395,9 +402,7 @@
             </calcite-tip-group>
             <calcite-tip heading="Square Nature">
               <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is square. And the text will run out before the end of the image.
-              </p>
+              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
               <p>
                 In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -408,9 +413,7 @@
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
             <calcite-tip heading="The lack of imagery">
-              <p>
-                This tip has no image. As such, the content area will take up the entire width of the tip.
-              </p>
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
               <p>
                 This is the next paragraph and should show how wide the content area is now. Of course, the width of the
                 overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
@@ -447,23 +450,23 @@
         const popupToggle = document.getElementById("popup-toggle");
         const popupPanel = document.getElementById("contextual-panel");
 
-        popupToggle.addEventListener("click", function() {
+        popupToggle.addEventListener("click", function () {
           popupPanel.hasAttribute("collapsed")
-          ? popupPanel.removeAttribute("collapsed")
-          : popupPanel.setAttribute("collapsed", "");
+            ? popupPanel.removeAttribute("collapsed")
+            : popupPanel.setAttribute("collapsed", "");
 
           popupToggle.hasAttribute("active")
-          ? popupToggle.removeAttribute("active")
-          : popupToggle.setAttribute("active", "");
+            ? popupToggle.removeAttribute("active")
+            : popupToggle.setAttribute("active", "");
         });
 
         const layersToggle = document.getElementById("layers-toggle");
         const layersPanel = document.getElementById("primary-panel");
 
-        layersToggle.addEventListener("click", function() {
+        layersToggle.addEventListener("click", function () {
           layersPanel.hasAttribute("collapsed")
-          ? layersPanel.removeAttribute("collapsed")
-          : layersPanel.setAttribute("collapsed", "");
+            ? layersPanel.removeAttribute("collapsed")
+            : layersPanel.setAttribute("collapsed", "");
 
           layersToggle.hasAttribute("active")
             ? layersToggle.removeAttribute("active")

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -70,7 +70,7 @@
                 <calcite-action text="Add" icon="plus"> </calcite-action>
               </calcite-action-group>
             </calcite-action-pad>
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Add" icon="plus"> </calcite-action>
                 <calcite-action text="Save" disabled icon="save"> </calcite-action>
@@ -82,7 +82,12 @@
                 <calcite-action text="Layers" indicator icon="layers"> </calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
-            <calcite-panel heading="Primary Panel" summary="This is the primary panel." height-scale="l" width-scale="m">
+            <calcite-panel
+              heading="Primary Panel"
+              summary="This is the primary panel."
+              height-scale="l"
+              width-scale="m"
+            >
               <calcite-block collapsible heading="Primary Content" summary="This is the primary.">
                 <calcite-block-content>
                   <calcite-action
@@ -401,8 +406,14 @@
           <footer slot="footer">Footer</footer>
         </calcite-shell>
       </div>
-      <calcite-popover label="right start popover" placement="right-start" reference-element="action-pad-button" add-click-handle class="popover">
-        <calcite-panel theme="light">
+      <calcite-popover
+        label="right start popover"
+        placement="right-start"
+        reference-element="action-pad-button"
+        add-click-handle
+        class="popover"
+      >
+        <calcite-panel class="calcite-theme-light">
           <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" label="options" icon="ellipsis"> </calcite-action>
@@ -418,10 +429,7 @@
               label="about starvation and the food that Live Aid bought"
               value="3"
             ></calcite-pick-list-item>
-            <calcite-pick-list-item
-              label="about disease, baby rock, Hudson, rock,"
-              value="4"
-            ></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
           </calcite-pick-list>
           <calcite-button slot="footer-actions" width="half">Yeah!</calcite-button>
           <calcite-button slot="footer-actions" width="half" appearance="clear">Naw.</calcite-button>

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -48,8 +48,8 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel slot="primary-panel" position="start" >
-            <calcite-action-bar slot="action-bar" theme="dark">
+          <calcite-shell-panel slot="primary-panel" position="start">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Add" icon="plus"> </calcite-action>
                 <calcite-action text="Save" disabled icon="save"> </calcite-action>
@@ -64,25 +64,10 @@
             <calcite-panel heading="This the left panel" summary="I'm a summary." width-scale="m">
               <calcite-block collapsible heading="Primary Content" summary="This is the primary.">
                 <calcite-block-content>
-                  <calcite-action
-                    text="Side ActionPad"
-                    text-enabled
-                    indicator
-                    icon="caret-square-right"
-                  >
+                  <calcite-action text="Side ActionPad" text-enabled indicator icon="caret-square-right">
                   </calcite-action>
-                  <calcite-action
-                    text="Anchored Shell Floating Panel"
-                    text-enabled
-                    icon="extent"
-                  >
-                  </calcite-action>
-                  <calcite-action
-                    text="Over Shell Floating Panel"
-                    text-enabled
-                    icon="arrow-up-right"
-                  >
-                  </calcite-action>
+                  <calcite-action text="Anchored Shell Floating Panel" text-enabled icon="extent"> </calcite-action>
+                  <calcite-action text="Over Shell Floating Panel" text-enabled icon="arrow-up-right"> </calcite-action>
                 </calcite-block-content>
               </calcite-block>
               <calcite-block collapsible heading="Transpancy by predominant percentage" open>
@@ -118,7 +103,7 @@
             </calcite-panel>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" position="end" detached >
+          <calcite-shell-panel slot="contextual-panel" position="end" detached>
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Add" active icon="plus"> </calcite-action>
@@ -134,7 +119,7 @@
                 <calcite-action text="Tips" id="tip-manager-button" icon="lightbulb"> </calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
-            <calcite-flow id="flow" >
+            <calcite-flow id="flow">
               <calcite-panel heading="Layer settings" height-scale="l" width-scale="m">
                 <calcite-action slot="header-menu-actions" text="Do a cool thing" text-enabled></calcite-action>
                 <calcite-action slot="header-menu-actions" text="Do a cool thing" text-enabled></calcite-action>
@@ -203,7 +188,12 @@
                 <calcite-button width="half" scale="s" appearance="outline" slot="footer-actions">Save</calcite-button>
                 <calcite-button width="half" scale="s" slot="footer-actions">Cancel</calcite-button>
               </calcite-panel>
-              <calcite-panel heading="A capability" summary="U.S. Demographics - State" height-scale="l" width-scale="m">
+              <calcite-panel
+                heading="A capability"
+                summary="U.S. Demographics - State"
+                height-scale="l"
+                width-scale="m"
+              >
                 <calcite-action
                   slot="header-actions-end"
                   icon="banana"

--- a/src/demos/shell/demo-app-rtl.html
+++ b/src/demos/shell/demo-app-rtl.html
@@ -8,7 +8,6 @@
 
     <script src="../_assets/head.js"></script>
 
-
     <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/themes/light/main.css" />
     <script src="https://js.arcgis.com/4.12/"></script>
     <style>
@@ -61,7 +60,7 @@
         <div class="shell-container">
           <calcite-shell>
             <calcite-shell-panel slot="primary-panel" position="start">
-              <calcite-action-bar slot="action-bar" theme="dark">
+              <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
                 <calcite-action-group>
                   <calcite-action text="Add" icon="plus"> </calcite-action>
                   <calcite-action text="Save" disabled icon="save"> </calcite-action>
@@ -102,21 +101,21 @@
                 </calcite-block>
                 <calcite-block collapsible open heading="Another Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="Additional Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="More Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thang.</p>
                     </div>
                   </calcite-block-content>
@@ -210,7 +209,7 @@
         <h2>Dark Theme</h2>
 
         <div class="shell-container">
-          <calcite-shell theme="dark">
+          <calcite-shell class="calcite-theme-dark">
             <calcite-shell-panel slot="primary-panel" position="start">
               <calcite-action-pad hidden>
                 <calcite-action-group>
@@ -241,21 +240,21 @@
                 </calcite-block>
                 <calcite-block collapsible open heading="Another Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="Additional Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="More Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>

--- a/src/demos/shell/demo-app.html
+++ b/src/demos/shell/demo-app.html
@@ -8,7 +8,6 @@
 
     <script src="../_assets/head.js"></script>
 
-
     <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/themes/light/main.css" />
     <script src="https://js.arcgis.com/4.12/"></script>
     <style>
@@ -61,7 +60,7 @@
         <div class="shell-container">
           <calcite-shell>
             <calcite-shell-panel slot="primary-panel" position="start">
-              <calcite-action-bar slot="action-bar" theme="dark">
+              <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
                 <calcite-action-group>
                   <calcite-action text="Add" icon="plus"> </calcite-action>
                   <calcite-action text="Save" disabled icon="save"> </calcite-action>
@@ -102,21 +101,21 @@
                 </calcite-block>
                 <calcite-block collapsible open heading="Another Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="Additional Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="More Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thang.</p>
                     </div>
                   </calcite-block-content>
@@ -228,9 +227,7 @@
               </calcite-tip-group>
               <calcite-tip heading="Square Nature">
                 <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-                <p>
-                  This tip has an image that is square. And the text will run out before the end of the image.
-                </p>
+                <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
                 <p>In astronomy, the terms object and body are often used interchangeably.</p>
                 <p>
                   In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -241,9 +238,7 @@
                 <a href="http://www.esri.com">View Esri</a>
               </calcite-tip>
               <calcite-tip heading="The lack of imagery">
-                <p>
-                  This tip has no image. As such, the content area will take up the entire width of the tip.
-                </p>
+                <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
                 <p>
                   This is the next paragraph and should show how wide the content area is now. Of course, the width of
                   the overall tip will affect things. In astronomy, the terms object and body are often used
@@ -261,7 +256,7 @@
         <h2>Dark Theme</h2>
 
         <div class="shell-container">
-          <calcite-shell theme="dark">
+          <calcite-shell class="calcite-theme-dark">
             <calcite-shell-panel slot="primary-panel" position="start">
               <calcite-action-pad hidden>
                 <calcite-action-group>
@@ -292,21 +287,21 @@
                 </calcite-block>
                 <calcite-block collapsible open heading="Another Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="Additional Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-block collapsible open heading="More Block" summary="This is the primary.">
                   <calcite-block-content>
-                    <div style="height: 300px;">
+                    <div style="height: 300px">
                       <p>Cool thing.</p>
                     </div>
                   </calcite-block-content>

--- a/src/demos/shell/nesting-testing-flow.html
+++ b/src/demos/shell/nesting-testing-flow.html
@@ -57,7 +57,7 @@
       <div class="shell-container">
         <calcite-shell content-behind>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>

--- a/src/demos/shell/nesting-testing.html
+++ b/src/demos/shell/nesting-testing.html
@@ -57,7 +57,7 @@
       <div class="shell-container">
         <calcite-shell content-behind>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>
@@ -160,12 +160,7 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-block-section text="Section is cool">
@@ -187,34 +182,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -222,34 +202,19 @@
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-label scale="s">
                     It's a label.
                     <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>

--- a/src/demos/shell/panel-with-action-bar.html
+++ b/src/demos/shell/panel-with-action-bar.html
@@ -7,7 +7,6 @@
     <title>Calcite Components: calcite-shell-panel</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>

--- a/src/demos/shell/popup-config-example.html
+++ b/src/demos/shell/popup-config-example.html
@@ -57,7 +57,7 @@
       <div class="shell-container">
         <calcite-shell content-behind>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
-            <calcite-action-bar slot="action-bar" theme="dark">
+            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>
@@ -205,8 +205,8 @@
                       <span slot="notice-message">Enable pop-ups to add images, charts, text, and fields.</span>
                     </calcite-notice>
                   </div> -->
-                  <!-- <calcite-sortable-list> -->
-                <calcite-block drag-handle heading="Media" summary="Multiple (2)" collapsible >
+                <!-- <calcite-sortable-list> -->
+                <calcite-block drag-handle heading="Media" summary="Multiple (2)" collapsible>
                   <calcite-icon icon="images" scale="m" slot="icon"></calcite-icon>
                   <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
                   <calcite-label scale="s">
@@ -239,8 +239,8 @@
                     </calcite-value-list-item>
                   </calcite-value-list>
                 </calcite-block>
-               
-                <calcite-block drag-handle heading="Fields list" summary="12/13 fields" collapsible  >
+
+                <calcite-block drag-handle heading="Fields list" summary="12/13 fields" collapsible>
                   <calcite-icon icon="feature-details" scale="m" slot="icon"></calcite-icon>
                   <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
                   <calcite-label scale="s">
@@ -285,12 +285,12 @@
                       <calcite-action icon="x" slot="actions-end" label="remove"></calcite-action>
                     </calcite-value-list-item>
                   </calcite-value-list>
-                </calcite-block> 
-                <calcite-block drag-handle heading="Text" summary="The trending population in this..." collapsible  >
-                    <calcite-icon icon="text" scale="m" slot="icon"></calcite-icon>
-                    <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
                 </calcite-block>
-            <!-- </calcite-sortable-list> -->
+                <calcite-block drag-handle heading="Text" summary="The trending population in this..." collapsible>
+                  <calcite-icon icon="text" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
+                </calcite-block>
+                <!-- </calcite-sortable-list> -->
 
                 <calcite-fab
                   slot="fab"

--- a/src/demos/theme/auto.html
+++ b/src/demos/theme/auto.html
@@ -35,29 +35,34 @@
       }
     </style>
 
-<script>
-    require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList","esri/widgets/Zoom"], function(WebMap, MapView, LayerList, Zoom) {
-      const webmap = new WebMap({
-        portalItem: {
-          id: "cc316ca9e0824970ad29ac558161d42d"
-        }
-      });
-
-      const view = new MapView({
-        container: "viewDiv",
-        map: webmap
-      });
-      view.when(function() {
-        var layerList = new LayerList({
-          view: view,
-          selectionEnabled: true,
-          container: "layerlist-container"
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
         });
 
-        view.ui.move("zoom", "bottom-right");
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap
+        });
+        view.when(function () {
+          var layerList = new LayerList({
+            view: view,
+            selectionEnabled: true,
+            container: "layerlist-container"
+          });
+
+          view.ui.move("zoom", "bottom-right");
+        });
       });
-    });
-  </script>
+    </script>
   </head>
   <body class="calcite-theme-auto">
     <main>
@@ -66,22 +71,15 @@
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
-                <calcite-action text="Save" icon="save" indicator>
-                </calcite-action>
-                <calcite-action text-enabled icon="map" text="New" slot="menu-actions">
-                </calcite-action>
-                <calcite-action text-enabled icon="collection" text="Open" slot="menu-actions">
-                </calcite-action>
-            </calcite-action-group>
-            <calcite-action-group>
-                <calcite-action icon="layers" text="Layers" active>
-                </calcite-action>
-                <calcite-action icon="basemap" text="Basemaps">
-                </calcite-action>
-                <calcite-action icon="legend" text="Legend">
-                </calcite-action>
-                <calcite-action icon="bookmark" text="Bookmarks">
-                </calcite-action>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action text-enabled icon="map" text="New" slot="menu-actions"> </calcite-action>
+                <calcite-action text-enabled icon="collection" text="Open" slot="menu-actions"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers" active> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action text="Share" icon="share"></calcite-action>
@@ -92,22 +90,25 @@
                 <calcite-action text="What's next" icon="mega-phone"></calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
-              <calcite-panel heading="Layers" height-scale="l" width-scale="m">
-                  <div id="layerlist-container"></div>
-                  <calcite-fab slot="fab" id="layer-fab" text="Add layers"></calcite-fab>
-                  <calcite-tooltip label="tooltip" reference-element="layer-fab" disable-pointer>Add layers</calcite-tooltip>
-              </calcite-panel>
+            <calcite-panel heading="Layers" height-scale="l" width-scale="m">
+              <div id="layerlist-container"></div>
+              <calcite-fab slot="fab" id="layer-fab" text="Add layers"></calcite-fab>
+              <calcite-tooltip label="tooltip" reference-element="layer-fab" disable-pointer
+                >Add layers</calcite-tooltip
+              >
+            </calcite-panel>
           </calcite-shell-panel>
 
           <calcite-shell-panel slot="contextual-panel" position="end">
             <calcite-action-bar slot="action-bar">
-              <calcite-tooltip slot="expand-tooltip" label="tooltip"  disable-pointer>Add layers</calcite-tooltip>
+              <calcite-tooltip slot="expand-tooltip" label="tooltip" disable-pointer>Add layers</calcite-tooltip>
               <calcite-action-group>
                 <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
                 <calcite-action text="Styles" icon="shapes"> </calcite-action>
                 <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
                 <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
-                <calcite-action text-enabled text="Configure attributes" icon="feature-details" slot="menu-actions"> </calcite-action>
+                <calcite-action text-enabled text="Configure attributes" icon="feature-details" slot="menu-actions">
+                </calcite-action>
                 <calcite-action text-enabled text="Labels" icon="label" slot="menu-actions"> </calcite-action>
                 <calcite-action text-enabled text="Tablew" icon="table" slot="menu-actions"> </calcite-action>
               </calcite-action-group>
@@ -116,7 +117,13 @@
                 <calcite-action icon="measure" text="Measure"></calcite-action>
                 <calcite-action text-enabled icon="road-sign" text="Directions" slot="menu-actions"></calcite-action>
                 <calcite-action text-enabled icon="point" text="Location" slot="menu-actions"></calcite-action>
-                <calcite-action text-enabled icon="pencil-square" text="Edit" disabled slot="menu-actions"></calcite-action>
+                <calcite-action
+                  text-enabled
+                  icon="pencil-square"
+                  text="Edit"
+                  disabled
+                  slot="menu-actions"
+                ></calcite-action>
                 <calcite-action text-enabled icon="clock" text="Time" disabled slot="menu-actions"></calcite-action>
               </calcite-action-group>
               <calcite-action-group slot="bottom-actions">
@@ -131,25 +138,21 @@
                 summary="Popular Demographics in the United States (Beta) - County"
                 width-scale="m"
               >
-              <calcite-action slot="header-actions-end" icon="x" text="Close">
-              </calcite-action>
+                <calcite-action slot="header-actions-end" icon="x" text="Close"> </calcite-action>
 
-                <calcite-block heading="Title"  summary="County: {NAME}" collapsible>
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action label="code icon" class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="Title" summary="County: {NAME}" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">County: {NAME}</button>
+                      <calcite-action label="code icon" class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
                 <calcite-sortable-list>
                   <calcite-block drag-handle heading="Attributes" summary="2/98" collapsible>
                     <calcite-icon icon="feature-details" scale="m" slot="icon"></calcite-icon>
                     <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    </calcite-button>
                     <calcite-value-list drag-enabled>
                       <calcite-value-list-item
                         label="2018 Total Households (Esri)"
@@ -163,7 +166,9 @@
                       ></calcite-value-list-item>
                     </calcite-value-list>
                     <div class="row">
-                        <calcite-button id="attribute-add" round icon="plus" scale="s" width="full" color="neutral">Select attributes</calcite-button>
+                      <calcite-button id="attribute-add" round icon="plus" scale="s" width="full" color="neutral"
+                        >Select attributes</calcite-button
+                      >
                     </div>
                   </calcite-block>
                   <calcite-block drag-handle heading="Image" collapsible>
@@ -172,26 +177,26 @@
                     <section class="form-section">
                       <label>
                         URL
-                        <input type="text" value="https://ca-times.brightspotcdn.com/dims4/default/"/>
+                        <input type="text" value="https://ca-times.brightspotcdn.com/dims4/default/" />
                       </label>
                     </section>
                     <calcite-block-section text="Options">
                       <section class="form-section">
                         <label>
                           Title
-                          <input type="text" placeholder="My cool title"/>
+                          <input type="text" placeholder="My cool title" />
                         </label>
                         <label>
                           Caption
-                          <input type="text" placeholder="My cool caption"/>
+                          <input type="text" placeholder="My cool caption" />
                         </label>
                         <label>
                           State
                           <select placeholder="My cool caption">
-                          <option value="Denial">Denial</option>
-                          <option value="Grace">Grace</option>
-                          <option value="Confusion">Confusion</option>
-                        </select>
+                            <option value="Denial">Denial</option>
+                            <option value="Grace">Grace</option>
+                            <option value="Confusion">Confusion</option>
+                          </select>
                         </label>
                       </section>
                     </calcite-block-section>
@@ -199,19 +204,19 @@
                       <section class="form-section">
                         <label>
                           Title
-                          <input type="text" placeholder="My cool title"/>
+                          <input type="text" placeholder="My cool title" />
                         </label>
                         <label>
                           Caption
-                          <input type="text" placeholder="My cool caption"/>
+                          <input type="text" placeholder="My cool caption" />
                         </label>
                         <label>
                           State
                           <select placeholder="My cool caption">
-                          <option value="Denial">Denial</option>
-                          <option value="Grace">Grace</option>
-                          <option value="Confusion">Confusion</option>
-                        </select>
+                            <option value="Denial">Denial</option>
+                            <option value="Grace">Grace</option>
+                            <option value="Confusion">Confusion</option>
+                          </select>
                         </label>
                       </section>
                     </calcite-block-section>
@@ -219,7 +224,9 @@
                   <calcite-block drag-handle heading="Text" summary="Cool. he {expression/..." collapsible>
                     <calcite-icon icon="image" scale="m" slot="icon"></calcite-icon>
                     <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <button class="multiline-button">Cool. he {expression/expr1} population is {expression/expr2}%...</button>
+                    <button class="multiline-button">
+                      Cool. he {expression/expr1} population is {expression/expr2}%...
+                    </button>
                   </calcite-block>
                 </calcite-sortable-list>
                 <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
@@ -230,7 +237,7 @@
             </calcite-flow>
           </calcite-shell-panel>
           <div class="gnav" slot="header">
-              <h2>Boomer v Millennial - California</h2>
+            <h2>Boomer v Millennial - California</h2>
           </div>
           <calcite-tip-manager slot="center-row" id="tip-manager" hidden>
             <calcite-tip-group group-title="Astronomy">
@@ -259,9 +266,7 @@
             </calcite-tip-group>
             <calcite-tip heading="Square Nature">
               <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is square. And the text will run out before the end of the image.
-              </p>
+              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
               <p>
                 In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -272,9 +277,7 @@
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
             <calcite-tip heading="The lack of imagery">
-              <p>
-                This tip has no image. As such, the content area will take up the entire width of the tip.
-              </p>
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
               <p>
                 This is the next paragraph and should show how wide the content area is now. Of course, the width of the
                 overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
@@ -287,7 +290,13 @@
           <footer slot="footer">Footer</footer>
         </calcite-shell>
       </div>
-      <calcite-popover label="right start popover" placement="right-start" reference-element="action-pad-button" add-click-handle class="popover">
+      <calcite-popover
+        label="right start popover"
+        placement="right-start"
+        reference-element="action-pad-button"
+        add-click-handle
+        class="popover"
+      >
         <calcite-panel>
           <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
           <calcite-pick-list filter-enabled filter-sticky>
@@ -306,10 +315,7 @@
               label="about starvation and the food that Live Aid bought"
               value="3"
             ></calcite-pick-list-item>
-            <calcite-pick-list-item
-              label="about disease, baby rock, Hudson, rock,"
-              value="4"
-            ></calcite-pick-list-item>
+            <calcite-pick-list-item label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
           </calcite-pick-list>
           <calcite-button slot="footer" width="half">Yeah!</calcite-button>
           <calcite-button slot="footer" width="half" appearance="clear">Naw.</calcite-button>
@@ -318,7 +324,7 @@
       <script>
         const tipManagerButton = document.getElementById("tip-manager-button");
         const tipManager = document.getElementById("tip-manager");
-        tipManagerButton.addEventListener("click", function() {
+        tipManagerButton.addEventListener("click", function () {
           tipManager.hasAttribute("hidden")
             ? tipManager.removeAttribute("hidden")
             : tipManager.setAttribute("hidden", "");

--- a/src/demos/tip-manager/basic.html
+++ b/src/demos/tip-manager/basic.html
@@ -6,7 +6,6 @@
     <title>Calcite Components: calcite-tip-manager</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>
@@ -32,18 +31,14 @@
             </calcite-tip>
             <calcite-tip heading="The Long Trees">
               <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is a pretty tall. And the text will run out before the end of the image.
-              </p>
+              <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
           </calcite-tip-group>
           <calcite-tip heading="Square Nature">
             <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-            <p>
-              This tip has an image that is square. And the text will run out before the end of the image.
-            </p>
+            <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
             <p>In astronomy, the terms object and body are often used interchangeably.</p>
             <p>
               In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -54,9 +49,7 @@
             <a href="http://www.esri.com">View Esri</a>
           </calcite-tip>
           <calcite-tip heading="The lack of imagery">
-            <p>
-              This tip has no image. As such, the content area will take up the entire width of the tip.
-            </p>
+            <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
             <p>
               This is the next paragraph and should show how wide the content area is now. Of course, the width of the
               overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
@@ -111,9 +104,7 @@
             </calcite-tip-group>
             <calcite-tip heading="Square Nature">
               <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is square. And the text will run out before the end of the image.
-              </p>
+              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
               <p>
                 In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
@@ -124,9 +115,7 @@
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
             <calcite-tip heading="The lack of imagery">
-              <p>
-                This tip has no image. As such, the content area will take up the entire width of the tip.
-              </p>
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
               <p>
                 This is the next paragraph and should show how wide the content area is now. Of course, the width of the
                 overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.

--- a/src/demos/tip/basic.html
+++ b/src/demos/tip/basic.html
@@ -6,7 +6,6 @@
     <title>Calcite Components: calcite-tip</title>
 
     <script src="../_assets/head.js"></script>
-
   </head>
 
   <body>
@@ -22,9 +21,7 @@
               This tip is how a tip should really look. It has a landscape or square image and a small amount of text
               content. This paragraph is in an "info" slot.
             </p>
-            <p>
-              This is another paragraph in a subsequent "info" slot.
-            </p>
+            <p>This is another paragraph in a subsequent "info" slot.</p>
             <a href="http://www.esri.com">This is a link.</a>
           </calcite-tip>
         </div>
@@ -32,9 +29,7 @@
         <h2>With no thumbnail</h2>
         <div>
           <calcite-tip heading="Celestial Bodies">
-            <p>
-              This tip has no image. As such, the content area will take up the entire width of the tip.
-            </p>
+            <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
             <p>
               This is the next paragraph and should show how wide the content area is now. Of course, the width of the
               overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
@@ -46,12 +41,8 @@
         <div>
           <calcite-tip>
             <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
-            <p>
-              This tip is how a tip should appear without a dismissible button as well as without a heading.
-            </p>
-            <p>
-              This is another paragraph in a subsequent "info" slot.
-            </p>
+            <p>This tip is how a tip should appear without a dismissible button as well as without a heading.</p>
+            <p>This is another paragraph in a subsequent "info" slot.</p>
             <a href="http://www.esri.com">This is a link.</a>
           </calcite-tip>
         </div>
@@ -59,12 +50,8 @@
         <div>
           <calcite-tip non-dismissible>
             <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
-            <p>
-              This tip is how a tip should appear without a dismissible button as well as without a heading.
-            </p>
-            <p>
-              This is another paragraph in a subsequent "info" slot.
-            </p>
+            <p>This tip is how a tip should appear without a dismissible button as well as without a heading.</p>
+            <p>This is another paragraph in a subsequent "info" slot.</p>
             <a href="http://www.esri.com">This is a link.</a>
           </calcite-tip>
         </div>
@@ -73,9 +60,7 @@
         <div dir="rtl">
           <calcite-tip heading="Celestial Bodies">
             <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
-            <p>
-              This tip has an image that is a pretty tall. And the text will run out before the end of the image.
-            </p>
+            <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
             <p>In astronomy, the terms object and body are often used interchangeably.</p>
             <a href="http://www.esri.com">View Esri</a>
           </calcite-tip>

--- a/src/demos/value-list/advanced.html
+++ b/src/demos/value-list/advanced.html
@@ -5,11 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Demos - ValueList</title>
     <script src="../_assets/head.js"></script>
-
   </head>
   <body>
     <main>
-      <section class="example-container" style="width: 28vw; margin-top: 2em;">
+      <section class="example-container" style="width: 28vw; margin-top: 2em">
         <h1>calcite-value-list</h1>
 
         <style>
@@ -26,11 +25,7 @@
         <h3>multiple</h3>
         <calcite-value-list id="one" multiple filter-enabled>
           <calcite-action slot="menu-actions" indicator text="Cool" icon="hamburger"> </calcite-action>
-          <calcite-value-list-item
-            label="2018 Population Density (Esri)"
-            description="{POPDENS_CY}"
-            value="POPDENS_CY"
-          >
+          <calcite-value-list-item label="2018 Population Density (Esri)" description="{POPDENS_CY}" value="POPDENS_CY">
             <calcite-action
               slot="actions-end"
               id="action-test"
@@ -54,11 +49,7 @@
             >
             </calcite-action>
           </calcite-value-list-item>
-          <calcite-value-list-item
-            label="2018 Total Households (Esri)"
-            description="{TOTHH_CY}"
-            value="TOTHH_CY"
-          >
+          <calcite-value-list-item label="2018 Total Households (Esri)" description="{TOTHH_CY}" value="TOTHH_CY">
             <calcite-action
               slot="actions-end"
               id="action-test"
@@ -137,10 +128,7 @@
         </script>
         <h3>No description</h3>
         <calcite-value-list id="three" label-editing-enabled>
-          <calcite-value-list-item
-            label="2018 Generation Alpha Population (Born 2017 or Later)"
-            value="GENALPHACY"
-          >
+          <calcite-value-list-item label="2018 Generation Alpha Population (Born 2017 or Later)" value="GENALPHACY">
             <calcite-action
               slot="actions-end"
               id="action-test"

--- a/src/demos/value-list/basic.html
+++ b/src/demos/value-list/basic.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Demos - ValueList</title>
     <script src="../_assets/head.js"></script>
-
   </head>
   <body>
     <main>
@@ -15,8 +14,7 @@
         <h3>multiple</h3>
         <calcite-value-list id="one" multiple filter-enabled>
           <calcite-action slot="menu-actions" indicator text="Cool" scale="s" icon="hamburger"> </calcite-action>
-          <calcite-value-list-item
-            label="START ACTIONS NESTED SLOT" description="Man's best friend" value="dogs">
+          <calcite-value-list-item label="START ACTIONS NESTED SLOT" description="Man's best friend" value="dogs">
             <calcite-action slot="actions-start" text="click-me" onClick="console.log('clicked');" icon="banana">
             </calcite-action>
             <calcite-action slot="actions-start" text="click-me" onClick="console.log('clicked');" icon="banana">
@@ -24,9 +22,7 @@
             <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="sliders">
             </calcite-action>
           </calcite-value-list-item>
-          <calcite-value-list-item
-            disable-select label="Cats" description="Independent and fluffy" value="cats" >
-
+          <calcite-value-list-item disable-select label="Cats" description="Independent and fluffy" value="cats">
             <calcite-action label="action start" slot="actions-start" scale="m">
               <div style="align-self: center; width: 16px; height: 16px; background-color: #56ccf2"></div>
             </calcite-action>
@@ -36,10 +32,10 @@
             label="Fish. But not just any fish, a tiger fish caught live in the Atlantic Ocean while on vacation."
             description="Easy to care for."
             value="fish"
-           >
-           <calcite-action label="action start" slot="actions-start" scale="m">
-            <div style="align-self: center; width: 16px; height: 16px; background-color: #990000"></div>
-          </calcite-action>
+          >
+            <calcite-action label="action start" slot="actions-start" scale="m">
+              <div style="align-self: center; width: 16px; height: 16px; background-color: #990000"></div>
+            </calcite-action>
           </calcite-value-list-item>
         </calcite-value-list>
 
@@ -47,14 +43,9 @@
         <h3>Pick many</h3>
         <calcite-value-list id="two" multiple filter-enabled>
           <calcite-value-list-item label="Toughness" description="Hard to damage" value="toughness" removable>
-
           </calcite-value-list-item>
-          <calcite-value-list-item label="Athletics" value="athletics" removable>
-
-          </calcite-value-list-item>
-          <calcite-value-list-item label="Investigation" value="investigation" removable>
-
-          </calcite-value-list-item>
+          <calcite-value-list-item label="Athletics" value="athletics" removable> </calcite-value-list-item>
+          <calcite-value-list-item label="Investigation" value="investigation" removable> </calcite-value-list-item>
         </calcite-value-list>
 
         <h2>ValueList - drag and drop enabled</h2>
@@ -62,11 +53,10 @@
         <calcite-value-list id="four" drag-enabled>
           <calcite-value-list-item label="Rent" description="Mortgage + housing costs" value="rent">
             <calcite-action label="action start" slot="actions-start" scale="m">
-              <div style="align-self: center; width: 16px; height: 16px; background-color: #56CCF2;"></div>
-          </calcite-action>
+              <div style="align-self: center; width: 16px; height: 16px; background-color: #56ccf2"></div>
+            </calcite-action>
           </calcite-value-list-item>
-          <calcite-value-list-item label="Food" description="its what you eat." value="food">
-          </calcite-value-list-item>
+          <calcite-value-list-item label="Food" description="its what you eat." value="food"> </calcite-value-list-item>
           <calcite-value-list-item label="Utilities" value="utilities"> </calcite-value-list-item>
           <calcite-value-list-item label="Entertainment" description="Toys and leisure" value="entertainment">
           </calcite-value-list-item>

--- a/src/demos/value-list/double-action.html
+++ b/src/demos/value-list/double-action.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Demos - ValueList</title>
     <script src="../_assets/head.js"></script>
-
   </head>
   <body>
     <main>

--- a/src/demos/value-list/value-update.html
+++ b/src/demos/value-list/value-update.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Demos - ValueList</title>
     <script src="../_assets/head.js"></script>
-
   </head>
   <body>
     <main>

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
         margin-top: 2rem;
       }
     </style>
-   <script src="demos/_assets/head.js"></script>
+    <script src="demos/_assets/head.js"></script>
   </head>
 
   <body>
@@ -366,7 +366,7 @@
       </div>
     </div>
 
-    <div class="demo demo-background-dark" theme="dark">
+    <div class="demo demo-background-dark calcite-theme-dark">
       <div class="demo-column">
         <calcite-accordion>
           <calcite-accordion-item item-title="Accordion Item"
@@ -521,7 +521,7 @@
       </div>
     </div>
 
-    <div class="demo demo-background-dark" theme="dark">
+    <div class="demo demo-background-dark calcite-theme-dark">
       <div class="demo-column">
         <calcite-stepper numbered="zom" icon="zar">
           <calcite-stepper-item item-title="Choose method" complete>


### PR DESCRIPTION
**Related Issue:** #2262

## Summary

Docs: remove theme attribute from demo html.

Runs prettier on HTML and fixes HTML errors. Adds prettier task to cleanup HTML.
