### PR TITLE
docs(radio-button-group, radio-button): fix "Docs" render issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.16.5",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.16.5.tgz",
-      "integrity": "sha512-zo3lvH6k2jOinffy+EhzP3puweFctYUFvCHkLIOlfW7l+MgpDRCgbnRk9x3nvbjd9xFPWJLwo/kRkYX3m5XqQQ==",
+      "version": "3.16.6",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.16.6.tgz",
+      "integrity": "sha512-R635GDLEsTT5zSQXHegmS8zjigVmXy7WDI6ompeKwWnUr/H7xnMdTuTa6VzdQDtVnG3XLvkwMsm0o603JcPNcQ==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.tsx
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.tsx
@@ -56,7 +56,7 @@ export class CalciteRadioButtonGroup {
     this.passPropsToRadioButtons();
   }
 
-  /** The name of the radio button group. <code>name</code> must be unique to other radio button group instances. */
+  /** The name of the radio button group. `name` must be unique to other radio button group instances. */
   @Prop({ reflect: true }) name!: string;
 
   /** Requires that a value is selected for the radio button group before the parent form will submit. */

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -98,7 +98,7 @@ export class CalciteRadioButton {
    */
   @Prop() label?: string;
 
-  /** The name of the radio button.  <code>name</code> is passed as a property automatically from <code>calcite-radio-button-group</code>. */
+  /** The name of the radio button. `name` is passed as a property automatically from `calcite-radio-button-group`. */
   @Prop({ reflect: true }) name: string;
 
   @Watch("name")
@@ -126,7 +126,7 @@ export class CalciteRadioButton {
     this.inputEl.required = required;
   }
 
-  /** The scale (size) of the radio button.  <code>scale</code> is passed as a property automatically from <code>calcite-radio-button-group</code>. */
+  /** The scale (size) of the radio button. `scale` is passed as a property automatically from `calcite-radio-button-group`. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /** The value of the radio button. */


### PR DESCRIPTION
**Related Issue:** #2542

## Summary
Fixes an issue where `<code>` blocks  in JSDoc comments prevented the Storybook "Docs" from rendering.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
