### PR TITLE
fix(radio-group-item): move transition style up from icon to label co…

### DIFF
--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.scss
@@ -14,7 +14,7 @@
     pointer-events-none
     items-center
     m-0.5;
-  transition-property: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out, color 0.1s ease-in-out;
+  transition: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out, color 0.1s ease-in-out;
 }
 
 .label--horizontal {


### PR DESCRIPTION
…lor to have icon and text color transition in lockstep

**Related Issue:** #3028

## Summary

Removed transition style on the icon and added a color transition on the label above. 
This update makes the icon and the text color transition in sync.

https://user-images.githubusercontent.com/19231036/137801983-a7fa252a-a66d-4fae-a701-7280aa58ddb9.mov



