### PR TITLE
refactor(filter): avoid stateful regexp used for filtering

### DIFF
--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -2,7 +2,7 @@ import { escapeRegExp, forIn } from "lodash-es";
 
 export const filter = (data: Array<object>, value: string): Array<any> => {
   const escapedValue = escapeRegExp(value);
-  const regex = new RegExp(escapedValue, "ig");
+  const regex = new RegExp(escapedValue, "i");
 
   if (data.length === 0) {
     console.warn(`No data was passed to the filter function.


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Removes the global flag to keep the regexp stateless.

✨ 🧹 ✨ 