### PR TITLE
build(ci): checkout action provides gh token for next deploy

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -22,12 +22,6 @@ jobs:
         if: ${{ env.NEXT_RELEASE_ENABLED }} == "true"
       - run: npm ci
       - run: npm test
-      - run: | # gh env vars dont work in node
-          npm install dotenv
-          touch .env
-          # adds a dotenv import to the top of the next deploy script
-          echo "require('dotenv').config({ path: '.env' })" | cat - /support/deployNextFromTravis.ts > temp && mv temp /support/deployNextFromTravis.ts
-          echo GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} >> .env 2> /dev/null
       - run: npm run util:deploy-next-from-travis
       - uses: toko-bifrost/ms-teams-deploy-card@3.1.2
         if: always()

--- a/support/deployNextFromTravis.ts
+++ b/support/deployNextFromTravis.ts
@@ -39,10 +39,10 @@ const exec = pify(childProcess.exec);
       console.log(" - prepping package...");
       await exec(`npm run util:prep-next-from-existing-build`);
 
+      // github token provided by the checkout action
+      // https://github.com/actions/checkout#usage
       console.log(" - pushing tags...");
-      await exec(
-        `npm run util:push-tags -- --quiet https://${process.env.GITHUB_TOKEN}@github.com/Esri/calcite-components master`
-      );
+      await exec(`npm run util:push-tags -- --quiet https://github.com/Esri/calcite-components master`);
 
       console.log(" - publishing @next...");
       await exec(`npm run util:publish-next`);


### PR DESCRIPTION
**Related Issue:** NA

## Summary
I still had the `undefined` env var issue after specifying the path to `.env`. I did some more research, and the checkout action I'm using takes care of the github token by default. They document an example of using the default token: https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

So we should be able to remove the GITHUB_TOKEN from the next deploy script completely.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
