### PR TITLE
ci: ensure usable tag range is available when prepping release commit

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -21,6 +21,9 @@ const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 (async function prepReleaseCommit(): Promise<void> {
   const { next } = argv;
 
+  // travis works with shallow clones, so we deepen the history when fetching tags
+  await exec("git fetch --deepen=150 --tags --quiet");
+
   const previousReleasedTag = (await exec("git describe --abbrev=0 --tags", { encoding: "utf-8" })).trim();
   const prereleaseVersionPattern = /-next\.\d+$/;
   const previousReleaseIsPrerelease = prereleaseVersionPattern.test(previousReleasedTag);


### PR DESCRIPTION
**Related Issue:** #2980

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR makes sure we have a valid range of tags available when generating the release commit. Travis works with shallow clones, so the logic that computes the `next` release version would fail as there were no available `next` tags. This only became an issue because the auto-next deployments were halted for quite some time and the tags are beyond the shallow clone history.

**Note**: The commit history is deepened to an arbitrary 150 commits beyond the limit to cover a few releases (instead of fetching the entire history). Once deployments are stable, this value can be reduced or removed entirely.