### PR TITLE
refactor: change onLabelClick to be a class method

### DIFF
--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -254,10 +254,10 @@ export class CalciteButton implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (event: CustomEvent): void => {
+  onLabelClick(event: CustomEvent): void {
     this.handleClick(event);
     this.setFocus();
-  };
+  }
 
   // act on a requested or nearby form based on type
   private handleClick = (e: Event): void => {

--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -198,9 +198,9 @@ export class CalciteCheckbox implements LabelableComponent {
     this.calciteCheckboxFocusedChange.emit(true);
   }
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.toggle();
-  };
+  }
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -305,9 +305,9 @@ export class CalciteCombobox implements LabelableComponent {
   //
   // --------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   keydownHandler = (event: KeyboardEvent): void => {
     const key = getKey(event.key, getElementDir(this.el));

--- a/src/components/calcite-inline-editable/calcite-inline-editable.tsx
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.tsx
@@ -193,9 +193,9 @@ export class CalciteInlineEditable implements LabelableComponent {
     }
   }
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -400,9 +400,9 @@ export class CalciteInputDatePicker implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   transitionEnd = (event: TransitionEvent): void => {
     if (event.propertyName === this.activeTransitionProp) {

--- a/src/components/calcite-input-time-picker/calcite-input-time-picker.tsx
+++ b/src/components/calcite-input-time-picker/calcite-input-time-picker.tsx
@@ -216,9 +216,9 @@ export class CalciteInputTimePicker implements LabelableComponent {
   //
   // --------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   private setCalciteInputEl = (el: HTMLCalciteInputElement): void => {
     this.calciteInputEl = el;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -385,9 +385,9 @@ export class CalciteInput implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   private clearInputValue = (nativeEvent: KeyboardEvent | MouseEvent): void => {
     this.setValue(null, nativeEvent, true);

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -189,7 +189,7 @@ export class CalciteRadioButton implements LabelableComponent {
     this.toggle();
   };
 
-  onLabelClick = (event: CustomEvent): void => {
+  onLabelClick(event: CustomEvent): void {
     if (!this.disabled && !this.hidden) {
       this.uncheckOtherRadioButtonsInGroup();
       const label = event.currentTarget as HTMLCalciteLabelElement;
@@ -207,7 +207,7 @@ export class CalciteRadioButton implements LabelableComponent {
       this.calciteRadioButtonChange.emit();
       this.setFocus();
     }
-  };
+  }
 
   private checkLastRadioButton(): void {
     const radioButtons = Array.from(this.rootNode.querySelectorAll("calcite-radio-button")).filter(

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -260,9 +260,9 @@ export class CalciteRadioGroup implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   private getItems(): NodeListOf<HTMLCalciteRadioGroupItemElement> {
     return this.el.querySelectorAll("calcite-radio-group-item");

--- a/src/components/calcite-rating/calcite-rating.tsx
+++ b/src/components/calcite-rating/calcite-rating.tsx
@@ -197,9 +197,9 @@ export class CalciteRating implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   private updateValue(value: number) {
     this.value = value;

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -178,9 +178,9 @@ export class CalciteSelect implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   private updateNativeElement(
     optionOrGroup: CalciteOptionOrGroup,

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -827,9 +827,9 @@ export class CalciteSlider implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     this.setFocus();
-  };
+  }
 
   private shouldMirror(): boolean {
     return this.mirrored && !this.hasHistogram;

--- a/src/components/calcite-switch/calcite-switch.tsx
+++ b/src/components/calcite-switch/calcite-switch.tsx
@@ -113,12 +113,12 @@ export class CalciteSwitch implements LabelableComponent {
   //
   //--------------------------------------------------------------------------
 
-  onLabelClick = (): void => {
+  onLabelClick(): void {
     if (!this.disabled) {
       this.toggle();
       this.setFocus();
     }
-  };
+  }
 
   private setupInput(): void {
     this.switched && this.inputEl.setAttribute("checked", "");


### PR DESCRIPTION
**Related Issue:** #3161 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates to the `LabelableComponent` utils made it possible to implement `onLabelClick` without binding it to the class instance. This PR simplifies implementations of the interface method.