### PR TITLE
docs(input-time-picker): specify step property is seconds

### DIFF
--- a/src/components/calcite-input-time-picker/calcite-input-time-picker.tsx
+++ b/src/components/calcite-input-time-picker/calcite-input-time-picker.tsx
@@ -103,7 +103,7 @@ export class CalciteInputTimePicker implements LabelableComponent, FormComponent
   /** The scale (size) of the time input */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** number that specifies the granularity that the value must adhere to */
+  /** number (seconds) that specifies the granularity that the value must adhere to */
   @Prop() step = 60;
 
   /** The selected time (always 24-hour format)*/


### PR DESCRIPTION
**Related Issue:** #2333

## Summary
Specify that the `input-time-picker` step property is in seconds
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
