### PR TITLE
fix(action-menu): target 1px margin more accurately to actions in menu

### DIFF
--- a/src/components/calcite-action-menu/calcite-action-menu.scss
+++ b/src/components/calcite-action-menu/calcite-action-menu.scss
@@ -7,7 +7,7 @@
   text-1;
 }
 
-::slotted(calcite-action) {
+.menu ::slotted(calcite-action) {
   @apply flex
   focus-base
   m-0.5;


### PR DESCRIPTION


**Related Issue:** #2459

## Summary
More accurately targets the 1px margin style to the actions in side the menu.
The 1px margin is to accommodate the focus ring.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
