### PR TITLE
fix(combobox): fix custom chip selection on blur

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -417,15 +417,17 @@ describe("calcite-combobox", () => {
             <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
             <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
           </calcite-combobox>
+          <button>OK</button>
         `
       );
       const chip = await page.find("calcite-combobox >>> calcite-chip");
       expect(chip).toBeNull();
 
       const input = await page.find("calcite-combobox >>> input");
+      const button = await page.find("button");
       await input.click();
-      await input.press("J");
-      await input.press("Tab");
+      await input.press("o");
+      await button.click();
       const chips = await page.findAll("calcite-combobox >>> calcite-chip");
       expect(chips.length).toBe(1);
     });

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -376,6 +376,10 @@ export class CalciteCombobox {
       return;
     }
 
+    if (this.allowCustomValues && this.text) {
+      this.addCustomChip(this.text);
+    }
+
     if (this.selectionMode === "single") {
       if (this.textInput) {
         this.textInput.value = "";
@@ -732,9 +736,6 @@ export class CalciteCombobox {
 
   comboboxBlurHandler = (event: FocusEvent): void => {
     this.setInactiveIfNotContained(event);
-    if (this.allowCustomValues && this.text) {
-      this.addCustomChip(this.text);
-    }
   };
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixing an issue with the combobox when you're using custom values, enter text, then select an item from the tags list. Also updated the test to behave more like an actual blur and used text that matches an existing option to cover this better.