### PR TITLE
chore(shell): use proper slot name for action

### DIFF
--- a/src/demos/shell/popup-config-example.html
+++ b/src/demos/shell/popup-config-example.html
@@ -201,12 +201,7 @@
                   <calcite-label scale="s">
                     Title
                     <calcite-input type="text" placeholder="My awesome title" value="{Cty_NAME}">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="input-action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                 </calcite-block>
@@ -225,22 +220,12 @@
                   <calcite-label scale="s">
                     Title
                     <calcite-input type="text" placeholder="My awesome title">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="input-action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input> </calcite-label
                   ><calcite-label scale="s">
                     Description
                     <calcite-input type="text" placeholder="My awesome description">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="input-action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <calcite-value-list drag-enabled>
@@ -259,22 +244,12 @@
                   <calcite-label scale="s">
                     Title
                     <calcite-input type="text" placeholder="My awesome title">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="input-action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input> </calcite-label
                   ><calcite-label scale="s">
                     Description
                     <calcite-input type="text" placeholder="My awesome description">
-                      <calcite-action
-                        text="cool action"
-                        icon="brackets-curly"
-                        slot="input-action"
-                        scale="s"
-                      ></calcite-action>
+                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
                     </calcite-input>
                   </calcite-label>
                   <h4>Field items</h4>


### PR DESCRIPTION
**Related Issue:** #2150

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes outdated input action slot names used in a shell demo.