### PR TITLE
test(slider): check if latest Screener story actually checked in (TESTING)

### DIFF
--- a/src/components/calcite-slider/calcite-slider.e2e.ts
+++ b/src/components/calcite-slider/calcite-slider.e2e.ts
@@ -2,6 +2,8 @@ import { newE2EPage } from "@stencil/core/testing";
 import { defaults, labelable, renders } from "../../tests/commonTests";
 import { getElementXY } from "../../tests/utils";
 
+/* COMMIT TO TEST SCREENER STORY */
+
 describe("calcite-slider", () => {
   const sliderWidthFor1To1PixelValueTrack = "116px";
 


### PR DESCRIPTION
**Related Issue:** n/a (testing the Screener failure that pr #3087 is currently showing, doesn't seem accurate)

## Summary
When I pull down master and check out the stories locally, I see that the slider story appears like so @ 1024 x 768px in Chrome:

![image](https://user-images.githubusercontent.com/42423180/140809820-ff0f5298-6c39-48ea-8a4c-ef9189c8b7f4.png)

However this is being picked up as a width change/[failure on my slider scales refactor pr](https://screener.io/v2/states/1leJJn.Esri-calcite-components/refs%2Fpull%2F3087%2Fmerge/1024x768/Chrome/componentscontrolsslider-histogram-0), trying to figure out why/if it's a false positive. (The only visual change to that story should be the tick color, not width.)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
