### PR TITLE
build(ci): fix ts dotenv issue for next deploy workflow

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -25,6 +25,7 @@ jobs:
       - run: | # gh env vars dont work in node
           npm install dotenv
           touch .env
+          # adds a dotenv import to the top of the next deploy script
           echo "require('dotenv').config({ path: '.env' })" | cat - /support/deployNextFromTravis.ts > temp && mv temp /support/deployNextFromTravis.ts
           echo GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} >> .env 2> /dev/null
       - run: npm run util:deploy-next-from-travis


### PR DESCRIPTION
**Related Issue:** NA

## Summary
The github_token env var was undefined: https://github.com/Esri/calcite-components/runs/3966858120?check_suite_focus=true#step:7:27

It looks like you need to manually add the path to `.env` when using typescript:
https://stackoverflow.com/questions/62287709/environment-variable-with-dotenv-and-typescript
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
