### PR TITLE
refactor(dropdown): use resource file for slot

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -22,9 +22,12 @@ import {
 } from "../../utils/popper";
 import { Instance as Popper, StrictModifiers } from "@popperjs/core";
 import { Scale } from "../interfaces";
-import { DefaultDropdownPlacement } from "./resources";
+import { DefaultDropdownPlacement, SLOTS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 
+/**
+ * @slot dropdown-trigger - A slot for the element that triggers the dropdown
+ */
 @Component({
   tag: "calcite-dropdown",
   styleUrl: "calcite-dropdown.scss",
@@ -146,7 +149,11 @@ export class CalciteDropdown {
           onKeyDown={this.keyDownHandler}
           ref={this.setReferenceEl}
         >
-          <slot aria-expanded={active.toString()} aria-haspopup="true" name="dropdown-trigger" />
+          <slot
+            aria-expanded={active.toString()}
+            aria-haspopup="true"
+            name={SLOTS.dropdownTrigger}
+          />
         </div>
         <div
           aria-hidden={(!active).toString()}

--- a/src/components/calcite-dropdown/resources.ts
+++ b/src/components/calcite-dropdown/resources.ts
@@ -1,1 +1,5 @@
 export const DefaultDropdownPlacement = "bottom-leading";
+
+export const SLOTS = {
+  dropdownTrigger: "dropdown-trigger"
+};


### PR DESCRIPTION
**Related Issue:** #2851

## Summary
Missed one hardcoded slot from calcite-dropdown.