### PR TITLE
feat(split-button): add width property, related styles, and doc 

### DIFF
--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -182,15 +182,13 @@ describe("calcite-split-button", () => {
     const container = await page.find(`calcite-split-button >>> .${CSS.widthAuto}`);
     expect(container).not.toBeNull();
     expect(container).toHaveClass(CSS.widthAuto);
-    
+
     element.setAttribute("width", "half");
     await page.waitForChanges();
     expect(container).toHaveClass(CSS.widthHalf);
-    
+
     element.setAttribute("width", "full");
     await page.waitForChanges();
     expect(container).toHaveClass(CSS.widthFull);
-
-    
   });
 });

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
+import { CSS } from "./resources";
 
 describe("calcite-split-button", () => {
   const content = `
@@ -58,6 +59,7 @@ describe("calcite-split-button", () => {
     expect(element).toEqualAttribute("scale", "m");
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("dropdown-icon-type", "chevron");
+    expect(element).toEqualAttribute("width", "auto");
   });
 
   it("renders requested props when valid props are provided", async () => {
@@ -69,6 +71,7 @@ describe("calcite-split-button", () => {
           dropdown-icon-type="caret"
           loading
           disabled
+          width="half"
           dropdown-label="more actions"
           primary-label="primary action">
       </calcite-split-button>`);
@@ -82,6 +85,7 @@ describe("calcite-split-button", () => {
     expect(element).toHaveAttribute("disabled");
     expect(primaryButton).toEqualAttribute("aria-label", "primary action");
     expect(dropdownButton).toEqualAttribute("aria-label", "more actions");
+    expect(element).toEqualAttribute("width", "half");
   });
 
   it("renders primaryText without icons as inner content of primary button", async () => {
@@ -166,5 +170,27 @@ describe("calcite-split-button", () => {
     const dropdownButton = await page.find("calcite-split-button >>> calcite-dropdown calcite-button");
     expect(primaryButton).toEqualAttribute("split-child", "primary");
     expect(dropdownButton).toEqualAttribute("split-child", "secondary");
+  });
+
+  it("adds the relevant CSS class based on the width attribute", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-split-button width="auto"></calcite-split-button>`
+    );
+
+    const element = await page.find(`calcite-split-button`);
+    const container = await page.find(`calcite-split-button >>> .${CSS.widthAuto}`);
+    expect(container).not.toBeNull();
+    expect(container).toHaveClass(CSS.widthAuto);
+    
+    element.setAttribute("width", "half");
+    await page.waitForChanges();
+    expect(container).toHaveClass(CSS.widthHalf);
+    
+    element.setAttribute("width", "full");
+    await page.waitForChanges();
+    expect(container).toHaveClass(CSS.widthFull);
+
+    
   });
 });

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -174,9 +174,7 @@ describe("calcite-split-button", () => {
 
   it("adds the relevant CSS class based on the width attribute", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-split-button width="auto"></calcite-split-button>`
-    );
+    await page.setContent(`<calcite-split-button width="auto"></calcite-split-button>`);
 
     const element = await page.find(`calcite-split-button`);
     const container = await page.find(`calcite-split-button >>> .${CSS.widthAuto}`);

--- a/src/components/calcite-split-button/calcite-split-button.scss
+++ b/src/components/calcite-split-button/calcite-split-button.scss
@@ -66,6 +66,18 @@
   }
 }
 
+.width-auto {
+  @apply w-auto;
+}
+
+.width-half {
+  @apply w-1/2;
+}
+
+.width-full {
+  @apply w-full;
+}
+
 .split-button__divider-container {
   @apply w-px flex items-stretch;
   transition: 0.15s ease-in-out;

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -1,7 +1,8 @@
 import { Component, Element, Event, EventEmitter, h, Prop, VNode } from "@stencil/core";
+import { CSS } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { ButtonAppearance, ButtonColor, DropdownIconType } from "../calcite-button/interfaces";
-import { FlipContext, Scale } from "../interfaces";
+import { FlipContext, Scale, Width } from "../interfaces";
 
 @Component({
   tag: "calcite-split-button",
@@ -48,6 +49,9 @@ export class CalciteSplitButton {
   /** specify the scale of the control, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
 
+ /** specify the width of the button, defaults to auto */
+ @Prop({ reflect: true }) width: Width = "auto";
+
   /** fired when the primary button is clicked */
   @Event() calciteSplitButtonPrimaryClick: EventEmitter;
 
@@ -56,8 +60,16 @@ export class CalciteSplitButton {
 
   render(): VNode {
     const dir = getElementDir(this.el);
+    const widthClasses = {
+      [CSS.container]: true,
+      [CSS.widthAuto]: this.width === "auto",
+      [CSS.widthHalf]: this.width === "half",
+      [CSS.widthFull]: this.width === "full"
+    };
+    const buttonWidth = this.width === "auto" ? "auto" : "full";
+
     return (
-      <div class="split-button__container" dir={dir}>
+      <div class={widthClasses} dir={dir}>
         <calcite-button
           appearance={this.appearance}
           aria-label={this.primaryLabel}
@@ -71,11 +83,12 @@ export class CalciteSplitButton {
           onClick={this.calciteSplitButtonPrimaryClickHandler}
           scale={this.scale}
           splitChild={"primary"}
+          width={buttonWidth}
         >
           {this.primaryText}
         </calcite-button>
-        <div class="split-button__divider-container">
-          <div class="split-button__divider" />
+        <div class={CSS.dividerContainer}>
+          <div class={CSS.divider} />
         </div>
         <calcite-dropdown
           dir={dir}

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -49,8 +49,8 @@ export class CalciteSplitButton {
   /** specify the scale of the control, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
 
- /** specify the width of the button, defaults to auto */
- @Prop({ reflect: true }) width: Width = "auto";
+  /** specify the width of the button, defaults to auto */
+  @Prop({ reflect: true }) width: Width = "auto";
 
   /** fired when the primary button is clicked */
   @Event() calciteSplitButtonPrimaryClick: EventEmitter;

--- a/src/components/calcite-split-button/readme.md
+++ b/src/components/calcite-split-button/readme.md
@@ -34,6 +34,7 @@ The calcite-split-button control is one that combines a button with a dropdown m
 | `primaryLabel`       | `primary-label`         | optionally pass an aria-label for the primary button                                                     | `string`                                           | `undefined` |
 | `primaryText`        | `primary-text`          | text for primary action button                                                                           | `string`                                           | `undefined` |
 | `scale`              | `scale`                 | specify the scale of the control, defaults to m                                                          | `"l" \| "m" \| "s"`                                | `"m"`       |
+| `width`             | `width`                  | specify the width of the split button, defaults to auto                                                  | `"auto" \| "full" \| "half"`                       | `"auto"`       |
 
 ## Events
 

--- a/src/components/calcite-split-button/resources.ts
+++ b/src/components/calcite-split-button/resources.ts
@@ -1,0 +1,8 @@
+export const CSS = {
+    container: "split-button__container",
+    dividerContainer: "split-button__divider-container",
+    divider: "split-button__divider",
+    widthAuto: "width-auto",
+    widthHalf: "width-half",
+    widthFull: "width-full"
+};

--- a/src/components/calcite-split-button/resources.ts
+++ b/src/components/calcite-split-button/resources.ts
@@ -1,8 +1,8 @@
 export const CSS = {
-    container: "split-button__container",
-    dividerContainer: "split-button__divider-container",
-    divider: "split-button__divider",
-    widthAuto: "width-auto",
-    widthHalf: "width-half",
-    widthFull: "width-full"
+  container: "split-button__container",
+  dividerContainer: "split-button__divider-container",
+  divider: "split-button__divider",
+  widthAuto: "width-auto",
+  widthHalf: "width-half",
+  widthFull: "width-full"
 };


### PR DESCRIPTION
**Related Issue:** (#921)

## Summary
Adds a width property. Behavior and style match Button's width property.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
