### PR TITLE
fix(dropdown-item): match padding for RTL vs LTR and links vs non-links, consistent focus and hover states for all

### DIFF
--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -55,13 +55,16 @@
   @apply ml-auto mr-0;
 }
 
+.calcite--rtl a.dropdown-link {
+  @apply pr-0 pl-0;
+}
+
 //focus
 :host,
 .container--link a {
   @apply focus-base;
 }
-:host(:focus),
-.container--link a:focus {
+:host(:focus) {
   @apply focus-inset;
 }
 
@@ -74,20 +77,25 @@
 }
 
 .container--s .dropdown-link {
-  @apply px-3 py-2;
+  @apply text--2h pr-2 pl-6 py-1;
 }
 
 .container--m .dropdown-link {
-  @apply px-4 py-3;
+  @apply text--1h pr-3 pl-8 py-2;
 }
 
 .container--l .dropdown-link {
-  @apply px-5 py-4;
+  @apply text-0h pr-4 pl-10 py-3;
 }
 
 :host(:hover) .container,
 :host(:active) .container {
   @apply bg-foreground-2 text-color-1 no-underline;
+}
+
+:host(:hover) .container--link a,
+:host(:active) .container--link a {
+  @apply text-color-1;
 }
 
 :host(:focus) .container {
@@ -111,7 +119,8 @@
   }
 }
 
-:host([active]) .container:not(.container--none-selection) {
+:host([active]) .container:not(.container--none-selection),
+:host([active]) .container--link a {
   @apply text-color-1 font-medium;
   &:before {
     @apply opacity-100;
@@ -120,19 +129,6 @@
   & calcite-icon {
     color: theme("backgroundColor.brand");
   }
-}
-
-// none selection mode and scales
-.container--s.container--none-selection {
-  @apply pl-1;
-}
-
-.container--m.container--none-selection {
-  @apply pl-2;
-}
-
-.container--l.container--none-selection {
-  @apply pl-3;
 }
 
 // no dot for none and multi modes

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -113,7 +113,7 @@
     left: unset;
     right: theme("spacing.4");
   }
-  & a.dropdown-link {
+  & .dropdown-link {
     @apply pr-0 pl-0;
   }
 }

--- a/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
+++ b/src/components/calcite-dropdown-item/calcite-dropdown-item.scss
@@ -55,10 +55,6 @@
   @apply ml-auto mr-0;
 }
 
-.calcite--rtl a.dropdown-link {
-  @apply pr-0 pl-0;
-}
-
 //focus
 :host,
 .container--link a {
@@ -93,8 +89,8 @@
   @apply bg-foreground-2 text-color-1 no-underline;
 }
 
-:host(:hover) .container--link a,
-:host(:active) .container--link a {
+:host(:hover) .container--link .dropdown-link,
+:host(:active) .container--link .dropdown-link {
   @apply text-color-1;
 }
 
@@ -117,10 +113,13 @@
     left: unset;
     right: theme("spacing.4");
   }
+  & a.dropdown-link {
+    @apply pr-0 pl-0;
+  }
 }
 
 :host([active]) .container:not(.container--none-selection),
-:host([active]) .container--link a {
+:host([active]) .container--link .dropdown-link {
   @apply text-color-1 font-medium;
   &:before {
     @apply opacity-100;

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -512,7 +512,6 @@ export class CalciteInput implements LabelableComponent {
     if (direction === "up" && ((!inputMax && inputMax !== 0) || inputVal < inputMax)) {
       newValue = (inputVal + inputStep).toString();
     }
-
     if (direction === "down" && ((!inputMin && inputMin !== 0) || inputVal > inputMin)) {
       newValue = (inputVal - inputStep).toString();
     }

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -512,6 +512,7 @@ export class CalciteInput implements LabelableComponent {
     if (direction === "up" && ((!inputMax && inputMax !== 0) || inputVal < inputMax)) {
       newValue = (inputVal + inputStep).toString();
     }
+
     if (direction === "down" && ((!inputMin && inputMin !== 0) || inputVal > inputMin)) {
       newValue = (inputVal - inputStep).toString();
     }


### PR DESCRIPTION
**Related Issue:** #3349

## Summary

Dropdown items now have consistent padding for RTL/LTR as well as links/non-links.
Focus and Hover states are now consistent for both RTL/LTR and links/non-links.

Observe the behavior on demo Codepen before:
https://codepen.io/ellupp/pen/YzxZaQz?editors=1000

Current

https://user-images.githubusercontent.com/19231036/140199954-25bb7354-5879-4839-be77-d837c4fe329e.mov



