### PR TITLE
chore(linting): enable JS linting for config files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,6 @@
 {
   "*.html": ["prettier --write"],
+  "*.js": ["eslint --ext .js --fix", "prettier --write"],
   "*.{json,md}": ["prettier --write"],
   "*.scss": ["stylelint --fix", "prettier --write"],
   "*.{ts,tsx}": ["tslint --project tsconfig-tslint.json --fix", "eslint --ext .ts,.tsx --fix", "prettier --write"]

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",
     "lint": "concurrently npm:lint:*",
     "lint:html": "prettier --write \"**/*.html\"",
+    "lint:js": "eslint --ext .js --fix . && prettier --write \"**/*.ts?(x)\"",
     "lint:json": "prettier --write \"**/*.json\"",
     "lint:md": "prettier --write \"**/*.md\"",
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\"",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

We still have a couple of config JS files in the codebase (e.g., `screener.config.js`, `tailwind.config.js`). This updates our linting config and scripts to process them.