### PR TITLE
chore: fix CDN-updating logic

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -1,4 +1,3 @@
-import { version } from "../package.json";
 import type { Options } from "standard-version";
 
 const childProcess = require("child_process");
@@ -91,7 +90,7 @@ async function runStandardVersion(next: boolean, standardVersionOptions: Options
     await exec(`git add ${changelogPath}`);
   }
 
-  await updateReadmeCdnUrls();
+  await updateReadmeCdnUrls(standardVersionOptions.releaseAs);
   await exec(`git add ${readmePath}`);
 
   await standardVersion(standardVersionOptions);
@@ -136,9 +135,9 @@ async function getUnreleasedChangelogContents(): Promise<string> {
   ).trim();
 }
 
-async function updateReadmeCdnUrls(): Promise<void> {
-  const scriptTagPattern = /(<script type="module" src=").+("><\/script>)/;
-  const linkTagPattern = /(<link rel="stylesheet" type="text\/css" href=").+(" \/>)/;
+async function updateReadmeCdnUrls(version: string): Promise<void> {
+  const scriptTagPattern = /(<script\s+type="module"\s+src=").+("\s*><\/script>)/m;
+  const linkTagPattern = /(<link\s+rel="stylesheet"\s+type="text\/css"\s+href=").+("\s*\/>)/m;
   const baseCdnUrl = `https://unpkg.com/@esri/calcite-components@${version}/dist/calcite/calcite.`;
 
   const readmeContent: string = await fs.readFile(readmePath, { encoding: "utf8" });


### PR DESCRIPTION
**Related Issue:** #2623

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes the CDN-URL-updating code:

* update regexps to handle formatted script/link tags – previously would not match after formatting
* use releaseAs version to generate CDN URLs – previously would use pre-bump/outdated version

