### PR TITLE
chore: remove title from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.md
+++ b/.github/ISSUE_TEMPLATE/accessibility.md
@@ -1,7 +1,6 @@
 ---
 name: Accessibility
 about: Report an accessibility issue in a component.
-title: "A11y: "
 labels: a11y, bug, 0 - new, p - high, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,6 @@
 ---
 name: Bug
 about: Report a bug in a component.
-title: "Bug: "
 labels: bug, 0 - new, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,7 +1,6 @@
 ---
 name: Documentation
 about: Report issues with documentation.
-title: "Docs: "
 labels: docs, 0 - new, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,7 +1,6 @@
 ---
 name: Enhancement
 about: Request for a feature to be added to an existing component.
-title: "Enhancement: "
 labels: enhancement, 0 - new, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/new-component.md
+++ b/.github/ISSUE_TEMPLATE/new-component.md
@@ -1,7 +1,6 @@
 ---
 name: New Component
 about: Request for a new component to be added.
-title: "New Component: "
 labels: new component, 0 - new, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,6 @@
 ---
 name: Question
 about: Request for information - not code changes.
-title: "Question: "
 labels: question, 0 - new
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,7 +1,6 @@
 ---
 name: Refactor
 about: Propose a code rework that does not effect functionality.
-title: "Refactor: "
 labels: refactor, 0 - new, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,7 +1,6 @@
 ---
 name: Research
 about: Request an investigation into a specific topic.
-title: "Research: "
 labels: 0 - new, research, needs triage
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/tooling.md
+++ b/.github/ISSUE_TEMPLATE/tooling.md
@@ -1,7 +1,6 @@
 ---
 name: Tooling
 about: Request improvements to our component workflow.
-title: "Tooling: "
 labels: tooling, 0 - new, needs triage
 assignees: ""
 ---


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Sometimes people forget to fill out the title which is possible since we already prefill some of it. If we remove the prefilled part and people don't add a title then the issue won't submit. All of the titles are duplicates of the labels that are added to the issue so having both is redundant anyway
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
