### PR TITLE
fix(slider): slider range max value capped to provided max

### DIFF
--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -613,7 +613,7 @@ export class CalciteSlider implements LabelableComponent {
           "tick__label--max": isMaxTickLabel
         }}
       >
-        {`${tick > this.max ? this.max : tick}`.toLocaleString()}
+        {Math.min(tick, this.max).toLocaleString()}
       </span>
     );
     if (this.labelTicks && !this.hasHistogram && !this.isRange) {


### PR DESCRIPTION
**Related Issue:** #3142 

## Summary

Fix the odd slider range value when the `max` value exceeds the range due to step.
