### PR TITLE
docs(action-block): slot icon position is wrong

### DIFF
--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -6,7 +6,7 @@ import { CalciteHeading, HeadingLevel } from "../functional/CalciteHeading";
 import { Status } from "../interfaces";
 
 /**
- * @slot icon - A slot for adding a trailing header icon.
+ * @slot icon - A slot for adding a leading header icon.
  * @slot control - A slot for adding a single HTML input element in a header.
  * @slot header-menu-actions - a slot for adding an overflow menu with actions inside a dropdown.
  * @slot - A slot for adding content to the block.

--- a/src/components/calcite-block/readme.md
+++ b/src/components/calcite-block/readme.md
@@ -85,7 +85,7 @@ Renders a header with a clickable icon to toggle the block open and closed.
 |                         | A slot for adding content to the block.                            |
 | `"control"`             | A slot for adding a single HTML input element in a header.         |
 | `"header-menu-actions"` | a slot for adding an overflow menu with actions inside a dropdown. |
-| `"icon"`                | A slot for adding a trailing header icon.                          |
+| `"icon"`                | A slot for adding a leading header icon.                           |
 
 ## Dependencies
 


### PR DESCRIPTION
**Related Issue:** #2531

## Summary

Updated doc to leading, not trailing. This was likely caused by a typo.