### PR TITLE
refactor(inline-editable): tailwindify/match figma

### DIFF
--- a/src/components/calcite-inline-editable/calcite-inline-editable.scss
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.scss
@@ -19,7 +19,7 @@
 :host(:not([editing-enabled])) {
   .calcite-inline-editable__wrapper {
     &:hover {
-      @apply bg-foreground-2;
+      @apply bg-foreground-3;
     }
   }
 }
@@ -96,7 +96,7 @@
     &::slotted(*) {
       textarea,
       input {
-        @apply bg-foreground-2;
+        @apply bg-foreground-3;
       }
     }
   }

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -116,7 +116,7 @@ export class CalciteInlineEditable {
               label={this.intlEnableEditing}
               onClick={this.enableEditingHandler}
               ref={(el) => (this.enableEditingButton = el)}
-              scale={this.scale}
+              scale="s"
             />
           )}
           {this.shouldShowControls && [

--- a/src/demos/calcite-inline-editable.html
+++ b/src/demos/calcite-inline-editable.html
@@ -51,7 +51,7 @@
         <calcite-label scale="l">
           L
           <calcite-inline-editable>
-            <calcite-input placeholder="Day of the week" />
+            <calcite-input value="Wednesday" placeholder="Day of the week" />
           </calcite-inline-editable>
         </calcite-label>
       </calcite-accordion-item>


### PR DESCRIPTION
**Related Issue:** #2468 #2041

## Summary

- s, m, l size adjustments 24, 32, 44 (this was actually handled by Ben with the input :) thx @bpatterson88 
- The text color when there's a value is ui-text-1 which matches Figma, placeholder text is browser default for placheolder (I believe)
- inline with controls: These are calcite-buttons, which means that they use the s, m, and l assigned icons. Figma has 16px icon for all sizes. This means L uses the 24px icons for `x` and check (due to L calcite-button).
- `x` idle/hover states: I tried using calcite-action, however, the scale is off because calcite-action has S 32px, M 48px, L 64px, which is different than input S 24px, M 32px, L 44px. other option would be to not use calcite-button and just use button, but we should use the CC as much as possible throughout components

Looking for some guidance on these items
@bstifle @caripizza @macandcheese 