### PR TITLE
fix(stepper-item): remove margin-bottom for calcite-stepper-item

### DIFF
--- a/src/components/calcite-stepper-item/calcite-stepper-item.scss
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.scss
@@ -33,6 +33,7 @@
   flex-grow
   flex-col
   relative;
+  margin-bottom: var(--calcite-stepper-item-spacing-unit-s);
 }
 
 :host .container {
@@ -243,10 +244,6 @@
   & .stepper-item-content {
     @apply p-0;
   }
-}
-
-:host([layout="vertical"]) {
-  margin-bottom: var(--calcite-stepper-item-spacing-unit-s);
 }
 
 // only show the content for vertical items

--- a/src/components/calcite-stepper-item/calcite-stepper-item.scss
+++ b/src/components/calcite-stepper-item/calcite-stepper-item.scss
@@ -232,7 +232,6 @@
     mx-0
     mt-0;
   padding-left: var(--calcite-stepper-item-spacing-unit-l);
-  margin-bottom: var(--calcite-stepper-item-spacing-unit-s);
 
   & .stepper-item-icon {
     @apply mt-px mr-0 mb-0 ml-auto order-3;
@@ -244,6 +243,10 @@
   & .stepper-item-content {
     @apply p-0;
   }
+}
+
+:host([layout="vertical"]) {
+  margin-bottom: var(--calcite-stepper-item-spacing-unit-s);
 }
 
 // only show the content for vertical items


### PR DESCRIPTION
**Related Issue:** #2715 

## Summary

This  fix  removes the `margin-bottom` of container in `calcite-stepper-item ` and apply it to the `:host `element 
