### PR TITLE
docs(color-picker): add usage examples

### DIFF
--- a/src/components/calcite-color-picker/readme.md
+++ b/src/components/calcite-color-picker/readme.md
@@ -7,7 +7,7 @@
 ### Basic
 
 ```html
-<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default" />
+<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default"></calcite-color-picker>
 ```
 
 ### Minimal
@@ -15,7 +15,7 @@
 For a minimal design, you can hide unused color formats and options:
 
 ```html
-<calcite-color-picker appearance="minimal" value="" allow-empty hide-saved hide-channels />
+<calcite-color-picker appearance="minimal" value="" allow-empty hide-saved hide-channels></calcite-color-picker>
 ```
 
 ## Properties

--- a/src/components/calcite-color-picker/readme.md
+++ b/src/components/calcite-color-picker/readme.md
@@ -7,7 +7,7 @@
 ### Basic
 
 ```html
-<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default"></calcite-color-picker>
+<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default" />
 ```
 
 ### Minimal
@@ -15,14 +15,7 @@
 For a minimal design, you can hide unused color formats and options:
 
 ```html
-<calcite-color-picker
-  appearance="minimal"
-  allow-empty=""
-  value=""
-  hide-saved="true"
-  hide-channels="true"
-  hide-hex="false"
-/>
+<calcite-color-picker appearance="minimal" value="" allow-empty hide-saved hide-channels />
 ```
 
 ## Properties

--- a/src/components/calcite-color-picker/readme.md
+++ b/src/components/calcite-color-picker/readme.md
@@ -2,6 +2,29 @@
 
 <!-- Auto Generated Below -->
 
+## Usage
+
+### Basic
+
+```html
+<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default"></calcite-color-picker>
+```
+
+### Minimal
+
+For a minimal design, you can hide unused color formats and options:
+
+```html
+<calcite-color-picker
+  appearance="minimal"
+  allow-empty=""
+  value=""
+  hide-saved="true"
+  hide-channels="true"
+  hide-hex="false"
+/>
+```
+
 ## Properties
 
 | Property          | Attribute           | Description                                                                                                                                                                                                                                     | Type                                                                                                                                       | Default            |

--- a/src/components/calcite-color-picker/usage/Basic.md
+++ b/src/components/calcite-color-picker/usage/Basic.md
@@ -1,0 +1,3 @@
+```html
+<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default"></calcite-color-picker>
+```

--- a/src/components/calcite-color-picker/usage/Basic.md
+++ b/src/components/calcite-color-picker/usage/Basic.md
@@ -1,3 +1,3 @@
 ```html
-<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default" />
+<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default"></calcite-color-picker>
 ```

--- a/src/components/calcite-color-picker/usage/Basic.md
+++ b/src/components/calcite-color-picker/usage/Basic.md
@@ -1,3 +1,3 @@
 ```html
-<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default"></calcite-color-picker>
+<calcite-color-picker dir="ltr" scale="m" value="#b33f33" appearance="default" />
 ```

--- a/src/components/calcite-color-picker/usage/Minimal.md
+++ b/src/components/calcite-color-picker/usage/Minimal.md
@@ -1,12 +1,5 @@
 For a minimal design, you can hide unused color formats and options:
 
 ```html
-<calcite-color-picker
-  appearance="minimal"
-  allow-empty=""
-  value=""
-  hide-saved="true"
-  hide-channels="true"
-  hide-hex="false"
-/>
+<calcite-color-picker appearance="minimal" value="" allow-empty hide-saved hide-channels />
 ```

--- a/src/components/calcite-color-picker/usage/Minimal.md
+++ b/src/components/calcite-color-picker/usage/Minimal.md
@@ -1,5 +1,5 @@
 For a minimal design, you can hide unused color formats and options:
 
 ```html
-<calcite-color-picker appearance="minimal" value="" allow-empty hide-saved hide-channels />
+<calcite-color-picker appearance="minimal" value="" allow-empty hide-saved hide-channels></calcite-color-picker>
 ```

--- a/src/components/calcite-color-picker/usage/Minimal.md
+++ b/src/components/calcite-color-picker/usage/Minimal.md
@@ -1,0 +1,12 @@
+For a minimal design, you can hide unused color formats and options:
+
+```html
+<calcite-color-picker
+  appearance="minimal"
+  allow-empty=""
+  value=""
+  hide-saved="true"
+  hide-channels="true"
+  hide-hex="false"
+/>
+```


### PR DESCRIPTION
**Related Issue:** #
- #2492 

## Summary
Add usage examples for the calcite-color-picker documentation.