### PR TITLE
fix(label): avoid associating labels to nested labelable components

### DIFF
--- a/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
+++ b/src/components/calcite-tile-select/calcite-tile-select.e2e.ts
@@ -5,8 +5,7 @@ import { html } from "../../tests/utils";
 describe("calcite-tile-select", () => {
   it("renders", async () => renders("calcite-tile-select", { display: "block" }));
 
-  it("is accessible", async () =>
-    accessible(`<calcite-label><calcite-tile-select></calcite-tile-select>Label</calcite-label>`));
+  it("is accessible", async () => accessible(`<calcite-tile-select heading="label"></calcite-tile-select>`));
 
   it("has defaults", async () =>
     defaults("calcite-tile-select", [

--- a/src/utils/label.spec.ts
+++ b/src/utils/label.spec.ts
@@ -1,0 +1,200 @@
+import { connectLabel, disconnectLabel, getLabelText, LabelableComponent, labelClickEvent } from "./label";
+
+describe("label", () => {
+  function createFakeLabelable(overrides: Partial<LabelableComponent>): LabelableComponent {
+    const base = {
+      el: null,
+      label: null,
+      labelEl: null,
+      onLabelClick: jest.fn()
+    };
+
+    return { ...base, ...overrides };
+  }
+
+  describe("connectLabel/disconnectLabel", () => {
+    describe("wires up the associated label", () => {
+      beforeEach(() => {
+        // we polyfill composedPath since Stencil's MockEvent does not support it: https://github.com/ionic-team/stencil/blob/main/src/mock-doc/event.ts#L5-L40
+        CustomEvent.prototype.composedPath = function () {
+          // based on https://gist.github.com/rockinghelvetica/00b9f7b5c97a16d3de75ba99192ff05c
+          if (this.path) {
+            return this.path;
+          }
+          let target = this.target;
+
+          this.path = [];
+          while (target.parentNode !== null) {
+            this.path.push(target);
+            target = target.parentNode;
+          }
+          this.path.push(document, window);
+          return this.path;
+        };
+      });
+
+      /**
+       * This util helps simulate calcite-label's behavior since we cannot use the component here
+       */
+      function wireUpFakeLabel(label: HTMLElement): void {
+        label.addEventListener("click", (event: MouseEvent) => {
+          label.dispatchEvent(new CustomEvent(labelClickEvent, { detail: { sourceEvent: event } }));
+        });
+      }
+
+      it("ignores labelable with no associated label", () => {
+        document.body.innerHTML = `
+          <fake-labelable id="unlabeled"></fake-labelable>
+      `;
+
+        const fakeLabelableEl = document.querySelector<HTMLElement>("#unlabeled");
+
+        const nonLabelable = createFakeLabelable({
+          el: fakeLabelableEl
+        });
+
+        connectLabel(nonLabelable);
+
+        expect(nonLabelable.labelEl).toBeNull();
+
+        disconnectLabel(nonLabelable);
+
+        expect(nonLabelable.labelEl).toBeNull();
+      });
+
+      it("supports for attribute", () => {
+        document.body.innerHTML = `
+        <calcite-label for="for">label</calcite-label>
+        <fake-labelable id="for"></fake-labelable>
+      `;
+
+        const labelEl = document.querySelector<HTMLElement>("calcite-label");
+        const fakeLabelableEl = document.querySelector<HTMLElement>("#for");
+        wireUpFakeLabel(labelEl);
+
+        const labelable = createFakeLabelable({
+          el: fakeLabelableEl
+        });
+
+        connectLabel(labelable);
+
+        expect(labelable.labelEl).toBe(labelEl);
+
+        labelEl.click();
+
+        expect(labelable.onLabelClick).toHaveBeenCalledTimes(1);
+
+        disconnectLabel(labelable);
+
+        expect(labelable.labelEl).toBe(labelEl);
+
+        labelEl.click();
+
+        expect(labelable.onLabelClick).toHaveBeenCalledTimes(1);
+      });
+
+      it("supports wrapped labelable", () => {
+        document.body.innerHTML = `
+        <calcite-label>
+          label
+          <fake-labelable></fake-labelable>
+        </calcite-label>
+      `;
+
+        const labelEl = document.querySelector<HTMLElement>("calcite-label");
+        const fakeLabelableEl = document.querySelector<HTMLElement>("fake-labelable");
+
+        wireUpFakeLabel(labelEl);
+
+        const labelable = createFakeLabelable({
+          el: fakeLabelableEl
+        });
+
+        connectLabel(labelable);
+
+        expect(labelable.labelEl).toBe(labelEl);
+
+        labelEl.click();
+
+        expect(labelable.onLabelClick).toHaveBeenCalledTimes(1);
+
+        disconnectLabel(labelable);
+
+        expect(labelable.labelEl).toBe(labelEl);
+
+        labelEl.click();
+
+        expect(labelable.onLabelClick).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not support nested labelables", () => {
+        document.body.innerHTML = `
+        <calcite-label>
+          label
+          <fake-labelable id="outer">
+            <fake-labelable id="inner"></fake-labelable>
+          </fake-labelable>
+        </calcite-label>
+      `;
+
+        const labelEl = document.querySelector<HTMLElement>("calcite-label");
+        const fakeInnerLabelableEl = document.querySelector<HTMLElement>("#inner");
+        const fakeOuterLabelableEl = document.querySelector<HTMLElement>("#outer");
+
+        wireUpFakeLabel(labelEl);
+
+        const innerLabelable = createFakeLabelable({
+          el: fakeInnerLabelableEl
+        });
+
+        connectLabel(innerLabelable);
+
+        expect(innerLabelable.labelEl).toBeNull();
+
+        const outerLabelable = createFakeLabelable({
+          el: fakeOuterLabelableEl
+        });
+
+        connectLabel(outerLabelable);
+
+        expect(outerLabelable.labelEl).toBe(labelEl);
+
+        labelEl.click();
+
+        expect(outerLabelable.onLabelClick).toHaveBeenCalledTimes(1);
+
+        disconnectLabel(outerLabelable);
+
+        labelEl.click();
+
+        expect(outerLabelable.onLabelClick).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  it("getLabelText", () => {
+    const label = "from-label";
+
+    expect(getLabelText(createFakeLabelable({ label }))).toBe("from-label");
+
+    const labelEl = document.createElement("calcite-label");
+    labelEl.textContent = "from-text-content";
+
+    expect(
+      getLabelText(
+        createFakeLabelable({
+          labelEl
+        })
+      )
+    ).toBe("from-text-content");
+
+    expect(
+      getLabelText(
+        createFakeLabelable({
+          label,
+          labelEl
+        })
+      )
+    ).toBe("from-label");
+  });
+});

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -54,12 +54,13 @@ const findLabelForComponent = (componentEl: HTMLElement): HTMLCalciteLabelElemen
 };
 
 function hasAncestorCustomElements(label: HTMLCalciteLabelElement, componentEl: HTMLElement): boolean {
-  let composedPath: HTMLElement[];
+  let traversedElements: HTMLElement[];
   const customElementAncestorCheckEventType = "custom-element-ancestor-check";
 
   const listener = (event) => {
     event.stopImmediatePropagation();
-    composedPath = event.composedPath() as HTMLElement[];
+    const composedPath = event.composedPath() as HTMLElement[];
+    traversedElements = composedPath.slice(composedPath.indexOf(label), composedPath.indexOf(componentEl));
   };
 
   label.addEventListener(customElementAncestorCheckEventType, listener, { once: true });
@@ -67,7 +68,7 @@ function hasAncestorCustomElements(label: HTMLCalciteLabelElement, componentEl: 
   componentEl.dispatchEvent(new CustomEvent(customElementAncestorCheckEventType, { composed: true, bubbles: true }));
   label.removeEventListener(customElementAncestorCheckEventType, listener);
 
-  const ancestorCustomElements = composedPath
+  const ancestorCustomElements = traversedElements
     .filter((el) => el !== componentEl && el !== label)
     .filter((el) => el.tagName?.includes("-"));
 

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -60,7 +60,7 @@ function hasAncestorCustomElements(label: HTMLCalciteLabelElement, componentEl: 
   const listener = (event) => {
     event.stopImmediatePropagation();
     const composedPath = event.composedPath() as HTMLElement[];
-    traversedElements = composedPath.slice(composedPath.indexOf(label), composedPath.indexOf(componentEl));
+    traversedElements = composedPath.slice(composedPath.indexOf(componentEl), composedPath.indexOf(label));
   };
 
   label.addEventListener(customElementAncestorCheckEventType, listener, { once: true });

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -22,8 +22,13 @@ export interface LabelableComponent {
   onLabelClick: (event: CustomEvent<any>) => void;
 }
 
+/**
+ * Exported for testing purposes only
+ * @internal
+ */
+export const labelClickEvent = "calciteInternalLabelClick";
+
 const labelTagName = "calcite-label";
-const labelClickEvent = "calciteInternalLabelClick";
 const onLabelClickMap = new WeakMap<HTMLCalciteLabelElement, typeof onLabelClick>();
 
 const findLabelForComponent = (componentEl: HTMLElement): HTMLCalciteLabelElement | null => {

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -27,12 +27,47 @@ const labelClickEvent = "calciteInternalLabelClick";
 const onLabelClickMap = new WeakMap<HTMLCalciteLabelElement, typeof onLabelClick>();
 
 const findLabelForComponent = (componentEl: HTMLElement): HTMLCalciteLabelElement | null => {
-  const id = componentEl.id;
-  return (
-    (id && (queryElementRoots(componentEl, `${labelTagName}[for="${id}"]`) as HTMLCalciteLabelElement)) ||
-    closestElementCrossShadowBoundary(componentEl, labelTagName)
-  );
+  const { id } = componentEl;
+
+  const forLabel = id && (queryElementRoots(componentEl, `${labelTagName}[for="${id}"]`) as HTMLCalciteLabelElement);
+
+  if (forLabel) {
+    return forLabel;
+  }
+
+  const parentLabel = closestElementCrossShadowBoundary<HTMLCalciteLabelElement>(componentEl, labelTagName);
+
+  if (
+    !parentLabel ||
+    // labelable components within other custom elements are not considered labelable
+    hasAncestorCustomElements(parentLabel, componentEl)
+  ) {
+    return null;
+  }
+
+  return parentLabel;
 };
+
+function hasAncestorCustomElements(label: HTMLCalciteLabelElement, componentEl: HTMLElement): boolean {
+  let composedPath: HTMLElement[];
+  const customElementAncestorCheckEventType = "custom-element-ancestor-check";
+
+  const listener = (event) => {
+    event.stopImmediatePropagation();
+    composedPath = event.composedPath() as HTMLElement[];
+  };
+
+  label.addEventListener(customElementAncestorCheckEventType, listener, { once: true });
+
+  componentEl.dispatchEvent(new CustomEvent(customElementAncestorCheckEventType, { composed: true, bubbles: true }));
+  label.removeEventListener(customElementAncestorCheckEventType, listener);
+
+  const ancestorCustomElements = composedPath
+    .filter((el) => el !== componentEl && el !== label)
+    .filter((el) => el.tagName?.includes("-"));
+
+  return ancestorCustomElements.length > 0;
+}
 
 /**
  * Helper to set up label interactions on connectedCallback.


### PR DESCRIPTION
**Related Issue:** #3344 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where components with nested labelable components (either in shadow DOM or slotted) could potentially be associated with the label instead of the owning component. For example, in the following snippet, the label gets associated with the slotted button.

```html
<calcite-label>
  Labeled input (wrapped) ⛔
  <calcite-input>
    <calcite-button id="action-slot" slot="action">Go</calcite-button>
  </calcite-input>
</calcite-label>
```

Note that this is not an issue with for-associated labels.

```html
<calcite-label for=input>
  Labeled input (for) ✅
</calcite-label>
<calcite-input id=input>
  <calcite-button id="action-slot" slot="action">Go</calcite-button>
</calcite-input>
```

The label lookup occurs in component's `connectedCallback`, which is not guaranteed to be called in hierarchical order. This is because each component's `connectedCallback` method gets called in the order that they are defined in the browser. For consumers of the lazy-loaded bundle, this order will vary.

This PR changes the rules for labelable components and will no longer associate a labelable component if it is a child of another custom element.

Just as an idea, if we needed to support nested labelables, we could refactor the label util to handle the nested lookup to be async and resolve when `calcite-label` has finished loading or to resolve the lookup when clicked.