### PR TITLE
refactor(filter): enforce items prop via type

### DIFF
--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -138,12 +138,12 @@ describe("calcite-filter", () => {
       });
     });
 
-    it("updates filtered items after filtering", async () => {
-      function assertMatchingItems(filtered: any[], values: string[]): void {
-        expect(filtered).toHaveLength(values.length);
-        values.forEach((value) => expect(filtered.find((element) => element.value === value)).toBeDefined());
-      }
+    function assertMatchingItems(filtered: any[], values: string[]): void {
+      expect(filtered).toHaveLength(values.length);
+      values.forEach((value) => expect(filtered.find((element) => element.value === value)).toBeDefined());
+    }
 
+    it("updates filtered items after filtering", async () => {
       const filterChangeSpy = await page.spyOnEvent("calciteFilterChange");
       let waitForEvent = page.waitForEvent("calciteFilterChange");
       const filter = await page.find("calcite-filter");
@@ -179,10 +179,9 @@ describe("calcite-filter", () => {
 
       await filter.callMethod("setFocus");
       await filter.type("volt");
-      const event = await waitForEvent;
+      await waitForEvent;
 
-      expect(event.detail.length).toBe(1);
-      expect(event.detail.find((element) => element.value === "franco")).toBeDefined();
+      assertMatchingItems(await filter.getProperty("filteredItems"), ["franco"]);
     });
 
     it("should escape regex", async () => {
@@ -191,10 +190,9 @@ describe("calcite-filter", () => {
 
       await filter.callMethod("setFocus");
       await filter.type("regex()");
-      const event = await waitForEvent;
+      await waitForEvent;
 
-      expect(event.detail.length).toBe(1);
-      expect(event.detail.find((element) => element.value === "regex")).toBeDefined();
+      assertMatchingItems(await filter.getProperty("filteredItems"), ["regex"]);
     });
   });
 

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -48,7 +48,7 @@ export class CalciteFilter {
    *
    * This property is required.
    */
-  @Prop({ mutable: true }) items: object[];
+  @Prop({ mutable: true }) items!: object[];
 
   @Watch("items")
   watchItemsHandler(): void {

--- a/src/components/calcite-pick-list/shared-list-render.tsx
+++ b/src/components/calcite-pick-list/shared-list-render.tsx
@@ -37,9 +37,9 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
           {filterEnabled ? (
             <calcite-filter
               aria-label={filterPlaceholder}
-              data={dataForFilter}
               dir={getElementDir(el)}
               disabled={loading || disabled}
+              items={dataForFilter}
               onCalciteFilterChange={handleFilter}
               placeholder={filterPlaceholder}
               ref={setFilterEl}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This is a follow-up from https://github.com/Esri/calcite-components/issues/2208#issuecomment-963767923. Note that this depends on https://github.com/Esri/calcite-components/pull/3475 landing first.