### PR TITLE
docs(notice): fix typo in usage example

### DIFF
--- a/src/components/calcite-notice/usage/basic.md
+++ b/src/components/calcite-notice/usage/basic.md
@@ -2,6 +2,7 @@
 <calcite-notice scale="l" width="half" active>
   <div slot="title">Something failed</div>
   <div slot="message">That thing you wanted to do didn't work as expected</div>
-  <calcite-action id="retry-action" slot="icon-end" title="Retry" icon="reset"></calcite-action>
+  <calcite-link slot="link" href="/">View details</calcite-link>
+  <calcite-action id="retry-action" slot="actions-end" title="Retry" icon="reset"></calcite-action>
 </calcite-notice>
 ```


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Fixes a slot typo I made and adds a calcite-link to demonstrate using the `link` slot.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
