### PR TITLE
refactor(Block heading): match Figma and utilize Tailwind

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -79,7 +79,7 @@ calcite-handle {
 .header .title .heading {
   @apply p-0
     text--1
-    text-color-1
+    text-color-2
     font-medium
     word-break
     leading-tight

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -79,7 +79,7 @@ calcite-handle {
 .header .title .heading {
   @apply p-0
     text--1
-    text-color-3
+    text-color-1
     font-medium
     word-break
     leading-tight


### PR DESCRIPTION
**Related Issue:** #2735

## Summary

Heading text adjusted from `ui-text-3` to `ui-text-1` by default.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
