### PR TITLE
feat(button,link): allow disabling animation and customizing animation/transition duration

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -44,7 +44,8 @@
     font-inherit
     font-normal;
   // include transition from focus
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out,
+  transition: color var(--calcite-animation-timing) ease-in-out,
+    background-color var(--calcite-animation-timing) ease-in-out, box-shadow var(--calcite-animation-timing) ease-in-out,
     outline-offset 100ms ease-in-out, outline-color 100ms ease-in-out;
   &:hover {
     @apply no-underline;
@@ -194,9 +195,10 @@
 
 .calcite-button--loader {
   @apply flex;
-  calcite-loader {
+  --calcite-animation-timing: 300ms calcite-loader {
     @apply m-0;
-    transition: width 300ms ease-in-out, opacity 300ms ease-in-out, transform 300ms ease-in-out;
+    transition: width var(--calcite-animation-timing) ease-in-out, opacity var(--calcite-animation-timing) ease-in-out,
+      transform var(--calcite-animation-timing) ease-in-out;
     &.loading-in {
       animation-name: loader-in;
       animation-duration: 310ms;

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -44,9 +44,10 @@
     font-inherit
     font-normal;
   // include transition from focus
-  transition: color var(--calcite-animation-timing) ease-in-out,
-    background-color var(--calcite-animation-timing) ease-in-out, box-shadow var(--calcite-animation-timing) ease-in-out,
-    outline-offset 100ms ease-in-out, outline-color 100ms ease-in-out;
+  transition: color var(--calcite-internal-animation-timing) ease-in-out,
+    background-color var(--calcite-internal-animation-timing) ease-in-out,
+    box-shadow var(--calcite-internal-animation-timing) ease-in-out, outline-offset 100ms ease-in-out,
+    outline-color 100ms ease-in-out;
   &:hover {
     @apply no-underline;
   }
@@ -195,10 +196,11 @@
 
 .calcite-button--loader {
   @apply flex;
-  --calcite-animation-timing: 300ms calcite-loader {
+  calcite-loader {
     @apply m-0;
-    transition: width var(--calcite-animation-timing) ease-in-out, opacity var(--calcite-animation-timing) ease-in-out,
-      transform var(--calcite-animation-timing) ease-in-out;
+    transition: width var(--calcite-internal-animation-timing-slow) ease-in-out,
+      opacity var(--calcite-internal-animation-timing-slow) ease-in-out,
+      transform var(--calcite-internal-animation-timing-slow) ease-in-out;
     &.loading-in {
       animation-name: loader-in;
       animation-duration: 310ms;

--- a/src/components/calcite-link/calcite-link.scss
+++ b/src/components/calcite-link/calcite-link.scss
@@ -74,7 +74,7 @@ calcite-icon {
     background-position: 0% 100%, 100% 100%;
     background-repeat: no-repeat, no-repeat;
     background-size: 0% 1px, 100% 1px;
-    transition: all 0.15s ease-in-out, background-size 0.3s ease-in-out;
+    transition: all var(--calcite-animation-timing) ease-in-out;
 
     &:hover,
     &:focus {

--- a/src/components/calcite-link/calcite-link.scss
+++ b/src/components/calcite-link/calcite-link.scss
@@ -66,7 +66,8 @@ calcite-icon {
       border-none
       bg-transparent
       relative
-      text-color-link;
+      text-color-link
+      transition-default;
     line-height: inherit;
     white-space: initial;
     background-image: linear-gradient(currentColor, currentColor),
@@ -74,7 +75,6 @@ calcite-icon {
     background-position: 0% 100%, 100% 100%;
     background-repeat: no-repeat, no-repeat;
     background-size: 0% 1px, 100% 1px;
-    transition: all var(--calcite-animation-timing) ease-in-out;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
**Related Issue:** #3081 

## Summary

This will allow to disable animations for `calcite-button` & `calcite-link` when `--calcite-animation-timing-factor` is set to 0 and customize the duration of  animation/transition timing
