### PR TITLE
Elijbet/3372 fix popover to allow full width content

### DIFF
--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -63,11 +63,11 @@
 }
 
 .content {
-  @apply flex
-  flex-col
+  @apply flex-col
   flex-no-wrap
   self-center
   h-full;
+  flex: 1 0 auto;
 }
 
 .calcite--rtl {


### PR DESCRIPTION
**Related Issue:** #3372

## Summary

Adds a flex modification to the content on popover to allow for notice to be set to width= "full".

Before:
https://codepen.io/afreitag/pen/oNewOXR?editors=1000

After:
![notice covering popover](https://user-images.githubusercontent.com/19231036/140818748-f5c90d97-4d8c-4e1f-b1a2-b1d88849a55c.jpg)

