### PR TITLE
chore(linting): disable unstable @stencil/eslint-plugin rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,9 @@
   },
   "plugins": ["@esri/calcite-components", "@typescript-eslint", "eslint-plugin-react", "jest", "prettier", "unicorn"],
   "rules": {
+    "@stencil/decorators-context": "off",
     "@stencil/decorators-style": "warn",
+    "@stencil/no-unused-watch": "off",
     "@stencil/own-methods-must-be-private": "off",
     "@stencil/own-props-must-be-private": "off",
     "@stencil/prefer-vdom-listener": "warn",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

After bumping versions in #2585, the following rules started incorrectly reporting errors on valid code: 

`@stencil/decorators-context`
`@stencil/no-unused-watch`

This PR disables them in the meantime.