### PR TITLE
fix(inline-editable, input, radio-button): namespace scoped CSS classes

### DIFF
--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -88,7 +88,7 @@ describe("calcite-inline-editable", () => {
         "calciteInlineEditableEnableEditingChange"
       );
       const element = await page.find("calcite-inline-editable");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
       expect(element).toHaveAttribute("editing-enabled");
       expect(calciteInlineEditableEnableEditingChange).toHaveReceivedEventTimes(1);
@@ -131,7 +131,7 @@ describe("calcite-inline-editable", () => {
     it("disables editing when the child input loses focus", async () => {
       const element = await page.find("calcite-inline-editable");
       const input = await page.find("calcite-input");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
       expect(element).toHaveAttribute("editing-enabled");
       input.triggerEvent("calciteInputBlur");
@@ -178,7 +178,7 @@ describe("calcite-inline-editable", () => {
         "calciteInlineEditableEnableEditingChange"
       );
       const element = await page.find("calcite-inline-editable");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
       expect(element).toHaveAttribute("editing-enabled");
       expect(calciteInlineEditableEnableEditingChange).toHaveReceivedEventTimes(1);
@@ -199,7 +199,7 @@ describe("calcite-inline-editable", () => {
       const element = await page.find("calcite-inline-editable");
       const input = await element.find("calcite-input");
       await element.click();
-      const cancelEditingButton = await element.find(".calcite-inline-editable-cancel-editing-button");
+      const cancelEditingButton = await element.find(".calcite-inline-editable__cancel-editing-button");
       expect(await input.getProperty("value")).toBe("John Doe");
       await page.$eval("calcite-input input", (input: HTMLInputElement): void => {
         input.setSelectionRange(input.value.length, input.value.length);
@@ -234,7 +234,7 @@ describe("calcite-inline-editable", () => {
     it("does not disable editing when input focus is lost", async () => {
       const element = await page.find("calcite-inline-editable");
       const input = await page.find("calcite-input");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
       expect(element).toHaveAttribute("editing-enabled");
       input.triggerEvent("calciteInputBlur");
@@ -246,9 +246,9 @@ describe("calcite-inline-editable", () => {
       const calciteInlineEditableChangesConfirm = await page.spyOnEvent("calciteInlineEditableChangesConfirm");
       const element = await page.find("calcite-inline-editable");
       const input = await page.find("calcite-input");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
-      const confirmChangesButton = await element.find(".calcite-inline-editable-confirm-changes-button");
+      const confirmChangesButton = await element.find(".calcite-inline-editable__confirm-changes-button");
       await page.$eval("calcite-input input", (input: HTMLInputElement): void => {
         input.setSelectionRange(input.value.length, input.value.length);
       });
@@ -269,9 +269,9 @@ describe("calcite-inline-editable", () => {
       });
       const calciteInlineEditableChangesConfirm = await page.spyOnEvent("calciteInlineEditableChangesConfirm");
       const input = await page.find("calcite-input");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
-      const confirmChangesButton = await element.find(".calcite-inline-editable-confirm-changes-button");
+      const confirmChangesButton = await element.find(".calcite-inline-editable__confirm-changes-button");
       await page.$eval("calcite-input input", (input: HTMLInputElement): void => {
         input.setSelectionRange(input.value.length, input.value.length);
       });
@@ -293,9 +293,9 @@ describe("calcite-inline-editable", () => {
       });
       const calciteInlineEditableChangesConfirm = await page.spyOnEvent("calciteInlineEditableChangesConfirm");
       const input = await page.find("calcite-input");
-      const enableEditingButton = await element.find(".calcite-inline-editable-enable-editing-button");
+      const enableEditingButton = await element.find(".calcite-inline-editable__enable-editing-button");
       await enableEditingButton.click();
-      const confirmChangesButton = await element.find(".calcite-inline-editable-confirm-changes-button");
+      const confirmChangesButton = await element.find(".calcite-inline-editable__confirm-changes-button");
       await page.$eval("calcite-input input", (input: HTMLInputElement): void => {
         input.setSelectionRange(input.value.length, input.value.length);
       });
@@ -349,11 +349,11 @@ describe("calcite-inline-editable", () => {
             await label.click();
             return document.activeElement.className;
           })
-        ).toContain("calcite-inline-editable-enable-editing-button");
+        ).toContain("calcite-inline-editable__enable-editing-button");
       });
 
       it("focuses the input when editing is enabled and the label is subsequently clicked", async () => {
-        const enableEditingButton = await page.find(".calcite-inline-editable-enable-editing-button");
+        const enableEditingButton = await page.find(".calcite-inline-editable__enable-editing-button");
         await enableEditingButton.click();
         const label = await page.find("label");
         await label.click();

--- a/src/components/calcite-inline-editable/calcite-inline-editable.scss
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.scss
@@ -1,60 +1,60 @@
 :host([scale="s"]) {
-  .calcite-inline-editable-controls-wrapper {
+  .calcite-inline-editable__controls-wrapper {
     height: 32px;
   }
 }
 
 :host([scale="m"]) {
-  .calcite-inline-editable-controls-wrapper {
+  .calcite-inline-editable__controls-wrapper {
     height: 44px;
   }
 }
 
 :host([scale="l"]) {
-  .calcite-inline-editable-controls-wrapper {
+  .calcite-inline-editable__controls-wrapper {
     height: 56px;
   }
 }
 
 :host(:not([editing-enabled])) {
-  .calcite-inline-editable-wrapper {
+  .calcite-inline-editable__wrapper {
     &:hover {
       background: var(--calcite-ui-foreground-2);
     }
   }
 }
 
-.calcite-inline-editable-wrapper {
+.calcite-inline-editable__wrapper {
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
   transition: $transition;
   background: var(--calcite-ui-foreground-1);
 
-  .calcite-inline-editable-input-wrapper {
+  .calcite-inline-editable__input-wrapper {
     flex: 1;
   }
 }
 
-.calcite-inline-editable-controls-wrapper {
+.calcite-inline-editable__controls-wrapper {
   display: flex;
 }
 
-.calcite-inline-editable-cancel-editing-button-wrapper {
+.calcite-inline-editable__cancel-editing-button-wrapper {
   border: 1px solid var(--calcite-ui-border-1);
   border-left: none;
   border-right: none;
 }
 
 :host([disabled]) {
-  .calcite-inline-editable-cancel-editing-button-wrapper {
+  .calcite-inline-editable__cancel-editing-button-wrapper {
     border-color: var(--calcite-ui-border-2);
   }
 }
 
 :host {
   &::slotted(*) {
-    .calcite-input-element-wrapper {
+    .calcite-input__element-wrapper {
       textarea,
       input {
         transition: $transition;
@@ -65,7 +65,7 @@
 
 :host(:not([editing-enabled])) {
   &::slotted(*) {
-    .calcite-input-element-wrapper {
+    .calcite-input__element-wrapper {
       background: transparent;
     }
   }
@@ -77,7 +77,7 @@
       display: none;
     }
 
-    .calcite-input-element-wrapper {
+    .calcite-input__element-wrapper {
       display: flex;
       cursor: pointer;
       textarea,
@@ -103,7 +103,7 @@
 :host([dir="rtl"]) {
   &:not([editing-enabled]) {
     &::slotted(*) {
-      .calcite-input-element-wrapper {
+      .calcite-input__element-wrapper {
         textarea,
         input {
           padding-right: 0;
@@ -118,7 +118,7 @@
   :host {
     &:not([editing-enabled]) {
       &::slotted(*) {
-        .calcite-input-element-wrapper {
+        .calcite-input__element-wrapper {
           textarea,
           input {
             padding-right: 0;

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -11,7 +11,7 @@ import {
 } from "@stencil/core";
 import { getElementProp } from "../../utils/dom";
 import { Scale } from "../interfaces";
-import { TEXT } from "./resources";
+import { TEXT, CSS } from "./resources";
 
 /**
  * @slot - slot for rendering a `<calcite-input>`
@@ -97,19 +97,19 @@ export class CalciteInlineEditable {
   render(): VNode {
     return (
       <div
-        class="calcite-inline-editable-wrapper"
+        class={CSS.wrapper}
         onClick={this.enableEditingHandler}
         onKeyDown={this.escapeKeyHandler}
         onTransitionEnd={this.transitionEnd}
       >
-        <div class="calcite-inline-editable-input-wrapper">
+        <div class={CSS.inputWrapper}>
           <slot />
         </div>
-        <div class="calcite-inline-editable-controls-wrapper">
+        <div class={CSS.controlsWrapper}>
           {!this.editingEnabled && (
             <calcite-button
               appearance="transparent"
-              class="calcite-inline-editable-enable-editing-button"
+              class={CSS.enableEditingButton}
               color="neutral"
               disabled={this.disabled}
               iconStart="pencil"
@@ -120,10 +120,10 @@ export class CalciteInlineEditable {
             />
           )}
           {this.shouldShowControls && [
-            <div class="calcite-inline-editable-cancel-editing-button-wrapper">
+            <div class={CSS.cancelEditingButtonWrapper}>
               <calcite-button
                 appearance="transparent"
-                class="calcite-inline-editable-cancel-editing-button"
+                class={CSS.cancelEditingButton}
                 color="neutral"
                 disabled={this.disabled}
                 iconStart="x"
@@ -134,7 +134,7 @@ export class CalciteInlineEditable {
             </div>,
             <calcite-button
               appearance="solid"
-              class="calcite-inline-editable-confirm-changes-button"
+              class={CSS.confirmChangesButton}
               color="blue"
               disabled={this.disabled}
               iconStart="check"

--- a/src/components/calcite-inline-editable/resources.ts
+++ b/src/components/calcite-inline-editable/resources.ts
@@ -1,3 +1,13 @@
+export const CSS = {
+  wrapper: "calcite-inline-editable__wrapper",
+  confirmChangesButton: "calcite-inline-editable__confirm-changes-button",
+  cancelEditingButton: "calcite-inline-editable__cancel-editing-button",
+  inputWrapper: "calcite-inline-editable__input-wrapper",
+  cancelEditingButtonWrapper: "calcite-inline-editable__cancel-editing-button-wrapper",
+  enableEditingButton: "calcite-inline-editable__enable-editing-button",
+  controlsWrapper: "calcite-inline-editable__controls-wrapper"
+};
+
 export const TEXT = {
   intlEnablingEditing: "Click to edit",
   intlCancelEditing: "Cancel",

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.scss
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.scss
@@ -105,7 +105,7 @@
   visibility: visible;
 }
 
-.input .calcite-input-wrapper {
+.input .calcite-input__wrapper {
   margin-top: 0;
 }
 

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -195,10 +195,10 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(await element.getProperty("value")).toBe("3.123");
     await numberHorizontalItemDown.click();
@@ -232,10 +232,10 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
 
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(await element.getProperty("value")).toBe("15");
     await numberHorizontalItemDown.click();
@@ -258,10 +258,10 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
 
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(await element.getProperty("value")).toBe("5.5");
     await numberHorizontalItemDown.click();
@@ -284,10 +284,10 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
 
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(await element.getProperty("value")).toBe("5");
     await numberHorizontalItemDown.click();
@@ -332,7 +332,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     expect(await element.getProperty("value")).toBe("12");
     await numberHorizontalItemDown.click();
@@ -354,7 +354,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(await element.getProperty("value")).toBe("8");
     await numberHorizontalItemUp.click();
@@ -376,7 +376,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     expect(await element.getProperty("value")).toBe("2");
     await numberHorizontalItemDown.click();
@@ -398,7 +398,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(await element.getProperty("value")).toBe("-2");
     await numberHorizontalItemUp.click();
@@ -650,7 +650,7 @@ describe("calcite-input", () => {
     const calciteInputInput = await page.spyOnEvent("calciteInputInput");
 
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
     );
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await numberHorizontalItemUp.click();
@@ -659,7 +659,7 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
 
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .calcite-input-number-button-item[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
     );
     await numberHorizontalItemDown.click();
     await page.waitForChanges();

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -91,7 +91,7 @@ describe("calcite-input", () => {
     <calcite-input icon="key" type="number"></calcite-input>
     `);
 
-    const icon = await page.find("calcite-input .calcite-input-icon");
+    const icon = await page.find("calcite-input .calcite-input__icon");
     expect(icon).not.toBeNull();
   });
 
@@ -101,7 +101,7 @@ describe("calcite-input", () => {
     <calcite-input icon="key" type="date"></calcite-input>
     `);
 
-    const icon = await page.find("calcite-input .calcite-input-icon");
+    const icon = await page.find("calcite-input .calcite-input__icon");
     expect(icon).not.toBeNull();
   });
 
@@ -111,7 +111,7 @@ describe("calcite-input", () => {
     <calcite-input icon type="date"></calcite-input>
     `);
 
-    const icon = await page.find("calcite-input .calcite-input-icon");
+    const icon = await page.find("calcite-input .calcite-input__icon");
     expect(icon).not.toBeNull();
   });
 
@@ -121,7 +121,7 @@ describe("calcite-input", () => {
     <calcite-input icon type="number"></calcite-input>
     `);
 
-    const icon = await page.find("calcite-input .calcite-input-icon");
+    const icon = await page.find("calcite-input .calcite-input__icon");
     expect(icon).toBeNull();
   });
 
@@ -131,12 +131,12 @@ describe("calcite-input", () => {
     <calcite-input type="number"></calcite-input>
     `);
 
-    const numberVerticalWrapper = await page.find("calcite-input .calcite-input-number-button-wrapper");
+    const numberVerticalWrapper = await page.find("calcite-input .calcite-input__number-button-wrapper");
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .number-button-item-horizontal[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item--horizontal[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .number-button-item-horizontal[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item--horizontal[data-adjustment='up']"
     );
 
     expect(numberVerticalWrapper).not.toBeNull();
@@ -150,12 +150,12 @@ describe("calcite-input", () => {
     <calcite-input type="number" number-button-type="horizontal"></calcite-input>
     `);
 
-    const numberVerticalWrapper = await page.find("calcite-input .calcite-input-number-button-wrapper");
+    const numberVerticalWrapper = await page.find("calcite-input .calcite-input__number-button-wrapper");
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .number-button-item-horizontal[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item--horizontal[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .number-button-item-horizontal[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item--horizontal[data-adjustment='up']"
     );
 
     expect(numberVerticalWrapper).toBeNull();
@@ -169,12 +169,12 @@ describe("calcite-input", () => {
     <calcite-input type="number" number-button-type="none"></calcite-input>
     `);
 
-    const numberVerticalWrapper = await page.find("calcite-input .calcite-input-number-button-wrapper");
+    const numberVerticalWrapper = await page.find("calcite-input .calcite-input__number-button-wrapper");
     const numberHorizontalItemDown = await page.find(
-      "calcite-input .number-button-item-horizontal[data-adjustment='down']"
+      "calcite-input .calcite-input__number-button-item--horizontal[data-adjustment='down']"
     );
     const numberHorizontalItemUp = await page.find(
-      "calcite-input .number-button-item-horizontal[data-adjustment='up']"
+      "calcite-input .calcite-input__number-button-item--horizontal[data-adjustment='up']"
     );
 
     expect(numberVerticalWrapper).toBeNull();
@@ -505,7 +505,7 @@ describe("calcite-input", () => {
     await page.setContent(`
     <calcite-input clearable value="John Doe"></calcite-input>
     `);
-    const clearButton = await page.find("calcite-input .calcite-input-clear-button");
+    const clearButton = await page.find("calcite-input .calcite-input__clear-button");
     expect(clearButton).not.toBe(null);
   });
 
@@ -515,7 +515,7 @@ describe("calcite-input", () => {
     <calcite-input clearable></calcite-input>
     `);
 
-    const clearButton = await page.find("calcite-input .calcite-input-clear-button");
+    const clearButton = await page.find("calcite-input .calcite-input__clear-button");
     expect(clearButton).toBe(null);
   });
 
@@ -525,7 +525,7 @@ describe("calcite-input", () => {
     <calcite-input></calcite-input>
     `);
 
-    const clearButton = await page.find("calcite-input .calcite-input-clear-button");
+    const clearButton = await page.find("calcite-input .calcite-input__clear-button");
     expect(clearButton).toBe(null);
   });
 
@@ -550,7 +550,7 @@ describe("calcite-input", () => {
     `);
 
     const element = await page.find("calcite-input");
-    const clearButton = await page.find(".calcite-input-clear-button");
+    const clearButton = await page.find(".calcite-input__clear-button");
     expect(await element.getProperty("value")).toBe("John Doe");
     await clearButton.click();
     await page.waitForChanges();
@@ -565,7 +565,7 @@ describe("calcite-input", () => {
 
     const calciteInputInput = await page.spyOnEvent("calciteInputInput");
     const element = await page.find("calcite-input");
-    const clearButton = await page.find(".calcite-input-clear-button");
+    const clearButton = await page.find(".calcite-input__clear-button");
     expect(await element.getProperty("value")).toBe("John Doe");
     await clearButton.click();
     await page.waitForChanges();
@@ -598,7 +598,7 @@ describe("calcite-input", () => {
 
     const calciteInputInput = await page.spyOnEvent("calciteInputInput");
     const element = await page.find("calcite-input");
-    const clearButton = await page.find(".calcite-input-clear-button");
+    const clearButton = await page.find(".calcite-input__clear-button");
     expect(await element.getProperty("value")).toBe("John Doe");
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await clearButton.click();

--- a/src/components/calcite-input/calcite-input.resources.ts
+++ b/src/components/calcite-input/calcite-input.resources.ts
@@ -1,3 +1,18 @@
+export const CSS = {
+  loader: "calcite-input__loader",
+  clearButton: "calcite-input__clear-button",
+  inputIcon: "calcite-input__icon",
+  prefix: "calcite-input__prefix",
+  suffix: "calcite-input__suffix",
+  numberButtonWrapper: "calcite-input__number-button-wrapper",
+  buttonItemHorizontal: "calcite-input__number-button-item--horizontal",
+  wrapper: "calcite-input__element-wrapper",
+  inputWrapper: "calcite-input__wrapper",
+  actionWrapper: "calcite-input__action-wrapper",
+  resizeIconWrapper: "calcite-input__resize-icon-wrapper",
+  numberButtonItem: "calcite-input__number-button-item"
+};
+
 export const INPUT_TYPE_ICONS = {
   tel: "phone",
   password: "lock",

--- a/src/components/calcite-input/calcite-input.scss
+++ b/src/components/calcite-input/calcite-input.scss
@@ -2,23 +2,23 @@
 :host([scale="s"]) {
   & textarea,
   & input,
-  & .calcite-input-prefix,
-  & .calcite-input-suffix {
+  & .calcite-input__prefix,
+  & .calcite-input__suffix {
     @apply text--2 p-2 h-8;
   }
   & textarea {
     min-height: 32px;
   }
-  & .calcite-input-number-button-wrapper,
-  & .calcite-action-wrapper calcite-button,
-  & .calcite-action-wrapper calcite-button button {
+  & .calcite-input__number-button-wrapper,
+  & .calcite-input__action-wrapper calcite-button,
+  & .calcite-input__action-wrapper calcite-button button {
     @apply h-8;
   }
   & textarea,
   & input[type="file"] {
     @apply h-auto;
   }
-  & .calcite-input-clear-button {
+  & .calcite-input__clear-button {
     min-height: 32px;
     min-width: 32px;
   }
@@ -27,24 +27,24 @@
 :host([scale="m"]) {
   & textarea,
   & input,
-  & .calcite-input-prefix,
-  & .calcite-input-suffix {
+  & .calcite-input__prefix,
+  & .calcite-input__suffix {
     @apply text--1 p-3;
     height: 44px;
   }
   & textarea {
     min-height: 44px;
   }
-  & .calcite-input-number-button-wrapper,
-  & .calcite-action-wrapper calcite-button,
-  & .calcite-action-wrapper calcite-button button {
+  & .calcite-input__number-button-wrapper,
+  & .calcite-input__action-wrapper calcite-button,
+  & .calcite-input__action-wrapper calcite-button button {
     height: 44px;
   }
   & textarea,
   & input[type="file"] {
     @apply h-auto;
   }
-  & .calcite-input-clear-button {
+  & .calcite-input__clear-button {
     min-height: 44px;
     min-width: 44px;
   }
@@ -53,24 +53,24 @@
 :host([scale="l"]) {
   & textarea,
   & input,
-  & .calcite-input-prefix,
-  & .calcite-input-suffix {
+  & .calcite-input__prefix,
+  & .calcite-input__suffix {
     @apply text-1 p-4;
     height: 56px;
   }
   & textarea {
     min-height: 56px;
   }
-  & .calcite-input-number-button-wrapper,
-  & .calcite-action-wrapper calcite-button,
-  & .calcite-action-wrapper calcite-button button {
+  & .calcite-input__number-button-wrapper,
+  & .calcite-input__action-wrapper calcite-button,
+  & .calcite-input__action-wrapper calcite-button button {
     height: 56px;
   }
   & textarea,
   & input[type="file"] {
     height: auto;
   }
-  & .calcite-input-clear-button {
+  & .calcite-input__clear-button {
     min-height: 56px;
     min-width: 56px;
   }
@@ -80,7 +80,7 @@
 :host([disabled]) {
   pointer-events: none;
 
-  & .calcite-input-wrapper {
+  & .calcite-input__wrapper {
     opacity: var(--calcite-ui-opacity-disabled);
     pointer-events: none;
   }
@@ -185,7 +185,7 @@
   padding-left: $baseline * 2;
 }
 //positioning wrapper for icon and loader
-.calcite-input-element-wrapper {
+.calcite-input__element-wrapper {
   display: inline-flex;
   flex: 1;
   min-width: 20%;
@@ -193,7 +193,7 @@
   order: 3;
 }
 
-.calcite-input-icon {
+.calcite-input__icon {
   display: block;
   position: absolute;
   pointer-events: none;
@@ -205,11 +205,11 @@
 }
 
 // adjust for larger icon of scale l
-:host([scale="l"]) .calcite-input-icon {
+:host([scale="l"]) .calcite-input__icon {
   top: calc(50% - 12px);
 }
 
-.calcite--rtl .calcite-input-icon {
+.calcite--rtl .calcite-input__icon {
   left: unset;
   right: $baseline/2;
 }
@@ -234,7 +234,7 @@ input[type="time"]::-webkit-clear-button {
   display: none;
 }
 
-.calcite-input-clear-button {
+.calcite-input__clear-button {
   display: flex;
   align-self: stretch;
   align-items: center;
@@ -261,13 +261,13 @@ input[type="time"]::-webkit-clear-button {
 }
 
 .calcite--rtl {
-  .calcite-input-clear-button {
+  .calcite-input__clear-button {
     border-left: 1px solid var(--calcite-ui-border-1);
     border-right: none;
   }
 }
 
-.calcite-input-clear-button {
+.calcite-input__clear-button {
   @include focus-style-base();
   &:focus {
     @include focus-style-inset();
@@ -275,7 +275,7 @@ input[type="time"]::-webkit-clear-button {
 }
 
 // loading
-.calcite-input-loading {
+.calcite-input__loader {
   display: block;
   pointer-events: none;
   position: absolute;
@@ -285,14 +285,14 @@ input[type="time"]::-webkit-clear-button {
 }
 
 // slotted action
-.calcite-action-wrapper {
+.calcite-input__action-wrapper {
   display: flex;
   order: 7;
 }
 
 // prefix and suffix
-.calcite-input-prefix,
-.calcite-input-suffix {
+.calcite-input__prefix,
+.calcite-input__suffix {
   display: flex;
   align-items: center;
   align-content: center;
@@ -308,28 +308,28 @@ input[type="time"]::-webkit-clear-button {
   line-height: 1;
 }
 
-.calcite-input-prefix {
+.calcite-input__prefix {
   order: 2;
   border-right-width: 0px;
 }
-.calcite-input-suffix {
+.calcite-input__suffix {
   order: 5;
   border-left-width: 0px;
 }
 
 .calcite--rtl {
-  & .calcite-input-prefix {
+  & .calcite-input__prefix {
     border-right-width: 1px;
     border-left-width: 0px;
   }
-  & .calcite-input-suffix {
+  & .calcite-input__suffix {
     border-left-width: 1px;
     border-right-width: 0px;
   }
 }
 
 // readonly
-:host([readonly]) .calcite-input-number-button-item {
+:host([readonly]) .calcite-input__number-button-item {
   pointer-events: none;
 }
 
@@ -374,7 +374,7 @@ input[type="time"]::-webkit-clear-button {
   }
 }
 
-.calcite-input-number-button-wrapper {
+.calcite-input__number-button-wrapper {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -384,7 +384,7 @@ input[type="time"]::-webkit-clear-button {
   order: 6;
 }
 
-:host([number-button-type="vertical"]) .calcite-input-wrapper {
+:host([number-button-type="vertical"]) .calcite-input__wrapper {
   flex-direction: row;
   display: flex;
 }
@@ -405,7 +405,7 @@ input[type="time"]::-webkit-clear-button {
   }
 }
 
-.calcite-input-number-button-item.number-button-item-horizontal {
+.calcite-input-number-button-item.calcite-input__number-button-item--horizontal {
   &[data-adjustment="down"],
   &[data-adjustment="up"] {
     min-height: 100%;
@@ -418,20 +418,20 @@ input[type="time"]::-webkit-clear-button {
   }
 }
 
-.calcite-input-number-button-item.number-button-item-horizontal[data-adjustment="down"] {
+.calcite-input-number-button-item.calcite-input__number-button-item--horizontal[data-adjustment="down"] {
   border-left: 1px solid var(--calcite-ui-border-1);
   border-right: 0px;
 }
 
-.calcite-input-number-button-item.number-button-item-horizontal[data-adjustment="up"] {
+.calcite-input-number-button-item.calcite-input__number-button-item--horizontal[data-adjustment="up"] {
   order: 5;
 }
 .calcite--rtl {
-  .calcite-input-number-button-item.number-button-item-horizontal[data-adjustment="down"] {
+  .calcite-input-number-button-item.calcite-input__number-button-item--horizontal[data-adjustment="down"] {
     border-right: 1px solid var(--calcite-ui-border-1);
     border-left: 0px;
   }
-  .calcite-input-number-button-item.number-button-item-horizontal[data-adjustment="up"] {
+  .calcite-input-number-button-item.calcite-input__number-button-item--horizontal[data-adjustment="up"] {
     border-left: 1px solid var(--calcite-ui-border-1);
     border-right: 0px;
   }
@@ -441,7 +441,7 @@ input[type="time"]::-webkit-clear-button {
   border-top: 0;
 }
 
-.calcite-input-number-button-item {
+.calcite-input__number-button-item {
   display: flex;
   align-self: center;
   align-items: center;
@@ -468,13 +468,13 @@ input[type="time"]::-webkit-clear-button {
 }
 
 :host([number-button-type="vertical"]) .calcite--rtl {
-  .calcite-input-number-button-item {
+  .calcite-input__number-button-item {
     border-right: none;
     border-left: 1px solid var(--calcite-ui-border-1);
   }
 }
 
-.calcite-input-wrapper {
+.calcite-input__wrapper {
   display: flex;
   flex-direction: row;
   position: relative;
@@ -500,12 +500,12 @@ input[type="time"]::-webkit-clear-button {
 
 // hide custom textarea resize icon for ie11, defer to browser arrows
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .calcite-input-resize-icon-wrapper {
+  .calcite-input__resize-icon-wrapper {
     display: none;
   }
 }
 
-.calcite-input-resize-icon-wrapper {
+.calcite-input__resize-icon-wrapper {
   background-color: var(--calcite-ui-foreground-1);
   color: var(--calcite-ui-text-3);
   position: absolute;
@@ -528,7 +528,7 @@ input[type="time"]::-webkit-clear-button {
     right: unset;
   }
 
-  .calcite-input-resize-icon-wrapper {
+  .calcite-input__resize-icon-wrapper {
     left: 2px;
     right: unset;
     & calcite-icon {
@@ -563,7 +563,7 @@ $inputStatusColors: "invalid" var(--calcite-ui-danger), "valid" var(--calcite-ui
   $name: nth($statusColor, 1);
   $color: nth($statusColor, 2);
 
-  :host([status="#{$name}"]) .calcite-input-icon {
+  :host([status="#{$name}"]) .calcite-input__icon {
     color: $color;
   }
 }

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -15,7 +15,7 @@ import {
 } from "@stencil/core";
 import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
 import { getKey } from "../../utils/key";
-import { INPUT_TYPE_ICONS, SLOTS } from "./calcite-input.resources";
+import { CSS, INPUT_TYPE_ICONS, SLOTS } from "./calcite-input.resources";
 import { InputPlacement } from "./interfaces";
 import { Position } from "../interfaces";
 import {
@@ -570,7 +570,7 @@ export class CalciteInput {
     const dir = getElementDir(this.el);
 
     const loader = (
-      <div class="calcite-input-loading">
+      <div class={CSS.loader}>
         <calcite-progress label={this.intlLoading} type="indeterminate" />
       </div>
     );
@@ -578,17 +578,13 @@ export class CalciteInput {
     const iconScale = this.scale === "s" || this.scale === "m" ? "s" : "m";
 
     const inputClearButton = (
-      <button
-        class="calcite-input-clear-button"
-        disabled={this.loading}
-        onClick={this.clearInputValue}
-      >
+      <button class={CSS.clearButton} disabled={this.loading} onClick={this.clearInputValue}>
         <calcite-icon icon="x" scale={iconScale} />
       </button>
     );
     const iconEl = (
       <calcite-icon
-        class="calcite-input-icon"
+        class={CSS.inputIcon}
         dir={dir}
         flipRtl={this.iconFlipRtl}
         icon={this.requestedIcon}
@@ -597,11 +593,11 @@ export class CalciteInput {
     );
 
     const numberButtonClassModifier =
-      this.numberButtonType === "horizontal" ? "number-button-item-horizontal" : null;
+      this.numberButtonType === "horizontal" ? CSS.buttonItemHorizontal : null;
 
     const numberButtonsHorizontalUp = (
       <div
-        class={`calcite-input-number-button-item ${numberButtonClassModifier}`}
+        class={`${CSS.numberButtonItem} ${numberButtonClassModifier}`}
         data-adjustment="up"
         onMouseDown={this.numberButtonMouseDownHandler}
       >
@@ -611,7 +607,7 @@ export class CalciteInput {
 
     const numberButtonsHorizontalDown = (
       <div
-        class={`calcite-input-number-button-item ${numberButtonClassModifier}`}
+        class={`${CSS.numberButtonItem} ${numberButtonClassModifier}`}
         data-adjustment="down"
         onMouseDown={this.numberButtonMouseDownHandler}
       >
@@ -620,15 +616,15 @@ export class CalciteInput {
     );
 
     const numberButtonsVertical = (
-      <div class={`calcite-input-number-button-wrapper`}>
+      <div class={CSS.numberButtonWrapper}>
         {numberButtonsHorizontalUp}
         {numberButtonsHorizontalDown}
       </div>
     );
 
-    const prefixText = <div class="calcite-input-prefix">{this.prefixText}</div>;
+    const prefixText = <div class={CSS.prefix}>{this.prefixText}</div>;
 
-    const suffixText = <div class="calcite-input-suffix">{this.suffixText}</div>;
+    const suffixText = <div class={CSS.suffix}>{this.suffixText}</div>;
 
     const localeNumberInput =
       this.type === "number" ? (
@@ -677,7 +673,7 @@ export class CalciteInput {
         value={this.value}
       />,
       this.isTextarea ? (
-        <div class="calcite-input-resize-icon-wrapper">
+        <div class={CSS.resizeIconWrapper}>
           <calcite-icon icon="chevron-down" scale="s" />
         </div>
       ) : null
@@ -685,19 +681,19 @@ export class CalciteInput {
 
     return (
       <Host onClick={this.inputFocusHandler}>
-        <div class={{ "calcite-input-wrapper": true, [CSS_UTILITY.rtl]: dir === "rtl" }} dir={dir}>
+        <div class={{ [CSS.inputWrapper]: true, [CSS_UTILITY.rtl]: dir === "rtl" }} dir={dir}>
           {this.type === "number" && this.numberButtonType === "horizontal"
             ? numberButtonsHorizontalDown
             : null}
           {this.prefixText ? prefixText : null}
-          <div class="calcite-input-element-wrapper">
+          <div class={CSS.wrapper}>
             {localeNumberInput}
             {childEl}
             {this.isClearable ? inputClearButton : null}
             {this.requestedIcon ? iconEl : null}
             {this.loading ? loader : null}
           </div>
-          <div class="calcite-action-wrapper">
+          <div class={CSS.actionWrapper}>
             <slot name={SLOTS.action} />
           </div>
           {this.type === "number" && this.numberButtonType === "vertical"

--- a/src/components/calcite-radio-button/calcite-radio-button.scss
+++ b/src/components/calcite-radio-button/calcite-radio-button.scss
@@ -1,6 +1,6 @@
 :host {
   @apply cursor-pointer inline-block;
-  .container {
+  .calcite-radio-button__container {
     @apply relative;
   }
 }

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -14,6 +14,7 @@ import { guid } from "../../utils/guid";
 import { focusElement } from "../../utils/dom";
 import { Scale } from "../interfaces";
 import { hiddenInputStyle } from "../../utils/form";
+import { CSS } from "./resources";
 
 @Component({
   tag: "calcite-radio-button",

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -339,7 +339,7 @@ export class CalciteRadioButton {
     const value = this.value?.toString();
 
     return (
-      <div class="container">
+      <div class={CSS.container}>
         <input
           aria-label={this.label || null}
           checked={this.checked}

--- a/src/components/calcite-radio-button/resources.ts
+++ b/src/components/calcite-radio-button/resources.ts
@@ -1,0 +1,3 @@
+export const CSS = {
+  container: "calcite-radio-button__container"
+};


### PR DESCRIPTION
**Related Issue:** #2422

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR namespaces classes (following [BEM](http://getbem.com/)) of currently scoped components since these are not transformed by the Stencil build and are available in the light DOM. 

This is a stopgap solution until all scoped components use shadow DOM.
