### PR TITLE
refactor: make updatePopper helper async

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.tsx
+++ b/src/components/calcite-combobox/calcite-combobox.tsx
@@ -153,7 +153,7 @@ export class CalciteCombobox implements LabelableComponent {
     const { popper, menuEl } = this;
     const modifiers = this.getModifiers();
     popper
-      ? updatePopper({
+      ? await updatePopper({
           el: menuEl,
           modifiers,
           placement: ComboboxDefaultPlacement,

--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -184,7 +184,7 @@ export class CalciteDropdown {
     const modifiers = this.getModifiers();
 
     popper
-      ? updatePopper({
+      ? await updatePopper({
           el: menuEl,
           modifiers,
           placement,

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -188,7 +188,7 @@ export class CalciteInputDatePicker implements LabelableComponent {
     const modifiers = this.getModifiers();
 
     popper
-      ? updatePopper({
+      ? await updatePopper({
           el: menuEl,
           modifiers,
           placement: DEFAULT_PLACEMENT,

--- a/src/components/calcite-popover/calcite-popover.tsx
+++ b/src/components/calcite-popover/calcite-popover.tsx
@@ -212,7 +212,7 @@ export class CalcitePopover {
     const modifiers = this.getModifiers();
 
     popper
-      ? updatePopper({
+      ? await updatePopper({
           el,
           modifiers,
           placement,

--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -133,7 +133,7 @@ export class CalciteTooltip {
     const modifiers = this.getModifiers();
 
     popper
-      ? updatePopper({
+      ? await updatePopper({
           el,
           modifiers,
           placement,

--- a/src/utils/popper.ts
+++ b/src/utils/popper.ts
@@ -71,7 +71,7 @@ export function createPopper({
   });
 }
 
-export function updatePopper({
+export async function updatePopper({
   el,
   modifiers,
   placement: PopperPlacement,
@@ -81,10 +81,10 @@ export function updatePopper({
   modifiers: Partial<StrictModifiers>[];
   popper: Popper;
   placement: PopperPlacement;
-}): void {
+}): Promise<void> {
   const placement = getPlacement(el, PopperPlacement);
 
-  popper.setOptions({
+  await popper.setOptions({
     modifiers,
     placement
   });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This ensures `updatePopper` awaits on `Popper#setOptions` since [it is async](https://github.com/popperjs/popper-core/blob/b13deeed239f8b8db9637c1411d4a57d1159cbb6/src/types.js#L124-L126).