### PR TITLE
fix(tooltip-manager): mousing out of the tooltip should close the tooltip. #3171

### DIFF
--- a/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
+++ b/src/components/calcite-tooltip-manager/calcite-tooltip-manager.tsx
@@ -131,14 +131,15 @@ export class CalciteTooltipManager {
 
   activeTooltipHover = (event: MouseEvent): void => {
     const { tooltipEl, hoverTimeouts } = this;
+    const { type } = event;
 
     if (!tooltipEl) {
       return;
     }
 
-    if (event.composedPath().includes(tooltipEl)) {
+    if (type === "mouseover" && event.composedPath().includes(tooltipEl)) {
       this.clearHoverTimeout(tooltipEl);
-    } else if (!hoverTimeouts.has(tooltipEl)) {
+    } else if (type === "mouseout" && !hoverTimeouts.has(tooltipEl)) {
       this.hoverTooltip({ tooltip: tooltipEl, value: false });
     }
   };


### PR DESCRIPTION
**Related Issue:** #3171

## Summary

fix(tooltip-manager): mousing out of the tooltip should close the tooltip. #3171

- Makes sure the event type is correct before clearing timeout or closing.