### PR TITLE
docs(popover): Remove reference to image slot.

### DIFF
--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -448,8 +448,7 @@ export class CalcitePopover {
           >
             {this.renderHeader()}
             <div class={CSS.content}>
-              <
-              />
+              <slot />
             </div>
             {!heading ? this.renderCloseButton() : null}
           </div>


### PR DESCRIPTION
**Related Issue:** #2936

## Summary

Removes documentation for the image slot which no longer exists.