### PR TITLE
feat(combobox): tab complete of custom values comboboxes

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -447,13 +447,11 @@ describe("calcite-combobox", () => {
       const button = await page.find("button");
       await input.click();
       await input.press("o");
-      await button.click();
+      await input.press("Tab");
       let chips = await page.findAll("calcite-combobox >>> calcite-chip");
       expect(chips.length).toBe(1);
-
-      await input.click();
-      await input.press("z");
-      await input.press("Tab");
+      await input.press("j");
+      await button.click();
       chips = await page.findAll("calcite-combobox >>> calcite-chip");
       expect(chips.length).toBe(2);
     });

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -146,9 +146,12 @@ export class CalciteCombobox {
       case "Tab":
         this.activeChipIndex = -1;
         this.activeItemIndex = -1;
-        this.active = false;
         if (this.allowCustomValues && this.text) {
           this.addCustomChip(this.text, true);
+          event.preventDefault();
+          event.stopPropagation();
+        } else {
+          this.active = false;
         }
         break;
       case "ArrowLeft":


### PR DESCRIPTION
## Summary

Slight teak to keyboard handling for comboboxes. Tab will enter the current custom entry if available and leave focus on the combobox input. If there is no text tab acts normally.

/cc @capeoples 