### PR TITLE
feat(slider): Add support for histogram color stops

### DIFF
--- a/src/components/calcite-graph/calcite-graph.e2e.ts
+++ b/src/components/calcite-graph/calcite-graph.e2e.ts
@@ -72,9 +72,9 @@ describe("calcite-graph", () => {
         [6, 2]
       ];
       elm.colorStops = [
-        [0, "red"],
-        [0.5, "green"],
-        [1, "blue"]
+        { offset: 0, color: "red" },
+        { offset: 0.5, color: "green" },
+        { offset: 1, color: "blue" }
       ];
     });
 

--- a/src/components/calcite-graph/calcite-graph.e2e.ts
+++ b/src/components/calcite-graph/calcite-graph.e2e.ts
@@ -60,4 +60,32 @@ describe("calcite-graph", () => {
       "M 0,60 L 0,20 L 0,20 C 16.666666666666664,-10.000000000000014 33.333333333333336,-40 50,-40 C 100,-40 150,-33.33333333333334 200,-20 C 233.33333333333334,-11.111111111111114 266.66666666666663,24.444444444444443 300,60 L 300,60 Z"
     );
   });
+
+  it("uses color-stops when provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-graph></calcite-graph>`);
+    await page.$eval("calcite-graph", (elm: any) => {
+      elm.data = [
+        [0, 4],
+        [1, 7],
+        [4, 6],
+        [6, 2]
+      ];
+      elm.colorStops = [
+        [0, "red"],
+        [0.5, "green"],
+        [1, "blue"]
+      ];
+    });
+
+    await page.waitForChanges();
+
+    const linearGradient = await page.find("calcite-graph >>> linearGradient");
+    const linearGradientId = linearGradient.getAttribute("id");
+
+    const path = await page.find("calcite-graph >>> path");
+    const fill = path.getAttribute("fill");
+
+    expect(fill).toBe(`url(#${linearGradientId})`);
+  });
 });

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Prop, h, VNode } from "@stencil/core";
-import { DataSeries } from "./interfaces";
+import { ColorStop, DataSeries } from "./interfaces";
 import { guid } from "../../utils/guid";
 import { area, range, translate } from "./util";
 
@@ -33,7 +33,7 @@ export class CalciteGraph {
    * Array of values describing a single color stop ([offset, color, opacity])
    * These color stops should be sorted by offset value
    */
-  @Prop() colorStops: [number, string, number][];
+  @Prop() colorStops: ColorStop[];
 
   /** Width of graph in pixels*/
   @Prop() width = 300;
@@ -87,7 +87,7 @@ export class CalciteGraph {
         {colorStops ? (
           <defs>
             <linearGradient id={`linear-gradient-${id}`} x1="0" x2="1" y1="0" y2="0">
-              {colorStops.map(([offset, color, opacity = 1]) => (
+              {colorStops.map(({ offset, color, opacity }) => (
                 <stop offset={`${offset * 100}%`} stop-color={color} stop-opacity={opacity}/>
               ))}
             </linearGradient>

--- a/src/components/calcite-graph/calcite-graph.tsx
+++ b/src/components/calcite-graph/calcite-graph.tsx
@@ -29,6 +29,12 @@ export class CalciteGraph {
    */
   @Prop() data: DataSeries = [];
 
+  /**
+   * Array of values describing a single color stop ([offset, color, opacity])
+   * These color stops should be sorted by offset value
+   */
+  @Prop() colorStops: [number, string, number][];
+
   /** Width of graph in pixels*/
   @Prop() width = 300;
 
@@ -48,8 +54,8 @@ export class CalciteGraph {
   //--------------------------------------------------------------------------
 
   render(): VNode {
-    const { data, width, height, highlightMax, highlightMin } = this;
-    const id = this.maskId;
+    const { data, colorStops, width, height, highlightMax, highlightMin } = this;
+    const id = this.graphId;
 
     // if we have no data, return empty svg
     if (!data || data.length === 0) {
@@ -69,6 +75,7 @@ export class CalciteGraph {
     const [hMinX] = t([highlightMin, max[1]]);
     const [hMaxX] = t([highlightMax, max[1]]);
     const areaPath = area({ data, min, max, t });
+    const fill = colorStops ? `url(#linear-gradient-${id})` : undefined;
     return (
       <svg
         class="svg"
@@ -77,59 +84,61 @@ export class CalciteGraph {
         viewBox={`0 0 ${width} ${height}`}
         width={width}
       >
-        {highlightMin !== undefined ? (
-          <svg
-            class="svg"
-            height={height}
-            preserveAspectRatio="none"
-            viewBox={`0 0 ${width} ${height}`}
-            width={width}
-          >
-            <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-              M 0,0
-              L ${hMinX - 1},0
-              L ${hMinX - 1},${height}
-              L 0,${height}
-              Z
-            `}
-                fill="white"
-              />
-            </mask>
+        {colorStops ? (
+          <defs>
+            <linearGradient id={`linear-gradient-${id}`} x1="0" x2="1" y1="0" y2="0">
+              {colorStops.map(([offset, color, opacity = 1]) => (
+                <stop offset={`${offset * 100}%`} stop-color={color} stop-opacity={opacity}/>
+              ))}
+            </linearGradient>
+          </defs>
+        ) : null}
 
-            <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-              M ${hMinX + 1},0
-              L ${hMaxX - 1},0
-              L ${hMaxX - 1},${height}
-              L ${hMinX + 1}, ${height}
-              Z
-            `}
-                fill="white"
-              />
-            </mask>
+        {highlightMin !== undefined ? [
+          <mask height="100%" id={`${id}1`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+            M 0,0
+            L ${hMinX - 1},0
+            L ${hMinX - 1},${height}
+            L 0,${height}
+            Z
+          `}
+              fill="white"
+            />
+          </mask>,
 
-            <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
-              <path
-                d={`
-                  M ${hMaxX + 1},0
-                  L ${width},0
-                  L ${width},${height}
-                  L ${hMaxX + 1}, ${height}
-                  Z
-                `}
-                fill="white"
-              />
-            </mask>
+          <mask height="100%" id={`${id}2`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+            M ${hMinX + 1},0
+            L ${hMaxX - 1},0
+            L ${hMaxX - 1},${height}
+            L ${hMinX + 1}, ${height}
+            Z
+          `}
+              fill="white"
+            />
+          </mask>,
 
-            <path class="graph-path" d={areaPath} mask={`url(#${id}1)`} />
-            <path class="graph-path--highlight" d={areaPath} mask={`url(#${id}2)`} />
-            <path class="graph-path" d={areaPath} mask={`url(#${id}3)`} />
-          </svg>
-        ) : (
-          <path class="graph-path" d={areaPath} />
+          <mask height="100%" id={`${id}3`} width="100%" x="0%" y="0%">
+            <path
+              d={`
+                M ${hMaxX + 1},0
+                L ${width},0
+                L ${width},${height}
+                L ${hMaxX + 1}, ${height}
+                Z
+              `}
+              fill="white"
+            />
+          </mask>,
+
+          <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}1)`} />,
+          <path class="graph-path--highlight" d={areaPath} fill={fill} mask={`url(#${id}2)`} />,
+          <path class="graph-path" d={areaPath} fill={fill} mask={`url(#${id}3)`} />
+         ] : (
+          <path class="graph-path" d={areaPath} fill={fill} />
         )}
       </svg>
     );
@@ -141,5 +150,5 @@ export class CalciteGraph {
   //
   //--------------------------------------------------------------------------
 
-  private maskId = `calcite-graph-mask-${guid()}`;
+  private graphId = `calcite-graph-${guid()}`;
 }

--- a/src/components/calcite-graph/interfaces.ts
+++ b/src/components/calcite-graph/interfaces.ts
@@ -25,3 +25,9 @@ export interface Graph extends Extent {
 }
 
 export interface TranslateOptions extends Dimensions, Extent {}
+
+export interface ColorStop {
+  offset: number;
+  color: string;
+  opacity?: number;
+}

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { defaults, renders } from "../../tests/commonTests";
+import { defaults, HYDRATED_ATTR, renders } from "../../tests/commonTests";
 
 describe("calcite-slider", () => {
   it("renders", async () => renders("calcite-slider"));
@@ -335,6 +335,46 @@ describe("calcite-slider", () => {
       expect(await slider.getProperty("minValue")).toBe(25);
       expect(await slider.getProperty("maxValue")).toBe(75);
       expect(changeEvent).toHaveReceivedEventTimes(5);
+    });
+  });
+
+  describe("histogram", () => {
+    it("creates calcite-graph with provided data", async () => {
+      const html = `<calcite-slider></calcite-slider>`;
+      const page = await newE2EPage({ html });
+
+      const { histogram, histogramColors } = await page.$eval("calcite-slider", (elm: any) => {
+        const histogram = [
+          [0, 4],
+          [1, 7],
+          [4, 6],
+          [6, 2]
+        ];
+
+        const histogramColors = [
+          { offset: 0, color: "red" },
+          { offset: 0.5, color: "green" },
+          { offset: 1, color: "blue" }
+        ];
+
+        elm.histogram = histogram;
+        elm.histogramColors = histogramColors;
+
+        return { histogram, histogramColors };
+      });
+
+      await page.waitForChanges();
+
+      const graph = await page.find("calcite-slider >>> calcite-graph");
+
+      expect(graph).toHaveAttribute(HYDRATED_ATTR);
+      expect(await graph.isVisible()).toBe(true);
+
+      const data = await graph.getProperty("data");
+      expect(data).toEqual(histogram);
+
+      const colorStops = await graph.getProperty("colorStops");
+      expect(colorStops).toEqual(histogramColors);
     });
   });
 });

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -340,10 +340,9 @@ describe("calcite-slider", () => {
 
   describe("histogram", () => {
     it("creates calcite-graph with provided data", async () => {
-      const html = `<calcite-slider></calcite-slider>`;
-      const page = await newE2EPage({ html });
+      const page = await newE2EPage({ html: `<calcite-slider></calcite-slider>` });
 
-      const { histogram, histogramColors } = await page.$eval("calcite-slider", (elm: any) => {
+      const { histogram, histogramStops } = await page.$eval("calcite-slider", (elm: any) => {
         const histogram = [
           [0, 4],
           [1, 7],
@@ -351,30 +350,27 @@ describe("calcite-slider", () => {
           [6, 2]
         ];
 
-        const histogramColors = [
+        const histogramStops = [
           { offset: 0, color: "red" },
           { offset: 0.5, color: "green" },
           { offset: 1, color: "blue" }
         ];
 
         elm.histogram = histogram;
-        elm.histogramColors = histogramColors;
+        elm.histogramStops = histogramStops;
 
-        return { histogram, histogramColors };
+        return { histogram, histogramStops };
       });
 
       await page.waitForChanges();
 
       const graph = await page.find("calcite-slider >>> calcite-graph");
 
-      expect(graph).toHaveAttribute(HYDRATED_ATTR);
-      expect(await graph.isVisible()).toBe(true);
-
       const data = await graph.getProperty("data");
       expect(data).toEqual(histogram);
 
       const colorStops = await graph.getProperty("colorStops");
-      expect(colorStops).toEqual(histogramColors);
+      expect(colorStops).toEqual(histogramStops);
     });
   });
 });

--- a/src/components/calcite-slider/calcite-slider.stories.ts
+++ b/src/components/calcite-slider/calcite-slider.stories.ts
@@ -71,6 +71,33 @@ export const Histogram = (): HTMLCalciteSliderElement => {
   return slider;
 };
 
+export const HistogramWithColors = (): HTMLCalciteSliderElement => {
+  const slider = document.createElement("calcite-slider");
+  slider.min = number("min", 0);
+  slider.minValue = number("min-value", 25);
+  slider.max = number("max", 100);
+  slider.maxValue = number("max-value", 75);
+  slider.histogram = array(
+    "histogram",
+    [
+      [0, 0],
+      [20, 12],
+      [40, 25],
+      [60, 55],
+      [80, 10],
+      [100, 0]
+    ],
+    "  "
+  );
+  const colors = array("histogram colors", ["red", "green", "blue"]);
+  const offsets = array(
+    "histogram color offsets",
+    colors.map((_, i) => `${(1 / (colors.length - 1)) * i}`)
+  );
+  slider.histogramColors = colors.map((color, i) => [parseFloat(offsets[i]), color]);
+  return slider;
+};
+
 export const DarkMode = (): string => html`
   <calcite-slider min="0" max="100" value="50" step="1" label="Temperature" class="calcite-theme-dark"></calcite-slider>
 `;

--- a/src/components/calcite-slider/calcite-slider.stories.ts
+++ b/src/components/calcite-slider/calcite-slider.stories.ts
@@ -94,7 +94,7 @@ export const HistogramWithColors = (): HTMLCalciteSliderElement => {
     "histogram color offsets",
     colors.map((_, i) => `${(1 / (colors.length - 1)) * i}`)
   );
-  slider.histogramColors = colors.map((color, i) => [parseFloat(offsets[i]), color]);
+  slider.histogramStops = colors.map((color, i) => ({ offset: parseFloat(offsets[i]), color }));
   return slider;
 };
 

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -53,10 +53,9 @@ export class CalciteSlider {
   }
 
   /**
-   * Array of values describing a single color stop ([offset, color, opacity]).
-   * These color stops should be sorted by offset value.
+   * Array of values describing a single color stop, sorted by offset ascending.
    */
-  @Prop() histogramColors: ColorStop[]
+  @Prop() histogramStops: ColorStop[]
 
   /** Label handles with their numeric value */
   @Prop({ reflect: true }) labelHandles?: boolean;
@@ -591,7 +590,7 @@ export class CalciteSlider {
       <div class="graph">
         <calcite-graph
           data={this.histogram}
-          colorStops={this.histogramColors}
+          colorStops={this.histogramStops}
           height={48}
           highlightMax={this.isRange ? this.maxValue : this.value}
           highlightMin={this.isRange ? this.minValue : this.min}

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -14,7 +14,7 @@ import {
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
 import { getKey } from "../../utils/key";
-import { DataSeries } from "../calcite-graph/interfaces";
+import { ColorStop, DataSeries } from "../calcite-graph/interfaces";
 import { hasLabel, intersects } from "../../utils/dom";
 import { clamp } from "../../utils/math";
 
@@ -51,6 +51,12 @@ export class CalciteSlider {
   @Watch("histogram") histogramWatcher(newHistogram: DataSeries): void {
     this.hasHistogram = !!newHistogram;
   }
+
+  /**
+   * Array of values describing a single color stop ([offset, color, opacity]).
+   * These color stops should be sorted by offset value.
+   */
+  @Prop() histogramColors: ColorStop[]
 
   /** Label handles with their numeric value */
   @Prop({ reflect: true }) labelHandles?: boolean;
@@ -585,6 +591,7 @@ export class CalciteSlider {
       <div class="graph">
         <calcite-graph
           data={this.histogram}
+          colorStops={this.histogramColors}
           height={48}
           highlightMax={this.isRange ? this.maxValue : this.value}
           highlightMin={this.isRange ? this.minValue : this.min}

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -589,8 +589,8 @@ export class CalciteSlider {
     return this.histogram ? (
       <div class="graph">
         <calcite-graph
-          data={this.histogram}
           colorStops={this.histogramStops}
+          data={this.histogram}
           height={48}
           highlightMax={this.isRange ? this.maxValue : this.value}
           highlightMin={this.isRange ? this.minValue : this.min}

--- a/src/demos/calcite-graph.html
+++ b/src/demos/calcite-graph.html
@@ -28,7 +28,17 @@
       <calcite-graph></calcite-graph>
     </p>
 
+    <h3>Highlight Range</h3>
+    <calcite-graph class="highlight-range"></calcite-graph>
+
+    <h3>Color Stops</h3>
+    <calcite-graph class="color-stops"></calcite-graph>
+
+    <h3>Highlight Range and Color Stops</h3>
+    <calcite-graph class="highlight-range color-stops"></calcite-graph>
+
     <script>
+      // Fill all graphs with the same data.
       var data = [
         [0, 0],
         [10, 80],
@@ -42,8 +52,21 @@
         [90, 10],
         [100, 0]
       ];
-      [].slice.call(document.querySelectorAll("calcite-graph")).forEach(function (graphElement) {
+      document.querySelectorAll("calcite-graph").forEach(function (graphElement) {
         graphElement.data = data;
+      });
+
+      // Add highlight ranges
+      document.querySelectorAll(".highlight-range").forEach(function (graphElement) {
+        graphElement.highlightMin = 25;
+        graphElement.highlightMax = 75;
+      });
+
+      // Add color stops
+      var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
+      var colorStops = rainbow.map((color, i) => [(1 / (rainbow.length - 1)) * i, color]);
+      document.querySelectorAll(".color-stops").forEach(function (graphElement) {
+        graphElement.colorStops = colorStops;
       });
     </script>
   </body>

--- a/src/demos/calcite-graph.html
+++ b/src/demos/calcite-graph.html
@@ -64,7 +64,7 @@
 
       // Add color stops
       var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
-      var colorStops = rainbow.map((color, i) => [(1 / (rainbow.length - 1)) * i, color]);
+      var colorStops = rainbow.map((color, i) => ({ offset: (1 / (rainbow.length - 1)) * i, color }));
       document.querySelectorAll(".color-stops").forEach(function (graphElement) {
         graphElement.colorStops = colorStops;
       });

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -2612,9 +2612,7 @@
       });
 
       var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
-      var colorStops = rainbow.map((color, i) => {
-        offset: (1 / (rainbow.length - 1)) * i, color;
-      });
+      var colorStops = rainbow.map((color, i) => ({ offset: (1 / (rainbow.length - 1)) * i, color }));
       document.querySelectorAll(".js-histogram-colors").forEach(function (graphElement) {
         graphElement.histogramColors = colorStops;
       });

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -2614,7 +2614,7 @@
       var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
       var colorStops = rainbow.map((color, i) => ({ offset: (1 / (rainbow.length - 1)) * i, color }));
       document.querySelectorAll(".js-histogram-colors").forEach(function (graphElement) {
-        graphElement.histogramColors = colorStops;
+        graphElement.histogramStops = colorStops;
       });
     </script>
   </body>

--- a/src/demos/calcite-slider.html
+++ b/src/demos/calcite-slider.html
@@ -211,6 +211,15 @@
               precise
             ></calcite-slider>
 
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
+            ></calcite-slider>
+
             <h3>Histogram Disabled</h3>
             <calcite-slider min="0" max="100" value="60" step="1" class="js-histogram" disabled></calcite-slider>
           </demo-spacer>
@@ -804,6 +813,15 @@
               label-handles
               label-ticks
               precise
+            ></calcite-slider>
+
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
             ></calcite-slider>
 
             <h3>Histogram Disabled</h3>
@@ -1426,6 +1444,16 @@
               precise
             ></calcite-slider>
 
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
+            ></calcite-slider>
+
             <h3>Histogram Disabled</h3>
             <calcite-slider
               mirrored
@@ -2172,6 +2200,16 @@
               precise
             ></calcite-slider>
 
+            <h3>Histogram with Color Stops</h3>
+            <calcite-slider
+              mirrored
+              min="0"
+              max="100"
+              value="60"
+              step="1"
+              class="js-histogram js-histogram-colors"
+            ></calcite-slider>
+
             <h3>Histogram Disabled</h3>
             <calcite-slider
               mirrored
@@ -2571,6 +2609,14 @@
       ];
       [].slice.call(document.querySelectorAll(".js-histogram")).forEach(function (graphElement) {
         graphElement.histogram = histogram;
+      });
+
+      var rainbow = ["red", "orange", "yellow", "green", "cyan", "blue", "violet"];
+      var colorStops = rainbow.map((color, i) => {
+        offset: (1 / (rainbow.length - 1)) * i, color;
+      });
+      document.querySelectorAll(".js-histogram-colors").forEach(function (graphElement) {
+        graphElement.histogramColors = colorStops;
       });
     </script>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -78,9 +78,6 @@
           <calcite-link href="/demos/fab">calcite-fab</calcite-link>
         </li>
         <li>
-          <calcite-link href="/demos/calcite-graph.html">calcite-graph</calcite-link>
-        </li>
-        <li>
           <calcite-link href="/demos/calcite-icon.html">calcite-icon</calcite-link>
         </li>
         <li>

--- a/src/index.html
+++ b/src/index.html
@@ -78,6 +78,9 @@
           <calcite-link href="/demos/fab">calcite-fab</calcite-link>
         </li>
         <li>
+          <calcite-link href="/demos/calcite-graph.html">calcite-graph</calcite-link>
+        </li>
+        <li>
           <calcite-link href="/demos/calcite-icon.html">calcite-icon</calcite-link>
         </li>
         <li>


### PR DESCRIPTION
**Related Issue:** #834

## Summary

Adds support for color stops for the `<calcite-graph>` component. A subsequent PR will add color stop support to the `<calcite-slider>` component.

```tsx
/**
 * Array of values describing a single color stop ([offset, color, opacity])
 * These color stops should be sorted by offset value
 */
@Prop() colorStops: [number, string, number][];
```
Color stops are added via a `<linearGradient>` element and apply along the x-axis.

![image](https://user-images.githubusercontent.com/8754/126005402-c945381e-97a6-4096-9b0c-4df909bc7680.png)

- [x] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

## Discussion question
This is pretty rudimentary support for adding a linear gradient with color stops. It solves the use case in the related issue, but are there other, more complex, use cases that we want to be prepared to support in the future?