### PR TITLE
chore(actions): need info edit event removes label

### DIFF
--- a/.github/workflows/need-info-verify.yml
+++ b/.github/workflows/need-info-verify.yml
@@ -1,13 +1,13 @@
 name: 'Need Info - Verify'
 on:
   issues:
-    types: [labeled]
+    types: [labeled, edited]
     branches: [master]
   issue_comment:
-    types: [created]
+    types: [created, edited]
     branches: [master]
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: benelan/need-info-action@v1.2.0
+      - uses: benelan/need-info-action@v1.3.1


### PR DESCRIPTION
## Summary
- When an issue is marked with the `need more info` label and the user edits the issue body to add all of the required items, the label is removed
- This came up in issue 3071 (I don't want to actually link the issue since this isn't a fix for it)

## Changes
- add edit event to gh action
- bump action version to correctly handle edit events