### PR TITLE
test(action): refactor story to use Screener steps

### DIFF
--- a/.storybook/helpers.ts
+++ b/.storybook/helpers.ts
@@ -1,5 +1,8 @@
 import * as icons from "@esri/calcite-ui-icons";
 import { boolean as booleanKnob } from "@storybook/addon-knobs";
+import { Steps } from "screener-storybook/src/screener";
+import { THEMES } from "../src/utils/resources";
+import { ThemeName } from "../src/components/interfaces";
 
 // we can get all unique icon names from all size 16 non-filled icons.
 export const iconNames = Object.keys(icons)
@@ -13,4 +16,40 @@ export const boolean = (prop, value, standalone = true) => {
   const propValue = (standalone && knob) || !standalone ? prop : "";
   const attrValue = standalone ? "" : `="${knob}"`;
   return `${propValue}${attrValue}`;
+};
+
+export interface Story {
+  (): string;
+  decorators?: ((Story: Story) => DocumentFragment)[];
+}
+
+export const setKnobs = ({ story, knobs }: { story: string; knobs: { name: string; value: string }[] }) => {
+  return `window.location.href = "?path=/story/${story}${knobs
+    .map(({ name, value }) => `&knob-${name}=${value}`)
+    .join("")}"`;
+};
+
+export const setTheme = (value: ThemeName) => `${THEMES.map(
+  (theme) => `document.body.classList.toggle('${theme.className}', ${(theme.name === value).toString()});`
+).join("")}
+`;
+
+export const createSteps = (componentSelector: string): Steps => {
+  return new Steps().wait(`${componentSelector}[calcite-hydrated]`);
+};
+
+export const stepStory = (story: Story, steps: Steps): Story => {
+  const stepsDecorator = (Story: Story) => {
+    const node = document.createRange().createContextualFragment(Story());
+    (node as any).steps = steps.end();
+    return node;
+  };
+
+  if (story.decorators) {
+    story.decorators.push(stepsDecorator);
+  } else {
+    story.decorators = [stepsDecorator];
+  }
+
+  return story;
 };

--- a/.storybook/resources.ts
+++ b/.storybook/resources.ts
@@ -1,4 +1,4 @@
-import { Appearance, Position, Scale } from "../src/components/interfaces";
+import { Alignment, Appearance, Position, Scale } from "../src/components/interfaces";
 
 interface AttributeMetadata<T> {
   values: T[];
@@ -6,26 +6,32 @@ interface AttributeMetadata<T> {
 }
 
 interface CommonAttributes {
+  alignment: AttributeMetadata<Alignment>;
+  appearance: AttributeMetadata<Appearance>;
   scale: AttributeMetadata<Scale>;
   position: AttributeMetadata<Position>;
-  appearance: AttributeMetadata<Appearance>;
 }
 
 const positionOptions: Position[] = ["start", "end"];
 const scaleOptions: Scale[] = ["s", "m", "l"];
+const alignmentOptions: Alignment[] = ["start", "center", "end"];
 const appearanceOptions: Appearance[] = ["solid", "clear", "outline"];
 
 export const ATTRIBUTES: CommonAttributes = {
-  scale: {
-    values: scaleOptions,
-    defaultValue: scaleOptions[1]
+  alignment: {
+    values: alignmentOptions,
+    defaultValue: alignmentOptions[0]
+  },
+  appearance: {
+    values: appearanceOptions,
+    defaultValue: appearanceOptions[0]
   },
   position: {
     values: positionOptions,
     defaultValue: positionOptions[0]
   },
-  appearance: {
-    values: appearanceOptions,
-    defaultValue: appearanceOptions[0]
+  scale: {
+    values: scaleOptions,
+    defaultValue: scaleOptions[1]
   }
 };

--- a/screener.config.js
+++ b/screener.config.js
@@ -14,5 +14,6 @@ module.exports = {
     minLayoutDimension: 1,
     minLayoutPosition: 1
   },
-  failureExitCode: 0
+  failureExitCode: 0,
+  includeRules: [/Components\/Buttons\/Action/]
 };

--- a/src/components/calcite-action/calcite-action.stories.ts
+++ b/src/components/calcite-action/calcite-action.stories.ts
@@ -3,11 +3,13 @@ import {
   Attribute,
   filterComponentAttributes,
   Attributes,
-  createComponentHTML as create,
-  themesDarkDefault
+  createComponentHTML as create
 } from "../../../.storybook/utils";
 import readme from "./readme.md";
+import { html } from "../../tests/utils";
+import { createSteps, stepStory, setTheme, setKnobs } from "../../../.storybook/helpers";
 import { ATTRIBUTES } from "../../../.storybook/resources";
+const { alignment, appearance, scale } = ATTRIBUTES;
 
 export default {
   title: "Components/Buttons/Action",
@@ -17,10 +19,24 @@ export default {
 };
 
 const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ exceptions } = { exceptions: [] }) => {
-  const { appearance, scale } = ATTRIBUTES;
-
   return filterComponentAttributes(
     [
+      {
+        name: "active",
+        commit(): Attribute {
+          this.value = boolean("active", false);
+          delete this.build;
+          return this;
+        }
+      },
+      {
+        name: "alignment",
+        commit(): Attribute {
+          this.value = select("alignment", alignment.values, alignment.defaultValue);
+          delete this.build;
+          return this;
+        }
+      },
       {
         name: "appearance",
         commit(): Attribute {
@@ -30,14 +46,13 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
         }
       },
       {
-        name: "active",
+        name: "compact",
         commit(): Attribute {
-          this.value = boolean("active", false);
+          this.value = boolean("compact", false);
           delete this.build;
           return this;
         }
       },
-
       {
         name: "disabled",
         commit(): Attribute {
@@ -107,22 +122,367 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
   );
 };
 
-export const basic = (): string => create("calcite-action", createAttributes());
-export const darkThemeRTL = (): string =>
-  create(
-    "calcite-action",
-    createAttributes({ exceptions: ["dir", "class"] }).concat([
-      {
-        name: "dir",
-        value: "rtl"
-      },
-      {
-        name: "class",
-        value: "calcite-theme-dark"
-      }
-    ])
-  );
+export const Default = stepStory(
+  (): string => html`${create("calcite-action", createAttributes())}`,
+  createSteps("calcite-action")
+    // Default
+    .snapshot("Default")
 
-darkThemeRTL.story = {
-  parameters: { themes: themesDarkDefault }
-};
+    // Default Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Default Dark")
+
+    // Default RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Default RTL")
+
+    // Default Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Default Dark RTL")
+
+    // Active
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({ story: "components-buttons-action--default", knobs: [{ name: "active", value: "true" }] })
+    )
+    .snapshot("Active")
+
+    // Active Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Active Dark")
+
+    // Active RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Active RTL")
+
+    // Active Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Active Dark RTL")
+
+    // Appearance Clear
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "appearance", value: "clear" }]
+      })
+    )
+    .snapshot("Appearance Clear")
+
+    // Appearance Clear Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Appearance Clear Dark")
+
+    // Appearance Clear RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Appearance Clear RTL")
+
+    // Appearance Clear Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Appearance Clear Dark RTL")
+
+    // Appearance Outline
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({ story: "components-buttons-action--default", knobs: [{ name: "appearance", value: "outline" }] })
+    )
+    .snapshot("Appearance Outline")
+
+    // Appearance Outline Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Appearance Outline Dark")
+
+    // Appearance Outline RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Appearance Outline RTL")
+
+    // Appearance Outline Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Appearance Outline Dark RTL")
+
+    // Compact
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "compact", value: "true" }]
+      })
+    )
+    .snapshot("Compact")
+
+    // Compact Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Compact Dark")
+
+    // Compact RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Compact RTL")
+
+    // Compact Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Compact Dark RTL")
+
+    // Disabled
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "disabled", value: "true" }]
+      })
+    )
+    .snapshot("Disabled")
+
+    // Disabled Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Disabled Dark")
+
+    // Disabled RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Disabled RTL")
+
+    // Disabled Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Disabled Dark RTL")
+
+    // Indicator
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "indicator", value: "true" }]
+      })
+    )
+    .snapshot("Indicator")
+
+    // Indicator Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Indicator Dark")
+
+    // Indicator Icon Only
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [
+          { name: "indicator", value: "true" },
+          { name: "textEnabled", value: "false" }
+        ]
+      })
+    )
+    .snapshot("Indicator")
+
+    // Indicator Icon Only Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Indicator Icon Only Dark")
+
+    // Loading
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "loading", value: "true" }]
+      })
+    )
+    .snapshot("Loading")
+
+    // Loading Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Loading Dark")
+
+    // Loading RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Loading RTL")
+
+    // Loading Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Loading Dark RTL")
+
+    // Scale Small
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "scale", value: "s" }]
+      })
+    )
+    .snapshot("Scale Small")
+
+    // Scale Small Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Scale Small Dark")
+
+    // Scale Small RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Scale Small RTL")
+
+    // Scale Small Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Scale Small Dark RTL")
+
+    // Scale Large
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(setKnobs({ story: "components-buttons-action--default", knobs: [{ name: "scale", value: "l" }] }))
+    .snapshot("Scale Large")
+
+    // Scale Large Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Scale Large Dark")
+
+    // Scale Large RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Scale Large RTL")
+
+    // Scale Large Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Scale Large Dark RTL")
+
+    // Text Not Enabled
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [{ name: "textEnabled", value: "false" }]
+      })
+    )
+    .snapshot("Text Not Enabled")
+
+    // Text Not Enabled Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Text Not Enabled Dark")
+
+    // Alignment Center
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [
+          { name: "alignment", value: "center" },
+          { name: "textEnabled", value: "true" }
+        ]
+      })
+    )
+    .snapshot("Alignment Center")
+
+    // Alignment Center Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Alignment Center Dark")
+
+    // Alignment Center RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Alignment Center RTL")
+
+    // Alignment Center Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Alignment Center Dark RTL")
+
+    // Alignment End
+    .ltr()
+    .executeScript(setTheme("light"))
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [
+          { name: "alignment", value: "end" },
+          { name: "textEnabled", value: "true" }
+        ]
+      })
+    )
+    .snapshot("Alignment End")
+
+    // Alignment End Dark
+    .executeScript(setTheme("dark"))
+    .snapshot("Alignment End Dark")
+
+    // Alignment End RTL
+    .rtl()
+    .executeScript(setTheme("light"))
+    .snapshot("Alignment End RTL")
+
+    // Alignment End Dark RTL
+    .executeScript(setTheme("dark"))
+    .snapshot("Alignment End Dark RTL")
+
+    // Collapsed with Indicator Medium
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [
+          { name: "indicator", value: "true" },
+          { name: "textEnabled", value: "false" }
+        ]
+      })
+    )
+    .executeScript(setTheme("light"))
+    .snapshot("Collapsed with Indicator")
+    .rtl()
+    .snapshot("Collapsed with Indicator RTL")
+    .ltr()
+    .executeScript(setTheme("dark"))
+    .snapshot("Collapsed with Indicator Dark")
+    .rtl()
+    .snapshot("Collapsed with Indicator RTL Dark")
+
+    // Collapsed with Indicator Small
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [
+          { name: "indicator", value: "true" },
+          { name: "textEnabled", value: "false" },
+          { name: "scale", value: "s" }
+        ]
+      })
+    )
+    .executeScript(setTheme("light"))
+    .snapshot("Collapsed with Indicator Small")
+    .rtl()
+    .snapshot("Collapsed with Indicator Small RTL")
+    .ltr()
+    .executeScript(setTheme("dark"))
+    .snapshot("Collapsed with Indicator Small Dark")
+    .rtl()
+    .snapshot("Collapsed with Indicator Small Dark RTL")
+
+    // Collapsed with Indicator Large
+    .executeScript(
+      setKnobs({
+        story: "components-buttons-action--default",
+        knobs: [
+          { name: "indicator", value: "true" },
+          { name: "textEnabled", value: "false" },
+          { name: "scale", value: "l" }
+        ]
+      })
+    )
+    .executeScript(setTheme("light"))
+    .snapshot("Collapsed with Indicator Large")
+    .rtl()
+    .snapshot("Collapsed with Indicator Large RTL")
+    .ltr()
+    .executeScript(setTheme("dark"))
+    .snapshot("Collapsed with Indicator Large Dark")
+    .rtl()
+    .snapshot("Collapsed with Indicator Large Dark RTL")
+);

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -34,8 +34,6 @@ export class CalciteAction {
   //  Properties
   //
   // --------------------------------------------------------------------------
-  /** Specify the appearance style of the action, defaults to solid. */
-  @Prop({ reflect: true }) appearance: Appearance = "solid";
 
   /**
    * Indicates whether the action is highlighted.
@@ -46,6 +44,9 @@ export class CalciteAction {
    * Indicates the alignment when text-enabled is false.
    */
   @Prop({ reflect: true }) alignment?: Alignment;
+
+  /** Specify the appearance style of the action, defaults to solid. */
+  @Prop({ reflect: true }) appearance: Appearance = "solid";
 
   /**
    * Compact mode is used internally by components to reduce side padding, e.g. calcite-block-section.

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -8,4 +8,5 @@ export type Position = "start" | "end";
 export type Scale = "s" | "m" | "l";
 export type Status = "invalid" | "valid" | "idle";
 export type ThemeClass = "calcite-theme-light" | "calcite-theme-dark" | "calcite-theme-auto";
+export type ThemeName = "light" | "dark" | "auto";
 export type Width = "auto" | "half" | "full";

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -1,7 +1,33 @@
+import { ThemeClass, ThemeName } from "../components/interfaces";
+
+const autoTheme = "calcite-theme-auto";
+const darkTheme = "calcite-theme-dark";
+const lightTheme = "calcite-theme-light";
+
+interface Theme {
+  name: ThemeName;
+  className: ThemeClass;
+}
+
+export const THEMES: Theme[] = [
+  {
+    name: "light",
+    className: lightTheme
+  },
+  {
+    name: "dark",
+    className: darkTheme
+  },
+  {
+    name: "auto",
+    className: autoTheme
+  }
+];
+
 export const CSS_UTILITY = {
-  autoTheme: "calcite-theme-auto",
-  darkTheme: "calcite-theme-dark",
-  lightTheme: "calcite-theme-light",
+  autoTheme,
+  darkTheme,
+  lightTheme,
   rtl: "calcite--rtl"
 };
 


### PR DESCRIPTION
**Related Issue:** #2019

## Summary

test(action): refactor story to use Screener steps

### How this works

This PR uses [screener-storybook](https://github.com/screener-io/screener-storybook) to test for visual changes to or storybook stories and introduces the use of the [screener storybook Steps](https://screener.io/v2/docs/test-interactions_ to test for interaction changes.

The Steps API allows you to interact or call methods before taking a snapshot of the story.

This will allow us to replace all the RTL and Dark theme stories by calling a method to change to RTL or Dark theme in the same story and take a snapshot. 

For example, instead of setting a knob to open a component, we can click the component's button to open it.

### This PR:

Uses screener-storybook steps: https://screener.io/v2/docs/test-interactions within storybook to take screenshots after interactions as well as changes for dark theme and RTL.

- Replaces dark and RTL stories for the Popover and Tooltip with Screener steps
- Introduces a storybook helper to setup tests for a story
- Exposes a couple strings of JS scripts for toggling theme and setting knobs on a screener run

### The plan

- Do this for all other storybook stories.
- Replace all "Dark" theme and "RTL" stories with screener steps
- Remove any stories where content doesn't change
- Use screener interactions (click/hover) where applicable instead of separate stories or setting knob values.

### Proposed plan for testing

- In order to test the changes, you have to look at the screener build.
- You should see new screenshots with the name of the snapshots that are provided in the steps code.

### Resources

Screener-runner executeScript types: https://github.com/screener-io/screener-runner/blob/ad615d12691c52ac13d069df960f204725486cfd/src/steps.js

### Acceptance Criteria

- [ ] Setup a comprehensive set of snapshots for `calcite-action` and compare the Screener run time of the isolated calcite-action tests before and after this change