### PR TITLE
refactor: add util to create observers consistently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9698,12 +9698,6 @@
         "@types/react": "*"
       }
     },
-    "@types/resize-observer-browser": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz",
-      "integrity": "sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg==",
-      "dev": true
-    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@types/jest-axe": "3.5.2",
     "@types/lodash-es": "4.17.4",
     "@types/pify": "5.0.1",
-    "@types/resize-observer-browser": "0.1.6",
     "@types/rimraf": "3.0.2",
     "@types/semver": "7.3.8",
     "@types/shell-quote": "1.7.1",

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -15,6 +15,7 @@ import { CalciteExpandToggle, toggleChildActionText } from "../functional/Calcit
 import { CSS, SLOTS, TEXT } from "./resources";
 import { getSlotted, focusElement } from "../../utils/dom";
 import { getOverflowCount, overflowActions, queryActions } from "./utils";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-action`s that will appear at the top of the action bar.
@@ -112,13 +113,13 @@ export class CalciteActionBar {
 
   @Element() el: HTMLCalciteActionBarElement;
 
-  mutationObserver = new MutationObserver(() => {
+  mutationObserver = createObserver("mutation", () => {
     const { el, expanded } = this;
     toggleChildActionText({ parent: el, expanded });
     this.resize(el.clientHeight);
   });
 
-  resizeObserver = new ResizeObserver((entries) => this.resizeHandlerEntries(entries));
+  resizeObserver = createObserver("resize", (entries) => this.resizeHandlerEntries(entries));
 
   expandToggleEl: HTMLCalciteActionElement;
 
@@ -134,27 +135,27 @@ export class CalciteActionBar {
   //
   // --------------------------------------------------------------------------
 
-  componentWillLoad(): void {
+  componentDidLoad(): void {
+    this.resize(this.el.clientHeight);
+  }
+
+  connectedCallback(): void {
     const { el, expandDisabled, expanded } = this;
 
     if (!expandDisabled) {
       toggleChildActionText({ parent: el, expanded });
     }
 
-    this.mutationObserver.observe(el, { childList: true });
+    this.mutationObserver?.observe(el, { childList: true });
 
     if (!this.overflowActionsDisabled) {
-      this.resizeObserver.observe(el);
+      this.resizeObserver?.observe(el);
     }
   }
 
-  componentDidLoad(): void {
-    this.resize(this.el.clientHeight);
-  }
-
   disconnectedCallback(): void {
-    this.mutationObserver.disconnect();
-    this.resizeObserver.disconnect();
+    this.mutationObserver?.disconnect();
+    this.resizeObserver?.disconnect();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -18,6 +18,7 @@ import { PopperPlacement, OverlayPositioning } from "../../utils/popper";
 import { Placement } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
+import { createObserver } from "../../utils/observers";
 
 const SUPPORTED_BUTTON_NAV_KEYS = ["ArrowUp", "ArrowDown"];
 const SUPPORTED_MENU_NAV_KEYS = ["ArrowUp", "ArrowDown", "End", "Home"];
@@ -142,7 +143,7 @@ export class CalciteActionMenu {
 
   actionElements: HTMLCalciteActionElement[] = [];
 
-  mutationObserver = new MutationObserver(() => this.getActions());
+  mutationObserver = createObserver("mutation", () => this.getActions());
 
   guid = `calcite-action-menu-${guid()}`;
 

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -18,6 +18,7 @@ import { CSS, TEXT } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 
 import { getElementDir } from "../../utils/dom";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding a `calcite-icon`.
@@ -118,7 +119,7 @@ export class CalciteAction {
 
   buttonEl: HTMLButtonElement;
 
-  observer = new MutationObserver(() => forceUpdate(this));
+  mutationObserver = createObserver("mutation", () => forceUpdate(this));
 
   // --------------------------------------------------------------------------
   //
@@ -127,11 +128,11 @@ export class CalciteAction {
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    this.observer.observe(this.el, { childList: true, subtree: true });
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   disconnectedCallback(): void {
-    this.observer.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -8,6 +8,7 @@ import {
 import { ButtonAlignment, ButtonAppearance, ButtonColor } from "./interfaces";
 import { FlipContext, Scale, Width } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
+import { createObserver } from "../../utils/observers";
 
 @Component({
   tag: "calcite-button",
@@ -121,7 +122,7 @@ export class CalciteButton {
   }
 
   disconnectedCallback(): void {
-    this.observer.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   componentWillLoad(): void {
@@ -215,7 +216,7 @@ export class CalciteButton {
   //--------------------------------------------------------------------------
 
   /** watches for changing text content **/
-  private observer: MutationObserver;
+  private mutationObserver = createObserver("mutation", () => this.updateHasContent());
 
   /** the rendered child element */
   private childEl?: HTMLElement;
@@ -238,12 +239,7 @@ export class CalciteButton {
   }
 
   private setupTextContentObserver() {
-    if (Build.isBrowser) {
-      this.observer = new MutationObserver(() => {
-        this.updateHasContent();
-      });
-      this.observer.observe(this.el, { childList: true, subtree: true });
-    }
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -8,7 +8,6 @@ import {
   EventEmitter,
   Element,
   VNode,
-  Build,
   Method,
   Watch,
   Host
@@ -34,6 +33,7 @@ import {
   ComboboxDefaultPlacement
 } from "./resources";
 import { getItemAncestors, getItemChildren, hasActiveChildren } from "./utils";
+import { createObserver } from "../../utils/observers";
 
 interface ItemData {
   label: string;
@@ -211,19 +211,12 @@ export class CalciteCombobox {
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    if (Build.isBrowser) {
-      this.observer = new MutationObserver(this.updateItems);
-    }
-
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.createPopper();
   }
 
   componentWillLoad(): void {
     this.updateItems();
-  }
-
-  componentDidLoad(): void {
-    this.observer?.observe(this.el, { childList: true, subtree: true });
   }
 
   componentDidRender(): void {
@@ -234,7 +227,7 @@ export class CalciteCombobox {
   }
 
   disconnectedCallback(): void {
-    this.observer?.disconnect();
+    this.mutationObserver?.disconnect();
     this.destroyPopper();
   }
 
@@ -278,7 +271,7 @@ export class CalciteCombobox {
 
   data: ItemData[];
 
-  observer: MutationObserver = null;
+  mutationObserver = createObserver("mutation", () => this.updateItems());
 
   private guid: string = guid();
 

--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -3,6 +3,7 @@ import { Component, Element, Listen, Method, State, h, VNode } from "@stencil/co
 import { CSS } from "./resources";
 
 import { FlowDirection } from "./interfaces";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-panel`s to the flow.
@@ -62,12 +63,12 @@ export class CalciteFlow {
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    this.panelItemObserver.observe(this.el, { childList: true, subtree: true });
+    this.panelItemMutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.updateFlowProps();
   }
 
   disconnectedCallback(): void {
-    this.panelItemObserver.disconnect();
+    this.panelItemMutationObserver?.disconnect();
   }
 
   // --------------------------------------------------------------------------
@@ -125,7 +126,7 @@ export class CalciteFlow {
     }
   };
 
-  panelItemObserver = new MutationObserver(this.updateFlowProps);
+  panelItemMutationObserver: MutationObserver = createObserver("mutation", this.updateFlowProps);
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-icon/calcite-icon.tsx
+++ b/src/components/calcite-icon/calcite-icon.tsx
@@ -4,6 +4,7 @@ import { getElementDir } from "../../utils/dom";
 import { fetchIcon, scaleToPx } from "./utils";
 import { Scale } from "../interfaces";
 import { CalciteIconPath, CalciteMultiPathEntry } from "@esri/calcite-ui-icons";
+import { createObserver } from "../../utils/observers";
 
 @Component({
   tag: "calcite-icon",
@@ -73,10 +74,8 @@ export class CalciteIcon {
   }
 
   disconnectedCallback(): void {
-    if (this.intersectionObserver) {
-      this.intersectionObserver.disconnect();
-      this.intersectionObserver = null;
-    }
+    this.intersectionObserver?.disconnect();
+    this.intersectionObserver = null;
   }
 
   async componentWillLoad(): Promise<void> {
@@ -151,16 +150,8 @@ export class CalciteIcon {
   }
 
   private waitUntilVisible(callback: () => void): void {
-    if (
-      !Build.isBrowser ||
-      typeof window === "undefined" ||
-      !(window as any).IntersectionObserver
-    ) {
-      callback();
-      return;
-    }
-
-    this.intersectionObserver = new IntersectionObserver(
+    this.intersectionObserver = createObserver(
+      "intersection",
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
@@ -172,6 +163,11 @@ export class CalciteIcon {
       },
       { rootMargin: "50px" }
     );
+
+    if (!this.intersectionObserver) {
+      callback();
+      return;
+    }
 
     this.intersectionObserver.observe(this.el);
   }

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -1,5 +1,4 @@
 import {
-  Build,
   Component,
   Element,
   Event,
@@ -28,6 +27,7 @@ import { Scale } from "../interfaces";
 import { ModalBackgroundColor } from "./interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 import { TEXT, SLOTS, CSS, ICONS } from "./resources";
+import { createObserver } from "../../utils/observers";
 
 const isFocusableExtended = (el: CalciteFocusableElement): boolean => {
   return isCalciteFocusable(el) || isFocusable(el);
@@ -119,13 +119,8 @@ export class CalciteModal {
   }
 
   connectedCallback(): void {
-    if (Build.isBrowser) {
-      if (!this.mutationObserver) {
-        this.mutationObserver = new MutationObserver(this.updateFooterVisibility);
-      }
-      this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
-      this.updateFooterVisibility();
-    }
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
+    this.updateFooterVisibility();
   }
 
   disconnectedCallback(): void {
@@ -243,7 +238,9 @@ export class CalciteModal {
 
   modalContent: HTMLDivElement;
 
-  private mutationObserver: MutationObserver = null;
+  private mutationObserver: MutationObserver = createObserver("mutation", () =>
+    this.updateFooterVisibility()
+  );
 
   previousActiveElement: HTMLElement;
 

--- a/src/components/calcite-option/calcite-option.tsx
+++ b/src/components/calcite-option/calcite-option.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop, VNode, Element, EventEmitter, Event, Watch } from "@stencil/core";
+import { createObserver } from "../../utils/observers";
 
 @Component({
   tag: "calcite-option",
@@ -65,7 +66,7 @@ export class CalciteOption {
 
   private internallySetValue: any;
 
-  private mutationObserver = new MutationObserver(() => {
+  private mutationObserver: MutationObserver = createObserver("mutation", () => {
     this.ensureTextContentDependentProps();
     this.calciteOptionChange.emit();
   });
@@ -112,14 +113,14 @@ export class CalciteOption {
 
   connectedCallback(): void {
     this.ensureTextContentDependentProps();
-    this.mutationObserver.observe(this.el, {
+    this.mutationObserver?.observe(this.el, {
       childList: true,
       attributeFilter: ["label", "value"]
     });
   }
 
   disconnectedCallback(): void {
-    this.mutationObserver.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -32,6 +32,7 @@ import {
 } from "./shared-list-logic";
 import List from "./shared-list-render";
 import { HeadingLevel } from "../functional/CalciteHeading";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
@@ -103,7 +104,7 @@ export class CalcitePickList<
 
   lastSelectedItem: ItemElement = null;
 
-  observer = new MutationObserver(mutationObserverCallback.bind(this));
+  mutationObserver = createObserver("mutation", mutationObserverCallback.bind(this));
 
   @Element() el: HTMLCalcitePickListElement;
 

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -30,11 +30,11 @@ export function initialize<T extends Lists>(this: List<T>): void {
 }
 
 export function initializeObserver<T extends Lists>(this: List<T>): void {
-  this.observer.observe(this.el, { childList: true, subtree: true });
+  this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
 }
 
 export function cleanUpObserver<T extends Lists>(this: List<T>): void {
-  this.observer.disconnect();
+  this.mutationObserver?.disconnect();
 }
 
 // --------------------------------------------------------------------------

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -7,7 +7,6 @@ import {
   Element,
   Host,
   Watch,
-  Build,
   State,
   VNode
 } from "@stencil/core";
@@ -15,6 +14,7 @@ import { getElementDir, getElementProp } from "../../utils/dom";
 import { RadioAppearance } from "../calcite-radio-group/interfaces";
 import { Position, Layout, Scale } from "../interfaces";
 import { SLOTS, CSS } from "./resources";
+import { createObserver } from "../../utils/observers";
 
 @Component({
   tag: "calcite-radio-group-item",
@@ -73,16 +73,14 @@ export class CalciteRadioGroupItem {
     if (inputProxy) {
       this.value = inputProxy.value;
       this.checked = inputProxy.checked;
-      if (Build.isBrowser) {
-        this.mutationObserver.observe(inputProxy, { attributes: true });
-      }
+      this.mutationObserver?.observe(inputProxy, { attributes: true });
     }
 
     this.inputProxy = inputProxy;
   }
 
   disconnectedCallback(): void {
-    this.mutationObserver.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   componentWillLoad(): void {
@@ -151,17 +149,13 @@ export class CalciteRadioGroupItem {
 
   private inputProxy: HTMLInputElement;
 
-  private mutationObserver = this.getMutationObserver();
+  private mutationObserver = createObserver("mutation", () => this.syncFromExternalInput());
 
   //--------------------------------------------------------------------------
   //
   //  Private Methods
   //
   //--------------------------------------------------------------------------
-
-  private getMutationObserver(): MutationObserver | null {
-    return Build.isBrowser && new MutationObserver(() => this.syncFromExternalInput());
-  }
 
   private syncFromExternalInput(): void {
     if (this.inputProxy) {

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -15,6 +15,7 @@ import { Scale, Width } from "../interfaces";
 import { CSS } from "./resources";
 import { FocusRequest } from "../calcite-label/interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
+import { createObserver } from "../../utils/observers";
 
 type CalciteOptionOrGroup = HTMLCalciteOptionElement | HTMLCalciteOptionGroupElement;
 type NativeOptionOrGroup = HTMLOptionElement | HTMLOptGroupElement;
@@ -91,7 +92,7 @@ export class CalciteSelect {
 
   private componentToNativeEl = new Map<CalciteOptionOrGroup, NativeOptionOrGroup>();
 
-  private mutationObserver = new MutationObserver(() => this.populateInternalSelect());
+  private mutationObserver = createObserver("mutation", () => this.populateInternalSelect());
 
   private selectEl: HTMLSelectElement;
 
@@ -104,14 +105,14 @@ export class CalciteSelect {
   connectedCallback(): void {
     const { el } = this;
 
-    this.mutationObserver.observe(el, {
+    this.mutationObserver?.observe(el, {
       subtree: true,
       childList: true
     });
   }
 
   disconnectedCallback(): void {
-    this.mutationObserver.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-sortable-list/calcite-sortable-list.tsx
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.tsx
@@ -10,6 +10,7 @@ import {
   h,
   VNode
 } from "@stencil/core";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding sortable items
@@ -65,7 +66,8 @@ export class CalciteSortableList {
 
   items: Element[] = [];
 
-  observer = new MutationObserver(() => {
+  mutationObserver = createObserver("mutation", () => {
+    this.cleanUpDragAndDrop();
     this.items = Array.from(this.el.children);
     this.setUpDragAndDrop();
   });
@@ -85,7 +87,7 @@ export class CalciteSortableList {
   }
 
   disconnectedCallback(): void {
-    this.observer.disconnect();
+    this.mutationObserver?.disconnect();
     this.cleanUpDragAndDrop();
   }
 
@@ -132,7 +134,7 @@ export class CalciteSortableList {
       default:
         return;
     }
-    this.observer.disconnect();
+    this.mutationObserver?.disconnect();
 
     if (appendInstead) {
       sortItem.parentElement.appendChild(sortItem);
@@ -167,7 +169,7 @@ export class CalciteSortableList {
       },
       // Element dragging started
       onStart: () => {
-        this.observer.disconnect();
+        this.mutationObserver?.disconnect();
       },
       // Element dragging ended
       onEnd: () => {
@@ -188,7 +190,7 @@ export class CalciteSortableList {
   }
 
   beginObserving(): void {
-    this.observer.observe(this.el, { childList: true, subtree: true });
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-tab-title/calcite-tab-title.tsx
+++ b/src/components/calcite-tab-title/calcite-tab-title.tsx
@@ -20,6 +20,7 @@ import { getKey } from "../../utils/key";
 import { TabID, TabLayout, TabPosition } from "../calcite-tabs/interfaces";
 import { FlipContext, Scale } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
+import { createObserver } from "../../utils/observers";
 
 @Component({
   tag: "calcite-tab-title",
@@ -94,7 +95,7 @@ export class CalciteTabTitle {
   }
 
   disconnectedCallback(): void {
-    this.observer.disconnect();
+    this.mutationObserver?.disconnect();
     // Dispatching to body in order to be listened by other elements that are still connected to the DOM.
     document.body?.dispatchEvent(
       new CustomEvent("calciteTabTitleUnregister", {
@@ -296,7 +297,9 @@ export class CalciteTabTitle {
   //--------------------------------------------------------------------------
 
   /** watches for changing text content **/
-  private observer: MutationObserver;
+  private mutationObserver: MutationObserver = createObserver("mutation", () =>
+    this.updateHasText()
+  );
 
   @State() private controls: string;
 
@@ -318,12 +321,7 @@ export class CalciteTabTitle {
   }
 
   private setupTextContentObserver(): void {
-    if (Build.isBrowser) {
-      this.observer = new MutationObserver(() => {
-        this.updateHasText();
-      });
-      this.observer.observe(this.el, { childList: true, subtree: true });
-    }
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   private emitActiveTab(): void {

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -13,6 +13,7 @@ import {
 import { CSS, ICONS, TEXT, HEADING_LEVEL } from "./resources";
 import { getElementDir } from "../../utils/dom";
 import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-tip`s.
@@ -93,7 +94,7 @@ export class CalciteTipManager {
 
   @State() groupTitle: string;
 
-  observer = new MutationObserver(() => this.setUpTips());
+  mutationObserver = createObserver("mutation", () => this.setUpTips());
 
   container: HTMLDivElement;
 
@@ -105,11 +106,11 @@ export class CalciteTipManager {
 
   connectedCallback(): void {
     this.setUpTips();
-    this.observer.observe(this.el, { childList: true, subtree: true });
+    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   disconnectedCallback(): void {
-    this.observer.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -32,6 +32,7 @@ import {
 } from "../calcite-pick-list/shared-list-logic";
 import List from "../calcite-pick-list/shared-list-render";
 import { getRoundRobinIndex } from "../../utils/array";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
@@ -110,7 +111,7 @@ export class CalciteValueList<
 
   lastSelectedItem: ItemElement = null;
 
-  observer = new MutationObserver(mutationObserverCallback.bind(this));
+  mutationObserver = createObserver("mutation", mutationObserverCallback.bind(this));
 
   sortable: Sortable;
 

--- a/src/utils/observers.ts
+++ b/src/utils/observers.ts
@@ -1,0 +1,57 @@
+import { Build } from "@stencil/core";
+
+type ObserverType = "mutation" | "intersection" | "resize";
+
+type ObserverCallbackType<T extends ObserverType> = T extends "mutation"
+  ? MutationCallback
+  : T extends "intersection"
+  ? IntersectionObserverCallback
+  : T extends "resize"
+  ? ResizeObserverCallback
+  : never;
+
+type ObserverOptions<T extends ObserverType> = T extends "mutation"
+  ? MutationObserverInit
+  : T extends "intersection"
+  ? IntersectionObserverInit
+  : T extends "resize"
+  ? never
+  : never;
+
+type ObserverClassType<T extends ObserverType> = T extends "mutation"
+  ? typeof MutationObserver
+  : T extends "intersection"
+  ? typeof IntersectionObserver
+  : T extends "resize"
+  ? typeof ResizeObserver
+  : never;
+
+type ObserverInstanceType<T extends ObserverType> = T extends "mutation"
+  ? MutationObserver
+  : T extends "intersection"
+  ? IntersectionObserver
+  : T extends "resize"
+  ? ResizeObserver
+  : never;
+
+/**
+ * This utility ensures observers are created only for browser contexts.
+ *
+ * @param type - the type of observer to create
+ * @param callback - the observer callback
+ * @param options - the observer options
+ */
+export function createObserver<T extends ObserverType>(
+  type: T,
+  callback: ObserverCallbackType<T>,
+  options?: ObserverOptions<T>
+): ObserverInstanceType<T> | undefined {
+  const Observer = getObserver<T>(type);
+  return Build.isBrowser ? (new Observer(callback as any, options as any) as any) : undefined;
+}
+
+function getObserver<T extends ObserverType>(type: T): ObserverClassType<T> {
+  return (
+    type === "intersection" ? IntersectionObserver : type === "mutation" ? MutationObserver : ResizeObserver
+  ) as any;
+}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Introduces a utility to consistently create observers (mutation, intersection, resize) for browser contexts. This will help with prerendering.