### PR TITLE
build(ci): use dotenv for next deploy workflow

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -19,11 +19,14 @@ jobs:
         env:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_SLUG: "Esri/calcite-components"
         if: ${{ env.NEXT_RELEASE_ENABLED }} == "true"
       - run: npm ci
       - run: npm test
+      - run: | # gh env vars dont work in node
+          npm install dotenv
+          touch .env
+          echo "require('dotenv').config()" | cat - /support/deployNextFromTravis.ts > temp && mv temp /support/deployNextFromTravis.ts
+          echo GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} >> .env 2> /dev/null
       - run: npm run util:deploy-next-from-travis
       - uses: toko-bifrost/ms-teams-deploy-card@3.1.2
         if: always()

--- a/support/deployNextFromTravis.ts
+++ b/support/deployNextFromTravis.ts
@@ -40,7 +40,9 @@ const exec = pify(childProcess.exec);
       await exec(`npm run util:prep-next-from-existing-build`);
 
       console.log(" - pushing tags...");
-      await exec(`npm run util:push-tags -- --quiet https://$GITHUB_TOKEN@github.com/$REPO_SLUG master`);
+      await exec(
+        `npm run util:push-tags -- --quiet https://${process.env.GITHUB_TOKEN}@github.com/Esri/calcite-components master`
+      );
 
       console.log(" - publishing @next...");
       await exec(`npm run util:publish-next`);


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Getting closer! I have a new error: https://github.com/Esri/calcite-components/runs/3958534840?check_suite_focus=true#step:6:27

The GH environment variables aren't showing up so I changed it to use dotenv like the screener workflow
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
