### PR TITLE
chore(deps): update calicte-ui-icons in lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,9 +3607,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.16.5",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.16.5.tgz",
-      "integrity": "sha512-zo3lvH6k2jOinffy+EhzP3puweFctYUFvCHkLIOlfW7l+MgpDRCgbnRk9x3nvbjd9xFPWJLwo/kRkYX3m5XqQQ==",
+      "version": "3.16.6",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.16.6.tgz",
+      "integrity": "sha512-R635GDLEsTT5zSQXHegmS8zjigVmXy7WDI6ompeKwWnUr/H7xnMdTuTa6VzdQDtVnG3XLvkwMsm0o603JcPNcQ==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {


### PR DESCRIPTION
**Related Issue:** # (N/A)

## Summary
Updates the version of calcite-ui-icons in package-lock.json (match package.json version)
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
