### PR TITLE
fix(tree-item): update `indeterminate` on ancestor tree-items when `selected` on load

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -40,7 +40,8 @@ describe("calcite-tree-item", () => {
       {
         propertyName: "hasChildren",
         defaultValue: false
-      }
+      },
+      { propertyName: "indeterminate", defaultValue: undefined }
     ]));
 
   it("should expand/collapse children when the icon is clicked", async () => {
@@ -142,5 +143,35 @@ describe("calcite-tree-item", () => {
     });
 
     expect(hash).toEqual("#inner");
+  });
+
+  describe("when a tree-item has ancestors selection-mode and is selected", () => {
+    it("should update its ancestor tree-items' interminate properties", async () => {
+      const tree = `<calcite-tree selection-mode="ancestors">
+        <calcite-tree-item expanded data-id="ancestor">
+          <span> Fruits </span>
+          <calcite-tree slot="children">
+            <calcite-tree-item>
+              <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
+            </calcite-tree-item>
+            <calcite-tree-item expanded data-id="ancestor">
+              <span> Pears </span>
+              <calcite-tree slot="children">
+                <calcite-tree-item selected>
+                  <calcite-link href="#go" tabindex="-1"> Anjou </calcite-link>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <calcite-link href="#go" tabindex="-1"> Bartlett </calcite-link>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+      `;
+      const page = await newE2EPage({ html: tree });
+      const ancestors = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
+      ancestors.forEach(async (node) => expect(await node.getProperty("indeterminate")).toBe(true));
+    });
   });
 });

--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -146,7 +146,7 @@ describe("calcite-tree-item", () => {
   });
 
   describe("when a tree-item has ancestors selection-mode and is selected", () => {
-    it("should update its ancestor tree-items' interminate properties", async () => {
+    it("should update its ancestor tree-items' indeterminate properties", async () => {
       const tree = `<calcite-tree selection-mode="ancestors">
         <calcite-tree-item expanded data-id="ancestor">
           <span> Fruits </span>

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -125,6 +125,10 @@ export class CalciteTreeItem {
     }
   }
 
+  componentDidLoad(): void {
+    this.updateAncestorTree();
+  }
+
   render(): VNode {
     const rtl = getElementDir(this.el) === "rtl";
     const showBulletPoint =
@@ -392,4 +396,17 @@ export class CalciteTreeItem {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private updateAncestorTree = (): void => {
+    if (this.selected && this.selectionMode === TreeSelectionMode.Ancestors) {
+      const ancestors: HTMLCalciteTreeItemElement[] = [];
+      let parent = this.el.parentElement.closest("calcite-tree-item");
+      while (parent) {
+        ancestors.push(parent);
+        parent = parent.parentElement.closest("calcite-tree-item");
+      }
+      ancestors.forEach((item) => (item.indeterminate = true));
+      return;
+    }
+  };
 }

--- a/src/demos/calcite-tree-scales.html
+++ b/src/demos/calcite-tree-scales.html
@@ -27,8 +27,6 @@
     <main id="tree-scales">
       <h2>Scales</h2>
 
-      <p>The following trees have no initial tree items selected.</p>
-
       <h3 id="tree-single">selection-mode "single" (default)</h3>
       <section class="scales">
         <calcite-tree lines aria-labelledby="tree-single" scale="s">
@@ -58,7 +56,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -114,7 +112,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -170,7 +168,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -229,7 +227,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -285,7 +283,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -341,7 +339,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -400,7 +398,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -456,7 +454,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -512,7 +510,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -571,7 +569,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -627,7 +625,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -683,7 +681,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -742,7 +740,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -798,7 +796,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>
@@ -854,7 +852,7 @@
                   </calcite-tree-item>
                 </calcite-tree>
               </calcite-tree-item>
-              <calcite-tree-item>
+              <calcite-tree-item selected>
                 <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
               </calcite-tree-item>
               <calcite-tree-item>


### PR DESCRIPTION
**Related Issue:** #2112

## Summary
Fixes an issue where a tree-item with "ancestors" selection-mode would appear as selected, but its ancestor tree-items would not load with an `indeterminate` checkbox. Now ancestors will render with their indeterminate checkboxes on initial page load.

(The fix borrows the logic from calcite-tree's private [`updateAncestorTree`](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-tree/calcite-tree.tsx#L231-L236) method.)
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
