### PR TITLE
fix(popover): add forceUpdate to ensure Action is available for setFocus

### DIFF
--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -3,6 +3,7 @@ import {
   Element,
   Event,
   EventEmitter,
+  forceUpdate,
   Host,
   Method,
   Prop,
@@ -216,8 +217,12 @@ export class CalcitePopover {
 
   @Method()
   async setFocus(focusId?: PopoverFocusId): Promise<void> {
-    if (focusId === "close-button") {
-      this.closeButtonEl?.focus();
+    const { closeButtonEl } = this;
+
+    if (focusId === "close-button" && closeButtonEl) {
+      forceUpdate(closeButtonEl);
+      closeButtonEl.setFocus();
+
       return;
     }
 


### PR DESCRIPTION


**Related Issue:** #2130

## Summary
Fixes setFocus method of Popover.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
