### PR TITLE
docs(assets): fix broken color link

### DIFF
--- a/src/assets/styles/readme.md
+++ b/src/assets/styles/readme.md
@@ -2,11 +2,11 @@
 
 When building any component in calcite-components or [calcite-components](https://github.com/esri/calcite-components), please use these set of global variables (CSS variables and Sass mixins or variables)
 
-## From calcite-components
+## From [calcite-colors](https://github.com/Esri/calcite-colors)
 
 ### Color
 
-[`_colors.scss`](https://github.com/Esri/calcite-components/blob/master/src/assets/styles/_colors.scss): you'll find the global CSS variables for both light and dark theme.
+[`colors.scss`](https://github.com/Esri/calcite-colors/blob/master/dist/colors.scss): you'll find the global CSS variables for both light and dark theme.
 
 ## From [calcite-base](https://github.com/esri/calcite-base)
 


### PR DESCRIPTION
**Related Issue:** #2999

## Summary
The link to the color assets was broken.