### PR TITLE
fix(action-bar): Better handling of overflow actions on smaller screens

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -301,4 +301,87 @@ describe("calcite-action-bar", () => {
 
     expect(await button.getProperty("scale")).toBe("l");
   });
+
+  describe("overflow actions", () => {
+    it("should slot 'menu-actions' on sublist changes", async () => {
+      const page = await newE2EPage({
+        html: html`<calcite-action-bar style="height: 290px">
+          <calcite-action-group id="dynamic-group"
+            ><calcite-action text="Layer properties" icon="sliders-horizontal"></calcite-action>
+            <calcite-action id="second-action" text="Styles" icon="shapes"></calcite-action
+          ></calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Save" icon="save" disabled></calcite-action>
+            <calcite-action icon="layers" text="Layers"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group slot="bottom-actions">
+            <calcite-action text="Tips" icon="lightbulb"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>`
+      });
+      await page.waitForChanges();
+
+      const dynamicGroupActionsSelector = "#dynamic-group calcite-action";
+      const slottedActionsSelector = `calcite-action[slot="menu-actions"]`;
+
+      expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(2);
+      expect(await page.findAll(slottedActionsSelector)).toHaveLength(0);
+
+      await page.$eval("calcite-action-bar", (element: HTMLCalciteActionBarElement) => {
+        element.ownerDocument.getElementById("second-action").insertAdjacentHTML(
+          "afterend",
+          `
+          <calcite-action text="Styles" icon="shapes"></calcite-action>
+          <calcite-action text="Filter" icon="layer-filter"></calcite-action>
+          <calcite-action text="Configure pop-ups" icon="popup"></calcite-action>
+          <calcite-action text="Configure attributes" icon="feature-details"></calcite-action>
+          <calcite-action text="Labels" icon="label" active></calcite-action>
+          <calcite-action text="Table" icon="table"></calcite-action>`
+        );
+      });
+      await page.waitForChanges();
+
+      expect(await page.findAll(slottedActionsSelector)).toHaveLength(7);
+      expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
+    });
+
+    it("should slot 'menu-actions' on resize", async () => {
+      const page = await newE2EPage({
+        html: html`<calcite-action-bar style="height: 290px">
+          <calcite-action-group id="dynamic-group"
+            ><calcite-action text="Layer properties" icon="sliders-horizontal"></calcite-action>
+            <calcite-action text="Styles" icon="shapes"></calcite-action>
+            <calcite-action text="Styles" icon="shapes"></calcite-action>
+            <calcite-action text="Filter" icon="layer-filter"></calcite-action>
+            <calcite-action text="Configure pop-ups" icon="popup"></calcite-action>
+            <calcite-action text="Configure attributes" icon="feature-details"></calcite-action>
+            <calcite-action text="Labels" icon="label" active></calcite-action>
+            <calcite-action text="Table" icon="table"></calcite-action
+          ></calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Save" icon="save" disabled></calcite-action>
+            <calcite-action icon="layers" text="Layers"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group slot="bottom-actions">
+            <calcite-action text="Tips" icon="lightbulb"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>`
+      });
+      await page.waitForChanges();
+
+      const dynamicGroupActionsSelector = "#dynamic-group calcite-action";
+      const slottedActionsSelector = `calcite-action[slot="menu-actions"]`;
+
+      expect(await page.findAll(slottedActionsSelector)).toHaveLength(7);
+      expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
+
+      await page.$eval("calcite-action-bar", (element: HTMLCalciteActionBarElement) => {
+        element.style.height = "550px";
+      });
+      await page.waitForChanges();
+
+      expect(await page.findAll(slottedActionsSelector)).toHaveLength(2);
+      expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
+    });
+  });
 });

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -45,7 +45,7 @@ export class CalciteActionBar {
       toggleChildActionText({ parent: this.el, expanded: this.expanded });
     }
 
-    this.resize(this.el.clientHeight);
+    this.resizeFromHost();
   }
 
   /**
@@ -116,7 +116,7 @@ export class CalciteActionBar {
   mutationObserver = createObserver("mutation", () => {
     const { el, expanded } = this;
     toggleChildActionText({ parent: el, expanded });
-    this.resize(el.clientHeight);
+    this.resizeFromHost();
   });
 
   resizeObserver = createObserver("resize", (entries) => this.resizeHandlerEntries(entries));
@@ -136,7 +136,7 @@ export class CalciteActionBar {
   // --------------------------------------------------------------------------
 
   componentDidLoad(): void {
-    this.resize(this.el.clientHeight);
+    this.resizeFromHost();
   }
 
   connectedCallback(): void {
@@ -146,11 +146,13 @@ export class CalciteActionBar {
       toggleChildActionText({ parent: el, expanded });
     }
 
-    this.mutationObserver?.observe(el, { childList: true });
+    this.mutationObserver?.observe(el, { childList: true, subtree: true });
 
     if (!this.overflowActionsDisabled) {
       this.resizeObserver?.observe(el);
     }
+
+    this.resizeFromHost();
   }
 
   disconnectedCallback(): void {
@@ -192,6 +194,10 @@ export class CalciteActionBar {
     }
   };
 
+  resizeFromHost = (): void => {
+    this.resize(this.el.clientHeight);
+  };
+
   resizeHandlerEntries = (entries: ResizeObserverEntry[]): void => {
     entries.forEach(this.resizeHandler);
   };
@@ -212,7 +218,7 @@ export class CalciteActionBar {
       overflowActionsDisabled
     } = this;
 
-    if (typeof height !== "number" || overflowActionsDisabled) {
+    if (typeof height !== "number" || overflowActionsDisabled || height === 0) {
       return;
     }
 

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -218,7 +218,7 @@ export class CalciteActionBar {
       overflowActionsDisabled
     } = this;
 
-    if (typeof height !== "number" || overflowActionsDisabled || height === 0) {
+    if (typeof height !== "number" || overflowActionsDisabled || !height) {
       return;
     }
 

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -218,7 +218,7 @@ export class CalciteActionBar {
       overflowActionsDisabled
     } = this;
 
-    if (typeof height !== "number" || overflowActionsDisabled || !height) {
+    if (!height || overflowActionsDisabled) {
       return;
     }
 

--- a/src/components/functional/CalciteExpandToggle.tsx
+++ b/src/components/functional/CalciteExpandToggle.tsx
@@ -2,6 +2,7 @@ import { FunctionalComponent, h } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
 import { queryActions } from "../calcite-action-bar/utils";
 import { Position, Scale } from "../interfaces";
+import { SLOTS as ACTION_GROUP_SLOTS } from "../calcite-action-group/resources";
 
 interface CalciteExpandToggleProps {
   expanded: boolean;
@@ -32,7 +33,7 @@ export function toggleChildActionText({
   expanded: boolean;
 }): void {
   queryActions(parent)
-    .filter((el) => el.slot !== "menu-actions")
+    .filter((el) => el.slot !== ACTION_GROUP_SLOTS.menuActions)
     .forEach((action) => (action.textEnabled = expanded));
   parent.querySelectorAll("calcite-action-group").forEach((group) => (group.expanded = expanded));
 }


### PR DESCRIPTION
**Related Issue:** #3025

## Summary

fix(action-bar): Better handling of overflow actions on smaller screens #3042

## This PR

- Modifies the mutationObserver to listen to `subtree` changes.
- Calls resize on `connectedCallback`
- Checks resize for an actual height greater than 0 before continuing.
- Cleans up code for resizing based on the host element clientHeight.
- Cleans up code for a slot name.