### PR TITLE
test(tree): add test for select event

### DIFF
--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 
 describe("calcite-tree", () => {
   it("renders", async () => {
@@ -85,5 +86,42 @@ describe("calcite-tree", () => {
     expect(grandchildTwo).not.toHaveAttribute("selected");
     expect(two).not.toHaveAttribute("selected");
     expect(two).toHaveAttribute("indeterminate");
+  });
+
+  it("allows selecting items", async () => {
+    const page = await newE2EPage({
+      html: html`<calcite-tree input-enabled selection-mode="ancestors">
+        <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
+        <calcite-tree-item id="two">
+          <span>Two</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item id="child-one">
+              <span>Child 1</span>
+              <calcite-tree slot="children">
+                <calcite-tree-item id="grandchild-one">
+                  <span>Grandchild 1</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>`
+    });
+
+    const tree = await page.find("calcite-tree");
+    const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
+    const one = await page.find("#one");
+    const childOne = await page.find("#child-one");
+    const grandchildOne = await page.find("#grandchild-one");
+
+    await one.click();
+    expect(selectEventSpy).toHaveReceivedEventTimes(1);
+
+    await childOne.press(" ");
+    expect(selectEventSpy).toHaveReceivedEventTimes(2);
+
+    await grandchildOne.press("Enter");
+
+    expect(selectEventSpy).toHaveReceivedEventTimes(3);
   });
 });


### PR DESCRIPTION
**Related Issue:** #2290 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Adds missing test for the tree select event. 

### Pending

- [ ] Confirm whether topmost tree should emit a single event per item selection regardless of nesting.