### PR TITLE
refactor(block-section): use CalciteLabel for toggle header

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.e2e.ts
+++ b/src/components/calcite-block-section/calcite-block-section.e2e.ts
@@ -135,12 +135,14 @@ describe("calcite-block-section", () => {
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
 
     await toggle.click();
+    await page.waitForChanges();
 
     expect(toggleSpy).toHaveReceivedEventTimes(1);
     expect(await element.getProperty("open")).toBe(true);
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
 
     await toggle.click();
+    await page.waitForChanges();
 
     expect(toggleSpy).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("open")).toBe(false);

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -65,7 +65,7 @@
     @apply pointer-events-none mx-1;
   }
   .status-icon {
-    @apply mx-1;
+    @apply mr-1;
   }
 }
 
@@ -87,6 +87,10 @@
 
     calcite-switch {
       @apply ml-0 mr-2;
+    }
+
+    .status-icon {
+      @apply mr-0 ml-1;
     }
   }
   .section-header {

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -113,6 +113,7 @@ export class CalciteBlockSection {
             [CSS.toggle]: true,
             [CSS.toggleSwitch]: true
           }}
+          onKeyDown={this.handleHeaderLabelKeyDown}
           title={toggleLabel}
         >
           <span class={CSS.toggleSwitchText}>{text}</span>

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -106,14 +106,13 @@ export class CalciteBlockSection {
 
     const headerNode =
       toggleDisplay === "switch" ? (
-        <label
+        <calcite-label
+          layout="inline-space-between"
           aria-label={toggleLabel}
           class={{
             [CSS.toggle]: true,
             [CSS.toggleSwitch]: true
           }}
-          onKeyDown={this.handleHeaderLabelKeyDown}
-          tabIndex={0}
           title={toggleLabel}
         >
           <span class={CSS.toggleSwitchText}>{text}</span>
@@ -121,9 +120,8 @@ export class CalciteBlockSection {
             onCalciteSwitchChange={this.toggleSection}
             scale="s"
             switched={open}
-            tabIndex={-1}
           />
-        </label>
+        </calcite-label>
       ) : (
         <button
           aria-label={toggleLabel}

--- a/src/components/calcite-link/calcite-link.scss
+++ b/src/components/calcite-link/calcite-link.scss
@@ -8,12 +8,12 @@
     rounded-none
     border-none
     font-inherit
-    cursor-pointer;
+    cursor-pointer
+    transition-default;
   text-decoration: none;
   line-height: inherit;
   font-size: inherit;
   -webkit-appearance: none;
-  transition: $transition;
   &:hover {
     text-decoration: none;
   }
@@ -28,8 +28,16 @@
   }
 }
 
+calcite-icon {
+  width: 1em;
+  height: 1em;
+  min-width: unset;
+  min-height: unset;
+}
+
 .calcite-link--icon {
-  transition: $transition;
+  @apply transition-default align-text-top;
+  margin-top: 0.125rem;
 }
 
 // disabled styles
@@ -37,8 +45,7 @@
   @apply pointer-events-none;
   span,
   a {
-    @apply pointer-events-none;
-    opacity: var(--calcite-ui-opacity-disabled);
+    @apply pointer-events-none opacity-disabled;
   }
 }
 // icon positioning and styles
@@ -75,19 +82,14 @@
     background-repeat: no-repeat, no-repeat;
     background-size: 0% 1px, 100% 1px;
     transition: all 0.15s ease-in-out, background-size 0.3s ease-in-out;
-  }
-  &:hover,
-  &:focus {
-    //FIXME: Should these 2 also use text-color-link?
-    color: var(--calcite-ui-brand);
-    background-size: 100% 1px, 100% 1px;
-    & .calcite-link--icon {
-      fill: var(--calcite-ui-brand);
+
+    &:hover,
+    &:focus {
+      background-size: 100% 1px, 100% 1px;
     }
-  }
-  &:active {
-    @apply text-color-link;
-    background-size: 100% 2px, 100% 2px;
+    &:active {
+      background-size: 100% 2px, 100% 2px;
+    }
   }
 }
 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -48,6 +48,10 @@
   @apply focus-outset;
 }
 
+.container {
+  @apply flex;
+}
+
 .track {
   @apply relative 
     inline-block 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -8,7 +8,6 @@
   }
 }
 
-:host,
 :host([scale="m"]) {
   .track {
     @apply w-8 h-4;

--- a/src/demos/calcite-link.html
+++ b/src/demos/calcite-link.html
@@ -39,6 +39,17 @@
 
     <br />
 
+
+  <h3>Text sizes</h3>
+  <p style="font-size:10px"><calcite-link icon-start="information" icon-end="information-f">Link example text</calcite-link><br /></p>
+  <p style="font-size:12px"><calcite-link icon-start="information" icon-end="information-f">Link example text</calcite-link><br /></p>
+  <p style="font-size:14px"><calcite-link icon-start="information" icon-end="information-f">Link example text</calcite-link><br /></p>
+  <p style="font-size:16px"><calcite-link icon-start="information" icon-end="information-f">Link example text</calcite-link><br /></p>
+  <p style="font-size:18px"><calcite-link icon-start="information" icon-end="information-f">Link example text</calcite-link><br /></p>
+  <p style="font-size:20px"><calcite-link icon-start="information" icon-end="information-f">Link example text</calcite-link><br /></p>
+  <p style="font-size:16px"><calcite-link icon-start="information" icon-end="information">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry' 1.10.32. The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.</calcite-link><br /></p>
+
+
     <h3>Tooltip trigger</h3>
     <calcite-tooltip-manager>
       <calcite-link icon-start="information" id="tooltip-example">span to gain focus</calcite-link>


### PR DESCRIPTION
**Related Issue:** #2232

## Summary
Refactor to use our label component.
Includes a fix for Switch's vertical alignment issue.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
