### PR TITLE
chore(ci): use the same bot account for all actions

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -10,6 +10,7 @@ jobs:
         uses: Goobles/gh-actions-merge-command@v1
         with:
           allow_ff: false
-          user_name: ${{ github.actor }}
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -34,8 +34,9 @@ const exec = pify(childProcess.exec);
       console.log("Deploying @next 🚧");
 
       console.log(" - adding user details...");
-      await exec(`git config --global user.email "actions@github.com"`);
-      await exec(`git config --global user.name "Deploy Next"`);
+
+      await exec(`git config --global user.email "github-actions[bot]@users.noreply.github.com"`);
+      await exec(`git config --global user.name "github-actions[bot]"`);
 
       // the setup-node gh action handles the token
       // https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Use the same github actions bot account for all of our ci stuff. Right now two of them are using a different `actions@github.com` account.

https://github.com/actions/checkout/discussions/479#discussioncomment-625461
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
