### PR TITLE
feat(combobox): match combobox height with single selection mode

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -44,7 +44,6 @@
   box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
   padding: var(--calcite-combobox-item-spacing-unit-s) var(--calcite-combobox-item-spacing-unit-l) 0
     var(--calcite-combobox-item-spacing-unit-l);
-  transition: 500ms ease;
 }
 
 :host(:focus-within) .wrapper,

--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -44,6 +44,7 @@
   box-shadow: inset 0 0 0 1px var(--calcite-ui-border-input);
   padding: var(--calcite-combobox-item-spacing-unit-s) var(--calcite-combobox-item-spacing-unit-l) 0
     var(--calcite-combobox-item-spacing-unit-l);
+  transition: 500ms ease;
 }
 
 :host(:focus-within) .wrapper,

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -34,7 +34,6 @@ import {
 } from "./resources";
 import { getItemAncestors, getItemChildren, hasActiveChildren } from "./utils";
 import { createObserver } from "../../utils/observers";
-
 interface ItemData {
   label: string;
   value: string;
@@ -856,8 +855,8 @@ export class CalciteCombobox {
           aria-label={label}
           class={{
             input: true,
+            "input--single": true,
             "input--transparent": this.activeChipIndex > -1,
-            "input--single": single,
             "input--hidden": showLabel,
             "input--icon": single && needsIcon
           }}
@@ -952,8 +951,8 @@ export class CalciteCombobox {
           aria-owns={guid}
           class={{
             wrapper: true,
-            "wrapper--active": open,
-            "wrapper--single": single
+            "wrapper--single": single || !this.selectedItems.length,
+            "wrapper--active": open
           }}
           onClick={this.setFocusClick}
           ref={this.setReferenceEl}


### PR DESCRIPTION
**Related Issue:** #2624 

## Summary

Match `combobox` height when selection mode is `multi `or `ancestor` with single-selection mode.