### PR TITLE
docs: add missing storybook readmes

### DIFF
--- a/src/components/calcite-list/calcite-list.stories.ts
+++ b/src/components/calcite-list/calcite-list.stories.ts
@@ -1,12 +1,13 @@
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import itemReadme from "../calcite-list-item/readme.md";
+import groupReadme from "../calcite-list-item-group/readme.md";
 import { html, placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/List",
-
   parameters: {
-    notes: readme
+    notes: [readme, itemReadme, groupReadme]
   }
 };
 

--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -7,12 +7,14 @@ import {
   themesDarkDefault
 } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import itemReadme from "../calcite-pick-list-item/readme.md";
+import groupReadme from "../calcite-pick-list-group/readme.md";
 import { html } from "../../tests/utils";
 
 export default {
   title: "Components/Pick List",
   parameters: {
-    notes: readme
+    notes: [readme, itemReadme, groupReadme]
   }
 };
 

--- a/src/components/calcite-popover/calcite-popover.stories.ts
+++ b/src/components/calcite-popover/calcite-popover.stories.ts
@@ -1,6 +1,7 @@
 import { select, number, text } from "@storybook/addon-knobs";
 import { boolean } from "../../../.storybook/helpers";
 import readme from "./readme.md";
+import managerReadme from "../calcite-popover-manager/readme.md";
 import { themesDarkDefault } from "../../../.storybook/utils";
 
 const placements = [
@@ -50,9 +51,8 @@ const referenceElementHTML = `<calcite-popover-manager>Ut enim ad minim veniam, 
 
 export default {
   title: "Components/Popover",
-
   parameters: {
-    notes: readme
+    notes: [readme, managerReadme]
   }
 };
 

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -3,15 +3,13 @@ import { filterComponentAttributes, Attributes, createComponentHTML as create } 
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import readme from "./readme.md";
 import panelReadme from "../calcite-shell-panel/readme.md";
+import centerRowReadme from "../calcite-shell-center-row/readme.md";
 import { html, placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/Shell",
   parameters: {
-    notes: {
-      shell: readme,
-      panel: panelReadme
-    }
+    notes: [readme, panelReadme, centerRowReadme]
   }
 };
 

--- a/src/components/calcite-tip/calcite-tip.stories.ts
+++ b/src/components/calcite-tip/calcite-tip.stories.ts
@@ -7,13 +7,14 @@ import {
   themesDarkDefault
 } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import groupReadme from "../calcite-tip-group/readme.md";
 import { TEXT } from "./resources";
 import { placeholderImage } from "../../tests/utils";
 
 export default {
   title: "Components/Tips/Tip",
   parameters: {
-    notes: readme
+    notes: [readme, groupReadme]
   }
 };
 

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -7,12 +7,13 @@ import {
   themesDarkDefault
 } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import itemReadme from "../calcite-value-list-item/readme.md";
 import { html } from "../../tests/utils";
 
 export default {
   title: "Components/Value List",
   parameters: {
-    notes: readme
+    notes: [readme, itemReadme]
   }
 };
 


### PR DESCRIPTION
**Related Issue:** #2887

## Summary
Some of the child components did not have their readmes on storybook, such as `calcite-value-list-item`. I added the missing readmes under the parent components, similar to how [calcite-stepper](https://esri.github.io/calcite-components/?path=/docs/components-stepper--simple) is [implemented](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-stepper/calcite-stepper.stories.ts#L12).