### PR TITLE
fix(input): fix inconsistent value stepping

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -318,24 +318,22 @@ describe("calcite-input", () => {
 
   it("correctly increments and decrements value by one when any is set for step", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input type="number" step="any" value="5.5"></calcite-input>
-    `);
+    await page.setContent(html`<calcite-input type="number" step="any" value="5.5"></calcite-input>`);
 
     const element = await page.find("calcite-input");
 
     const numberHorizontalItemDown = await page.find("calcite-input >>> .number-button-item[data-adjustment='down']");
     const numberHorizontalItemUp = await page.find("calcite-input >>> .number-button-item[data-adjustment='up']");
-    expect(await element.getProperty("value")).toBe("5.5");
+
     await numberHorizontalItemDown.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("5");
+    expect(await element.getProperty("value")).toBe("4.5");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("6");
+    expect(await element.getProperty("value")).toBe("5.5");
     await numberHorizontalItemUp.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("7");
+    expect(await element.getProperty("value")).toBe("6.5");
   });
 
   it("correctly increments and decrements value by one when step is undefined", async () => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -383,22 +383,26 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
   incrementOrDecrementNumberValue(
     direction: NumberNudgeDirection,
-    inputMax: number,
-    inputMin: number,
+    inputMax: number | null,
+    inputMin: number | null,
     nativeEvent: KeyboardEvent | MouseEvent
   ): void {
-    const value = this.value;
+    const { value } = this;
     const inputStep = this.step === "any" ? 1 : Math.abs(this.step || 1);
     const inputVal = value && value !== "" ? parseFloat(value) : 0;
-    let newValue = value;
 
-    if (direction === "up" && ((!inputMax && inputMax !== 0) || inputVal < inputMax)) {
-      newValue = (inputVal + inputStep).toFixed(decimalPlaces(inputStep)).toString();
-    }
-    if (direction === "down" && ((!inputMin && inputMin !== 0) || inputVal > inputMin)) {
-      newValue = (inputVal - inputStep).toFixed(decimalPlaces(inputStep)).toString();
-    }
-    this.setValue(newValue, nativeEvent, true);
+    const adjustment = direction === "up" ? 1 : -1;
+    const nudgedValue = inputVal + inputStep * adjustment;
+    const finalValue =
+      (typeof inputMin === "number" && !isNaN(inputMin) && nudgedValue < inputMin) ||
+      (typeof inputMax === "number" && !isNaN(inputMax) && nudgedValue > inputMax)
+        ? inputVal
+        : nudgedValue;
+
+    const inputValPlaces = decimalPlaces(inputVal);
+    const inputStepPlaces = decimalPlaces(inputStep);
+
+    this.setValue(finalValue.toFixed(Math.max(inputValPlaces, inputStepPlaces)), nativeEvent, true);
   }
 
   private clearInputValue = (nativeEvent: KeyboardEvent | MouseEvent): void => {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR fixes a regression introduced by https://github.com/Esri/calcite-components/issues/3443 ([repro case](https://codepen.io/jcfranco/pen/MWvMQWM)). 

cc @benelan 