### PR TITLE
chore(ci): use a non-bot account as the merge user

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -10,6 +10,7 @@ jobs:
         uses: Goobles/gh-actions-merge-command@v1
         with:
           allow_ff: false
-          user_name: ${{ github.actor }}
+          user_name: ${{ secrets.PRIMARY_CONTACT }}
+          user_email: belan@esri.com
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Related Issue:** NA

## Summary
It looks like GH might have a bug (or possibly expected behavior) where if a pr event is triggered by a bot account the checks won't run correctly. I created an issue with them, but I'm testing to see if using my user account is a valid workaround
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
