### PR TITLE
docs(modal): events emit  after the animation not before

### DIFF
--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -265,10 +265,10 @@ export class CalciteModal {
   //  Events
   //
   //--------------------------------------------------------------------------
-  /** Fired when the modal begins the open animation */
+  /** Fired when the modal finishes the open animation */
   @Event() calciteModalOpen: EventEmitter;
 
-  /** Fired when the modal begins the close animation */
+  /** Fired when the modal finishes the close animation */
   @Event() calciteModalClose: EventEmitter;
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #2179

## Summary
Correct the doc to specify that the modal open/close events fire after the animation finishes
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
