### PR TITLE
feat(input): add enterkeyhint property to specify mobile enter key type

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -171,6 +171,13 @@ export class CalciteInput implements LabelableComponent {
   @Prop() suffixText?: string;
 
   /**
+   * A hint to the browser for which enter key to display.
+   * Possible values: `enter`, `done`, `go`, `next`,
+   * `previous`, `search`, and `send`.
+   */
+  @Prop() enterkeyhint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send";
+
+  /**
    * specify the input type
    *
    * Note that the following types add type-specific icons by default: `date`, `email`, `password`, `search`, `tel`, `time`
@@ -672,6 +679,7 @@ export class CalciteInput implements LabelableComponent {
           autofocus={this.autofocus ? true : null}
           defaultValue={this.defaultValue}
           disabled={this.disabled ? true : null}
+          enterKeyHint={this.enterkeyhint}
           key="localized-input"
           maxLength={this.maxLength}
           minLength={this.minLength}
@@ -695,6 +703,7 @@ export class CalciteInput implements LabelableComponent {
         autofocus={this.autofocus ? true : null}
         defaultValue={this.defaultValue}
         disabled={this.disabled ? true : null}
+        enterKeyHint={this.enterkeyhint}
         max={this.maxString}
         maxLength={this.maxLength}
         min={this.minString}

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -170,11 +170,7 @@ export class CalciteInput implements LabelableComponent {
   /** optionally add suffix  **/
   @Prop() suffixText?: string;
 
-  /**
-   * A hint to the browser for which enter key to display.
-   * Possible values: `enter`, `done`, `go`, `next`,
-   * `previous`, `search`, and `send`.
-   */
+  /** A hint to the browser for which enter key to display */
   @Prop() enterkeyhint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send";
 
   /**


### PR DESCRIPTION
**Related Issue:** #3383

## Summary
Added `enterkeyhint` property to input which specifies which type of `enter` key should be provided on a mobile keyboard
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
