### PR TITLE
chore(action): automatically notify teams channel about releases

### DIFF
--- a/.github/workflows/teams-release-msg.yml
+++ b/.github/workflows/teams-release-msg.yml
@@ -1,0 +1,27 @@
+name: Release Notification
+on:
+  release:
+    types: [published]
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release version
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const release = context.payload.release
+            if (!release) {
+              console.log("No release found")
+              return
+            }
+            core.exportVariable("RELEASE_VERSION", release.tag_name);
+      - name: Wait for npm release
+        run: sleep 30m
+        shell: bash
+      - name: Teams channel notification
+        uses: FTsbrown/msteams-action@master
+        with:
+          TITLE: ${{ env.RELEASE_VERSION }}
+          BODY: "🚀 <code>@esri/calcite-components@${{ env.RELEASE_VERSION }}</code> released! Check out the [changelog](https://github.com/Esri/calcite-components/blob/master/CHANGELOG.md) for more info. 🚀"
+          MS_TEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URI }}


### PR DESCRIPTION
## Summary
- When a github release is published this action will run
- It gets the release version using the tag
- Waits 30 min to make sure we have time to release to npm
- Sends the message to the CC teams channel
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
