### PR TITLE
feat(list-item): add padding when there is only a label or only a description

### DIFF
--- a/src/components/calcite-list-item/calcite-list-item.scss
+++ b/src/components/calcite-list-item/calcite-list-item.scss
@@ -61,6 +61,9 @@
 .label,
 .description {
   @apply font-normal font-sans text--2 word-break;
+  &:only-child {
+    @apply py-1 m-0;
+  }
 }
 
 .label {

--- a/src/components/calcite-list/calcite-list.stories.ts
+++ b/src/components/calcite-list/calcite-list.stories.ts
@@ -32,6 +32,18 @@ export const Simple = (): string => html`
   </calcite-list>
 `;
 
+export const OnlyLabel = (): string => html`
+  <calcite-list>
+    <calcite-list-item label="This has no description."> </calcite-list-item>
+  </calcite-list>
+`;
+
+export const OnlyDescription = (): string => html`
+  <calcite-list>
+    <calcite-list-item description="This has no label."> </calcite-list-item>
+  </calcite-list>
+`;
+
 export const NestedListItems = (): string => html`
   <calcite-list>
     <calcite-list-item


### PR DESCRIPTION
**Related Issue:** #3362

## Summary
Keeps list-item from being too small when there's only a label or description.

Accomplished by adding padding around `label` or `description` when they are `:only-child`.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
