### PR TITLE
fix(action-bar, action-pad): expanded property should no longer alter actions within an action-menu

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -34,6 +34,32 @@ describe("calcite-action-bar", () => {
     ]));
 
   describe("expand functionality", () => {
+    it("should not modify actions within an action-menu", async () => {
+      const page = await newE2EPage({
+        html: html`<calcite-action-bar expanded>
+          <calcite-action-group>
+            <calcite-action id="action-bar-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action-menu label="Save and open">
+              <calcite-action id="menu-action" text-enabled text="Save" label="Save" icon="save"></calcite-action>
+            </calcite-action-menu>
+          </calcite-action-group>
+        </calcite-action-bar>`
+      });
+      await page.waitForChanges();
+      const actionBar = await page.find("calcite-action-bar");
+      const actionBarAction = await page.find("#action-bar-action");
+      const menuAction = await page.find("#menu-action");
+      expect(await actionBar.getProperty("expanded")).toBe(true);
+      expect(await actionBarAction.getProperty("textEnabled")).toBe(true);
+      expect(await menuAction.getProperty("textEnabled")).toBe(true);
+      actionBar.setProperty("expanded", false);
+      await page.waitForChanges();
+      expect(await menuAction.getProperty("textEnabled")).toBe(true);
+      expect(await actionBarAction.getProperty("textEnabled")).toBe(false);
+    });
+
     it("should be expandable by default", async () => {
       const page = await newE2EPage();
 

--- a/src/components/functional/CalciteExpandToggle.tsx
+++ b/src/components/functional/CalciteExpandToggle.tsx
@@ -1,5 +1,6 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
+import { queryActions } from "../calcite-action-bar/utils";
 import { Position } from "../interfaces";
 
 interface CalciteExpandToggleProps {
@@ -29,7 +30,7 @@ export function toggleChildActionText({
   parent: HTMLElement;
   expanded: boolean;
 }): void {
-  Array.from(parent.querySelectorAll("calcite-action"))
+  queryActions(parent)
     .filter((el) => el.slot !== "menu-actions")
     .forEach((action) => (action.textEnabled = expanded));
   parent.querySelectorAll("calcite-action-group").forEach((group) => (group.expanded = expanded));


### PR DESCRIPTION
**Related Issue:** #2813

## Summary

- PR makes sure that actions within the action-menu are not modified from the action-bar expanding.

fix(action-bar, action-pad): expanded property should no longer alter actions within an action-menu. #2813