### PR TITLE
docs(action): Deprecate calciteActionClick.

### DIFF
--- a/src/components/calcite-action/calcite-action.e2e.ts
+++ b/src/components/calcite-action/calcite-action.e2e.ts
@@ -133,40 +133,4 @@ describe("calcite-action", () => {
 
     expect(clickSpy).toHaveReceivedEventTimes(0);
   });
-
-  it("should emit 'calciteActionClick' event", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action text="hello world"></calcite-action>`
-    });
-
-    await page.waitForChanges();
-
-    const clickSpy = await page.spyOnEvent("calciteActionClick");
-
-    const button = await page.find("calcite-action >>> button");
-
-    await button.click();
-
-    await page.waitForChanges();
-
-    expect(clickSpy).toHaveReceivedEventTimes(1);
-  });
-
-  it("should not emit 'calciteActionClick' event when disabled", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action text="hello world" disabled></calcite-action>`
-    });
-
-    await page.waitForChanges();
-
-    const clickSpy = await page.spyOnEvent("calciteActionClick");
-
-    const button = await page.find("calcite-action >>> button");
-
-    await button.click();
-
-    await page.waitForChanges();
-
-    expect(clickSpy).toHaveReceivedEventTimes(0);
-  });
 });

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -104,6 +104,7 @@ export class CalciteAction {
 
   /**
    * Emitted when the action has been clicked.
+   * @deprecated use onClick instead.
    */
   @Event() calciteActionClick: EventEmitter;
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Use onClick instead.

docs(action): Deprecate calciteActionClick.