### PR TITLE
feat(tile): add content-start/content-end slots

### DIFF
--- a/src/components/calcite-tile/calcite-tile.e2e.ts
+++ b/src/components/calcite-tile/calcite-tile.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, hidden, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, reflects, renders, slots } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
+import { SLOTS } from "./resources";
 
 describe("calcite-tile", () => {
   it("renders", async () => renders("calcite-tile", { display: "inline-block" }));
@@ -14,6 +15,8 @@ describe("calcite-tile", () => {
       { propertyName: "focused", defaultValue: false },
       { propertyName: "hidden", defaultValue: false }
     ]));
+
+  it("has slots", async () => slots("calcite-tile", SLOTS));
 
   it("reflects", async () =>
     reflects("calcite-tile", [

--- a/src/components/calcite-tile/calcite-tile.scss
+++ b/src/components/calcite-tile/calcite-tile.scss
@@ -26,6 +26,10 @@
   @apply pointer-events-none;
 }
 
+.container {
+  @apply flex items-center gap-2;
+}
+
 .tile {
   @apply grid
     grid-cols-1

--- a/src/components/calcite-tile/calcite-tile.scss
+++ b/src/components/calcite-tile/calcite-tile.scss
@@ -27,14 +27,18 @@
 }
 
 .container {
-  @apply flex flex-col items-start;
+  @apply grid
+  grid-cols-1
+  gap-2
+  pointer-events-none;
 }
 
 .content {
   @apply justify-center
   flex
   flex-auto
-  flex-col;
+  flex-col
+  gap-2;
 }
 
 .content-container {
@@ -58,12 +62,6 @@
   }
 }
 
-.tile {
-  @apply grid
-    grid-cols-1
-    gap-2
-    pointer-events-none;
-}
 .heading {
   @apply text--1-wrap
     text-color-2
@@ -78,7 +76,7 @@
   .icon {
     @apply self-end;
   }
-  .heading {
+  .content-container {
     @apply self-center;
   }
 }

--- a/src/components/calcite-tile/calcite-tile.scss
+++ b/src/components/calcite-tile/calcite-tile.scss
@@ -27,7 +27,35 @@
 }
 
 .container {
-  @apply flex items-center gap-2;
+  @apply flex flex-col items-start;
+}
+
+.content {
+  @apply justify-center
+  flex
+  flex-auto
+  flex-col;
+}
+
+.content-container {
+  @apply flex
+  flex-auto
+  focus-base
+  items-stretch
+  p-0
+  text-color-2;
+}
+
+.content-slot-container {
+  @apply flex items-center bg-foreground-1;
+
+  &:first-child {
+    @apply pr-3;
+  }
+
+  &:last-child {
+    @apply pl-3;
+  }
 }
 
 .tile {

--- a/src/components/calcite-tile/calcite-tile.stories.ts
+++ b/src/components/calcite-tile/calcite-tile.stories.ts
@@ -65,3 +65,16 @@ export const RTL = (): string => html`
   >
   </calcite-tile>
 `;
+
+export const LargeTile = (): string => html`
+  <calcite-tile
+    ${boolean("active", false)}
+    description=""
+    heading="${text("heading", "Tile heading lorem ipsum!")}"
+    ${boolean("disabled", false)}
+    ${boolean("hidden", false)}
+    href="${text("href", "#")}"
+    icon="${select("icon", iconNames, "layer")}"
+  >
+  </calcite-tile>
+`;

--- a/src/components/calcite-tile/calcite-tile.tsx
+++ b/src/components/calcite-tile/calcite-tile.tsx
@@ -75,14 +75,12 @@ export class CalciteTile {
       : undefined;
 
     return (
-      <div class="container">
-        <div class={{ "large-visual": isLargeVisual, tile: true }}>
-          {icon && (
-            <div class="icon">
-              <calcite-icon icon={icon} scale="l" style={iconStyle} />
-            </div>
-          )}
-        </div>
+      <div class={{ container: true, "large-visual": isLargeVisual }}>
+        {icon && (
+          <div class="icon">
+            <calcite-icon icon={icon} scale="l" style={iconStyle} />
+          </div>
+        )}
         <div class="content-container">
           {getSlotted(el, SLOTS.contentStart) ? (
             <div class="content-slot-container">

--- a/src/components/calcite-tile/calcite-tile.tsx
+++ b/src/components/calcite-tile/calcite-tile.tsx
@@ -1,5 +1,6 @@
-import { Component, Fragment, h, Prop, VNode } from "@stencil/core";
+import { Component, Element, Fragment, h, Prop, VNode } from "@stencil/core";
 import { SLOTS } from "./resources";
+import { getSlotted } from "../../utils/dom";
 
 /**
  * @slot content-start - A slot for adding non-actionable elements before the tile content.
@@ -11,6 +12,14 @@ import { SLOTS } from "./resources";
   shadow: true
 })
 export class CalciteTile {
+  // --------------------------------------------------------------------------
+  //
+  //  Private Properties
+  //
+  // --------------------------------------------------------------------------
+
+  @Element() el: HTMLCalciteTileElement;
+
   //--------------------------------------------------------------------------
   //
   //  Properties
@@ -56,7 +65,7 @@ export class CalciteTile {
   // --------------------------------------------------------------------------
 
   renderTile(): VNode {
-    const { icon, heading, description } = this;
+    const { icon, el, heading, description } = this;
     const isLargeVisual = heading && icon && !description;
     const iconStyle = isLargeVisual
       ? {
@@ -67,19 +76,29 @@ export class CalciteTile {
 
     return (
       <div class="container">
-        <slot name={SLOTS.contentStart} />
         <div class={{ "large-visual": isLargeVisual, tile: true }}>
           {icon && (
             <div class="icon">
               <calcite-icon icon={icon} scale="l" style={iconStyle} />
             </div>
           )}
-          <div>
+        </div>
+        <div class="content-container">
+          {getSlotted(el, SLOTS.contentStart) ? (
+            <div class="content-slot-container">
+              <slot name={SLOTS.contentStart} />
+            </div>
+          ) : null}
+          <div class="content">
             {heading && <div class="heading">{heading}</div>}
             {description && <div class="description">{description}</div>}
           </div>
+          {getSlotted(el, SLOTS.contentEnd) ? (
+            <div class="content-slot-container">
+              <slot name={SLOTS.contentEnd} />
+            </div>
+          ) : null}
         </div>
-        <slot name={SLOTS.contentEnd} />
       </div>
     );
   }

--- a/src/components/calcite-tile/calcite-tile.tsx
+++ b/src/components/calcite-tile/calcite-tile.tsx
@@ -1,5 +1,10 @@
 import { Component, Fragment, h, Prop, VNode } from "@stencil/core";
+import { SLOTS } from "./resources";
 
+/**
+ * @slot content-start - A slot for adding non-actionable elements before the tile content.
+ * @slot content-end - A slot for adding non-actionable elements after the tile content.
+ */
 @Component({
   tag: "calcite-tile",
   styleUrl: "calcite-tile.scss",
@@ -51,22 +56,30 @@ export class CalciteTile {
   // --------------------------------------------------------------------------
 
   renderTile(): VNode {
-    const isLargeVisual = this.heading && this.icon && !this.description;
+    const { icon, heading, description } = this;
+    const isLargeVisual = heading && icon && !description;
     const iconStyle = isLargeVisual
       ? {
           height: "64px",
           width: "64px"
         }
       : undefined;
+
     return (
-      <div class={{ "large-visual": isLargeVisual, tile: true }}>
-        {this.icon && (
-          <div class="icon">
-            <calcite-icon icon={this.icon} scale="l" style={iconStyle} />
+      <div class="container">
+        <slot name={SLOTS.contentStart} />
+        <div class={{ "large-visual": isLargeVisual, tile: true }}>
+          {icon && (
+            <div class="icon">
+              <calcite-icon icon={icon} scale="l" style={iconStyle} />
+            </div>
+          )}
+          <div>
+            {heading && <div class="heading">{heading}</div>}
+            {description && <div class="description">{description}</div>}
           </div>
-        )}
-        {this.heading && <div class="heading">{this.heading}</div>}
-        {this.description && <div class="description">{this.description}</div>}
+        </div>
+        <slot name={SLOTS.contentEnd} />
       </div>
     );
   }

--- a/src/components/calcite-tile/resources.ts
+++ b/src/components/calcite-tile/resources.ts
@@ -1,0 +1,4 @@
+export const SLOTS = {
+  contentStart: "content-start",
+  contentEnd: "content-end"
+};

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -85,6 +85,23 @@
       </div>
     </div>
 
+    <!-- slots -->
+    <div class="parent">
+      <div class="child right-aligned-text">slots</div>
+
+      <div class="child">
+        <calcite-tile
+          href="/"
+          icon="layers"
+          heading="Tile title lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+        >
+          <calcite-icon slot="content-start" icon="banana"></calcite-icon>
+          <calcite-icon slot="content-end" icon="banana"></calcite-icon>
+        </calcite-tile>
+      </div>
+    </div>
+
     <!-- large visual -->
     <div class="parent">
       <div class="child right-aligned-text">large visual</div>

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -173,3 +173,34 @@ export async function focusable(componentTagOrHTML: TagOrHTML, options?: Focusab
 
   expect(await page.evaluate((selector) => document.activeElement.matches(selector), focusTargetSelector)).toBe(true);
 }
+
+/**
+ * Helper for asserting named slots.
+ *
+ * @param componentTagOrHTML - the component tag or HTML markup to test against
+ * @param slots - a component's SLOTS resource object or an array of slot names
+ */
+export async function slots(componentTagOrHTML: TagOrHTML, slots: Record<string, string> | string[]): Promise<void> {
+  const page = await simplePageSetup(componentTagOrHTML);
+  const tag = getTag(componentTagOrHTML);
+  const slotNames = Array.isArray(slots) ? slots : Object.values(slots);
+
+  const allSlotsAssigned = await page.$eval(
+    tag,
+    (component, slotNames) => {
+      return slotNames
+        .map((slot) => {
+          const el = document.createElement("div");
+          el.slot = slot;
+
+          component.append(el);
+
+          return el.assignedSlot;
+        })
+        .every((assignedSlot) => !!assignedSlot);
+    },
+    slotNames
+  );
+
+  expect(allSlotsAssigned).toBe(true);
+}


### PR DESCRIPTION
**Related Issue:** #2113 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This updates `calcite-tile` to start following the standardization of slots (content) per our [prop vs slot discussion](https://github.com/Esri/calcite-components/wiki/Property-vs-Slot) to support slotting icons.

![Screen Shot 2021-08-24 at 9 37 28 AM](https://user-images.githubusercontent.com/197440/130656058-e5f94018-6063-409f-9e1b-8f23c833b1e6.png)

@asangma Can you review the structure & spacing?

### Questions

* Story or demo page update for slots? Both? 
* Do we need to update the doc on guidance on using the slots? E.g., The `icon` prop should not be used along with a slotted icon (per https://github.com/Esri/calcite-components/issues/2113#issuecomment-866047377).
