### PR TITLE
feat(slider): add support for mirroring slider

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -1,13 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { HYDRATED_ATTR } from "../../tests/commonTests";
+import { defaults, renders } from "../../tests/commonTests";
 
 describe("calcite-slider", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-slider></calcite-slider>");
-    const element = await page.find("calcite-slider");
-    expect(element).toHaveAttribute(HYDRATED_ATTR);
-  });
+  it("renders", async () => renders("calcite-slider"));
+
+  it("has defaults", async () =>
+    defaults("calcite-slider", [
+      {
+        propertyName: "mirrored",
+        defaultValue: false
+      }
+    ]));
 
   it("becomes inactive from disabled prop", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -85,7 +85,7 @@ $tick-height: 4px;
       top: 0;
       bottom: 0;
     }
-    &--minValue.hyphen::after {
+    &.hyphen::after {
       content: "\2014";
       display: inline-block;
       width: 1em;
@@ -355,5 +355,19 @@ $tick-height: 4px;
   .graph-path--highlight {
     fill: var(--calcite-ui-brand);
     opacity: 0.25;
+  }
+}
+
+:host([mirrored]:not([has-histogram])) {
+  .tick__label--min {
+    right: 0;
+    left: unset;
+    text-align: right;
+  }
+
+  .tick__label--max {
+    right: unset;
+    left: 0;
+    text-align: left;
   }
 }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -683,52 +683,46 @@ export class CalciteSlider {
     }
   }
 
-  @Listen("keydown") keyDownHandler(e: KeyboardEvent): void {
-    const value = this[this.activeProp];
-    switch (getKey(e.key)) {
-      case "ArrowUp":
-      case "ArrowRight":
-        e.preventDefault();
-        this[this.activeProp] = this.clamp(value + this.step, this.activeProp);
-        this.emitChange();
-        break;
-      case "ArrowDown":
-      case "ArrowLeft":
-        e.preventDefault();
-        this[this.activeProp] = this.clamp(value - this.step, this.activeProp);
-        this.emitChange();
-        break;
-      case "PageUp":
-        if (this.pageStep) {
-          e.preventDefault();
-          this[this.activeProp] = this.clamp(value + this.pageStep, this.activeProp);
-          this.emitChange();
-        }
-        break;
-      case "PageDown":
-        if (this.pageStep) {
-          e.preventDefault();
-          this[this.activeProp] = this.clamp(value - this.pageStep, this.activeProp);
-          this.emitChange();
-        }
-        break;
-      case "Home":
-        e.preventDefault();
-        this[this.activeProp] = this.clamp(this.min, this.activeProp);
-        this.emitChange();
-        break;
-      case "End":
-        e.preventDefault();
-        this[this.activeProp] = this.clamp(this.max, this.activeProp);
-        this.emitChange();
-        break;
+  @Listen("keydown") keyDownHandler(event: KeyboardEvent): void {
+    const mirror = this.shouldMirror();
+    const { activeProp, max, min, pageStep, step } = this;
+    const value = this[activeProp];
+    const key = getKey(event.key);
 
-      // prevent activation keys from firing a click event
-      case "Enter":
-      case " ":
-        e.preventDefault();
-        break;
+    if (key === "Enter" || key === " ") {
+      event.preventDefault();
+      return;
     }
+
+    let adjustment: number;
+
+    if (key === "ArrowUp" || key === "ArrowRight") {
+      const directionFactor = mirror && key === "ArrowRight" ? -1 : 1;
+      adjustment = value + step * directionFactor;
+    } else if (key === "ArrowDown" || key === "ArrowLeft") {
+      const directionFactor = mirror && key === "ArrowLeft" ? -1 : 1;
+      adjustment = value - step * directionFactor;
+    } else if (key === "PageUp") {
+      if (pageStep) {
+        adjustment = value + pageStep;
+      }
+    } else if (key === "PageDown") {
+      if (pageStep) {
+        adjustment = value - pageStep;
+      }
+    } else if (key === "Home") {
+      adjustment = min;
+    } else if (key === "End") {
+      adjustment = max;
+    }
+
+    if (isNaN(adjustment)) {
+      return;
+    }
+
+    event.preventDefault();
+    this[activeProp] = this.clamp(adjustment, activeProp);
+    this.emitChange();
   }
 
   @Listen("mousedown")

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -20,7 +20,7 @@
       }
       .two-columns {
         display: grid;
-        grid-template-columns: 350px 350px;
+        grid-template-columns: 1fr 1fr;
         grid-gap: 20px;
       }
 
@@ -38,991 +38,2513 @@
     <h1>Calcite Slider</h1>
 
     <div class="two-columns">
-      <div class="demo-background-light">
-        <h2>Single Value</h2>
+      <div class="two-columns">
+        <div class="demo-background-light">
+          <h2>Single Value</h2>
 
-        <demo-spacer>
-          <h3>Handle</h3>
-          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+          <demo-spacer>
+            <h3>Handle</h3>
+            <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
 
-          <h3>Labeled Handle</h3>
-          <calcite-slider
-            min="100"
-            max="1000"
-            value="1000"
-            step="10"
-            label="Temperature"
-            label-handles
-          ></calcite-slider>
+            <h3>Labeled Handle</h3>
+            <calcite-slider
+              min="100"
+              max="1000"
+              value="1000"
+              step="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Precise Handle</h3>
-          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
-          </calcite-slider>
+            <h3>Precise Handle</h3>
+            <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+            </calcite-slider>
 
-          <h3>Precise Labeled Handle</h3>
-          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
-          </calcite-slider>
+            <h3>Precise Labeled Handle</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              value="100000"
+              step="1000"
+              label="Temperature"
+              precise
+              label-handles
+            >
+            </calcite-slider>
 
-          <h3>Ticks</h3>
-          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+            <h3>Ticks</h3>
+            <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
 
-          <h3>Ticks with Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
-          </calcite-slider>
-          <calcite-slider min="-100" max="0" value="0" step="10" ticks="10" label="Temperature" label-handles>
-          </calcite-slider>
+            <h3>Ticks with Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+            </calcite-slider>
+            <calcite-slider min="-100" max="0" value="0" step="10" ticks="10" label="Temperature" label-handles>
+            </calcite-slider>
 
-          <h3>Ticks with Precise Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="50"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            precise
-          ></calcite-slider>
+            <h3>Ticks with Precise Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="50"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            ></calcite-slider>
 
-          <h3>Ticks with Precise Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
-          </calcite-slider>
+            <h3>Ticks with Precise Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
+            </calcite-slider>
 
-          <h3>Labeled Ticks</h3>
-          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
-          </calcite-slider>
+            <h3>Labeled Ticks</h3>
+            <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="40"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="40"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Precise Handle</h3>
-          <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Handle</h3>
+            <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Precise Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="23"
-            step="10"
-            ticks="10"
-            label-handles
-            label-ticks
-            precise
-            label="Temperature"
-          ></calcite-slider>
+            <h3>Labeled Ticks with Precise Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="23"
+              step="10"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+              label="Temperature"
+            ></calcite-slider>
 
-          <h3>Disabled</h3>
-          <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+            <h3>Disabled</h3>
+            <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
 
-          <h3>Histogram</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+            <h3>Histogram</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
 
-          <h3>Histogram with Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+            <h3>Histogram with Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
 
-          <h3>Histogram with Precise Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+            <h3>Histogram with Precise Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
 
-          <h3>Histogram with Precise Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
-          </calcite-slider>
+            <h3>Histogram with Precise Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+            </calcite-slider>
 
-          <h3>Histogram with Ticks</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
 
-          <h3>Histogram with Ticks and Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
-          </calcite-slider>
+            <h3>Histogram with Ticks and Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
+            </calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="60"
-            step="10"
-            class="js-histogram"
-            ticks="10"
-            precise
-          ></calcite-slider>
+            <h3>Histogram with Ticks and Precise Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
-          </calcite-slider>
+            <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="60"
-            step="10"
-            class="js-histogram"
-            ticks="10"
-            label-handles
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="60"
-            step="10"
-            class="js-histogram"
-            ticks="10"
-            label-handles
-            label-ticks
-            precise
-          ></calcite-slider>
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram Disabled</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
-        </demo-spacer>
+            <h3>Histogram Disabled</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+          </demo-spacer>
 
-        <h2>Range</h2>
+          <h2>Range</h2>
 
-        <demo-spacer>
-          <h3>Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-          ></calcite-slider>
+          <demo-spacer>
+            <h3>Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+            ></calcite-slider>
 
-          <h3>Labeled Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            label-handles
-          ></calcite-slider>
+            <h3>Labeled Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Precise Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            precise
-          ></calcite-slider>
+            <h3>Labeled Handles (edge positioning)</h3>
 
-          <h3>Precise Labeled Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            precise
-            label-handles
-          >
-          </calcite-slider>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="0"
+              max-value="0"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks</h3>
-          <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
-          </calcite-slider>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="0"
+              max-value="0.5"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks with Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-          ></calcite-slider>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="0"
+              max-value="5"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks with Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            precise
-          >
-          </calcite-slider>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="100"
+              max-value="100"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks with Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-            precise
-          >
-          </calcite-slider>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="99.5"
+              max-value="100"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Labeled Ticks</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-ticks
-          >
-          </calcite-slider>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="95"
+              max-value="100"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Labeled Ticks with Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-            label-ticks
-          ></calcite-slider>
+            <h3>Precise Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+            ></calcite-slider>
 
-          <h3>Labeled Ticks with Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            precise
-            label-ticks
-          ></calcite-slider>
+            <h3>Precise Labeled Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+              label-handles
+            >
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Precise Labeled Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="30000"
-            max-value="80000"
-            step="10000"
-            ticks="10000"
-            label="Temperature"
-            precise
-            label-handles
-            label-ticks
-          ></calcite-slider>
+            <h3>Ticks</h3>
+            <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+            </calcite-slider>
 
-          <h3>Histogram</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-          ></calcite-slider>
+            <h3>Ticks with Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-          ></calcite-slider>
-          <calcite-slider
-            min="-100"
-            max="0"
-            min-value="-100"
-            max-value="0"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-          ></calcite-slider>
+            <h3>Ticks with Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            precise
-          ></calcite-slider>
+            <h3>Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            precise
-            label-handles
-          ></calcite-slider>
+            <h3>Labeled Ticks</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-ticks
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Ticks</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            precise
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="30000"
+              max-value="80000"
+              step="10000"
+              ticks="10000"
+              label="Temperature"
+              precise
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-            precise
-          >
-          </calcite-slider>
+            <h3>Histogram</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Histogram with Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
+            <calcite-slider
+              min="-100"
+              max="0"
+              min-value="-100"
+              max-value="0"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Histogram with Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-ticks
-            precise
-          >
-          </calcite-slider>
+            <h3>Histogram with Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-            label-ticks
-            precise
-          >
-          </calcite-slider>
-        </demo-spacer>
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+          </demo-spacer>
+        </div>
+
+        <div class="demo-background-dark calcite-theme-dark">
+          <h2>Single Value</h2>
+
+          <demo-spacer>
+            <h3>Handle</h3>
+            <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+
+            <h3>Labeled Handle</h3>
+            <calcite-slider
+              min="100"
+              max="1000"
+              value="1000"
+              step="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Precise Handle</h3>
+            <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+            </calcite-slider>
+
+            <h3>Precise Labeled Handle</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              value="100000"
+              step="1000"
+              label="Temperature"
+              precise
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Ticks</h3>
+            <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+
+            <h3>Ticks with Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
+            </calcite-slider>
+
+            <h3>Ticks with Precise Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="50"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            ></calcite-slider>
+
+            <h3>Ticks with Precise Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
+            </calcite-slider>
+
+            <h3>Labeled Ticks</h3>
+            <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="40"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Precise Handle</h3>
+            <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Precise Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="23"
+              step="10"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+              label="Temperature"
+            ></calcite-slider>
+
+            <h3>Disabled</h3>
+            <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+
+            <h3>Histogram</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+
+            <h3>Histogram with Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+
+            <h3>Histogram with Precise Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+
+            <h3>Histogram with Precise Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+            </calcite-slider>
+
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+
+            <h3>Histogram with Ticks and Labeled Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+            <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram Disabled</h3>
+            <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
+          </demo-spacer>
+
+          <h2>Range</h2>
+
+          <demo-spacer>
+            <h3>Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+            ></calcite-slider>
+
+            <h3>Labeled Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Precise Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+            ></calcite-slider>
+
+            <h3>Precise Labeled Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Ticks</h3>
+            <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
+            </calcite-slider>
+
+            <h3>Ticks with Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Ticks with Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            ></calcite-slider>
+
+            <h3>Labeled Ticks with Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+              label-ticks
+            ></calcite-slider>
+
+            <h3>Labeled Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              min="10000"
+              max="100000"
+              min-value="30000"
+              max-value="80000"
+              step="10000"
+              ticks="10000"
+              label="Temperature"
+              precise
+              label-handles
+              label-ticks
+            ></calcite-slider>
+
+            <h3>Histogram</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            ></calcite-slider>
+
+            <h3>Histogram with Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Histogram with Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram with Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+              label-handles
+            ></calcite-slider>
+
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+          </demo-spacer>
+        </div>
       </div>
+      <div class="two-columns">
+        <div class="demo-background-light">
+          <h2>Single Value (mirrored)</h2>
 
-      <div class="demo-background-dark calcite-theme-dark">
-        <h2>Single Value</h2>
+          <demo-spacer>
+            <h3>Handle</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              value="100000"
+              step="1000"
+              label="Temperature"
+            ></calcite-slider>
 
-        <demo-spacer>
-          <h3>Handle</h3>
-          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature"></calcite-slider>
+            <h3>Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="100"
+              max="1000"
+              value="1000"
+              step="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Labeled Handle</h3>
-          <calcite-slider
-            min="100"
-            max="1000"
-            value="1000"
-            step="10"
-            label="Temperature"
-            label-handles
-          ></calcite-slider>
+            <h3>Precise Handle</h3>
+            <calcite-slider mirrored min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+            </calcite-slider>
 
-          <h3>Precise Handle</h3>
-          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
-          </calcite-slider>
+            <h3>Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              value="100000"
+              step="1000"
+              label="Temperature"
+              precise
+              label-handles
+            >
+            </calcite-slider>
 
-          <h3>Precise Labeled Handle</h3>
-          <calcite-slider min="10000" max="100000" value="100000" step="1000" label="Temperature" precise label-handles>
-          </calcite-slider>
+            <h3>Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="20"
+              step="10"
+              ticks="10"
+              label="Temperature"
+            ></calcite-slider>
 
-          <h3>Ticks</h3>
-          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label="Temperature"></calcite-slider>
+            <h3>Ticks with Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="40"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            >
+            </calcite-slider>
+            <calcite-slider
+              mirrored
+              min="-100"
+              max="0"
+              value="0"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            >
+            </calcite-slider>
 
-          <h3>Ticks with Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="40" step="10" ticks="10" label="Temperature" label-handles>
-          </calcite-slider>
+            <h3>Ticks with Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="50"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            ></calcite-slider>
 
-          <h3>Ticks with Precise Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="50"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            precise
-          ></calcite-slider>
+            <h3>Ticks with Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Ticks with Precise Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" ticks="10" label="Temperature" label-handles precise>
-          </calcite-slider>
+            <h3>Labeled Ticks</h3>
+            <calcite-slider mirrored min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+            </calcite-slider>
 
-          <h3>Labeled Ticks</h3>
-          <calcite-slider min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
-          </calcite-slider>
+            <h3>Labeled Ticks with Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="40"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="40"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="23"
+              step="10"
+              ticks="10"
+              label-ticks
+              precise
+              label="Temperature"
+            >
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Precise Handle</h3>
-          <calcite-slider min="0" max="100" value="23" step="10" ticks="10" label-ticks precise label="Temperature">
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="23"
+              step="10"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+              label="Temperature"
+            ></calcite-slider>
 
-          <h3>Labeled Ticks with Precise Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="23"
-            step="10"
-            ticks="10"
-            label-handles
-            label-ticks
-            precise
-            label="Temperature"
-          ></calcite-slider>
+            <h3>Disabled</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="40"
+              step="1"
+              label="Temperature"
+              disabled
+            ></calcite-slider>
 
-          <h3>Disabled</h3>
-          <calcite-slider min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+            <h3>Histogram</h3>
+            <calcite-slider mirrored min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
 
-          <h3>Histogram</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+            <h3>Histogram with Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles></calcite-slider>
+            <h3>Histogram with Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram"
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram with Precise Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" precise></calcite-slider>
+            <h3>Histogram with Precise Labeled Handle</h3>
+            <calcite-slider mirrored min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+            </calcite-slider>
 
-          <h3>Histogram with Precise Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
-          </calcite-slider>
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10"></calcite-slider>
+            <h3>Histogram with Ticks and Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Ticks and Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles>
-          </calcite-slider>
+            <h3>Histogram with Ticks and Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="60"
-            step="10"
-            class="js-histogram"
-            ticks="10"
-            precise
-          ></calcite-slider>
+            <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Labeled Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-handles precise>
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider mirrored min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="60"
-            step="10"
-            class="js-histogram"
-            ticks="10"
-            label-handles
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-ticks
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Handle</h3>
-          <calcite-slider min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks precise>
-          </calcite-slider>
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            value="60"
-            step="10"
-            class="js-histogram"
-            ticks="10"
-            label-handles
-            label-ticks
-            precise
-          ></calcite-slider>
+            <h3>Histogram Disabled</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram"
+              disabled
+            ></calcite-slider>
+          </demo-spacer>
 
-          <h3>Histogram Disabled</h3>
-          <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
-        </demo-spacer>
+          <h2>Range (mirrored)</h2>
 
-        <h2>Range</h2>
+          <demo-spacer>
+            <h3>Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+            ></calcite-slider>
 
-        <demo-spacer>
-          <h3>Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-          ></calcite-slider>
+            <h3>Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Labeled Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            label-handles
-          ></calcite-slider>
+            <h3>Labeled Handles (edge positioning)</h3>
 
-          <h3>Precise Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            precise
-          ></calcite-slider>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="0"
+              max-value="0"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Precise Labeled Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="10000"
-            max-value="100000"
-            step="1000"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            precise
-            label-handles
-          >
-          </calcite-slider>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="0"
+              max-value="0.5"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks</h3>
-          <calcite-slider min="0" max="100" min-value="20" max-value="80" step="10" ticks="10" label="Temperature">
-          </calcite-slider>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="0"
+              max-value="5"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks with Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-          ></calcite-slider>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="100"
+              max-value="100"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks with Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            precise
-          >
-          </calcite-slider>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="99.5"
+              max-value="100"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Ticks with Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-            precise
-          >
-          </calcite-slider>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="95"
+              max-value="100"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Labeled Ticks</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+            ></calcite-slider>
 
-          <h3>Labeled Ticks with Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            label-handles
-            label-ticks
-          ></calcite-slider>
+            <h3>Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+              label-handles
+            >
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="20"
-            max-value="80"
-            step="10"
-            ticks="10"
-            label="Temperature"
-            precise
-            label-ticks
-          ></calcite-slider>
+            <h3>Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+            >
+            </calcite-slider>
 
-          <h3>Labeled Ticks with Precise Labeled Handles</h3>
-          <calcite-slider
-            min="10000"
-            max="100000"
-            min-value="30000"
-            max-value="80000"
-            step="10000"
-            ticks="10000"
-            label="Temperature"
-            precise
-            label-handles
-            label-ticks
-          ></calcite-slider>
+            <h3>Ticks with Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-          ></calcite-slider>
+            <h3>Ticks with Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-          ></calcite-slider>
+            <h3>Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              precise
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            precise
-          ></calcite-slider>
+            <h3>Labeled Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-ticks
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="85"
-            step="1"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            precise
-            label-handles
-          ></calcite-slider>
+            <h3>Labeled Ticks with Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-          >
-          </calcite-slider>
+            <h3>Labeled Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="30000"
+              max-value="80000"
+              step="10000"
+              ticks="10000"
+              label="Temperature"
+              precise
+              label-handles
+              label-ticks
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            precise
-          >
-          </calcite-slider>
+            <h3>Histogram</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            ></calcite-slider>
 
-          <h3>Histogram with Ticks and Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-            precise
-          >
-          </calcite-slider>
+            <h3>Histogram with Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
+            <calcite-slider
+              mirrored
+              min="-100"
+              max="0"
+              min-value="-100"
+              max-value="0"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Histogram with Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-            label-ticks
-          >
-          </calcite-slider>
+            <h3>Histogram with Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+              label-handles
+            ></calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-ticks
-            precise
-          >
-          </calcite-slider>
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            >
+            </calcite-slider>
 
-          <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
-          <calcite-slider
-            min="0"
-            max="100"
-            min-value="50"
-            max-value="80"
-            step="10"
-            ticks="10"
-            min-label="Temperature range (lower)"
-            max-label="Temperature range (upper)"
-            class="js-histogram"
-            label-handles
-            label-ticks
-            precise
-          >
-          </calcite-slider>
-        </demo-spacer>
+            <h3>Histogram with Ticks and Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+          </demo-spacer>
+        </div>
+
+        <div class="demo-background-dark calcite-theme-dark">
+          <h2>Single Value (mirrored)</h2>
+
+          <demo-spacer>
+            <h3>Handle</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              value="100000"
+              step="1000"
+              label="Temperature"
+            ></calcite-slider>
+
+            <h3>Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="100"
+              max="1000"
+              value="1000"
+              step="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Precise Handle</h3>
+            <calcite-slider mirrored min="10000" max="100000" value="100000" step="1000" label="Temperature" precise>
+            </calcite-slider>
+
+            <h3>Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              value="100000"
+              step="1000"
+              label="Temperature"
+              precise
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="20"
+              step="10"
+              ticks="10"
+              label="Temperature"
+            ></calcite-slider>
+
+            <h3>Ticks with Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="40"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Ticks with Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="50"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            ></calcite-slider>
+
+            <h3>Ticks with Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks</h3>
+            <calcite-slider mirrored min="0" max="100" value="20" step="10" ticks="10" label-ticks label="Temperature">
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="40"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="23"
+              step="10"
+              ticks="10"
+              label-ticks
+              precise
+              label="Temperature"
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="23"
+              step="10"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+              label="Temperature"
+            ></calcite-slider>
+
+            <h3>Disabled</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="40"
+              step="1"
+              label="Temperature"
+              disabled
+            ></calcite-slider>
+
+            <h3>Histogram</h3>
+            <calcite-slider mirrored min="0" max="100" value="60" step="1" class="js-histogram"></calcite-slider>
+
+            <h3>Histogram with Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Histogram with Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram"
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram with Precise Labeled Handle</h3>
+            <calcite-slider mirrored min="0" max="100" value="60" step="1" class="js-histogram" label-handles precise>
+            </calcite-slider>
+
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+            ></calcite-slider>
+
+            <h3>Histogram with Ticks and Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider mirrored min="0" max="100" value="60" step="10" class="js-histogram" ticks="10" label-ticks>
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handle</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="10"
+              class="js-histogram"
+              ticks="10"
+              label-handles
+              label-ticks
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram Disabled</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram"
+              disabled
+            ></calcite-slider>
+          </demo-spacer>
+
+          <h2>Range (mirrored)</h2>
+
+          <demo-spacer>
+            <h3>Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+            ></calcite-slider>
+
+            <h3>Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+            ></calcite-slider>
+
+            <h3>Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="10000"
+              max-value="100000"
+              step="1000"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              precise
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+            >
+            </calcite-slider>
+
+            <h3>Ticks with Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Ticks with Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Labeled Ticks with Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              label-handles
+              label-ticks
+            ></calcite-slider>
+
+            <h3>Labeled Ticks with Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="20"
+              max-value="80"
+              step="10"
+              ticks="10"
+              label="Temperature"
+              precise
+              label-ticks
+            ></calcite-slider>
+
+            <h3>Labeled Ticks with Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="10000"
+              max="100000"
+              min-value="30000"
+              max-value="80000"
+              step="10000"
+              ticks="10000"
+              label="Temperature"
+              precise
+              label-handles
+              label-ticks
+            ></calcite-slider>
+
+            <h3>Histogram</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            ></calcite-slider>
+
+            <h3>Histogram with Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            ></calcite-slider>
+
+            <h3>Histogram with Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            ></calcite-slider>
+
+            <h3>Histogram with Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="85"
+              step="1"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+              label-handles
+            ></calcite-slider>
+
+            <h3>Histogram with Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+
+            <h3>Histogram with Labeled Ticks and Precise Labeled Handles</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              min-value="50"
+              max-value="80"
+              step="10"
+              ticks="10"
+              min-label="Temperature range (lower)"
+              max-label="Temperature range (upper)"
+              class="js-histogram"
+              label-handles
+              label-ticks
+              precise
+            >
+            </calcite-slider>
+          </demo-spacer>
+        </div>
       </div>
     </div>
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -215,3 +215,12 @@ export function setRequestedIcon(
     return iconObject[matchedValue];
   }
 }
+
+export function intersects(rect1: DOMRect, rect2: DOMRect): boolean {
+  return !(
+    rect2.left > rect1.right ||
+    rect2.right < rect1.left ||
+    rect2.top > rect1.bottom ||
+    rect2.bottom < rect1.top
+  );
+}


### PR DESCRIPTION
**Related Issue:** #720

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds a `mirrored` property to `calcite-slider` (default false). When set to true, it will invert the slider unless there is a histogram associated. In this case, `mirrored` has no effect. This decision is based on https://material.io/design/usability/bidirectionality.html#mirroring-layout, talking to some teams that work w/ data visualization + sliders and some good ol' fashioned googling.

**Extras**

* sorts props alphabetically
* fixed casing of an internal type
* refactored method arguments/vars to make them value-agnostic - these are now left/right-based
* adds local vars to store bounding client rects to avoid duplicate computations
* adds another column for testing mirrored along with some edge-positioning cases
    <img width="1082" alt="Screen Shot 2021-07-07 at 2 33 32 PM" src="https://user-images.githubusercontent.com/197440/124837278-6379f900-df39-11eb-9707-2e0e16374e9d.png">
