### PR TITLE
refactor(calcite-dropdown): updated scale l icon size and font size to match figma

### DIFF
--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.scss
@@ -13,7 +13,7 @@
 }
 
 .container--l {
-  @apply text-1h;
+  @apply text-0h;
   .dropdown-title {
     @apply p-4;
   }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -7,7 +7,7 @@
 }
 
 .container--l {
-  @apply text-1h pr-4 pl-10 py-3;
+  @apply text-0h pr-4 pl-10 py-3;
 }
 
 // RTL

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -56,7 +56,7 @@
 }
 
 .dropdown-item-content {
-  @apply mr-auto;
+  @apply mr-auto ml-1;
 }
 
 .calcite--rtl .dropdown-item-content {
@@ -214,7 +214,7 @@
 // icon start & end
 .container--s {
   .dropdown-item-icon-start {
-    @apply mr-2;
+    @apply mr-2 ml-1;
   }
   .dropdown-item-icon-end {
     @apply ml-2;
@@ -223,7 +223,7 @@
 
 .container--m {
   .dropdown-item-icon-start {
-    @apply mr-3;
+    @apply mr-3 ml-1;
   }
   .dropdown-item-icon-end {
     @apply ml-3;
@@ -232,7 +232,7 @@
 
 .container--l {
   .dropdown-item-icon-start {
-    @apply mr-4;
+    @apply mr-4 ml-1;
   }
   .dropdown-item-icon-end {
     @apply ml-4;

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -39,7 +39,8 @@
     @apply absolute
       opacity-0
       duration-150
-      ease-in-out;
+      ease-in-out
+      text--2h;
     color: theme("borderColor.color.1");
   }
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -105,14 +105,13 @@ export class CalciteDropdownItem {
     ]);
     const dir = getElementDir(this.el);
     const scale = getElementProp(this.el, "scale", "m");
-    const iconScale = scale === "l" ? "m" : "s";
     const iconStartEl = (
       <calcite-icon
         class="dropdown-item-icon-start"
         dir={dir}
         flipRtl={this.iconFlipRtl === "start" || this.iconFlipRtl === "both"}
         icon={this.iconStart}
-        scale={iconScale}
+        scale="s"
       />
     );
     const contentNode = (
@@ -126,7 +125,7 @@ export class CalciteDropdownItem {
         dir={dir}
         flipRtl={this.iconFlipRtl === "end" || this.iconFlipRtl === "both"}
         icon={this.iconEnd}
-        scale={iconScale}
+        scale="s"
       />
     );
 

--- a/src/demos/calcite-dropdown.html
+++ b/src/demos/calcite-dropdown.html
@@ -108,6 +108,36 @@
       </calcite-dropdown>
       <br />
       <br />
+
+      <h3>Dropdown scales + Icon start + Multi select</h3>
+
+      <calcite-dropdown scale="s" selection-mode="multi">
+        <calcite-button scale="s" slot="dropdown-trigger">Scale S small</calcite-button>
+        <calcite-dropdown-group group-title="View">
+          <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+          <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+          <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
+
+      <calcite-dropdown scale="m" selection-mode="multi">
+        <calcite-button scale="m" slot="dropdown-trigger">Scale M medium</calcite-button>
+        <calcite-dropdown-group group-title="View">
+          <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+          <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+          <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
+
+      <calcite-dropdown scale="l" selection-mode="multi">
+        <calcite-button color="neutral" scale="l" slot="dropdown-trigger">Scale L large</calcite-button>
+        <calcite-dropdown-group group-title="View">
+          <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
+          <calcite-dropdown-item icon-start="grid">Grid</calcite-dropdown-item>
+          <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
+
       <h3>Disabled dropdown</h3>
       <calcite-dropdown disabled>
         <calcite-button slot="dropdown-trigger">Disabled dropdown</calcite-button>


### PR DESCRIPTION
**Related Issue:** #2041

## Summary

- Updated scale L icon size to S
- Updated scale L font size to 1h
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
