### PR TITLE
fix(custom-elements): add missing action component helper bundles

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -10,15 +10,10 @@ export const create: () => Config = () => ({
   namespace: "calcite",
   bundles: [
     { components: ["calcite-accordion", "calcite-accordion-item"] },
-    {
-      components: [
-        "calcite-action",
-        "calcite-action-group",
-        "calcite-action-menu",
-        "calcite-action-bar",
-        "calcite-action-pad"
-      ]
-    },
+    { components: ["calcite-action"] },
+    { components: ["calcite-action-bar"] },
+    { components: ["calcite-action-menu"] },
+    { components: ["calcite-action-pad"] },
     { components: ["calcite-alert"] },
     { components: ["calcite-avatar"] },
     { components: ["calcite-block", "calcite-block-section"] },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Splits up action components to main entry files. This also helps the build process generate the helper bundles included in the `custom-elements-bundle` output target.

Note: `calcite-action-group` is intentionally left out since it is a support component used by both `calcite-action-bar` and `calcite-action-pad`.