### PR TITLE
fix(popover, tooltip): Query for referenceElement if needed when the tooltip/popover is opened or closed. #2446

### DIFF
--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -90,6 +90,10 @@ describe("calcite-popover", () => {
 
     const element = await page.find("calcite-popover");
 
+    let computedStyle: CSSStyleDeclaration = await element.getComputedStyle();
+
+    expect(computedStyle.transform).toBe("matrix(0, 0, 0, 0, 0, 0)");
+
     await page.$eval("calcite-popover", (elm: any) => {
       const referenceElement = document.createElement("div");
       document.body.appendChild(referenceElement);
@@ -98,9 +102,9 @@ describe("calcite-popover", () => {
 
     await page.waitForChanges();
 
-    const computedStyle = await element.getComputedStyle();
+    computedStyle = await element.getComputedStyle();
 
-    expect(computedStyle.transform).not.toBe("none");
+    expect(computedStyle.transform).not.toBe("matrix(0, 0, 0, 0, 0, 0)");
   });
 
   it("open popover should be visible", async () => {
@@ -148,7 +152,7 @@ describe("calcite-popover", () => {
 
     const computedStyle = await element.getComputedStyle();
 
-    expect(computedStyle.transform).not.toBe("none");
+    expect(computedStyle.transform).not.toBe("matrix(0, 0, 0, 0, 0, 0)");
   });
 
   it("should show closeButton when enabled", async () => {

--- a/src/components/calcite-popover/calcite-popover.e2e.ts
+++ b/src/components/calcite-popover/calcite-popover.e2e.ts
@@ -291,4 +291,35 @@ describe("calcite-popover", () => {
     expect(id).toEqual(userDefinedId);
     expect(referenceId).toEqual(userDefinedId);
   });
+
+  it("should get referenceElement when opened", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-popover placement="auto" reference-element="ref">content</calcite-popover>`);
+
+    await page.waitForChanges();
+
+    const element = await page.find("calcite-popover");
+
+    let computedStyle: CSSStyleDeclaration = await element.getComputedStyle();
+
+    expect(computedStyle.transform).toBe("matrix(0, 0, 0, 0, 0, 0)");
+
+    await page.evaluate(() => {
+      const referenceElement = document.createElement("div");
+      referenceElement.id = "ref";
+      referenceElement.innerHTML = "test";
+      document.body.appendChild(referenceElement);
+    });
+
+    await page.waitForChanges();
+
+    element.setProperty("open", true);
+
+    await page.waitForChanges();
+
+    computedStyle = await element.getComputedStyle();
+
+    expect(computedStyle.transform).not.toBe("matrix(0, 0, 0, 0, 0, 0)");
+  });
 });

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -116,8 +116,13 @@ export class CalcitePopover {
 
   @Watch("open")
   openHandler(open: boolean): void {
+    if (!this._referenceElement) {
+      this.referenceElementHandler();
+    }
+
     this.reposition();
     this.setExpandedAttr();
+
     if (open) {
       this.calcitePopoverOpen.emit();
     } else {

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -69,6 +69,8 @@ describe("calcite-tooltip", () => {
 
     const element = await page.find("calcite-tooltip");
 
+    expect(computedStyle.transform).toBe("none");
+
     await page.$eval("calcite-tooltip", (elm: any) => {
       const referenceElement = document.createElement("div");
       document.body.appendChild(referenceElement);
@@ -241,5 +243,36 @@ describe("calcite-tooltip", () => {
 
     expect(id).toEqual(userDefinedId);
     expect(referenceId).toEqual(userDefinedId);
+  });
+
+  it("should get referenceElement when opened", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-tooltip placement="auto" reference-element="ref">content</calcite-tooltip>`);
+
+    await page.waitForChanges();
+
+    const element = await page.find("calcite-tooltip");
+
+    let computedStyle: CSSStyleDeclaration = await element.getComputedStyle();
+
+    expect(computedStyle.transform).toBe("matrix(0, 0, 0, 0, 0, 0)");
+
+    await page.evaluate(() => {
+      const referenceElement = document.createElement("div");
+      referenceElement.id = "ref";
+      referenceElement.innerHTML = "test";
+      document.body.appendChild(referenceElement);
+    });
+
+    await page.waitForChanges();
+
+    element.setProperty("open", true);
+
+    await page.waitForChanges();
+
+    computedStyle = await element.getComputedStyle();
+
+    expect(computedStyle.transform).not.toBe("matrix(0, 0, 0, 0, 0, 0)");
   });
 });

--- a/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
+++ b/src/components/calcite-tooltip/calcite-tooltip.e2e.ts
@@ -69,7 +69,9 @@ describe("calcite-tooltip", () => {
 
     const element = await page.find("calcite-tooltip");
 
-    expect(computedStyle.transform).toBe("none");
+    let computedStyle: CSSStyleDeclaration = await element.getComputedStyle();
+
+    expect(computedStyle.transform).toBe("matrix(0, 0, 0, 0, 0, 0)");
 
     await page.$eval("calcite-tooltip", (elm: any) => {
       const referenceElement = document.createElement("div");
@@ -79,9 +81,9 @@ describe("calcite-tooltip", () => {
 
     await page.waitForChanges();
 
-    const computedStyle = await element.getComputedStyle();
+    computedStyle = await element.getComputedStyle();
 
-    expect(computedStyle.transform).not.toBe("none");
+    expect(computedStyle.transform).not.toBe("matrix(0, 0, 0, 0, 0, 0)");
   });
 
   it("open tooltip should be visible", async () => {
@@ -129,7 +131,7 @@ describe("calcite-tooltip", () => {
 
     const computedStyle = await element.getComputedStyle();
 
-    expect(computedStyle.transform).not.toBe("none");
+    expect(computedStyle.transform).not.toBe("matrix(0, 0, 0, 0, 0, 0)");
   });
 
   it("should honor hover interaction", async () => {

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -54,6 +54,10 @@ export class CalciteTooltip {
 
   @Watch("open")
   openHandler(): void {
+    if (!this._referenceElement) {
+      this.referenceElementHandler();
+    }
+
     this.reposition();
   }
 


### PR DESCRIPTION
**Related Issue:** #2446

## Summary

fix(popover, tooltip): Query for referenceElement if needed when the tooltip/popover is opened or closed. #2446