### PR TITLE
chore(ci): log tags and add noVerify to commit on next release script

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -79,10 +79,14 @@ async function getStandardVersionOptions(next: boolean, semverTags: string[]): P
   const target = next ? "next" : "beta";
   const targetVersionPattern = new RegExp(`-${target}\\.\\d+$`);
 
+  await exec(`echo ${semverTags}`);
+
   // we keep track of `beta` and `next` releases since `standard-version` resets the version number when going in between
   // this should not be needed after v1.0.0 since there would no longer be a beta version to keep track of
   const targetDescendingOrderTags = semverTags.filter((tag) => targetVersionPattern.test(tag)).sort(semver.rcompare);
   const targetReleaseVersion = semver.inc(targetDescendingOrderTags[0], "prerelease", target);
+
+  await exec(`echo ${targetDescendingOrderTags}`);
 
   if (!targetVersionPattern.test(targetReleaseVersion)) {
     throw new Error(`target release version does not have prerelease identifier (${target})`);
@@ -90,6 +94,7 @@ async function getStandardVersionOptions(next: boolean, semverTags: string[]): P
 
   const standardVersionOptions: Options = {
     commitAll: true,
+    noVerify: true,
     header,
     releaseAs: targetReleaseVersion,
     releaseCommitMessageFormat: "{{currentTag}}"


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Last run tried to publish on the current next release and we noticed that it was linting on the commit:
https://github.com/Esri/calcite-components/runs/4159041103?check_suite_focus=true#step:5:60

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
