### PR TITLE
chore(actions): use dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+    # Conventional commits
+    commit-message:
+      prefix: "build(deps): "
+    # Ignore updates to packages below
+    ignore:
+      - dependency-name: "typescript"
+      - dependency-name: "tailwindcss"
+      - dependency-name: "@types/jest"
+      - dependency-name: "jest"
+      - dependency-name: "jest-cli"
+      - dependency-name: "puppeteer"


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Our current dependency updater script is [failing](https://github.com/Esri/calcite-components/runs/3762023039?check_suite_focus=true#step:5:69) so we will try out dependabot for now