### PR TITLE
feat(tile-select): add calciteTileSelectChange event

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -160,7 +160,7 @@ export class CalciteCheckbox implements LabelableComponent {
    *
    * @internal
    */
-  @Event() calciteCheckboxBlur: EventEmitter;
+  @Event() calciteInternalCheckboxBlur: EventEmitter;
 
   /** Emitted when the checkbox checked status changes */
   @Event() calciteCheckboxChange: EventEmitter;
@@ -170,7 +170,7 @@ export class CalciteCheckbox implements LabelableComponent {
    *
    * @internal
    */
-  @Event() calciteCheckboxFocus: EventEmitter;
+  @Event() calciteInternalCheckboxFocus: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -194,12 +194,12 @@ export class CalciteCheckbox implements LabelableComponent {
 
   private onInputBlur() {
     this.focused = false;
-    this.calciteCheckboxBlur.emit(false);
+    this.calciteInternalCheckboxBlur.emit(false);
   }
 
   private onInputFocus() {
     this.focused = true;
-    this.calciteCheckboxFocus.emit(true);
+    this.calciteInternalCheckboxFocus.emit(true);
   }
 
   onLabelClick = (): void => {

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -49,7 +49,7 @@ export class CalciteRadioButton implements LabelableComponent {
     if (this.inputEl) {
       this.inputEl.checked = newChecked;
     }
-    this.calciteRadioButtonCheckedChange.emit(newChecked);
+    this.calciteInternalRadioButtonCheckedChange.emit(newChecked);
   }
 
   /** The disabled state of the radio button. */
@@ -229,7 +229,7 @@ export class CalciteRadioButton implements LabelableComponent {
   /** @internal */
   @Method()
   async emitCheckedChange(): Promise<void> {
-    this.calciteRadioButtonCheckedChange.emit();
+    this.calciteInternalRadioButtonCheckedChange.emit();
   }
 
   private setInputEl = (el): void => {
@@ -275,7 +275,7 @@ export class CalciteRadioButton implements LabelableComponent {
    * Fires when the radio button is blurred.
    * @internal
    */
-  @Event() calciteRadioButtonBlur: EventEmitter;
+  @Event() calciteInternalRadioButtonBlur: EventEmitter;
 
   /**
    * Fires only when the radio button is checked.  This behavior is identical to the native HTML input element.
@@ -290,13 +290,13 @@ export class CalciteRadioButton implements LabelableComponent {
    * Use calciteRadioButtonChange or calciteRadioButtonGroupChange for responding to changes in the checked value for forms.
    * @internal
    */
-  @Event() calciteRadioButtonCheckedChange: EventEmitter;
+  @Event() calciteInternalRadioButtonCheckedChange: EventEmitter;
 
   /**
    * Fires when the radio button is focused.
    * @internal
    */
-  @Event() calciteRadioButtonFocus: EventEmitter;
+  @Event() calciteInternalRadioButtonFocus: EventEmitter;
 
   //--------------------------------------------------------------------------
   //
@@ -325,12 +325,12 @@ export class CalciteRadioButton implements LabelableComponent {
 
   private onInputBlur = (): void => {
     this.focused = false;
-    this.calciteRadioButtonBlur.emit();
+    this.calciteInternalRadioButtonBlur.emit();
   };
 
   private onInputFocus = (): void => {
     this.focused = true;
-    this.calciteRadioButtonFocus.emit();
+    this.calciteInternalRadioButtonFocus.emit();
   };
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-tile-select/calcite-tile-select.tsx
+++ b/src/components/calcite-tile-select/calcite-tile-select.tsx
@@ -144,12 +144,13 @@ export class CalciteTileSelect {
     this.calciteTileSelectChange.emit();
   }
 
-  @Listen("calciteCheckboxFocus")
+  @Listen("calciteInternalCheckboxFocus")
   checkboxFocusHandler(event: CustomEvent): void {
     const checkbox = event.target as HTMLCalciteCheckboxElement;
     if (checkbox === this.input) {
       this.focused = event.detail;
     }
+    event.stopPropagation();
   }
 
   @Listen("calciteRadioButtonChange")
@@ -162,7 +163,7 @@ export class CalciteTileSelect {
     this.calciteTileSelectChange.emit();
   }
 
-  @Listen("calciteRadioButtonCheckedChange")
+  @Listen("calciteInternalRadioButtonCheckedChange")
   radioButtonCheckedChangeHandler(event: CustomEvent): void {
     const radioButton = event.target as HTMLCalciteRadioButtonElement;
     if (radioButton === this.input) {
@@ -171,12 +172,13 @@ export class CalciteTileSelect {
     event.stopPropagation();
   }
 
-  @Listen("calciteRadioButtonFocus")
+  @Listen("calciteInternalRadioButtonFocus")
   radioButtonFocusHandler(event: CustomEvent): void {
     const radioButton = event.target as HTMLCalciteRadioButtonElement;
     if (radioButton === this.input) {
       this.focused = radioButton.focused;
     }
+    event.stopPropagation();
   }
 
   @Listen("click")

--- a/src/demos/calcite-tile-select.html
+++ b/src/demos/calcite-tile-select.html
@@ -645,15 +645,5 @@
         </calcite-tile-select-group>
       </div>
     </div>
-
-    <script>
-      (async () => {
-        await customElements.whenDefined("calcite-tile-select");
-
-        document.addEventListener("calciteTileSelectChange", (event) => {
-          console.log("calciteTileSelectChange", event.target.name, event.target.value, event.target.checked);
-        });
-      })();
-    </script>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #3175 

## Summary

This PR adds a new `calciteTileSelectChange` event to `calcite-tile-select` that emits on every toggle for checkboxes and only when a radio is checked, which matches the HTML spec.

This PR also adds an internal `calciteCheckboxBlur` event to `calcite-checkbox` and an internal `calciteRadioButtonBlur` event to `calcite-radio-button` so that the previously named "focusedChanged" events can be updated to match the native nomenclature for focus and blur events in the HTML spec.  This PR also simplifies the names of event handlers and makes them more meaningful.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
