### PR TITLE
chore: use github secrets for verifier usernames

### DIFF
--- a/.github/workflows/assign-for-verification.yml
+++ b/.github/workflows/assign-for-verification.yml
@@ -7,22 +7,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v4
+        env:
+          PRIMARY_CONTACT: ${{secrets.PRIMARY_CONTACT}}
+          SECONDARY_CONTACTS: ${{secrets.SECONDARY_CONTACTS}}
         with:
           script: |
+            const { PRIMARY_CONTACT, SECONDARY_CONTACTS } = process.env
             const { label, sender } = context.payload;
             if (sender && label && label.name === "3 - installed") {
+              const secondaryArr = SECONDARY_CONTACTS.split(",").map(c => c.trim());
+              const secondaryContact = secondaryArr[Math.floor(Math.random() * secondaryArr.length)];
               const assignees =
-                sender.login !== "benelan" ? ["benelan"] : ["jcfranco", "julio8a"];
-              await github.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "Installed, assigning for verification.",
-              });
+                sender.login !== PRIMARY_CONTACT
+                  ? [PRIMARY_CONTACT]
+                  : [secondaryContact]
               await github.issues.update({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 assignees,
+              });
+              await github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "Installed and assigned for verification.",
               });
             }

--- a/.github/workflows/need-info-close.yml
+++ b/.github/workflows/need-info-close.yml
@@ -13,4 +13,4 @@ jobs:
           remove-stale-when-updated: false
           stale-issue-label: "need more info"
           stale-pr-label: "need more info"
-          close-issue-message: "This issue has been automatically closed due to missing information. We will reopen the issue if the information is provided and `benelan` is mentioned in the comment."
+          close-issue-message: "This issue has been automatically closed due to missing information. We will reopen the issue if the information is provided and `${{secrets.PRIMARY_CONTACT}}` is mentioned in the comment."


### PR DESCRIPTION
## Summary
- Created two new github secrets:
  - PRIMARY_CONTACT: a single username that will be the primary point of contact used in github actions. Right now the value is `benelan`
  - SECONDARY_CONTACTS: A comma separated list of secondary contacts. It can be as many as needed. Right now the value is `jcfranco, julio8a`
- Changed all gh actions with hardcoded usernames to use the new gh secrets
- Changed the gh action that assigns verifiers for installed issues to randomly select a secondary contact if it is the primary contact's issue
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
