### PR TITLE
refactor(calcite-label): stop spreading attributes to the label element

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
+++ b/src/components/calcite-checkbox/calcite-checkbox.e2e.ts
@@ -209,16 +209,13 @@ describe("calcite-checkbox", () => {
     const input = await page.find("input");
     const label = await page.find("label");
 
-    expect(calciteCheckbox).not.toHaveAttribute("checked");
     expect(await calciteCheckbox.getProperty("checked")).toBe(false);
-    expect(input).not.toHaveAttribute("checked");
     expect(await input.getProperty("checked")).toBe(false);
 
     await label.click();
 
     await page.waitForChanges();
 
-    expect(calciteCheckbox).toHaveAttribute("checked");
     expect(await calciteCheckbox.getProperty("checked")).toBe(true);
     expect(await input.getProperty("checked")).toBe(true);
   });

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, Listen, h, Prop, EventEmitter, VNode } from "@stencil/core";
-import { getAttributes, getElementDir, queryElementRoots } from "../../utils/dom";
+import { getElementDir, queryElementRoots } from "../../utils/dom";
 import { FocusRequest } from "./interfaces";
 import { Alignment, Scale, Status } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -150,17 +150,9 @@ export class CalciteLabel {
   //--------------------------------------------------------------------------
 
   render(): VNode {
-    const attributes = getAttributes(this.el, [
-      "disabled",
-      "id",
-      "dir",
-      "layout",
-      "scale",
-      "status"
-    ]);
     const dir = getElementDir(this.el);
     return (
-      <label {...attributes} class={{ [CSS_UTILITY.rtl]: dir === "rtl" }}>
+      <label class={{ [CSS_UTILITY.rtl]: dir === "rtl" }} htmlFor={this.for}>
         <slot />
       </label>
     );


### PR DESCRIPTION
**Related Issue:** #1579 