### PR TITLE
docs(block): change header-with-control example

### DIFF
--- a/src/components/calcite-block/readme.md
+++ b/src/components/calcite-block/readme.md
@@ -40,7 +40,7 @@ Renders a header and control with a slot for adding a single HTML element (in th
 
 ```html
 <calcite-block heading="This header" summary="it has an input">
-  <div slot="control"><input placeholder="I am in control">
+  <calcite-action icon="pencil" text="edit" slot="control"></calcite-action>
 </calcite-block>
 ```
 

--- a/src/components/calcite-block/usage/Header-with-control.md
+++ b/src/components/calcite-block/usage/Header-with-control.md
@@ -2,6 +2,6 @@ Renders a header and control with a slot for adding a single HTML element (in th
 
 ```html
 <calcite-block heading="This header" summary="it has an input">
-  <div slot="control"><input placeholder="I am in control">
+  <calcite-action icon="pencil" text="edit" slot="control"></calcite-action>
 </calcite-block>
 ```


### PR DESCRIPTION
**Related Issue:** #2850

## Summary
Changed block's Header-with-control usage example