### PR TITLE
refactor: add util type for asserting on global test props

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -4,7 +4,7 @@ import { CSS, DEFAULT_COLOR, DEFAULT_STORAGE_KEY_PREFIX, DIMENSIONS, TEXT } from
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing";
 import { ColorValue } from "./interfaces";
 import SpyInstance = jest.SpyInstance;
-import { selectText } from "../../tests/utils";
+import { GlobalTestProps, selectText } from "../../tests/utils";
 
 describe("calcite-color-picker", () => {
   let consoleSpy: SpyInstance;
@@ -474,10 +474,9 @@ describe("calcite-color-picker", () => {
     await page.waitForChanges();
     x = 0;
 
-    type TestWindow = {
+    type TestWindow = GlobalTestProps<{
       internalColor: HTMLCalciteColorPickerElement["color"];
-    } & Window &
-      typeof globalThis;
+    }>;
 
     await page.evaluateHandle(() => {
       const color = document.querySelector("calcite-color-picker");

--- a/src/components/calcite-tree/calcite-tree.e2e.ts
+++ b/src/components/calcite-tree/calcite-tree.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, HYDRATED_ATTR, defaults } from "../../tests/commonTests";
-import { html } from "../../tests/utils";
+import { GlobalTestProps, html } from "../../tests/utils";
 import { CSS } from "../calcite-tree-item/resources";
 import { TreeSelectionMode } from "./interfaces";
 
@@ -244,10 +244,9 @@ describe("calcite-tree", () => {
 
         const [item1, item2] = await page.findAll("calcite-tree-item");
 
-        type TestWindow = {
+        type TestWindow = GlobalTestProps<{
           selectedIds: string[];
-        } & Window &
-          typeof globalThis;
+        }>;
 
         await page.evaluateHandle(() =>
           document.addEventListener("calciteTreeSelect", ({ detail }: CustomEvent) => {

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -3,12 +3,12 @@ import { JSX } from "../components";
 import { toHaveNoViolations } from "jest-axe";
 import axe from "axe-core";
 import { config } from "../../stencil.config";
-import { html } from "./utils";
+import { GlobalTestProps, html } from "./utils";
 
 expect.extend(toHaveNoViolations);
 
 type CalciteComponentTag = keyof JSX.IntrinsicElements;
-type AxeOwningWindow = Window & { axe: typeof axe } & typeof globalThis;
+type AxeOwningWindow = GlobalTestProps<{ axe: typeof axe }>;
 type ComponentHTML = string;
 type TagOrHTML = CalciteComponentTag | ComponentHTML;
 

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -2,6 +2,11 @@ import { E2EElement, E2EPage } from "@stencil/core/testing";
 import { BoundingBox, JSONObject } from "puppeteer";
 import dedent from "dedent";
 
+/**
+ * Util to help type global props for testing.
+ */
+export type GlobalTestProps<T> = T & Window & typeof globalThis;
+
 type DragAndDropSelector = string | SelectorOptions;
 
 type PointerPosition = {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Introduces helper to tack on __typed__ global props for testing purposes. 

Here's a usage example:

```ts
it("does something", async () => {
  // ... page setup

  type TestWindow = GlobalTestProps<{
    someTestPropForLater: boolean;
  }>;

  await page.evaluate(() => {
      //...browser-context code
      (window as TestWindow).someTestPropForLater = true;
  });

  //... some test steps

  const result = await page.evaluate(() => (window as TestWindow).someTestPropForLater);

  expect(result).toBe(true);
});
```

Pulls util from https://github.com/Esri/calcite-components/pull/2777 to make the PR a bit leaner.

