### PR TITLE
fix(block): stops rendering collapsibleIcon when there are header-menu-actions

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -196,9 +196,6 @@ describe("calcite-block", () => {
       const controlSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.control}]`);
       expect(await controlSlot.isVisible()).toBe(true);
 
-      const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
-      expect(collapsibleIcon).toBeNull();
-
       const block = await page.find("calcite-block");
       const blockToggleSpy = await block.spyOnEvent("calciteBlockToggle");
 
@@ -210,6 +207,17 @@ describe("calcite-block", () => {
       await block.click();
       await block.click();
       expect(blockToggleSpy).toHaveReceivedEventTimes(2);
+    });
+
+    it("does not render collapsible icon when a control is added to the header", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-block heading="test-heading" collapsible>
+          <calcite-action text="test" icon="banana" slot="${SLOTS.control}"></calcite-action>
+        </calcite-block>`
+      );
+      const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
+      expect(collapsibleIcon).toBeNull();
     });
 
     it("supports a header icon", async () => {
@@ -252,6 +260,17 @@ describe("calcite-block", () => {
 
       const actionAssignedSlot = await page.$eval("calcite-action", (action) => action.assignedSlot.name);
       expect(actionAssignedSlot).toBe(SLOTS.headerMenuActions);
+    });
+
+    it("does not render collapsible icon when actions are added to the header menu", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-block heading="test-heading" collapsible>
+          <calcite-action text="test" icon="banana" slot="${SLOTS.headerMenuActions}"></calcite-action>
+        </calcite-block>`
+      );
+      const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
+      expect(collapsibleIcon).toBeNull();
     });
   });
 });

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -201,7 +201,7 @@ export class CalciteBlock {
             title={toggleLabel}
           >
             {headerContent}
-            {!hasControl ? (
+            {!hasControl && !hasMenuActions ? (
               <calcite-icon
                 aria-hidden="true"
                 class={CSS.toggleIcon}


### PR DESCRIPTION
**Related Issue:** (#2740)

## Summary
- adds logic to not render collapsibleIcon when `header-menu-actions` has content
- adds explicit test for this
- adds explicit test to not render collapsibleIcon when `control` has content

cc @caripizza @jcfranco 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
