### PR TITLE
fix(color-picker): ensure props/attrs are initialized consistently

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.tsx
+++ b/src/components/calcite-color-picker/calcite-color-picker.tsx
@@ -689,14 +689,6 @@ export class CalciteColorPicker {
   //--------------------------------------------------------------------------
 
   componentWillLoad(): void {
-    const storageKey = `${DEFAULT_STORAGE_KEY_PREFIX}${this.storageId}`;
-
-    if (this.storageId && localStorage.getItem(storageKey)) {
-      this.savedColors = JSON.parse(localStorage.getItem(storageKey));
-    }
-  }
-
-  connectedCallback(): void {
     const { allowEmpty, color, format, value } = this;
 
     const willSetNoColor = allowEmpty && !value;
@@ -713,6 +705,12 @@ export class CalciteColorPicker {
     this.internalColorSet(initialColor, false, "initial");
 
     this.updateDimensions(this.scale);
+
+    const storageKey = `${DEFAULT_STORAGE_KEY_PREFIX}${this.storageId}`;
+
+    if (this.storageId && localStorage.getItem(storageKey)) {
+      this.savedColors = JSON.parse(localStorage.getItem(storageKey));
+    }
   }
 
   disconnectedCallback(): void {


### PR DESCRIPTION
**Related Issue:** #3552 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This moves the color-picker's initialization logic to `componentWillLoad` to ensure initial properties/attributes are processed properly. 

### Notes

* There is no automated test for this as it seems to be only reproducible with the `custom-elements` output target, which our E2E test setup does not use.
* We should audit all components to see if they suffer from the same issue

### Manual testing steps

* Cloned [`calcite-components-examples`](https://github.com/Esri/calcite-components-examples/)
* Updated `rollup` example to follow  codesandbox from the issue description: https://codesandbox.io/s/calcite-components-color-picker-initial-value-setting-in-custom-elements-bundle-t3seb?file=/src/main.js
* Created a local calcite-components build with the fix and npm linked both
* Verified that the color-picker does initialize as expected