### PR TITLE
fix(shell-panel): Correct resizing of panels in RTL direction. #2770

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -276,7 +276,7 @@ export class CalciteShellPanel {
     const dir = getElementStyleDir(el);
 
     const directionKeys = ["ArrowLeft", "ArrowRight"];
-    const directionFactor = dir === "rtl" ? -1 : 1;
+    const directionFactor = dir === "rtl" && directionKeys.includes(key) ? -1 : 1;
 
     const increaseKeys =
       key === "ArrowUp" ||

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -12,7 +12,7 @@ import {
 } from "@stencil/core";
 import { CSS, SLOTS, TEXT } from "./resources";
 import { Position, Scale } from "../interfaces";
-import { getSlotted } from "../../utils/dom";
+import { getSlotted, getElementStyleDir } from "../../utils/dom";
 import { clamp } from "../../utils/math";
 
 /**
@@ -248,6 +248,7 @@ export class CalciteShellPanel {
   getKeyAdjustedWidth = (event: KeyboardEvent): number | null => {
     const { key } = event;
     const {
+      el,
       step,
       stepMultiplier,
       contentWidthMin,
@@ -272,8 +273,17 @@ export class CalciteShellPanel {
       event.preventDefault();
     }
 
+    const dir = getElementStyleDir(el);
+
+    const directionKeys = ["ArrowLeft", "ArrowRight"];
+
+    if (dir === "rtl") {
+      directionKeys.reverse();
+    }
+
     const increaseKeys =
-      key === "ArrowUp" || (position === "end" ? key === "ArrowLeft" : key === "ArrowRight");
+      key === "ArrowUp" ||
+      (position === "end" ? key === directionKeys[0] : key === directionKeys[1]);
 
     if (increaseKeys) {
       const stepValue = event.shiftKey ? multipliedStep : step;
@@ -282,7 +292,8 @@ export class CalciteShellPanel {
     }
 
     const decreaseKeys =
-      key === "ArrowDown" || (position === "end" ? key === "ArrowRight" : key === "ArrowLeft");
+      key === "ArrowDown" ||
+      (position === "end" ? key === directionKeys[1] : key === directionKeys[0]);
 
     if (decreaseKeys) {
       const stepValue = event.shiftKey ? multipliedStep : step;
@@ -321,12 +332,17 @@ export class CalciteShellPanel {
   separatorPointerMove = (event: PointerEvent): void => {
     event.preventDefault();
 
-    const { initialContentWidth, position, initialClientX } = this;
+    const { el, initialContentWidth, position, initialClientX } = this;
     const offset = event.clientX - initialClientX;
+    const dir = getElementStyleDir(el);
 
-    this.setContentWidth(
-      position === "end" ? initialContentWidth - offset : initialContentWidth + offset
-    );
+    const directionValues = [initialContentWidth + offset, initialContentWidth - offset];
+
+    if (dir === "rtl") {
+      directionValues.reverse();
+    }
+
+    this.setContentWidth(position === "end" ? directionValues[1] : directionValues[0]);
   };
 
   separatorPointerUp = (event: PointerEvent): void => {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -276,10 +276,7 @@ export class CalciteShellPanel {
     const dir = getElementStyleDir(el);
 
     const directionKeys = ["ArrowLeft", "ArrowRight"];
-
-    if (dir === "rtl") {
-      directionKeys.reverse();
-    }
+    const directionFactor = dir === "rtl" ? -1 : 1;
 
     const increaseKeys =
       key === "ArrowUp" ||
@@ -288,7 +285,7 @@ export class CalciteShellPanel {
     if (increaseKeys) {
       const stepValue = event.shiftKey ? multipliedStep : step;
 
-      return initialContentWidth + stepValue;
+      return initialContentWidth + directionFactor * stepValue;
     }
 
     const decreaseKeys =
@@ -298,7 +295,7 @@ export class CalciteShellPanel {
     if (decreaseKeys) {
       const stepValue = event.shiftKey ? multipliedStep : step;
 
-      return initialContentWidth - stepValue;
+      return initialContentWidth - directionFactor * stepValue;
     }
 
     if (typeof contentWidthMin === "number" && key === "Home") {
@@ -336,13 +333,12 @@ export class CalciteShellPanel {
     const offset = event.clientX - initialClientX;
     const dir = getElementStyleDir(el);
 
-    const directionValues = [initialContentWidth + offset, initialContentWidth - offset];
+    const adjustmentDirection = dir === "rtl" ? -1 : 1;
+    const adjustedOffset =
+      position === "end" ? -adjustmentDirection * offset : adjustmentDirection * offset;
+    const width = initialContentWidth + adjustedOffset;
 
-    if (dir === "rtl") {
-      directionValues.reverse();
-    }
-
-    this.setContentWidth(position === "end" ? directionValues[1] : directionValues[0]);
+    this.setContentWidth(width);
   };
 
   separatorPointerUp = (event: PointerEvent): void => {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -26,6 +26,13 @@ export function getThemeName(el: HTMLElement): "light" | "dark" {
   return closestElementCrossShadowBoundary(el, `.${CSS_UTILITY.darkTheme}`) ? "dark" : "light";
 }
 
+export function getElementStyleDir(el: HTMLElement): Direction {
+  return (window.getComputedStyle(el).direction as Direction) || "ltr";
+}
+
+/**
+ * @deprecated use getElementStyleDir instead.
+ */
 export function getElementDir(el: HTMLElement): Direction {
   const prop = "dir";
   const selector = `[${prop}]`;


### PR DESCRIPTION
**Related Issue:** #2770

## Summary

fix(shell-panel): Correct resizing of panels in RTL direction. #2770

- Fixes logic to handle resizing via mouse and keyboard when in RTL
- Deprecates `getElementDir`
  - The problem with this utility method is that it only considers the dir attribute. Someone could set CSS `direction: rtl` and this wouldn't find it.
  - The other reason for deprecating this is to make sure that components that use it evaluate if they actually need to. Many components can just use CSS logical properties instead.
- Adds `getElementStyleDir` which looks for the CSS direction value.
  - This is only necessary when needing to know the direction to do something in JS.

cc @jcfranco 
