### PR TITLE
feat(slider): add histogram color support

### DIFF
--- a/src/components/calcite-graph/calcite-graph.e2e.ts
+++ b/src/components/calcite-graph/calcite-graph.e2e.ts
@@ -60,4 +60,28 @@ describe("calcite-graph", () => {
       "M 0,60 L 0,20 L 0,20 C 16.666666666666664,-10.000000000000014 33.333333333333336,-40 50,-40 C 100,-40 150,-33.33333333333334 200,-20 C 233.33333333333334,-11.111111111111114 266.66666666666663,24.444444444444443 300,60 L 300,60 Z"
     );
   });
+
+  it("uses color-stops when provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-graph></calcite-graph>`);
+    await page.$eval("calcite-graph", (elm: any) => {
+      elm.data = [
+        [0, 4],
+        [1, 7],
+        [4, 6],
+        [6, 2]
+      ];
+      elm.colorStops = [[0, 'red'], [0.5, 'green'], [1, 'blue']];
+    });
+
+    await page.waitForChanges();
+
+    const linearGradient = await page.find('calcite-graph >>> linearGradient');
+    const linearGradientId = linearGradient.getAttribute('id');
+
+    const path = await page.find('calcite-graph >>> path');
+    const fill = path.getAttribute('fill');
+
+    expect(fill).toBe(`url(#${linearGradientId})`);
+  });
 });

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -41,6 +41,12 @@ export class CalciteGraph {
   /** End of highlight color if highlighting range */
   @Prop() highlightMax: number;
 
+  /**
+   * Array of values describing a single color stop ([offset, color, opacity])
+   * These color stops should be sorted by offset value
+   */
+  @Prop() colorStops: [number, string, number][];
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -48,7 +54,7 @@ export class CalciteGraph {
   //--------------------------------------------------------------------------
 
   render(): VNode {
-    const { data, width, height, highlightMax, highlightMin } = this;
+    const { data, colorStops, width, height, highlightMax, highlightMin } = this;
     const id = this.maskId;
 
     // if we have no data, return empty svg
@@ -69,6 +75,7 @@ export class CalciteGraph {
     const [hMinX] = t([highlightMin, max[1]]);
     const [hMaxX] = t([highlightMax, max[1]]);
     const areaPath = area({ data, min, max, t });
+    const fill = colorStops ? `url(#linear-gradient-${id})` : undefined;
     return (
       <svg
         class="svg"
@@ -77,6 +84,16 @@ export class CalciteGraph {
         viewBox={`0 0 ${width} ${height}`}
         width={width}
       >
+        {colorStops ? (
+          <defs>
+            <linearGradient id={`linear-gradient-${id}`} x1="0" x2="1" y1="0" y2="0">
+              {colorStops.map(([offset, color, opacity = 1]) => (
+                <stop offset={`${offset * 100}%`} stop-color={color} stop-opacity={opacity}/>
+              ))}
+            </linearGradient>
+          </defs>
+        ) : null}
+
         {highlightMin !== undefined ? (
           <svg
             class="svg"
@@ -124,12 +141,12 @@ export class CalciteGraph {
               />
             </mask>
 
-            <path class="graph-path" d={areaPath} mask={`url(#${id}1)`} />
-            <path class="graph-path--highlight" d={areaPath} mask={`url(#${id}2)`} />
-            <path class="graph-path" d={areaPath} mask={`url(#${id}3)`} />
+            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />
+            <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />
+            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
           </svg>
         ) : (
-          <path class="graph-path" d={areaPath} />
+          <path class="graph-path" d={areaPath} fill={fill} />
         )}
       </svg>
     );

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -55,7 +55,7 @@ export class CalciteGraph {
 
   render(): VNode {
     const { data, colorStops, width, height, highlightMax, highlightMin } = this;
-    const id = this.maskId;
+    const id = this.graphId;
 
     // if we have no data, return empty svg
     if (!data || data.length === 0) {
@@ -94,58 +94,50 @@ export class CalciteGraph {
           </defs>
         ) : null}
 
-        {highlightMin !== undefined ? (
-          <svg
-            class="svg"
-            height={height}
-            preserveAspectRatio="none"
-            viewBox={`0 0 ${width} ${height}`}
-            width={width}
-          >
-            <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-              M 0,0
-              L ${hMinX - 1},0
-              L ${hMinX - 1},${height}
-              L 0,${height}
-              Z
-            `}
-                fill="white"
-              />
-            </mask>
+        {highlightMin !== undefined ? [
+          <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+            M 0,0
+            L ${hMinX - 1},0
+            L ${hMinX - 1},${height}
+            L 0,${height}
+            Z
+          `}
+              fill="white"
+            />
+          </mask>,
 
-            <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-              M ${hMinX + 1},0
-              L ${hMaxX - 1},0
-              L ${hMaxX - 1},${height}
-              L ${hMinX + 1}, ${height}
-              Z
-            `}
-                fill="white"
-              />
-            </mask>
+          <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+            M ${hMinX + 1},0
+            L ${hMaxX - 1},0
+            L ${hMaxX - 1},${height}
+            L ${hMinX + 1}, ${height}
+            Z
+          `}
+              fill="white"
+            />
+          </mask>,
 
-            <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-                  M ${hMaxX + 1},0
-                  L ${width},0
-                  L ${width},${height}
-                  L ${hMaxX + 1}, ${height}
-                  Z
-                `}
-                fill="white"
-              />
-            </mask>
+          <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+                M ${hMaxX + 1},0
+                L ${width},0
+                L ${width},${height}
+                L ${hMaxX + 1}, ${height}
+                Z
+              `}
+              fill="white"
+            />
+          </mask>,
 
-            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />
-            <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />
-            <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
-          </svg>
-        ) : (
+          <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />,
+          <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />,
+          <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
+         ] : (
           <path class="graph-path" d={areaPath} fill={fill} />
         )}
       </svg>
@@ -158,5 +150,5 @@ export class CalciteGraph {
   //
   //--------------------------------------------------------------------------
 
-  private maskId = `calcite-graph-mask-${guid()}`;
+  private graphId = `calcite-graph-${guid()}`;
 }

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { defaults, renders } from "../../tests/commonTests";
+import { defaults, renders, HYDRATED_ATTR } from "../../tests/commonTests";
 
 describe("calcite-slider", () => {
   it("renders", async () => renders("calcite-slider"));
@@ -335,6 +335,46 @@ describe("calcite-slider", () => {
       expect(await slider.getProperty("minValue")).toBe(25);
       expect(await slider.getProperty("maxValue")).toBe(75);
       expect(changeEvent).toHaveReceivedEventTimes(5);
+    });
+  });
+
+  describe("histogram", () => {
+    it("creates calcite-graph with provided data", async () => {
+      const html = `<calcite-slider></calcite-slider>`;
+      const page = await newE2EPage({ html });
+
+      const { histogram, histogramColors } = await page.$eval("calcite-slider", (elm: any) => {
+        const histogram = [
+          [0, 4],
+          [1, 7],
+          [4, 6],
+          [6, 2]
+        ];
+
+        const histogramColors = [
+          [0, "red"],
+          [0.5, "green"],
+          [1, "blue"]
+        ];
+
+        elm.histogram = histogram;
+        elm.histogramColors = histogramColors;
+
+        return { histogram, histogramColors };
+      });
+
+      await page.waitForChanges();
+
+      const graph = await page.find("calcite-slider >>> calcite-graph");
+
+      expect(graph).toHaveAttribute(HYDRATED_ATTR);
+      expect(await graph.isVisible()).toBe(true);
+
+      const data = await graph.getProperty("data");
+      expect(data).toEqual(histogram);
+
+      const colorStops = await graph.getProperty("colorStops");
+      expect(colorStops).toEqual(histogramColors);
     });
   });
 });

--- a/src/components/calcite-slider/calcite-slider.stories.ts
+++ b/src/components/calcite-slider/calcite-slider.stories.ts
@@ -1,4 +1,4 @@
-import { text, number, array } from "@storybook/addon-knobs";
+import { text, number, array, object } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import { darkBackground } from "../../../.storybook/utils";
 import readme from "./readme.md";
@@ -68,6 +68,30 @@ export const Histogram = (): HTMLCalciteSliderElement => {
     ],
     "  "
   );
+  return slider;
+};
+
+export const HistogramWithColors = (): HTMLCalciteSliderElement => {
+  const slider = document.createElement("calcite-slider");
+  slider.min = number("min", 0);
+  slider.minValue = number("min-value", 25);
+  slider.max = number("max", 100);
+  slider.maxValue = number("max-value", 75);
+  slider.histogram = array(
+    "histogram",
+    [
+      [0, 0],
+      [20, 12],
+      [40, 25],
+      [60, 55],
+      [80, 10],
+      [100, 0]
+    ],
+    "  "
+  );
+  const colors = array('histogram colors', ["red", "green", "blue"]);
+  const offsets = array('histogram color offsets', colors.map((_, i) => `${(1 / (colors.length - 1))*i}`));
+  slider.histogramColors = colors.map((color, i) => [parseFloat(offsets[i]), color]);
   return slider;
 };
 

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -52,6 +52,12 @@ export class CalciteSlider {
     this.hasHistogram = !!newHistogram;
   }
 
+  /**
+   * Array of values describing a single color stop ([offset, color, opacity]).
+   * These color stops should be sorted by offset value.
+   */
+  @Prop() histogramColors: [number, string, number][]
+
   /** Label handles with their numeric value */
   @Prop({ reflect: true }) labelHandles?: boolean;
 
@@ -584,6 +590,7 @@ export class CalciteSlider {
     return this.histogram ? (
       <div class="graph">
         <calcite-graph
+          colorStops={this.histogramColors}
           data={this.histogram}
           height={48}
           highlightMax={this.isRange ? this.maxValue : this.value}

--- a/src/components/calcite-slider/readme.md
+++ b/src/components/calcite-slider/readme.md
@@ -30,26 +30,27 @@ If you'd like to allow an upper and lower value selection (two handles), you can
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                                                 | Type      | Default     |
-| -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `disabled`     | `disabled`      | Disable and gray out the slider                                                                                                             | `boolean` | `false`     |
-| `hasHistogram` | `has-histogram` | Indicates if a histogram is present                                                                                                         | `boolean` | `false`     |
-| `histogram`    | --              | Display a histogram above the slider                                                                                                        | `Point[]` | `undefined` |
-| `labelHandles` | `label-handles` | Label handles with their numeric value                                                                                                      | `boolean` | `undefined` |
-| `labelTicks`   | `label-ticks`   | Label tick marks with their numeric value.                                                                                                  | `boolean` | `undefined` |
-| `max`          | `max`           | Maximum selectable value                                                                                                                    | `number`  | `100`       |
-| `maxLabel`     | `max-label`     | Label for second handle if needed (ex. "Temperature, upper bound")                                                                          | `string`  | `undefined` |
-| `maxValue`     | `max-value`     | Currently selected upper number (if multi-select)                                                                                           | `number`  | `undefined` |
-| `min`          | `min`           | Minimum selectable value                                                                                                                    | `number`  | `0`         |
-| `minLabel`     | `min-label`     | Label for first (or only) handle (ex. "Temperature, lower bound")                                                                           | `string`  | `undefined` |
-| `minValue`     | `min-value`     | Currently selected lower number (if multi-select)                                                                                           | `number`  | `undefined` |
-| `mirrored`     | `mirrored`      | When true, the slider will display values from high to low. Note that this value will be ignored if the slider has an associated histogram. | `boolean` | `false`     |
-| `pageStep`     | `page-step`     | Interval to move on page up/page down keys                                                                                                  | `number`  | `undefined` |
-| `precise`      | `precise`       | Use finer point for handles                                                                                                                 | `boolean` | `undefined` |
-| `snap`         | `snap`          | When true, enables snap selection along the step interval                                                                                   | `boolean` | `false`     |
-| `step`         | `step`          | Interval to move on up/down keys                                                                                                            | `number`  | `1`         |
-| `ticks`        | `ticks`         | Show tick marks on the number line at provided interval                                                                                     | `number`  | `undefined` |
-| `value`        | `value`         | Currently selected number (if single select)                                                                                                | `number`  | `null`      |
+| Property          | Attribute       | Description                                                                                                                                 | Type                         | Default     |
+| ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------- |
+| `disabled`        | `disabled`      | Disable and gray out the slider                                                                                                             | `boolean`                    | `false`     |
+| `hasHistogram`    | `has-histogram` | Indicates if a histogram is present                                                                                                         | `boolean`                    | `false`     |
+| `histogram`       | --              | Display a histogram above the slider                                                                                                        | `Point[]`                    | `undefined` |
+| `histogramColors` | --              | Color stops for the histogram                                                                                                               | `[number, string, number][]` | `undefined` |
+| `labelHandles`    | `label-handles` | Label handles with their numeric value                                                                                                      | `boolean`                    | `undefined` |
+| `labelTicks`      | `label-ticks`   | Label tick marks with their numeric value.                                                                                                  | `boolean`                    | `undefined` |
+| `max`             | `max`           | Maximum selectable value                                                                                                                    | `number`                     | `100`       |
+| `maxLabel`        | `max-label`     | Label for second handle if needed (ex. "Temperature, upper bound")                                                                          | `string`                     | `undefined` |
+| `maxValue`        | `max-value`     | Currently selected upper number (if multi-select)                                                                                           | `number`                     | `undefined` |
+| `min`             | `min`           | Minimum selectable value                                                                                                                    | `number`                     | `0`         |
+| `minLabel`        | `min-label`     | Label for first (or only) handle (ex. "Temperature, lower bound")                                                                           | `string`                     | `undefined` |
+| `minValue`        | `min-value`     | Currently selected lower number (if multi-select)                                                                                           | `number`                     | `undefined` |
+| `mirrored`        | `mirrored`      | When true, the slider will display values from high to low. Note that this value will be ignored if the slider has an associated histogram. | `boolean`                    | `false`     |
+| `pageStep`        | `page-step`     | Interval to move on page up/page down keys                                                                                                  | `number`                     | `undefined` |
+| `precise`         | `precise`       | Use finer point for handles                                                                                                                 | `boolean`                    | `undefined` |
+| `snap`            | `snap`          | When true, enables snap selection along the step interval                                                                                   | `boolean`                    | `false`     |
+| `step`            | `step`          | Interval to move on up/down keys                                                                                                            | `number`                     | `1`         |
+| `ticks`           | `ticks`         | Show tick marks on the number line at provided interval                                                                                     | `number`                     | `undefined` |
+| `value`           | `value`         | Currently selected number (if single select)                                                                                                | `number`                     | `null`      |
 
 ## Events
 

--- a/src/demos/calcite-graph.html
+++ b/src/demos/calcite-graph.html
@@ -28,7 +28,17 @@
       <calcite-graph></calcite-graph>
     </p>
 
+    <h3>Highlight Range</h3>
+    <calcite-graph class="highlight-range"></calcite-graph>
+
+    <h3>Color Stops</h3>
+    <calcite-graph class="color-stops"></calcite-graph>
+
+    <h3>Highlight Range and Color Stops</h3>
+    <calcite-graph class="highlight-range color-stops"></calcite-graph>
+
     <script>
+      // Fill all graphs with the same data.
       var data = [
         [0, 0],
         [10, 80],
@@ -42,8 +52,21 @@
         [90, 10],
         [100, 0]
       ];
-      [].slice.call(document.querySelectorAll("calcite-graph")).forEach(function (graphElement) {
+      document.querySelectorAll("calcite-graph").forEach(function (graphElement) {
         graphElement.data = data;
+      });
+
+      // Add highlight ranges
+      document.querySelectorAll(".highlight-range").forEach(function (graphElement) {
+        graphElement.highlightMin = 25;
+        graphElement.highlightMax = 75;
+      });
+
+      // Add color stops
+      var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
+      var colorStops = rainbow.map((color, i) => [(1 / (rainbow.length - 1)) * i, color]);
+      document.querySelectorAll(".color-stops").forEach(function (graphElement) {
+        graphElement.colorStops = colorStops;
       });
     </script>
   </body>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -211,6 +211,15 @@
               precise
             ></calcite-slider>
 
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
+            ></calcite-slider>
+
             <h3>Histogram Disabled</h3>
             <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
           </demo-spacer>
@@ -804,6 +813,15 @@
               label-handles
               label-ticks
               precise
+            ></calcite-slider>
+
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
             ></calcite-slider>
 
             <h3>Histogram Disabled</h3>
@@ -1426,6 +1444,16 @@
               precise
             ></calcite-slider>
 
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
+            ></calcite-slider>
+
             <h3>Histogram Disabled</h3>
             <calcite-slider
               mirrored
@@ -2172,6 +2200,16 @@
               precise
             ></calcite-slider>
 
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
+            ></calcite-slider>
+
             <h3>Histogram Disabled</h3>
             <calcite-slider
               mirrored
@@ -2571,6 +2609,12 @@
       ];
       [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
         graphElement.histogram = histogram;
+      });
+
+      var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
+      var colorStops = rainbow.map((color, i) => [(1 / (rainbow.length - 1)) * i, color]);
+      document.querySelectorAll(".js-histogram-colors").forEach(function (graphElement) {
+        graphElement.histogramColors = colorStops;
       });
     </script>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -78,6 +78,9 @@
           <calcite-link href="/demos/fab">calcite-fab</calcite-link>
         </li>
         <li>
+          <calcite-link href="/demos/calcite-graph.html">calcite-graph</calcite-link>
+        </li>
+        <li>
           <calcite-link href="/demos/calcite-icon.html">calcite-icon</calcite-link>
         </li>
         <li>


### PR DESCRIPTION
**Related Issue:** #834 

## Summary

This is **part 2 (of 2)** of adding color-stop support to calcite-slider. Part 1 is #2562. This should be rebased and reviewed after #2562 is merged.

This PR adds a `histogramColors` property to `<calcite-slider>`. The value to passed to `<calcite-graph>`. The rest of the changes are documentation and testing.

![image](https://user-images.githubusercontent.com/8754/126213231-4af6270b-f643-4f12-a762-24218a1908a2.png)


- [x] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge
