### PR TITLE
fix(slider): focus respective thumb when click on track for range slider

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { defaults, formAssociated, labelable, renders } from "../../tests/commonTests";
-import { getElementXY } from "../../tests/utils";
+import { getElementXY, html } from "../../tests/utils";
 
 describe("calcite-slider", () => {
   const sliderWidthFor1To1PixelValueTrack = "116px";
@@ -196,68 +196,81 @@ describe("calcite-slider", () => {
     expect(changeEvent).toHaveReceivedEventTimes(1);
   });
 
-  it("should focus the minthumb when clicked on track close to minvalue", async () => {
-    const page = await newE2EPage({
-      html: `
-      <calcite-slider
-      style="width:${sliderWidthFor1To1PixelValueTrack}"
-      min="0"
-      max="100"
-      min-value="0"
-      max-value="80"
-      step="10"
-      ticks="10"
-    ></calcite-slider>
-      `
+  describe("thumb focus in range", () => {
+    const sliderForThumbFocusTests = `<calcite-slider
+    style="width:${sliderWidthFor1To1PixelValueTrack}"
+    min="0"
+    max="100"
+    min-value="0"
+    max-value="100"
+    ticks="10"
+  ></calcite-slider>`;
+
+    it("should focus the min thumb when clicked on track close to minValue", async () => {
+      const page = await newE2EPage({
+        html: html`${sliderForThumbFocusTests}`
+      });
+      await page.waitForChanges();
+      const slider = await page.find("calcite-slider");
+      const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
+
+      await page.mouse.move(trackX + 30, trackY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      const isMinThumbFocused = await page.$eval("calcite-slider", (slider) =>
+        slider.shadowRoot.activeElement?.classList.contains("thumb--minValue")
+      );
+
+      expect(await slider.getProperty("minValue")).toBe(0);
+      expect(await slider.getProperty("maxValue")).toBe(100);
+      expect(isMinThumbFocused).toBe(true);
     });
-    await page.waitForChanges();
-    const slider = await page.find("calcite-slider");
-    const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
-    await page.mouse.move(trackX + 30, trackY);
-    await page.mouse.down();
-    await page.mouse.up();
-    await page.waitForChanges();
+    it("should focus the max thumb when clicked on track close to maxValue", async () => {
+      const page = await newE2EPage({
+        html: html`${sliderForThumbFocusTests}`
+      });
+      await page.waitForChanges();
+      const slider = await page.find("calcite-slider");
+      const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
-    const isMinThumbFocused = await page.$eval("calcite-slider", (slider) =>
-      slider.shadowRoot.activeElement?.classList.contains("thumb--minValue")
-    );
+      await page.mouse.move(trackX + 60, trackY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.waitForChanges();
 
-    expect(await slider.getProperty("minValue")).toBe(0);
-    expect(await slider.getProperty("maxValue")).toBe(80);
-    expect(isMinThumbFocused).toBe(true);
-  });
+      const isMaxThumbFocused = await page.$eval("calcite-slider", (slider) =>
+        slider.shadowRoot.activeElement?.classList.contains("thumb--value")
+      );
 
-  it("should focus the maxthumb when clicked on track close to maxvalue", async () => {
-    const page = await newE2EPage({
-      html: `
-      <calcite-slider
-      style="width:${sliderWidthFor1To1PixelValueTrack}"
-      min="0"
-      max="100"
-      min-value="0"
-      max-value="80"
-      step="10"
-      ticks="10"
-    ></calcite-slider>
-      `
+      expect(await slider.getProperty("minValue")).toBe(0);
+      expect(await slider.getProperty("maxValue")).toBe(100);
+      expect(isMaxThumbFocused).toBe(true);
     });
-    await page.waitForChanges();
-    const slider = await page.find("calcite-slider");
-    const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
-    await page.mouse.move(trackX + 50, trackY);
-    await page.mouse.down();
-    await page.mouse.up();
-    await page.waitForChanges();
+    it("should focus the max thumb when clicked on middle of the track", async () => {
+      const page = await newE2EPage({
+        html: html`${sliderForThumbFocusTests}`
+      });
+      await page.waitForChanges();
+      const slider = await page.find("calcite-slider");
+      const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
-    const isMaxThumbFocused = await page.$eval("calcite-slider", (slider) =>
-      slider.shadowRoot.activeElement?.classList.contains("thumb--value")
-    );
+      await page.mouse.move(trackX + 50, trackY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.waitForChanges();
 
-    expect(await slider.getProperty("minValue")).toBe(0);
-    expect(await slider.getProperty("maxValue")).toBe(80);
-    expect(isMaxThumbFocused).toBe(true);
+      const isMaxThumbFocused = await page.$eval("calcite-slider", (slider) =>
+        slider.shadowRoot.activeElement?.classList.contains("thumb--value")
+      );
+
+      expect(await slider.getProperty("minValue")).toBe(0);
+      expect(await slider.getProperty("maxValue")).toBe(100);
+      expect(isMaxThumbFocused).toBe(true);
+    });
   });
 
   describe("mouse interaction", () => {

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -211,6 +211,7 @@ describe("calcite-slider", () => {
       `
     });
     await page.waitForChanges();
+    const slider = await page.find("calcite-slider");
     const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
     await page.mouse.move(trackX + 30, trackY);
@@ -222,6 +223,8 @@ describe("calcite-slider", () => {
       slider.shadowRoot.activeElement?.classList.contains("thumb--minValue")
     );
 
+    expect(await slider.getProperty("minValue")).toBe(0);
+    expect(await slider.getProperty("maxValue")).toBe(80);
     expect(isMinThumbFocused).toBe(true);
   });
 
@@ -240,6 +243,7 @@ describe("calcite-slider", () => {
       `
     });
     await page.waitForChanges();
+    const slider = await page.find("calcite-slider");
     const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
     await page.mouse.move(trackX + 50, trackY);
@@ -251,6 +255,8 @@ describe("calcite-slider", () => {
       slider.shadowRoot.activeElement?.classList.contains("thumb--value")
     );
 
+    expect(await slider.getProperty("minValue")).toBe(0);
+    expect(await slider.getProperty("maxValue")).toBe(80);
     expect(isMaxThumbFocused).toBe(true);
   });
 

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -197,18 +197,18 @@ describe("calcite-slider", () => {
   });
 
   describe("thumb focus in range", () => {
-    const sliderForThumbFocusTests = `<calcite-slider
-    style="width:${sliderWidthFor1To1PixelValueTrack}"
-    min="0"
-    max="100"
-    min-value="0"
-    max-value="100"
-    ticks="10"
-  ></calcite-slider>`;
+    const sliderForThumbFocusTests = html`<calcite-slider
+      style="width:${sliderWidthFor1To1PixelValueTrack}"
+      min="0"
+      max="100"
+      min-value="0"
+      max-value="100"
+      ticks="10"
+    ></calcite-slider>`;
 
     it("should focus the min thumb when clicked on track close to minValue", async () => {
       const page = await newE2EPage({
-        html: html`${sliderForThumbFocusTests}`
+        html: `${sliderForThumbFocusTests}`
       });
       await page.waitForChanges();
       const slider = await page.find("calcite-slider");
@@ -230,7 +230,7 @@ describe("calcite-slider", () => {
 
     it("should focus the max thumb when clicked on track close to maxValue", async () => {
       const page = await newE2EPage({
-        html: html`${sliderForThumbFocusTests}`
+        html: `${sliderForThumbFocusTests}`
       });
       await page.waitForChanges();
       const slider = await page.find("calcite-slider");
@@ -252,7 +252,7 @@ describe("calcite-slider", () => {
 
     it("should focus the max thumb when clicked on middle of the track", async () => {
       const page = await newE2EPage({
-        html: html`${sliderForThumbFocusTests}`
+        html: `${sliderForThumbFocusTests}`
       });
       await page.waitForChanges();
       const slider = await page.find("calcite-slider");

--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -196,6 +196,64 @@ describe("calcite-slider", () => {
     expect(changeEvent).toHaveReceivedEventTimes(1);
   });
 
+  it("should focus the minthumb when clicked on track close to minvalue", async () => {
+    const page = await newE2EPage({
+      html: `
+      <calcite-slider
+      style="width:${sliderWidthFor1To1PixelValueTrack}"
+      min="0"
+      max="100"
+      min-value="0"
+      max-value="80"
+      step="10"
+      ticks="10"
+    ></calcite-slider>
+      `
+    });
+    await page.waitForChanges();
+    const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
+
+    await page.mouse.move(trackX + 30, trackY);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.waitForChanges();
+
+    const isMinThumbFocused = await page.$eval("calcite-slider", (slider) =>
+      slider.shadowRoot.activeElement?.classList.contains("thumb--minValue")
+    );
+
+    expect(isMinThumbFocused).toBe(true);
+  });
+
+  it("should focus the maxthumb when clicked on track close to maxvalue", async () => {
+    const page = await newE2EPage({
+      html: `
+      <calcite-slider
+      style="width:${sliderWidthFor1To1PixelValueTrack}"
+      min="0"
+      max="100"
+      min-value="0"
+      max-value="80"
+      step="10"
+      ticks="10"
+    ></calcite-slider>
+      `
+    });
+    await page.waitForChanges();
+    const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
+
+    await page.mouse.move(trackX + 50, trackY);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.waitForChanges();
+
+    const isMaxThumbFocused = await page.$eval("calcite-slider", (slider) =>
+      slider.shadowRoot.activeElement?.classList.contains("thumb--value")
+    );
+
+    expect(isMaxThumbFocused).toBe(true);
+  });
+
   describe("mouse interaction", () => {
     it("single handle: clicking the track changes value on mousedown, emits on mouseup", async () => {
       const page = await newE2EPage({

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -302,14 +302,11 @@ $tick-height: 4px;
   margin-left: -2px;
   border: 1px solid var(--calcite-ui-foreground-1);
   background-color: var(--calcite-ui-border-1);
+  pointer-events: none;
 }
 
 .tick--active {
   background-color: var(--calcite-ui-brand);
-}
-
-.tick--active--range {
-  pointer-events: none;
 }
 
 .tick__label {

--- a/src/components/calcite-slider/calcite-slider.scss
+++ b/src/components/calcite-slider/calcite-slider.scss
@@ -308,6 +308,10 @@ $tick-height: 4px;
   background-color: var(--calcite-ui-brand);
 }
 
+.tick--active--range {
+  pointer-events: none;
+}
+
 .tick__label {
   position: absolute;
   font-size: var(--calcite-font-size--2);

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -889,7 +889,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     const ticks = [];
     let current = this.min;
     while (this.ticks && current < this.max + this.ticks) {
-      ticks.push(current);
+      ticks.push(Math.min(current, this.max));
       current = current + this.ticks;
     }
     return ticks;

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -569,7 +569,8 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
                   <span
                     class={{
                       tick: true,
-                      "tick--active": activeTicks
+                      "tick--active": activeTicks,
+                      "tick--active--range": this.isRange
                     }}
                     style={{
                       left: mirror ? "" : tickOffset,

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -569,8 +569,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
                   <span
                     class={{
                       tick: true,
-                      "tick--active": activeTicks,
-                      "tick--active--range": this.isRange
+                      "tick--active": activeTicks
                     }}
                     style={{
                       left: mirror ? "" : tickOffset,
@@ -753,7 +752,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
 
   @Listen("click")
   clickHandler(event: PointerEvent): void {
-    this.focusActiveHandle(event);
+    this.focusActiveHandle(event.clientX);
   }
 
   @Listen("pointerdown")
@@ -905,7 +904,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     document.addEventListener("pointercancel", this.dragEnd);
   }
 
-  private focusActiveHandle(event: PointerEvent): void {
+  private focusActiveHandle(valueX: number): void {
     switch (this.dragProp) {
       case "minValue":
         this.minHandle.focus();
@@ -914,7 +913,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
         this.maxHandle.focus();
         break;
       case "minMaxValue":
-        this.getClosestHandle(event).focus();
+        this.getClosestHandle(valueX).focus();
         break;
       default:
         break;
@@ -962,7 +961,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     document.removeEventListener("pointerup", this.dragEnd);
     document.removeEventListener("pointercancel", this.dragEnd);
 
-    this.focusActiveHandle(event);
+    this.focusActiveHandle(event.clientX);
     if (this.lastDragPropValue != this[this.dragProp]) {
       this.emitChange();
     }
@@ -1048,25 +1047,12 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     return num;
   }
 
-  /**
-   * Get the closest thumb when clicked on the track
-   * @param event
-   * @returns {HTMLButtonElement}
-   * @internal
-   */
-  private getClosestHandle(event: PointerEvent): HTMLButtonElement {
-    return this.getDistanceX(this.maxHandle, event.clientX) >
-      this.getDistanceX(this.minHandle, event.clientX)
+  private getClosestHandle(valueX: number): HTMLButtonElement {
+    return this.getDistanceX(this.maxHandle, valueX) > this.getDistanceX(this.minHandle, valueX)
       ? this.minHandle
       : this.maxHandle;
   }
 
-  /**
-   * Get distance along X-axis between thumb and mouse click
-   * @param el
-   * @param event
-   * @returns {number}
-   */
   private getDistanceX(el: HTMLButtonElement, valueX: number): number {
     return Math.abs(el.getBoundingClientRect().left - valueX);
   }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -889,7 +889,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     const ticks = [];
     let current = this.min;
     while (this.ticks && current < this.max + this.ticks) {
-      ticks.push(Math.min(current, this.max));
+      ticks.push(current);
       current = current + this.ticks;
     }
     return ticks;

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -906,14 +906,15 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
 
   private focusActiveHandle(): void {
     switch (this.dragProp) {
-      default:
-      case "maxValue":
-        this.maxHandle.focus();
-        break;
       case "minValue":
         this.minHandle.focus();
         break;
+      case "maxValue":
+        this.maxHandle.focus();
+        break;
       case "minMaxValue":
+        break;
+      default:
         break;
     }
   }

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -751,8 +751,8 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   }
 
   @Listen("click")
-  clickHandler(): void {
-    this.focusActiveHandle();
+  clickHandler(event: MouseEvent): void {
+    this.focusActiveHandle(event);
   }
 
   @Listen("pointerdown")
@@ -904,7 +904,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     document.addEventListener("pointercancel", this.dragEnd);
   }
 
-  private focusActiveHandle(): void {
+  private focusActiveHandle(event: MouseEvent): void {
     switch (this.dragProp) {
       case "minValue":
         this.minHandle.focus();
@@ -913,6 +913,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
         this.maxHandle.focus();
         break;
       case "minMaxValue":
+        this.getClosestHandle(event).focus();
         break;
       default:
         break;
@@ -955,12 +956,12 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     this.calciteSliderChange.emit();
   }
 
-  private dragEnd = (): void => {
+  private dragEnd = (event: MouseEvent): void => {
     document.removeEventListener("pointermove", this.dragUpdate);
     document.removeEventListener("pointerup", this.dragEnd);
     document.removeEventListener("pointercancel", this.dragEnd);
 
-    this.focusActiveHandle();
+    this.focusActiveHandle(event);
     if (this.lastDragPropValue != this[this.dragProp]) {
       this.emitChange();
     }
@@ -1044,6 +1045,28 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
       num = this.clamp(step);
     }
     return num;
+  }
+
+  /**
+   * Get the closest thumb when clicked on the track
+   * @param event
+   * @returns {HTMLButtonElement}
+   * @internal
+   */
+  private getClosestHandle(event: MouseEvent): HTMLButtonElement {
+    return this.getDistanceX(this.maxHandle, event) > this.getDistanceX(this.minHandle, event)
+      ? this.minHandle
+      : this.maxHandle;
+  }
+
+  /**
+   * Get distance along X-axis between thumb and mouse click
+   * @param el
+   * @param event
+   * @returns {number}
+   */
+  private getDistanceX(el: HTMLButtonElement, event: MouseEvent): number {
+    return Math.abs(el.getBoundingClientRect().left - event.clientX);
   }
 
   private getFontSizeForElement(element: HTMLElement): number {

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -751,7 +751,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   }
 
   @Listen("click")
-  clickHandler(event: MouseEvent): void {
+  clickHandler(event: PointerEvent): void {
     this.focusActiveHandle(event);
   }
 
@@ -904,7 +904,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     document.addEventListener("pointercancel", this.dragEnd);
   }
 
-  private focusActiveHandle(event: MouseEvent): void {
+  private focusActiveHandle(event: PointerEvent): void {
     switch (this.dragProp) {
       case "minValue":
         this.minHandle.focus();
@@ -956,7 +956,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     this.calciteSliderChange.emit();
   }
 
-  private dragEnd = (event: MouseEvent): void => {
+  private dragEnd = (event: PointerEvent): void => {
     document.removeEventListener("pointermove", this.dragUpdate);
     document.removeEventListener("pointerup", this.dragEnd);
     document.removeEventListener("pointercancel", this.dragEnd);
@@ -1053,8 +1053,9 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
    * @returns {HTMLButtonElement}
    * @internal
    */
-  private getClosestHandle(event: MouseEvent): HTMLButtonElement {
-    return this.getDistanceX(this.maxHandle, event) > this.getDistanceX(this.minHandle, event)
+  private getClosestHandle(event: PointerEvent): HTMLButtonElement {
+    return this.getDistanceX(this.maxHandle, event.clientX) >
+      this.getDistanceX(this.minHandle, event.clientX)
       ? this.minHandle
       : this.maxHandle;
   }
@@ -1065,8 +1066,8 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
    * @param event
    * @returns {number}
    */
-  private getDistanceX(el: HTMLButtonElement, event: MouseEvent): number {
-    return Math.abs(el.getBoundingClientRect().left - event.clientX);
+  private getDistanceX(el: HTMLButtonElement, valueX: number): number {
+    return Math.abs(el.getBoundingClientRect().left - valueX);
   }
 
   private getFontSizeForElement(element: HTMLElement): number {


### PR DESCRIPTION
**Related Issue:** #3109 

## Summary

This fix make sure the corresponding thumb is focused on` click `and the closest thumb `:focus` is set to true when the user click on track.
