### PR TITLE
chore: stop prompting for pushes to master on scripts

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,7 +5,7 @@
 protected_branch='master'
 current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 
-if [ $protected_branch = $current_branch ]
+if [ $protected_branch = $current_branch ] && [ exec < /dev/tty ]
 then
     read -p "You're about to push master, is that what you intended? [y|n] " -n 1 -r < /dev/tty
     echo


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
The pre-push husky hook was messing up the deploy next script, so I changed it to only prompt on interactive terminals
https://github.com/Esri/calcite-components/runs/3969156543?check_suite_focus=true#step:6:28
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
