### PR TITLE
chore(deps): bump calcite-ui-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3657,9 +3657,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.17.0.tgz",
-      "integrity": "sha512-WQlPbypKNno61FUvJakxU5KLvMVm7/snb5CN5E4atZZ+1K8Wi9TzXQOweGeb555OGRLpgpBJFdf9UIzAVFOVgQ==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.17.2.tgz",
+      "integrity": "sha512-NAawUDq0jzAy1EYdfcuzvfkTLUQ4Z+zJ7hStpUwvDjebr1th3HPXg62k8oV6z1YWSpRzuxFvWa0EgcY1afSuwA==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/plugin-proposal-numeric-separator": "7.14.5",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.1",
-    "@esri/calcite-ui-icons": "3.17.0",
+    "@esri/calcite-ui-icons": "3.17.2",
     "@esri/eslint-plugin-calcite-components": "0.1.1",
     "@rollup/plugin-babel": "5.3.0",
     "@stencil/eslint-plugin": "0.3.1",


### PR DESCRIPTION
**Related Issue:** NA

## Summary
bumping calcite-ui-icons version. The only change was new icon additions
https://github.com/Esri/calcite-ui-icons/releases
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
