### PR TITLE
fix(block-section): enable text wrap

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -57,6 +57,7 @@
     my-0;
 
   text-align: initial;
+  overflow-wrap: anywhere;
 }
 
 .toggle--switch {

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -52,7 +52,10 @@
 
       <div class="child">
         <calcite-block heading="Heading" summary="summary" collapsible open>
-          <calcite-block-section text="input block-section" open>
+          <calcite-block-section
+            text="input block-section ahgscvagcvagvcacvgacvagcvagjcvajghcvajghvcagcvjahcvahjcvahchjacvhavcahkcvajhcvachacfhjcvahjcvahjcvahjcvajh"
+            open
+          >
             <calcite-input
               icon="form-field"
               placeholder="This is an input field... enter something here"


### PR DESCRIPTION
**Related Issue:** #3069 

## Summary

This will fix the overflow  of lengthy text /URL  in `calcite-block-section` with `overflow-wrap` set to anywhere