### PR TITLE
fix(tree): allow focusing out of tree via shift + tab

### DIFF
--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -47,7 +47,7 @@ describe("calcite-tree", () => {
       expect(await page.evaluate(() => document.activeElement.matches("body"))).toBe(true);
     });
 
-    it("doesn't hold on to focus", async () => {
+    it("doesn't trap focus", async () => {
       const page = await newE2EPage({
         html: html` <calcite-tree>
           <calcite-tree-item id="one">1</calcite-tree-item>

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 
 describe("calcite-tree", () => {
   it("renders", async () => {
@@ -11,6 +12,67 @@ describe("calcite-tree", () => {
   });
 
   it("is accessible", async () => accessible(`<calcite-tree></calcite-tree>`));
+
+  describe("it forwards focus", () => {
+    it("to first selected item", async () => {
+      const page = await newE2EPage({
+        html: html` <calcite-tree>
+          <calcite-tree-item id="one">1</calcite-tree-item>
+          <calcite-tree-item id="two" selected>2</calcite-tree-item>
+          <calcite-tree-item id="three">3</calcite-tree-item>
+        </calcite-tree>`
+      });
+
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("calcite-tree-item#two"))).toBe(true);
+    });
+
+    it("to first item if none selected", async () => {
+      const page = await newE2EPage({
+        html: html` <calcite-tree>
+          <calcite-tree-item id="one">1</calcite-tree-item>
+          <calcite-tree-item id="two">2</calcite-tree-item>
+          <calcite-tree-item id="three">3</calcite-tree-item>
+        </calcite-tree>`
+      });
+
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("calcite-tree-item#one"))).toBe(true);
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("body"))).toBe(true);
+    });
+
+    it("doesn't hold on to focus", async () => {
+      const page = await newE2EPage({
+        html: html` <calcite-tree>
+          <calcite-tree-item id="one">1</calcite-tree-item>
+        </calcite-tree>`
+      });
+
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("calcite-tree-item#one"))).toBe(true);
+
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("body"))).toBe(true);
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("calcite-tree-item#one"))).toBe(true);
+
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("Tab");
+
+      expect(await page.evaluate(() => document.activeElement.matches("body"))).toBe(true);
+    });
+  });
 
   it("is accessible: with nested children", async () =>
     accessible(`

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -7,8 +7,7 @@ import {
   EventEmitter,
   Listen,
   h,
-  VNode,
-  Method
+  VNode
 } from "@stencil/core";
 import { focusElement, nodeListToArray } from "../../utils/dom";
 import { TreeItemSelectDetail } from "../calcite-tree-item/interfaces";

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -7,9 +7,10 @@ import {
   EventEmitter,
   Listen,
   h,
-  VNode
+  VNode,
+  Method
 } from "@stencil/core";
-import { nodeListToArray } from "../../utils/dom";
+import { focusElement, nodeListToArray } from "../../utils/dom";
 import { TreeItemSelectDetail } from "../calcite-tree-item/interfaces";
 import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
@@ -73,7 +74,7 @@ export class CalciteTree {
           this.selectionMode === TreeSelectionMode.MultiChildren
         }
         role={!this.child ? "tree" : undefined}
-        tabindex={!this.child ? "0" : undefined}
+        tabIndex={this.getRootTabIndex()}
       >
         <slot />
       </Host>
@@ -88,12 +89,28 @@ export class CalciteTree {
 
   @Listen("focus") onFocus(): void {
     if (!this.child) {
-      const selectedNode = this.el.querySelector(
-        "calcite-tree-item[selected]"
-      ) as HTMLCalciteTreeItemElement;
-      const firstNode = this.el.querySelector("calcite-tree-item") as HTMLCalciteTreeItemElement;
+      const focusTarget =
+        this.el.querySelector<HTMLCalciteTreeItemElement>("calcite-tree-item[selected]") ||
+        this.el.querySelector<HTMLCalciteTreeItemElement>("calcite-tree-item");
 
-      (selectedNode || firstNode).focus();
+      focusElement(focusTarget);
+    }
+  }
+
+  @Listen("focusin") onFocusIn(event: FocusEvent): void {
+    const focusedFromRootOrOutsideTree =
+      event.relatedTarget === this.el || !this.el.contains(event.relatedTarget as HTMLElement);
+
+    if (focusedFromRootOrOutsideTree) {
+      this.el.tabIndex = -1;
+    }
+  }
+
+  @Listen("focusout") onFocusOut(event: FocusEvent): void {
+    const willFocusOutsideTree = !this.el.contains(event.relatedTarget as HTMLElement);
+
+    if (willFocusOutsideTree) {
+      this.el.tabIndex = this.getRootTabIndex();
     }
   }
 
@@ -250,4 +267,14 @@ export class CalciteTree {
    * Emitted when user selects/deselects tree items. An object including an array of selected items will be passed in the event's `detail` property.
    */
   @Event() calciteTreeSelect: EventEmitter<TreeSelectDetail>;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  getRootTabIndex(): number {
+    return !this.child ? 0 : -1;
+  }
 }


### PR DESCRIPTION
**Related Issue:** #683 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where tree would keep focusing on the first tabbable item when you tried focusing out of it. This updates the component to make the root only tabbable if focus has been moved outside.

This also has a test for this case, but it's weird to have a test for browser element tabbing. 

I looked at adding a `setFocus` method, but will create a separate issue for it instead since I'm not sure if we need special considerations for focusing based on the selection mode.