### PR TITLE
fix(label): fix issue where clicking on a wrapped labelable component would not update its value correctly

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -4,6 +4,7 @@ import {
   Event,
   EventEmitter,
   h,
+  Host,
   Listen,
   Method,
   Prop,
@@ -145,10 +146,6 @@ export class CalciteCheckbox implements LabelableComponent {
   };
 
   private clickHandler = (): void => {
-    if (this.labelEl) {
-      return;
-    }
-
     this.toggle();
   };
 
@@ -257,12 +254,14 @@ export class CalciteCheckbox implements LabelableComponent {
 
   render(): VNode {
     return (
-      <div class={{ focused: this.focused }} onClick={this.clickHandler}>
-        <svg class="check-svg" viewBox="0 0 16 16">
-          <path d={this.getPath()} />
-        </svg>
-        <slot />
-      </div>
+      <Host onClick={this.clickHandler}>
+        <div class={{ focused: this.focused, test: true }}>
+          <svg class="check-svg" viewBox="0 0 16 16">
+            <path d={this.getPath()} />
+          </svg>
+          <slot />
+        </div>
+      </Host>
     );
   }
 }

--- a/src/components/calcite-label/calcite-label.tsx
+++ b/src/components/calcite-label/calcite-label.tsx
@@ -57,7 +57,9 @@ export class CalciteLabel {
   /**
    * @internal
    */
-  @Event({ bubbles: false }) calciteInternalLabelClick: EventEmitter<void>;
+  @Event({ bubbles: false }) calciteInternalLabelClick: EventEmitter<{
+    sourceEvent: MouseEvent;
+  }>;
 
   //--------------------------------------------------------------------------
   //
@@ -65,8 +67,10 @@ export class CalciteLabel {
   //
   //--------------------------------------------------------------------------
 
-  labelClickHandler = (): void => {
-    this.calciteInternalLabelClick.emit();
+  labelClickHandler = (event: MouseEvent): void => {
+    this.calciteInternalLabelClick.emit({
+      sourceEvent: event
+    });
   };
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -182,10 +182,6 @@ export class CalciteRadioButton implements LabelableComponent {
   };
 
   private clickHandler = (): void => {
-    if (this.labelEl) {
-      return;
-    }
-
     this.toggle();
   };
 
@@ -193,15 +189,17 @@ export class CalciteRadioButton implements LabelableComponent {
     if (!this.disabled && !this.hidden) {
       this.uncheckOtherRadioButtonsInGroup();
       const label = event.currentTarget as HTMLCalciteLabelElement;
-      const firstButton = this.rootNode.querySelector<HTMLCalciteRadioButtonElement>(
-        label.for
-          ? `calcite-radio-button[id="${label.for}"]`
-          : `calcite-radio-button[name="${this.name}"]`
-      );
+      const radioButton = label.for
+        ? this.rootNode.querySelector<HTMLCalciteRadioButtonElement>(
+            `calcite-radio-button[id="${label.for}"]`
+          )
+        : label.querySelector<HTMLCalciteRadioButtonElement>(
+            `calcite-radio-button[name="${this.name}"]`
+          );
 
-      if (firstButton) {
-        firstButton.checked = true;
-        firstButton.focused = true;
+      if (radioButton) {
+        radioButton.checked = true;
+        radioButton.focused = true;
       }
 
       this.calciteRadioButtonChange.emit();

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -141,10 +141,6 @@ export class CalciteSwitch implements LabelableComponent {
   }
 
   private clickHandler = (): void => {
-    if (this.labelEl) {
-      return;
-    }
-
     this.toggle();
   };
 

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -267,7 +267,15 @@ async function assertLabelable({
   }
 
   if (propertyToToggle) {
-    expect(await component.getProperty(propertyToToggle)).toBe(!initialPropertyValue);
+    const toggledPropertyValue = !initialPropertyValue;
+    expect(await component.getProperty(propertyToToggle)).toBe(toggledPropertyValue);
+
+    // assert that direct clicks on component toggle property correctly
+    await component.setProperty(propertyToToggle, initialPropertyValue); // we reset as not all components toggle when clicked
+    await page.waitForChanges();
+    await component.click();
+    await page.waitForChanges();
+    expect(await component.getProperty(propertyToToggle)).toBe(toggledPropertyValue);
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #3146 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR fixes an issue that affected wrapped labelable components.

### Notable changes

* Updates `calcite-checkbox` to handle clicks on the host (otherwise, it could fail in [certain scenarios](https://codepen.io/jcfranco/pen/rNwbGNb))
* Updates label utils to avoid emitting the label click event if the user clicks directly on the labelable component – this ends up simplifying code on `LabelableComponent` implementors
* Fix logic for querying `calcite-radio-button` when wrapped vs referenced with `for`
* Updates `labelable` test util to also cover clicking on the component directly

### Next steps

* Will update `calcite-radio-group.e2e.ts` tests to use `calcite-label` to be closer to the intended usage.
* Will tidy up `LabelableComponent` implementors to no longer use bound methods, as it's no longer required
