### PR TITLE
fix(block-section): style update to align better with label and switch combo.

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -22,7 +22,7 @@
     border-0
     text-color-2
     font-sans
-    font-normal
+    font-medium
     w-full;
 }
 
@@ -33,8 +33,7 @@
     flex
     mx-0
     my-1
-    pl-0
-    pr-1
+    px-0
     py-2
     select-none
     text--1
@@ -62,7 +61,7 @@
 
 .toggle--switch {
   calcite-switch {
-    @apply pointer-events-none mx-1;
+    @apply pointer-events-none ml-1;
   }
   .status-icon {
     @apply mx-1;
@@ -83,10 +82,8 @@
 
 .calcite--rtl {
   .toggle--switch {
-    @apply pr-0 pl-2;
-
     calcite-switch {
-      @apply ml-0 mr-2;
+      @apply ml-0 mr-1;
     }
   }
   .section-header {

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -64,7 +64,7 @@
     @apply pointer-events-none ml-1;
   }
   .status-icon {
-    @apply mx-1;
+    @apply ml-2;
   }
 }
 
@@ -85,8 +85,8 @@
     calcite-switch {
       @apply ml-0 mr-1;
     }
-  }
-  .section-header {
-    @apply pr-0 pl-1;
+    .status-icon {
+      @apply ml-0 mr-2;
+    }
   }
 }

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -138,7 +138,7 @@
                 I'm this panel's content.
               </calcite-panel>
               <calcite-panel heading="Configure popup" dismissible>
-                <calcite-block heading="Basic" summary="Collapsible with section" collapsible>
+                <calcite-block heading="Basic" summary="Collapsible with section" collapsible open>
                   <calcite-list id="one" multiple style="margin-bottom: var(--calcite-spacing-double)">
                     <calcite-list-item label="Population 2018" description="{ POP_2018 }" value="dogs">
                       <calcite-action slot="actions-end" text="click-me" onClick="console.log('clicked');" icon="x">
@@ -187,12 +187,16 @@
                       <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
                     </calcite-label>
                   </calcite-block-section>
-                  <calcite-block-section text="Switch section" toggle-display="switch">
+                  <calcite-block-section text="This is switch section" toggle-display="switch">
                     <calcite-label scale="s">
                       It's a label.
                       <calcite-input type="text" placeholder="This is stuff." scale="s"> </calcite-input>
                     </calcite-label>
                   </calcite-block-section>
+                  <calcite-label layout="inline-space-between" scale="m">
+                    This is a label
+                    <calcite-switch scale="s"></calcite-switch>
+                  </calcite-label>
                 </calcite-block>
 
                 <calcite-block heading="With control" summary="Collapsible" collapsible>


### PR DESCRIPTION
**Related Issue:** #2577

## Summary
* cleans up styles that were causing misalignments with label+switch
* adds example in a demo

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
