### PR TITLE
build(ci): fix npm token issue in next deploy script

### DIFF
--- a/support/deployNextFromTravis.ts
+++ b/support/deployNextFromTravis.ts
@@ -34,7 +34,7 @@ const exec = pify(childProcess.exec);
     } else {
       console.log("Deploying @next 🚧");
 
-      await fs.writeFile(".npmrc", "//registry.npmjs.org/:_authToken=${NPM_TOKEN}", { flag: "a" });
+      await exec("npm config set '//registry.npmjs.org/:_authToken' '${NPM_TOKEN}'");
 
       console.log(" - prepping package...");
       await exec(`npm run util:prep-next-from-existing-build`);


### PR DESCRIPTION
**Related Issue:** NA

## Summary
The next deploy script failed, this should fix it according to google
https://github.com/Esri/calcite-components/runs/3945958282?check_suite_focus=true#step:6:23
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
