### PR TITLE
test: enhance drag-and-drop util and add mouse cursor tracking util

### DIFF
--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -5,7 +5,9 @@ import dedent from "dedent";
 type DragAndDropSelector = string | SelectorOptions;
 
 type PointerPosition = {
-  vertical: "bottom" | "center" | "top";
+  vertical?: "bottom" | "center" | "top";
+  horizontal?: "left" | "center" | "right";
+  offset?: [number, number];
 };
 
 interface SelectorOptions extends JSONObject {
@@ -39,13 +41,19 @@ export async function dragAndDrop(
   }
 
   async function createEventInitializer(selector: DragAndDropSelector): Promise<MouseInitEvent> {
-    const { vertical: verticalPos }: PointerPosition =
-      typeof selector === "string" || !selector.pointerPosition ? { vertical: "center" } : selector.pointerPosition;
+    const {
+      vertical: verticalPos,
+      horizontal: horizontalPos,
+      offset = [0, 0]
+    }: PointerPosition = typeof selector === "string" || !selector.pointerPosition
+      ? { vertical: "center" }
+      : selector.pointerPosition;
     const { height, width, x, y } = await getBounds(selector);
     const verticalOffset = verticalPos === "top" ? 0 : verticalPos === "bottom" ? height : height / 2;
+    const horizontalOffset = horizontalPos === "left" ? 0 : horizontalPos === "right" ? width : width / 2;
 
-    const eventX = x + width / 2;
-    const eventY = y + verticalOffset;
+    const eventX = x + horizontalOffset + offset[0];
+    const eventY = y + verticalOffset + offset[1];
 
     return {
       bubbles: true,
@@ -200,4 +208,91 @@ export function placeholderImage({
   }
 
   return cleaned;
+}
+
+/**
+ * This util helps visualize mouse movement when running tests in headful mode.
+ *
+ * Note that this util should only be used for test debugging purposes and not be included in a test.
+ *
+ * Based on https://github.com/puppeteer/puppeteer/issues/4378#issuecomment-499726973
+ */
+export async function visualizeMouseCursor(page: E2EPage): Promise<void> {
+  await page.evaluate(() => {
+    const box = document.createElement("puppeteer-mouse-pointer");
+    const styleElement = document.createElement("style");
+    styleElement.innerHTML = `
+        puppeteer-mouse-pointer {
+          pointer-events: none;
+          position: absolute;
+          top: 0;
+          z-index: 10000;
+          left: 0;
+          width: 20px;
+          height: 20px;
+          background: rgba(0,0,0,.4);
+          border: 1px solid white;
+          border-radius: 10px;
+          margin: -10px 0 0 -10px;
+          padding: 0;
+          transition: background .2s, border-radius .2s, border-color .2s;
+        }
+        puppeteer-mouse-pointer.button-1 {
+          transition: none;
+          background: rgba(0,0,0,0.9);
+        }
+        puppeteer-mouse-pointer.button-2 {
+          transition: none;
+          border-color: rgba(0,0,255,0.9);
+        }
+        puppeteer-mouse-pointer.button-3 {
+          transition: none;
+          border-radius: 4px;
+        }
+        puppeteer-mouse-pointer.button-4 {
+          transition: none;
+          border-color: rgba(255,0,0,0.9);
+        }
+        puppeteer-mouse-pointer.button-5 {
+          transition: none;
+          border-color: rgba(0,255,0,0.9);
+        }
+      `;
+    document.head.appendChild(styleElement);
+    document.body.appendChild(box);
+
+    document.addEventListener(
+      "mousemove",
+      (event) => {
+        box.style.left = event.pageX + "px";
+        box.style.top = event.pageY + "px";
+        updateButtons(event.buttons);
+      },
+      true
+    );
+
+    document.addEventListener(
+      "mousedown",
+      (event) => {
+        updateButtons(event.buttons);
+        box.classList.add("button-" + event.which);
+      },
+      true
+    );
+
+    document.addEventListener(
+      "mouseup",
+      (event) => {
+        updateButtons(event.buttons);
+        box.classList.remove("button-" + event.which);
+      },
+      true
+    );
+
+    function updateButtons(buttons: number): void {
+      for (let i = 0; i < 5; i++) {
+        box.classList.toggle("button-" + i, (buttons & (1 << i)) as unknown as boolean);
+      }
+    }
+  });
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

These test util improvements came from #2303: 

* `dragAndDrop` – this can now be configured to place the pointer position horizontally and even specify an x,y offset.
* `visualizeMouseCursor` – this helps debug headful E2E tests by showing where the mouse cursor is during the test
  **note**: this should only be used for debugging and not be included in a test (custom ESLint rule candidate)