### PR TITLE
ci(screener): disables alwaysAcceptBaseBranch setting

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -1,13 +1,13 @@
 module.exports = {
-  projectRepo: "Esri/calcite-components",
-  storybookConfigDir: ".storybook",
-  storybookStaticDir: "./__docs-temp__",
+  projectRepo: 'Esri/calcite-components',
+  storybookConfigDir: '.storybook',
+  storybookStaticDir: './__docs-temp__',
   apiKey: process.env.SCREENER_API_KEY,
-  resolution: "1024x768",
-  baseBranch: "master",
+  resolution: '1024x768',
+  baseBranch: 'master',
   browsers: [
     {
-      browserName: "chrome"
+      browserName: 'chrome'
     }
   ],
   failureExitCode: 0

--- a/screener.config.js
+++ b/screener.config.js
@@ -1,14 +1,13 @@
 module.exports = {
-  alwaysAcceptBaseBranch: true,
-  projectRepo: 'Esri/calcite-components',
-  storybookConfigDir: '.storybook',
-  storybookStaticDir: './__docs-temp__',
+  projectRepo: "Esri/calcite-components",
+  storybookConfigDir: ".storybook",
+  storybookStaticDir: "./__docs-temp__",
   apiKey: process.env.SCREENER_API_KEY,
-  resolution: '1024x768',
-  baseBranch: 'master',
+  resolution: "1024x768",
+  baseBranch: "master",
   browsers: [
     {
-      browserName: 'chrome'
+      browserName: "chrome"
     }
   ],
   failureExitCode: 0


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Disables the `alwaysAcceptBaseBranch` Screener setting (from pr #2843).

**Why?**
We don't want undesirable changes that inadvertently get merged into master to be assumed to be correct. These were leading to false positives on subsequent pr builds.

According to Screener, this is how the setting functions:

> Yes, the "alwaysAcceptBaseBranch" is making an assumption that everything in your base branch is correct, and will automatically accept all states - Loyal

For additional insight, see pr #2978 for screenshot examples with the diff behavior Screener failed to pick up with this setting enabled.

**What else did we learn?**
- removal of stories does not impact test results (ie., this won't fail Screener)
- Screener's default settings ignore small layout position/dimension differences. According to Loyal at Screener:

> This can be made stricter using the diffOptions setting in your screener.config.js:
>```
>diffOptions: {
>  minLayoutPosition: 1,
>  minLayoutDimension: 1
>}
>```
>The above sample options will set the minimum threshold to trigger a layout change on > 1px

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
