### PR TITLE
chore: automate browserslist db update

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -1,0 +1,18 @@
+name: "Update component doc"
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+jobs:
+  update-component-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: fregante/setup-git-user@v1
+
+      - name: Update caniuse database and create PR if applicable
+        uses: c2corg/browserslist-update-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-browserslist-db


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Adds GH action to automate browserslist's database and submit a PR every week.