### PR TITLE
fix(tree): fix item selection when multi + input-enabled

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -191,7 +191,7 @@ export class CalciteTreeItem {
     }
     this.expanded = !this.expanded;
     this.calciteTreeItemSelect.emit({
-      modifyCurrentSelection: (e as any).shiftKey,
+      modifyCurrentSelection: (e as any).shiftKey || this.inputEnabled,
       forceToggle: false
     });
   }

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -187,6 +187,47 @@ describe("calcite-tree", () => {
       expect(selectEventSpy).toHaveReceivedEventTimes(3);
     });
 
+    describe("has selected items in the selection event payload", () =>
+      it("contains current selection when selection=multi + input-enabled", async () => {
+        const page = await newE2EPage({
+          html: html` <calcite-tree selection-mode="multi" input-enabled>
+            <calcite-tree-item id="1">1</calcite-tree-item>
+            <calcite-tree-item id="2">2</calcite-tree-item>
+          </calcite-tree>`
+        });
+
+        const [item1, item2] = await page.findAll("calcite-tree-item");
+
+        type TestWindow = {
+          selectedIds: string[];
+        } & Window &
+          typeof globalThis;
+
+        await page.evaluateHandle(() =>
+          document.addEventListener("calciteTreeSelect", ({ detail }: CustomEvent) => {
+            (window as TestWindow).selectedIds = detail.selected.map((item) => item.id);
+          })
+        );
+
+        const getSelectedIds = async (): Promise<any> => page.evaluate(() => (window as TestWindow).selectedIds);
+
+        await item1.click();
+
+        expect(await getSelectedIds()).toEqual(["1"]);
+
+        await item2.click();
+
+        expect(await getSelectedIds()).toEqual(["1", "2"]);
+
+        await item2.click();
+
+        expect(await getSelectedIds()).toEqual(["1"]);
+
+        await item1.click();
+
+        expect(await getSelectedIds()).toEqual([]);
+      }));
+
     it("emits once when the tree item checkbox label is clicked", async () => {
       const page = await newE2EPage({
         html: html`<calcite-tree input-enabled selection-mode="ancestors">


### PR DESCRIPTION
**Related Issue:** #2437 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where clicking a tree-item's checkbox would not toggle the selection when a tree is in multi selection mode with input-enabled.

@paulcpederson Can you help test this one? I'm not clear if other selection modes + input-enabled need to work differently. The ancestor selection-mode + input-enabled from the demo page appear to work fine. I added an E2E test to start keeping track of this.