### PR TITLE
refactor: add types to EventEmitter definitions

### DIFF
--- a/BOILERPLATE_COMPONENT.md
+++ b/BOILERPLATE_COMPONENT.md
@@ -70,7 +70,7 @@ export class CalciteExample {
   // --------------------------------------------------------------------------
 
   @Event()
-  calciteExampleEvent: EventEmitter;
+  calciteExampleEvent: EventEmitter<string>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -54,22 +54,30 @@ export class CalciteAccordionItem {
   /**
    * @internal
    */
-  @Event() calciteAccordionItemKeyEvent: EventEmitter;
+  @Event() calciteAccordionItemKeyEvent: EventEmitter<{
+    parent: HTMLCalciteAccordionElement;
+    item: KeyboardEvent;
+  }>;
 
   /**
    * @internal
    */
-  @Event() calciteAccordionItemSelect: EventEmitter;
+  @Event() calciteAccordionItemSelect: EventEmitter<{
+    requestedAccordionItem: HTMLCalciteAccordionItemElement;
+  }>;
 
   /**
    * @internal
    */
-  @Event() calciteAccordionItemClose: EventEmitter;
+  @Event() calciteAccordionItemClose: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteAccordionItemRegister: EventEmitter;
+  @Event() calciteAccordionItemRegister: EventEmitter<{
+    parent: HTMLCalciteAccordionElement;
+    position: number;
+  }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -48,7 +48,9 @@ export class CalciteAccordion {
   /**
    * @internal
    */
-  @Event() calciteAccordionChange: EventEmitter;
+  @Event() calciteAccordionChange: EventEmitter<{
+    requestedAccordionItem: HTMLCalciteAccordionItemElement;
+  }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -97,7 +97,7 @@ export class CalciteActionBar {
   /**
    * Emitted when expanded has been toggled.
    */
-  @Event() calciteActionBarToggle: EventEmitter;
+  @Event() calciteActionBarToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -107,7 +107,7 @@ export class CalciteActionMenu {
   /**
    * Emitted when the open property has changed.
    */
-  @Event() calciteActionMenuOpenChange: EventEmitter;
+  @Event() calciteActionMenuOpenChange: EventEmitter<boolean>;
 
   @Listen("click", { target: "window" })
   closeCalciteActionMenuOnClick(event: Event): void {

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -87,7 +87,7 @@ export class CalciteActionPad {
   /**
    * Emitted when expanded has been toggled.
    */
-  @Event() calciteActionPadToggle: EventEmitter;
+  @Event() calciteActionPadToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -106,7 +106,7 @@ export class CalciteAction {
    * Emitted when the action has been clicked.
    * @deprecated use onClick instead.
    */
-  @Event() calciteActionClick: EventEmitter;
+  @Event() calciteActionClick: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -178,24 +178,30 @@ export class CalciteAlert {
   //--------------------------------------------------------------------------
 
   /** Fired when an alert is closed */
-  @Event() calciteAlertClose: EventEmitter;
+  @Event() calciteAlertClose: EventEmitter<{
+    el: HTMLCalciteAlertElement;
+    queue: HTMLCalciteAlertElement[];
+  }>;
 
   /** Fired when an alert is opened */
-  @Event() calciteAlertOpen: EventEmitter;
+  @Event() calciteAlertOpen: EventEmitter<{
+    el: HTMLCalciteAlertElement;
+    queue: HTMLCalciteAlertElement[];
+  }>;
 
   /**
    * Fired to sync queue when opened or closed
    *
    * @internal
    */
-  @Event() calciteAlertSync: EventEmitter;
+  @Event() calciteAlertSync: EventEmitter<{ queue: HTMLCalciteAlertElement[] }>;
 
   /**
    * Fired when an alert is added to dom - used to receive initial queue
    *
    * @internal
    */
-  @Event() calciteAlertRegister: EventEmitter;
+  @Event() calciteAlertRegister: EventEmitter<void>;
 
   // when an alert is opened or closed, update queue and determine active alert
   @Listen("calciteAlertSync", { target: "window" })

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -72,7 +72,7 @@ export class CalciteBlockSection {
   /**
    * Emitted when the header has been clicked.
    */
-  @Event() calciteBlockSectionToggle: EventEmitter;
+  @Event() calciteBlockSectionToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -105,7 +105,7 @@ export class CalciteBlock {
   /**
    * Emitted when the header has been clicked.
    */
-  @Event() calciteBlockToggle: EventEmitter;
+  @Event() calciteBlockToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-card/calcite-card.tsx
+++ b/src/components/calcite-card/calcite-card.tsx
@@ -68,7 +68,7 @@ export class CalciteCard {
   //--------------------------------------------------------------------------
 
   /** Fired when a selectable card is selected */
-  @Event() calciteCardSelect: EventEmitter;
+  @Event() calciteCardSelect: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -147,14 +147,14 @@ export class CalciteCheckbox {
   //--------------------------------------------------------------------------
 
   /** Emitted when the checkbox checked status changes */
-  @Event() calciteCheckboxChange: EventEmitter;
+  @Event() calciteCheckboxChange: EventEmitter<void>;
 
   /**
    * Emitted when the checkbox focused state changes
    *
    * @internal
    */
-  @Event() calciteCheckboxFocusedChange: EventEmitter;
+  @Event() calciteCheckboxFocusedChange: EventEmitter<boolean>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -69,7 +69,7 @@ export class CalciteChip {
   // --------------------------------------------------------------------------
 
   /** Emitted when the dismiss button is clicked */
-  @Event() calciteChipDismiss: EventEmitter;
+  @Event() calciteChipDismiss: EventEmitter<HTMLCalciteChipElement>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
+++ b/src/components/calcite-color-picker-hex-input/calcite-color-picker-hex-input.tsx
@@ -142,7 +142,7 @@ export class CalciteColorPickerHexInput {
   /**
    * Emitted when the hex value changes.
    */
-  @Event() calciteColorPickerHexInputChange: EventEmitter;
+  @Event() calciteColorPickerHexInputChange: EventEmitter<void>;
 
   private onCalciteInputBlur = (event: Event): void => {
     const node = event.currentTarget as HTMLCalciteInputElement;

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -331,14 +331,14 @@ export class CalciteColorPicker {
   /**
    * Fires when the color value has changed.
    */
-  @Event() calciteColorPickerChange: EventEmitter;
+  @Event() calciteColorPickerChange: EventEmitter<void>;
 
   /**
    * Fires as the color value changes.
    *
    * This is similar to the change event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
    */
-  @Event() calciteColorPickerInput: EventEmitter;
+  @Event() calciteColorPickerInput: EventEmitter<void>;
 
   private handleTabActivate = (event: Event): void => {
     this.channelMode = (event.currentTarget as HTMLElement).getAttribute(

--- a/src/components/calcite-combobox-item/calcite-combobox-item.tsx
+++ b/src/components/calcite-combobox-item/calcite-combobox-item.tsx
@@ -100,7 +100,7 @@ export class CalciteComboboxItem {
   /**
    * Emitted whenever the item is selected or unselected.
    */
-  @Event() calciteComboboxItemChange: EventEmitter;
+  @Event() calciteComboboxItemChange: EventEmitter<HTMLCalciteComboboxItemElement>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -190,19 +190,19 @@ export class CalciteCombobox {
   }>;
 
   /** Called when a selected item in the combobox is dismissed via its chip **/
-  @Event() calciteComboboxChipDismiss: EventEmitter;
+  @Event() calciteComboboxChipDismiss: EventEmitter<HTMLCalciteChipElement>;
 
   /**
    * Fired when the combobox is opened
    * @internal
    */
-  @Event() calciteComboboxOpen: EventEmitter;
+  @Event() calciteComboboxOpen: EventEmitter<void>;
 
   /**
    *  Fired when the combobox is closed
    * @internal
    */
-  @Event() calciteComboboxClose: EventEmitter;
+  @Event() calciteComboboxClose: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-date-picker-day/calcite-date-picker-day.tsx
+++ b/src/components/calcite-date-picker-day/calcite-date-picker-day.tsx
@@ -107,13 +107,13 @@ export class CalciteDatePickerDay {
   /**
    * Emitted when user selects day
    */
-  @Event() calciteDaySelect: EventEmitter;
+  @Event() calciteDaySelect: EventEmitter<void>;
 
   /**
    * Emitted when user hovers over a day
    * @internal
    */
-  @Event() calciteDayHover: EventEmitter;
+  @Event() calciteDayHover: EventEmitter<{ disabled: boolean }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-date-picker-month/calcite-date-picker-month.tsx
+++ b/src/components/calcite-date-picker-month/calcite-date-picker-month.tsx
@@ -74,23 +74,23 @@ export class CalciteDatePickerMonth {
   /**
    * Event emitted when user selects the date.
    */
-  @Event() calciteDatePickerSelect: EventEmitter;
+  @Event() calciteDatePickerSelect: EventEmitter<Date>;
 
   /**
    * Event emitted when user hovers the date.
    * @internal
    */
-  @Event() calciteDatePickerHover: EventEmitter;
+  @Event() calciteDatePickerHover: EventEmitter<Date>;
 
   /**
    * Active date for the user keyboard access.
    */
-  @Event() calciteDatePickerActiveDateChange: EventEmitter;
+  @Event() calciteDatePickerActiveDateChange: EventEmitter<Date>;
 
   /**
    * @internal
    */
-  @Event() calciteDatePickerMouseOut: EventEmitter;
+  @Event() calciteDatePickerMouseOut: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
+++ b/src/components/calcite-dropdown-group/calcite-dropdown-group.tsx
@@ -54,7 +54,10 @@ export class CalciteDropdownGroup {
   /**
    * @internal
    */
-  @Event() calciteDropdownItemChange: EventEmitter;
+  @Event() calciteDropdownItemChange: EventEmitter<{
+    requestedDropdownItem: HTMLCalciteDropdownItemElement;
+    requestedDropdownGroup: HTMLCalciteDropdownGroupElement;
+  }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.tsx
@@ -70,13 +70,16 @@ export class CalciteDropdownItem {
   /**
    * @internal
    */
-  @Event() calciteDropdownItemSelect: EventEmitter;
+  @Event() calciteDropdownItemSelect: EventEmitter<{
+    requestedDropdownItem: HTMLCalciteDropdownItemElement;
+    requestedDropdownGroup: HTMLCalciteDropdownGroupElement;
+  }>;
 
   /** @internal */
   @Event() calciteDropdownItemKeyEvent: EventEmitter<ItemKeyboardEvent>;
 
   /** @internal */
-  @Event() calciteDropdownCloseRequest: EventEmitter;
+  @Event() calciteDropdownCloseRequest: EventEmitter<void>;
   //--------------------------------------------------------------------------
   //
   //  Public Methods

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -76,7 +76,7 @@ export class CalciteFilter {
   /**
    * This event fires when the filter text changes.
    */
-  @Event() calciteFilterChange: EventEmitter;
+  @Event() calciteFilterChange: EventEmitter<object[]>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-handle/calcite-handle.tsx
+++ b/src/components/calcite-handle/calcite-handle.tsx
@@ -42,7 +42,10 @@ export class CalciteHandle {
   /**
    * Emitted when the the handle is activated and the up or down arrow key is pressed.
    */
-  @Event() calciteHandleNudge: EventEmitter;
+  @Event() calciteHandleNudge: EventEmitter<{
+    handle: HTMLCalciteHandleElement;
+    direction: string;
+  }>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -158,17 +158,17 @@ export class CalciteInlineEditable {
   /**
    * @internal
    */
-  @Event() calciteInlineEditableEditingCancel: EventEmitter;
+  @Event() calciteInlineEditableEditingCancel: EventEmitter<TransitionEvent>;
 
   /**
    * @internal
    */
-  @Event() calciteInlineEditableChangesConfirm: EventEmitter;
+  @Event() calciteInlineEditableChangesConfirm: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInlineEditableEnableEditingChange: EventEmitter;
+  @Event() calciteInlineEditableEnableEditingChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -153,12 +153,12 @@ export class CalciteInputDatePicker {
   /**
    * @internal
    */
-  @Event() calciteInputDatePickerOpen: EventEmitter;
+  @Event() calciteInputDatePickerOpen: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInputDatePickerClose: EventEmitter;
+  @Event() calciteInputDatePickerClose: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -323,23 +323,33 @@ export class CalciteInput {
   /**
    * @internal
    */
-  @Event() calciteInputFocus: EventEmitter;
+  @Event() calciteInputFocus: EventEmitter<{
+    element: HTMLInputElement | HTMLTextAreaElement;
+    value: string;
+  }>;
 
   /**
    * @internal
    */
-  @Event() calciteInputBlur: EventEmitter;
+  @Event() calciteInputBlur: EventEmitter<{
+    element: HTMLInputElement | HTMLTextAreaElement;
+    value: string;
+  }>;
 
   /**
    * This event fires each time a new value is typed.
    */
-  @Event({ cancelable: true }) calciteInputInput: EventEmitter;
+  @Event({ cancelable: true }) calciteInputInput: EventEmitter<{
+    element: HTMLInputElement | HTMLTextAreaElement;
+    value: string;
+    nativeEvent: any;
+  }>;
 
   /**
    * This event fires each time a new value is typed and committed.
    * @internal
    */
-  @Event() calciteInputChange: EventEmitter;
+  @Event() calciteInputChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -260,10 +260,10 @@ export class CalciteModal {
   //
   //--------------------------------------------------------------------------
   /** Fired when the modal begins the open animation */
-  @Event() calciteModalOpen: EventEmitter;
+  @Event() calciteModalOpen: EventEmitter<void>;
 
   /** Fired when the modal begins the close animation */
-  @Event() calciteModalClose: EventEmitter;
+  @Event() calciteModalClose: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -138,10 +138,10 @@ export class CalciteNotice {
   //--------------------------------------------------------------------------
 
   /** Fired when an notice is closed */
-  @Event() calciteNoticeClose: EventEmitter;
+  @Event() calciteNoticeClose: EventEmitter<void>;
 
   /** Fired when an Notice is opened */
-  @Event() calciteNoticeOpen: EventEmitter;
+  @Event() calciteNoticeOpen: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-option-group/calcite-option-group.tsx
+++ b/src/components/calcite-option-group/calcite-option-group.tsx
@@ -41,8 +41,7 @@ export class CalciteOptionGroup {
   /**
    * @internal
    */
-  @Event()
-  private calciteOptionGroupChange: EventEmitter;
+  @Event() private calciteOptionGroupChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-option/calcite-option.tsx
+++ b/src/components/calcite-option/calcite-option.tsx
@@ -79,8 +79,7 @@ export class CalciteOption {
   /**
    * @internal
    */
-  @Event()
-  private calciteOptionChange: EventEmitter;
+  @Event() private calciteOptionChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -141,17 +141,17 @@ export class CalcitePanel {
   /**
    * Emitted when the close button has been clicked.
    */
-  @Event() calcitePanelDismissedChange: EventEmitter;
+  @Event() calcitePanelDismissedChange: EventEmitter<void>;
 
   /**
    * Emitted when the content has been scrolled.
    */
-  @Event() calcitePanelScroll: EventEmitter;
+  @Event() calcitePanelScroll: EventEmitter<void>;
 
   /**
    * Emitted when the back button has been clicked.
    */
-  @Event() calcitePanelBackClick: EventEmitter;
+  @Event() calcitePanelBackClick: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -135,7 +135,9 @@ export class CalcitePickList<
   /**
    * Emitted when any of the item selections have changed.
    */
-  @Event() calciteListChange: EventEmitter;
+  @Event() calciteListChange: EventEmitter<
+    Map<string, HTMLCalcitePickListItemElement> | Map<string, HTMLCalciteValueListItemElement>
+  >;
 
   @Listen("calciteListItemRemove")
   calciteListItemRemoveHandler(event: CustomEvent<void>): void {

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -195,10 +195,10 @@ export class CalcitePopover {
   //
   //--------------------------------------------------------------------------
   /** Fired when the popover is closed */
-  @Event() calcitePopoverClose: EventEmitter;
+  @Event() calcitePopoverClose: EventEmitter<void>;
 
   /** Fired when the popover is opened */
-  @Event() calcitePopoverOpen: EventEmitter;
+  @Event() calcitePopoverOpen: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.tsx
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.tsx
@@ -108,7 +108,7 @@ export class CalciteRadioButtonGroup {
   /**
    * @todo doc
    */
-  @Event() calciteRadioButtonGroupChange: EventEmitter;
+  @Event() calciteRadioButtonGroupChange: EventEmitter<any>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -231,20 +231,20 @@ export class CalciteRadioButton {
    * directly on the element, but instead either attach it to a node that contains all of the radio buttons in the group
    * or use the calciteRadioButtonGroupChange event if using this with calcite-radio-button-group.
    */
-  @Event() calciteRadioButtonChange: EventEmitter;
+  @Event() calciteRadioButtonChange: EventEmitter<void>;
 
   /**
    * Fires when the checked property changes.  This is an internal event used for styling purposes only.
    * Use calciteRadioButtonChange or calciteRadioButtonGroupChange for responding to changes in the checked value for forms.
    * @internal
    */
-  @Event() calciteRadioButtonCheckedChange: EventEmitter;
+  @Event() calciteRadioButtonCheckedChange: EventEmitter<boolean | undefined>;
 
   /**
    * Fires when the radio button is either focused or blurred.
    * @internal
    */
-  @Event() calciteRadioButtonFocusedChange: EventEmitter;
+  @Event() calciteRadioButtonFocusedChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -138,8 +138,7 @@ export class CalciteRadioGroupItem {
    * Fires when the item has been selected.
    * @internal
    */
-  @Event()
-  calciteRadioGroupItemChange: EventEmitter;
+  @Event() calciteRadioGroupItemChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -76,7 +76,7 @@ export class CalciteShellPanel {
   /**
    * Emitted when collapse has been toggled.
    */
-  @Event() calciteShellPanelToggle: EventEmitter;
+  @Event() calciteShellPanelToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -757,7 +757,7 @@ export class CalciteSlider {
    * expensive operations consider using a debounce or throttle to avoid
    * locking up the main thread.
    */
-  @Event() calciteSliderChange: EventEmitter;
+  @Event() calciteSliderChange: EventEmitter<void>;
 
   /**
    * Fires on all updates to the slider.
@@ -766,7 +766,7 @@ export class CalciteSlider {
    * locking up the main thread.
    * @deprecated use calciteSliderChange instead
    */
-  @Event() calciteSliderUpdate: EventEmitter;
+  @Event() calciteSliderUpdate: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-sortable-list/calcite-sortable-list.tsx
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.tsx
@@ -98,7 +98,7 @@ export class CalciteSortableList {
   /**
    * Emitted when the order of the list has changed.
    */
-  @Event() calciteListOrderChange: EventEmitter;
+  @Event() calciteListOrderChange: EventEmitter<void>;
 
   @Listen("calciteHandleNudge")
   calciteHandleNudgeHandler(event: CustomEvent): void {

--- a/src/components/calcite-split-button/calcite-split-button.tsx
+++ b/src/components/calcite-split-button/calcite-split-button.tsx
@@ -59,10 +59,10 @@ export class CalciteSplitButton {
   @Prop({ reflect: true }) width: Width = "auto";
 
   /** fired when the primary button is clicked */
-  @Event() calciteSplitButtonPrimaryClick: EventEmitter;
+  @Event() calciteSplitButtonPrimaryClick: EventEmitter<MouseEvent>;
 
   /** fired when the secondary button is clicked */
-  @Event() calciteSplitButtonSecondaryClick: EventEmitter;
+  @Event() calciteSplitButtonSecondaryClick: EventEmitter<MouseEvent>;
 
   render(): VNode {
     const dir = getElementDir(this.el);

--- a/src/components/calcite-stepper-item/calcite-stepper-item.tsx
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.tsx
@@ -84,17 +84,23 @@ export class CalciteStepperItem {
   /**
    * @internal
    */
-  @Event() calciteStepperItemKeyEvent: EventEmitter;
+  @Event() calciteStepperItemKeyEvent: EventEmitter<{ item: KeyboardEvent }>;
 
   /**
    * @internal
    */
-  @Event() calciteStepperItemSelect: EventEmitter;
+  @Event() calciteStepperItemSelect: EventEmitter<{
+    position: number;
+    content: HTMLElement[] | NodeListOf<any>;
+  }>;
 
   /**
    * @internal
    */
-  @Event() calciteStepperItemRegister: EventEmitter;
+  @Event() calciteStepperItemRegister: EventEmitter<{
+    position: number;
+    content: HTMLElement[] | NodeListOf<any>;
+  }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-stepper/calcite-stepper.tsx
+++ b/src/components/calcite-stepper/calcite-stepper.tsx
@@ -68,7 +68,7 @@ export class CalciteStepper {
    * This event fires when the active stepper item has changed.
    * @internal
    */
-  @Event() calciteStepperItemChange: EventEmitter;
+  @Event() calciteStepperItemChange: EventEmitter<{ position: number }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -134,7 +134,7 @@ export class CalciteSwitch {
   /**
    * Fires when the switched value has changed.
    */
-  @Event() calciteSwitchChange: EventEmitter;
+  @Event() calciteSwitchChange: EventEmitter<{ switched: boolean }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -244,12 +244,12 @@ export class CalciteTabTitle {
   /**
    * @internal
    */
-  @Event() calciteTabsFocusNext: EventEmitter;
+  @Event() calciteTabsFocusNext: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteTabsFocusPrevious: EventEmitter;
+  @Event() calciteTabsFocusPrevious: EventEmitter<void>;
 
   /**
    * @internal

--- a/src/components/calcite-tab/calcite-tab.tsx
+++ b/src/components/calcite-tab/calcite-tab.tsx
@@ -99,7 +99,7 @@ export class CalciteTab {
   /**
    * @internal
    */
-  @Event() calciteTabRegister: EventEmitter;
+  @Event() calciteTabRegister: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -141,7 +141,7 @@ export class CalciteTipManager {
   /**
    * Emitted when the `calcite-tip-manager` has been toggled open or closed.
    */
-  @Event() calciteTipManagerToggle: EventEmitter;
+  @Event() calciteTipManagerToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -64,7 +64,7 @@ export class CalciteTip {
   /**
    * Emitted when the component has been dismissed.
    */
-  @Event() calciteTipDismiss: EventEmitter;
+  @Event() calciteTipDismiss: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -149,12 +149,14 @@ export class CalciteValueList<
   /**
    * Emitted when any of the item selections have changed.
    */
-  @Event() calciteListChange: EventEmitter;
+  @Event() calciteListChange: EventEmitter<
+    Map<string, HTMLCalcitePickListItemElement> | Map<string, HTMLCalciteValueListItemElement>
+  >;
 
   /**
    * Emitted when the order of the list has changed.
    */
-  @Event() calciteListOrderChange: EventEmitter;
+  @Event() calciteListOrderChange: EventEmitter<any[]>;
 
   @Listen("calciteListItemRemove")
   calciteListItemRemoveHandler(event: CustomEvent<void>): void {


### PR DESCRIPTION
**Related Issue:** #2854 

## Summary
Previously, event emitters were not defined with a type argument, which caused them to autocast to `EventEmitter<any>`. This PR contains EventEmitter definitions with strict types to maintain types through the emit() function.

All types are based on the arguments currently being passed to emit(). There are no changes in functionality, just passing along types through the events instead of using `any`
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
