### PR TITLE
refactor (calcite-font-weight-bold): updated weight to 600

### DIFF
--- a/src/assets/styles/_type.scss
+++ b/src/assets/styles/_type.scss
@@ -19,5 +19,5 @@
   --calcite-font-weight-light: 300;
   --calcite-font-weight-normal: 400;
   --calcite-font-weight-medium: 500;
-  --calcite-font-weight-bold: 700;
+  --calcite-font-weight-bold: 600;
 }

--- a/src/assets/styles/_type.scss
+++ b/src/assets/styles/_type.scss
@@ -20,4 +20,5 @@
   --calcite-font-weight-normal: 400;
   --calcite-font-weight-medium: 500;
   --calcite-font-weight-bold: 600;
+  // space
 }

--- a/src/assets/styles/_type.scss
+++ b/src/assets/styles/_type.scss
@@ -20,5 +20,4 @@
   --calcite-font-weight-normal: 400;
   --calcite-font-weight-medium: 500;
   --calcite-font-weight-bold: 600;
-  // space
 }

--- a/src/assets/styles/readme.md
+++ b/src/assets/styles/readme.md
@@ -59,7 +59,7 @@ Two font weights are available using CSS vars.
 | --calcite-font-weight-light  | 300   |
 | --calcite-font-weight-normal | 400   |
 | --calcite-font-weight-medium | 500   |
-| --calcite-font-weight-bold   | 700   |
+| --calcite-font-weight-bold   | 600   |
 
 Example:
 


### PR DESCRIPTION
**Related Issue:** #2728

## Summary

Updated `--calcite-font-weight-bold` from `700` to `600` and updated styles README to reflect that change.


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
