### PR TITLE
fix(color-picker): render current value when set initially with custom format

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -303,7 +303,16 @@ describe("calcite-color-picker", () => {
         await page.setContent(`<calcite-color-picker format='rgb-css' value='${initialValue}'></calcite-color-picker>`);
         const color = await page.find("calcite-color-picker");
 
+        const initialValueIsRendered = await page.$eval(
+          "calcite-color-picker",
+          (picker: HTMLCalciteColorPickerElement, initialValue: string) =>
+            // color prop is used to render the active color
+            picker.color.string() === initialValue,
+          initialValue
+        );
+
         expect(await color.getProperty("value")).toEqual(initialValue);
+        expect(initialValueIsRendered).toBe(true);
         assertNoChangeEvents();
       });
 
@@ -553,6 +562,7 @@ describe("calcite-color-picker", () => {
       const picker = await page.find("calcite-color-picker");
       const spy = await picker.spyOnEvent("calciteColorPickerChange");
       const currentValue = await picker.getProperty("value");
+      const format = await picker.getProperty("format");
       picker.setProperty("value", unsupportedValue);
       await page.waitForChanges();
 
@@ -561,7 +571,9 @@ describe("calcite-color-picker", () => {
 
       expect(consoleSpy).toBeCalledTimes(1);
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringMatching(`ignoring invalid color value: ${unsupportedValue}`)
+        expect.stringMatching(
+          `ignoring color value (${unsupportedValue}) as it is not compatible with the current format (${format})`
+        )
       );
     }
 

--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -572,7 +572,9 @@ describe("calcite-color-picker", () => {
       expect(consoleSpy).toBeCalledTimes(1);
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringMatching(
-          `ignoring color value (${unsupportedValue}) as it is not compatible with the current format (${format})`
+          new RegExp(
+            `\\s*ignoring color value \\(${unsupportedValue}\\) as it is not compatible with the current format \\(${format}\\)\\s*`
+          )
         )
       );
     }

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -266,7 +266,6 @@ export class CalciteColorPicker {
 
     if (modeChanged || colorChanged) {
       this.color = color;
-
       this.calciteColorPickerInput.emit();
       if (!dragging) {
         this.calciteColorPickerChange.emit();

--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -242,7 +242,7 @@ export class CalciteColorPicker {
       const nextMode = parseMode(value);
 
       if (!nextMode || (format !== "auto" && nextMode !== format)) {
-        console.warn(`ignoring invalid color value: ${value}`);
+        this.showIncompatibleColorWarning(value, format);
         this.value = oldValue;
         return;
       }
@@ -266,6 +266,7 @@ export class CalciteColorPicker {
 
     if (modeChanged || colorChanged) {
       this.color = color;
+
       this.calciteColorPickerInput.emit();
       if (!dragging) {
         this.calciteColorPickerChange.emit();
@@ -691,15 +692,19 @@ export class CalciteColorPicker {
   }
 
   connectedCallback(): void {
-    const { color, format, value } = this;
+    const { allowEmpty, color, format, value } = this;
 
-    // format is user set
-    const initialValueDefault = format === "auto" ? defaultValue : this.toValue(color, format);
-    const initialValue = format === "auto" || value === defaultValue ? value : initialValueDefault;
+    const valueIsNoColor = allowEmpty && !value;
+    const parsedMode = parseMode(value);
+    const valueIsCompatible = (format === "auto" && parsedMode) || format === parsedMode;
+    const initialColor = valueIsNoColor ? null : valueIsCompatible ? Color(value) : color;
+
+    if (!valueIsCompatible) {
+      this.showIncompatibleColorWarning(value, format);
+    }
 
     this.setMode(format);
-    this.handleValueChange(initialValue, initialValueDefault);
-
+    this.internalColorSet(initialColor, false);
     this.updateDimensions(this.scale);
   }
 
@@ -967,6 +972,12 @@ export class CalciteColorPicker {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private showIncompatibleColorWarning(value: ColorValue, format: Format): void {
+    console.warn(
+      `ignoring color value (${value}) as it is not compatible with the current format (${format})`
+    );
+  }
 
   private setMode(format: CalciteColorPicker["format"]): void {
     this.mode = format === "auto" ? this.mode : format;


### PR DESCRIPTION
**Related Issue:** #2994 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

The way the initial value and default were set would sometimes skip setting the internal color and mess up rendering if there was a custom value and format set by the user. 