### PR TITLE
test(input): skip unstable locale tests

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -739,7 +739,8 @@ describe("calcite-input", () => {
   });
 
   describe("number locale support", () => {
-    const localesWithIssues = ["ar", "bs", "mk"];
+    // "nb" and "es-MX" locales skipped per: https://github.com/Esri/calcite-components/issues/2323
+    const localesWithIssues = ["ar", "bs", "mk", "nb", "es-MX"];
     locales
       .filter((locale) => !localesWithIssues.includes(locale))
       .forEach((locale) => {


### PR DESCRIPTION
**Related Issue:** #2323

## Summary
Skips the tests per the issue. (Since it's testing programmatically I just added the problematic locales to be filtered out.)
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
