### PR TITLE
fix(action-menu): Focus on the menu's trigger when a slotted action is clicked and the menu is closed

### DIFF
--- a/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
+++ b/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
@@ -193,5 +193,14 @@ describe("calcite-action-menu", () => {
     await page.waitForChanges();
 
     expect(await actionMenu.getProperty("open")).toBe(false);
+
+    const shadowFocusTargetSelector = `.${CSS.menuButton}`;
+    expect(
+      await page.$eval(
+        "calcite-action-menu",
+        (element: HTMLElement, selector: string) => element.shadowRoot.activeElement.matches(selector),
+        shadowFocusTargetSelector
+      )
+    ).toBe(true);
   });
 });

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -261,6 +261,7 @@ export class CalciteActionMenu {
 
   handleCalciteActionClick = (): void => {
     this.open = false;
+    this.setFocus();
   };
 
   menuButtonClick = (): void => {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

fix(action-menu): Focus on the menu's trigger when a slotted action is clicked and the menu is closed.

When an action in the `calcite-action-menu` is clicked, the menu is closed but now nothing is focused. This restores focus to the button that opened the menu when an action has been clicked and the menu is now closed.