### PR TITLE
build(ci): fix incorrect npm script name

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -17,16 +17,17 @@ jobs:
           node-version: lts/*
           registry-url: https://registry.npmjs.org/
         env:
-          NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: e2e test
         run: |
           npm ci
           npm test
       - name: next deployment
+        env:
+          NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
         run: |
-          if [ $NEXT_RELEASE_ENABLED == "true" ]; then
-            npm run util:deploy-next-from-travis
+          if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
+            npm run util:deploy-next-from-ci
           else
             echo "Next release is disabled"
           fi


### PR DESCRIPTION
**Related Issue:** #3305
## Summary
There was a merge conflict with the PR linked above, and I missed that the npm script name was still `...-travis`. I fixed that and cleaned up the env var syntax
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
