### PR TITLE
feat(notice): allow slotting action

### DIFF
--- a/src/components/calcite-notice/calcite-notice.e2e.ts
+++ b/src/components/calcite-notice/calcite-notice.e2e.ts
@@ -1,5 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, renders } from "../../tests/commonTests";
+import { accessible, focusable, renders } from "../../tests/commonTests";
+import { CSS, SLOTS } from "./calcite-notice.resources";
+import { html } from "../../tests/utils";
 
 describe("calcite-notice", () => {
   const noticeContent = `
@@ -26,8 +28,8 @@ describe("calcite-notice", () => {
     <calcite-link slot="link" href="">Action</calcite-link>
     </calcite-notice>`);
     const element = await page.find("calcite-notice");
-    const close = await page.find("calcite-notice >>> .notice-close");
-    const icon = await page.find("calcite-notice >>> .notice-icon");
+    const close = await page.find(`calcite-notice >>> .${CSS.close}`);
+    const icon = await page.find(`calcite-notice >>> .${CSS.icon}`);
     expect(element).toEqualAttribute("color", "blue");
     expect(close).toBeNull();
     expect(icon).toBeNull();
@@ -41,8 +43,8 @@ describe("calcite-notice", () => {
     </calcite-notice>`);
 
     const element = await page.find("calcite-notice");
-    const close = await page.find("calcite-notice >>> .notice-close");
-    const icon = await page.find("calcite-notice >>> .notice-icon");
+    const close = await page.find(`calcite-notice >>> .${CSS.close}`);
+    const icon = await page.find(`calcite-notice >>> .${CSS.icon}`);
 
     expect(element).toEqualAttribute("color", "yellow");
     expect(close).not.toBeNull();
@@ -56,8 +58,8 @@ describe("calcite-notice", () => {
     ${noticeContent}
     </calcite-notice>`);
 
-    const close = await page.find("calcite-notice >>> .notice-close");
-    const icon = await page.find("calcite-notice >>> .notice-icon");
+    const close = await page.find(`calcite-notice >>> .${CSS.close}`);
+    const icon = await page.find(`calcite-notice >>> .${CSS.icon}`);
     expect(close).not.toBeNull();
     expect(icon).not.toBeNull();
   });
@@ -71,7 +73,7 @@ describe("calcite-notice", () => {
     `);
 
     const notice1 = await page.find("#notice-1");
-    const noticeclose1 = await page.find("#notice-1 >>> .notice-close");
+    const noticeclose1 = await page.find(`#notice-1 >>> .${CSS.close}`);
     const animationDurationInMs = 400;
 
     expect(await notice1.isVisible()).toBe(true);
@@ -79,5 +81,18 @@ describe("calcite-notice", () => {
     await noticeclose1.click();
     await page.waitForTimeout(animationDurationInMs);
     expect(await notice1.isVisible()).not.toBe(true);
+  });
+
+  it("allows users to slot in a trailing action", async () => {
+    const page = await newE2EPage({
+      html: html` <calcite-notice active dismissible>
+        ${noticeContent}
+        <calcite-action label="banana" icon="banana" slot=${SLOTS.actionEnd}></calcite-action>
+      </calcite-notice>`
+    });
+
+    const actionAssignedSlot = await page.$eval("calcite-action", (action) => action.assignedSlot.name);
+
+    expect(actionAssignedSlot).toBe(SLOTS.actionEnd);
   });
 });

--- a/src/components/calcite-notice/calcite-notice.resources.ts
+++ b/src/components/calcite-notice/calcite-notice.resources.ts
@@ -5,5 +5,14 @@ export const TEXT = {
 export const SLOTS = {
   title: "title",
   message: "message",
-  link: "link"
+  link: "link",
+  actionEnd: "icon-end"
+};
+
+export const CSS = {
+  actionEnd: "action-end",
+  close: "notice-close",
+  container: "container",
+  content: "notice-content",
+  icon: "notice-icon"
 };

--- a/src/components/calcite-notice/calcite-notice.scss
+++ b/src/components/calcite-notice/calcite-notice.scss
@@ -81,12 +81,6 @@
   }
 }
 
-.calcite--rtl {
-  @apply text-right;
-  border-left: none;
-  border-right: 0px solid;
-}
-
 :host([active]) {
   @apply flex;
 }
@@ -137,17 +131,6 @@
   }
 }
 
-.calcite--rtl .notice-content {
-  padding: var(--calcite-notice-spacing-token-small) 0 var(--calcite-notice-spacing-token-small)
-    var(--calcite-notice-spacing-token-small);
-
-  &:first-of-type:not(:only-child) {
-    padding-right: var(--calcite-notice-spacing-token-large);
-  }
-  &:only-of-type {
-    padding: var(--calcite-notice-spacing-token-small) var(--calcite-notice-spacing-token-large);
-  }
-}
 .notice-icon {
   @apply flex items-center;
   @include notice-element-base;
@@ -165,6 +148,44 @@
 
   &:active {
     @apply bg-foreground-3;
+  }
+}
+
+.action-end {
+  @apply flex self-stretch border-l border-l-color-3;
+  border-left-style: solid;
+}
+
+.action-end + .notice-close {
+  @apply border-l border-l-color-3;
+  border-left-style: solid;
+}
+
+.calcite--rtl {
+  @apply text-right;
+  border-left: none;
+  border-right: 0px solid;
+
+  .notice-content {
+    padding: var(--calcite-notice-spacing-token-small) 0 var(--calcite-notice-spacing-token-small)
+      var(--calcite-notice-spacing-token-small);
+
+    &:first-of-type:not(:only-child) {
+      padding-right: var(--calcite-notice-spacing-token-large);
+    }
+    &:only-of-type {
+      padding: var(--calcite-notice-spacing-token-small) var(--calcite-notice-spacing-token-large);
+    }
+  }
+
+  .action-end {
+    @apply border-l-0 border-r border-r-color-3;
+    border-right-style: solid;
+  }
+
+  .action-end + .notice-close {
+    @apply border-l-0 border-r border-r-color-3;
+    border-right-style: solid;
   }
 }
 

--- a/src/components/calcite-notice/calcite-notice.stories.ts
+++ b/src/components/calcite-notice/calcite-notice.stories.ts
@@ -52,6 +52,23 @@ CustomIcon.story = {
   name: "Custom icon"
 };
 
+export const WithAction = (): string => html`
+  <div style="width:600px;max-width:100%;text-align:center;">
+    <calcite-notice
+      ${boolean("icon", true)}
+      ${boolean("active", true)}
+      ${boolean("dismissible", false)}
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      width="${select("width", ["auto", "half", "full"], "auto")}"
+      color="${select("color", ["green", "red", "yellow", "blue"], "red")}"
+    >
+      <div slot="title">Notice with action</div>
+      <div slot="message">This shows a notice with a custom action</div>
+      <calcite-action label="Retry" icon="reset" slot="icon-end"></calcite-action>
+    </calcite-notice>
+  </div>
+`;
+
 export const DarkMode = (): string => html`
   <div style="width:600px;max-width:100%;text-align:center;">
     <calcite-notice

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -10,10 +10,10 @@ import {
   Watch
 } from "@stencil/core";
 
-import { SLOTS, TEXT } from "./calcite-notice.resources";
+import { CSS, SLOTS, TEXT } from "./calcite-notice.resources";
 import { Scale, Width } from "../interfaces";
 import { StatusColor, StatusIcons } from "../calcite-alert/interfaces";
-import { getElementDir, setRequestedIcon } from "../../utils/dom";
+import { getElementDir, getSlotted, setRequestedIcon } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";
 
 /** Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
@@ -26,6 +26,7 @@ import { CSS_UTILITY } from "../../utils/resources";
  * @slot title - Title of the notice (optional)
  * @slot message - Main text of the notice
  * @slot link - Optional action to take from the notice (undo, try again, link to page, etc.)
+ * @slot action-end - Allows adding a `calcite-action` at the end of the notice
  */
 
 @Component({
@@ -91,11 +92,12 @@ export class CalciteNotice {
   }
 
   render(): VNode {
-    const dir = getElementDir(this.el);
+    const { el } = this;
+    const dir = getElementDir(el);
     const closeButton = (
       <button
         aria-label={this.intlClose}
-        class="notice-close"
+        class={CSS.close}
         onClick={this.close}
         ref={() => this.closeButton}
       >
@@ -103,19 +105,25 @@ export class CalciteNotice {
       </button>
     );
 
+    const hasAction = getSlotted(el, SLOTS.actionEnd);
+
     return (
-      <div class={{ container: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
+      <div class={{ [CSS.container]: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
         {this.requestedIcon ? (
-          <div class="notice-icon">
-            
+          <div class={CSS.icon}>
             <calcite-icon icon={this.requestedIcon} scale={this.scale === "s" ? "s" : "m"} />
           </div>
         ) : null}
-        <div class="notice-content">
+        <div class={CSS.content}>
           <slot name={SLOTS.title} />
           <slot name={SLOTS.message} />
           <slot name={SLOTS.link} />
         </div>
+        {hasAction ? (
+          <div class={CSS.actionEnd}>
+            <slot name={SLOTS.actionEnd} />
+          </div>
+        ) : null}
         {this.dismissible ? closeButton : null}
       </div>
     );

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -105,7 +105,7 @@ export class CalciteNotice {
       </button>
     );
 
-    const hasAction = getSlotted(el, SLOTS.actionEnd);
+    const hasActionEnd = getSlotted(el, SLOTS.actionEnd);
 
     return (
       <div class={{ [CSS.container]: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
@@ -119,7 +119,7 @@ export class CalciteNotice {
           <slot name={SLOTS.message} />
           <slot name={SLOTS.link} />
         </div>
-        {hasAction ? (
+        {hasActionEnd ? (
           <div class={CSS.actionEnd}>
             <slot name={SLOTS.actionEnd} />
           </div>

--- a/src/demos/calcite-notice.html
+++ b/src/demos/calcite-notice.html
@@ -50,21 +50,39 @@
     <br />
 
     <h3>Sizes</h3>
-    <calcite-notice style="margin: 0 20px;" icon color="blue" id="notice-ten" width="auto" scale="s" active dismissible>
+    <calcite-notice style="margin: 0 20px" icon color="blue" id="notice-ten" width="auto" scale="s" active dismissible>
       <div slot="title">Title</div>
       <div slot="message">Body lorem ipsum</div>
       <calcite-link slot="link" title="my action">View item </calcite-link>
     </calcite-notice>
     <br />
 
-    <calcite-notice style="margin: 0 20px;" icon color="blue" id="notice-eleven" width="auto" scale="m" active dismissible>
+    <calcite-notice
+      style="margin: 0 20px"
+      icon
+      color="blue"
+      id="notice-eleven"
+      width="auto"
+      scale="m"
+      active
+      dismissible
+    >
       <div slot="title">Title</div>
       <div slot="message">Body lorem ipsum</div>
       <calcite-link slot="link" title="my action">View item </calcite-link>
     </calcite-notice>
     <br />
 
-    <calcite-notice style="margin: 0 20px;" icon color="blue" id="notice-twelve" width="auto" scale="l" active dismissible>
+    <calcite-notice
+      style="margin: 0 20px"
+      icon
+      color="blue"
+      id="notice-twelve"
+      width="auto"
+      scale="l"
+      active
+      dismissible
+    >
       <div slot="title">Title</div>
       <div slot="message">Body lorem ipsum</div>
       <calcite-link slot="link" title="my action">View item </calcite-link>
@@ -154,5 +172,26 @@
         <div>A second slotted div</div>
       </div>
     </calcite-notice>
+    <br />
+    <br />
+    <calcite-notice dismissible color="green" size="l" id="notice-five" active>
+      <div slot="title">Welcome to your new website</div>
+      <div slot="message">
+        <div>That thing you wanted to do didn't work as expected</div>
+        <div>A second slotted div</div>
+      </div>
+    </calcite-notice>
+    <br />
+    <br />
+    <calcite-tooltip-manager>
+      <calcite-notice scale="l" width="half" active>
+        <div slot="title">Something failed</div>
+        <div slot="message">That thing you wanted to do didn't work as expected</div>
+        <calcite-action id="retry-action" slot="icon-end" title="Retry" icon="reset"></calcite-action>
+      </calcite-notice>
+    </calcite-tooltip-manager>
+    <calcite-tooltip reference-element="retry-action" placement="top"> Retry that action </calcite-tooltip>
+    <br />
+    <br />
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #2144 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds a new slot (`action-end`) for a calcite-action.

![notice-with-action](https://user-images.githubusercontent.com/197440/123036450-ff383080-d3a1-11eb-9165-749c74a61639.gif)

The end action can be used alongside `dismissible` as well:

![Screen Shot 2021-06-22 at 9 51 56 PM](https://user-images.githubusercontent.com/197440/123037812-2b54b100-d3a4-11eb-9a38-8a989e045261.png)

