### PR TITLE
fix(dropdown): stop calciteDropdownClose event from firing twice when closing the dropdown

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.tsx
+++ b/src/components/calcite-dropdown/calcite-dropdown.tsx
@@ -312,7 +312,7 @@ export class CalciteDropdown {
 
   private referenceEl: HTMLDivElement;
 
-  private activeTransitionProp = "opacity";
+  private activeTransitionProp = "visibility";
 
   private scrollerEl: HTMLDivElement;
 


### PR DESCRIPTION
**Related Issue:** ##1688

## Summary

When calciteDropdownItemSelect closes the dropdown, transitionEnd fires for each property transitioned.
this.calciteDropdownClose.emit() fires on the 'opacity' property when this.active changes to false, but opacity then is transitioned twice (I think for icon and popper repositioning). Changed it to a property 'visibility' that fires only once when closing. 