### PR TITLE
docs(modal): allow scrolling on storybook

### DIFF
--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -2,6 +2,11 @@
 
 `calcite-modal` allows you to show a modal/dialog to your users. The modal handles fencing focus and animating in/out.
 
+<style>
+*{
+    overflow:auto !important;
+}
+</style>
 <!-- Auto Generated Below -->
 
 ## Usage

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -3,9 +3,9 @@
 `calcite-modal` allows you to show a modal/dialog to your users. The modal handles fencing focus and animating in/out.
 
 <style>
-*{
-    overflow:auto !important;
-}
+  * {
+      overflow:auto !important;
+  }
 </style>
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-modal/readme.md
+++ b/src/components/calcite-modal/readme.md
@@ -3,7 +3,7 @@
 `calcite-modal` allows you to show a modal/dialog to your users. The modal handles fencing focus and animating in/out.
 
 <style>
-  * {
+  html {
       overflow:auto !important;
   }
 </style>

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -8,7 +8,7 @@ import { getSlotted } from "../../utils/dom";
  * @slot footer - A slot for adding footer content. This content will be positioned at the bottom of the shell.
  * @slot primary-panel - A slot for adding the leading `calcite-shell-panel`.
  * @slot contextual-panel - A slot for adding the trailing `calcite-shell-panel`.
- * @slot bottom-panel - A slot for adding a bottom floating panel such as a chart or `calcite-tip-manager`.
+ * @slot center-row - A slot for adding custom content in the center row.
  */
 @Component({
   tag: "calcite-shell",


### PR DESCRIPTION
**Related Issue:** #1476 
Its a bit hacky but it fixes the doc issue. Tested locally
## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
