### PR TITLE
fix(calcite-input): number values properly nudge when step is set to a decimal or "any"

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -188,10 +188,10 @@ describe("calcite-input", () => {
       focusTargetSelector: "input"
     }));
 
-  it("correctly increments and decrements value when number buttons are clicked", async () => {
+  it("correctly increments and decrements decimal value when number buttons are clicked and the step precision matches the precision of the initial value", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-input type="number" value="3.123"></calcite-input>
+      <calcite-input type="number" value="3.123" step="0.001"></calcite-input>
     `);
 
     const element = await page.find("calcite-input");
@@ -204,13 +204,13 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("3.123");
     await numberHorizontalItemDown.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("2.123");
+    expect(await element.getProperty("value")).toBe("3.122");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe("3.123");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("4.123");
+    expect(await element.getProperty("value")).toBe("3.124");
     await numberHorizontalItemUp.click();
     await numberHorizontalItemUp.click();
     await numberHorizontalItemUp.click();
@@ -221,10 +221,46 @@ describe("calcite-input", () => {
     await numberHorizontalItemUp.click();
     await numberHorizontalItemUp.click();
     await numberHorizontalItemUp.click();
-    expect(await element.getProperty("value")).toBe("14.123");
+    expect(await element.getProperty("value")).toBe("3.134");
   });
 
-  it("correctly increments and decrements value when number buttons are clicked and step is set", async () => {
+  it("correctly increments and decrements initial decimal value by 1 when number buttons are clicked and step is set to default of 1.", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-input type="number" value="3.123"></calcite-input>
+    `);
+
+    const element = await page.find("calcite-input");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input .calcite-input__number-button-item[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input .calcite-input__number-button-item[data-adjustment='up']"
+    );
+    expect(await element.getProperty("value")).toBe("3.123");
+    await numberHorizontalItemDown.click();
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("2");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("3");
+    await numberHorizontalItemUp.click();
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("4");
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    await numberHorizontalItemUp.click();
+    expect(await element.getProperty("value")).toBe("14");
+  });
+
+  it("correctly increments and decrements value when number buttons are clicked and step is set to an integer", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-input type="number" step="10" value="15"></calcite-input>
@@ -250,6 +286,37 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("25");
   });
 
+  it("correctly increments and decrements value when number buttons are clicked and step is set to a decimal", async () => {
+    const page = await newE2EPage({
+      html: `
+          <calcite-input step="0.1" type="number"></calcite-input>
+        `
+    });
+    const input = await page.find("calcite-input");
+    const buttonUp = await page.find('button[data-adjustment="up"]');
+    const buttonDown = await page.find('button[data-adjustment="down"]');
+
+    await buttonUp.click();
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("0.1");
+
+    await buttonUp.click();
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("0.2");
+
+    await buttonDown.click();
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("0.1");
+
+    await buttonDown.click();
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("0");
+  });
+
   it("correctly increments and decrements value by one when any is set for step", async () => {
     const page = await newE2EPage();
     await page.setContent(`
@@ -267,13 +334,13 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("5.5");
     await numberHorizontalItemDown.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("4.5");
+    expect(await element.getProperty("value")).toBe("4");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("5.5");
+    expect(await element.getProperty("value")).toBe("5");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("6.5");
+    expect(await element.getProperty("value")).toBe("6");
   });
 
   it("correctly increments and decrements value by one when step is undefined", async () => {
@@ -892,6 +959,35 @@ describe("calcite-input", () => {
       await page.waitForChanges();
 
       expect(await input.getProperty("value")).toBe("18");
+    });
+
+    it("up/down arrow keys increments and decrements correctly when the step is a decimal", async () => {
+      const page = await newE2EPage({
+        html: `
+          <calcite-input step="0.1" type="number"></calcite-input>
+        `
+      });
+      const input = await page.find("calcite-input");
+      await input.callMethod("setFocus");
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0.1");
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0.2");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0.1");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0");
     });
 
     it("allows decimals only when the step is a decimal", async () => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -502,17 +502,13 @@ export class CalciteInput {
     if (this.type !== "number") {
       return;
     }
+    const value = this.value;
     const decimals = this.step?.toString().split(".")[1]?.length || 0;
     const inputMax = this.maxString ? parseFloat(this.maxString) : null;
     const inputMin = this.minString ? parseFloat(this.minString) : null;
     const inputStep = this.step === "any" ? 1 : Math.abs(this.step || 1);
-    const inputVal =
-      this.value && this.value !== ""
-        ? decimals
-          ? parseFloat(this.value)
-          : parseInt(this.value)
-        : 0;
-    let newValue = this.value;
+    const inputVal = value && value !== "" ? (decimals ? parseFloat(value) : parseInt(value)) : 0;
+    let newValue = value;
 
     if (direction === "up" && ((!inputMax && inputMax !== 0) || inputVal < inputMax)) {
       newValue = (inputVal + inputStep).toFixed(decimals);

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -502,19 +502,24 @@ export class CalciteInput {
     if (this.type !== "number") {
       return;
     }
-    const decimals = this.value?.split(".")[1]?.length || 0;
+    const decimals = this.step?.toString().split(".")[1]?.length || 0;
     const inputMax = this.maxString ? parseFloat(this.maxString) : null;
     const inputMin = this.minString ? parseFloat(this.minString) : null;
     const inputStep = this.step === "any" ? 1 : Math.abs(this.step || 1);
-    let inputVal = this.value && this.value !== "" ? parseFloat(this.value) : 0;
+    const inputVal =
+      this.value && this.value !== ""
+        ? decimals
+          ? parseFloat(this.value)
+          : parseInt(this.value)
+        : 0;
     let newValue = this.value;
 
     if (direction === "up" && ((!inputMax && inputMax !== 0) || inputVal < inputMax)) {
-      newValue = (inputVal += inputStep).toFixed(decimals).toString();
+      newValue = (inputVal + inputStep).toFixed(decimals);
     }
 
     if (direction === "down" && ((!inputMin && inputMin !== 0) || inputVal > inputMin)) {
-      newValue = (inputVal -= inputStep).toFixed(decimals).toString();
+      newValue = (inputVal - inputStep).toFixed(decimals);
     }
 
     this.setValue(newValue, nativeEvent, true);


### PR DESCRIPTION
**Related Issue:** #2918

## Summary

This fixes an issue where nudging number values when step is set to a decimal was setting the value to 1 and then further nudging wouldn't have any effect.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
