### PR TITLE
fix(combobox): use normal pointer for input of single select combobox

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -70,7 +70,7 @@
 }
 
 .input--single {
-  @apply mb-0 mt-0 cursor-pointer p-0;
+  @apply mb-0 mt-0 p-0;
 }
 
 .wrapper--active .input-single {


### PR DESCRIPTION
## Summary

Text input for single select combobox was using a pointer cursor. This is inconsistent with all the other inputs, comboboxes, etc. This was probably a mistake when I added this mode.

