### PR TITLE
refactor(Date Picker): match Figma and utilize Tailwind

### DIFF
--- a/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.scss
+++ b/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.scss
@@ -36,7 +36,7 @@
 }
 
 .chevron {
-  @apply text-color-2
+  @apply text-color-3
     flex-grow-0
     box-content
     outline-none
@@ -60,7 +60,7 @@
 
   &:hover,
   &:focus {
-    @apply bg-foreground-2 fill-color-1;
+    @apply text-color-1 bg-foreground-2 fill-color-1;
   }
 
   &:active {

--- a/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.scss
+++ b/src/components/calcite-date-picker-month-header/calcite-date-picker-month-header.scss
@@ -9,16 +9,16 @@
 
 :host([scale="s"]) {
   .text {
-    @apply text--1h;
+    @apply text--1h my-2;
   }
   .chevron {
-    @apply h-10;
+    @apply h-9;
   }
 }
 
 :host([scale="m"]) {
   .text {
-    @apply text-0h;
+    @apply text-0h my-3;
   }
   .chevron {
     @apply h-12;
@@ -27,10 +27,11 @@
 
 :host([scale="l"]) {
   .text {
-    @apply text-1h;
+    @apply text-1h my-4;
   }
   .chevron {
-    @apply h-16;
+    // @apply h-16;
+    height: 3.5rem;
   }
 }
 
@@ -93,6 +94,7 @@
     font-medium
     leading-tight
     mx-1
+    my-auto
     inline-block;
   font-size: inherit;
 }

--- a/src/components/calcite-date-picker-month/calcite-date-picker-month.scss
+++ b/src/components/calcite-date-picker-month/calcite-date-picker-month.scss
@@ -20,15 +20,15 @@
 }
 
 :host([scale="s"]) .week-header {
-  @apply text--2h pt-2 pb-4 px-0;
+  @apply text--2h pt-2 pb-3 px-0;
 }
 
 :host([scale="m"]) .week-header {
-  @apply text--2h pt-3 pb-6 px-0;
+  @apply text--2h pt-3 pb-4 px-0;
 }
 
 :host([scale="l"]) .week-header {
-  @apply text--1h pt-4 pb-8 px-0;
+  @apply text--1h pt-4 pb-5 px-0;
 }
 
 .week-days {

--- a/src/components/calcite-date-picker-month/calcite-date-picker-month.scss
+++ b/src/components/calcite-date-picker-month/calcite-date-picker-month.scss
@@ -20,15 +20,15 @@
 }
 
 :host([scale="s"]) .week-header {
-  @apply text--2h py-4 px-0;
+  @apply text--2h pt-2 pb-4 px-0;
 }
 
 :host([scale="m"]) .week-header {
-  @apply text--2h py-6 px-0;
+  @apply text--2h pt-3 pb-6 px-0;
 }
 
 :host([scale="l"]) .week-header {
-  @apply text--1h pt-8 pb-6 px-0;
+  @apply text--1h pt-4 pb-8 px-0;
 }
 
 .week-days {


### PR DESCRIPTION
**Related Issue:** #2465

## Summary

Adjusted spacing on `calcite-datepicker` header spaing Figma design.

![CleanShot 2021-08-03 at 16 38 55](https://user-images.githubusercontent.com/9469422/128095314-82fd6ad5-20c3-4651-bf68-79b26ae3d082.png)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
