### PR TITLE
build: transpile numeric separators from color package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,19 +1624,19 @@
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz",
-      "integrity": "sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+      "integrity": "sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -68,10 +68,12 @@
     "sortablejs": "1.14.0"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-numeric-separator": "7.14.5",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.0",
     "@esri/calcite-ui-icons": "3.16.6",
     "@esri/eslint-plugin-calcite-components": "0.1.1",
+    "@rollup/plugin-babel": "5.3.0",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "2.0.0",
     "@stencil/sass": "1.4.1",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,6 +1,7 @@
 import { Config } from "@stencil/core";
 import { postcss } from "@stencil/postcss";
 import { sass } from "@stencil/sass";
+import babel from "@rollup/plugin-babel";
 import autoprefixer from "autoprefixer";
 import tailwind from "tailwindcss";
 import { generatePreactTypes } from "./support/preact";
@@ -105,6 +106,14 @@ export const create: () => Config = () => ({
       plugins: [tailwind(), autoprefixer()]
     })
   ],
+  rollupPlugins: {
+    after: [
+      babel({
+        include: [/\/color\//],
+        plugins: ["@babel/plugin-proposal-numeric-separator"]
+      })
+    ]
+  },
   testing: {
     moduleNameMapper: {
       "^/assets/(.*)$": "<rootDir>/src/tests/iconPathDataStub.ts"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

The latest `color` package is on the bleeding-edge and may cause issues for clients that have a build process that does not target ES2021. This PR tweaks the build to transpile numeric separators from the package. 

cc @dasa