### PR TITLE
feat(tree-item): allow disabling animation & customizing animation/transition duration

### DIFF
--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -82,8 +82,9 @@
   margin-inline-end: theme("margin.5");
   transform: scaleY(0);
   opacity: 0;
-  transition: var(--calcite-animation-timing) $easing-function, opacity var(--calcite-animation-timing) $easing-function,
-    all var(--calcite-animation-timing) ease-in-out; // note that we're transitioning transform, not height!
+  transition: var(--calcite-internal-animation-timing) $easing-function,
+    opacity var(--calcite-internal-animation-timing) $easing-function,
+    all var(--calcite-internal-animation-timing) ease-in-out; // note that we're transitioning transform, not height!
   transform-origin: top; // keep the top of the element in the same place. this is optional.
 
   // vertical lines

--- a/src/components/calcite-tree-item/calcite-tree-item.scss
+++ b/src/components/calcite-tree-item/calcite-tree-item.scss
@@ -82,7 +82,8 @@
   margin-inline-end: theme("margin.5");
   transform: scaleY(0);
   opacity: 0;
-  transition: 0.15s $easing-function, opacity 0.15s $easing-function, all 0.15s ease-in-out; // note that we're transitioning transform, not height!
+  transition: var(--calcite-animation-timing) $easing-function, opacity var(--calcite-animation-timing) $easing-function,
+    all var(--calcite-animation-timing) ease-in-out; // note that we're transitioning transform, not height!
   transform-origin: top; // keep the top of the element in the same place. this is optional.
 
   // vertical lines


### PR DESCRIPTION
**Related Issue:** #3081 

## Summary
This will allow to disable animations for `calcite-tree-item` when `--calcite-animation-timing-factor` is set to `0` and customize the duration of animation/transition timing