### PR TITLE
test(tip-manager): updated tip and tip-manager into one demo page

### DIFF
--- a/src/demos/tip-manager/basic.html
+++ b/src/demos/tip-manager/basic.html
@@ -5,14 +5,117 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Calcite Components: calcite-tip-manager</title>
 
+    <style>
+      .parent {
+        display: flex;
+        align-items: center;
+        margin: 25px 0;
+      }
+
+      .child {
+        flex: 0 1 50%;
+        margin: 0 25px;
+        color: var(--calcite-ui-text-3);
+        font-family: var(--calcite-sans-family);
+        font-size: var(--calcite-font-size-0);
+        font-weight: var(--calcite-font-weight-medium);
+      }
+
+      .right-aligned-text {
+        text-align: right;
+        flex: 0 0 15%;
+      }
+
+      .add-tip {
+        padding-right: 25px;
+      }
+
+      hr {
+        margin: 60px 0;
+        border-top: 1px solid var(--calcite-ui-border-2);
+      }
+    </style>
+
     <script src="../_assets/head.js"></script>
   </head>
 
   <body>
-    <main>
-      <section class="example-container">
-        <h1>Tip Manager</h1>
+    <div>
+      <calcite-button href="/" icon-start="arrow-left" color="neutral"> Home </calcite-button>
+    </div>
 
+    <h1 style="margin: 0 auto; text-align: center"> Tip-manager </h1>
+
+
+    <!-- tip with thumbnail -->
+    <div class="parent">
+      <div class="child right-aligned-text"> tip with thumbnail </div>
+
+      <div class="child">
+        <calcite-tip heading="Celestial Bodies!">
+          <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
+          <p>
+            This tip is how a tip should really look. It has a landscape or square image and a small amount of text
+            content. This paragraph is in an "info" slot.
+          </p>
+          <p>This is another paragraph in a subsequent "info" slot.</p>
+          <a href="http://www.esri.com">This is a link.</a>
+        </calcite-tip>
+      </div>
+    </div>
+
+
+     <!-- tip with no thumbnail -->
+     <div class="parent">
+      <div class="child right-aligned-text"> tip with no thumbnail </div>
+
+      <div class="child">
+        <calcite-tip heading="Celestial Bodies">
+          <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
+          <p>
+            This is the next paragraph and should show how wide the content area is now. Of course, the width of the
+            overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
+          </p>
+          <a href="http://www.esri.com">View Esri</a>
+        </calcite-tip>
+      </div>
+    </div>
+
+
+    <!-- tip without header -->
+    <div class="parent">
+      <div class="child right-aligned-text"> tip without header </div>
+
+      <div class="child">
+        <calcite-tip>
+          <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
+          <p>This tip is how a tip should appear without a dismissible button as well as without a heading.</p>
+          <p>This is another paragraph in a subsequent "info" slot.</p>
+          <a href="http://www.esri.com">This is a link.</a>
+        </calcite-tip>
+      </div>
+    </div>
+
+    <hr>
+
+    <!-- add and remove button -->
+    <div class="parent">
+      <div class="child right-aligned-text"></div>
+      <div class="child">
+        <p>
+          <calcite-button id="add" class="add-tip" appearance="solid" icon-end="plus"> add a new tip </calcite-button>
+
+          <calcite-button id="remove" appearance="solid" icon-end="x"> remove last tip </calcite-button>
+        </p>
+      </div>
+
+    </div>
+
+    <!-- tip manager -->
+    <div class="parent">
+      <div class="child right-aligned-text"> tip-manager </div>
+
+      <div class="child">
         <calcite-tip-manager>
           <calcite-tip-group group-title="Astronomy">
             <calcite-tip heading="The Red Rocks and Blue Water">
@@ -57,74 +160,22 @@
             <a href="http://www.esri.com">View Esri</a>
           </calcite-tip>
         </calcite-tip-manager>
-        <section id="actions">
-          <button id="add">Add a new Tip</button>
-          <button id="remove">Remove Last Tip</button>
-        </section>
-        <script>
-          let count = 0;
-          document.getElementById("add").addEventListener("click", () => {
-            const mgr = document.querySelector("calcite-tip-manager");
-            const tips = mgr.querySelectorAll("calcite-tip");
-            const newTip = tips[tips.length - 1].cloneNode(true);
-            mgr.appendChild(newTip);
-          });
-          document.getElementById("remove").addEventListener("click", () => {
-            const mgr = document.querySelector("calcite-tip-manager");
-            const tips = mgr.querySelectorAll("calcite-tip");
-            tips[tips.length - 1].remove();
-          });
-        </script>
-        <h2>RTL Tip Manager</h2>
-        <section dir="rtl">
-          <calcite-tip-manager>
-            <calcite-tip-group group-title="Astronomy">
-              <calcite-tip heading="The Red Rocks and Blue Water">
-                <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
-                <p>
-                  This tip is how a tip should really look. It has a landscape or square image and a small amount of
-                  text content. This paragraph is in an "info" slot.
-                </p>
-                <p>
-                  This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum
-                  is a placeholder text commonly used to demonstrate the visual form of a document without relying on
-                  meaningful content (also called greeking). Replacing the actual content with placeholder text allows
-                  designers to design the form of the content before the content itself has been produced.
-                </p>
-                <a href="http://www.esri.com">This is the "link" slot.</a>
-              </calcite-tip>
-              <calcite-tip heading="The Long Trees">
-                <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
-                <p>
-                  This tip has an image that is a pretty tall. And the text will run out before the end of the image.
-                </p>
-                <p>In astronomy, the terms object and body are often used interchangeably.</p>
-                <a href="http://www.esri.com">View Esri</a>
-              </calcite-tip>
-            </calcite-tip-group>
-            <calcite-tip heading="Square Nature">
-              <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-              <p>This tip has an image that is square. And the text will run out before the end of the image.</p>
-              <p>In astronomy, the terms object and body are often used interchangeably.</p>
-              <p>
-                In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
-                visual form of a document without relying on meaningful content (also called greeking). Replacing the
-                actual content with placeholder text allows designers to design the form of the content before the
-                content itself has been produced.
-              </p>
-              <a href="http://www.esri.com">View Esri</a>
-            </calcite-tip>
-            <calcite-tip heading="The lack of imagery">
-              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
-              <p>
-                This is the next paragraph and should show how wide the content area is now. Of course, the width of the
-                overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
-              </p>
-              <a href="http://www.esri.com">View Esri</a>
-            </calcite-tip>
-          </calcite-tip-manager>
-        </section>
-      </section>
-    </main>
+      </div>
+    </div>
+
+    <script>
+      let count = 0;
+      document.getElementById("add").addEventListener("click", () => {
+        const mgr = document.querySelector("calcite-tip-manager");
+        const tips = mgr.querySelectorAll("calcite-tip");
+        const newTip = tips[tips.length - 1].cloneNode(true);
+        mgr.appendChild(newTip);
+      });
+      document.getElementById("remove").addEventListener("click", () => {
+        const mgr = document.querySelector("calcite-tip-manager");
+        const tips = mgr.querySelectorAll("calcite-tip");
+        tips[tips.length - 1].remove();
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #2692 

## Summary
- combined _calcite-tip_ and _calcite-tip-manager_ into one demo
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
