### PR TITLE
fix(list): update display to block and updates related test

### DIFF
--- a/src/components/calcite-list/calcite-list.e2e.ts
+++ b/src/components/calcite-list/calcite-list.e2e.ts
@@ -1,7 +1,7 @@
 import { accessible, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-list", () => {
-  it("renders", async () => renders("calcite-list", { display: "flex" }));
+  it("renders", async () => renders("calcite-list", { display: "block" }));
 
   it("honors hidden attribute", async () => hidden("calcite-list"));
 

--- a/src/components/calcite-list/calcite-list.scss
+++ b/src/components/calcite-list/calcite-list.scss
@@ -1,5 +1,5 @@
 :host {
-  @apply flex;
+  @apply block;
 }
 
 .container {


### PR DESCRIPTION
**Related Issue:** (#2729)

## Summary
Updates CalciteList :host display to be `block`.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
