### PR TITLE
ci(screener): enable alwaysAcceptBaseBranch

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  alwaysAcceptBaseBranch: true,
   projectRepo: 'Esri/calcite-components',
   storybookConfigDir: '.storybook',
   storybookStaticDir: './__docs-temp__',


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

`screener-runner` has [an option](https://github.com/screener-io/screener-runner/#:~:text=alwaysAcceptBaseBranch) that sounds like it would help with some visual diff inconsistencies we've noticed between PRs:

> alwaysAcceptBaseBranch: Option to automatically accept new and changed states in base branch. Assumes base branch should always be correct.

This PR enables this option for testing. 

If this ends up working the way we need it, we can schedule a date to ensure all PRs have the latest version of `master` merged into them. In theory, the base for all screenshot diffs would be the same and the only visual diffs we get should be related to the PR.

@eriklharper @caripizza For us to test this, would we need to accept some invalid changes in master and see how Screener behaves with a PR with small or no visual changes?

cc @driskull @julio8a 