### PR TITLE
fix(color-picker): fix value for empty color-picker with different initial format

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -255,6 +255,25 @@ describe("calcite-color-picker", () => {
     hsv: { h: 0, s: 0, v: 100 }
   };
 
+  const clearAndEnterHexOrChannelValue = async (
+    page: E2EPage,
+    channelInputOrHexInput: E2EElement,
+    value: string
+  ): Promise<void> => {
+    await channelInputOrHexInput.callMethod("setFocus");
+    await selectText(channelInputOrHexInput);
+
+    const currentValue = await channelInputOrHexInput.getProperty("value");
+
+    for (let i = 0; i < currentValue?.length; i++) {
+      await page.keyboard.press("Backspace");
+    }
+
+    await channelInputOrHexInput.type(value);
+    await page.keyboard.press("Enter");
+    await page.waitForChanges();
+  };
+
   describe("color format", () => {
     describe("when set initially", () => {
       let page: E2EPage;
@@ -615,21 +634,6 @@ describe("calcite-color-picker", () => {
   });
 
   describe("color inputs", () => {
-    const clearAndEnterValue = async (page: E2EPage, inputOrHexInput: E2EElement, value: string): Promise<void> => {
-      await inputOrHexInput.callMethod("setFocus");
-      await selectText(inputOrHexInput);
-
-      const currentValue = await inputOrHexInput.getProperty("value");
-
-      for (let i = 0; i < currentValue.length; i++) {
-        await page.keyboard.press("Backspace");
-      }
-
-      await inputOrHexInput.type(value);
-      await page.keyboard.press("Enter");
-      await page.waitForChanges();
-    };
-
     describe("keeps value in same format when applying updates", () => {
       let page: E2EPage;
       let picker: E2EElement;
@@ -644,7 +648,7 @@ describe("calcite-color-picker", () => {
       const updateColorWithAllInputs = async (assertColorUpdate: (value: ColorValue) => void): Promise<void> => {
         const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
-        await clearAndEnterValue(page, hexInput, "abc");
+        await clearAndEnterHexOrChannelValue(page, hexInput, "abc");
 
         assertColorUpdate(await picker.getProperty("value"));
 
@@ -655,17 +659,17 @@ describe("calcite-color-picker", () => {
 
         await rgbModeButton.click();
 
-        await clearAndEnterValue(page, rInput, "128");
-        await clearAndEnterValue(page, gInput, "64");
-        await clearAndEnterValue(page, bInput, "32");
+        await clearAndEnterHexOrChannelValue(page, rInput, "128");
+        await clearAndEnterHexOrChannelValue(page, gInput, "64");
+        await clearAndEnterHexOrChannelValue(page, bInput, "32");
 
         assertColorUpdate(await picker.getProperty("value"));
 
         await hsvModeButton.click();
 
-        await clearAndEnterValue(page, hInput, "180");
-        await clearAndEnterValue(page, sInput, "90");
-        await clearAndEnterValue(page, vInput, "45");
+        await clearAndEnterHexOrChannelValue(page, hInput, "180");
+        await clearAndEnterHexOrChannelValue(page, sInput, "90");
+        await clearAndEnterHexOrChannelValue(page, vInput, "45");
 
         assertColorUpdate(await picker.getProperty("value"));
       };
@@ -798,7 +802,7 @@ describe("calcite-color-picker", () => {
           const picker = await page.find("calcite-color-picker");
 
           const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
-          await clearAndEnterValue(page, hexInput, "abc");
+          await clearAndEnterHexOrChannelValue(page, hexInput, "abc");
 
           expect(await picker.getProperty("value")).toBe("#aabbcc");
 
@@ -809,17 +813,17 @@ describe("calcite-color-picker", () => {
 
           await rgbModeButton.click();
 
-          await clearAndEnterValue(page, rInput, "128");
-          await clearAndEnterValue(page, gInput, "64");
-          await clearAndEnterValue(page, bInput, "32");
+          await clearAndEnterHexOrChannelValue(page, rInput, "128");
+          await clearAndEnterHexOrChannelValue(page, gInput, "64");
+          await clearAndEnterHexOrChannelValue(page, bInput, "32");
 
           expect(await picker.getProperty("value")).toBe("#804020");
 
           await hsvModeButton.click();
 
-          await clearAndEnterValue(page, hInput, "180");
-          await clearAndEnterValue(page, sInput, "90");
-          await clearAndEnterValue(page, vInput, "45");
+          await clearAndEnterHexOrChannelValue(page, hInput, "180");
+          await clearAndEnterHexOrChannelValue(page, sInput, "90");
+          await clearAndEnterHexOrChannelValue(page, vInput, "45");
 
           expect(await picker.getProperty("value")).toBe("#0b7373");
         });
@@ -905,7 +909,7 @@ describe("calcite-color-picker", () => {
             const picker = await page.find("calcite-color-picker");
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
-            await clearAndEnterValue(page, hexInput, "");
+            await clearAndEnterHexOrChannelValue(page, hexInput, "");
 
             expect(await picker.getProperty("value")).toBe(null);
           });
@@ -923,7 +927,7 @@ describe("calcite-color-picker", () => {
 
             await rgbModeButton.click();
 
-            await clearAndEnterValue(page, rInput, "");
+            await clearAndEnterHexOrChannelValue(page, rInput, "");
 
             // clearing one clears the rest
             expect(await gInput.getProperty("value")).toBeUndefined();
@@ -946,7 +950,7 @@ describe("calcite-color-picker", () => {
 
             await hsvModeButton.click();
 
-            await clearAndEnterValue(page, hInput, "");
+            await clearAndEnterHexOrChannelValue(page, hInput, "");
 
             // clearing one clears the rest
             expect(await sInput.getProperty("value")).toBeUndefined();
@@ -962,7 +966,7 @@ describe("calcite-color-picker", () => {
 
           const assertChannelValueNudge = async (page: E2EPage, calciteInput: E2EElement): Promise<void> => {
             await calciteInput.callMethod("setFocus");
-            await clearAndEnterValue(page, calciteInput, "");
+            await clearAndEnterHexOrChannelValue(page, calciteInput, "");
 
             // using page.waitForChanges as keyboard nudges occur in the next frame
 
@@ -970,13 +974,13 @@ describe("calcite-color-picker", () => {
             await page.waitForChanges();
             expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
 
-            await clearAndEnterValue(page, calciteInput, "");
+            await clearAndEnterHexOrChannelValue(page, calciteInput, "");
 
             await page.keyboard.press("ArrowDown");
             await page.waitForChanges();
             expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
 
-            await clearAndEnterValue(page, calciteInput, "");
+            await clearAndEnterHexOrChannelValue(page, calciteInput, "");
 
             await page.keyboard.down("Shift");
             await page.keyboard.press("ArrowUp");
@@ -984,7 +988,7 @@ describe("calcite-color-picker", () => {
             await page.waitForChanges();
             expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
 
-            await clearAndEnterValue(page, calciteInput, "");
+            await clearAndEnterHexOrChannelValue(page, calciteInput, "");
 
             await page.keyboard.down("Shift");
             await page.keyboard.press("ArrowDown");
@@ -1013,6 +1017,18 @@ describe("calcite-color-picker", () => {
           await assertChannelValueNudge(page, hInput);
           await assertChannelValueNudge(page, sInput);
           await assertChannelValueNudge(page, vInput);
+        });
+
+        it("changes the value to the specified format after being empty", async () => {
+          const page = await newE2EPage({
+            html: "<calcite-color-picker allow-empty value='' format='rgb'></calcite-color-picker>"
+          });
+          const color = await page.find("calcite-color-picker");
+
+          const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
+          await clearAndEnterHexOrChannelValue(page, hexInput, supportedFormatToSampleValue.hex);
+
+          expect(await color.getProperty("value")).toEqual(supportedFormatToSampleValue.rgb);
         });
       });
     });

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -96,7 +96,7 @@ export class CalciteColorPicker {
 
   @Watch("format")
   handleFormatChange(format: CalciteColorPicker["format"]): void {
-    this.mode = format === "auto" ? this.mode : format;
+    this.setMode(format);
     this.value = this.toValue(this.color);
   }
 
@@ -248,7 +248,7 @@ export class CalciteColorPicker {
       }
 
       modeChanged = this.mode !== nextMode;
-      this.mode = nextMode;
+      this.setMode(nextMode);
     }
 
     const dragging = this.sliderThumbState === "drag" || this.hueThumbState === "drag";
@@ -693,9 +693,11 @@ export class CalciteColorPicker {
   connectedCallback(): void {
     const { color, format, value } = this;
 
-    const initialValueDefault = format !== "auto" ? this.toValue(color, format) : defaultValue;
-    const initialValue = format !== "auto" && value === defaultValue ? initialValueDefault : value;
+    // format is user set
+    const initialValueDefault = format === "auto" ? defaultValue : this.toValue(color, format);
+    const initialValue = format === "auto" || value === defaultValue ? value : initialValueDefault;
 
+    this.setMode(format);
     this.handleValueChange(initialValue, initialValueDefault);
 
     this.updateDimensions(this.scale);
@@ -965,6 +967,10 @@ export class CalciteColorPicker {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private setMode(format: CalciteColorPicker["format"]): void {
+    this.mode = format === "auto" ? this.mode : format;
+  }
 
   private captureHueSliderColor(x: number): void {
     const {


### PR DESCRIPTION
**Related Issue:** #2853 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a bug where the internal mode was not set properly when a user set an initial format, which would prevent the `value` prop from being updated.
