### PR TITLE
build(ci): try to fix screener github bug

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -33,6 +33,6 @@ jobs:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: Screener Report
           description: Click details to view the report on Screener
-          state: ${{ job.status }}
+          state: success
           sha: ${{github.event.pull_request.head.sha || github.sha}}
           target_url: ${{ steps.report.outputs.report }}

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  screen:
+  screenshot_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  screener:
+  screen:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Maybe the screener check is showing the old one since I named it the same thing? So I changed the new one from `screener` to `screen` lets so if that gets rid of this weird bug
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
