### PR TITLE
feat(scrim): render default slot

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -15,7 +15,7 @@
   --calcite-button-transparent-hover: #{rgba($blk-240, 0.05)};
   --calcite-button-transparent-press: #{rgba($blk-240, 0.08)};
   --calcite-link-blue-underline: #{rgba($h-bb-070, 0.4)};
-  --calcite-scrim-background: #{rgba($blk-000, 0.75)};
+  --calcite-scrim-background: #{rgba($blk-000, 0.85)};
 }
 
 @mixin calcite-theme-dark-extended {
@@ -29,7 +29,7 @@
   --calcite-button-transparent-hover: #{rgba($blk-000, 0.05)};
   --calcite-button-transparent-press: #{rgba($blk-000, 0.08)};
   --calcite-link-blue-underline: #{rgba($d-bb-420, 0.4)};
-  --calcite-scrim-background: #{rgba($blk-240, 0.75)};
+  --calcite-scrim-background: #{rgba($blk-240, 0.85)};
 }
 
 :root {

--- a/src/components/calcite-loader/calcite-loader.scss
+++ b/src/components/calcite-loader/calcite-loader.scss
@@ -50,7 +50,10 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
 }
 
 .loader__text {
-  @apply block text-center;
+  @apply block
+  text--2h
+  text-center
+  text-color-1;
   margin-top: calc(var(--calcite-loader-size) + theme("spacing.6"));
 }
 

--- a/src/components/calcite-scrim/calcite-scrim.e2e.ts
+++ b/src/components/calcite-scrim/calcite-scrim.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { CSS } from "./resources";
 
 describe("calcite-scrim", () => {
   it("renders", async () => renders("<calcite-scrim></calcite-scrim>", { display: "flex" }));
@@ -38,6 +39,26 @@ describe("calcite-scrim", () => {
     expect(loader).toBeDefined();
   });
 
+  it("does not render conent if the default slot if it is empty", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-scrim></calcite-scrim>`);
+
+    const contentNode = await page.find(`calcite-scrim >>> .${CSS.content}`);
+
+    expect(contentNode).toBeNull();
+  });
+
+  it("renders conent in the default slot has content", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-scrim>This is a test.</calcite-scrim>`);
+
+    const contentNode = await page.find(`calcite-scrim >>> .${CSS.content}`);
+
+    expect(contentNode).not.toBeNull();
+  });
+
   describe("CSS properties for light/dark themes", () => {
     const scrimSnippet = `
     <div style="position: relative; width: 200px; height: 200px; overflow: auto;">
@@ -68,7 +89,7 @@ describe("calcite-scrim", () => {
         scrim = await page.find("calcite-scrim >>> .scrim");
         scrimStyles = await scrim.getComputedStyle();
         scrimBgStyle = await scrimStyles.getPropertyValue("background-color");
-        expect(scrimBgStyle).toEqual("rgba(255, 255, 255, 0.75)");
+        expect(scrimBgStyle).toEqual("rgba(255, 255, 255, 0.85)");
       });
     });
 
@@ -80,7 +101,7 @@ describe("calcite-scrim", () => {
         scrim = await page.find("calcite-scrim >>> .scrim");
         scrimStyles = await scrim.getComputedStyle();
         scrimBgStyle = await scrimStyles.getPropertyValue("background-color");
-        expect(scrimBgStyle).toEqual("rgba(0, 0, 0, 0.75)");
+        expect(scrimBgStyle).toEqual("rgba(0, 0, 0, 0.85)");
       });
     });
 

--- a/src/components/calcite-scrim/calcite-scrim.e2e.ts
+++ b/src/components/calcite-scrim/calcite-scrim.e2e.ts
@@ -39,6 +39,41 @@ describe("calcite-scrim", () => {
     expect(loader).toBeDefined();
   });
 
+  it("does not allow clicks in underlying nodes", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <calcite-panel>
+        <calcite-button>Test</calcite-button>
+        <calcite-scrim></calcite-scrim>
+      </calcite-panel>
+    `);
+
+    const button = await page.find(`calcite-button`);
+
+    const clickSpy = await button.spyOnEvent("click");
+
+    expect(clickSpy).toHaveReceivedEventTimes(0);
+  });
+
+  it("does allow clickss inside default node", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <calcite-scrim>
+        <calcite-button>Test</calcite-button>
+      </calcite-scrim>
+    `);
+
+    const button = await page.find(`calcite-button`);
+
+    const clickSpy = await button.spyOnEvent("click");
+
+    await button.click();
+
+    expect(clickSpy).toHaveReceivedEventTimes(1);
+  });
+
   it("does not render content if the default slot if it is empty", async () => {
     const page = await newE2EPage();
 

--- a/src/components/calcite-scrim/calcite-scrim.e2e.ts
+++ b/src/components/calcite-scrim/calcite-scrim.e2e.ts
@@ -39,7 +39,7 @@ describe("calcite-scrim", () => {
     expect(loader).toBeDefined();
   });
 
-  it("does not render conent if the default slot if it is empty", async () => {
+  it("does not render content if the default slot if it is empty", async () => {
     const page = await newE2EPage();
 
     await page.setContent(`<calcite-scrim></calcite-scrim>`);

--- a/src/components/calcite-scrim/calcite-scrim.scss
+++ b/src/components/calcite-scrim/calcite-scrim.scss
@@ -21,7 +21,6 @@
 .scrim {
   @apply flex
   absolute
-  select-none
   overflow-hidden
   inset-0
   content-center

--- a/src/components/calcite-scrim/calcite-scrim.scss
+++ b/src/components/calcite-scrim/calcite-scrim.scss
@@ -25,7 +25,13 @@
   overflow-hidden
   inset-0
   content-center
-  items-center;
+  items-center
+  flex-col
+  justify-center;
   animation: calcite-scrim-fade-in 250ms ease-in-out;
   background-color: var(--calcite-scrim-background);
+}
+
+.content {
+  @apply p-4;
 }

--- a/src/components/calcite-scrim/calcite-scrim.tsx
+++ b/src/components/calcite-scrim/calcite-scrim.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, VNode } from "@stencil/core";
+import { Component, Element, Prop, h, VNode } from "@stencil/core";
 
 import { CSS, TEXT } from "./resources";
 
@@ -27,19 +27,32 @@ export class CalciteScrim {
 
   // --------------------------------------------------------------------------
   //
+  //  Private Properties
+  //
+  // --------------------------------------------------------------------------
+
+  @Element() el: HTMLCalciteScrimElement;
+
+  // --------------------------------------------------------------------------
+  //
   //  Render Method
   //
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const loaderNode = this.loading ? <calcite-loader active label={this.intlLoading} /> : null;
+    const { el, loading, intlLoading } = this;
+    const hasContent = el.innerHTML.trim().length > 0;
+    const loaderNode = loading ? <calcite-loader active label={intlLoading} /> : null;
+    const contentNode = hasContent ? (
+      <div class={CSS.content}>
+        <slot />
+      </div>
+    ) : null;
 
     return (
       <div class={CSS.scrim}>
         {loaderNode}
-        <div class={CSS.content}>
-          <slot />
-        </div>
+        {contentNode}
       </div>
     );
   }

--- a/src/components/calcite-scrim/calcite-scrim.tsx
+++ b/src/components/calcite-scrim/calcite-scrim.tsx
@@ -34,6 +34,13 @@ export class CalciteScrim {
   render(): VNode {
     const loaderNode = this.loading ? <calcite-loader active label={this.intlLoading} /> : null;
 
-    return <div class={CSS.scrim}>{loaderNode}</div>;
+    return (
+      <div class={CSS.scrim}>
+        {loaderNode}
+        <div class={CSS.content}>
+          <slot />
+        </div>
+      </div>
+    );
   }
 }

--- a/src/demos/calcite-scrim.html
+++ b/src/demos/calcite-scrim.html
@@ -134,9 +134,11 @@
 
       <!-- scrim with content in default slot-->
       <div class="child">
-        Determinate loader in default slot
+        Determinate loader in default slot<br />(Scrim hiding is scripted.)
         <div style="margin: 1rem 0">
-          <calcite-button id="replay-m" appearance="outline" icon-start="refresh" scale="m">Replay loader</calcite-button>
+          <calcite-button id="replay-m" appearance="outline" icon-start="refresh" scale="m"
+            >Replay loader</calcite-button
+          >
         </div>
         <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
           <calcite-scrim id="scrim-determinate">

--- a/src/demos/calcite-scrim.html
+++ b/src/demos/calcite-scrim.html
@@ -17,12 +17,15 @@
       .child {
         display: flex;
         justify-content: center;
+        align-items: center;
+        flex-direction: column;
         flex: 1 1 auto;
         color: var(--calcite-ui-text-3);
         font-family: var(--calcite-sans-family);
         font-size: var(--calcite-font-size-0);
         font-weight: var(--calcite-font-weight-medium);
-        padding: 15px;
+        padding: 1rem;
+        margin-bottom: 2rem;
       }
     </style>
     <script src="./_assets/head.js"></script>
@@ -34,6 +37,7 @@
     <!-- simple panel example -->
     <div class="parent">
       <div class="child">
+        Default
         <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
           <calcite-scrim></calcite-scrim>
           <div style="width: 400px; height: 400px; overflow: auto">
@@ -66,6 +70,7 @@
 
       <!-- loading scrim panel -->
       <div class="child">
+        Loading
         <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
           <calcite-scrim loading></calcite-scrim>
           <div style="width: 400px; height: 400px; overflow: auto">
@@ -95,10 +100,44 @@
           </div>
         </div>
       </div>
+      <div class="child">
+        Simple text content in default slot
+        <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
+          <calcite-scrim> This is just text. </calcite-scrim>
+          <div style="width: 400px; height: 400px; overflow: auto">
+            <p>
+              Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum
+              tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas
+              semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+            </p>
+            <ul>
+              <li>
+                Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in,
+                diam. Sed arcu. Cras consequat.
+              </li>
+              <li>
+                Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.
+                Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+              </li>
+              <li>
+                Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique
+                cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.
+              </li>
+              <li>
+                Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate,
+                nunc.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
 
       <!-- scrim with content in default slot-->
-      <div class="child" style="flex-direction: column; justify-content: center; align-items: center">
+      <div class="child">
         Determinate loader in default slot
+        <div style="margin: 1rem 0">
+          <calcite-button id="replay-m" appearance="outline" icon-start="refresh" scale="m">Replay loader</calcite-button>
+        </div>
         <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
           <calcite-scrim id="scrim-determinate">
             <calcite-loader
@@ -138,8 +177,38 @@
             </ul>
           </div>
         </div>
-        <div style="text-align: center; margin-top: 1rem">
-          <calcite-button id="replay-m" appearance="transparent" icon="refresh">Replay</calcite-button>
+      </div>
+
+      <!-- loading scrim panel -->
+      <div class="child">
+        Loading and with text content in default slot
+        <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
+          <calcite-scrim loading> This is just text. </calcite-scrim>
+          <div style="width: 400px; height: 400px; overflow: auto">
+            <p>
+              Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum
+              tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas
+              semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+            </p>
+            <ul>
+              <li>
+                Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in,
+                diam. Sed arcu. Cras consequat.
+              </li>
+              <li>
+                Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.
+                Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+              </li>
+              <li>
+                Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique
+                cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.
+              </li>
+              <li>
+                Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate,
+                nunc.
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/src/demos/calcite-scrim.html
+++ b/src/demos/calcite-scrim.html
@@ -95,6 +95,78 @@
           </div>
         </div>
       </div>
+
+      <!-- scrim with content in default slot-->
+      <div class="child" style="flex-direction: column; justify-content: center; align-items: center">
+        Determinate loader in default slot
+        <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
+          <calcite-scrim id="scrim-determinate">
+            <calcite-loader
+              label="loading"
+              active
+              type="determinate"
+              value="0"
+              id="loader-determinate-m"
+              text="Loading Brunswick stew"
+              scale="m"
+            >
+            </calcite-loader>
+          </calcite-scrim>
+          <div style="width: 400px; height: 400px; overflow: auto">
+            <p>
+              Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum
+              tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas
+              semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+            </p>
+            <ul>
+              <li>
+                Morbi in sem quis dui placerat ornare. Pellentesque odio nisi, euismod in, pharetra a, ultricies in,
+                diam. Sed arcu. Cras consequat.
+              </li>
+              <li>
+                Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat.
+                Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+              </li>
+              <li>
+                Phasellus ultrices nulla quis nibh. Quisque a lectus. Donec consectetuer ligula vulputate sem tristique
+                cursus. Nam nulla quam, gravida non, commodo a, sodales sit amet, nisi.
+              </li>
+              <li>
+                Pellentesque fermentum dolor. Aliquam quam lectus, facilisis auctor, ultrices ut, elementum vulputate,
+                nunc.
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div style="text-align: center; margin-top: 1rem">
+          <calcite-button id="replay-m" appearance="transparent" icon="refresh">Replay</calcite-button>
+        </div>
+      </div>
     </div>
+    <script>
+      (function () {
+        const scrim = document.querySelector("#scrim-determinate");
+        const determinateLoaderMedium = document.querySelector("#loader-determinate-m");
+        const randoms = [0, 0, 0, 0, 0, 0, 1, 3];
+        function updateLoader() {
+          const random = randoms[Math.floor(Math.random() * randoms.length)];
+          determinateLoaderMedium.value = Math.min(determinateLoaderMedium.value + random, 100);
+          if (determinateLoaderMedium.value !== 100) {
+            requestAnimationFrame(updateLoader);
+          } else {
+            scrim.setAttribute("hidden", "true");
+          }
+        }
+
+        updateLoader();
+
+        document.querySelector("#replay-m").addEventListener("click", function () {
+          cancelAnimationFrame(updateLoader);
+          determinateLoaderMedium.value = 0;
+          scrim.removeAttribute("hidden");
+          updateLoader();
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/demos/calcite-scrim.html
+++ b/src/demos/calcite-scrim.html
@@ -135,12 +135,12 @@
       <!-- scrim with content in default slot-->
       <div class="child">
         Determinate loader in default slot<br />(Scrim hiding is scripted.)
-        <div style="margin: 1rem 0">
-          <calcite-button id="replay-m" appearance="outline" icon-start="refresh" scale="m"
-            >Replay loader</calcite-button
-          >
-        </div>
         <div tabindex="0" style="position: relative; width: 400px; height: 400px; padding: 25px">
+          <div style="margin: 1rem 0">
+            <calcite-button id="replay-m" appearance="outline" width="full" icon-start="refresh" scale="m"
+              >Replay loader</calcite-button
+            >
+          </div>
           <calcite-scrim id="scrim-determinate">
             <calcite-loader
               label="loading"
@@ -152,6 +152,7 @@
               scale="m"
             >
             </calcite-loader>
+            <calcite-button width="full" icon-start="x" id="cancel-load">Cancel</calcite-button>
           </calcite-scrim>
           <div style="width: 400px; height: 400px; overflow: auto">
             <p>
@@ -236,6 +237,11 @@
           determinateLoaderMedium.value = 0;
           scrim.removeAttribute("hidden");
           updateLoader();
+        });
+
+        document.querySelector("#cancel-load").addEventListener("click", function () {
+          cancelAnimationFrame(updateLoader);
+          scrim.setAttribute("hidden", "true");
         });
       })();
     </script>


### PR DESCRIPTION
**Related Issue:** #2801

## Summary
* updates render to include default slot
* updates tests
* updates scrim bg color per @bstifle 


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
