### PR TITLE
feat(shell, shell-panel, panel): targets border styles to known, slotted components

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -89,7 +89,7 @@
     justify-start
     sticky
     top-0
-    border-b-color-2
+    border-b-color-3
     w-full;
   flex: 0 0 auto;
   min-height: theme("spacing.12");
@@ -122,7 +122,7 @@
 }
 
 .back-button {
-  @apply border-color-2
+  @apply border-color-3
   border-solid
   border-0
   border-r;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -80,7 +80,7 @@
   --calcite-shell-panel-detached-max-height: 80vh;
 }
 
-.content--detached {
+.content.content--detached {
   @apply rounded
   shadow-0
   h-auto
@@ -91,6 +91,7 @@
 
   ::slotted(calcite-panel),
   ::slotted(calcite-flow) {
+    @apply border-none;
     max-height: unset;
   }
 }
@@ -99,12 +100,22 @@
   @apply hidden;
 }
 
-:host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
-  @apply border-r border-r-color-3;
-  border-right-style: solid;
+slot[name="action-bar"]::slotted(calcite-action-bar),
+.content ::slotted(calcite-flow),
+.content ::slotted(calcite-panel) {
+  @apply border
+  border-color-3
+  border-solid;
 }
 
-:host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
-  @apply border-l border-l-color-3;
-  border-left-style: solid;
+:host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar),
+:host([position="start"]) .content ::slotted(calcite-flow),
+:host([position="start"]) .content ::slotted(calcite-panel) {
+  @apply border-l-0;
+}
+
+:host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar),
+:host([position="end"]) .content ::slotted(calcite-flow),
+:host([position="end"]) .content ::slotted(calcite-panel) {
+  @apply border-r-0;
 }

--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -24,12 +24,7 @@
     flex-auto 
     flex 
     flex-row 
-    relative 
-    border-0
-    border-t
-    border-b
-    border-solid
-    border-color-3
+    relative
     justify-between 
     overflow-hidden;
 }
@@ -40,15 +35,11 @@
 
 .content {
   @apply flex
+    flex-col
+    flex-no-wrap
     h-full 
     overflow-auto 
-    w-full 
-    border-0
-    border-l 
-    border-r 
-    border-solid
-    border-color-3;
-  flex-flow: column nowrap;
+    w-full;
 }
 
 .content ::slotted(calcite-shell-center-row),
@@ -78,6 +69,15 @@
 ::slotted(calcite-shell-center-row) {
   @apply relative;
   z-index: 1;
+}
+
+::slotted(calcite-panel),
+::slotted(calcite-flow) {
+  @apply border
+  border-color-3
+  border-solid
+  border-l-0
+  border-r-0;
 }
 
 slot[name="center-row"]::slotted(calcite-shell-center-row:not([detached])) {

--- a/src/demos/shell/demo-app-blank.html
+++ b/src/demos/shell/demo-app-blank.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+
+    <title>Boomer v Millennial - California</title>
+
+    <script src="../_assets/head.js"></script>
+
+    <style>
+      html,
+      body,
+      main,
+      .shell-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
+      .padded-content {
+        padding: 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="shell-container">
+        <calcite-shell>
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start">
+            <!-- <div slot="action-bar">
+                  Actionbar
+              </div> -->
+            <calcite-action-bar slot="action-bar">
+              <calcite-action-group>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action text-enabled icon="map" text="New" slot="menu-actions"> </calcite-action>
+                <calcite-action text-enabled icon="collection" text="Open" slot="menu-actions"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers" active> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action text="Share" icon="share"></calcite-action>
+                <calcite-action text="Print" icon="print"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Feedback" icon="speech-bubble-plus"></calcite-action>
+                <calcite-action text="What's next" icon="mega-phone"></calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-panel heading="Panel">
+              <div class="padded-content">Panel content<br />Padding is fake.</div>
+            </calcite-panel>
+          </calcite-shell-panel>
+
+          <calcite-shell-panel slot="contextual-panel" position="end">
+            <!-- <div slot="action-bar">
+                Actionbar
+            </div> -->
+            <calcite-action-bar slot="action-bar">
+              <calcite-tooltip slot="expand-tooltip" label="tooltip" disable-pointer>Add layers</calcite-tooltip>
+              <calcite-action-group>
+                <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
+                <calcite-action text="Styles" icon="shapes"> </calcite-action>
+                <calcite-action text="Filter" icon="layer-filter"> </calcite-action>
+                <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
+                <calcite-action text-enabled text="Configure attributes" icon="feature-details" slot="menu-actions">
+                </calcite-action>
+                <calcite-action text-enabled text="Labels" icon="label" slot="menu-actions"> </calcite-action>
+                <calcite-action text-enabled text="Tablew" icon="table" slot="menu-actions"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="search" text="Search"></calcite-action>
+                <calcite-action icon="measure" text="Measure"></calcite-action>
+                <calcite-action text-enabled icon="road-sign" text="Directions" slot="menu-actions"></calcite-action>
+                <calcite-action text-enabled icon="point" text="Location" slot="menu-actions"></calcite-action>
+                <calcite-action
+                  text-enabled
+                  icon="pencil-square"
+                  text="Edit"
+                  disabled
+                  slot="menu-actions"
+                ></calcite-action>
+                <calcite-action text-enabled icon="clock" text="Time" disabled slot="menu-actions"></calcite-action>
+              </calcite-action-group>
+              <calcite-action-group slot="bottom-actions">
+                <calcite-action text="Tips" id="tip-manager-button">
+                  <calcite-icon icon="lightbulb" scale="s"></calcite-icon>
+                </calcite-action>
+              </calcite-action-group>
+            </calcite-action-bar>
+            <calcite-flow>
+              <calcite-panel heading="Flow 01">
+                <div class="padded-content">Flow 01 content<br />Padding is fake.</div>
+              </calcite-panel>
+              <calcite-panel heading="Flow 02">
+                <div class="padded-content">Flow 02 content<br />Padding is fake.</div>
+              </calcite-panel>
+            </calcite-flow>
+          </calcite-shell-panel>
+          <div class="gnav" slot="header">
+            <h2>Boomer v Millennial - California</h2>
+          </div>
+          <calcite-panel heading="Main content">
+            <div class="padded-content">The borders are only applied to "known" components.<br />Padding is fake.</div>
+          </calcite-panel>
+          <!-- <calcite-flow>
+            <calcite-panel heading="Flow 01">
+                Flow 01
+            </calcite-panel>
+            <calcite-panel heading="Flow 02">
+                Flow 02
+            </calcite-panel>
+        </calcite-flow> -->
+          <!-- <div class="main-content">
+              Main content
+          </div> -->
+
+          <footer slot="footer">Footer</footer>
+        </calcite-shell>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION


**Related Issue:** #2992

## Summary
* no longer adds borders directly to container divs
  *  allows users to add whatever without getting default borders
* applies borders to known components
* includes border-color alignment in Panel
* adds related demo

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
