### PR TITLE
test(combobox): stabilize test

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.e2e.ts
+++ b/src/components/calcite-combobox/calcite-combobox.e2e.ts
@@ -52,13 +52,11 @@ describe("calcite-combobox", () => {
       </calcite-combobox>`
     });
 
+    const items = await page.findAll("calcite-combobox-item");
     const eventSpy = await page.spyOnEvent("calciteComboboxFilterChange");
     await page.keyboard.press("Tab");
-    const openEvent = page.waitForEvent("calciteComboboxOpen");
+    await page.waitForEvent("calciteComboboxOpen");
     await page.keyboard.type("one");
-    await openEvent;
-
-    const items = await page.findAll("calcite-combobox-item");
     await items[1].waitForNotVisible();
     const item1Visible = await items[0].isVisible();
     const item2Visible = await items[1].isVisible();


### PR DESCRIPTION
**Related Issue:** #1876

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Stabilizes test by waiting for combobox to be open before typing.