### PR TITLE
chore(action): allow ember-twiddle repro samples

### DIFF
--- a/.github/need-info.yml
+++ b/.github/need-info.yml
@@ -19,5 +19,7 @@ requiredItems:
       - "esri.github.io/calcite-components/?path=/story/components-"
       - "esri.github.io/calcite-components/iframe.html?"
       - "developers.arcgis.com/calcite-design-system/components/"
+      - "ember-twiddle.com/"
+      - "jsfiddle.net/"
 commentFooter: "This issue will be automatically closed in three days if the information is not provided. Thanks for your understanding."
 excludeComments: true


### PR DESCRIPTION
**Related Issue:** #3243

## Summary
Allow more sites for repro samples
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
