### PR TITLE
revert(action): reverting #3415 after verifying deployed story correctly displays

### DIFF
--- a/src/components/calcite-action/calcite-action.stories.ts
+++ b/src/components/calcite-action/calcite-action.stories.ts
@@ -132,10 +132,7 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
 
 const selector = "calcite-action";
 
-export const Default = (): string =>
-  html`<div style="width: 150px">${create("calcite-action", createAttributes())}</div>`;
-
-export const Steps = stepStory(
+export const Default = stepStory(
   (): string => html`<div style="width: 150px">${create("calcite-action", createAttributes())}</div>`,
 
   createSteps("calcite-action")


### PR DESCRIPTION


**Related Issue:** #3415

## Summary

This PR reverts #3415 after verifying @driskull's fix in #3421 in the production Storybook website.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
