### PR TITLE
test(date-picker): stabilize test

### DIFF
--- a/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
@@ -126,12 +126,13 @@ describe("calcite-date-picker", () => {
         html: `<calcite-date-picker scale="m" locale="sk" value="2000-11-27"></calcite-date-picker>`
       });
       await page.waitForChanges();
-      const text: string = await page.evaluate(() => {
-        return document
-          .querySelector("calcite-date-picker")
-          .shadowRoot?.querySelector("calcite-date-picker-month")
-          .shadowRoot?.querySelector(".week-header")?.textContent;
-      });
+      const text: string = await page.evaluate(
+        () =>
+          document
+            .querySelector("calcite-date-picker")
+            .shadowRoot.querySelector("calcite-date-picker-month")
+            .shadowRoot.querySelector(".week-header").textContent
+      );
 
       expect(text).toEqual("po");
     });

--- a/src/components/calcite-date-picker/calcite-date-picker.tsx
+++ b/src/components/calcite-date-picker/calcite-date-picker.tsx
@@ -151,8 +151,6 @@ export class CalciteDatePicker {
   //
   // --------------------------------------------------------------------------
   connectedCallback(): void {
-    this.loadLocaleData();
-
     if (this.value) {
       this.valueAsDate = dateFromISO(this.value);
     }
@@ -172,6 +170,10 @@ export class CalciteDatePicker {
     if (this.max) {
       this.maxAsDate = dateFromISO(this.max);
     }
+  }
+
+  async componentWillLoad(): Promise<void> {
+    await this.loadLocaleData();
   }
 
   render(): VNode {


### PR DESCRIPTION
**Related Issue:** #2894

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Stabilizes date-picker test by waiting on locale date before first render.
