### PR TITLE
feat: Add animation classes.

### DIFF
--- a/src/assets/styles/_animation.scss
+++ b/src/assets/styles/_animation.scss
@@ -39,3 +39,31 @@
     transform: scale3D(1, 1, 1);
   }
 }
+
+:root {
+  --calcite-animation-timing: 0.6s;
+}
+
+// allows animation trigger vis JS by adding class to element
+.calcite-animate {
+  opacity: 0;
+  animation-fill-mode: both;
+  animation-duration: var(--calcite-animation-timing);
+}
+
+// specify animation
+.calcite-animate__in {
+  animation-name: in;
+}
+
+.calcite-animate__in-down {
+  animation-name: in-down;
+}
+
+.calcite-animate__in-up {
+  animation-name: in-up;
+}
+
+.calcite-animate__in-scale {
+  animation-name: in-scale;
+}


### PR DESCRIPTION
**Related Issue:** #2411 

## Summary
Animation keyframes exist in Calcite, but they are not available via any classes. 

Add `.calcite-animate` and related classes
Add `:root {--calcite-animation-timing: 0.6s;}` 

Remainder of implementation is up to end user.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
