### PR TITLE
refactor (calcite tip manager) close button size

### DIFF
--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -282,11 +282,12 @@ export class CalciteTipManager {
           </CalciteHeading>
           <calcite-action
             class={CSS.close}
-            icon={ICONS.close}
             onClick={this.hideTipManager}
             scale="m"
             text={closeLabel}
-          />
+          >
+            <calcite-icon icon={ICONS.close} scale="m" />
+          </calcite-action>
         </header>
         <div
           class={{


### PR DESCRIPTION
**Related Issue:** #2856

## Summary

When using tip manager the close button should be medium and not small.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
