### PR TITLE
Testing isolated calcite-action with Screener before Screener Steps refactor

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -14,5 +14,6 @@ module.exports = {
     minLayoutDimension: 1,
     minLayoutPosition: 1
   },
-  failureExitCode: 0
+  failureExitCode: 0,
+  includeRules: [/Components\/Buttons\/Action/]
 };


### PR DESCRIPTION


**Related Issue:** #2019

This is a test in support of #2019 that will not need to be merged because it is being used to test Screener performance on `calcite-action` in isolation before the comprehensive steps being added to the story.