### PR TITLE
fix(slider): prevent Enter/Space from setting value to 0

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -98,6 +98,11 @@ describe("calcite-slider", () => {
     expect(await slider.getProperty("value")).toBe(0);
     await handle.press("End");
     expect(await slider.getProperty("value")).toBe(100);
+
+    // activation keys should not affect the value
+    await handle.press(" ");
+    await handle.press("Enter");
+    expect(await slider.getProperty("value")).toBe(100);
   });
 
   it("only selects values on step interval when snap prop is passed", async () => {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -703,6 +703,12 @@ export class CalciteSlider {
         this[this.activeProp] = this.bound(this.max, this.activeProp);
         this.emitChange();
         break;
+
+      // prevent activation keys from firing a click event
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        break;
     }
   }
 


### PR DESCRIPTION
**Related Issue:** #2316 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where pressing the Enter/Space key would fire a click event on the button element used for the thumb and would set the value to 0.