### PR TITLE
fix(color-picker): improve mouse tracking when dragging color field/hue slider thumb

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -274,17 +274,13 @@ export class CalciteColorPicker {
     return this.color || this.previousColor || DEFAULT_COLOR;
   }
 
-  private activeThumbX: number;
-
-  private activeThumbY: number;
+  private activeColorFieldAndSliderRect: DOMRect;
 
   private colorUpdateLocked = false;
 
+  private colorFieldAndSliderHovered = false;
+
   private fieldAndSliderRenderingContext: CanvasRenderingContext2D;
-
-  private globalThumbX: number;
-
-  private globalThumbY: number;
 
   private colorFieldScopeNode: HTMLDivElement;
 
@@ -485,6 +481,7 @@ export class CalciteColorPicker {
 
   private handleColorFieldAndSliderMouseLeave = (): void => {
     this.colorFieldAndSliderInteractive = false;
+    this.colorFieldAndSliderHovered = false;
 
     if (this.sliderThumbState !== "drag" && this.hueThumbState !== "drag") {
       this.hueThumbState = "idle";
@@ -495,10 +492,6 @@ export class CalciteColorPicker {
 
   private handleColorFieldAndSliderMouseDown = (event: MouseEvent): void => {
     const { offsetX, offsetY } = event;
-    this.activeThumbX = offsetX;
-    this.activeThumbY = offsetY;
-    this.globalThumbX = offsetX;
-    this.globalThumbY = offsetY;
     const region = this.getCanvasRegion(offsetY);
 
     if (region === "color-field") {
@@ -514,11 +507,15 @@ export class CalciteColorPicker {
 
     document.addEventListener("mousemove", this.globalMouseMoveHandler);
     document.addEventListener("mouseup", this.globalMouseUpHandler, { once: true });
+
+    this.activeColorFieldAndSliderRect =
+      this.fieldAndSliderRenderingContext.canvas.getBoundingClientRect();
   };
 
   private globalMouseUpHandler = (): void => {
     this.hueThumbState = "idle";
     this.sliderThumbState = "idle";
+    this.activeColorFieldAndSliderRect = null;
     this.drawColorFieldAndSlider();
   };
 
@@ -531,26 +528,46 @@ export class CalciteColorPicker {
       return;
     }
 
-    this.globalThumbX = this.globalThumbX + event.movementX;
-    this.globalThumbY = this.globalThumbY + event.movementY;
+    let samplingX: number;
+    let samplingY: number;
 
-    this.activeThumbX = clamp(this.globalThumbX, 0, dimensions.colorField.width);
-    this.activeThumbY = clamp(
-      this.globalThumbY,
-      0,
-      dimensions.colorField.height + dimensions.slider.height
-    );
+    if (this.colorFieldAndSliderHovered) {
+      samplingX = event.offsetX;
+      samplingY = event.offsetY;
+    } else {
+      const { clientX, clientY } = event;
+      const colorFieldAndSliderRect = this.activeColorFieldAndSliderRect;
+      const colorFieldWidth = dimensions.colorField.width;
+      const colorFieldHeight = dimensions.colorField.height;
+      const hueSliderHeight = dimensions.slider.height;
 
-    const region: ReturnType<CalciteColorPicker["getCanvasRegion"]> = hueThumbDragging
-      ? "color-field"
-      : sliderThumbDragging
-      ? "slider"
-      : this.getCanvasRegion(this.activeThumbY);
+      if (
+        clientX < colorFieldAndSliderRect.x + colorFieldWidth &&
+        clientX > colorFieldAndSliderRect.x
+      ) {
+        samplingX = clientX - colorFieldAndSliderRect.x;
+      } else if (clientX < colorFieldAndSliderRect.x) {
+        samplingX = 0;
+      } else {
+        samplingX = colorFieldWidth;
+      }
 
-    if (region === "color-field") {
-      this.captureColorFieldColor(this.activeThumbX, this.activeThumbY, false);
-    } else if (region === "slider") {
-      this.captureHueSliderColor(this.activeThumbX);
+      if (
+        clientY < colorFieldAndSliderRect.y + colorFieldHeight + hueSliderHeight &&
+        clientY > colorFieldAndSliderRect.y
+      ) {
+        samplingY = clientY - colorFieldAndSliderRect.y;
+      } else if (clientY < colorFieldAndSliderRect.y) {
+        samplingY = 0;
+      } else {
+        samplingY = colorFieldHeight + hueSliderHeight;
+      }
+    }
+
+    if (hueThumbDragging) {
+      this.captureColorFieldColor(samplingX, samplingY, false);
+    } else {
+      this.captureHueSliderColor(samplingX);
     }
   };
 
@@ -560,6 +577,7 @@ export class CalciteColorPicker {
     } = this;
 
     this.colorFieldAndSliderInteractive = offsetY <= colorField.height + slider.height;
+    this.colorFieldAndSliderHovered = true;
 
     const region = this.getCanvasRegion(offsetY);
 


### PR DESCRIPTION
**Related Issue:** #2335 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This revisits mouse tracking when the color field/hue slider thumb is dragged. The previous implementation could get out of sync in some cases (e.g, `MouseEvent#movement(X|Y)` would emit non-zero values when the cursor would move past the edge, Chrome and Firefox emit 0). This approach is simpler and slightly more efficient since it won't have to calculate the canvas region when the mouse is dragged outside of its bounds.