### PR TITLE
feat(button): show animation when loading changes

### DIFF
--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -12,7 +12,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(element).toEqualAttribute("color", "blue");
@@ -49,7 +49,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(element).toEqualAttribute("color", "blue");
@@ -73,7 +73,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(element).toEqualAttribute("color", "red");
@@ -97,7 +97,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(element).toEqualAttribute("color", "red");
@@ -121,7 +121,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).not.toBeNull();
     expect(elementAsButton).toBeNull();
@@ -141,7 +141,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
@@ -160,7 +160,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
@@ -177,7 +177,7 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
@@ -194,13 +194,33 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).not.toBeNull();
     expect(iconEnd).not.toBeNull();
     expect(loader).toBeNull();
+  });
+
+  it("renders with a loader and an icon-start when both icon-start and loader are requested, no text", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-button loading icon-start='plus'></calcite-button>`);
+    const element = await page.find("calcite-button");
+    const elementAsButton = await page.find("calcite-button >>> button");
+    const elementAsLink = await page.find("calcite-button >>> a");
+    const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
+    const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
+    expect(element).toHaveAttribute(HYDRATED_ATTR);
+    expect(elementAsLink).toBeNull();
+    expect(elementAsButton).not.toBeNull();
+    expect(iconStart).not.toBeNull();
+    expect(iconEnd).toBeNull();
+    expect(loader).not.toBeNull();
+    expect(loader).not.toHaveClass(CSS.loadingIn);
+    // one icon only buttons should stay square
+    expect(await elementAsButton.getProperty("offsetWidth")).toEqual(await elementAsButton.getProperty("offsetHeight"));
   });
 
   it("renders with a loader and an icon-start when both icon-start and loader are requested", async () => {
@@ -211,13 +231,14 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).not.toBeNull();
     expect(iconEnd).toBeNull();
     expect(loader).not.toBeNull();
+    expect(loader).not.toHaveClass(CSS.loadingIn);
   });
 
   it("renders with a loader and an icon-end when both icon-end and loader are requested", async () => {
@@ -228,13 +249,14 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).toBeNull();
     expect(iconEnd).not.toBeNull();
     expect(loader).not.toBeNull();
+    expect(loader).not.toHaveClass(CSS.loadingIn);
   });
 
   it("renders with a loader and an icon-start and icon-end when all are requested", async () => {
@@ -245,13 +267,14 @@ describe("calcite-button", () => {
     const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
     const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
-    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader}`);
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
     expect(element).toHaveAttribute(HYDRATED_ATTR);
     expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).not.toBeNull();
     expect(iconEnd).not.toBeNull();
     expect(loader).not.toBeNull();
+    expect(loader).not.toHaveClass(CSS.loadingIn);
   });
 
   it("hascontent class is present on rendered child when content (as text) is present", async () => {
@@ -369,6 +392,64 @@ describe("calcite-button", () => {
       await page.waitForChanges();
       buttonHoverStyle = await buttonEl.getComputedStyle(":hover");
       expect(buttonHoverStyle.getPropertyValue("background-color")).toEqual(overrideStyle);
+    });
+  });
+
+  describe("when loading changes", () => {
+    it("should render loader with loading-in animation when new value is true", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <calcite-button id="one-icon" icon-start='plus'></calcite-button>
+        <calcite-button id="two-icons" icon-start='arrow-right' icon-end='download'></calcite-button>
+        <calcite-button id="icons-and-text" icon-start='arrow-right' icon-end='download'>Go!</calcite-button>
+      `);
+      const button1 = await page.find("calcite-button[id='one-icon']");
+      const button2 = await page.find("calcite-button[id='two-icons']");
+      const button3 = await page.find("calcite-button[id='icons-and-text']");
+      await button1.setProperty("loading", true);
+      await button2.setProperty("loading", true);
+      await button3.setProperty("loading", true);
+      await page.waitForChanges();
+      const loader1 = await page.find(`calcite-button[id='one-icon'] >>> .${CSS.buttonLoader} calcite-loader`);
+      const loader2 = await page.find(`calcite-button[id='two-icons'] >>> .${CSS.buttonLoader} calcite-loader`);
+      const loader3 = await page.find(`calcite-button[id='icons-and-text'] >>> .${CSS.buttonLoader} calcite-loader`);
+      const loader1styles = await loader1.getComputedStyle();
+      const loader2styles = await loader2.getComputedStyle();
+      const loader3styles = await loader3.getComputedStyle();
+      expect(loader1).toHaveClass(CSS.loadingIn);
+      expect(loader1styles["animation-name"]).toEqual("loader-in");
+      expect(loader2).toHaveClass(CSS.loadingIn);
+      expect(loader2styles["animation-name"]).toEqual("loader-in");
+      expect(loader3).toHaveClass(CSS.loadingIn);
+      expect(loader3styles["animation-name"]).toEqual("loader-in");
+    });
+
+    it("should render loader with loading-out animation when new value is false", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <calcite-button loading id="one-icon" icon-start='plus'></calcite-button>
+        <calcite-button loading id="two-icons" icon-start='arrow-right' icon-end='download'></calcite-button>
+        <calcite-button loading id="icons-and-text" icon-start='arrow-right' icon-end='download'>Go!</calcite-button>
+      `);
+      const button1 = await page.find("calcite-button[id='one-icon']");
+      const button2 = await page.find("calcite-button[id='two-icons']");
+      const button3 = await page.find("calcite-button[id='icons-and-text']");
+      await button1.setProperty("loading", false);
+      await button2.setProperty("loading", false);
+      await button3.setProperty("loading", false);
+      await page.waitForChanges();
+      const loader1 = await page.find(`calcite-button[id='one-icon'] >>> .${CSS.buttonLoader} calcite-loader`);
+      const loader2 = await page.find(`calcite-button[id='two-icons'] >>> .${CSS.buttonLoader} calcite-loader`);
+      const loader3 = await page.find(`calcite-button[id='icons-and-text'] >>> .${CSS.buttonLoader} calcite-loader`);
+      const loader1styles = await loader1.getComputedStyle();
+      const loader2styles = await loader2.getComputedStyle();
+      const loader3styles = await loader3.getComputedStyle();
+      expect(loader1).toHaveClass(CSS.loadingOut);
+      expect(loader1styles["animation-name"]).toEqual("loader-out");
+      expect(loader2).toHaveClass(CSS.loadingOut);
+      expect(loader2styles["animation-name"]).toEqual("loader-out");
+      expect(loader3).toHaveClass(CSS.loadingOut);
+      expect(loader3styles["animation-name"]).toEqual("loader-out");
     });
   });
 });

--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -203,24 +203,20 @@ describe("calcite-button", () => {
     expect(loader).toBeNull();
   });
 
-  it("renders with a loader and an icon-start when both icon-start and loader are requested, no text", async () => {
+  it("renders hidden icon when both icon and loader are requested, no text", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-button loading icon-start='plus'></calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
-    const elementAsLink = await page.find("calcite-button >>> a");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
-    const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
     const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-    expect(element).toHaveAttribute(HYDRATED_ATTR);
-    expect(elementAsLink).toBeNull();
     expect(elementAsButton).not.toBeNull();
     expect(iconStart).not.toBeNull();
-    expect(iconEnd).toBeNull();
+    expect(await iconStart.isVisible()).toBeFalsy();
     expect(loader).not.toBeNull();
     expect(loader).not.toHaveClass(CSS.loadingIn);
     // one icon only buttons should stay square
-    expect(await elementAsButton.getProperty("offsetWidth")).toEqual(await elementAsButton.getProperty("offsetHeight"));
+    expect(await element.getProperty("offsetWidth")).toEqual(await element.getProperty("offsetHeight"));
   });
 
   it("renders with a loader and an icon-start when both icon-start and loader are requested", async () => {

--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -451,5 +451,17 @@ describe("calcite-button", () => {
       expect(loader3).toHaveClass(CSS.loadingOut);
       expect(loader3styles["animation-name"]).toEqual("loader-out");
     });
+
+    it("should remove calcite-loader from dom when new value is false", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-button loading icon-start='plus'></calcite-button>`);
+      const animationDurationInMs = 300;
+      const element = await page.find("calcite-button");
+      await element.setProperty("loading", false);
+      await page.waitForChanges();
+      await page.waitForTimeout(animationDurationInMs);
+      const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
+      expect(loader).toBeNull();
+    });
   });
 });

--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -214,7 +214,6 @@ describe("calcite-button", () => {
     expect(iconStart).not.toBeNull();
     expect(await iconStart.isVisible()).toBeFalsy();
     expect(loader).not.toBeNull();
-    expect(loader).not.toHaveClass(CSS.loadingIn);
     // one icon only buttons should stay square
     expect(await element.getProperty("offsetWidth")).toEqual(await element.getProperty("offsetHeight"));
   });
@@ -234,7 +233,6 @@ describe("calcite-button", () => {
     expect(iconStart).not.toBeNull();
     expect(iconEnd).toBeNull();
     expect(loader).not.toBeNull();
-    expect(loader).not.toHaveClass(CSS.loadingIn);
   });
 
   it("renders with a loader and an icon-end when both icon-end and loader are requested", async () => {
@@ -252,7 +250,6 @@ describe("calcite-button", () => {
     expect(iconStart).toBeNull();
     expect(iconEnd).not.toBeNull();
     expect(loader).not.toBeNull();
-    expect(loader).not.toHaveClass(CSS.loadingIn);
   });
 
   it("renders with a loader and an icon-start and icon-end when all are requested", async () => {
@@ -270,7 +267,6 @@ describe("calcite-button", () => {
     expect(iconStart).not.toBeNull();
     expect(iconEnd).not.toBeNull();
     expect(loader).not.toBeNull();
-    expect(loader).not.toHaveClass(CSS.loadingIn);
   });
 
   it("hascontent class is present on rendered child when content (as text) is present", async () => {

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -177,13 +177,11 @@
 }
 
 :host([alignment="center"]) {
-  .calcite--rtl {
-    a:not(.content--slotted),
-    button:not(.content--slotted) {
-      .icon--start + .icon--end {
-        margin-left: unset;
-        margin-right: $baseline/3;
-      }
+  a.calcite--rtl:not(.content--slotted),
+  button.calcite--rtl:not(.content--slotted) {
+    .icon--start + .icon--end {
+      margin-left: unset;
+      margin-right: $baseline/3;
     }
   }
 }
@@ -207,11 +205,44 @@
   }
 }
 
+@keyframes loader-in {
+  0% {
+    width: 0;
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  100% {
+    width: 1rem;
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes loader-out {
+  0% {
+    width: 1rem;
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    width: 0;
+    opacity: 0;
+    transform: scale(0.5);
+  }
+}
+
 .calcite-button--loader {
-  margin-inline-end: $baseline/3;
   display: flex;
   calcite-loader {
     margin: 0;
+    transition: width 300ms ease-in-out, opacity 300ms ease-in-out, transform 300ms ease-in-out;
+    &.loading-in {
+      animation-name: loader-in;
+      animation-duration: 300ms;
+    }
+    &.loading-out {
+      animation-name: loader-out;
+      animation-duration: 300ms;
+    }
   }
 }
 
@@ -507,6 +538,12 @@ $btnScales: "s" 12px 1.33 7px 12px, "m" 14px 1.15 13px 20px, "l" 18px 1.2 15px 2
     $compensated-padding-y: $padding-y + 1px;
     @include btn-scale($font-size, $line-height, $compensated-padding-y, $padding-x);
   }
+  :host([scale="#{$name}"][loading]) button.content--slotted,
+  :host([scale="#{$name}"][loading]) a.content--slotted {
+    .calcite-button--loader {
+      margin-inline-end: $baseline/3;
+    }
+  }
 }
 
 // generate fab scales
@@ -520,6 +557,13 @@ $btnScales2: "s" 12px 32px, "m" 14px 44px, "l" 18px 56px;
   :host([scale="#{$name}"]) button:not(.content--slotted),
   :host([scale="#{$name}"]) a:not(.content--slotted) {
     @include btn-scale-notext($font-size, $size);
+  }
+  :host([scale="#{$name}"][loading]) button:not(.content--slotted),
+  :host([scale="#{$name}"][loading]) a:not(.content--slotted) {
+    .icon--start,
+    .icon--end {
+      @apply hidden;
+    }
   }
 }
 

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Method, Prop, Build, State, VNode } from "@stencil/core";
+import { Component, Element, h, Method, Prop, Build, State, VNode, Watch } from "@stencil/core";
 import { CSS, TEXT } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { ButtonAlignment, ButtonAppearance, ButtonColor } from "./interfaces";
@@ -89,6 +89,26 @@ export class CalciteButton {
   /** specify the width of the button, defaults to auto */
   @Prop({ reflect: true }) width: Width = "auto";
 
+  @Watch("loading")
+  loadingChanged(newValue: boolean, oldValue: boolean): void {
+    if (!!newValue && !oldValue) {
+      this.loaderEl = document.createElement("calcite-loader");
+      this.loaderEl.setAttribute("active", "");
+      this.loaderEl.setAttribute("inline", "");
+      this.loaderEl.setAttribute("label", this.intlLoading);
+      this.loaderEl.setAttribute("class", CSS.loadingIn);
+      this.loaderContainer.appendChild(this.loaderEl);
+    }
+    if (!newValue && !!oldValue) {
+      this.loaderEl.setAttribute("class", CSS.loadingOut);
+      requestAnimationFrame(() => {
+        window.setTimeout(() => {
+          this.loaderContainer.removeChild(this.loaderEl);
+        }, 300);
+      });
+    }
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -113,15 +133,15 @@ export class CalciteButton {
     }
   }
 
+  componentDidLoad(): void {
+    this.renderLoader();
+  }
+
   render(): VNode {
     const dir = getElementDir(this.el);
     const Tag = this.childElType;
 
-    const loader = (
-      <div class={CSS.buttonLoader}>
-        <calcite-loader active inline label={this.intlLoading} />
-      </div>
-    );
+    const loader = <div class={CSS.buttonLoader} ref={(el) => (this.loaderContainer = el)} />;
 
     const iconScale = this.scale === "l" ? "m" : "s";
 
@@ -163,7 +183,7 @@ export class CalciteButton {
         target={this.childElType === "a" && this.el.getAttribute("target")}
         type={this.childElType === "button" && this.type}
       >
-        {this.loading ? loader : null}
+        {loader}
         {this.iconStart ? iconStartEl : null}
         {this.hasContent ? contentEl : null}
         {this.iconEnd ? iconEndEl : null}
@@ -196,6 +216,12 @@ export class CalciteButton {
 
   /** the node type of the rendered child element */
   private childElType?: "a" | "button" = "button";
+
+  /** the rendered loader container */
+  private loaderContainer?: HTMLDivElement;
+
+  /** the rendered loader element */
+  private loaderEl?: HTMLCalciteLoaderElement;
 
   /** determine if there is slotted content for styling purposes */
   @State() private hasContent?: boolean = false;
@@ -252,4 +278,15 @@ export class CalciteButton {
       e.preventDefault();
     }
   };
+
+  private renderLoader(): VNode {
+    if (this.loading) {
+      this.loaderEl = document.createElement("calcite-loader");
+      this.loaderEl.setAttribute("active", "");
+      this.loaderEl.setAttribute("inline", "");
+      this.loaderEl.setAttribute("label", this.intlLoading);
+      this.loaderContainer.appendChild(this.loaderEl);
+    }
+    return null;
+  }
 }

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -93,14 +93,14 @@ export class CalciteButton {
   loadingChanged(newValue: boolean, oldValue: boolean): void {
     if (!!newValue && !oldValue) {
       this.loaderEl = document.createElement("calcite-loader");
-      this.loaderEl.setAttribute("active", "");
-      this.loaderEl.setAttribute("inline", "");
-      this.loaderEl.setAttribute("label", this.intlLoading);
-      this.loaderEl.setAttribute("class", CSS.loadingIn);
+      this.loaderEl.active = true;
+      this.loaderEl.inline = true;
+      this.loaderEl.label = this.intlLoading;
+      this.loaderEl.className = CSS.loadingIn;
       this.loaderContainer.appendChild(this.loaderEl);
     }
     if (!newValue && !!oldValue) {
-      this.loaderEl.setAttribute("class", CSS.loadingOut);
+      this.loaderEl.className = CSS.loadingOut;
       requestAnimationFrame(() => {
         window.setTimeout(() => {
           this.loaderContainer.removeChild(this.loaderEl);
@@ -282,9 +282,9 @@ export class CalciteButton {
   private renderLoader(): VNode {
     if (this.loading) {
       this.loaderEl = document.createElement("calcite-loader");
-      this.loaderEl.setAttribute("active", "");
-      this.loaderEl.setAttribute("inline", "");
-      this.loaderEl.setAttribute("label", this.intlLoading);
+      this.loaderEl.active = true;
+      this.loaderEl.inline = true;
+      this.loaderEl.label = this.intlLoading;
       this.loaderContainer.appendChild(this.loaderEl);
     }
     return null;

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -220,7 +220,7 @@ export class CalciteButton {
   /** determine if there is slotted content for styling purposes */
   @State() private hasContent?: boolean = false;
 
-  /** determine if there is slotted content for styling purposes */
+  /** determine if loader present for styling purposes */
   @State() private hasLoader?: boolean = false;
 
   private updateHasContent() {

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -92,20 +92,12 @@ export class CalciteButton {
   @Watch("loading")
   loadingChanged(newValue: boolean, oldValue: boolean): void {
     if (!!newValue && !oldValue) {
-      this.loaderEl = document.createElement("calcite-loader");
-      this.loaderEl.active = true;
-      this.loaderEl.inline = true;
-      this.loaderEl.label = this.intlLoading;
-      this.loaderEl.className = CSS.loadingIn;
-      this.loaderContainer.appendChild(this.loaderEl);
+      this.hasLoader = true;
     }
     if (!newValue && !!oldValue) {
-      this.loaderEl.className = CSS.loadingOut;
-      requestAnimationFrame(() => {
-        window.setTimeout(() => {
-          this.loaderContainer.removeChild(this.loaderEl);
-        }, 300);
-      });
+      window.setTimeout(() => {
+        this.hasLoader = false;
+      }, 300);
     }
   }
 
@@ -117,6 +109,7 @@ export class CalciteButton {
 
   connectedCallback(): void {
     this.childElType = this.href ? "a" : "button";
+    this.hasLoader = this.loading;
     this.setupTextContentObserver();
   }
 
@@ -133,15 +126,22 @@ export class CalciteButton {
     }
   }
 
-  componentDidLoad(): void {
-    this.renderLoader();
-  }
-
   render(): VNode {
     const dir = getElementDir(this.el);
     const Tag = this.childElType;
 
-    const loader = <div class={CSS.buttonLoader} ref={(el) => (this.loaderContainer = el)} />;
+    const loader = (
+      <div class={CSS.buttonLoader}>
+        {this.hasLoader ? (
+          <calcite-loader
+            active
+            class={this.loading ? CSS.loadingIn : CSS.loadingOut}
+            inline
+            label={this.intlLoading}
+          />
+        ) : null}
+      </div>
+    );
 
     const iconScale = this.scale === "l" ? "m" : "s";
 
@@ -217,14 +217,11 @@ export class CalciteButton {
   /** the node type of the rendered child element */
   private childElType?: "a" | "button" = "button";
 
-  /** the rendered loader container */
-  private loaderContainer?: HTMLDivElement;
-
-  /** the rendered loader element */
-  private loaderEl?: HTMLCalciteLoaderElement;
-
   /** determine if there is slotted content for styling purposes */
   @State() private hasContent?: boolean = false;
+
+  /** determine if there is slotted content for styling purposes */
+  @State() private hasLoader?: boolean = false;
 
   private updateHasContent() {
     const slottedContent = this.el.textContent.trim().length > 0 || this.el.childNodes.length > 0;
@@ -278,15 +275,4 @@ export class CalciteButton {
       e.preventDefault();
     }
   };
-
-  private renderLoader(): VNode {
-    if (this.loading) {
-      this.loaderEl = document.createElement("calcite-loader");
-      this.loaderEl.active = true;
-      this.loaderEl.inline = true;
-      this.loaderEl.label = this.intlLoading;
-      this.loaderContainer.appendChild(this.loaderEl);
-    }
-    return null;
-  }
 }

--- a/src/components/calcite-button/resources.ts
+++ b/src/components/calcite-button/resources.ts
@@ -4,7 +4,9 @@ export const CSS = {
   contentSlotted: "content--slotted",
   icon: "icon",
   iconStart: "icon--start",
-  iconEnd: "icon--end"
+  iconEnd: "icon--end",
+  loadingIn: "loading-in",
+  loadingOut: "loading-out"
 };
 
 export const TEXT = {

--- a/src/demos/_assets/loadingButton.ts
+++ b/src/demos/_assets/loadingButton.ts
@@ -1,5 +1,5 @@
 // example for adding and removing loading state from button
 function loadingButton(el: HTMLElement, duration: number): void {
-  el.setAttribute("loading", "true");
-  setTimeout(() => el.setAttribute("loading", "false"), duration);
+  el.setAttribute("loading", "");
+  setTimeout(() => el.removeAttribute("loading"), duration);
 }

--- a/src/demos/calcite-button.html
+++ b/src/demos/calcite-button.html
@@ -436,6 +436,75 @@
     </section>
 
     <section>
+      <calcite-label layout="inline">
+        Toggle loading animation
+        <calcite-switch id="loading-switch"></calcite-switch>
+      </calcite-label>
+      <script>
+        const switchEl = document.querySelector("#loading-switch");
+        switchEl.addEventListener("calciteSwitchChange", () => {
+          document.querySelectorAll(".loading-transition").forEach((button) => {
+            button.toggleAttribute("loading");
+          });
+        });
+      </script>
+
+      <calcite-button
+        class="loading-transition"
+        color="red"
+        appearance="solid"
+        icon-start="attachment"
+      ></calcite-button>
+      <calcite-button
+        class="loading-transition"
+        color="red"
+        appearance="solid"
+        icon-end="download"
+        round
+      ></calcite-button>
+      <calcite-button
+        class="loading-transition"
+        color="red"
+        appearance="solid"
+        icon-start="attachment"
+        icon-end="download"
+      ></calcite-button>
+      <calcite-button
+        class="loading-transition"
+        color="red"
+        appearance="solid"
+        icon-start="attachment"
+        round
+        icon-end="download"
+      ></calcite-button>
+      <calcite-button class="loading-transition" color="red" appearance="solid">Attachments</calcite-button>
+      <calcite-button class="loading-transition" color="red" appearance="solid" round>Attachments</calcite-button>
+      <calcite-button class="loading-transition" color="red" appearance="solid" icon-end="download"
+        >Attachments</calcite-button
+      >
+      <calcite-button class="loading-transition" round color="red" appearance="solid" icon-end="download"
+        >Attachments</calcite-button
+      >
+      <calcite-button
+        class="loading-transition"
+        color="red"
+        appearance="solid"
+        icon-start="attachment"
+        icon-end="download"
+        >Attachments</calcite-button
+      >
+      <calcite-button
+        class="loading-transition"
+        round
+        color="red"
+        appearance="solid"
+        icon-start="attachment"
+        icon-end="download"
+        >Attachments</calcite-button
+      >
+    </section>
+
+    <section>
       <h3>Icons, and icons in combination with loader</h3>
       <h5>pass path data - recommend using Calcite UI Icon Filled variants @ 24.</h5>
       <calcite-button


### PR DESCRIPTION
**Related Issue:** #2420

## Summary
Adds a loading animation to calcite-button when `loading` changes (ensures 1 icon only buttons stay square when loading, per Figma spec).

(See "Toggle loading animation" in calcite-button.html for demo.)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
