### PR TITLE
fix(notice): fix setFocus

### DIFF
--- a/src/components/calcite-notice/calcite-notice.e2e.ts
+++ b/src/components/calcite-notice/calcite-notice.e2e.ts
@@ -95,4 +95,33 @@ describe("calcite-notice", () => {
 
     expect(actionAssignedSlot).toBe(SLOTS.actionEnd);
   });
+
+  describe("focusable", () => {
+    it("with link and dismissible => focuses on link", () =>
+      focusable(html` <calcite-notice id="notice-1" active dismissible> ${noticeContent}</calcite-notice>`, {
+        focusTargetSelector: `calcite-link`
+      }));
+
+    it("when dismissible => focuses on close button", () =>
+      focusable(
+        html` <calcite-notice id="notice-1" active dismissible>
+          <div slot="title">Title Text</div>
+          <div slot="message">Message Text</div>
+        </calcite-notice>`,
+        {
+          shadowFocusTargetSelector: `.${CSS.close}`
+        }
+      ));
+
+    it("without link nor dismissible => does not focus", () =>
+      focusable(
+        html` <calcite-notice id="notice-1" active>
+          <div slot="title">Title Text</div>
+          <div slot="message">Message Text</div>
+        </calcite-notice>`,
+        {
+          focusTargetSelector: "body"
+        }
+      ));
+  });
 });

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -88,7 +88,7 @@ export class CalciteNotice {
   }
 
   componentDidLoad(): void {
-    this.noticeLinkEl = this.el.querySelectorAll("calcite-link")[0] as HTMLCalciteLinkElement;
+    this.noticeLinkEl = this.el.querySelector("calcite-link") as HTMLCalciteLinkElement;
   }
 
   render(): VNode {
@@ -99,7 +99,7 @@ export class CalciteNotice {
         aria-label={this.intlClose}
         class={CSS.close}
         onClick={this.close}
-        ref={() => this.closeButton}
+        ref={(el) => (this.closeButton = el)}
       >
         <calcite-icon icon="x" scale={this.scale === "s" ? "s" : "m"} />
       </button>
@@ -176,7 +176,7 @@ export class CalciteNotice {
   //--------------------------------------------------------------------------
 
   /** the close button element */
-  private closeButton?: HTMLElement;
+  private closeButton?: HTMLButtonElement;
 
   /** the notice link child element  */
   private noticeLinkEl?: HTMLCalciteLinkElement;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This came up during #2144 and fixes a bug that would prevent `setFocus` from working.