### PR TITLE
fix(tree): prevent emitting selection event twice when a tree-item's checkbox label is clicked

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -124,6 +124,7 @@
 .calcite-tree-label {
   display: flex;
   align-items: center;
+  pointer-events: none;
 }
 
 .calcite-tree-children {

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -133,7 +133,6 @@ export class CalciteTreeItem {
           class="calcite-tree-checkbox"
           data-test-id="checkbox"
           indeterminate={this.hasChildren && this.indeterminate}
-          onClick={this.checkboxClickHandler}
           scale={this.scale}
           tabIndex={-1}
         />
@@ -209,15 +208,6 @@ export class CalciteTreeItem {
   };
 
   childrenClickHandler = (event: MouseEvent): void => event.stopPropagation();
-
-  checkboxClickHandler = (event: Event): void => {
-    event.stopPropagation();
-    this.calciteTreeItemSelect.emit({
-      modifyCurrentSelection: (event as any).shiftKey,
-      forceToggle: true
-    });
-    this.el.focus();
-  };
 
   @Listen("keydown") keyDownHandler(e: KeyboardEvent): void {
     let root;

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -149,40 +149,60 @@ describe("calcite-tree", () => {
     expect(two).toHaveAttribute("indeterminate");
   });
 
-  it("allows selecting items", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-tree input-enabled selection-mode="ancestors">
-        <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
-        <calcite-tree-item id="two">
-          <span>Two</span>
-          <calcite-tree slot="children">
-            <calcite-tree-item id="child-one">
-              <span>Child 1</span>
-              <calcite-tree slot="children">
-                <calcite-tree-item id="grandchild-one">
-                  <span>Grandchild 1</span>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-          </calcite-tree>
-        </calcite-tree-item>
-      </calcite-tree>`
+  describe("item selection", () => {
+    it("allows selecting items", async () => {
+      const page = await newE2EPage({
+        html: html`<calcite-tree input-enabled selection-mode="ancestors">
+          <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
+          <calcite-tree-item id="two">
+            <span>Two</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item id="child-one">
+                <span>Child 1</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item id="grandchild-one">
+                    <span>Grandchild 1</span>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>`
+      });
+
+      const tree = await page.find("calcite-tree");
+      const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
+      const one = await page.find("#one");
+      const childOne = await page.find("#child-one");
+      const grandchildOne = await page.find("#grandchild-one");
+
+      await one.click();
+      expect(selectEventSpy).toHaveReceivedEventTimes(1);
+
+      await childOne.press(" ");
+      expect(selectEventSpy).toHaveReceivedEventTimes(2);
+
+      await grandchildOne.press("Enter");
+
+      expect(selectEventSpy).toHaveReceivedEventTimes(3);
     });
 
-    const tree = await page.find("calcite-tree");
-    const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
-    const one = await page.find("#one");
-    const childOne = await page.find("#child-one");
-    const grandchildOne = await page.find("#grandchild-one");
+    it("emits once when the tree item checkbox label is clicked", async () => {
+      const page = await newE2EPage({
+        html: html`<calcite-tree input-enabled selection-mode="ancestors">
+          <calcite-tree-item>1</calcite-tree-item>
+        </calcite-tree>`
+      });
 
-    await one.click();
-    expect(selectEventSpy).toHaveReceivedEventTimes(1);
+      const tree = await page.find("calcite-tree");
+      const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
+      const treeItemCheckboxLabel = await page.find("calcite-tree-item >>> .calcite-tree-label");
 
-    await childOne.press(" ");
-    expect(selectEventSpy).toHaveReceivedEventTimes(2);
+      await treeItemCheckboxLabel.click();
+      expect(selectEventSpy).toHaveReceivedEventTimes(1);
 
-    await grandchildOne.press("Enter");
-
-    expect(selectEventSpy).toHaveReceivedEventTimes(3);
+      await treeItemCheckboxLabel.click();
+      expect(selectEventSpy).toHaveReceivedEventTimes(2);
+    });
   });
 });


### PR DESCRIPTION
**Related Issue:** #2196 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR fixes an issue caused the default behavior from the tree item's checkbox label. Clicking it would cause a 2 clicks to be fired (from the host and checkbox+label). The internal label + checkbox are no longer interactive since the item itself handles this already.