### PR TITLE
feat(flow): add match-height class

### DIFF
--- a/src/components/calcite-flow/calcite-flow.scss
+++ b/src/components/calcite-flow/calcite-flow.scss
@@ -23,6 +23,12 @@
     @apply h-full;
   }
 
+  ::slotted(.calcite-match-height:last-child) {
+    @apply flex
+    flex-auto
+    overflow-hidden;
+  }
+
   .frame--advancing {
     animation: calcite-frame-advance $transition;
   }

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -14,7 +14,7 @@
   max-width: unset;
 }
 
-::slotted(.calcite-match-height) {
+::slotted(.calcite-match-height:last-child) {
   @apply flex
   flex-auto
   overflow-hidden;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -14,7 +14,7 @@
   max-width: unset;
 }
 
-::slotted(.calcite-match-height:last-child) {
+::slotted(.calcite-match-height) {
   @apply flex
   flex-auto
   overflow-hidden;

--- a/src/demos/shell/nesting-testing-flow.html
+++ b/src/demos/shell/nesting-testing-flow.html
@@ -21,6 +21,9 @@
       }
     </style>
     <style>
+      #toggles-drag {
+        display: none;
+      }
       #viewDiv {
         padding: 0;
         margin: 0;
@@ -116,153 +119,159 @@
             </calcite-button>
             <some-custom-element class="calcite-match-height">
               <calcite-flow>
-                <calcite-panel heading="first panel"> Test </calcite-panel>
-                <calcite-panel heading="Flow & DIVs" summary="Extra nested divs" dismissible>
-                  <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
-                    <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
-                      <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
-                        <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
-                        </calcite-action>
-                      </calcite-value-list-item>
-                      <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
-                        <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
-                        </calcite-action>
-                      </calcite-value-list-item>
-                      <calcite-value-list-item
-                        label="Fish. But not just any fish."
-                        description="Easy to care for."
-                        value="fish"
-                      >
-                        <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
-                        </calcite-action>
-                      </calcite-value-list-item>
-                    </calcite-value-list>
+                <some-custom-element class="calcite-match-height">
+                  <calcite-panel heading="first panel">
+                    <calcite-action text="I'm in the first panel." icon="banana" text-enabled></calcite-action>
+                  </calcite-panel>
+                </some-custom-element>
+                <some-custom-element class="calcite-match-height">
+                  <calcite-panel heading="Flow & DIVs" summary="Extra nested divs" dismissible>
+                    <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
+                      <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
+                        <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
+                          <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                          </calcite-action>
+                        </calcite-value-list-item>
+                        <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
+                          <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                          </calcite-action>
+                        </calcite-value-list-item>
+                        <calcite-value-list-item
+                          label="Fish. But not just any fish."
+                          description="Easy to care for."
+                          value="fish"
+                        >
+                          <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
+                          </calcite-action>
+                        </calcite-value-list-item>
+                      </calcite-value-list>
 
-                    <!-- Using Button -->
-                    <calcite-label scale="s">
-                      It's a label (btn).
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-button
-                          slot="action"
-                          appearance="transparent"
-                          color="neutral"
-                          icon-start="brackets-curly"
-                          scale="s"
-                        ></calcite-button>
-                      </calcite-input>
-                    </calcite-label>
-                    <!-- Using Action -->
-                    <calcite-label scale="s">
-                      It's a label (action).
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action text="cool action" icon="pencil" slot="action" scale="s"></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
+                      <!-- Using Button -->
+                      <calcite-label scale="s">
+                        It's a label (btn).
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-button
+                            slot="action"
+                            appearance="transparent"
+                            color="neutral"
+                            icon-start="brackets-curly"
+                            scale="s"
+                          ></calcite-button>
+                        </calcite-input>
+                      </calcite-label>
+                      <!-- Using Action -->
+                      <calcite-label scale="s">
+                        It's a label (action).
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action text="cool action" icon="pencil" slot="action" scale="s"></calcite-action>
+                        </calcite-input>
+                      </calcite-label>
 
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                    <calcite-block-section text="Section is cool">
                       <calcite-label scale="s">
                         It's a label.
-                        <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
                       </calcite-label>
-                    </calcite-block-section>
-                    <calcite-block-section text="Switch section" toggle-display="switch">
+                      <calcite-block-section text="Section is cool">
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                        </calcite-label>
+                      </calcite-block-section>
+                      <calcite-block-section text="Switch section" toggle-display="switch">
+                        <calcite-label scale="s">
+                          It's a label.
+                          <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                        </calcite-label>
+                      </calcite-block-section>
+                    </calcite-block>
+
+                    <calcite-block heading="With control" summary="Collapsible" collapsible>
+                      <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
                       <calcite-label scale="s">
                         It's a label.
-                        <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
                       </calcite-label>
-                    </calcite-block-section>
-                  </calcite-block>
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
+                      </calcite-label>
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
+                      </calcite-label>
+                    </calcite-block>
+                    <calcite-block heading="Basic" summary="Not collapsible">
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
+                      </calcite-label>
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
+                      </calcite-label>
+                      <calcite-label scale="s">
+                        It's a label.
+                        <calcite-input type="text" placeholder="This is stuff." scale="s">
+                          <calcite-action
+                            text="cool action"
+                            icon="brackets-curly"
+                            slot="action"
+                            scale="s"
+                          ></calcite-action>
+                        </calcite-input>
+                      </calcite-label>
+                    </calcite-block>
 
-                  <calcite-block heading="With control" summary="Collapsible" collapsible>
-                    <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                  </calcite-block>
-                  <calcite-block heading="Basic" summary="Not collapsible">
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s">
-                        <calcite-action
-                          text="cool action"
-                          icon="brackets-curly"
-                          slot="action"
-                          scale="s"
-                        ></calcite-action>
-                      </calcite-input>
-                    </calcite-label>
-                  </calcite-block>
-
-                  <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
-                  <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
-                    Add label class
-                  </calcite-tooltip>
-                  <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                  <calcite-button slot="footer-actions" width="half">Done</calcite-button>
-                </calcite-panel>
+                    <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
+                    <calcite-tooltip label="tooltip" reference-element="label-fab" disable-pointer>
+                      Add label class
+                    </calcite-tooltip>
+                    <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
+                    <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                  </calcite-panel>
+                </some-custom-element>
               </calcite-flow>
             </some-custom-element>
           </calcite-shell-panel>

--- a/src/demos/shell/nesting-testing.html
+++ b/src/demos/shell/nesting-testing.html
@@ -19,8 +19,10 @@
         width: 100%;
         height: 100%;
       }
-    </style>
-    <style>
+      .toggles,
+      #toggles-drag {
+        display: none;
+      }
       #viewDiv {
         padding: 0;
         margin: 0;
@@ -116,107 +118,89 @@
             </calcite-button>
             <some-custom-element class="calcite-match-height">
               <calcite-panel heading="Panel & DIVs" summary="Extra nested divs" dismissible>
-                <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
-                  <calcite-value-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
-                    <calcite-value-list-item label="Dogs" description="Man's best friend" value="dogs">
-                      <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
-                      </calcite-action>
-                    </calcite-value-list-item>
-                    <calcite-value-list-item label="Cats" description="Independent and fluffy" value="cats">
-                      <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
-                      </calcite-action>
-                    </calcite-value-list-item>
-                    <calcite-value-list-item
-                      label="Fish. But not just any fish."
-                      description="Easy to care for."
-                      value="fish"
+                <calcite-block heading="Long ol' thing" open collapsible>
+                  <!-- <calcite-action text="cool" slot="control" icon="banana"></calcite-action> -->
+                  <calcite-action text="cool" icon="banana" text-enabled slot="header-menu-actions"></calcite-action>
+                  <calcite-action text="cool" icon="banana" text-enabled slot="header-menu-actions"></calcite-action>
+                  <div>
+                    <calcite-button alignment="center" appearance="transparent" width="full" scale="s"
+                      >The button</calcite-button
                     >
-                      <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
-                      </calcite-action>
-                    </calcite-value-list-item>
-                  </calcite-value-list>
-
-                  <!-- Using Button -->
-                  <calcite-label scale="s">
-                    It's a label (btn).
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-button
-                        slot="action"
-                        appearance="transparent"
-                        color="neutral"
-                        icon-start="brackets-curly"
-                        scale="s"
-                      ></calcite-button>
-                    </calcite-input>
-                  </calcite-label>
-                  <!-- Using Action -->
-                  <calcite-label scale="s">
-                    It's a label (action).
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="pencil" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-                  <calcite-block-section text="Section is cool">
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
-                    </calcite-label>
-                  </calcite-block-section>
-                  <calcite-block-section text="Switch section" toggle-display="switch">
-                    <calcite-label scale="s">
-                      It's a label.
-                      <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
-                    </calcite-label>
-                  </calcite-block-section>
-                </calcite-block>
-
-                <calcite-block heading="With control" summary="Collapsible" collapsible>
-                  <calcite-action label="ellipsis" slot="control" icon="ellipsis" scale="m"></calcite-action>
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-                </calcite-block>
-                <calcite-block heading="Basic" summary="Not collapsible">
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
-                  <calcite-label scale="s">
-                    It's a label.
-                    <calcite-input type="text" placeholder="This is stuff." scale="s">
-                      <calcite-action text="cool action" icon="brackets-curly" slot="action" scale="s"></calcite-action>
-                    </calcite-input>
-                  </calcite-label>
+                    <calcite-list>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="States">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Rivers">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                      <calcite-list-item label="Capitals">
+                        <calcite-icon icon="chevron-right" slot="content-end" scale="s"></calcite-icon>
+                      </calcite-list-item>
+                    </calcite-list>
+                  </div>
                 </calcite-block>
 
                 <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>


### PR DESCRIPTION
**Related Issue:** #2741 

## Summary
* Adds `calcite-match-height` class and styles to Flow.
* updates demo to reveal match-height usage with custom elements.

@jcfranco @caripizza This should be extremely low-risk as the class is 100% opt-in.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
