### PR TITLE
chore: new bugs require a repro sample

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,9 +24,11 @@ please add a 👍 reaction to the existing issue instead of creating a new one.
 
 <!-- What you expected instead, and why -->
 
-### Reproduction Steps or Sample
+### Reproduction Steps and Sample
 
-<!-- no code screenshots -->
+<!-- A codepen, codesandbox, or jsbin sample and the steps to reproduce the issue -->
+
+_Sample_:
 
 1.
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -26,7 +26,10 @@ please add a 👍 reaction to the existing issue instead of creating a new one.
 
 ### Reproduction Steps and Sample
 
-<!-- A codepen, codesandbox, or jsbin sample and the steps to reproduce the issue -->
+<!--
+* A codepen, codesandbox, or jsbin sample and the steps to reproduce the issue are required
+* There are links to template samples in the contributing documentation: https://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#before-filing-an-issue
+-->
 
 _Sample_:
 

--- a/.github/need-info.yml
+++ b/.github/need-info.yml
@@ -1,0 +1,21 @@
+labelToAdd: 'need more info'
+labelsToCheck:
+  - bug
+commentHeader: 'More information is required to proceed with this issue:'
+requiredItems:
+  -
+    response: '- Copy the [issue template](https://github.com/Esri/calcite-components/issues/new?assignees=&labels=bug%2C+0+-+new%2C+needs+triage&template=bug.md&title=Bug%3A+) format and paste it into a comment, providing all of the requested items'
+    requireAll: true
+    content:
+      - '### Actual Behavior'
+      - '### Expected Behavior'
+      - '### Reproduction Steps and Sample'
+      - '### Relevant Info'
+  -
+    response: '- Provide a [codepen](https://codepen.io/pen), [codesandbox](https://codesandbox.io/s), or [jsbin](https://jsbin.com) that reproduces the issue'
+    requireAll: false
+    content:
+      - 'https://jsbin.com/'
+      - 'https://codepen.io/'
+      - 'https://codesandbox.io/'
+commentFooter: 'This issue will be automatically closed in three days if the information is not provided. Thanks for your understanding.'

--- a/.github/need-info.yml
+++ b/.github/need-info.yml
@@ -12,7 +12,7 @@ requiredItems:
       - '### Reproduction Steps and Sample'
       - '### Relevant Info'
   -
-    response: '- Provide a [codepen](https://codepen.io/pen), [codesandbox](https://codesandbox.io/s), or [jsbin](https://jsbin.com) that reproduces the issue'
+    response: '- Provide a [codepen](https://codepen.io/pen?template=RwgrjEx), [codesandbox](https://codesandbox.io/s/calcite-template-p95kp?file=/src/App.js), or [jsbin](https://jsbin.com/zocobeqopu/edit?html,css,js,output) that reproduces the issue'
     requireAll: false
     content:
       - 'https://jsbin.com/'

--- a/.github/workflows/need-info-close.yml
+++ b/.github/workflows/need-info-close.yml
@@ -1,0 +1,16 @@
+name: "Need Info - Close"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-stale: -1
+          days-before-close: 3
+          remove-stale-when-updated: false
+          stale-issue-label: "need more info"
+          stale-pr-label: "need more info"
+          close-issue-message: "This issue has been automatically closed due to missing information. We will reopen the issue if the information is provided and `benelan` is mentioned in the comment."

--- a/.github/workflows/need-info-verify.yml
+++ b/.github/workflows/need-info-verify.yml
@@ -1,0 +1,13 @@
+name: 'Need Info - Verify'
+on:
+  issues:
+    types: [labeled]
+    branches: [master]
+  issue_comment:
+    types: [created]
+    branches: [master]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benelan/need-info-action@v1.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,7 @@ If you aren't familiar with the basics of WebComponents and Shadow DOM please re
 
 ### Before filing an issue
 
-If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/calcite-components/issues) first. Have you found a new bug? Want to request a new feature? We'd [love](https://github.com/Esri/calcite-components/issues/new) to hear from you.
-
-**Please include the following information in your issue:**
-
-- Browser (or Node.js) version
-- A snippet of code
-- an explanation of
-  - What you saw
-  - What you expected to see
+If something isn't working the way you expect, please take a look at the [existing issues](https://github.com/Esri/calcite-components/issues) before logging a new one. Have you found a new bug? Want to request a new feature? We'd love to hear from you! Please make sure to provide all of the requested info from the appropriate [issue template](https://github.com/Esri/calcite-components/issues/new/choose) so we can work on resolving the issue as soon as possible.
 
 ### Getting a development environment set up
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you aren't familiar with the basics of WebComponents and Shadow DOM please re
 
 ### Before filing an issue
 
-If something isn't working the way you expect, please take a look at the [existing issues](https://github.com/Esri/calcite-components/issues) before logging a new one. Have you found a new bug? Want to request a new feature? We'd love to hear from you! Please make sure to provide all of the requested info from the appropriate [issue template](https://github.com/Esri/calcite-components/issues/new/choose) so we can work on resolving the issue as soon as possible.
+If something isn't working the way you expect, please take a look at the [existing issues](https://github.com/Esri/calcite-components/issues) before logging a new one. Have you found a new bug? Want to request a new feature? We'd love to hear from you! Please make sure to provide all of the requested info from the appropriate [issue template](https://github.com/Esri/calcite-components/issues/new/choose) so we can work on resolving the issue as soon as possible. A sample that reproduces the issue is required for logging bugs, we created templates in [codepen](https://codepen.io/pen?template=RwgrjEx), [codesandbox](https://codesandbox.io/s/calcite-template-p95kp?file=/src/App.js), and [jsbin](https://jsbin.com/zocobeqopu/edit?html,css,js,output) to help get started.
 
 ### Getting a development environment set up
 


### PR DESCRIPTION
**Related Issue:** #2962 

## Summary
Repro samples and the full issue template format will now be required when logging bugs. 

- Updated the contributing doc and bug issue template to mention the new requirement
- Added a new [github action](https://github.com/benelan/need-info-action) to automatically request more info and close the issue if none are provided
- If an issue has a `need more info` label it will be closed in three days unless info is provided, so keep that in mind when adding the label manually