### PR TITLE
chore(deps): fix git user setup for dep-updater

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - uses: fregante/setup-git-user@v1
 
       - name: run dependency-updating script
-        uses: fregante/setup-git-user@v1
         run:  |
           npm install
           npm run deps:update


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes `update-deps` error reported in some GH Action workflow runs (e.g., https://github.com/Esri/calcite-components/actions/runs/1057612143):

> Error : .github#L1
> a step cannot have both the `uses` and `run` keys

Thanks for reporting this, @caripizza!