### PR TITLE
test(tree): fix Jest warning

### DIFF
--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -187,7 +187,7 @@ describe("calcite-tree", () => {
       expect(selectEventSpy).toHaveReceivedEventTimes(3);
     });
 
-    describe("has selected items in the selection event payload", () =>
+    describe("has selected items in the selection event payload", () => {
       it("contains current selection when selection=multi + input-enabled", async () => {
         const page = await newE2EPage({
           html: html` <calcite-tree selection-mode="multi" input-enabled>
@@ -226,7 +226,8 @@ describe("calcite-tree", () => {
         await item1.click();
 
         expect(await getSelectedIds()).toEqual([]);
-      }));
+      });
+    });
 
     it("emits once when the tree item checkbox label is clicked", async () => {
       const page = await newE2EPage({


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes test warning reported in https://github.com/Esri/calcite-components/commit/44af3096adb6bbf5424c7aae83df054513c79016#r53757509.