### PR TITLE
docs(tree, tree-item): fix slot documentation

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -18,6 +18,10 @@ import { Scale } from "../interfaces";
 import { CSS, SLOTS, ICONS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 
+/**
+ * @slot children - A slot for adding nested `calcite-tree` elements.
+ * @slot - A slot for adding content to the item.
+ */
 @Component({
   tag: "calcite-tree-item",
   styleUrl: "calcite-tree-item.scss",

--- a/src/components/calcite-tree/calcite-tree.tsx
+++ b/src/components/calcite-tree/calcite-tree.tsx
@@ -15,7 +15,7 @@ import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
 
 /**
- * @slot children - a slot for adding child components, commonly calcite-tree-item
+ * @slot - A slot for `calcite-tree-item` elements.
  */
 @Component({
   tag: "calcite-tree",


### PR DESCRIPTION
**Related Issue:** #2807

## Summary
Fixed the tree and tree-item slot documentation pointed out by @jcfranco during verification.