### PR TITLE
fix(accordion): match icon directions with block when positioned at start

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -3,7 +3,7 @@
   --calcite-accordion-item-flex-direction: row-reverse;
   --calcite-accordion-item-icon-rotation: theme("rotate.-90");
   --calcite-accordion-item-active-icon-rotation: theme("rotate.0");
-  --calcite-accordion-item-icon-rotation-rtl: theme("rotate.-90");
+  --calcite-accordion-item-icon-rotation-rtl: theme("rotate.90");
   --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.0");
   --calcite-accordion-item-icon-spacing-start: 0;
   --calcite-accordion-item-icon-spacing-end: var(--calcite-accordion-icon-margin);

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -2,9 +2,9 @@
 .icon-position--start {
   --calcite-accordion-item-flex-direction: row-reverse;
   --calcite-accordion-item-icon-rotation: theme("rotate.-90");
-  --calcite-accordion-item-active-icon-rotation: theme("rotate.180");
+  --calcite-accordion-item-active-icon-rotation: theme("rotate.0");
   --calcite-accordion-item-icon-rotation-rtl: theme("rotate.-90");
-  --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.-180");
+  --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.0");
   --calcite-accordion-item-icon-spacing-start: 0;
   --calcite-accordion-item-icon-spacing-end: var(--calcite-accordion-icon-margin);
 }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -1,20 +1,22 @@
-// icon position variants for child
-.icon-position--start {
-  --calcite-accordion-item-flex-direction: row-reverse;
+%icon-position {
+  /* icon rotation variables */
   --calcite-accordion-item-icon-rotation: theme("rotate.-90");
   --calcite-accordion-item-active-icon-rotation: theme("rotate.0");
   --calcite-accordion-item-icon-rotation-rtl: theme("rotate.90");
   --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.0");
+}
+
+// icon position variants for child
+.icon-position--start {
+  @extend %icon-position;
+  --calcite-accordion-item-flex-direction: row-reverse;
   --calcite-accordion-item-icon-spacing-start: 0;
   --calcite-accordion-item-icon-spacing-end: var(--calcite-accordion-icon-margin);
 }
 
 .icon-position--end {
+  @extend %icon-position;
   --calcite-accordion-item-flex-direction: row;
-  --calcite-accordion-item-icon-rotation: theme("rotate.-90");
-  --calcite-accordion-item-active-icon-rotation: theme("rotate.0");
-  --calcite-accordion-item-icon-rotation-rtl: theme("rotate.90");
-  --calcite-accordion-item-active-icon-rotation-rtl: theme("rotate.0");
   --calcite-accordion-item-icon-spacing-start: var(--calcite-accordion-icon-margin);
   --calcite-accordion-item-icon-spacing-end: 0;
 }


### PR DESCRIPTION


**Related Issue:** [#2597
](https://github.com/Esri/calcite-components/issues/2597)
## Summary

This fixes the issue in `calcite-accordion` where direction of icons are opposite  when `icon-position` is set to start