### PR TITLE
chore(ci): dont close prs and give more time to provide more info

### DIFF
--- a/.github/need-info.yml
+++ b/.github/need-info.yml
@@ -21,5 +21,5 @@ requiredItems:
       - "developers.arcgis.com/calcite-design-system/components/"
       - "ember-twiddle.com/"
       - "jsfiddle.net/"
-commentFooter: "This issue will be automatically closed in three days if the information is not provided. Thanks for your understanding."
+commentFooter: "This issue will be automatically closed in five days if the information is not provided. Thanks for your understanding."
 excludeComments: true

--- a/.github/workflows/need-info-close.yml
+++ b/.github/workflows/need-info-close.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/stale@v3
         with:
           days-before-stale: -1
-          days-before-close: 3
+          days-before-pr-close: -1
+          days-before-issue-close: 5
           remove-stale-when-updated: false
           stale-issue-label: "need more info"
-          stale-pr-label: "need more info"
           close-issue-message: "This issue has been automatically closed due to missing information. We will reopen the issue if the information is provided and `${{secrets.PRIMARY_CONTACT}}` is mentioned in the comment."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,10 +12,8 @@ jobs:
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
           stale-pr-message: "This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
           close-issue-message: "This issue has been automatically closed due to inactivity."
-          close-pr-message: "This PR has been automatically closed due to inactivity."
           exempt-issue-labels: "0 - new,1 - assigned"
           days-before-issue-stale: 30
           days-before-issue-close: 7
           days-before-pr-stale: 7
-          days-before-pr-close: 3
-          delete-branch: true
+          days-before-pr-close: -1


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- A bunch of PRs closed as stale that I had to reopen. PRs shouldn't close as stale and delete the branch.
- I also gave people an extra couple of days to provide needed info before an issue closes
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
