### PR TITLE
chore(actions): only run on opened event

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -1,7 +1,8 @@
 name: PR Bot
 on:
   pull_request:
-    branches: [ master ]
+    types: [opened]
+    branches: [master]
 jobs:
   assign:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
the pr bot kept assigning the creator even when they tried to assign someone else. Only running the action when a PR is opened will fix that