### PR TITLE
ci: avoid failing process for handled errors

### DIFF
--- a/support/deployNextFromTravis.ts
+++ b/support/deployNextFromTravis.ts
@@ -91,6 +91,5 @@ const exec = pify(childProcess.exec);
     await deployNextFromTravis();
   } catch (error) {
     console.log("An error occurred during deployment ❌");
-    process.exitCode = 1;
   }
 })();


### PR DESCRIPTION
**Related Issue:** #3057 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates the `deployNextFromTravis.ts` to no longer fail the process when it handles an error. This would have a side-effect of failing the entire Travis build:

> If the script returns a nonzero status, deployment is considered a failure, and the build will be marked as “errored”.

☝🏼  from https://docs.travis-ci.com/user/deployment/script/

**Example errored build from https://app.travis-ci.com/github/Esri/calcite-components/builds/237925338**

```
Determining @next deployability 🔍
Building deployable candidate ⚙️
Deploying @next 🚧
 - prepping package...
An error occurred during deployment ❌
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @esri/calcite-components@1.0.0-beta.65 util:deploy-next-from-travis: `ts-node --project ./tsconfig-node-scripts.json support/deployNextFromTravis.ts`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @esri/calcite-components@1.0.0-beta.65 util:deploy-next-from-travis script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2021-09-17T16_19_28_025Z-debug.log
Script failed with status 1
```
