### PR TITLE
feat(filter): add filter component

### DIFF
--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -30,7 +30,7 @@ describe("calcite-filter", () => {
       await page.setContent("<calcite-filter></calcite-filter>");
       await page.evaluate(() => {
         const filter = document.querySelector("calcite-filter");
-        filter.data = [{ foo: "bar" }];
+        filter.items = [{ foo: "bar" }];
       });
     });
 
@@ -97,7 +97,7 @@ describe("calcite-filter", () => {
       await page.setContent("<calcite-filter></calcite-filter>");
       await page.evaluate(() => {
         const filter = document.querySelector("calcite-filter");
-        filter.data = [
+        filter.items = [
           {
             name: "Harry",
             description: "developer",
@@ -138,7 +138,7 @@ describe("calcite-filter", () => {
       });
     });
 
-    it("updates filtered data after filtering", async () => {
+    it("updates filtered items after filtering", async () => {
       function assertMatchingItems(filtered: any[], values: string[]): void {
         expect(filtered).toHaveLength(values.length);
         values.forEach((value) => expect(filtered.find((element) => element.value === value)).toBeDefined());
@@ -153,7 +153,7 @@ describe("calcite-filter", () => {
 
       expect(filterChangeSpy).toHaveReceivedEventTimes(1);
 
-      assertMatchingItems(await filter.getProperty("filteredData"), ["harry", "matt", "franco", "jon"]);
+      assertMatchingItems(await filter.getProperty("filteredItems"), ["harry", "matt", "franco", "jon"]);
 
       // event detail is deprecated
       assertMatchingItems(event.detail, ["harry", "matt", "franco", "jon"]);
@@ -161,19 +161,19 @@ describe("calcite-filter", () => {
       waitForEvent = page.waitForEvent("calciteFilterChange");
       await page.evaluate(() => {
         const filter = document.querySelector("calcite-filter");
-        filter.data = filter.data.slice(3);
+        filter.items = filter.items.slice(3);
       });
       event = await waitForEvent;
 
       expect(filterChangeSpy).toHaveReceivedEventTimes(2);
 
-      assertMatchingItems(await filter.getProperty("filteredData"), ["jon"]);
+      assertMatchingItems(await filter.getProperty("filteredItems"), ["jon"]);
 
       // event detail is deprecated
       assertMatchingItems(event.detail, ["jon"]);
     });
 
-    it("searches recursively in data and works and matches on a partial string ignoring case", async () => {
+    it("searches recursively in items and works and matches on a partial string ignoring case", async () => {
       const waitForEvent = page.waitForEvent("calciteFilterChange");
       const filter = await page.find("calcite-filter");
 
@@ -196,5 +196,19 @@ describe("calcite-filter", () => {
       expect(event.detail.length).toBe(1);
       expect(event.detail.find((element) => element.value === "regex")).toBeDefined();
     });
+  });
+
+  it("sets items from deprecated data property", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-filter></calcite-filter>");
+
+    const filter = await page.find("calcite-filter");
+    const data = [{ foo: "bar" }];
+    filter.setProperty("data", data);
+    await page.waitForChanges();
+
+    const items = await filter.getProperty("items");
+
+    expect(items).toEqual(data);
   });
 });

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -102,6 +102,18 @@ export class CalciteFilter {
 
   textInput: HTMLCalciteInputElement;
 
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    if (this.data && !this.items) {
+      this.items = this.data;
+    }
+  }
+
   // --------------------------------------------------------------------------
   //
   //  Events

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -35,7 +35,7 @@ export class CalciteFilter {
    *
    * @deprecated use `items` instead.
    */
-  @Prop() data!: object[];
+  @Prop() data: object[];
 
   @Watch("data")
   watchDataHandler(value: object[]): void {

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -45,8 +45,10 @@ export class CalciteFilter {
   /**
    * The items to filter through. The filter uses this as the starting point, and returns items
    * that contain the string entered in the input, using a partial match and recursive search.
+   *
+   * This property is required.
    */
-  @Prop({ mutable: true }) items!: object[];
+  @Prop({ mutable: true }) items: object[];
 
   @Watch("items")
   watchItemsHandler(): void {

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -32,11 +32,24 @@ export class CalciteFilter {
   /**
    * The input data. The filter uses this as the starting point, and returns items
    * that contain the string entered in the input, using a partial match and recursive search.
+   *
+   * @deprecated use `items` instead.
    */
   @Prop() data!: object[];
 
   @Watch("data")
-  watchDataHandler(): void {
+  watchDataHandler(value: object[]): void {
+    this.items = value;
+  }
+
+  /**
+   * The items to filter through. The filter uses this as the starting point, and returns items
+   * that contain the string entered in the input, using a partial match and recursive search.
+   */
+  @Prop({ mutable: true }) items!: object[];
+
+  @Watch("items")
+  watchItemsHandler(): void {
     this.filter(this.value);
   }
 
@@ -46,11 +59,11 @@ export class CalciteFilter {
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The resulting data after filtering.
+   * The resulting items after filtering.
    *
    * @readonly
    */
-  @Prop({ mutable: true }) filteredData: CalciteFilter["data"] = [];
+  @Prop({ mutable: true }) filteredItems: CalciteFilter["items"] = [];
 
   /**
    * A text label that will appear on the clear button.
@@ -119,9 +132,7 @@ export class CalciteFilter {
   filter = debounce((value: string): void => {
     const regex = new RegExp(value, "i");
 
-    if (this.data.length === 0) {
-      console.warn(`No data was passed to calcite-filter.
-      The data property expects an array of objects`);
+    if (this.items.length === 0) {
       this.updateFiltered([]);
       return;
     }
@@ -144,7 +155,7 @@ export class CalciteFilter {
       return found;
     };
 
-    const result = this.data.filter((item) => {
+    const result = this.items.filter((item) => {
       return find(item, regex);
     });
 
@@ -168,8 +179,8 @@ export class CalciteFilter {
   };
 
   updateFiltered(filtered: any[]): void {
-    this.filteredData.length = 0;
-    this.filteredData = this.filteredData.concat(filtered);
+    this.filteredItems.length = 0;
+    this.filteredItems = this.filteredItems.concat(filtered);
     this.calciteFilterChange.emit(filtered);
   }
 

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -33,7 +33,7 @@ export class CalciteFilter {
    * The input data. The filter uses this as the starting point, and returns items
    * that contain the string entered in the input, using a partial match and recursive search.
    */
-  @Prop() data: object[];
+  @Prop() data!: object[];
 
   @Watch("data")
   watchDataHandler(): void {
@@ -44,6 +44,13 @@ export class CalciteFilter {
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
    */
   @Prop({ reflect: true }) disabled = false;
+
+  /**
+   * The resulting data after filtering.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) filteredData: CalciteFilter["data"] = [];
 
   /**
    * A text label that will appear on the clear button.
@@ -115,7 +122,7 @@ export class CalciteFilter {
     if (this.data.length === 0) {
       console.warn(`No data was passed to calcite-filter.
       The data property expects an array of objects`);
-      this.calciteFilterChange.emit([]);
+      this.updateFiltered([]);
       return;
     }
 
@@ -133,6 +140,7 @@ export class CalciteFilter {
           found = true;
         }
       });
+
       return found;
     };
 
@@ -140,7 +148,7 @@ export class CalciteFilter {
       return find(item, regex);
     });
 
-    this.calciteFilterChange.emit(result);
+    this.updateFiltered(result);
   }, filterDebounceInMs);
 
   inputHandler = (event: CustomEvent): void => {
@@ -156,9 +164,14 @@ export class CalciteFilter {
 
   clear = (): void => {
     this.value = "";
-    this.calciteFilterChange.emit(this.data);
     this.setFocus();
   };
+
+  updateFiltered(filtered: any[]): void {
+    this.filteredData.length = 0;
+    this.filteredData = this.filteredData.concat(filtered);
+    this.calciteFilterChange.emit(filtered);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-filter/resources.ts
+++ b/src/components/calcite-filter/resources.ts
@@ -3,6 +3,7 @@ export const CSS = {
   searchIcon: "search-icon",
   clearButton: "clear-button"
 };
+
 export const TEXT = {
   filterLabel: "Filter",
   clear: "Clear filter"


### PR DESCRIPTION
**Related Issue:** #2208 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR makes some tweaks to the existing, internal, filter component for its premiere:

```ts
interface HTMLCalciteFilterElement {
  data: T[]; // deprecated
  items!: T[]; // ✨ new✨
  filteredItems: T[]; // T = the item type ✨ new✨
}
```

### Notes

* The event detail will be deprecated in favor of this new property.
* `items` will be doc'd as required, but enforced via types next release
* `data` is deprecated and will be removed in next release as it was not publicly doc'd

### Questions

* Would renaming data => `items` and `filteredData` => `filteredItems` or `filtered` be a better fit? If so, for this release, we can add them and deprecate `data` and remove in the next sprint since the filter was never publicly doc'd
* Do we need a story + SDK entry for this? Filter is useful for a consistent filtering experience, but not sure what the examples/stories need to cover. cc @caripizza @macandcheese @benelan 

### Miscellaneous

* This commit is being treated as a new component being added, so I also tidied up a few tests and resource files. Let me know if you want me to break these out.

