### PR TITLE
chore(ci): add user information to next deploy script and refactor conditionals

### DIFF
--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -33,14 +33,18 @@ const exec = pify(childProcess.exec);
     } else {
       console.log("Deploying @next 🚧");
 
+      console.log(" - adding user details...");
+      await exec(`git config --global user.email "actions@github.com"`);
+      await exec(`git config --global user.name "Deploy Next"`);
+
       // the setup-node gh action handles the token
       // https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
 
       console.log(" - prepping package...");
       await exec(`npm run util:prep-next-from-existing-build`);
 
-      // make sure that the changes are committed
-      if ((await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`))) {
+      const changesCommitted = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
+      if (changesCommitted) {
         console.log("an error occurred committing changes");
         process.exitCode = 1;
       }
@@ -52,8 +56,8 @@ const exec = pify(childProcess.exec);
       console.log(" - pushing tags...");
       await exec(`git push --follow-tags origin master`);
 
-      // make sure that the changes are pushed
-      if ((await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`))) {
+      const changesPushed = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
+      if (changesPushed) {
         console.log("an error occurred pushing changes");
         process.exitCode = 1;
       }

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -43,8 +43,8 @@ const exec = pify(childProcess.exec);
       console.log(" - prepping package...");
       await exec(`npm run util:prep-next-from-existing-build`);
 
-      const changesCommitted = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
-      if (changesCommitted) {
+      const changesCommitted = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
+      if (!changesCommitted) {
         console.log("an error occurred committing changes");
         process.exitCode = 1;
       }
@@ -56,8 +56,8 @@ const exec = pify(childProcess.exec);
       console.log(" - pushing tags...");
       await exec(`git push --follow-tags origin master`);
 
-      const changesPushed = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
-      if (changesPushed) {
+      const changesPushed = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
+      if (!changesPushed) {
         console.log("an error occurred pushing changes");
         process.exitCode = 1;
       }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Added user information to the next deploy script based on this error message from the previous run:
https://github.com/Esri/calcite-components/runs/4158364090?check_suite_focus=true#step:5:55
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
