### PR TITLE
chore: add a11y audit issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/a11y-audit.md
+++ b/.github/ISSUE_TEMPLATE/a11y-audit.md
@@ -1,0 +1,45 @@
+---
+name: A11y Audit
+about: For internal use only.
+title: "A11y Audit: "
+labels: a11y, 0 - new, p - high, needs triage
+assignees: ""
+---
+
+### Issue Summary
+
+<!-- A clear and concise description of the bug, defect, or problem -->
+
+### Related Standards
+
+<!-- [WCAG links, etc] -->
+
+### Reproduction Steps
+
+<!-- Steps to reproduce the behavior -->
+
+### Expected Behavior
+
+<!-- A clear and concise description of what you expected, or what should happen -->
+
+[Recommendation]
+
+[Code Example]
+
+### Remediation Steps
+
+<!-- Tips and approaches to remediating the issue, and bringing it into conformance. -->
+
+### Screenshots/Images
+
+<!-- If applicable, add screenshots to help define the bug or defect -->
+
+### Additional Context
+
+<!-- Add any other context about the bug or defect here. -->
+
+### Issue Source
+
+<!-- Link to the Instance ID page in AMP -->
+
+- Instance:


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Add a new template for internal use while creating ally audit issues
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
