### PR TITLE
fix(panel): outline no longer overlap with action button

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -10,14 +10,13 @@
 .button {
   @apply bg-foreground-1
     border-none
-    box-border
     cursor-pointer
     fill-color-3
     flex
     focus-base
     items-center
     justify-start
-    m-1
+    m-0
     relative
     text--2h
     font-medium

--- a/src/components/calcite-list-item/calcite-list-item.scss
+++ b/src/components/calcite-list-item/calcite-list-item.scss
@@ -93,7 +93,8 @@
 .actions-start,
 .actions-end {
   ::slotted(calcite-action) {
-    @apply self-stretch;
+    @apply self-stretch
+    m-1;
 
     color: inherit;
   }


### PR DESCRIPTION
**Related Issue:** #3029 

## Summary

This fix will make sure the `outline` of `calcite-panel` don't overlap with action button of `calcite-list-item`