### PR TITLE
fix(slider): align histogram minValue thumb when both minValue/maxValue are zero

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -441,43 +441,66 @@ describe("calcite-slider", () => {
     });
   });
 
-  describe("when a non-histogram range has 0 for both minValue and maxValue", () => {
+  describe("when a range has 0 for both minValue and maxValue", () => {
     const slider = `<calcite-slider
       min="-10"
       max="1"
       min-value="0"
       max-value="0"`;
+    const nonMirroredSlider = `<div style="width: 300px; margin: 1rem;">${slider}></calcite-slider></div>`;
+    const mirroredSlider = `<div style="width: 300px; margin: 1rem;">${slider} mirrored></calcite-slider></div>`;
 
     it("should position the minValue thumb beside the maxValue thumb", async () => {
-      const page = await newE2EPage({
-        html: `
-        <div style="width: 300px; margin: 1rem;">
-          ${slider}></calcite-slider>
-        </div>
-        `
-      });
+      const page = await newE2EPage({ html: nonMirroredSlider });
       const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
       const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
-      const minHandleStyles = await minValueThumb.getComputedStyle();
-      const maxHandleStyles = await maxValueThumb.getComputedStyle();
-      expect(minHandleStyles.left).toBe("258.172px");
-      expect(maxHandleStyles.right).toBe("25.8125px");
+      const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
+      const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
+      expect(minHandleLeft).toBe("258.172px");
+      expect(maxHandleRight).toBe("25.8125px");
     });
 
     it("should position the minValue thumb beside the maxValue thumb when mirrored", async () => {
-      const page = await newE2EPage({
-        html: `
-        <div style="width: 300px; margin: 1rem;">
-          ${slider} mirrored></calcite-slider>
-        </div>
-        `
-      });
+      const page = await newE2EPage({ html: mirroredSlider });
       const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
       const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
-      const minHandleStyles = await minValueThumb.getComputedStyle();
-      const maxHandleStyles = await maxValueThumb.getComputedStyle();
-      expect(minHandleStyles.left).toBe("25.8125px");
-      expect(maxHandleStyles.right).toBe("258.172px");
+      const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
+      const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
+      expect(minHandleLeft).toBe("25.8125px");
+      expect(maxHandleRight).toBe("258.172px");
+    });
+
+    describe("when it's a histogram range", () => {
+      it("should position the minValue thumb beside the maxValue thumb", async () => {
+        const page = await newE2EPage({ html: nonMirroredSlider });
+        await page.$eval("calcite-slider", (slider: HTMLCalciteSliderElement) => {
+          slider.histogram = [
+            [0, 0],
+            [20, 12],
+            [40, 25],
+            [60, 55],
+            [80, 10],
+            [100, 0]
+          ];
+        });
+        await page.waitForChanges();
+        const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
+        const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+        const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
+        const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
+        expect(minHandleLeft).toBe("258.172px");
+        expect(maxHandleRight).toBe("25.8125px");
+      });
+
+      it("should position the minValue thumb beside the maxValue thumb when mirrored", async () => {
+        const page = await newE2EPage({ html: mirroredSlider });
+        const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
+        const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+        const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
+        const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
+        expect(minHandleLeft).toBe("25.8125px");
+        expect(maxHandleRight).toBe("258.172px");
+      });
     });
   });
 });

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -470,37 +470,25 @@ describe("calcite-slider", () => {
       expect(maxHandleRight).toBe("258.172px");
     });
 
-    describe("when it's a histogram range", () => {
-      it("should position the minValue thumb beside the maxValue thumb", async () => {
-        const page = await newE2EPage({ html: nonMirroredSlider });
-        await page.$eval("calcite-slider", (slider: HTMLCalciteSliderElement) => {
-          slider.histogram = [
-            [0, 0],
-            [20, 12],
-            [40, 25],
-            [60, 55],
-            [80, 10],
-            [100, 0]
-          ];
-        });
-        await page.waitForChanges();
-        const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
-        const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
-        const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
-        const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
-        expect(minHandleLeft).toBe("258.172px");
-        expect(maxHandleRight).toBe("25.8125px");
+    it("should position the minValue thumb beside the maxValue thumb when it's a histogram range", async () => {
+      const page = await newE2EPage({ html: nonMirroredSlider });
+      await page.$eval("calcite-slider", (slider: HTMLCalciteSliderElement) => {
+        slider.histogram = [
+          [0, 0],
+          [20, 12],
+          [40, 25],
+          [60, 55],
+          [80, 10],
+          [100, 0]
+        ];
       });
-
-      it("should position the minValue thumb beside the maxValue thumb when mirrored", async () => {
-        const page = await newE2EPage({ html: mirroredSlider });
-        const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
-        const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
-        const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
-        const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
-        expect(minHandleLeft).toBe("25.8125px");
-        expect(maxHandleRight).toBe("258.172px");
-      });
+      await page.waitForChanges();
+      const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
+      const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
+      const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
+      const maxHandleRight = await (await maxValueThumb.getComputedStyle()).right;
+      expect(minHandleLeft).toBe("258.172px");
+      expect(maxHandleRight).toBe("25.8125px");
     });
   });
 });

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -825,7 +825,12 @@ export class CalciteSlider {
   }
 
   private shouldUseMinValue(): boolean {
-    return this.isRange && !this.hasHistogram && this.minValue === 0;
+    if (!this.isRange) {
+      return;
+    }
+    return (
+      (this.hasHistogram && this.maxValue === 0) || (!this.hasHistogram && this.minValue === 0)
+    );
   }
 
   private generateTickValues(): number[] {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -826,7 +826,7 @@ export class CalciteSlider {
 
   private shouldUseMinValue(): boolean {
     if (!this.isRange) {
-      return;
+      return false;
     }
     return (
       (this.hasHistogram && this.maxValue === 0) || (!this.hasHistogram && this.minValue === 0)


### PR DESCRIPTION
**Related Issue:** #2480 (follow-on to pr #3083)

## Summary
Fixes an issue where a histogram range slider's minValue thumb is not placed correctly when both minValue and maxValue are 0. ([Repro with Storybook iframe url](https://esri.github.io/calcite-components/iframe.html?id=components-controls-slider--histogram&args=&knob-min=-10&knob-min-value=0&knob-max=1&knob-max-value=0&knob-ticks=1&knob-label-handles=true&knob-label-ticks=true&viewMode=story))

(The highlighted histogram range will still need to be fixed in #2914.)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
