### PR TITLE
refactor(action bar): border added when position start or end used

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.scss
+++ b/src/components/calcite-action-bar/calcite-action-bar.scss
@@ -15,6 +15,14 @@
   max-width: 20vw;
 }
 
+:host([position="start"]) {
+  @apply border-0 border-r border-color-2 border-solid;
+}
+
+:host([position="end"]) {
+  @apply border-0 border-l border-color-2 border-solid;
+}
+
 ::slotted(calcite-action-group) {
   @apply border-0
     border-b

--- a/src/demos/calcite-action.html
+++ b/src/demos/calcite-action.html
@@ -315,6 +315,37 @@
       </div>
     </div>
 
+    <!-- action bar position -->
+    <div class="parent-action-bar">
+      <div class="child right-aligned-text">action bar position</div>
+
+      <div class="child-action-bar">
+        <div>start</div>
+        <calcite-action-bar position="start">
+          <calcite-action-group>
+            <calcite-action text="Add" icon="plus"> </calcite-action>
+            <calcite-action text="Save" icon="save"> </calcite-action>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Layers" icon="layers"> </calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      </div>
+
+      <div class="child-action-bar">
+        <div>end</div>
+        <calcite-action-bar position="end">
+          <calcite-action-group>
+            <calcite-action text="Add" icon="plus"> </calcite-action>
+            <calcite-action text="Save" icon="save"> </calcite-action>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Layers" icon="layers"> </calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      </div>
+    </div>
+
     <!-- add action -->
     <div class="parent-action-bar">
       <div class="child right-aligned-text">add action</div>


### PR DESCRIPTION
**Related Issue:** #1926

## Summary

Updated border on action bar to show borders when start (border-right) or end (border-left) used. Update demo page to showcase this feature update.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
