### PR TITLE
build(ci): fix the conditional for deploying next

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -1,4 +1,4 @@
-name: Deploy Next
+name: Build
 concurrency:
   group: deploy_next
   cancel-in-progress: true
@@ -19,10 +19,14 @@ jobs:
         env:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ env.NEXT_RELEASE_ENABLED }} == "true"
-      - run: npm ci
-      - run: npm test
-      - run: npm run util:deploy-next-from-travis
+      - run: |
+          npm ci
+          npm test
+          if [ $NEXT_RELEASE_ENABLED == "true" ]; then
+            npm run util:deploy-next-from-travis
+          else
+            echo "Next release is disabled"
+          fi
       - uses: toko-bifrost/ms-teams-deploy-card@3.1.2
         if: always()
         with:


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Fix the conditional for skipping the next deployment
- Change the workflow name to "Build" so we can replace the travis status badge in the readme
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
