### PR TITLE
feat(graph): Add support for color stops

### DIFF
--- a/src/components/calcite-graph/calcite-graph.e2e.ts
+++ b/src/components/calcite-graph/calcite-graph.e2e.ts
@@ -60,4 +60,28 @@ describe("calcite-graph", () => {
       "M 0,60 L 0,20 L 0,20 C 16.666666666666664,-10.000000000000014 33.333333333333336,-40 50,-40 C 100,-40 150,-33.33333333333334 200,-20 C 233.33333333333334,-11.111111111111114 266.66666666666663,24.444444444444443 300,60 L 300,60 Z"
     );
   });
+
+  it("uses color-stops when provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-graph></calcite-graph>`);
+    await page.$eval("calcite-graph", (elm: any) => {
+      elm.data = [
+        [0, 4],
+        [1, 7],
+        [4, 6],
+        [6, 2]
+      ];
+      elm.colorStops = [[0, 'red'], [0.5, 'green'], [1, 'blue']];
+    });
+
+    await page.waitForChanges();
+
+    const linearGradient = await page.find('calcite-graph >>> linearGradient');
+    const linearGradientId = linearGradient.getAttribute('id');
+
+    const path = await page.find('calcite-graph >>> path');
+    const fill = path.getAttribute('fill');
+
+    expect(fill).toBe(`url(#${linearGradientId})`);
+  });
 });

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -41,6 +41,12 @@ export class CalciteGraph {
   /** End of highlight color if highlighting range */
   @Prop() highlightMax: number;
 
+  /**
+   * Array of values describing a single color stop ([offset, color, opacity])
+   * These color stops should be sorted by offset value
+   */
+  @Prop() colorStops: [number, string, number][];
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -48,7 +54,7 @@ export class CalciteGraph {
   //--------------------------------------------------------------------------
 
   render(): VNode {
-    const { data, width, height, highlightMax, highlightMin } = this;
+    const { data, colorStops, width, height, highlightMax, highlightMin } = this;
     const id = this.maskId;
 
     // if we have no data, return empty svg
@@ -69,6 +75,7 @@ export class CalciteGraph {
     const [hMinX] = t([highlightMin, max[1]]);
     const [hMaxX] = t([highlightMax, max[1]]);
     const areaPath = area({ data, min, max, t });
+    const fill = colorStops ? `url(#linear-gradient-${id})` : undefined;
     return (
       <svg
         class="svg"
@@ -77,6 +84,16 @@ export class CalciteGraph {
         viewBox={`0 0 ${width} ${height}`}
         width={width}
       >
+        {colorStops ? (
+          <defs>
+            <linearGradient id={`linear-gradient-${id}`} x1="0" x2="1" y1="0" y2="0">
+              {colorStops.map(([offset, color, opacity = 1]) => (
+                <stop offset={`${offset * 100}%`} stop-color={color} stop-opacity={opacity}/>
+              ))}
+            </linearGradient>
+          </defs>
+        ) : null}
+
         {highlightMin !== undefined ? (
           <svg
             class="svg"
@@ -124,12 +141,12 @@ export class CalciteGraph {
               />
             </mask>
 
-            <path class="graph-path" d={areaPath} mask={`url(#${id}1)`} />
-            <path class="graph-path--highlight" d={areaPath} mask={`url(#${id}2)`} />
-            <path class="graph-path" d={areaPath} mask={`url(#${id}3)`} />
+            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />
+            <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />
+            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
           </svg>
         ) : (
-          <path class="graph-path" d={areaPath} />
+          <path class="graph-path" d={areaPath} fill={fill} />
         )}
       </svg>
     );

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -55,7 +55,7 @@ export class CalciteGraph {
 
   render(): VNode {
     const { data, colorStops, width, height, highlightMax, highlightMin } = this;
-    const id = this.maskId;
+    const id = this.graphId;
 
     // if we have no data, return empty svg
     if (!data || data.length === 0) {
@@ -94,58 +94,50 @@ export class CalciteGraph {
           </defs>
         ) : null}
 
-        {highlightMin !== undefined ? (
-          <svg
-            class="svg"
-            height={height}
-            preserveAspectRatio="none"
-            viewBox={`0 0 ${width} ${height}`}
-            width={width}
-          >
-            <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-              M 0,0
-              L ${hMinX - 1},0
-              L ${hMinX - 1},${height}
-              L 0,${height}
-              Z
-            `}
-                fill="white"
-              />
-            </mask>
+        {highlightMin !== undefined ? [
+          <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+            M 0,0
+            L ${hMinX - 1},0
+            L ${hMinX - 1},${height}
+            L 0,${height}
+            Z
+          `}
+              fill="white"
+            />
+          </mask>,
 
-            <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-              M ${hMinX + 1},0
-              L ${hMaxX - 1},0
-              L ${hMaxX - 1},${height}
-              L ${hMinX + 1}, ${height}
-              Z
-            `}
-                fill="white"
-              />
-            </mask>
+          <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+            M ${hMinX + 1},0
+            L ${hMaxX - 1},0
+            L ${hMaxX - 1},${height}
+            L ${hMinX + 1}, ${height}
+            Z
+          `}
+              fill="white"
+            />
+          </mask>,
 
-            <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-                  M ${hMaxX + 1},0
-                  L ${width},0
-                  L ${width},${height}
-                  L ${hMaxX + 1}, ${height}
-                  Z
-                `}
-                fill="white"
-              />
-            </mask>
+          <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+                M ${hMaxX + 1},0
+                L ${width},0
+                L ${width},${height}
+                L ${hMaxX + 1}, ${height}
+                Z
+              `}
+              fill="white"
+            />
+          </mask>,
 
-            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />
-            <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />
-            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
-          </svg>
-        ) : (
+          <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />,
+          <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />,
+          <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
+         ] : (
           <path class="graph-path" d={areaPath} fill={fill} />
         )}
       </svg>
@@ -158,5 +150,5 @@ export class CalciteGraph {
   //
   //--------------------------------------------------------------------------
 
-  private maskId = `calcite-graph-mask-${guid()}`;
+  private graphId = `calcite-graph-${guid()}`;
 }

--- a/src/demos/calcite-graph.html
+++ b/src/demos/calcite-graph.html
@@ -28,7 +28,17 @@
       <calcite-graph></calcite-graph>
     </p>
 
+    <h3>Highlight Range</h3>
+    <calcite-graph class="highlight-range"></calcite-graph>
+
+    <h3>Color Stops</h3>
+    <calcite-graph class="color-stops"></calcite-graph>
+
+    <h3>Highlight Range and Color Stops</h3>
+    <calcite-graph class="highlight-range color-stops"></calcite-graph>
+
     <script>
+      // Fill all graphs with the same data.
       var data = [
         [0, 0],
         [10, 80],
@@ -42,8 +52,21 @@
         [90, 10],
         [100, 0]
       ];
-      [].slice.call(document.querySelectorAll("calcite-graph")).forEach(function (graphElement) {
+      document.querySelectorAll("calcite-graph").forEach(function (graphElement) {
         graphElement.data = data;
+      });
+
+      // Add highlight ranges
+      document.querySelectorAll(".highlight-range").forEach(function (graphElement) {
+        graphElement.highlightMin = 25;
+        graphElement.highlightMax = 75;
+      });
+
+      // Add color stops
+      var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
+      var colorStops = rainbow.map((color, i) => [(1 / (rainbow.length - 1)) * i, color]);
+      document.querySelectorAll(".color-stops").forEach(function (graphElement) {
+        graphElement.colorStops = colorStops;
       });
     </script>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -78,6 +78,9 @@
           <calcite-link href="/demos/fab">calcite-fab</calcite-link>
         </li>
         <li>
+          <calcite-link href="/demos/calcite-graph.html">calcite-graph</calcite-link>
+        </li>
+        <li>
           <calcite-link href="/demos/calcite-icon.html">calcite-icon</calcite-link>
         </li>
         <li>


### PR DESCRIPTION
**Related Issue:** #834

## Summary

Adds support for color stops for the `<calcite-graph>` component. A subsequent PR will add color stop support to the `<calcite-slider>` component.

```tsx
/**
 * Array of values describing a single color stop ([offset, color, opacity])
 * These color stops should be sorted by offset value
 */
@Prop() colorStops: [number, string, number][];
```
Color stops are added via a `<linearGradient>` element and apply along the x-axis.

![image](https://user-images.githubusercontent.com/8754/126005402-c945381e-97a6-4096-9b0c-4df909bc7680.png)

- [x] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

## Discussion question
This is pretty rudimentary support for adding a linear gradient with color stops. It solves the use case in the related issue, but are there other, more complex, use cases that we want to be prepared to support in the future?