### PR TITLE
fix(calcite-input): number inputs with step="any" should allow decimals

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -907,6 +907,20 @@ describe("calcite-input", () => {
 
       expect(await input.getProperty("value")).toBe("1.5");
     });
+
+    it("allows decimals when step is any", async () => {
+      const page = await newE2EPage({
+        html: `
+          <calcite-input step="any" type="number"></calcite-input>
+        `
+      });
+      const input = await page.find("calcite-input");
+      await input.callMethod("setFocus");
+      await page.keyboard.type("1.5");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("1.5");
+    });
   });
 
   describe("number locale support", () => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -483,7 +483,8 @@ export class CalciteInput {
     const decimalSeparator = getDecimalSeparator(this.locale);
     if (
       event.key === decimalSeparator &&
-      (this.step === "any" ? true : isValidDecimal(this.step))
+      (this.step === "any" || isValidDecimal(this.step))
+      // (this.step === "any" ? true : isValidDecimal(this.step))
     ) {
       if (!this.value && !this.childNumberEl.value) {
         return;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -169,7 +169,7 @@ export class CalciteInput {
   @Prop({ mutable: true, reflect: true }) status: Status = "idle";
 
   /** input step */
-  @Prop({ mutable: true, reflect: true }) step?: number | "any";
+  @Prop({ reflect: true }) step?: number | "any" = 1;
 
   /** optionally add suffix  **/
   @Prop() suffixText?: string;
@@ -277,7 +277,6 @@ export class CalciteInput {
     this.form?.addEventListener("reset", this.reset);
     this.scale = getElementProp(this.el, "scale", this.scale);
     this.status = getElementProp(this.el, "status", this.status);
-    this.step = !this.step && this.type === "number" ? "any" : this.step;
     if (this.type === "number" && this.value) {
       if (isValidNumber(this.value)) {
         this.localizedValue = localizeNumberString(this.value, this.locale, this.groupSeparator);
@@ -484,7 +483,7 @@ export class CalciteInput {
     const decimalSeparator = getDecimalSeparator(this.locale);
     if (
       event.key === decimalSeparator &&
-      isValidDecimal(this.step === "any" ? 1 : (this.step as number))
+      (this.step === "any" ? true : isValidDecimal(this.step))
     ) {
       if (!this.value && !this.childNumberEl.value) {
         return;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -169,7 +169,7 @@ export class CalciteInput {
   @Prop({ mutable: true, reflect: true }) status: Status = "idle";
 
   /** input step */
-  @Prop({ reflect: true }) step?: number | "any" = 1;
+  @Prop({ reflect: true }) step?: number | "any";
 
   /** optionally add suffix  **/
   @Prop() suffixText?: string;
@@ -483,7 +483,7 @@ export class CalciteInput {
     const decimalSeparator = getDecimalSeparator(this.locale);
     if (
       event.key === decimalSeparator &&
-      (this.step === "any" || isValidDecimal(this.step))
+      (this.step === "any" || this.step && isValidDecimal(this.step))
     ) {
       if (!this.value && !this.childNumberEl.value) {
         return;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -484,7 +484,6 @@ export class CalciteInput {
     if (
       event.key === decimalSeparator &&
       (this.step === "any" || isValidDecimal(this.step))
-      // (this.step === "any" ? true : isValidDecimal(this.step))
     ) {
       if (!this.value && !this.childNumberEl.value) {
         return;

--- a/src/demos/calcite-input-number.html
+++ b/src/demos/calcite-input-number.html
@@ -75,7 +75,7 @@
           <calcite-input type="number" locale="fr" name="french" value="1234.56" step="0.01"></calcite-input>
           <calcite-input type="number" locale="fr" name="french-whole" value="1234" step="1"></calcite-input>
           <calcite-input type="number" locale="fr" name="french-novalue" step="1"></calcite-input>
-          <calcite-input type="number" name="step-any" step="any"></calcite-input>
+          <calcite-input type="number" name="step-any" step="any" placeholder='step="any"'></calcite-input>
           <button type="submit">Submit</button>
           <button type="reset">Reset</button>
           <div id="locales"></div>


### PR DESCRIPTION
**Related Issue:** #2764

This pr allows number inputs with `step="any"` to input decimal values akin to the native number input.