### PR TITLE
test(input): skip unstable test

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -908,7 +908,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe("1.5");
     });
 
-    it("allows decimals when step is any", async () => {
+    it.skip("allows decimals when step is any", async () => {
       const page = await newE2EPage({
         html: `
           <calcite-input step="any" type="number"></calcite-input>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Skips unstable `calcite-input` test: 

```
FAIL src/components/calcite-input/calcite-input.e2e.ts (380.725 s)
  ● calcite-input › number type › allows decimals when step is any
    expect(received).toBe(expected) // Object.is equality
    Expected: "1.5"
    Received: "15"
      920 |       await page.waitForChanges();
      921 | 
    > 922 |       expect(await input.getProperty("value")).toBe("1.5");
          |                                                ^
      923 |     });
      924 |   });
      925 | 
```

Reported in https://github.com/Esri/calcite-components/pull/2943#issuecomment-907709749.