### PR TITLE
fix(input): Prevent keyboard events from changing values when readOnly is true

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1185,7 +1185,7 @@ describe("calcite-input", () => {
     it("cannot be modified when readOnly is true", async () => {
       const page = await newE2EPage();
       await page.setContent(`
-      <calcite-input read-only value="John Doe"></calcite-input>
+      <calcite-input read-only value="John Doe" clearable></calcite-input>
       `);
 
       const calciteInputInput = await page.spyOnEvent("calciteInputInput");
@@ -1196,6 +1196,31 @@ describe("calcite-input", () => {
       await page.keyboard.press("a");
       await page.waitForChanges();
       expect(await element.getProperty("value")).toBe("John Doe");
+
+      await page.keyboard.press("Escape");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("John Doe");
+      expect(calciteInputInput).toHaveReceivedEventTimes(0);
+    });
+
+    it("number cannot be modified when readOnly is true", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+      <calcite-input type="number" read-only value="5"></calcite-input>
+      `);
+
+      const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+      const element = await page.find("calcite-input");
+      expect(await element.getProperty("value")).toBe("5");
+      await element.callMethod("setFocus");
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("5");
+
+      await page.keyboard.press("Escape");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("5");
       expect(calciteInputInput).toHaveReceivedEventTimes(0);
     });
 

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -350,6 +350,9 @@ export class CalciteInput {
 
   @Listen("keydown")
   keyDownHandler(event: KeyboardEvent): void {
+    if (this.readOnly || this.disabled) {
+      return;
+    }
     if (this.isClearable && getKey(event.key) === "Escape") {
       this.clearInputValue(event);
       event.preventDefault();
@@ -409,16 +412,25 @@ export class CalciteInput {
   };
 
   private inputInputHandler = (nativeEvent: InputEvent): void => {
+    if (this.disabled || this.readOnly) {
+      return;
+    }
     this.setValue((nativeEvent.target as HTMLInputElement).value, nativeEvent);
   };
 
   private inputKeyDownHandler = (event: KeyboardEvent): void => {
+    if (this.disabled || this.readOnly) {
+      return;
+    }
     if (event.key === "Enter") {
       this.calciteInputChange.emit();
     }
   };
 
   private inputNumberInputHandler = (nativeEvent: InputEvent): void => {
+    if (this.disabled || this.readOnly) {
+      return;
+    }
     const value = (nativeEvent.target as HTMLInputElement).value;
     const delocalizedValue = delocalizeNumberString(value, this.locale);
     if (nativeEvent.inputType === "insertFromPaste") {
@@ -433,7 +445,7 @@ export class CalciteInput {
   };
 
   private inputNumberKeyDownHandler = (event: KeyboardEvent): void => {
-    if (this.type !== "number") {
+    if (this.type !== "number" || this.disabled || this.readOnly) {
       return;
     }
     if (event.key === "ArrowUp") {


### PR DESCRIPTION
**Related Issue:** #2726

## Summary

fix(input): Prevent keyboard events from changing values when readOnly is true. #2726