### PR TITLE
fix(input): Internal buttons should not be able to submit forms

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -30,7 +30,12 @@ import {
 } from "../../utils/locale";
 import { numberKeys } from "../../utils/key";
 import { hiddenInputStyle } from "../../utils/form";
-import { isValidDecimal, isValidNumber, parseNumberString, sanitizeNumberString } from "../../utils/number";
+import {
+  isValidDecimal,
+  isValidNumber,
+  parseNumberString,
+  sanitizeNumberString
+} from "../../utils/number";
 import { CSS_UTILITY, TEXT } from "../../utils/resources";
 
 type NumberNudgeDirection = "up" | "down";
@@ -462,7 +467,10 @@ export class CalciteInput {
       return;
     }
     const decimalSeparator = getDecimalSeparator(this.locale);
-    if (event.key === decimalSeparator && isValidDecimal(this.step === "any" ? 1 : this.step as number)) {
+    if (
+      event.key === decimalSeparator &&
+      isValidDecimal(this.step === "any" ? 1 : (this.step as number))
+    ) {
       if (!this.value && !this.childNumberEl.value) {
         return;
       }
@@ -586,6 +594,7 @@ export class CalciteInput {
         disabled={this.disabled}
         onClick={this.clearInputValue}
         tabIndex={this.disabled ? -1 : 0}
+        type="button"
       >
         <calcite-icon icon="x" scale="s" />
       </button>
@@ -612,6 +621,7 @@ export class CalciteInput {
         disabled={this.disabled}
         onClick={this.numberButtonClickHandler}
         tabIndex={-1}
+        type="button"
       >
         <calcite-icon icon="chevron-up" scale="s" />
       </button>
@@ -627,6 +637,7 @@ export class CalciteInput {
         disabled={this.disabled}
         onClick={this.numberButtonClickHandler}
         tabIndex={-1}
+        type="button"
       >
         <calcite-icon icon="chevron-down" scale="s" />
       </button>


### PR DESCRIPTION
**Related Issue:** #2675

## Summary

fix(input): Internal buttons should not be able to submit forms. #2675

This sets all internal buttons to be a type of "button" so that they do not submit the form when an enter key is pressed on the search input element.