### PR TITLE
ci: use environment variable to set Screener API key

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -2,6 +2,8 @@ name: Screener
 on:
   pull_request:
     branches: [master]
+env:
+  SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
 jobs:
   screenshot_tests:
     runs-on: ubuntu-latest
@@ -12,12 +14,6 @@ jobs:
           node-version: lts/*
       - name: install dependencies
         run: npm install
-      - name: setup environment variables
-        run: | # gh env vars dont work in node
-          npm install dotenv
-          touch .env
-          echo "require('dotenv').config()" | cat - screener.config.js > temp && mv temp screener.config.js
-          echo SCREENER_API_KEY=${{ secrets.SCREENER_API_KEY }} >> .env 2> /dev/null
       - name: run screener check
         run: npm run test:storybook 2>&1 | tee log.txt ; ( exit ${PIPESTATUS[0]} )
       - name: parse screener report

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -2,8 +2,6 @@ name: Screener
 on:
   pull_request:
     branches: [master]
-env:
-  SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
 jobs:
   screenshot_tests:
     runs-on: ubuntu-latest
@@ -15,6 +13,8 @@ jobs:
       - name: install dependencies
         run: npm install
       - name: run screener check
+        env:
+          SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
         run: npm run test:storybook 2>&1 | tee log.txt ; ( exit ${PIPESTATUS[0]} )
       - name: parse screener report
         id: report


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Tweak API key approach based on some examples:

https://github.com/saucelabs/sauce_bindings/blob/99c9ea7c3928031b741d2f78fd6433a6013a1cd4/.github/workflows/dotnet.yml
https://github.com/microsoft/fluent-ui-react/blob/3fa9cbca5cde7a5da98b3c71bfc4bed7a56c743d/.github/workflows/screener.yml
https://github.com/microsoft/fluent-ui-react/blob/3fa9cbca5cde7a5da98b3c71bfc4bed7a56c743d/build/screener/screener.config.js