### PR TITLE
fix(input): prevent default behavior of cursor jumping to the beginning of input, match rate of native input type=number (100ms)

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -8,8 +8,8 @@ import { getElementXY } from "../../tests/utils";
 import { KeyInput } from "puppeteer";
 
 describe("calcite-input", () => {
-  const delayFor2UpdatesInMs = 1000;
-  const delayFor10UpdatesInMs = 5000;
+  const delayFor2UpdatesInMs = 200;
+  const delayFor11UpdatesInMs = 1200;
 
   it("honors form reset", async () => {
     const defaultValue = "defaultValue";
@@ -303,14 +303,14 @@ describe("calcite-input", () => {
 
     await page.mouse.move(buttonUpLocationX, buttonUpLocationY);
     await page.mouse.down();
-    await page.waitForTimeout(delayFor10UpdatesInMs);
+    await page.waitForTimeout(delayFor11UpdatesInMs);
     await page.mouse.up();
     await page.waitForChanges();
-    expect(await input.getProperty("value")).toBe("0.11");
+    expect(await input.getProperty("value")).toBe("0.12");
 
     await page.mouse.move(buttonDownLocationX, buttonDownLocationY);
     await page.mouse.down();
-    await page.waitForTimeout(delayFor10UpdatesInMs);
+    await page.waitForTimeout(delayFor11UpdatesInMs);
     await page.mouse.up();
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("0");
@@ -744,7 +744,7 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(3);
   });
 
-  it("should emit an event every 500ms on keyboard down ArrowUp/ArrowDown and stop on keyboard up", async () => {
+  it("should emit an event every 100ms on keyboard down ArrowUp/ArrowDown and stop on keyboard up", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-input type="number" value="0"></calcite-input>
@@ -771,7 +771,7 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(6);
   });
 
-  it("should emit an event every 500ms on mousedown on up/down buttons and stop on mouseup/mouseleave", async () => {
+  it("should emit an event every 100ms on mousedown on up/down buttons and stop on mouseup/mouseleave", async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <calcite-input type="number" value="0"></calcite-input>

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -260,8 +260,6 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   private nudgeNumberValueIntervalId;
 
-  private nudgeNumberValueIntervalCount: number;
-
   //--------------------------------------------------------------------------
   //
   //  State
@@ -525,12 +523,12 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     const valueNudgeDelayInMs = 100;
 
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-    this.nudgeNumberValueIntervalCount = 0;
+    let nudgeNumberValueIntervalCount = 0;
     this.nudgeNumberValueIntervalId = setInterval(() => {
-      this.nudgeNumberValueIntervalCount !== 0
+      nudgeNumberValueIntervalCount !== 0
         ? this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent)
         : null;
-      this.nudgeNumberValueIntervalCount++;
+      nudgeNumberValueIntervalCount++;
     }, valueNudgeDelayInMs);
   };
 

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -260,6 +260,8 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   private nudgeNumberValueIntervalId;
 
+  private nudgeNumberValueTimeoutId;
+
   //--------------------------------------------------------------------------
   //
   //  State
@@ -365,6 +367,9 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   //--------------------------------------------------------------------------
 
   keyDownHandler = (event: KeyboardEvent): void => {
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+    }
     if (this.readOnly || this.disabled) {
       return;
     }
@@ -516,17 +521,20 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
     const inputMax = this.maxString ? parseFloat(this.maxString) : null;
     const inputMin = this.minString ? parseFloat(this.minString) : null;
-    const valueNudgeDelayInMs = 500;
+    const valueNudgeDelayInMs = 100;
 
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
 
-    this.nudgeNumberValueIntervalId = setInterval(() => {
-      this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-    }, valueNudgeDelayInMs);
+    this.nudgeNumberValueTimeoutId = setTimeout(() => {
+      this.nudgeNumberValueIntervalId = setInterval(() => {
+        this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
+      }, valueNudgeDelayInMs);
+    }, 100);
   };
 
   private numberButtonMouseUpAndMouseOutHandler = (): void => {
     clearInterval(this.nudgeNumberValueIntervalId);
+    clearTimeout(this.nudgeNumberValueTimeoutId);
   };
 
   private numberButtonMouseDownHandler = (event: MouseEvent): void => {
@@ -615,6 +623,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   private inputKeyUpHandler = (): void => {
     clearInterval(this.nudgeNumberValueIntervalId);
+    clearTimeout(this.nudgeNumberValueTimeoutId);
   };
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -260,7 +260,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   private nudgeNumberValueIntervalId;
 
-  private nudgeNumberValueTimeoutId;
+  private nudgeNumberValueIntervalCount: number;
 
   //--------------------------------------------------------------------------
   //
@@ -367,6 +367,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   //--------------------------------------------------------------------------
 
   keyDownHandler = (event: KeyboardEvent): void => {
+    /* prevent default behavior for input to move the cursor to the beginning of the input with every ArrowUp press */
     if (event.key === "ArrowUp") {
       event.preventDefault();
     }
@@ -524,17 +525,17 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     const valueNudgeDelayInMs = 100;
 
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-
-    this.nudgeNumberValueTimeoutId = setTimeout(() => {
-      this.nudgeNumberValueIntervalId = setInterval(() => {
-        this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-      }, valueNudgeDelayInMs);
-    }, 100);
+    this.nudgeNumberValueIntervalCount = 0;
+    this.nudgeNumberValueIntervalId = setInterval(() => {
+      this.nudgeNumberValueIntervalCount !== 0
+        ? this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent)
+        : null;
+      this.nudgeNumberValueIntervalCount++;
+    }, valueNudgeDelayInMs);
   };
 
   private numberButtonMouseUpAndMouseOutHandler = (): void => {
     clearInterval(this.nudgeNumberValueIntervalId);
-    clearTimeout(this.nudgeNumberValueTimeoutId);
   };
 
   private numberButtonMouseDownHandler = (event: MouseEvent): void => {
@@ -623,7 +624,6 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   private inputKeyUpHandler = (): void => {
     clearInterval(this.nudgeNumberValueIntervalId);
-    clearTimeout(this.nudgeNumberValueTimeoutId);
   };
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #782

## Summary

Cursor behavior: 
The default behavior for input is to move the cursor to the beginning of the input when pressing Arrow Up. This results in cursor jumping back and forth as the value changes. The code now prevents this default behavior. 

Rate to match native input:
The input behavior now imitates the native HTML input type=“number”. The rate of increment/decrement is matched to be 100ms.
Now that the interval is shorter, pressing down too hard would result in incrementing/decrementing twice, which is why a local var is used as a flag to ignore the first interval call. It should start only if the user really intends to hold. 

e2e
This is followed with an update in count of emitted events in previous e2e tests.
