### PR TITLE
docs(split-button): adds width to story

### DIFF
--- a/src/components/calcite-split-button/calcite-split-button.stories.ts
+++ b/src/components/calcite-split-button/calcite-split-button.stories.ts
@@ -13,44 +13,50 @@ export default {
 };
 
 export const Simple = (): string => html`
-  <calcite-split-button
-    appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
-    color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
-    scale="${select("size", ["s", "m", "l"], "m")}"
-    ${boolean("loading", false)}
-    ${boolean("disabled", false)}
-    primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
-    primary-text="${text("primary-text", "Primary Option")}"
-    primary-label="${text("primary-label", "Primary Option")}"
-    dropdown-label="${text("dropdown-label", "Additional Options")}"
-    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
-  >
-    <calcite-dropdown-group selection-mode="none">
-      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-split-button>
+  <div style="width:70vw;">
+    <calcite-split-button
+      appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
+      color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
+      scale="${select("size", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
+      primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
+      primary-text="${text("primary-text", "Primary Option")}"
+      primary-label="${text("primary-label", "Primary Option")}"
+      dropdown-label="${text("dropdown-label", "Additional Options")}"
+      dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+    >
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>
+  </div>
 `;
 
 export const SimplePrimaryIconEnd = (): string => html`
-  <calcite-split-button
-    color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
-    scale="${select("size", ["s", "m", "l"], "m")}"
-    ${boolean("loading", false)}
-    ${boolean("disabled", false)}
-    primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
-    primary-text="${text("primary-text", "Primary Option")}"
-    primary-label="${text("primary-label", "Primary Option")}"
-    dropdown-label="${text("dropdown-label", "Additional Options")}"
-    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
-  >
-    <calcite-dropdown-group selection-mode="none">
-      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-split-button>
+  <div style="width:70vw;">
+    <calcite-split-button
+      color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
+      scale="${select("size", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
+      primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
+      primary-text="${text("primary-text", "Primary Option")}"
+      primary-label="${text("primary-label", "Primary Option")}"
+      dropdown-label="${text("dropdown-label", "Additional Options")}"
+      dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+    >
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>
+  </div>
 `;
 
 SimplePrimaryIconEnd.story = {
@@ -58,24 +64,27 @@ SimplePrimaryIconEnd.story = {
 };
 
 export const SimplePrimaryIconStartAndPrimaryIconEnd = (): string => html`
-  <calcite-split-button
-    color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
-    scale="${select("size", ["s", "m", "l"], "m")}"
-    ${boolean("loading", false)}
-    ${boolean("disabled", false)}
-    primary-icon-start="${select("primary-icon-end", iconNames, iconNames[0])}"
-    primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
-    primary-text="${text("primary-text", "Primary Option")}"
-    primary-label="${text("primary-label", "Primary Option")}"
-    dropdown-label="${text("dropdown-label", "Additional Options")}"
-    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
-  >
-    <calcite-dropdown-group selection-mode="none">
-      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-split-button>
+  <div style="width:70vw;">
+    <calcite-split-button
+      color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
+      scale="${select("size", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
+      primary-icon-start="${select("primary-icon-end", iconNames, iconNames[0])}"
+      primary-icon-end="${select("primary-icon-end", iconNames, iconNames[0])}"
+      primary-text="${text("primary-text", "Primary Option")}"
+      primary-label="${text("primary-label", "Primary Option")}"
+      dropdown-label="${text("dropdown-label", "Additional Options")}"
+      dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+    >
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>
+  </div>
 `;
 
 SimplePrimaryIconStartAndPrimaryIconEnd.story = {
@@ -83,11 +92,12 @@ SimplePrimaryIconStartAndPrimaryIconEnd.story = {
 };
 
 export const Rtl = (): string => html`
-  <div dir="rtl">
+  <div dir="rtl" style="width:70vw;">
     <calcite-split-button
       appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
       color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
       scale="${select("size", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
       ${boolean("loading", false)}
       ${boolean("disabled", false)}
       primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
@@ -109,24 +119,27 @@ Rtl.story = {
 };
 
 export const DarkMode = (): string => html`
-  <calcite-split-button
-    appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
-    color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
-    scale="${select("size", ["s", "m", "l"], "m")}"
-    ${boolean("loading", false)}
-    ${boolean("disabled", false)}
-    primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
-    primary-text="${text("primary-text", "Primary Option")}"
-    dropdown-label="${text("dropdown-label", "Additional Options")}"
-    dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
-    class="calcite-theme-dark"
-  >
-    <calcite-dropdown-group selection-mode="none">
-      <calcite-dropdown-item>Option 2</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 3</calcite-dropdown-item>
-      <calcite-dropdown-item>Option 4</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-split-button>
+  <div style="width:70vw;">
+    <calcite-split-button
+      appearance="${select("appearance", ["solid", "outline", "clear", "transparent"], "solid")}"
+      color="${select("color", ["blue", "red", "neutral", "inverse"], "blue")}"
+      scale="${select("size", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      ${boolean("loading", false)}
+      ${boolean("disabled", false)}
+      primary-icon-start="${select("primary-icon-start", iconNames, iconNames[0])}"
+      primary-text="${text("primary-text", "Primary Option")}"
+      dropdown-label="${text("dropdown-label", "Additional Options")}"
+      dropdown-icon-type="${select("dropdown-icon-type", ["chevron", "caret", "ellipsis", "overflow"], "chevron")}"
+      class="calcite-theme-dark"
+    >
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item>Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item>Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>
+  </div>
 `;
 
 DarkMode.story = {


### PR DESCRIPTION
**Related Issue:** #921

## Summary
Adds `width` property to the story.
Adds a width style to a container div to make it easier to see what `width` does.
Spaced adding this in #2347.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
