### PR TITLE
refactor(keys): tidy up keys util

### DIFF
--- a/src/components/calcite-time-picker/calcite-time-picker.tsx
+++ b/src/components/calcite-time-picker/calcite-time-picker.tsx
@@ -13,8 +13,9 @@ import {
   Method
 } from "@stencil/core";
 import { Scale } from "../interfaces";
-import { getKey, isActivationKey, isSpacebarKey, numberKeys } from "../../utils/key";
+import { getKey, isActivationKey, numberKeys } from "../../utils/key";
 import { isValidNumber } from "../../utils/number";
+
 import {
   Meridiem,
   formatTimePart,
@@ -290,10 +291,13 @@ export class CalciteTimePicker {
   };
 
   private buttonActivated(event: KeyboardEvent): boolean {
-    if (isSpacebarKey(event.key)) {
+    const key = getKey(event.key);
+
+    if (key === " ") {
       event.preventDefault();
     }
-    return isActivationKey(event.key);
+
+    return isActivationKey(key);
   }
 
   private focusHandler = (event: FocusEvent): void => {

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -15,7 +15,7 @@ import { TreeItemSelectDetail } from "./interfaces";
 import { TreeSelectionMode } from "../calcite-tree/interfaces";
 
 import { nodeListToArray, getElementDir, filterDirectChildren, getSlotted } from "../../utils/dom";
-import { getKey, isActivationKey } from "../../utils/key";
+import { getKey } from "../../utils/key";
 
 @Component({
   tag: "calcite-tree-item",

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -15,7 +15,7 @@ import { TreeItemSelectDetail } from "./interfaces";
 import { TreeSelectionMode } from "../calcite-tree/interfaces";
 
 import { nodeListToArray, getElementDir, filterDirectChildren, getSlotted } from "../../utils/dom";
-import { getKey } from "../../utils/key";
+import { getKey, isActivationKey } from "../../utils/key";
 
 @Component({
   tag: "calcite-tree-item",

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -24,16 +24,9 @@ export function getKey(key: string, dir?: "rtl" | "ltr"): string {
   return adjustedKey;
 }
 
-export function isActivationKey(keyName: string): boolean {
-  const key = getKey(keyName);
-  const isEnter = key === "Enter";
-  const isSpacebar = isSpacebarKey(key);
-  return isEnter || isSpacebar;
-}
-
-export function isSpacebarKey(keyName: string): boolean {
-  const key = getKey(keyName);
-  return key === " " || key === "Spacebar";
+export function isActivationKey(key: string): boolean {
+  key = getKey(key);
+  return key === "Enter" || key === " ";
 }
 
 export const numberKeys = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This came up from working on #2290. This drops `isSpacebarKey` since `getKey` util is used to normalize key values.