### PR TITLE
test(radio-button-group): add wrapping label to radio-buttons to reflect usage

### DIFF
--- a/src/components/calcite-radio-button-group/calcite-radio-button-group.e2e.ts
+++ b/src/components/calcite-radio-button-group/calcite-radio-button-group.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, reflects, renders } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 
 describe("calcite-radio-button-group", () => {
   it("renders", async () => renders("calcite-radio-button-group", { display: "flex" }));
@@ -19,21 +20,48 @@ describe("calcite-radio-button-group", () => {
     await hidden("calcite-radio-button-group");
 
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button-group name="first">
-        <calcite-radio-button value="first"></calcite-radio-button>
-        <calcite-radio-button value="second"></calcite-radio-button>
-        <calcite-radio-button value="third"></calcite-radio-button>
+        <calcite-label>
+          1-1
+          <calcite-radio-button value="first"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          1-2
+          <calcite-radio-button value="second"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          1-3
+          <calcite-radio-button value="third"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
       <calcite-radio-button-group name="second" hidden>
-        <calcite-radio-button value="first"></calcite-radio-button>
-        <calcite-radio-button value="second"></calcite-radio-button>
-        <calcite-radio-button value="third"></calcite-radio-button>
+        <calcite-label>
+          2-1
+          <calcite-radio-button value="first"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2-2
+          <calcite-radio-button value="second"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2-3
+          <calcite-radio-button value="third"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
       <calcite-radio-button-group name="third">
-        <calcite-radio-button value="first"></calcite-radio-button>
-        <calcite-radio-button value="second"></calcite-radio-button>
-        <calcite-radio-button value="third"></calcite-radio-button>
+        <calcite-label>
+          3-1
+          <calcite-radio-button value="first"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3-2
+          <calcite-radio-button value="second"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3-3
+          <calcite-radio-button value="third"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
     `);
 
@@ -61,13 +89,22 @@ describe("calcite-radio-button-group", () => {
 
   it("has a radio input for form compatibility", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-radio-button-group name="hidden-input">
+    await page.setContent(html`
+      <calcite-radio-button-group name="hidden-input">
+        <calcite-label>
+          1
           <calcite-radio-button value="1"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
           <calcite-radio-button value="2" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
           <calcite-radio-button value="3"></calcite-radio-button>
-        </calcite-radio-button-group>`
-    );
+        </calcite-label>
+      </calcite-radio-button-group>
+    `);
 
     const radioInputs = await page.findAll('input[type="radio"]');
     expect(radioInputs).toHaveLength(3);
@@ -82,13 +119,22 @@ describe("calcite-radio-button-group", () => {
 
   it("does not require an item to be checked", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-radio-button-group name="none-checked">
+    await page.setContent(html`
+      <calcite-radio-button-group name="none-checked">
+        <calcite-label>
+          1
           <calcite-radio-button value="1"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
           <calcite-radio-button value="2"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
           <calcite-radio-button value="3"></calcite-radio-button>
-        </calcite-radio-button-group>`
-    );
+        </calcite-label>
+      </calcite-radio-button-group>
+    `);
     const radioButtons = await page.findAll("calcite-radio-button");
     for (let i = 0; i < radioButtons.length; i++) {
       expect(await radioButtons[i].getProperty("checked")).toBe(false);
@@ -99,11 +145,20 @@ describe("calcite-radio-button-group", () => {
   it("when multiple items are checked, last one wins", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<calcite-radio-button-group name="multiple-checked">
+      html`<calcite-radio-button-group name="multiple-checked">
+        <calcite-label>
+          1
           <calcite-radio-button value="1" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
           <calcite-radio-button value="2" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
           <calcite-radio-button value="3" checked></calcite-radio-button>
-        </calcite-radio-button-group>`
+        </calcite-label>
+      </calcite-radio-button-group>`
     );
     await page.waitForChanges();
     const checkedItems = await page.findAll("calcite-radio-button[checked]");
@@ -115,13 +170,22 @@ describe("calcite-radio-button-group", () => {
 
   it("selects item with left and arrow keys", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-radio-button-group name="keyboard">
+    await page.setContent(html`
+      <calcite-radio-button-group name="keyboard">
+        <calcite-label>
+          1
           <calcite-radio-button value="1" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
           <calcite-radio-button value="2"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
           <calcite-radio-button value="3"></calcite-radio-button>
-        </calcite-radio-button-group>`
-    );
+        </calcite-label>
+      </calcite-radio-button-group>
+    `);
     const element = await page.find("calcite-radio-button-group");
 
     const firstElement = await element.find("calcite-radio-button[checked]");
@@ -161,13 +225,22 @@ describe("calcite-radio-button-group", () => {
 
   it("selects item with up and down keys", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-radio-button-group name="up-down-keys">
+    await page.setContent(html`
+      <calcite-radio-button-group name="up-down-keys">
+        <calcite-label>
+          1
           <calcite-radio-button value="1" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
           <calcite-radio-button value="2"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
           <calcite-radio-button value="3"></calcite-radio-button>
-        </calcite-radio-button-group>`
-    );
+        </calcite-label>
+      </calcite-radio-button-group>
+    `);
     const element = await page.find("calcite-radio-button-group");
 
     const firstElement = await element.find("calcite-radio-button[checked]");
@@ -205,10 +278,16 @@ describe("calcite-radio-button-group", () => {
 
   it("clicking a radio updates its checked status", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button-group name="radio">
-        <calcite-radio-button id="first" value="one" checked></calcite-radio-button>
-        <calcite-radio-button id="second" value="two"></calcite-radio-button>
+        <calcite-label>
+          1
+          <calcite-radio-button id="first" value="one" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
+          <calcite-radio-button id="second" value="two"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
     `);
 
@@ -230,11 +309,20 @@ describe("calcite-radio-button-group", () => {
 
   it("programmatically checking a radio button updates the group's state correctly", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button-group name="radio">
-        <calcite-radio-button id="first" value="one" checked></calcite-radio-button>
-        <calcite-radio-button id="second" value="two"></calcite-radio-button>
-        <calcite-radio-button id="third" value="three"></calcite-radio-button>
+        <calcite-label>
+          1
+          <calcite-radio-button id="first" value="one" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
+          <calcite-radio-button id="second" value="two"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
+          <calcite-radio-button id="third" value="three"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
     `);
     await page.evaluate(() => {
@@ -252,11 +340,20 @@ describe("calcite-radio-button-group", () => {
 
   it("programmatically un-checking a radio button updates the group's state correctly", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button-group name="radio">
-        <calcite-radio-button id="first" value="one" checked></calcite-radio-button>
-        <calcite-radio-button id="second" value="two"></calcite-radio-button>
-        <calcite-radio-button id="third" value="three"></calcite-radio-button>
+        <calcite-label>
+          1
+          <calcite-radio-button id="first" value="one" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
+          <calcite-radio-button id="second" value="two"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
+          <calcite-radio-button id="third" value="three"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
     `);
     await page.evaluate(() => {
@@ -280,10 +377,16 @@ describe("calcite-radio-button-group", () => {
 
   it("radio-buttons receive necessary props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button-group name="radio">
-        <calcite-radio-button value="one" checked></calcite-radio-button>
-        <calcite-radio-button value="two"></calcite-radio-button>
+        <calcite-label>
+          1
+          <calcite-radio-button value="one" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
+          <calcite-radio-button value="two"></calcite-radio-button>
+        </calcite-label>
       </calcite-radio-button-group>
     `);
 
@@ -298,13 +401,22 @@ describe("calcite-radio-button-group", () => {
 
   it("appropriately triggers the custom change event", async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-radio-button-group name="changeEvent">
-          <calcite-radio-button value="one"></calcite-radio-button>
+    await page.setContent(html`
+      <calcite-radio-button-group name="changeEvent">
+        <calcite-label>
+          1
+          <calcite-radio-button value="one" checked></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          2
           <calcite-radio-button value="two"></calcite-radio-button>
+        </calcite-label>
+        <calcite-label>
+          3
           <calcite-radio-button value="three"></calcite-radio-button>
-        </calcite-radio-button-group>`
-    );
+        </calcite-label>
+      </calcite-radio-button-group>
+    `);
 
     const group = await page.find("calcite-radio-button-group");
     const firstRadio = await page.find('calcite-radio-button[value="one"]');


### PR DESCRIPTION
**Related Issue:** #3161 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Beefs up radio-button-group tests. ✨💪🏼 🥩 ✨  

The updated tests should now catch regressions to #3161.