### PR TITLE
fix(color-picker): fix nudging hue slider with left/right arrows when color is #000 or #fff

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -346,7 +346,7 @@ export class CalciteColorPicker {
       ArrowLeft: { x: -10, y: 0 }
     };
 
-    if (Object.keys(arrowKeyToXYOffset).includes(key)) {
+    if (arrowKeyToXYOffset[key]) {
       event.preventDefault();
       this.scopeOrientation = key === "ArrowDown" || key === "ArrowUp" ? "vertical" : "horizontal";
       this.captureColorFieldColor(
@@ -354,7 +354,6 @@ export class CalciteColorPicker {
         this.colorFieldScopeTop + arrowKeyToXYOffset[key].y || 0,
         false
       );
-      return;
     }
   };
 
@@ -368,13 +367,12 @@ export class CalciteColorPicker {
       ArrowLeft: -1
     };
 
-    if (Object.keys(arrowKeyToXOffset).includes(key)) {
+    if (arrowKeyToXOffset[key]) {
       event.preventDefault();
       const delta = arrowKeyToXOffset[key] * modifier;
-      const hue = this.baseColorFieldColor?.hue();
-      const color = hue ? this.baseColorFieldColor.hue(hue + delta) : Color({ h: 0, s: 0, v: 100 });
+      const hue = this.baseColorFieldColor.hue();
+      const color = this.baseColorFieldColor.hue(hue + delta);
       this.internalColorSet(color, false);
-      return;
     }
   };
 


### PR DESCRIPTION
**Related Issue:** #2357 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This addresses an issue caused by the scope key-nudging logic never updating the current hue value when 0. Additionally includes some minor cleanup.