### PR TITLE
build(ci): add commit sha to screener run

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -19,20 +19,4 @@ jobs:
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
-        run: npm run test:storybook 2>&1 | tee log.txt ; ( exit ${PIPESTATUS[0]} )
-      - name: parse screener report
-        id: report
-        if: always()
-        run: |
-          URL=$(grep -Eo 'https://screener.io/v2/dashboard[^ >]+' log.txt|head -1)
-          echo "::set-output name=report::$URL"
-      - name: show screener report
-        if: always()
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          context: Screener Report
-          description: Click details to view the report on Screener
-          state: success
-          sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: ${{ steps.report.outputs.report }}
+        run: npm run test:storybook

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [master]
 jobs:
-  screener:
+  screenshot_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,4 +19,4 @@ jobs:
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
-        run: npm run test:storybook
+        run: npm run test:storybook || true

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [master]
 jobs:
-  screenshot_tests:
+  screener:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +18,7 @@ jobs:
       - name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
+          COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
         run: npm run test:storybook 2>&1 | tee log.txt ; ( exit ${PIPESTATUS[0]} )
       - name: parse screener report
         id: report

--- a/screener.config.js
+++ b/screener.config.js
@@ -3,6 +3,7 @@ module.exports = {
   storybookConfigDir: ".storybook",
   storybookStaticDir: "./__docs-temp__",
   apiKey: process.env.SCREENER_API_KEY,
+  commit: process.env.COMMIT_SHA,
   resolution: "1024x768",
   baseBranch: "master",
   browsers: [


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Add commit sha to the screener config as recommended by Loyal. Hopefully this gets the screener integration back
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
