### PR TITLE
fix(dropdown): fix processing of groups and items

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -10,7 +10,6 @@ import {
   VNode
 } from "@stencil/core";
 import { getElementDir, getElementProp } from "../../utils/dom";
-import { GroupRegistration, ItemRegistration } from "../calcite-dropdown/interfaces";
 import { SelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
 import { CSS } from "./resources";
@@ -55,25 +54,7 @@ export class CalciteDropdownGroup {
   /**
    * @internal
    */
-  @Event() calciteDropdownGroupRegister: EventEmitter<GroupRegistration>;
-
-  /**
-   * @internal
-   */
   @Event() calciteDropdownItemChange: EventEmitter;
-
-  // --------------------------------------------------------------------------
-  //
-  //  Private Methods
-  //
-  // --------------------------------------------------------------------------
-  setDropdownTitleRef = (node: HTMLSpanElement): void => {
-    this.titleEl = node;
-  };
-
-  setDropdownSeparatorRef = (node: HTMLDivElement): void => {
-    this.separatorEl = node;
-  };
 
   //--------------------------------------------------------------------------
   //
@@ -85,30 +66,17 @@ export class CalciteDropdownGroup {
     this.groupPosition = this.getGroupPosition();
   }
 
-  componentDidLoad(): void {
-    this.items = this.sortItems(this.items) as HTMLCalciteDropdownItemElement[];
-    this.calciteDropdownGroupRegister.emit({
-      items: this.items,
-      position: this.groupPosition,
-      group: this.el,
-      titleEl: this.titleEl,
-      separatorEl: this.separatorEl
-    });
-  }
-
   render(): VNode {
     const dir = getElementDir(this.el);
     const scale: Scale = this.scale || getElementProp(this.el, "scale", "m");
     const groupTitle = this.groupTitle ? (
-      <span aria-hidden="true" class="dropdown-title" ref={this.setDropdownTitleRef}>
+      <span aria-hidden="true" class="dropdown-title">
         {this.groupTitle}
       </span>
     ) : null;
 
     const dropdownSeparator =
-      this.groupPosition > 0 ? (
-        <div class="dropdown-separator" ref={this.setDropdownSeparatorRef} role="separator" />
-      ) : null;
+      this.groupPosition > 0 ? <div class="dropdown-separator" role="separator" /> : null;
 
     return (
       <Host role="menu">
@@ -136,23 +104,6 @@ export class CalciteDropdownGroup {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("calciteDropdownItemRegister") registerCalciteDropdownItem(
-    event: CustomEvent<ItemRegistration>
-  ): void {
-    const item = event.target as HTMLCalciteDropdownItemElement;
-
-    if (this.selectionMode === "none") {
-      item.active = false;
-    }
-
-    this.items.push({
-      item,
-      position: event.detail.position
-    });
-
-    event.stopPropagation();
-  }
-
   @Listen("calciteDropdownItemSelect") updateActiveItemOnChange(event: CustomEvent): void {
     this.requestedDropdownGroup = event.detail.requestedDropdownGroup;
     this.requestedDropdownItem = event.detail.requestedDropdownItem;
@@ -168,9 +119,6 @@ export class CalciteDropdownGroup {
   //
   //--------------------------------------------------------------------------
 
-  /** created list of dropdown items */
-  private items = [];
-
   /** position of group within a dropdown */
   private groupPosition: number;
 
@@ -179,10 +127,6 @@ export class CalciteDropdownGroup {
 
   /** the requested item */
   private requestedDropdownItem: HTMLCalciteDropdownItemElement;
-
-  private separatorEl: HTMLDivElement = null;
-
-  private titleEl: HTMLSpanElement = null;
 
   //--------------------------------------------------------------------------
   //
@@ -196,7 +140,4 @@ export class CalciteDropdownGroup {
       this.el
     );
   }
-
-  private sortItems = (items: any[]): any[] =>
-    items.sort((a, b) => a.position - b.position).map((a) => a.item);
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -11,7 +11,7 @@ import {
   VNode
 } from "@stencil/core";
 import { getAttributes, getElementDir, getElementProp } from "../../utils/dom";
-import { ItemKeyboardEvent, ItemRegistration } from "../calcite-dropdown/interfaces";
+import { ItemKeyboardEvent } from "../calcite-dropdown/interfaces";
 import { getKey } from "../../utils/key";
 import { FlipContext } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -66,9 +66,6 @@ export class CalciteDropdownItem {
   @Event() calciteDropdownItemKeyEvent: EventEmitter<ItemKeyboardEvent>;
 
   /** @internal */
-  @Event() calciteDropdownItemRegister: EventEmitter<ItemRegistration>;
-
-  /** @internal */
   @Event() calciteDropdownCloseRequest: EventEmitter;
   //--------------------------------------------------------------------------
   //
@@ -94,13 +91,6 @@ export class CalciteDropdownItem {
     if (this.selectionMode === "none") {
       this.active = false;
     }
-  }
-
-  componentWillLoad(): void {
-    this.itemPosition = this.getItemPosition();
-    this.calciteDropdownItemRegister.emit({
-      position: this.itemPosition
-    });
   }
 
   render(): VNode {
@@ -247,9 +237,6 @@ export class CalciteDropdownItem {
   //
   //--------------------------------------------------------------------------
 
-  /** position withing group */
-  private itemPosition: number;
-
   /** id of containing group */
   private parentDropdownGroupEl: HTMLCalciteDropdownGroupElement;
 
@@ -298,13 +285,5 @@ export class CalciteDropdownItem {
       requestedDropdownItem: this.el,
       requestedDropdownGroup: this.parentDropdownGroupEl
     });
-  }
-
-  private getItemPosition(): number {
-    const group = this.el.closest("calcite-dropdown-group") as HTMLCalciteDropdownGroupElement;
-
-    return group
-      ? Array.prototype.indexOf.call(group.querySelectorAll("calcite-dropdown-item"), this.el)
-      : 1;
   }
 }

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -1,6 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { HYDRATED_ATTR, accessible, defaults } from "../../tests/commonTests";
 import dedent from "dedent";
+import { html } from "../../tests/utils";
 
 describe("calcite-dropdown", () => {
   it("defaults", async () =>
@@ -618,28 +619,26 @@ describe("calcite-dropdown", () => {
     });
 
     it("control max items displayed", async () => {
-      const page = await newE2EPage();
-
       const maxItems = 7;
-
-      await page.setContent(`<calcite-dropdown max-items="${maxItems}">
-    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-    <calcite-dropdown-group group-title="First group">
-      <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
-    </calcite-dropdown-group>
-    <calcite-dropdown-group group-title="Second group">
-      <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-dropdown>`);
-      await page.waitForChanges();
+      const page = await newE2EPage({
+        html: html`<calcite-dropdown max-items="${maxItems}">
+          <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+          <calcite-dropdown-group group-title="First group">
+            <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
+          </calcite-dropdown-group>
+          <calcite-dropdown-group group-title="Second group">
+            <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>`
+      });
 
       const element = await page.find("calcite-dropdown");
       await element.click();
@@ -648,7 +647,7 @@ describe("calcite-dropdown", () => {
       const items = await page.findAll("calcite-dropdown-item");
 
       for (let i = 0; i < items.length; i++) {
-        expect(await items[i].isIntersectingViewport()).toBe(i <= maxItems);
+        expect(await items[i].isIntersectingViewport()).toBe(i <= maxItems - 1);
       }
     });
   });

--- a/src/components/calcite-dropdown/interfaces.ts
+++ b/src/components/calcite-dropdown/interfaces.ts
@@ -1,24 +1,7 @@
 import { PopperPlacement } from "../../utils/popper";
 
-export interface ItemRegistration {
-  position: number;
-}
-
 export interface ItemKeyboardEvent {
   keyboardEvent: KeyboardEvent;
-}
-
-export interface GroupRegistration {
-  items: HTMLCalciteDropdownItemElement[];
-  position: number;
-  group: HTMLCalciteDropdownGroupElement;
-  titleEl: HTMLSpanElement;
-  separatorEl: HTMLDivElement;
-}
-
-export interface RegisteredItem {
-  item: HTMLCalciteDropdownItemElement;
-  position: number;
 }
 
 export type DropdownPlacement = Extract<


### PR DESCRIPTION
**Related Issue:** #2268 #2026

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This refactors how items and groups are processed by the dropdown. It previously relied on events to register these elements, but these shouldn't be necessary because of [Stencil's lifecycle hierarchy](https://stenciljs.com/docs/component-lifecycle#lifecycle-hierarchy). 

The tests pass after refactoring and I also tested with the test case provided in #2026 (no more console error).