### PR TITLE
fix(accordion): match accordion icon directions with block

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -1,7 +1,7 @@
 // icon position variants for child
 .icon-position--start {
   --calcite-accordion-item-flex-direction: row-reverse;
-  --calcite-accordion-item-icon-rotation: theme("rotate.90");
+  --calcite-accordion-item-icon-rotation: theme("rotate.-90");
   --calcite-accordion-item-active-icon-rotation: theme("rotate.180");
   --calcite-accordion-item-icon-rotation-rtl: theme("rotate.-90");
   --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.-180");

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -126,7 +126,6 @@ export class CalciteAccordionItem {
                   : this.active
                   ? "minus"
                   : "plus"
-                //this.getIcon()
               }
               scale="s"
             />
@@ -240,12 +239,4 @@ export class CalciteAccordionItem {
       this.el
     );
   }
-
-  // private getIcon(): string {
-  //   if (this.iconType === ("chevron" || "caret")) {
-  //     return this.iconPosition === "start" ? `${this.iconType}Up` : `${this.iconType}Down`;
-  //   } else {
-  //     return this.active ? "minus" : "plus";
-  //   }
-  // }
 }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -119,13 +119,14 @@ export class CalciteAccordionItem {
             <calcite-icon
               class="accordion-item-expand-icon"
               icon={
-                this.iconType === "chevron"
-                  ? "chevronUp"
+                  this.iconType === "chevron"
+                  ? "chevronDown"
                   : this.iconType === "caret"
-                  ? "caretUp"
+                  ? "caretDown"
                   : this.active
                   ? "minus"
                   : "plus"
+                //this.getIcon()
               }
               scale="s"
             />
@@ -239,4 +240,12 @@ export class CalciteAccordionItem {
       this.el
     );
   }
+
+  // private getIcon(): string {
+  //   if (this.iconType === ("chevron" || "caret")) {
+  //     return this.iconPosition === "start" ? `${this.iconType}Up` : `${this.iconType}Down`;
+  //   } else {
+  //     return this.active ? "minus" : "plus";
+  //   }
+  // }
 }

--- a/src/demos/calcite-accordion.html
+++ b/src/demos/calcite-accordion.html
@@ -228,6 +228,125 @@
       </div>
     </div>
 
+    <!-- icon-type: caret -->
+    <div class="parent">
+      <div class="child right-aligned-text">icon-type: caret</div>
+
+      <div class="child">
+        <calcite-accordion icon-type="caret" scale="s">
+          <calcite-accordion-item item-title="Accordion Item" item-subtitle="A bit of subtext about this item"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 2"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 3 with a potentially two line title"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 4"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 5">
+            <calcite-tree lines>
+              <calcite-tree-item> Child 1 </calcite-tree-item>
+
+              <calcite-tree-item>
+                Child 2
+
+                <calcite-tree slot="children">
+                  <calcite-tree-item> Grandchild 1 </calcite-tree-item>
+
+                  <calcite-tree-item>
+                    Grandchild 2
+                    <calcite-tree slot="children">
+                      <calcite-tree-item> Great-Grandchild 1 </calcite-tree-item>
+                      <calcite-tree-item> Great-Grandchild 2 </calcite-tree-item>
+                    </calcite-tree>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-accordion-item>
+        </calcite-accordion>
+      </div>
+
+      <div class="child">
+        <calcite-accordion icon-type="caret" scale="m">
+          <calcite-accordion-item item-title="Accordion Item" item-subtitle="A bit of subtext about this item"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 2"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 3 with a potentially two line title"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 4"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 5">
+            <calcite-tree lines>
+              <calcite-tree-item> Child 1 </calcite-tree-item>
+
+              <calcite-tree-item>
+                Child 2
+
+                <calcite-tree slot="children">
+                  <calcite-tree-item> Grandchild 1 </calcite-tree-item>
+
+                  <calcite-tree-item>
+                    Grandchild 2
+                    <calcite-tree slot="children">
+                      <calcite-tree-item> Great-Grandchild 1 </calcite-tree-item>
+                      <calcite-tree-item> Great-Grandchild 2 </calcite-tree-item>
+                    </calcite-tree>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-accordion-item>
+        </calcite-accordion>
+      </div>
+
+      <div class="child">
+        <calcite-accordion icon-type="caret" scale="l">
+          <calcite-accordion-item item-title="Accordion Item" item-subtitle="A bit of subtext about this item"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 2"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 3 with a potentially two line title"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 4"
+            ><img src="https://placem.at/places?w=200&txt=0" />
+          </calcite-accordion-item>
+          <calcite-accordion-item item-title="Accordion Item 5">
+            <calcite-tree lines>
+              <calcite-tree-item> Child 1 </calcite-tree-item>
+
+              <calcite-tree-item>
+                Child 2
+
+                <calcite-tree slot="children">
+                  <calcite-tree-item> Grandchild 1 </calcite-tree-item>
+
+                  <calcite-tree-item>
+                    Grandchild 2
+                    <calcite-tree slot="children">
+                      <calcite-tree-item> Great-Grandchild 1 </calcite-tree-item>
+                      <calcite-tree-item> Great-Grandchild 2 </calcite-tree-item>
+                    </calcite-tree>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-accordion-item>
+        </calcite-accordion>
+      </div>
+    </div>
+
     <!-- icon-position: start -->
     <div class="parent">
       <div class="child right-aligned-text">icon-position: start</div>


### PR DESCRIPTION
Related Issue: [#2597](https://github.com/Esri/calcite-components/issues/2597)

## Summary
This fixes an issue in `calcite-accordion-item` where chevron and caret directions pointing opposite of `calcite-block` .