### PR TITLE
fix(checkbox): resize calcite-checkbox when unchecked & focusout

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -50,6 +50,7 @@
 :host([indeterminate]) {
   .check-svg {
     @apply bg-brand;
+    box-shadow: inset 0 0 0 1px var(--calcite-ui-brand);
   }
 }
 :host {

--- a/src/components/calcite-checkbox/calcite-checkbox.scss
+++ b/src/components/calcite-checkbox/calcite-checkbox.scss
@@ -49,7 +49,7 @@
 :host([checked]),
 :host([indeterminate]) {
   .check-svg {
-    @apply bg-brand shadow-outline-active;
+    @apply bg-brand;
   }
 }
 :host {


### PR DESCRIPTION
**Related Issue:** #2880 

## Summary
This fixes the `calcite-checbox` size shrink when it is unchecked & focusout and matches with size of checkbox when checked set to true