### PR TITLE
chore(template): request last working version for regressions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -44,9 +44,9 @@ _Sample_:
 
 <!--(e.g. Browser, OS, mobile, stack traces, related issues, suggestions/resources on how to fix)-->
 
-_Reproducible version_: `@esri/calcite-components@<version>`
+_Reproducible version_: `@esri/calcite-components@1.0.0-<version>`
 
 - [ ] CDN
 - [ ] NPM package
 
-Regression? _Last working version_: `@esri/calcite-components@<version>`
+Regression? _Last working version_: `@esri/calcite-components@1.0.0-<version>`


### PR DESCRIPTION
**Related Issue:** NA

## Summary
The issue bug template will request the last working version for regressions. I will create an action to automatically add the `regression` label if the working version is provided. This will help us prioritize regressions while triaging.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
