### PR TITLE
docs(alert): use correct slot names in usage ex, demo util

### DIFF
--- a/src/components/calcite-alert/usage/basic.md
+++ b/src/components/calcite-alert/usage/basic.md
@@ -2,13 +2,13 @@ A single instance of an alert. Multiple alerts will aggregate in a queue.
 
 ```html
 <calcite-alert>
-  <div slot="title">Title of alert</div>
-  <div slot="alert-message">Message text of the alert</div>
-  <a slot="alert-link" href="#">Retry</a>
+  <div slot="title">Title of alert #1</div>
+  <div slot="message">Message text of the alert</div>
+  <a slot="link" href="#">Retry</a>
 </calcite-alert>
 <calcite-alert>
-  <div slot="title">Title of alert</div>
-  <div slot="alert-message">Message text of the alert</div>
-  <a slot="alert-link" href="#">Retry</a>
+  <div slot="title">Title of alert #2</div>
+  <div slot="message">Message text of the alert</div>
+  <a slot="link" href="#">Retry</a>
 </calcite-alert>
 ```

--- a/src/demos/_assets/createAlert.ts
+++ b/src/demos/_assets/createAlert.ts
@@ -4,7 +4,7 @@ function createExampleAlert(id: string): void {
     "<calcite-alert id=" + id + " color='red'>",
     "<div slot='title'>Something failed</div>",
     "<div slot='message'>" + id + " That thing you wanted to do didn't work as expected</div>",
-    "<calcite-link slot='alert-link' title='my action' appearance='inline'>Take action</calcite-link>",
+    "<calcite-link slot='link' title='my action' appearance='inline'>Take action</calcite-link>",
     "</calcite-alert>"
   ].join("\n");
 


### PR DESCRIPTION
**Related Issue:** # n/a

## Summary
Updates outdated slot names for alert in its usage example and demo util.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
