### PR TITLE
refactor(popover)!: Renames 'closeButton' property to be 'dismissible'. #2223

### DIFF
--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -66,7 +66,7 @@ describe("calcite-popover", () => {
         defaultValue: false
       },
       {
-        propertyName: "closeButton",
+        propertyName: "dismissible",
         defaultValue: false
       },
       {
@@ -166,7 +166,7 @@ describe("calcite-popover", () => {
 
     const element = await page.find("calcite-popover");
 
-    element.setProperty("closeButton", true);
+    element.setProperty("dismissible", true);
 
     await page.waitForChanges();
 

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -54,7 +54,7 @@ export class CalcitePopover {
   /**
    * Display a close button within the Popover.
    */
-  @Prop({ reflect: true }) closeButton = false;
+  @Prop({ reflect: true }) dismissible = false;
 
   /**
    * Prevents flipping the popover's placement when it starts to overlap its reference element.
@@ -361,9 +361,9 @@ export class CalcitePopover {
   // --------------------------------------------------------------------------
 
   renderCloseButton(): VNode {
-    const { closeButton, intlClose } = this;
+    const { dismissible, intlClose } = this;
 
-    return closeButton ? (
+    return dismissible ? (
       <calcite-action
         class={CSS.closeButton}
         onClick={this.hide}


### PR DESCRIPTION
**Related Issue:** #2223

## Summary

refactor(popover)!: Renames 'closeButton' property to be 'dismissible'. #2223