### PR TITLE
docs(input): use correct action slot name

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -31,7 +31,7 @@ import { CSS_UTILITY } from "../../utils/resources";
 type NumberNudgeDirection = "up" | "down";
 
 /**
- * @slot `calcite-action` - A slot for positioning a button next to an input
+ * @slot action - A slot for positioning a button next to an input
  */
 @Component({
   tag: "calcite-input",


### PR DESCRIPTION
**Related Issue:** #2150

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes doc for input's action slot.