### PR TITLE
fix(tooltip-manager): Prevents closing prematurely for non-leaf nodes

### DIFF
--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -260,7 +260,7 @@ describe("calcite-tooltip-manager", () => {
     expect(await hoverTip.getProperty("open")).toBe(false);
 
     await page.$eval("#hoverRef", (elm: HTMLElement) => {
-      elm.dispatchEvent(new Event("mouseenter"));
+      elm.dispatchEvent(new Event("mouseover"));
     });
 
     await page.waitForTimeout(TOOLTIP_DELAY_MS);
@@ -313,7 +313,7 @@ describe("calcite-tooltip-manager", () => {
     expect(await hoverTip.getProperty("open")).toBe(false);
 
     await page.$eval("#hoverRef", (elm: HTMLElement) => {
-      elm.dispatchEvent(new Event("mouseenter"));
+      elm.dispatchEvent(new Event("mouseover"));
     });
 
     await page.waitForTimeout(TOOLTIP_DELAY_MS);

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS, MOUSE_THROTTLE_MS } from "../calcite-tooltip/resources";
+import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
@@ -267,8 +267,6 @@ describe("calcite-tooltip-manager", () => {
 
     await page.waitForChanges();
 
-    await page.waitForTimeout(MOUSE_THROTTLE_MS);
-
     expect(await focusTip.getProperty("open")).toBe(false);
 
     expect(await hoverTip.getProperty("open")).toBe(true);
@@ -309,8 +307,6 @@ describe("calcite-tooltip-manager", () => {
     await focusRef.focus();
 
     await page.waitForChanges();
-
-    await page.waitForTimeout(MOUSE_THROTTLE_MS);
 
     expect(await focusTip.getProperty("open")).toBe(true);
 

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
+import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS, MOUSE_THROTTLE_MS } from "../calcite-tooltip/resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
@@ -267,6 +267,8 @@ describe("calcite-tooltip-manager", () => {
 
     await page.waitForChanges();
 
+    await page.waitForTimeout(MOUSE_THROTTLE_MS);
+
     expect(await focusTip.getProperty("open")).toBe(false);
 
     expect(await hoverTip.getProperty("open")).toBe(true);
@@ -307,6 +309,8 @@ describe("calcite-tooltip-manager", () => {
     await focusRef.focus();
 
     await page.waitForChanges();
+
+    await page.waitForTimeout(MOUSE_THROTTLE_MS);
 
     expect(await focusTip.getProperty("open")).toBe(true);
 

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -2,6 +2,9 @@ import { Component, h, Listen, Prop, VNode, Element } from "@stencil/core";
 import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
 import { queryElementRoots } from "../../utils/dom";
 import { getKey } from "../../utils/key";
+import { throttle } from "lodash-es";
+
+const throttleFor60FpsInMs = 16;
 
 /**
  * @slot - A slot for adding elements that reference a 'calcite-tooltip' by the 'selector' property.
@@ -151,6 +154,8 @@ export class CalciteTooltipManager {
     this.hoverTooltip({ tooltip, value });
   };
 
+  hoverEventThrottled = throttle(this.hoverEvent, throttleFor60FpsInMs);
+
   focusEvent = (event: FocusEvent, value: boolean): void => {
     const tooltip = this.queryTooltip(event.target as HTMLElement);
 
@@ -190,14 +195,14 @@ export class CalciteTooltipManager {
     }
   }
 
-  @Listen("mouseenter", { capture: true })
+  @Listen("mouseover", { capture: true })
   mouseEnterShow(event: MouseEvent): void {
-    this.hoverEvent(event, true);
+    this.hoverEventThrottled(event, true);
   }
 
-  @Listen("mouseleave", { capture: true })
+  @Listen("mouseout", { capture: true })
   mouseLeaveHide(event: MouseEvent): void {
-    this.hoverEvent(event, false);
+    this.hoverEventThrottled(event, false);
   }
 
   @Listen("click", { capture: true })

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -1,12 +1,7 @@
 import { Component, h, Listen, Prop, VNode, Element } from "@stencil/core";
-import {
-  TOOLTIP_REFERENCE,
-  TOOLTIP_DELAY_MS,
-  MOUSE_THROTTLE_MS
-} from "../calcite-tooltip/resources";
+import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
 import { queryElementRoots } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-import { throttle } from "lodash-es";
 
 /**
  * @slot - A slot for adding elements that reference a 'calcite-tooltip' by the 'selector' property.
@@ -156,8 +151,6 @@ export class CalciteTooltipManager {
     this.hoverTooltip({ tooltip, value });
   };
 
-  hoverEventThrottled = throttle(this.hoverEvent, MOUSE_THROTTLE_MS);
-
   focusEvent = (event: FocusEvent, value: boolean): void => {
     const tooltip = this.queryTooltip(event.target as HTMLElement);
 
@@ -199,12 +192,12 @@ export class CalciteTooltipManager {
 
   @Listen("mouseover", { capture: true })
   mouseEnterShow(event: MouseEvent): void {
-    this.hoverEventThrottled(event, true);
+    this.hoverEvent(event, true);
   }
 
   @Listen("mouseout", { capture: true })
   mouseLeaveHide(event: MouseEvent): void {
-    this.hoverEventThrottled(event, false);
+    this.hoverEvent(event, false);
   }
 
   @Listen("click", { capture: true })

--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -1,10 +1,12 @@
 import { Component, h, Listen, Prop, VNode, Element } from "@stencil/core";
-import { TOOLTIP_REFERENCE, TOOLTIP_DELAY_MS } from "../calcite-tooltip/resources";
+import {
+  TOOLTIP_REFERENCE,
+  TOOLTIP_DELAY_MS,
+  MOUSE_THROTTLE_MS
+} from "../calcite-tooltip/resources";
 import { queryElementRoots } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 import { throttle } from "lodash-es";
-
-const throttleFor60FpsInMs = 16;
 
 /**
  * @slot - A slot for adding elements that reference a 'calcite-tooltip' by the 'selector' property.
@@ -154,7 +156,7 @@ export class CalciteTooltipManager {
     this.hoverTooltip({ tooltip, value });
   };
 
-  hoverEventThrottled = throttle(this.hoverEvent, throttleFor60FpsInMs);
+  hoverEventThrottled = throttle(this.hoverEvent, MOUSE_THROTTLE_MS);
 
   focusEvent = (event: FocusEvent, value: boolean): void => {
     const tooltip = this.queryTooltip(event.target as HTMLElement);

--- a/src/components/calcite-tooltip/resources.ts
+++ b/src/components/calcite-tooltip/resources.ts
@@ -4,6 +4,7 @@ export const CSS = {
 };
 
 export const TOOLTIP_DELAY_MS = 500;
+export const MOUSE_THROTTLE_MS = 16;
 
 export const TOOLTIP_REFERENCE = "data-calcite-tooltip-reference";
 export const ARIA_DESCRIBED_BY = "aria-describedby";

--- a/src/components/calcite-tooltip/resources.ts
+++ b/src/components/calcite-tooltip/resources.ts
@@ -4,7 +4,6 @@ export const CSS = {
 };
 
 export const TOOLTIP_DELAY_MS = 500;
-export const MOUSE_THROTTLE_MS = 16;
 
 export const TOOLTIP_REFERENCE = "data-calcite-tooltip-reference";
 export const ARIA_DESCRIBED_BY = "aria-describedby";

--- a/src/demos/calcite-tooltip.html
+++ b/src/demos/calcite-tooltip.html
@@ -105,7 +105,9 @@
       <section class="placements-container">
         <h2>Placements:</h2>
         <ol>
-          <li><calcite-button appearance="outline" id="tooltip-auto-ref">auto</calcite-button></li>
+          <li>
+            <calcite-button appearance="outline" id="tooltip-auto-ref"><span>auto</span></calcite-button>
+          </li>
           <li><calcite-button appearance="outline" id="tooltip-auto-start-ref">auto-start</calcite-button></li>
           <li><calcite-button appearance="outline" id="tooltip-auto-end-ref">auto-end</calcite-button></li>
           <li><calcite-button appearance="outline" id="tooltip-top-ref">top</calcite-button></li>


### PR DESCRIPTION
**Related Issue:** #2310

## Summary

fix(tooltip-manager): Prevents closing prematurely for non-leaf nodes #2310
