### PR TITLE
test(loader): remove unstable story that is causing screener failure

### DIFF
--- a/src/components/calcite-loader/calcite-loader.stories.ts
+++ b/src/components/calcite-loader/calcite-loader.stories.ts
@@ -22,17 +22,17 @@ export const Simple = (): string => html`
   />
 `;
 
-export const NoPadding = (): string => html`
-  <div style="border: 1px solid rgb(192,192,192, 0.5); width: 100px">
-    <calcite-loader
-      active
-      type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
-      scale="${select("scale", ["s", "m", "l"], "m")}"
-      ${boolean("no-padding", true)}
-      value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
-    />
-  </div>
-`;
+// export const NoPadding = (): string => html`
+//   <div style="border: 1px solid rgb(192,192,192, 0.5); width: 100px">
+//     <calcite-loader
+//       active
+//       type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
+//       scale="${select("scale", ["s", "m", "l"], "m")}"
+//       ${boolean("no-padding", true)}
+//       value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
+//     />
+//   </div>
+// `;
 
 export const Inline = (): string => html`
 <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">


### PR DESCRIPTION
**Related Issue:** #3370

## Summary
The PR linked above added a new story which is causing screener to fail. It looks like the loader is spinning and is in a different position on each snapshot which is causing screener to find changes. Here are some examples from recent PRs:

#3432 - [screener loader story change](https://screener.io/v2/states/1leJJn.Esri-calcite-components/refs%2Fpull%2F3432%2Fmerge/1024x768/Chrome/componentsloader-no-padding-0)

#3424 - [screener loader story change](https://screener.io/v2/states/1leJJn.Esri-calcite-components/refs%2Fpull%2F3424%2Fmerge/1024x768/Chrome/componentsloader-no-padding-0)

I commented out the story for now.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
