### PR TITLE
refactor(action): action active tap behavior

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -130,6 +130,10 @@
   @apply text-color-1 fill-color-1 bg-foreground-3;
 }
 
+:host([active]) .button:active {
+  @apply bg-foreground-1;
+}
+
 :host([appearance="clear"]) .button {
   @apply bg-transparent
     transition-shadow


### PR DESCRIPTION
**Related Issue:** #1082

## Summary

Calcite action tap behavior updated on active state. Background now changes to `foreground-1` from `foreground-3` when the button is actively clicked.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
