### PR TITLE
build(ci): use pull_request event for ci

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,6 +1,6 @@
 name: E2E
 on:
-  pull_request_target:
+  pull_request:
     branches: [master]
 jobs:
   e2e:

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -1,6 +1,6 @@
 name: Screener
 on:
-  pull_request_target:
+  pull_request:
     branches: [master]
 jobs:
   screener:


### PR DESCRIPTION
**Related Issue:** NA

## Summary
This PR will fix the issue of the ci not running on the PR branch. However with this change the ci will no longer work on external PRs. I will look into a better solution, but this needs to be changed now so that we can do installs internally.

cc @driskull @jcfranco 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
