### PR TITLE
fix(slider): align minValue thumb when both minValue/maxValue are zero

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -392,7 +392,6 @@ describe("calcite-slider", () => {
       max-value="5"
       step="10"
       ticks="10"
-      label="Temperature"
       label-handles
       label-ticks
       snap`;
@@ -439,6 +438,46 @@ describe("calcite-slider", () => {
       expect(await element.getProperty("minValue")).toBe(5);
       expect(await element.getProperty("maxValue")).toBe(10);
       expect(changeEvent).toHaveReceivedEventTimes(1);
+    });
+  });
+
+  describe("when a non-histogram range has 0 for both minValue and maxValue", () => {
+    const slider = `<calcite-slider
+      min="-10"
+      max="1"
+      min-value="0"
+      max-value="0"`;
+
+    it("should position the minValue thumb beside the maxValue thumb", async () => {
+      const page = await newE2EPage({
+        html: `
+        <div style="width: 300px; margin: 1rem;">
+          ${slider}></calcite-slider>
+        </div>
+        `
+      });
+      const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
+      const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+      const minHandleStyles = await minValueThumb.getComputedStyle();
+      const maxHandleStyles = await maxValueThumb.getComputedStyle();
+      expect(minHandleStyles.left).toBe("258.172px");
+      expect(maxHandleStyles.right).toBe("25.8125px");
+    });
+
+    it("should position the minValue thumb beside the maxValue thumb when mirrored", async () => {
+      const page = await newE2EPage({
+        html: `
+        <div style="width: 300px; margin: 1rem;">
+          ${slider} mirrored></calcite-slider>
+        </div>
+        `
+      });
+      const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
+      const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+      const minHandleStyles = await minValueThumb.getComputedStyle();
+      const maxHandleStyles = await maxValueThumb.getComputedStyle();
+      expect(minHandleStyles.left).toBe("25.8125px");
+      expect(maxHandleStyles.right).toBe("258.172px");
     });
   });
 });

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -143,7 +143,8 @@ export class CalciteSlider {
     const max = this.maxValue || this.value;
     const maxProp = this.isRange ? "maxValue" : "value";
     const value = this[maxProp];
-    const minInterval = this.getUnitInterval(min) * 100;
+    const useMinValue = this.shouldUseMinValue();
+    const minInterval = this.getUnitInterval(useMinValue ? this.minValue : min) * 100;
     const maxInterval = this.getUnitInterval(max) * 100;
     const mirror = this.shouldMirror();
     const leftThumbOffset = `${mirror ? 100 - minInterval : minInterval}%`;
@@ -528,12 +529,16 @@ export class CalciteSlider {
             <div class="ticks">
               {this.tickValues.map((tick) => {
                 const tickOffset = `${this.getUnitInterval(tick) * 100}%`;
+                let activeTicks = tick >= min && tick <= max;
+                if (useMinValue) {
+                  activeTicks = tick >= this.minValue && tick <= this.maxValue;
+                }
 
                 return (
                   <span
                     class={{
                       tick: true,
-                      "tick--active": tick >= min && tick <= max
+                      "tick--active": activeTicks
                     }}
                     style={{
                       left: mirror ? "" : tickOffset,
@@ -818,6 +823,10 @@ export class CalciteSlider {
 
   private shouldMirror(): boolean {
     return this.mirrored && !this.hasHistogram;
+  }
+
+  private shouldUseMinValue(): boolean {
+    return this.isRange && !this.hasHistogram && this.minValue === 0;
   }
 
   private generateTickValues(): number[] {


### PR DESCRIPTION
**Related Issue:** #2480

## Summary
Fixes an issue where a non-histogram range slider's minValue thumb is not placed correctly when both minValue and maxValue are `0`. ([Repro with Storybook iframe url](https://esri.github.io/calcite-components/iframe.html?id=components-controls-slider--range&knob-min=-100&knob-min-label=Temperature,%20lower%20bound&knob-min-value=0&knob-max=0&knob-max-label=Temperature,%20upper%20bound&knob-max-value=0&knob-step=1&knob-ticks=20&knob-label-ticks=true&knob-label-handles=false&viewMode=story))

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
