### PR TITLE
chore: format yml files using prettier

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,6 @@
 {
-  "*.html": ["prettier --write"],
+  "*.{json,md,html,yml}": ["prettier --write"],
   "*.js": ["eslint --ext .js --fix", "prettier --write"],
-  "*.{json,md}": ["prettier --write"],
   "*.scss": ["stylelint --fix", "prettier --write"],
   "*.{ts,tsx}": ["eslint --ext .ts,.tsx --fix", "prettier --write"]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:js": "eslint --ext .js --fix . && prettier --write \"**/*.js\"",
     "lint:json": "prettier --write \"**/*.json\"",
     "lint:md": "prettier --write \"**/*.md\"",
+    "lint:yml": "prettier --write \"**/*.yml\"",
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\"",
     "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\"",
     "posttest": "npm run test:prerender",


### PR DESCRIPTION
## Summary
Use prettier to format yml files the same way we do for other file types
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
