### PR TITLE
refactor(calcite-input-message): remove floating messages

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -14,7 +14,6 @@
   --calcite-alert-dismiss-progress-background: #{rgba($blk-000, 0.8)};
   --calcite-button-transparent-hover: #{rgba($blk-240, 0.05)};
   --calcite-button-transparent-press: #{rgba($blk-240, 0.08)};
-  --calcite-input-message-floating-background: #{rgba($blk-000, 0.96)};
   --calcite-link-blue-underline: #{rgba($h-bb-070, 0.4)};
   --calcite-scrim-background: #{rgba($blk-000, 0.75)};
 }
@@ -29,7 +28,6 @@
   --calcite-alert-dismiss-progress-background: #{rgba($blk-200, 0.8)};
   --calcite-button-transparent-hover: #{rgba($blk-000, 0.05)};
   --calcite-button-transparent-press: #{rgba($blk-000, 0.08)};
-  --calcite-input-message-floating-background: #{rgba($blk-200, 0.96)};
   --calcite-link-blue-underline: #{rgba($d-bb-420, 0.4)};
   --calcite-scrim-background: #{rgba($blk-240, 0.75)};
 }

--- a/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.stories.ts
@@ -37,7 +37,6 @@ export const WithLabel = (): string => html`
       <calcite-input-message
         ${boolean("active", false, "InputMessage") && "active"}
         ${boolean("icon", false, "InputMessage") && "icon"}
-        type="${select("type", ["default", "floating"], "default", "InputMessage")}"
         status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}"
       >
         ${text("text", "My great input message", "InputMessage")}
@@ -119,7 +118,6 @@ export const DarkMode = (): string => html`
       <calcite-input-message
         ${boolean("active", false, "InputMessage") && "active"}
         ${boolean("icon", false, "InputMessage") && "icon"}
-        type="${select("type", ["default", "floating"], "default", "InputMessage")}"
         status="${select("status", ["idle", "valid", "invalid"], "idle", "InputMessage")}"
       >
         ${text("text", "My great input message", "InputMessage")}

--- a/src/components/calcite-input-message/calcite-input-message.e2e.ts
+++ b/src/components/calcite-input-message/calcite-input-message.e2e.ts
@@ -16,18 +16,16 @@ describe("calcite-input-message", () => {
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "idle");
-    expect(element).toEqualAttribute("type", "default");
   });
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input-message status="valid" type="floating">Text</calcite-input-message>
+    <calcite-input-message status="valid">Text</calcite-input-message>
     `);
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "valid");
-    expect(element).toEqualAttribute("type", "floating");
   });
 
   it("inherits requested props when from wrapping calcite-label when props are provided", async () => {

--- a/src/components/calcite-input-message/calcite-input-message.scss
+++ b/src/components/calcite-input-message/calcite-input-message.scss
@@ -3,8 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-input-message-spacing-value: when type is default, the top margin above the input-message.
- *   When type is floating, the amount of padding around the input-message.
+ * @prop --calcite-input-message-spacing-value: the top margin above the input-message.
  */
 
 :host([scale="s"]) {
@@ -44,27 +43,6 @@
   margin-top: var(--calcite-input-message-spacing-value);
 }
 
-:host([type="floating"]) {
-  transform: translate3d(0, -$baseline, 0);
-  background-color: var(--calcite-input-message-floating-background);
-  position: absolute;
-  width: 100%;
-  top: 100%;
-  left: 0;
-  right: 0;
-  height: auto;
-  // accommodate for spacing of label
-  margin-top: -1.5rem;
-  border-radius: theme("borderRadius.sm");
-  box-shadow: theme("boxShadow.2");
-  padding: var(--calcite-input-message-spacing-value);
-  z-index: 101;
-}
-
-:host([type="floating"][active]) {
-  transform: translate3d(0, 0, 0);
-}
-
 .calcite-input-message-icon {
   display: inline-flex;
   flex-shrink: 0;
@@ -93,28 +71,5 @@ $inputStatusColors: "invalid" var(--calcite-ui-danger) var(--calcite-ui-danger)
     & .calcite-input-message-icon {
       color: $color;
     }
-  }
-}
-
-:host([type="floating"][active]) {
-  animation: floatingMessagePulse 0.5s ease-in-out;
-  animation-iteration-count: 1;
-}
-
-@keyframes floatingMessagePulse {
-  0% {
-    top: 100%;
-  }
-  25% {
-    top: 110%;
-  }
-  50% {
-    top: 100%;
-  }
-  75% {
-    top: 105%;
-  }
-  100% {
-    top: 100%;
   }
 }

--- a/src/components/calcite-input-message/calcite-input-message.tsx
+++ b/src/components/calcite-input-message/calcite-input-message.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Host, h, Prop, VNode, Watch } from "@stencil/core";
 import { getElementDir, getElementProp, setRequestedIcon } from "../../utils/dom";
 import { Scale, Status } from "../interfaces";
-import { InputMessageType, StatusIconDefaults } from "./interfaces";
+import { StatusIconDefaults } from "./interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 
 @Component({
@@ -36,8 +36,10 @@ export class CalciteInputMessage {
   /** specify the status of the input field, determines message and icons */
   @Prop({ reflect: true, mutable: true }) status: Status = "idle";
 
-  /** specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input) */
-  @Prop({ reflect: true }) type: InputMessageType = "default";
+   /** specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input)
+   * @deprecated "floating" type is no longer supported
+   */
+  @Prop({ reflect: true }) type: "default";
 
   @Watch("status")
   @Watch("icon")

--- a/src/components/calcite-input-message/interfaces.ts
+++ b/src/components/calcite-input-message/interfaces.ts
@@ -1,5 +1,3 @@
-export type InputMessageType = "default" | "floating";
-
 export enum StatusIconDefaults {
   valid = "check-circle",
   invalid = "exclamation-mark-triangle",

--- a/src/components/calcite-input/calcite-input.stories.ts
+++ b/src/components/calcite-input/calcite-input.stories.ts
@@ -41,7 +41,6 @@ export const WithLabel = (): string => html`
       </calcite-input>
       <calcite-input-message
         ${boolean("input-message-active", false)}
-        type="${select("input message type", ["default", "floating"], "default")}"
         status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
         >${text("input message text", "My great input message")}</calcite-input-message
       >
@@ -84,7 +83,6 @@ export const WithLabelAndInputMessage = (): string => html`
         ${boolean("active", true)}
         ${boolean("icon", false)}
         icon="${select("icon", iconNames, "", "Input Message")}"
-        type="${select("type", ["default", "floating"], "default", "Input Message")}"
         >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
       >
     </calcite-label>
@@ -154,7 +152,6 @@ export const WithSlottedAction = (): string => html`
       </calcite-input>
       <calcite-input-message
         ${boolean("input-message-active", false)}
-        type="${select("input message type", ["default", "floating"], "default")}"
         status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
         >${text("input message text", "My great input message")}</calcite-input-message
       >
@@ -177,7 +174,6 @@ export const Textarea = (): string => html`
       </calcite-input>
       <calcite-input-message
         ${boolean("input-message-active", false)}
-        type="${select("input message type", ["default", "floating"], "default")}"
         status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
         >${text("input message text", "My great input message")}</calcite-input-message
       >
@@ -212,7 +208,6 @@ export const SimpleDarkMode = (): string => html`
       </calcite-input>
       <calcite-input-message
         ${boolean("calcite-input-message-active", false)}
-        type="${select("input message type", ["default", "floating"], "default")}"
         status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
         >${text("input message text", "My great input message")}</calcite-input-message
       >
@@ -260,7 +255,6 @@ export const WithLabelAndInputMessageRTL = (): string => html`
         ${boolean("active", true)}
         ${boolean("icon", false)}
         icon="${select("icon", iconNames, "", "Input Message")}"
-        type="${select("type", ["default", "floating"], "default", "Input Message")}"
         >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
       >
     </calcite-label>

--- a/src/demos/_assets/validateInput.ts
+++ b/src/demos/_assets/validateInput.ts
@@ -49,7 +49,6 @@ function validatePasswordExampleFocusMessage(event): void {
     const message = document.createElement("calcite-input-message");
     message.active = true;
     message.id = "pw-status-1";
-    message.type = "floating";
     message.innerHTML = `This should be at least 6 characters long`;
     targetInput.appendChild(message);
   } else {


### PR DESCRIPTION
**Related Issue:** #2172 

## Summary

Prunes the floating input-message variant. 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
