### PR TITLE
docs(avatar, date-picker): add closing tags

### DIFF
--- a/src/components/calcite-avatar/usage/basic.md
+++ b/src/components/calcite-avatar/usage/basic.md
@@ -20,7 +20,8 @@ You can create an avatar for Ron by passing these properties directly to the ava
   user-id="a81470986eaeee1833b74b7d8abcd5b2"
   full-name="Ron Swanson"
   thumbnail="mySelf.jpg"
-/>
+>
+</calcite-avatar>
 ```
 
 When no thumbnail is provided, the avatar component will construct a useful placeholder, leveraging the user's information to construct a unique background-color with initials.

--- a/src/components/calcite-date-picker/usage/basic.md
+++ b/src/components/calcite-date-picker/usage/basic.md
@@ -1,5 +1,5 @@
 You can set a min and max range, as well as an initial value with ISO 8601 formatted strings:
 
 ```html
-<calcite-date-picker value="2020-03-27" min="2020-02-01" max="2021-01-01" />
+<calcite-date-picker value="2020-03-27" min="2020-02-01" max="2021-01-01"></calcite-date-picker>
 ```


### PR DESCRIPTION
**Related Issue:** ##2859

## Summary
Custom Elements should not be self closing, so I added closing tags to the usage examples that are.