### PR TITLE
chore(actions): fix milestone action to stop failing on dependabot prs

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -17,4 +17,4 @@ jobs:
   milestone:
     runs-on: ubuntu-latest
     steps:
-      - uses: benelan/milestone-action@v1.1.0
+      - uses: benelan/milestone-action@v1.1.1


### PR DESCRIPTION
**Related Issue:** #3077

## Summary
The milestone action is failing on PRs by dependabot. This is by design for security reasons, as described [here](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).

I [changed](https://github.com/benelan/milestone-action/blob/main/src/main.ts#L13-L15) the action to skip PRs by dependabot for the time being until I think of a better solution.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
