### PR TITLE
test(date-picker): skip unstable test

### DIFF
--- a/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
@@ -121,7 +121,7 @@ describe("calcite-date-picker", () => {
   });
 
   describe("when the locale is set to Slovak calendar", () => {
-    it("should start the week on Monday", async () => {
+    it.skip("should start the week on Monday", async () => {
       const page = await newE2EPage({
         html: `<calcite-date-picker scale="m" locale="sk" value="2000-11-27"></calcite-date-picker>`
       });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

🚫  ✅ 