### PR TITLE
chore(ci): fix github action push issue on protected branch

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -54,7 +54,7 @@ const exec = pify(childProcess.exec);
       // github token provided by the checkout action
       // https://github.com/actions/checkout#usage
       console.log(" - pushing tags...");
-      await exec(`git push --follow-tags origin master`);
+      await exec(`git push --atomic --follow-tags origin master`);
 
       const changesPushed = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
       if (!changesPushed) {

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -79,10 +79,14 @@ async function getStandardVersionOptions(next: boolean, semverTags: string[]): P
   const target = next ? "next" : "beta";
   const targetVersionPattern = new RegExp(`-${target}\\.\\d+$`);
 
+  await exec(`echo ${semverTags}`);
+
   // we keep track of `beta` and `next` releases since `standard-version` resets the version number when going in between
   // this should not be needed after v1.0.0 since there would no longer be a beta version to keep track of
   const targetDescendingOrderTags = semverTags.filter((tag) => targetVersionPattern.test(tag)).sort(semver.rcompare);
   const targetReleaseVersion = semver.inc(targetDescendingOrderTags[0], "prerelease", target);
+
+  await exec(`echo ${targetDescendingOrderTags}`);
 
   if (!targetVersionPattern.test(targetReleaseVersion)) {
     throw new Error(`target release version does not have prerelease identifier (${target})`);
@@ -90,6 +94,7 @@ async function getStandardVersionOptions(next: boolean, semverTags: string[]): P
 
   const standardVersionOptions: Options = {
     commitAll: true,
+    noVerify: true,
     header,
     releaseAs: targetReleaseVersion,
     releaseCommitMessageFormat: "{{currentTag}}"


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Added a new `ADMIN_TOKEN` secret with a PAT I generated. An admin token is needed in order to push to a protected branch
- Made the push `atomic` so it either all works or all fails
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
