### PR TITLE
fix(slider): move maxValue thumb when thumbs overlap at min edge

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -383,4 +383,62 @@ describe("calcite-slider", () => {
       }
     });
   });
+
+  describe("when range thumbs overlap at min edge", () => {
+    const slider = `<calcite-slider
+      min="5"
+      max="100"
+      min-value="5"
+      max-value="5"
+      step="10"
+      ticks="10"
+      label="Temperature"
+      label-handles
+      label-ticks
+      snap`;
+
+    it("click/tap should grab the max value thumb", async () => {
+      const page = await newE2EPage({
+        html: `
+        <div style="width: 300px; margin: 1rem;">
+          ${slider}></calcite-slider>
+        </div>
+        `
+      });
+      const element = await page.find("calcite-slider");
+      const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+      const changeEvent = await element.spyOnEvent("calciteSliderChange");
+      expect(await element.getProperty("minValue")).toBe(5);
+      expect(await element.getProperty("maxValue")).toBe(5);
+
+      await maxValueThumb.click();
+      await page.waitForChanges();
+
+      expect(await element.getProperty("minValue")).toBe(5);
+      expect(await element.getProperty("maxValue")).toBe(10);
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+    });
+
+    it("mirrored: click/tap should grab the max value thumb", async () => {
+      const page = await newE2EPage({
+        html: `
+        <div style="width: 300px; margin: 1rem;">
+          ${slider} mirrored></calcite-slider>
+        </div>
+        `
+      });
+      const element = await page.find("calcite-slider");
+      const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+      const changeEvent = await element.spyOnEvent("calciteSliderChange");
+      expect(await element.getProperty("minValue")).toBe(5);
+      expect(await element.getProperty("maxValue")).toBe(5);
+
+      await maxValueThumb.click();
+      await page.waitForChanges();
+
+      expect(await element.getProperty("minValue")).toBe(5);
+      expect(await element.getProperty("maxValue")).toBe(10);
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+    });
+  });
 });

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -735,7 +735,7 @@ export class CalciteSlider {
         prop = "minMaxValue";
       } else {
         const closerToMax = Math.abs(this.maxValue - position) < Math.abs(this.minValue - position);
-        prop = closerToMax ? "maxValue" : "minValue";
+        prop = closerToMax || position > this.maxValue ? "maxValue" : "minValue";
       }
     }
     this[prop] = this.clamp(position, prop);


### PR DESCRIPTION
**Related Issue:** #2481

## Summary
Fixes an issue where slider's maxValue thumb can't be moved via pointer if thumbs overlap at min edge. (Repro with [Storybook iframe url](https://esri.github.io/calcite-components/iframe.html?id=components-controls-slider--range&args=&knob-min=5&knob-min-label=Temperature,%20lower%20bound&knob-min-value=5&knob-max=100&knob-max-label=Temperature,%20upper%20bound&knob-max-value=5&knob-step=10&knob-ticks=10&knob-snap=true&knob-label-handles=true&knob-label-ticks=true&viewMode=story))

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
