### PR TITLE
feat(input): add calciteInputChange event

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -339,7 +339,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   /**
    * This event fires each time a new value is typed and committed.
    */
-  @Event() calciteInputChange: EventEmitter;
+  @Event() calciteInputChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -338,7 +338,6 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   /**
    * This event fires each time a new value is typed and committed.
-   * @internal
    */
   @Event() calciteInputChange: EventEmitter;
 

--- a/src/components/calcite-input/readme.md
+++ b/src/components/calcite-input/readme.md
@@ -28,7 +28,6 @@ You must use `focusin`/`focusout` instead of `focus`/`blur` because these events
 All events return an element and a value:
 
 ```js
-input.addEventListener("change", logChange);
 input.addEventListener("focusin", logFocus);
 input.addEventListener("focusout", logBlur);
 

--- a/src/components/calcite-input/usage/Native-events.md
+++ b/src/components/calcite-input/usage/Native-events.md
@@ -5,7 +5,6 @@ You must use `focusin`/`focusout` instead of `focus`/`blur` because these events
 All events return an element and a value:
 
 ```js
-input.addEventListener("change", logChange);
 input.addEventListener("focusin", logFocus);
 input.addEventListener("focusout", logBlur);
 


### PR DESCRIPTION
**Related Issue:** #3474

## Summary

This PR exposes the `calciteInputChange` event since the internal native `change` event can no longer be used after the changes introduced by #2570.  [There is already a test for this event in the code](https://github.com/Esri/calcite-components/blob/14ff2993e4e00dc885b0a5b3747c05d82b4f0bab/src/components/calcite-input/calcite-input.e2e.ts#L537-L574), so no need to add any additional ones for the purpose of this PR.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
