### PR TITLE
docs(panel): use proper slot names for leading/trailing actions

### DIFF
--- a/src/components/calcite-panel/usage/basic.md
+++ b/src/components/calcite-panel/usage/basic.md
@@ -27,18 +27,21 @@ Renders a panel with leading and trailing `calcite-action`s.
 
 ```html
 <calcite-panel>
-  <div slot="header-leading-content">
-    <calcite-action label="Performs my custom action" text="Perform Action!" text-enabled icon="home"></calcite-action>
-  </div>
+  <calcite-action
+    label="Performs my custom action"
+    text="Perform Action!"
+    text-enabled
+    icon="home"
+    slot="header-actions-start"
+  ></calcite-action>
   <div slot="header-content">Header!</div>
-  <div slot="header-trailing-content">
-    <calcite-action
-      label="Performs another custom action"
-      text="Perform Another Action!"
-      text-enabled
-      icon="blog"
-    ></calcite-action>
-  </div>
+  <calcite-action
+    label="Performs another custom action"
+    text="Perform Another Action!"
+    text-enabled
+    icon="blog"
+    slot="header-actions-end"
+  ></calcite-action>
   <p>Actions are in the top left and right.</p>
 </calcite-panel>
 ```


### PR DESCRIPTION
**Related Issue:** #2284

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes outdated slot names used in panel usage examples.