### PR TITLE
feat(pick-list, value-list): add prop to enable changing selection via keyboard in single-selection mode

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -24,6 +24,14 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
   return filterComponentAttributes(
     [
       {
+        name: "class",
+        commit(): Attribute {
+          this.value = select("class", theme.values, theme.defaultValue);
+          delete this.build;
+          return this;
+        }
+      },
+      {
         name: "dir",
         commit(): Attribute {
           this.value = select("dir", dir.values, dir.defaultValue);
@@ -64,9 +72,9 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
         }
       },
       {
-        name: "class",
+        name: "selection-follows-focus",
         commit(): Attribute {
-          this.value = select("class", theme.values, theme.defaultValue);
+          this.value = boolean("selection-follows-focus", false);
           delete this.build;
           return this;
         }

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -84,6 +84,11 @@ export class CalcitePickList<
    */
   @Prop({ reflect: true }) multiple = false;
 
+  /**
+   * When true and single-selection is enabled, the selection will change when navigating items via the keyboard.
+   */
+  @Prop() selectionFollowsFocus = false;
+
   // --------------------------------------------------------------------------
   //
   //  Private Properties

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -195,13 +195,13 @@ export async function setFocus<T extends Lists>(this: List<T>, focusId: ListFocu
     return items[0].setFocus();
   }
 
-  const selected = (items as ListItemElement<T>[]).find((item) => item.selected) || items[0];
+  const focusTarget = (items as ListItemElement<T>[]).find((item) => item.selected) || items[0];
 
   if (selectionFollowsFocus) {
-    selected.selected = true;
+    focusTarget.selected = true;
   }
 
-  return selected.setFocus();
+  return focusTarget.setFocus();
 }
 
 export function setUpItems<T extends Lists>(

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -125,7 +125,7 @@ export function keyDownHandler<T extends Lists>(this: List<T>, event: KeyboardEv
     return;
   }
 
-  const { items } = this;
+  const { items, multiple, selectionFollowsFocus } = this;
   const { length: totalItems } = items;
   const currentIndex = (items as ListItemElement<T>[]).indexOf(target as ListItemElement<T>);
 
@@ -139,6 +139,11 @@ export function keyDownHandler<T extends Lists>(this: List<T>, event: KeyboardEv
   const item = items[index];
 
   toggleSingleSelectItemTabbing(item, true);
+
+  if (!multiple && selectionFollowsFocus) {
+    item.selected = true;
+  }
+
   focusElement(item);
 }
 
@@ -180,7 +185,7 @@ export async function setFocus<T extends Lists>(this: List<T>, focusId: ListFocu
     return;
   }
 
-  const { multiple, items } = this;
+  const { items, multiple, selectionFollowsFocus } = this;
 
   if (items.length === 0) {
     return;
@@ -190,9 +195,13 @@ export async function setFocus<T extends Lists>(this: List<T>, focusId: ListFocu
     return items[0].setFocus();
   }
 
-  const selected = (items as ListItemElement<T>[]).find((item) => item.selected);
+  const selected = (items as ListItemElement<T>[]).find((item) => item.selected) || items[0];
 
-  return (selected ? selected : items[0]).setFocus();
+  if (selectionFollowsFocus) {
+    selected.selected = true;
+  }
+
+  return selected.setFocus();
 }
 
 export function setUpItems<T extends Lists>(

--- a/src/components/calcite-pick-list/shared-list-render.tsx
+++ b/src/components/calcite-pick-list/shared-list-render.tsx
@@ -31,7 +31,12 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
 }): VNode => {
   const defaultSlot = <slot />;
   return (
-    <Host aria-busy={loading.toString()} aria-disabled={disabled.toString()} role="menu" {...rest}>
+    <Host
+      aria-busy={loading.toString()}
+      aria-disabled={disabled.toString()}
+      role="listbox"
+      {...rest}
+    >
       <section>
         <header class={{ [CSS.sticky]: true }}>
           {filterEnabled ? (

--- a/src/components/calcite-pick-list/shared-list-render.tsx
+++ b/src/components/calcite-pick-list/shared-list-render.tsx
@@ -31,12 +31,7 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
 }): VNode => {
   const defaultSlot = <slot />;
   return (
-    <Host
-      aria-busy={loading.toString()}
-      aria-disabled={disabled.toString()}
-      role="listbox"
-      {...rest}
-    >
+    <Host aria-busy={loading.toString()} aria-disabled={disabled.toString()} role="menu" {...rest}>
       <section>
         <header class={{ [CSS.sticky]: true }}>
           {filterEnabled ? (

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -24,6 +24,14 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
   return filterComponentAttributes(
     [
       {
+        name: "class",
+        commit(): Attribute {
+          this.value = select("class", theme.values, theme.defaultValue);
+          delete this.build;
+          return this;
+        }
+      },
+      {
         name: "dir",
         commit(): Attribute {
           this.value = select("dir", dir.values, dir.defaultValue);
@@ -72,9 +80,9 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
         }
       },
       {
-        name: "class",
+        name: "selection-follows-focus",
         commit(): Attribute {
-          this.value = select("class", theme.values, theme.defaultValue);
+          this.value = boolean("selection-follows-focus", false);
           delete this.build;
           return this;
         }

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -89,6 +89,11 @@ export class CalciteValueList<
    */
   @Prop({ reflect: true }) multiple = false;
 
+  /**
+   * When true and single-selection is enabled, the selection will change when navigating items via the keyboard.
+   */
+  @Prop() selectionFollowsFocus = false;
+
   // --------------------------------------------------------------------------
   //
   //  Private Properties

--- a/src/demos/pick-list/basic.html
+++ b/src/demos/pick-list/basic.html
@@ -42,6 +42,13 @@
           pickList1.addEventListener("calciteListItemRemove", (event) => console.log("item removed", event));
         </script>
 
+        <h2>selection follows focus (single selection only)</h2>
+        <calcite-pick-list selection-follows-focus>
+          <calcite-pick-list-item label="Uno" removable value="1"></calcite-pick-list-item>
+          <calcite-pick-list-item label="Dos" value="2" removable selected></calcite-pick-list-item>
+          <calcite-pick-list-item label="Tres" value="3"></calcite-pick-list-item>
+        </calcite-pick-list>
+
         <h2>multi-select filter-enabled</h2>
         <calcite-pick-list id="two" multiple filter-enabled>
           <calcite-action scale="s" text="filters" slot="menu-actions" icon="sliders"> </calcite-action>

--- a/src/demos/value-list/basic.html
+++ b/src/demos/value-list/basic.html
@@ -11,6 +11,20 @@
       <section class="example-container">
         <h1>calcite-value-list</h1>
 
+        <h2>default selection</h2>
+        <calcite-value-list>
+          <calcite-value-list-item label="Uno" removable value="1"></calcite-value-list-item>
+          <calcite-value-list-item label="Dos" value="2" removable selected></calcite-value-list-item>
+          <calcite-value-list-item label="Tres" value="3"></calcite-value-list-item>
+        </calcite-value-list>
+
+        <h2>selection follows focus (single selection only)</h2>
+        <calcite-value-list selection-follows-focus>
+          <calcite-value-list-item label="Uno" removable value="1"></calcite-value-list-item>
+          <calcite-value-list-item label="Dos" value="2" removable selected></calcite-value-list-item>
+          <calcite-value-list-item label="Tres" value="3"></calcite-value-list-item>
+        </calcite-value-list>
+
         <h3>multiple</h3>
         <calcite-value-list id="one" multiple filter-enabled>
           <calcite-action slot="menu-actions" indicator text="Cool" scale="s" icon="hamburger"> </calcite-action>


### PR DESCRIPTION
**Related Issue:** #2344 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds a `selectionFollowsFocus` (default false) prop to both pick and value lists to allow users to change the selected item as they navigate items with the ⬆  ⬇️  keys.