### PR TITLE
refactor(input): simplify code for value nudging

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -522,12 +522,15 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     const valueNudgeDelayInMs = 100;
 
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-    let nudgeNumberValueIntervalCount = 0;
+
+    let firstValueNudge = true;
     this.nudgeNumberValueIntervalId = setInterval(() => {
-      nudgeNumberValueIntervalCount !== 0
-        ? this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent)
-        : null;
-      nudgeNumberValueIntervalCount++;
+      if (firstValueNudge) {
+        firstValueNudge = false;
+        return;
+      }
+
+      this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
     }, valueNudgeDelayInMs);
   };
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This refactors the value nudge interval to use a flag instead of keeping track of a counter.