### PR TITLE
fix(dropdown): revert dropdown-trigger-container width 

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -7,7 +7,7 @@
  */
 
 :host {
-  @apply relative inline-flex flex-grow;
+  @apply relative inline-flex flex-initial;
 }
 
 // disabled styles
@@ -31,7 +31,7 @@
   width: var(--calcite-dropdown-width);
 }
 .calcite-dropdown-trigger-container {
-  @apply relative w-full;
+  @apply flex flex-auto relative;
 }
 // width
 :host([width="s"]) {

--- a/src/components/calcite-dropdown/calcite-dropdown.scss
+++ b/src/components/calcite-dropdown/calcite-dropdown.scss
@@ -31,7 +31,7 @@
   width: var(--calcite-dropdown-width);
 }
 .calcite-dropdown-trigger-container {
-  @apply relative w-auto;
+  @apply relative w-full;
 }
 // width
 :host([width="s"]) {

--- a/src/demos/calcite-card.html
+++ b/src/demos/calcite-card.html
@@ -78,37 +78,37 @@
               id="card-icon-test-1"
               icon-start="circle"
             ></calcite-button>
-            <div slot="footer-trailing">
+            <calcite-button
+              slot="footer-trailing"
+              type="button"
+              scale="s"
+              color="neutral"
+              id="card-icon-test-2"
+              icon-start="circle"
+            ></calcite-button>
+            <calcite-button
+              slot="footer-trailing"
+              type="button"
+              scale="s"
+              color="neutral"
+              id="card-icon-test-3"
+              icon-start="circle"
+            ></calcite-button>
+            <calcite-dropdown type="hover" slot="footer-trailing">
               <calcite-button
-                type="button"
+                id="card-icon-test-4"
+                slot="dropdown-trigger"
                 scale="s"
                 color="neutral"
-                id="card-icon-test-2"
                 icon-start="circle"
-              ></calcite-button>
-              <calcite-button
-                type="button"
-                scale="s"
-                color="neutral"
-                id="card-icon-test-3"
-                icon-start="circle"
-              ></calcite-button>
-              <calcite-dropdown type="hover">
-                <calcite-button
-                  id="card-icon-test-4"
-                  slot="dropdown-trigger"
-                  scale="s"
-                  color="neutral"
-                  icon-start="circle"
-                >
-                </calcite-button>
-                <calcite-dropdown-group selection-mode="none">
-                  <calcite-dropdown-item>View details</calcite-dropdown-item>
-                  <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-                  <calcite-dropdown-item>Delete</calcite-dropdown-item>
-                </calcite-dropdown-group>
-              </calcite-dropdown>
-            </div>
+              >
+              </calcite-button>
+              <calcite-dropdown-group selection-mode="none">
+                <calcite-dropdown-item>View details</calcite-dropdown-item>
+                <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+                <calcite-dropdown-item>Delete</calcite-dropdown-item>
+              </calcite-dropdown-group>
+            </calcite-dropdown>
           </calcite-card>
         </calcite-tooltip-manager>
       </div>
@@ -131,24 +131,24 @@
             <h3 slot="title">My great Workforce project that might wrap two lines</h3>
             <span slot="subtitle">Johnathan Smith</span>
             <span slot="footer-leading">Nov 25, 2018</span>
-            <div slot="footer-trailing">
-              <calcite-button
-                id="card-icon-test-6"
-                scale="s"
-                appearance="transparent"
-                color="neutral"
-                icon-start="circle"
-              >
-              </calcite-button>
-              <calcite-button
-                id="card-icon-test-7"
-                scale="s"
-                appearance="transparent"
-                color="neutral"
-                icon-start="circle"
-              >
-              </calcite-button>
-            </div>
+            <calcite-button
+              slot="footer-trailing"
+              id="card-icon-test-6"
+              scale="s"
+              appearance="transparent"
+              color="neutral"
+              icon-start="circle"
+            >
+            </calcite-button>
+            <calcite-button
+              slot="footer-trailing"
+              id="card-icon-test-7"
+              scale="s"
+              appearance="transparent"
+              color="neutral"
+              icon-start="circle"
+            >
+            </calcite-button>
           </calcite-card>
         </calcite-tooltip-manager>
       </div>


### PR DESCRIPTION
**Related Issue:** (#2625)

## Summary
One line change to rule them all.
Reverts trigger width to 100%.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
