### PR TITLE
chore(deps): bump calcite-colors, resolve border color conflicts w/ backgrounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3601,9 +3601,9 @@
       "dev": true
     },
     "@esri/calcite-colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.0.0.tgz",
-      "integrity": "sha512-xsCRLwYHZ9wKFu4zhLTDXk28/wPiEVK4BDHwTr8o+AHCygoNfO2k9JjFP150avS53fldDOVqlEB+D0rr+CI5+w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.0.1.tgz",
+      "integrity": "sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw==",
       "dev": true
     },
     "@esri/calcite-ui-icons": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@esri/calcite-base": "^1.2.0",
-    "@esri/calcite-colors": "6.0.0",
+    "@esri/calcite-colors": "6.0.1",
     "@esri/calcite-ui-icons": "3.16.6",
     "@esri/eslint-plugin-calcite-components": "0.1.1",
     "@stencil/eslint-plugin": "0.3.1",

--- a/src/6-custom-theme.stories.mdx
+++ b/src/6-custom-theme.stories.mdx
@@ -29,8 +29,8 @@ export const Template = () =>
       --calcite-ui-text-inverse: ${color("--calcite-ui-text-inverse", "#ffffff")};
       --calcite-ui-text-link: ${color("--calcite-ui-text-link", "#00619b")};
       --calcite-ui-border-1: ${color("--calcite-ui-border-1", "#cacaca")};
-      --calcite-ui-border-2: ${color("--calcite-ui-border-2", "#dfdfdf")};
-      --calcite-ui-border-3: ${color("--calcite-ui-border-3", "#eaeaea")};
+      --calcite-ui-border-2: ${color("--calcite-ui-border-2", "#d4d4d4")};
+      --calcite-ui-border-3: ${color("--calcite-ui-border-3", "#dfdfdf")};
       --calcite-ui-border-input: ${color("--calcite-ui-border-input", "#949494")};
     "
   >


### PR DESCRIPTION
**Related Issue:** #2042

## Summary
Bumps calcite-colors dependency to get the updated border-color values in its latest release:

```scss
.calcite-theme-light {
  ...
  --calcite-ui-border-2: #d4d4d4; /* previous: #dfdfdf */
  --calcite-ui-border-3: #dfdfdf; /* previous: #eaeaea */
  ...
}
.calcite-theme-dark {
  ...
  --calcite-ui-border-1: #555555; /* previous: #4a4a4a */
  --calcite-ui-border-2: #4a4a4a; /* previous: #404040 */
  --calcite-ui-border-3: #404040; /* previous: #353535 */
  ...
}
```

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
