### PR TITLE
fix(block): block title and content now match on the x-axis #3186

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -73,7 +73,7 @@ calcite-handle {
 }
 
 .title {
-  @apply m-0 px-4 py-0;
+  @apply m-0 px-3 py-0;
 }
 
 .header .title .heading {


### PR DESCRIPTION
**Related Issue:** #3186

## Summary
The left and right padding of the `.title` class now matches the `.content` class
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

cc @lejara