### PR TITLE
refactor(Switch): match Figma and utilize Tailwind

### DIFF
--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -92,7 +92,7 @@
 
 :host([switched]) {
   .track {
-    @apply bg-brand border-color-brand;
+    @apply bg-brand border-color-brand-hover;
   }
   .handle {
     @apply left-auto border-color-brand;
@@ -102,7 +102,7 @@
 
 :host([switched]:hover) {
   .track {
-    @apply bg-brand border-color-brand;
+    @apply bg-brand border-color-brand-hover;
   }
   .handle {
     @apply border-color-brand-hover;

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -84,9 +84,8 @@
 :host(:hover),
 :host(:focus) {
   .handle {
-    @apply border-color-brand-hover;
-    box-shadow: inset 0 0 0 1px var(--calcite-ui-brand-hover);
-    @apply right-auto;
+    @apply border-color-brand;
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-brand);
   }
 }
 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -84,7 +84,8 @@
 :host(:hover),
 :host(:focus) {
   .handle {
-    @apply border-color-brand shadow-outline-active;
+    @apply border-color-brand-hover;
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-brand-hover);
     @apply right-auto;
   }
 }
@@ -104,7 +105,8 @@
     @apply bg-brand border-color-brand;
   }
   .handle {
-    @apply border-color-brand shadow-outline-active;
+    @apply border-color-brand-hover;
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-brand-hover);
   }
 }
 

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -1,5 +1,8 @@
 // sizes
 :host([scale="s"]) {
+  .container {
+    @apply h-3;
+  }
   .track {
     @apply w-6 h-3;
   }
@@ -9,6 +12,9 @@
 }
 
 :host([scale="m"]) {
+  .container {
+    @apply h-4;
+  }
   .track {
     @apply w-8 h-4;
   }
@@ -18,6 +24,9 @@
 }
 
 :host([scale="l"]) {
+  .container {
+    @apply h-6;
+  }
   .track {
     @apply w-12 h-6;
   }


### PR DESCRIPTION
**Related Issue:** #2461 

## Summary
Updates calcite-switch hover state on idle and active to grow inward as shown in Figma design.

- Changed `box-shadow` to use inset rather than the previous `shadow-outline-active` 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
