### PR TITLE
fix(combobox): in-progress custom values should get commited on blur or tab

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -448,8 +448,14 @@ describe("calcite-combobox", () => {
       await input.click();
       await input.press("o");
       await button.click();
-      const chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      let chips = await page.findAll("calcite-combobox >>> calcite-chip");
       expect(chips.length).toBe(1);
+
+      await input.click();
+      await input.press("z");
+      await input.press("Tab");
+      chips = await page.findAll("calcite-combobox >>> calcite-chip");
+      expect(chips.length).toBe(2);
     });
 
     it("should select known tag when input", async () => {

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -147,6 +147,9 @@ export class CalciteCombobox {
         this.activeChipIndex = -1;
         this.activeItemIndex = -1;
         this.active = false;
+        if (this.allowCustomValues && this.text) {
+          this.addCustomChip(this.text, true);
+        }
         break;
       case "ArrowLeft":
         this.previousChip();


### PR DESCRIPTION

## Summary

OK, last pr for this I swear. Was improving this test to cover both tab and click away blur and it revealed a bug where using tab key no longer entered the chip so I've addressed it here. 

FYI @driskull you were correct when you asked "Does this need a test?" in https://github.com/Esri/calcite-components/pull/2263 as the test only covered one of the two ways to tab away form the component.

Related prs: #2263 #2283