### PR TITLE
fix(dropdown): Set scroller height to zero when not active. #3071

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -170,7 +170,7 @@ export class CalciteDropdown {
             }}
             onTransitionEnd={this.transitionEnd}
             style={{
-              maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
+              maxHeight: !active || maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
             }}
           >
             <slot />


### PR DESCRIPTION
**Related Issue:** #3071

## Summary

fix(dropdown): Set scroller height to zero when not active. #3071