### PR TITLE
fix(modal): modal now doesn’t shrink when close button disabled

### DIFF
--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -348,4 +348,24 @@ describe("calcite-modal accessibility checks", () => {
     });
     expect(scrimStyles).toEqual("rgba(0, 0, 0, 0.75)");
   });
+
+  it("correctly reflects the scale of the modal on the close button icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html` <calcite-modal active></calcite-modal> `);
+    const modal = await page.find("calcite-modal");
+    modal.setProperty("scale", "s");
+    await page.waitForChanges();
+    let closeIcon = await page.find('calcite-modal >>> calcite-icon[scale="s"]');
+    expect(closeIcon).not.toBe(null);
+
+    modal.setProperty("scale", "m");
+    await page.waitForChanges();
+    closeIcon = await page.find('calcite-modal >>> calcite-icon[scale="m"]');
+    expect(closeIcon).not.toBe(null);
+
+    modal.setProperty("scale", "l");
+    await page.waitForChanges();
+    closeIcon = await page.find('calcite-modal >>> calcite-icon[scale="l"]');
+    expect(closeIcon).not.toBe(null);
+  });
 });

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -193,7 +193,12 @@ export class CalciteModal {
         ref={(el) => (this.closeButtonEl = el)}
         title={this.intlClose}
       >
-        <calcite-icon icon={ICONS.close} scale={this.scale === "s" ? "s" : "l"} />
+        <calcite-icon
+          icon={ICONS.close}
+          scale={
+            this.scale === "s" ? "s" : this.scale === "m" ? "m" : this.scale === "l" ? "l" : null
+          }
+        />
       </button>
     ) : null;
   }


### PR DESCRIPTION
**Related Issue:** #1707

## Summary

The error was occurring because icon is watching scale prop from modal, where “m” is set as a default. But the check for the scale on the icon was not accounting for medium scale, resulting in a large icon (and button) for a medium scale modal. Which made it shrink and expand when removing/adding the close button. The change in check now makes the modal scale reflect on icon for a corresponding scale.


https://user-images.githubusercontent.com/19231036/144491453-7321e9a1-e354-441f-8200-9d34a781c88d.mov


