### PR TITLE
chore(ci): move logging to help troubleshoot next script

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -65,11 +65,6 @@ const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
     await exec(`git tag --delete ${nextTagsSinceLastRelease.join(" ")}`);
 
     await runStandardVersion(next, standardVersionOptions);
-    // make sure that the changes are committed
-    if ((await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`))) {
-      console.log("an error occurred committing changes");
-      process.exitCode = 1;
-    }
   } catch (error) {
     console.log(changelogGenerationErrorMessage);
     await exec(`echo ${changelogGenerationErrorMessage}`);
@@ -77,7 +72,6 @@ const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
   } finally {
     // restore deleted prerelease tags
     await exec(`git fetch --tags`);
-    await exec(`git log --pretty=format:'%h : %s' --graph`);
   }
 })();
 


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Logging does not work in the `prepReleaseCommit` script so I moved it to the `deployNextFromCI` one.
- I am trying to get the workflow to fail if the commit or push does not happen.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
