### PR TITLE
fix(sortable-list): updated to use column layout

### DIFF
--- a/src/components/calcite-sortable-list/calcite-sortable-list.scss
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.scss
@@ -1,3 +1,15 @@
 :host {
   @apply flex;
 }
+
+.container {
+  @apply flex flex-auto;
+}
+
+.container--vertical {
+  @apply flex-col;
+}
+
+.container--horizontal {
+  @apply flex-row;
+}

--- a/src/components/calcite-sortable-list/calcite-sortable-list.tsx
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.tsx
@@ -49,7 +49,7 @@ export class CalciteSortableList {
   /**
    * Indicates the horizontal or vertical orientation of the component.
    */
-  @Prop({ reflect: true }) layout: Layout = "vertical";
+  @Prop() layout: Layout = "vertical";
 
   /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.

--- a/src/components/calcite-sortable-list/calcite-sortable-list.tsx
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.tsx
@@ -208,14 +208,14 @@ export class CalciteSortableList {
 
   render(): VNode {
     const { layout } = this;
-    const layoutProp = layout == "vertical" || layout == "horizontal" ? layout : "vertical";
-    const layoutClass = layoutProp === "vertical" ? CSS.containerVertical : CSS.containerHorizontal;
+    const horizontal = layout === "horizontal" || false;
 
     return (
       <div
         class={{
           [CSS.container]: true,
-          [layoutClass]: true
+          [CSS.containerVertical]: !horizontal,
+          [CSS.containerHorizontal]: horizontal
         }}
       >
         <slot />

--- a/src/components/calcite-sortable-list/calcite-sortable-list.tsx
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.tsx
@@ -11,6 +11,8 @@ import {
   VNode
 } from "@stencil/core";
 import { createObserver } from "../../utils/observers";
+import { Layout } from "../interfaces";
+import { CSS } from "./resources";
 
 /**
  * @slot - A slot for adding sortable items
@@ -43,6 +45,11 @@ export class CalciteSortableList {
    * The selector for the handle elements.
    */
   @Prop() handleSelector = "calcite-handle";
+
+  /**
+   * Indicates the horizontal or vertical orientation of the component.
+   */
+  @Prop({ reflect: true }) layout: Layout = "vertical";
 
   /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
@@ -200,6 +207,19 @@ export class CalciteSortableList {
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    return <slot />;
+    const { layout } = this;
+    const layoutProp = layout == "vertical" || layout == "horizontal" ? layout : "vertical";
+    const layoutClass = layoutProp === "vertical" ? CSS.containerVertical : CSS.containerHorizontal;
+
+    return (
+      <div
+        class={{
+          [CSS.container]: true,
+          [layoutClass]: true
+        }}
+      >
+        <slot />
+      </div>
+    );
   }
 }

--- a/src/components/calcite-sortable-list/readme.md
+++ b/src/components/calcite-sortable-list/readme.md
@@ -10,6 +10,7 @@
 | `dragSelector`   | `drag-selector`   | Specifies which items inside the element should be draggable.                                                        | `string`  | `undefined`        |
 | `group`          | `group`           | The list's group identifier. To drag elements from one list into another, both lists must have the same group value. | `string`  | `undefined`        |
 | `handleSelector` | `handle-selector` | The selector for the handle elements.                                                                                | `string`  | `"calcite-handle"` |
+| `layout`         | `layout`          | Indicates the horizontal or vertical orientation of the component.                                                   | `string`  | `"vertical"`       |
 | `loading`        | `loading`         | When true, content is waiting to be loaded. This state shows a busy indicator.                                       | `boolean` | `false`            |
 
 ## Events

--- a/src/components/calcite-sortable-list/resources.ts
+++ b/src/components/calcite-sortable-list/resources.ts
@@ -1,3 +1,6 @@
 export const CSS = {
-  sortItem: "sort-item"
+  sortItem: "sort-item",
+  container: "container",
+  containerHorizontal: "container--horizontal",
+  containerVertical: "container--vertical"
 };


### PR DESCRIPTION
**Related Issue:** #2889

## Summary
* Updates to use flex column layout 
* Adds `layout` property that defaults to "vertical"



<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
