### PR TITLE
test(color-picker): stabilize and unskip test

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -170,8 +170,9 @@ describe("calcite-color-picker", () => {
     const picker = await page.find("calcite-color-picker");
     const changeSpy = await picker.spyOnEvent("calciteColorPickerChange");
     const inputSpy = await picker.spyOnEvent("calciteColorPickerInput");
+    const colorFieldCenterValueHex = "#408048";
 
-    picker.setProperty("value", "#f0f");
+    picker.setProperty("value", colorFieldCenterValueHex);
     await page.waitForChanges();
 
     expect(changeSpy).toHaveReceivedEventTimes(1);

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -163,8 +163,7 @@ describe("calcite-color-picker", () => {
       }
     ]));
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("emits event when value changes", async () => {
+  it("emits event when value changes", async () => {
     const page = await newE2EPage({
       html: "<calcite-color-picker></calcite-color-picker>"
     });
@@ -207,6 +206,11 @@ describe("calcite-color-picker", () => {
     expect(changeSpy).toHaveReceivedEventTimes(5);
     expect(inputSpy).toHaveReceivedEventTimes(5);
 
+    // change by clicking stored color
+    await (await page.find(`calcite-color-picker >>> .${CSS.savedColor}`)).click();
+    expect(changeSpy).toHaveReceivedEventTimes(6);
+    expect(inputSpy).toHaveReceivedEventTimes(6);
+
     // change by dragging color field thumb
     const thumbRadius = DIMENSIONS.m.thumb.radius;
     const mouseDragSteps = 10;
@@ -224,11 +228,12 @@ describe("calcite-color-picker", () => {
     await page.mouse.up();
     await page.waitForChanges();
 
-    expect(changeSpy).toHaveReceivedEventTimes(6);
-    expect(inputSpy).toHaveReceivedEventTimes(9);
+    expect(changeSpy).toHaveReceivedEventTimes(7);
+    expect(inputSpy.length).toBeGreaterThan(7); // input event fires more than once
 
     // change by dragging hue slider thumb
     const [hueScopeX, hueScopeY] = await getElementXY(page, "calcite-color-picker", `.${CSS.hueScope}`);
+    const previousInputEventLength = inputSpy.length;
 
     await page.mouse.move(hueScopeX + thumbRadius, hueScopeY + thumbRadius);
     await page.mouse.down();
@@ -236,13 +241,8 @@ describe("calcite-color-picker", () => {
     await page.mouse.up();
     await page.waitForChanges();
 
-    expect(changeSpy).toHaveReceivedEventTimes(7);
-    expect(inputSpy).toHaveReceivedEventTimes(14);
-
-    // change by clicking stored color
-    await (await page.find(`calcite-color-picker >>> .${CSS.savedColor}`)).click();
     expect(changeSpy).toHaveReceivedEventTimes(8);
-    expect(inputSpy).toHaveReceivedEventTimes(15);
+    expect(inputSpy.length).toBeGreaterThan(previousInputEventLength + 1); // input event fires more than once
   });
 
   const supportedFormatToSampleValue = {


### PR DESCRIPTION
**Related Issue:** #2694

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Update test to allow variance in input event count during the simulated thumb drag portion.