### PR TITLE
chore(ci): allow users to run merge action in prs created by bot

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -2,7 +2,9 @@ name: Auto Merge
 on: issue_comment
 jobs:
   merge:
-    if: ${{ github.event.issue.user.login == github.actor }}
+    if: |
+      github.event.issue.user.login == 'github-actions[bot]' ||
+      github.event.issue.user.login == github.actor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
**Related Issue:** NA

## Summary
I had previously restricted the action to only allow a user to run the merge action on their own PRs. However this means no one could merge the PRs created by github actions, so I added a case for that
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
