### PR TITLE
feat(block): add slot for header menu actions

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, SLOTS, TEXT } from "./resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 
 describe("calcite-block", () => {
   it("renders", async () => renders("calcite-block"));
@@ -16,6 +17,14 @@ describe("calcite-block", () => {
       {
         propertyName: "headingLevel",
         defaultValue: undefined
+      },
+      {
+        propertyName: "intlLoading",
+        defaultValue: TEXT.loading
+      },
+      {
+        propertyName: "intlOptions",
+        defaultValue: TEXT.options
       },
       {
         propertyName: "open",
@@ -229,6 +238,20 @@ describe("calcite-block", () => {
 
       const statusIcon = await page.find(`calcite-block >>> .${CSS.statusIcon}`);
       expect(statusIcon).not.toBeNull();
+    });
+
+    it("allows users to slot in actions in a header menu", async () => {
+      const page = await newE2EPage({
+        html: html` <calcite-block heading="With header actions" summary="has header actions">
+          <calcite-action label="Add" icon="plus" slot="header-menu-actions"></calcite-action>
+        </calcite-block>`
+      });
+
+      const menuSlot = await page.find(`calcite-block >>> calcite-action-menu slot[name=${SLOTS.headerMenuActions}]`);
+      expect(menuSlot).toBeDefined();
+
+      const actionAssignedSlot = await page.$eval("calcite-action", (action) => action.assignedSlot.name);
+      expect(actionAssignedSlot).toBe(SLOTS.headerMenuActions);
     });
   });
 });

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -30,9 +30,9 @@
 
 .header-container {
   @apply grid items-stretch;
-  grid-template: auto / auto 1fr auto;
-  grid-template-areas: "handle header control";
-  grid-column: header-start / control-end;
+  grid-template: auto / auto 1fr auto auto;
+  grid-template-areas: "handle header control menu";
+  grid-column: header-start / menu-end;
   grid-row: 1 / 2;
 
   & > .header {
@@ -130,6 +130,10 @@ calcite-handle {
 .control-container {
   @apply flex m-0;
   grid-area: control;
+}
+
+calcite-action-menu {
+  grid-area: menu;
 }
 
 .calcite--rtl {

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,13 +1,14 @@
-import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
-import { CSS, SLOTS, TEXT, HEADING_LEVEL, ICONS } from "./resources";
+import { Component, Element, Event, EventEmitter, h, Host, Prop, VNode } from "@stencil/core";
+import { CSS, HEADING_LEVEL, ICONS, SLOTS, TEXT } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import { getElementDir, getSlotted } from "../../utils/dom";
-import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
+import { CalciteHeading, HeadingLevel } from "../functional/CalciteHeading";
 import { Status } from "../interfaces";
 
 /**
  * @slot icon - A slot for adding a trailing header icon.
  * @slot control - A slot for adding a single HTML input element in a header.
+ * @slot header-menu-actions - a slot for adding an overflow menu with actions inside a dropdown.
  * @slot - A slot for adding content to the block.
  */
 @Component({
@@ -59,6 +60,9 @@ export class CalciteBlock {
 
   /** string to override English loading text */
   @Prop() intlLoading?: string = TEXT.loading;
+
+  /** Text string used for the actions menu */
+  @Prop() intlOptions?: string = TEXT.options;
 
   /**
    * When true, content is waiting to be loaded. This state shows a busy indicator.
@@ -178,6 +182,7 @@ export class CalciteBlock {
     );
 
     const hasControl = !!getSlotted(el, SLOTS.control);
+    const hasMenuActions = !!getSlotted(el, SLOTS.headerMenuActions);
     const collapseIcon = open ? ICONS.opened : ICONS.closed;
 
     const headerNode = (
@@ -210,6 +215,11 @@ export class CalciteBlock {
           <div class={CSS.controlContainer}>
             <slot name={SLOTS.control} />
           </div>
+        ) : null}
+        {hasMenuActions ? (
+          <calcite-action-menu label={this.intlOptions || TEXT.options}>
+            <slot name={SLOTS.headerMenuActions} />
+          </calcite-action-menu>
         ) : null}
       </div>
     );

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -19,12 +19,14 @@ export const CSS = {
 export const TEXT = {
   collapse: "Collapse",
   expand: "Expand",
-  loading: "Loading"
+  loading: "Loading",
+  options: "Options"
 };
 
 export const SLOTS = {
   icon: "icon",
-  control: "control"
+  control: "control",
+  headerMenuActions: "header-menu-actions"
 };
 
 export const ICONS = {

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -29,6 +29,33 @@
           <label slot="control">test <input placeholder="I'm a header control" /></label>
         </calcite-block>
 
+        <h2>Header + actions menu</h2>
+
+        <calcite-block heading="With header actions" summary="has header actions">
+          <calcite-action
+            label="Add"
+            icon="plus"
+            text="Add item"
+            text-enabled
+            slot="header-menu-actions"
+          ></calcite-action>
+          <calcite-action icon="minus" text="Remove item" text-enabled slot="header-menu-actions"></calcite-action>
+        </calcite-block>
+
+        <h2>Header + control + actions menu</h2>
+
+        <calcite-block heading="With header actions" summary="has header actions">
+          <label slot="control">test <input placeholder="I'm a header control" /></label>
+          <calcite-action
+            label="Add"
+            icon="plus"
+            text="Add item"
+            text-enabled
+            slot="header-menu-actions"
+          ></calcite-action>
+          <calcite-action icon="minus" text="Remove item" text-enabled slot="header-menu-actions"></calcite-action>
+        </calcite-block>
+
         <h2>Header + control + content (collapsible)</h2>
 
         <calcite-block heading="With control + collapsible content" open collapsible>


### PR DESCRIPTION
**Related Issue:** #963 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds support for menu actions to the block header.

![block-with-header-actions](https://user-images.githubusercontent.com/197440/124309837-320bc280-db20-11eb-8491-08ebd7c3b86f.gif)
