### PR TITLE
feat(alert): allow disabling animation and customizing animation/transition duration

### DIFF
--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -76,7 +76,6 @@
 
 :host {
   @apply block;
-  --calcite-animation-timing: 300ms;
   .container {
     @apply shadow-2
       flex
@@ -102,8 +101,9 @@
     max-height: 0;
     z-index: 101;
     transform: translate3d(0, $baseline, 0);
-    transition: var(--calcite-animation-timing) $easing-function,
-      opacity var(--calcite-animation-timing) $easing-function, all var(--calcite-animation-timing) ease-in-out;
+    transition: var(--calcite-internal-animation-timing-slow) $easing-function,
+      opacity var(--calcite-internal-animation-timing-slow) $easing-function,
+      all var(--calcite-internal-animation-timing) ease-in-out;
   }
 }
 

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -101,7 +101,8 @@
     max-height: 0;
     z-index: 101;
     transform: translate3d(0, $baseline, 0);
-    transition: 300ms $easing-function, opacity 300ms $easing-function, all 0.15s ease-in-out;
+    transition: var(--calcite-animation-timing) $easing-function,
+      opacity var(--calcite-animation-timing) $easing-function, all 0.15s ease-in-out;
   }
 }
 
@@ -148,9 +149,9 @@
 }
 
 @mixin alert-element-base() {
+  @apply transition-default;
   padding: var(--calcite-alert-spacing-token-small) var(--calcite-alert-spacing-token-large);
   flex: 0 0 auto;
-  transition: all 0.15s ease-in-out;
 }
 
 .alert-content {
@@ -214,11 +215,11 @@
     text-color-2
     bg-foreground-1
     opacity-0
-    cursor-default;
+    cursor-default
+    transition-default;
   border-left: 0px solid transparent;
   border-right: 0px solid transparent;
   border-top-right-radius: 0;
-  transition: all 0.15s ease-in-out;
 
   &.active {
     @apply visible opacity-100;

--- a/src/components/calcite-alert/calcite-alert.scss
+++ b/src/components/calcite-alert/calcite-alert.scss
@@ -76,6 +76,7 @@
 
 :host {
   @apply block;
+  --calcite-animation-timing: 300ms;
   .container {
     @apply shadow-2
       flex
@@ -102,7 +103,7 @@
     z-index: 101;
     transform: translate3d(0, $baseline, 0);
     transition: var(--calcite-animation-timing) $easing-function,
-      opacity var(--calcite-animation-timing) $easing-function, all 0.15s ease-in-out;
+      opacity var(--calcite-animation-timing) $easing-function, all var(--calcite-animation-timing) ease-in-out;
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #3081 

## Summary

This will allow to disable animations for `calcite-alert` when `--calcite-animation-timing-factor` is set to 0 and customize the duration of animation timing 
