### PR TITLE
docs(faq): add section about slots

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -14,6 +14,29 @@ They were created for developers to be used in any framework and across any part
 
 Web components are reusable custom elements with their functionality encapsulated away from the rest of your code. They are built on Web Component standards, will work across modern browsers, and can be used with any JavaScript library or framework that works with HTML.
 
+## What are slots?
+
+Slots are a common web components concept, and chances are you already use them. For example, take the following HTML:
+
+```html
+<select>
+  <option value="js">JavaScript</option>
+  <option value="ts">TypeScript</option>
+</select>
+```
+
+The `option` elements are placed in `select`'s _default slot_. Additionally, the "JavaScript" and "TypeScript" text is placed in `option`'s respective default slot. Many Calcite Components also utilize default slots. For example, here is a `calcite-dropdown` component:
+
+```html
+<calcite-dropdown>
+  <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+  <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+  <calcite-dropdown-item>Title</calcite-dropdown-item>
+</calcite-dropdown>
+```
+
+The `calcite-dropdown-item`s are placed in `calcite-dropdown`'s default slot. In many cases a default slot is all that is needed. However, as components become more complicated, the need arises to position and style child components differently. This is where _named slots_ come into play. In the example above, we are passing `calcite-button` into the dropdown's `dropdown-trigger` slot. This informs the dropdown that the `calcite-button` component should be handled differently than the components in the default slot. For a more detailed explanation, I suggest reading the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots#adding_flexibility_with_slots) about slots.
+
 ## What about Internationalization?
 
 All of our components that provide strings in the user interface allow those strings to be set via a property. This allows you to define the string for the locale you would like. Your application can handle internationalization as it sees fit.

--- a/src/7-faq.stories.mdx
+++ b/src/7-faq.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta, Description } from '@storybook/addon-docs/blocks';
+
+<Meta title="Overview/FAQ" />
+
+import FAQ from '../FAQ.md';
+
+<Description markdown={FAQ} />


### PR DESCRIPTION
## Summary
- Added a brief explanation about slots to the faq doc
- Added the faq page to storybook since I will continue adding stuff here
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
