### PR TITLE
fix(calcite-list-item): adds bit of spacing between label and description

### DIFF
--- a/src/components/calcite-list-item/calcite-list-item.scss
+++ b/src/components/calcite-list-item/calcite-list-item.scss
@@ -60,7 +60,7 @@
 }
 
 .description {
-  @apply text-color-3;
+  @apply text-color-3 mt-0.5;
 }
 
 .content-start,


### PR DESCRIPTION
**Related Issue:** #2587

## Summary
Pre design spec, adds 2px spacing between label and description.

cc @bstifle 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
