### PR TITLE
feat(tip-manager): allow customizing animation/transition duration

### DIFF
--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -53,7 +53,6 @@
   &:focus {
     @apply focus-outset;
   }
-  --calcite-animation-timing: 150ms;
 }
 
 .tip-container {

--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -53,6 +53,7 @@
   &:focus {
     @apply focus-outset;
   }
+  --calcite-animation-timing: 150ms;
 }
 
 .tip-container {
@@ -64,7 +65,7 @@
     focus-base
     mt-px;
   animation-name: none;
-  animation-duration: 150ms;
+  animation-duration: var(--calcite-animation-timing);
   height: var(--calcite-tip-manager-height);
   &:focus {
     @apply focus-outset;

--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -64,7 +64,7 @@
     focus-base
     mt-px;
   animation-name: none;
-  animation-duration: var(--calcite-animation-timing);
+  animation-duration: var(--calcite-internal-animation-timing);
   height: var(--calcite-tip-manager-height);
   &:focus {
     @apply focus-outset;


### PR DESCRIPTION
**Related Issue:** #3081 

## Summary

This will allow to use global css variable `--calcite-animation-timing` for customizing duration for animations/transitions.


