### PR TITLE
chore: update calcite-ui-icons to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3250,9 +3250,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.16.6",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.16.6.tgz",
-      "integrity": "sha512-R635GDLEsTT5zSQXHegmS8zjigVmXy7WDI6ompeKwWnUr/H7xnMdTuTa6VzdQDtVnG3XLvkwMsm0o603JcPNcQ==",
+      "version": "3.16.9",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.16.9.tgz",
+      "integrity": "sha512-vJyMo5neAw2oHPws2si4frlRIuJT3AHwamKiUIcBtaNgHJ+0wnlpcELxTMVYxGni64bBEoKkX9gM7K/g34tGSQ==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/plugin-proposal-numeric-separator": "7.14.5",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.1",
-    "@esri/calcite-ui-icons": "3.16.6",
+    "@esri/calcite-ui-icons": "3.16.9",
     "@esri/eslint-plugin-calcite-components": "0.1.1",
     "@rollup/plugin-babel": "5.3.0",
     "@stencil/eslint-plugin": "0.3.1",


### PR DESCRIPTION
## Summary

Updating calcite-ui-icons to v3.16.9 to get that nice thumbs-down icon.