### PR TITLE
test(input): skip unstable test

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -990,7 +990,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe("0");
     });
 
-    it("allows decimals only when the step is a decimal", async () => {
+    it.skip("allows decimals only when the step is a decimal", async () => {
       const page = await newE2EPage({
         html: `
           <calcite-input step="0.001" type="number"></calcite-input>


### PR DESCRIPTION
**Related Issue:** #3017

## Summary
Skips the test for now since it seems to be failing somewhat often in Travis today:
- https://app.travis-ci.com/github/Esri/calcite-components/builds/237410600
- https://app.travis-ci.com/github/Esri/calcite-components/builds/237404008

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
