### PR TITLE
fix(combobox): add chevron icon at end of input regardless of selecti…

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -943,11 +943,9 @@ export class CalciteCombobox implements LabelableComponent {
 
   renderIconEnd(): VNode {
     return (
-      this.selectionMode === "single" && (
-        <span class="icon-end">
-          <calcite-icon icon="chevron-down" scale="s" />
-        </span>
-      )
+      <span class="icon-end">
+        <calcite-icon icon="chevron-down" scale="s" />
+      </span>
     );
   }
 


### PR DESCRIPTION
…on mode (#3055)

**Related Issue:** #

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
