### PR TITLE
feat(color-picker)!: introduce input event and modify change event to no longer fire as hue slider/color field thumbs are dragged

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -9,6 +9,23 @@ import { selectText } from "../../tests/utils";
 describe("calcite-color-picker", () => {
   let consoleSpy: SpyInstance;
 
+  async function getElementXY(
+    page: E2EPage,
+    elementSelector: string,
+    shadowSelector?: string
+  ): Promise<[number, number]> {
+    return page.evaluate(
+      ([elementSelector, shadowSelector]): [number, number] => {
+        const element = document.querySelector(elementSelector);
+        const measureTarget = shadowSelector ? element.shadowRoot.querySelector(shadowSelector) : element;
+        const { x, y } = measureTarget.getBoundingClientRect();
+
+        return [x, y];
+      },
+      [elementSelector, shadowSelector]
+    );
+  }
+
   beforeEach(
     () =>
       (consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {
@@ -146,18 +163,85 @@ describe("calcite-color-picker", () => {
       }
     ]));
 
-  it("emits color selection change", async () => {
+  it("emits event when value changes", async () => {
     const page = await newE2EPage({
       html: "<calcite-color-picker></calcite-color-picker>"
     });
     const picker = await page.find("calcite-color-picker");
+    const changeSpy = await picker.spyOnEvent("calciteColorPickerChange");
+    const inputSpy = await picker.spyOnEvent("calciteColorPickerInput");
 
-    const spy = await picker.spyOnEvent("calciteColorPickerChange");
-
-    picker.setProperty("value", "#FF00FF");
+    picker.setProperty("value", "#f0f");
     await page.waitForChanges();
 
-    expect(spy).toHaveReceivedEventTimes(1);
+    expect(changeSpy).toHaveReceivedEventTimes(1);
+    expect(inputSpy).toHaveReceivedEventTimes(1);
+
+    // save for future test/assertion
+    await (await page.find(`calcite-color-picker >>> .${CSS.saveColor}`)).click();
+
+    // change by clicking on field
+    await (await page.find(`calcite-color-picker >>> .${CSS.colorFieldAndSlider}`)).click();
+    expect(changeSpy).toHaveReceivedEventTimes(2);
+    expect(inputSpy).toHaveReceivedEventTimes(2);
+
+    // change by clicking on hue
+    await (await page.find(`calcite-color-picker >>> .${CSS.hueScope}`)).click();
+    expect(changeSpy).toHaveReceivedEventTimes(3);
+    expect(inputSpy).toHaveReceivedEventTimes(3);
+
+    // change by changing hex value
+    const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
+    await selectText(hexInput);
+    await hexInput.type("fff");
+    await hexInput.press("Enter");
+    expect(changeSpy).toHaveReceivedEventTimes(4);
+    expect(inputSpy).toHaveReceivedEventTimes(4);
+
+    // change by changing color channels (we only test R and assume the same holds for G/B & H/S/V channels)
+    const channelInput = await page.find(`calcite-color-picker >>> .${CSS.channel}`);
+    await selectText(channelInput);
+    await channelInput.type("254");
+    await channelInput.press("Enter");
+    expect(changeSpy).toHaveReceivedEventTimes(5);
+    expect(inputSpy).toHaveReceivedEventTimes(5);
+
+    // change by dragging color field thumb
+    const thumbRadius = DIMENSIONS.m.thumb.radius;
+    const mouseDragSteps = 10;
+    const [colorFieldScopeX, colorFieldScopeY] = await getElementXY(
+      page,
+      "calcite-color-picker",
+      `.${CSS.colorFieldScope}`
+    );
+
+    await page.mouse.move(colorFieldScopeX + thumbRadius, colorFieldScopeY + thumbRadius);
+    await page.mouse.down();
+    await page.mouse.move(colorFieldScopeX + thumbRadius + 10, colorFieldScopeY + thumbRadius, {
+      steps: mouseDragSteps
+    });
+    await page.mouse.up();
+    await page.waitForChanges();
+
+    expect(changeSpy).toHaveReceivedEventTimes(6);
+    expect(inputSpy).toHaveReceivedEventTimes(9);
+
+    // change by dragging hue slider thumb
+    const [hueScopeX, hueScopeY] = await getElementXY(page, "calcite-color-picker", `.${CSS.hueScope}`);
+
+    await page.mouse.move(hueScopeX + thumbRadius, hueScopeY + thumbRadius);
+    await page.mouse.down();
+    await page.mouse.move(hueScopeX + thumbRadius + 10, hueScopeY + thumbRadius, { steps: mouseDragSteps });
+    await page.mouse.up();
+    await page.waitForChanges();
+
+    expect(changeSpy).toHaveReceivedEventTimes(7);
+    expect(inputSpy).toHaveReceivedEventTimes(14);
+
+    // change by clicking stored color
+    await (await page.find(`calcite-color-picker >>> .${CSS.savedColor}`)).click();
+    expect(changeSpy).toHaveReceivedEventTimes(8);
+    expect(inputSpy).toHaveReceivedEventTimes(15);
   });
 
   const supportedFormatToSampleValue = {
@@ -297,13 +381,7 @@ describe("calcite-color-picker", () => {
     let changes = 0;
     const mediumScaleDimensions = DIMENSIONS.m;
     const widthOffset = 0.5;
-    const [fieldAndSliderX, fieldAndSliderY] = await page.evaluate(() => {
-      const color = document.querySelector("calcite-color-picker");
-      const fieldAndSliderArea = color.shadowRoot.querySelector("canvas");
-      const { x, y } = fieldAndSliderArea.getBoundingClientRect();
-
-      return [x, y];
-    });
+    const [fieldAndSliderX, fieldAndSliderY] = await getElementXY(page, "calcite-color-picker", "canvas");
 
     // clicking color field colors to pick a color
     await page.mouse.click(fieldAndSliderX, fieldAndSliderY);
@@ -385,7 +463,7 @@ describe("calcite-color-picker", () => {
     });
 
     expect(internalColorChanged).toBe(true);
-    expect(spy).toHaveReceivedEventTimes(changes);
+    expect(spy).toHaveReceivedEventTimes(++changes);
   });
 
   it("keeps tracking mouse movement when a thumb is actively dragged", async () => {

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -338,7 +338,9 @@ export class CalciteColorPicker {
   @Event() calciteColorPickerChange: EventEmitter;
 
   /**
-   * Fires when the color value input changes.
+   * Fires as the color value changes.
+   *
+   * This is similar to the change event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
    */
   @Event() calciteColorPickerInput: EventEmitter;
 

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -251,8 +251,13 @@ export class CalciteColorPicker {
       this.mode = nextMode;
     }
 
+    const dragging = this.sliderThumbState === "drag" || this.hueThumbState === "drag";
+
     if (this.colorUpdateLocked) {
-      this.calciteColorPickerChange.emit();
+      this.calciteColorPickerInput.emit();
+      if (!dragging) {
+        this.calciteColorPickerChange.emit();
+      }
       return;
     }
 
@@ -261,7 +266,10 @@ export class CalciteColorPicker {
 
     if (modeChanged || colorChanged) {
       this.color = color;
-      this.calciteColorPickerChange.emit();
+      this.calciteColorPickerInput.emit();
+      if (!dragging) {
+        this.calciteColorPickerChange.emit();
+      }
     }
   }
   //--------------------------------------------------------------------------
@@ -328,6 +336,11 @@ export class CalciteColorPicker {
    * Fires when the color value has changed.
    */
   @Event() calciteColorPickerChange: EventEmitter;
+
+  /**
+   * Fires when the color value input changes.
+   */
+  @Event() calciteColorPickerInput: EventEmitter;
 
   private handleTabActivate = (event: Event): void => {
     this.channelMode = (event.currentTarget as HTMLElement).getAttribute(
@@ -517,9 +530,15 @@ export class CalciteColorPicker {
   };
 
   private globalMouseUpHandler = (): void => {
+    const previouslyDragging = this.sliderThumbState === "drag" || this.hueThumbState === "drag";
+
     this.hueThumbState = "idle";
     this.sliderThumbState = "idle";
     this.drawColorFieldAndSlider();
+
+    if (previouslyDragging) {
+      this.calciteColorPickerChange.emit();
+    }
   };
 
   private globalMouseMoveHandler = (event: MouseEvent): void => {


### PR DESCRIPTION
**Related Issue:** #2303

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This introduces an input event that fires as the color field or hue slider thumb is dragged. The "minor" breaking change is that the change event will no longer fire when dragging and only when the thumb is released and final value is committed.