### PR TITLE
test(select): drop redundant test

### DIFF
--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -222,8 +222,6 @@ describe("calcite-select", () => {
       expect(selected[0].innerText).toBe("a");
     });
 
-    it("is labelable", async () => labelable("calcite-select"));
-
     it("internally maps children to native elements", async () => {
       const page = await newE2EPage({
         html: html`


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Removes duplicate [labelable test](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-select/calcite-select.e2e.ts#L42).

✨:broom:✨