### PR TITLE
test(animation): skip unstable test

### DIFF
--- a/src/tests/globalStyles.e2e.ts
+++ b/src/tests/globalStyles.e2e.ts
@@ -17,7 +17,7 @@ describe("global styles", () => {
     ];
 
     globalClasses.forEach((className) => {
-      it(`should support rendering component with ${className} animation`, async () => {
+      it.skip(`should support rendering component with ${className} animation`, async () => {
         const page = await newE2EPage({ html: snippet });
         const element = await page.find("calcite-notice");
         await element.setProperty("active", true);


### PR DESCRIPTION
**Related Issue:** #

## Summary
skipping unstable test:
`should support rendering component with ${className} animation`
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
