### PR TITLE
chore: add refactor issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,15 @@
+---
+name: Refactor
+about: Propose a code rework that does not effect functionality.
+title: "Refactor: "
+labels: refactor, 0 - new, needs triage
+assignees: ""
+---
+
+### Description <!--( What needs to change? )-->
+
+### Proposed Advantages <!--(Why should the code change? )-->
+
+### Relevant Info <!--(e.g. Dependencies, Blockers, Helpful Details)-->
+
+#### Which Component


### PR DESCRIPTION
**Related Issue:** #

## Summary
Added an issue template for refactors
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
