### PR TITLE
fix: remove quotes from generic font families

### DIFF
--- a/src/assets/styles/_type.scss
+++ b/src/assets/styles/_type.scss
@@ -1,6 +1,6 @@
 %type-vars {
-  --calcite-code-family: "Consolas", "Andale Mono", "Lucida Console", "Monaco", "monospace";
-  --calcite-sans-family: "Avenir Next", "Avenir", "Helvetica Neue", "sans-serif";
+  --calcite-code-family: "Consolas", "Andale Mono", "Lucida Console", "Monaco", monospace;
+  --calcite-sans-family: "Avenir Next", "Avenir", "Helvetica Neue", sans-serif;
 
   /* Component type variables */
   --calcite-font-size--3: 0.625rem; //  10px


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

**Related Issue:** #3438 

## Summary

Removes quotation marks from generic font families, per MDN documentation.