### PR TITLE
refactor(calcite-button)!: stop spreading attributes  BREAKING CHANGE: to set an aria-label on the button use the label attribute

### DIFF
--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -36,8 +36,8 @@ export class CalciteButton {
   /** specify the appearance style of the button, defaults to solid. */
   @Prop({ reflect: true }) appearance: ButtonAppearance = "solid";
 
-  /** The aria-label attribute to apply to the button or hyperlink */
-  @Prop() ariaLabel?: string;
+  /** Applies to the aria-label attribute on the button or hyperlink */
+  @Prop() label?: string;
 
   /** specify the color of the button, defaults to blue */
   @Prop({ reflect: true }) color: ButtonColor = "blue";
@@ -82,7 +82,7 @@ export class CalciteButton {
   @Prop() target?: string;
 
   /** The type attribute to apply to the button */
-  @Prop() type?: string;
+  @Prop({ mutable: true }) type?: string;
 
   /** specify the width of the button, defaults to auto */
   @Prop({ reflect: true }) width: Width = "auto";
@@ -149,7 +149,7 @@ export class CalciteButton {
 
     return (
       <Tag
-        aria-label={this.ariaLabel}
+        aria-label={this.label}
         class={{ [CSS_UTILITY.rtl]: dir === "rtl", [CSS.contentSlotted]: this.hasContent }}
         disabled={this.disabled}
         href={this.childElType === "a" && this.href}

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, h, Method, Prop, Build, State, VNode } from "@stencil/core";
 import { CSS, TEXT } from "./resources";
-import { getAttributes, getElementDir } from "../../utils/dom";
+import { getElementDir } from "../../utils/dom";
 import { ButtonAlignment, ButtonAppearance, ButtonColor } from "./interfaces";
 import { FlipContext, Scale, Width } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -98,22 +98,6 @@ export class CalciteButton {
 
   render(): VNode {
     const dir = getElementDir(this.el);
-    const attributes = getAttributes(this.el, [
-      "appearance",
-      "alignment",
-      "calcite-hydrated",
-      "class",
-      "color",
-      "dir",
-      "icon-start",
-      "icon-end",
-      "id",
-      "split-child",
-      "loading",
-      "scale",
-      "slot",
-      "width"
-    ]);
     const Tag = this.childElType;
 
     const loader = (
@@ -150,12 +134,19 @@ export class CalciteButton {
 
     return (
       <Tag
-        {...attributes}
+        aria-label={this.el.getAttribute("aria-label")}
         class={{ [CSS_UTILITY.rtl]: dir === "rtl", [CSS.contentSlotted]: this.hasContent }}
         disabled={this.disabled}
+        href={this.childElType === "a" && this.href}
+        name={this.childElType === "button" && this.el.getAttribute("name")}
         onClick={this.handleClick}
         ref={(el) => (this.childEl = el)}
+        rel={this.childElType === "a" && this.el.getAttribute("rel")}
+        role={this.el.getAttribute("role")}
         tabIndex={this.disabled ? -1 : null}
+        target={this.childElType === "a" && this.el.getAttribute("target")}
+        title={this.el.getAttribute("title")}
+        type={this.childElType === "button" && this.type}
       >
         {this.loading ? loader : null}
         {this.iconStart ? iconStartEl : null}

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -13,7 +13,6 @@ import { CSS_UTILITY } from "../../utils/resources";
 
 /** @slot default text slot for button text */
 
-/** Any attributes placed on <calcite-button> component will propagate to the rendered child */
 /** Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this. */
 /** It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission */
 export class CalciteButton {
@@ -31,8 +30,14 @@ export class CalciteButton {
   //
   //--------------------------------------------------------------------------
 
+  /** optionally specify alignment of button elements. */
+  @Prop({ reflect: true }) alignment?: ButtonAlignment = "center";
+
   /** specify the appearance style of the button, defaults to solid. */
   @Prop({ reflect: true }) appearance: ButtonAppearance = "solid";
+
+  /** The aria-label attribute to apply to the button or hyperlink */
+  @Prop() ariaLabel?: string;
 
   /** specify the color of the button, defaults to blue */
   @Prop({ reflect: true }) color: ButtonColor = "blue";
@@ -55,11 +60,14 @@ export class CalciteButton {
   /** string to override English loading text */
   @Prop() intlLoading?: string = TEXT.loading;
 
-  /** optionally specify alignment of button elements. */
-  @Prop({ reflect: true }) alignment?: ButtonAlignment = "center";
-
   /** optionally add a calcite-loader component to the button, disabling interaction.  */
   @Prop({ reflect: true }) loading?: boolean = false;
+
+  /** The name attribute to apply to the button */
+  @Prop() name?: string;
+
+  /** The rel attribute to apply to the hyperlink */
+  @Prop() rel?: string;
 
   /** optionally add a round style to the button  */
   @Prop({ reflect: true }) round?: boolean = false;
@@ -69,6 +77,12 @@ export class CalciteButton {
 
   /** is the button a child of a calcite-split-button */
   @Prop({ reflect: true }) splitChild?: "primary" | "secondary" | false = false;
+
+  /** The target attribute to apply to the hyperlink */
+  @Prop() target?: string;
+
+  /** The type attribute to apply to the button */
+  @Prop() type?: string;
 
   /** specify the width of the button, defaults to auto */
   @Prop({ reflect: true }) width: Width = "auto";
@@ -91,8 +105,9 @@ export class CalciteButton {
   componentWillLoad(): void {
     if (Build.isBrowser) {
       this.updateHasContent();
-      const elType = this.el.getAttribute("type");
-      this.type = this.childElType === "button" && elType ? elType : "submit";
+      if (this.childElType === "button" && !this.type) {
+        this.type = "submit";
+      }
     }
   }
 
@@ -134,18 +149,16 @@ export class CalciteButton {
 
     return (
       <Tag
-        aria-label={this.el.getAttribute("aria-label")}
+        aria-label={this.ariaLabel}
         class={{ [CSS_UTILITY.rtl]: dir === "rtl", [CSS.contentSlotted]: this.hasContent }}
         disabled={this.disabled}
         href={this.childElType === "a" && this.href}
-        name={this.childElType === "button" && this.el.getAttribute("name")}
+        name={this.childElType === "button" && this.name}
         onClick={this.handleClick}
         ref={(el) => (this.childEl = el)}
         rel={this.childElType === "a" && this.el.getAttribute("rel")}
-        role={this.el.getAttribute("role")}
         tabIndex={this.disabled ? -1 : null}
         target={this.childElType === "a" && this.el.getAttribute("target")}
-        title={this.el.getAttribute("title")}
         type={this.childElType === "button" && this.type}
       >
         {this.loading ? loader : null}
@@ -175,9 +188,6 @@ export class CalciteButton {
 
   /** watches for changing text content **/
   private observer: MutationObserver;
-
-  /** if button type is present, assign as prop */
-  private type?: string;
 
   /** the rendered child element */
   private childEl?: HTMLElement;

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -772,21 +772,21 @@ export class CalciteColorPicker {
               <div class={CSS.savedColorsButtons}>
                 <calcite-button
                   appearance="transparent"
-                  aria-label={intlDeleteColor}
                   class={CSS.deleteColor}
                   color="neutral"
                   disabled={noColor}
                   iconStart="minus"
+                  label={intlDeleteColor}
                   onClick={this.deleteColor}
                   scale={scale}
                 />
                 <calcite-button
                   appearance="transparent"
-                  aria-label={intlSaveColor}
                   class={CSS.saveColor}
                   color="neutral"
                   disabled={noColor}
                   iconStart="plus"
+                  label={intlSaveColor}
                   onClick={this.saveColor}
                   scale={scale}
                 />

--- a/src/components/calcite-fab/calcite-fab.e2e.ts
+++ b/src/components/calcite-fab/calcite-fab.e2e.ts
@@ -83,7 +83,7 @@ describe("calcite-fab", () => {
   });
 
   it("should be accessible", async () => {
-    await accessible(`<calcite-fab text="hello world"></calcite-fab>`);
-    await accessible(`<calcite-fab text="hello world" disabled text-enabled></calcite-fab>`);
+    await accessible(`<calcite-fab label="hello world" text="hello world"></calcite-fab>`);
+    await accessible(`<calcite-fab label="hello world" text="hello world" disabled text-enabled></calcite-fab>`);
   });
 });

--- a/src/components/calcite-fab/calcite-fab.e2e.ts
+++ b/src/components/calcite-fab/calcite-fab.e2e.ts
@@ -61,9 +61,9 @@ describe("calcite-fab", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-fab text="hello world" label="hi"></calcite-fab>`);
 
-    const button = await page.find(`calcite-fab >>> .${CSS.button}`);
-    expect(button.getAttribute("title")).toBe("hi");
-    expect(button.getAttribute("aria-label")).toBe("hi");
+    const calciteButton = await page.find(`calcite-fab >>> .${CSS.button}`);
+    expect(calciteButton.getAttribute("title")).toBe("hi");
+    expect(await calciteButton.getProperty("label")).toBe("hi");
   });
 
   it("should be disabled", async () => {

--- a/src/components/calcite-fab/calcite-fab.tsx
+++ b/src/components/calcite-fab/calcite-fab.tsx
@@ -97,12 +97,12 @@ export class CalciteFab {
     return (
       <calcite-button
         appearance={appearance}
-        aria-label={label}
         class={CSS.button}
         color={color}
         dir={dir}
         disabled={disabled}
         iconStart={icon}
+        label={label}
         loading={loading}
         ref={(buttonEl): void => {
           this.buttonEl = buttonEl;

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -102,11 +102,11 @@ export class CalciteInlineEditable {
           {!this.editingEnabled && (
             <calcite-button
               appearance="transparent"
-              aria-label={this.intlEnableEditing}
               class="calcite-inline-editable-enable-editing-button"
               color="neutral"
               disabled={this.disabled}
               iconStart="pencil"
+              label={this.intlEnableEditing}
               onClick={this.enableEditingHandler}
               ref={(el) => (this.enableEditingButton = el)}
               scale={this.scale}
@@ -116,22 +116,22 @@ export class CalciteInlineEditable {
             <div class="calcite-inline-editable-cancel-editing-button-wrapper">
               <calcite-button
                 appearance="transparent"
-                aria-label={this.intlCancelEditing}
                 class="calcite-inline-editable-cancel-editing-button"
                 color="neutral"
                 disabled={this.disabled}
                 iconStart="x"
+                label={this.intlCancelEditing}
                 onClick={this.cancelEditingHandler}
                 scale={this.scale}
               />
             </div>,
             <calcite-button
               appearance="solid"
-              aria-label={this.intlConfirmChanges}
               class="calcite-inline-editable-confirm-changes-button"
               color="blue"
               disabled={this.disabled}
               iconStart="check"
+              label={this.intlConfirmChanges}
               loading={this.loading}
               onClick={this.confirmChangesHandler}
               scale={this.scale}

--- a/src/components/calcite-split-button/calcite-split-button.e2e.ts
+++ b/src/components/calcite-split-button/calcite-split-button.e2e.ts
@@ -83,8 +83,8 @@ describe("calcite-split-button", () => {
     expect(element).toEqualAttribute("dropdown-icon-type", "caret");
     expect(element).toHaveAttribute("loading");
     expect(element).toHaveAttribute("disabled");
-    expect(primaryButton).toEqualAttribute("aria-label", "primary action");
-    expect(dropdownButton).toEqualAttribute("aria-label", "more actions");
+    expect(await primaryButton.getProperty("label")).toBe("primary action");
+    expect(await dropdownButton.getProperty("label")).toBe("more actions");
     expect(element).toEqualAttribute("width", "half");
   });
 

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -72,13 +72,13 @@ export class CalciteSplitButton {
       <div class={widthClasses} dir={dir}>
         <calcite-button
           appearance={this.appearance}
-          aria-label={this.primaryLabel}
           color={this.color}
           dir={dir}
           disabled={this.disabled}
           icon-end={this.primaryIconEnd ? this.primaryIconEnd : null}
           icon-start={this.primaryIconStart ? this.primaryIconStart : null}
           iconFlipRtl={this.primaryIconFlipRtl ? this.primaryIconFlipRtl : null}
+          label={this.primaryLabel}
           loading={this.loading}
           onClick={this.calciteSplitButtonPrimaryClickHandler}
           scale={this.scale}
@@ -99,11 +99,11 @@ export class CalciteSplitButton {
         >
           <calcite-button
             appearance={this.appearance}
-            aria-label={this.dropdownLabel}
             color={this.color}
             dir={dir}
             disabled={this.disabled}
             icon-start={this.dropdownIcon}
+            label={this.dropdownLabel}
             scale={this.scale}
             slot="dropdown-trigger"
             splitChild={"secondary"}


### PR DESCRIPTION
**Related Issue:** #1579