### PR TITLE
fix(color-picker): fix mouse tracking logic when moved within another component's shadow DOM

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -552,12 +552,13 @@ export class CalciteColorPicker {
     let samplingX: number;
     let samplingY: number;
 
+    const colorFieldAndSliderRect = this.activeColorFieldAndSliderRect;
+    const { clientX, clientY } = event;
+
     if (this.colorFieldAndSliderHovered) {
-      samplingX = event.offsetX;
-      samplingY = event.offsetY;
+      samplingX = clientX - colorFieldAndSliderRect.x;
+      samplingY = clientY - colorFieldAndSliderRect.y;
     } else {
-      const { clientX, clientY } = event;
-      const colorFieldAndSliderRect = this.activeColorFieldAndSliderRect;
       const colorFieldWidth = dimensions.colorField.width;
       const colorFieldHeight = dimensions.colorField.height;
       const hueSliderHeight = dimensions.slider.height;


### PR DESCRIPTION
**Related Issue:** #3035

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes an issue where the X/Y coordinates were sampled incorrectly while dragging the color field thumb when the component was placed within another shadow DOM root. 

**Note**: I'm looking at adding a specific test to catch this that doesn't involve an additional test suite run within shadow DOM.