### PR TITLE
fix(color-picker): handle hue scope when color is 000.

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -1178,5 +1178,18 @@ describe("calcite-color-picker", () => {
       await scopes[1].press("ArrowUp");
       expect(await picker.getProperty("value")).toBe("#007ec2");
     });
+
+    it("positions the scope correctly when the color is 000", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-color-picker value="#000"></calcite-color-picker>`
+      });
+
+      const [, hueSliderScope] = await page.findAll(`calcite-color-picker >>> .${CSS.scope}`);
+
+      expect(await hueSliderScope.getComputedStyle()).toMatchObject({
+        top: "157px",
+        left: "0px"
+      });
+    });
   });
 });

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -674,8 +674,8 @@ export class CalciteColorPicker {
         slider: { height: sliderHeight }
       }
     } = this;
-    const hueTop = hueScopeTop || sliderHeight / 2 + colorFieldHeight;
-    const hueLeft = hueScopeLeft || (colorFieldWidth * DEFAULT_COLOR.hue()) / HSV_LIMITS.h;
+    const hueTop = hueScopeTop ?? sliderHeight / 2 + colorFieldHeight;
+    const hueLeft = hueScopeLeft ?? (colorFieldWidth * DEFAULT_COLOR.hue()) / HSV_LIMITS.h;
     const elementDir = getElementDir(el);
     const noColor = color === null;
     const vertical = scopeOrientation === "vertical";


### PR DESCRIPTION
**Related Issue:** #2230 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Tweaks fallback logic for positioning the hue slider scopes.