### PR TITLE
docs(action-pad, action-bar): add group layout prop to story

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.scss
+++ b/src/components/calcite-action-bar/calcite-action-bar.scss
@@ -19,8 +19,7 @@
   @apply border-0
     border-b
     border-solid
-    border-color-2
-    py-0;
+    border-color-2;
 }
 
 .action-group--bottom {

--- a/src/components/calcite-action-bar/calcite-action-bar.scss
+++ b/src/components/calcite-action-bar/calcite-action-bar.scss
@@ -19,11 +19,8 @@
   @apply border-0
     border-b
     border-solid
-    border-color-2;
-}
-
-::slotted(calcite-action-group:last-child) {
-  @apply border-b-0;
+    border-color-2
+    py-0;
 }
 
 .action-group--bottom {

--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -41,6 +41,14 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
         }
       },
       {
+        name: "overflow-actions-disabled",
+        commit(): Attribute {
+          this.value = boolean("overflow-actions-disabled", false);
+          delete this.build;
+          return this;
+        }
+      },
+      {
         name: "dir",
         commit(): Attribute {
           this.value = select("dir", dir.values, dir.defaultValue);
@@ -90,15 +98,42 @@ export const basic = (): string =>
     "calcite-action-bar",
     createAttributes(),
     html`
-      <calcite-action-group>
+      <calcite-action-group layout="${select("group layout", ["horizontal", "vertical", "grid"], "vertical")}">
         <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
         <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
+        <calcite-action text="Clear" label="Clear" icon="erase"></calcite-action>
       </calcite-action-group>
-      <calcite-action-group>
+      <calcite-action-group layout="${select("group layout", ["horizontal", "vertical", "grid"], "vertical")}">
         <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
       </calcite-action-group>
     `
   );
+  
+  export const groupsWithGridLayout = (): string =>
+    create(
+      "calcite-action-bar",
+      createAttributes({ exceptions: ["overflow-actions-disabled"]}).concat([
+        {
+          name: "overflow-actions-disabled",
+          value: "true"
+        }
+      ]),
+      html`
+      <calcite-action-group layout="${select("group layout", ["vertical", "horizontal", "grid"], "grid")}" columns="${select("columns", ["1", "2", "3", "4", "5", "6"], "3")}">
+        <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
+        <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
+        <calcite-action text="Erase" label="Erase" icon="erase"></calcite-action>
+        <calcite-action text="Delete" label="Delete" icon="trash"></calcite-action>
+        <calcite-action text="Open" label="Open" icon="folder-open"></calcite-action>
+        <calcite-action text="Save" label="Save" icon="save"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group layout="${select("group layout", ["vertical", "horizontal", "grid"], "grid")}" columns="${select("columns", ["1", "2", "3", "4", "5", "6"], "3")}">
+        <calcite-action text="Title" label="Title" icon="title"></calcite-action>
+        <calcite-action text="Bold" label="Bold" icon="bold"></calcite-action>
+        <calcite-action text="Italicize" label="Italicize" icon="italicize"></calcite-action>
+      </calcite-action-group>
+      `
+    );
 
 export const darkThemeRTL = (): string =>
   create(

--- a/src/components/calcite-action-pad/calcite-action-pad.scss
+++ b/src/components/calcite-action-pad/calcite-action-pad.scss
@@ -26,7 +26,7 @@
 }
 
 .action-group--bottom {
-  @apply flex-grow justify-end pb-0;
+  @apply flex-grow justify-end py-0;
 }
 
 :host([layout="horizontal"]) {
@@ -45,8 +45,4 @@
   .container.calcite--rtl ::slotted(calcite-action-group) {
     @apply border-0 border-l;
   }
-}
-
-::slotted(calcite-action-group:last-child) {
-  @apply border-b-0;
 }

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -57,6 +57,14 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
         }
       },
       {
+        name: "layout",
+        commit(): Attribute {
+          this.value = select("layout", ["horizontal", "vertical"], "vertical")
+          delete this.build;
+          return this;
+        }
+      },
+      {
         name: "intl-expand",
         commit(): Attribute {
           this.value = text("intlExpand", TEXT.expand);
@@ -90,13 +98,34 @@ export const basic = (): string =>
     "calcite-action-pad",
     createAttributes(),
     html`
-      <calcite-action-group>
+      <calcite-action-group layout="${select("group layout", ["horizontal", "vertical"], "vertical")}">
         <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
         <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
       </calcite-action-group>
-      <calcite-action-group>
+      <calcite-action-group layout="${select("group layout", ["horizontal", "vertical"], "vertical")}">
         <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
       </calcite-action-group>
+    `
+  );
+
+export const groupsWithGridLayout = (): string =>
+  create(
+    "calcite-action-pad",
+    createAttributes(),
+    html`
+    <calcite-action-group layout="${select("group layout", ["vertical", "horizontal", "grid"], "grid")}" columns="${select("columns", ["1", "2", "3", "4", "5", "6"], "3")}">
+      <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
+      <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
+      <calcite-action text="Erase" label="Erase" icon="erase"></calcite-action>
+      <calcite-action text="Delete" label="Delete" icon="trash"></calcite-action>
+      <calcite-action text="Open" label="Open" icon="folder-open"></calcite-action>
+      <calcite-action text="Save" label="Save" icon="save"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group layout="${select("group layout", ["vertical", "horizontal", "grid"], "grid")}" columns="${select("columns", ["1", "2", "3", "4", "5", "6"], "3")}">
+      <calcite-action text="Title" label="Title" icon="title"></calcite-action>
+      <calcite-action text="Bold" label="Bold" icon="bold"></calcite-action>
+      <calcite-action text="Italicize" label="Italicize" icon="italicize"></calcite-action>
+    </calcite-action-group>
     `
   );
 


### PR DESCRIPTION
**Related Issue:** #none

## Summary
Nobody asked for it, but here it is.
Added the grid layout capability to the relevant storybooks.
Also added general layout props/values to ActionBar and ActionPad.
Includes a couple fixes for weird UI stuffs.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
