### PR TITLE
fix(slider): use non-breaking hyphen for colliding handle labels

### DIFF
--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -86,9 +86,9 @@ $tick-height: 4px;
       bottom: 0;
     }
     &.hyphen::after {
-      content: "\2014";
-      display: inline-block;
-      width: 1em;
+      content: "\2011";
+      display: inline;
+      margin-left: 0.1875em;
     }
   }
 


### PR DESCRIPTION
**Related Issue:** #3101

## Summary
Fixes an issue where a slider range with `label-handles` would wrap its minValue handle label's hyphen when both thumbs overlap near the max edge.

_Before_

![image](https://user-images.githubusercontent.com/42423180/135344940-4ac93794-4b11-4fa8-8a2c-cbd3aedde9b1.png)


_After_

![image](https://user-images.githubusercontent.com/42423180/135344676-fdd3c5cb-5b64-4f02-950f-3a6df3160b58.png)


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
