### PR TITLE
chore(ci): prepush hook checks for a conventional commit on the branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,7 +3,6 @@
 
 protected_branch='master'
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-echo "$current_branch"
 
 if [ $protected_branch = $current_branch ] && [ exec < /dev/tty ]
 then
@@ -19,11 +18,11 @@ else
     commit_messages=$(git log --format=%B $current_branch --not $protected_branch | tr '\n' ',')
 
     while [ "$commit_messages" != "$iteration" ]; do
-        # extract the substring from start of string up to delimiter.
+        # extract the substring from start of string up to delimiter
         iteration=${commit_messages%%,,*}
-        # delete this first "element" AND next separator.
+        # delete this first substring and the delimiter
         commit_messages=${commit_messages#$iteration,,}
-        # match conventional commit regex
+        # match substring for conventional commit regex
         [[ "$iteration" =~ $conventional_commit_regex ]] && exit 0
     done
     printf "Error: please make a conventional commit\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\n"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,5 +15,18 @@ then
     fi
     exit 1
 else
-    exit 0
+    exit_code=1
+    conventional_commit_regex='^((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?(!)?(: (.*\s*)*))'
+    commit_messages=$(git log --format=%B $current_branch --not $protected_branch | tr '\n' ',')
+
+    while [ "$commit_messages" != "$iteration" ]; do
+        # extract the substring from start of string up to delimiter.
+        iteration=${commit_messages%%,,*}
+        # delete this first "element" AND next separator.
+        commit_messages=${commit_messages#$iteration,,}
+        # match conventional commit regex
+        [[ "$iteration" =~ $conventional_commit_regex ]] && exit_code=0
+    done
+    [[ $exit_code -eq 1 ]] && printf "Error: please make a conventional commit\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\n"
+    exit $exit_code
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,9 @@
 #!/bin/bash
-
 # from https://riptutorial.com/git/example/16164/pre-push
 
 protected_branch='master'
 current_branch=$(git rev-parse --abbrev-ref HEAD)
+echo "$current_branch"
 
 if [ $protected_branch = $current_branch ] && [ exec < /dev/tty ]
 then
@@ -15,7 +15,6 @@ then
     fi
     exit 1
 else
-    exit_code=1
     conventional_commit_regex='^((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?(!)?(: (.*\s*)*))'
     commit_messages=$(git log --format=%B $current_branch --not $protected_branch | tr '\n' ',')
 
@@ -25,8 +24,8 @@ else
         # delete this first "element" AND next separator.
         commit_messages=${commit_messages#$iteration,,}
         # match conventional commit regex
-        [[ "$iteration" =~ $conventional_commit_regex ]] && exit_code=0
+        [[ "$iteration" =~ $conventional_commit_regex ]] && exit 0
     done
-    [[ $exit_code -eq 1 ]] && printf "Error: please make a conventional commit\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\n"
-    exit $exit_code
+    printf "Error: please make a conventional commit\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\n"
+    exit 1
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,7 +3,7 @@
 # from https://riptutorial.com/git/example/16164/pre-push
 
 protected_branch='master'
-current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 if [ $protected_branch = $current_branch ] && [ exec < /dev/tty ]
 then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,7 +14,7 @@ then
     fi
     exit 1
 else
-    conventional_commit_regex='^((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?(!)?(: (.*\s*)*))'
+    conventional_commit_regex='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w-\.\,\s]+\))?(!)?(: ([\w ])+([\s\S]*))'
     commit_messages=$(git log --format=%B $current_branch --not $protected_branch | tr '\n' ',')
 
     while [ "$commit_messages" != "$iteration" ]; do

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,6 +14,6 @@ then
     fi
     exit 1
 else
-    npm run util:conventional-commit
+    npm run util:check-squash-mergeable-branch
     exit
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,6 +14,6 @@ then
     fi
     exit 1
 else
-    ts-node ../support/matchConventionalCommit.ts
+    npm run util:conventional-commit
     exit
 fi

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "util:copy-icons": "cpy ./node_modules/@esri/calcite-ui-icons/js/*.json ./src/components/calcite-icon/assets/calcite-icon/",
     "util:deploy-next-from-existing-build": "npm run util:prep-next-from-existing-build && npm run util:push-tags && npm run util:publish-next",
     "util:deploy-next-from-ci": "ts-node --project ./tsconfig-node-scripts.json support/deployNextFromCI.ts",
+    "util:check-squash-mergeable-branch": "ts-node --project ./tsconfig-node-scripts.json support/checkSquashMergeableBranch.ts",
     "util:prep-next-from-existing-build": "ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts --next",
     "util:publish-next": "npm publish --tag next",
     "util:push-tags": "git push --follow-tags",
-    "util:run-tests": "npm run util:copy-icons && stencil test --no-docs --spec --e2e",
-    "util:conventional-commit": "ts-node --project ./tsconfig-node-scripts.json support/matchConventionalCommit.ts"
+    "util:run-tests": "npm run util:copy-icons && stencil test --no-docs --spec --e2e"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "util:prep-next-from-existing-build": "ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts --next",
     "util:publish-next": "npm publish --tag next",
     "util:push-tags": "git push --follow-tags",
-    "util:run-tests": "npm run util:copy-icons && stencil test --no-docs --spec --e2e"
+    "util:run-tests": "npm run util:copy-icons && stencil test --no-docs --spec --e2e",
+    "util:conventional-commit": "ts-node --project ./tsconfig-node-scripts.json support/matchConventionalCommit.ts"
   },
   "repository": {
     "type": "git",

--- a/support/checkSquashMergeableBranch.ts
+++ b/support/checkSquashMergeableBranch.ts
@@ -1,7 +1,12 @@
 const childProcess = require("child_process");
 const pify = require("pify");
-
 const exec = pify(childProcess.exec);
+
+/*
+This script checks how many commits there are on a branch;
+if there is only one commit it makes sure the message is in the conventional format.
+This ensures a conventional commit message when PRs are squash-merged.
+*/
 
 (async function runner(): Promise<void> {
   const conventionalCommitRegex =
@@ -14,7 +19,7 @@ const exec = pify(childProcess.exec);
     .split(";")
     .filter((commit: string) => !!commit);
 
-  process.exitCode = commits.length === 1 ? (commits[0].match(conventionalCommitRegex) ? 0 : 1) : 0;
+  process.exitCode = commits.length === 1 ? (commits[0].test(conventionalCommitRegex) ? 0 : 1) : 0;
 
   if (process.exitCode === 1) {
     console.log(

--- a/support/matchConventionalCommit.ts
+++ b/support/matchConventionalCommit.ts
@@ -15,9 +15,10 @@ const exec = pify(childProcess.exec);
     .filter((commit: string) => !!commit);
 
   process.exitCode = commits.length === 1 ? (commits[0].match(conventionalCommitRegex) ? 0 : 1) : 0;
+
   if (process.exitCode === 1) {
     console.log(
-      `Error: please amend your commit message using the conventional commit format\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\ngit commit --amend -m "conventional commit message"\n`
+      `https://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\nError: please amend your commit message using the conventional commit format\n\ngit commit --amend -m "conventional commit message"\n`
     );
   }
 })();

--- a/support/matchConventionalCommit.ts
+++ b/support/matchConventionalCommit.ts
@@ -17,7 +17,7 @@ const exec = pify(childProcess.exec);
   process.exitCode = commits.length === 1 ? (commits[0].match(conventionalCommitRegex) ? 0 : 1) : 0;
   if (process.exitCode === 1) {
     console.log(
-      "Error: please make a conventional commit\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\n"
+      `Error: please amend your commit message using the conventional commit format\nhttps://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#commit-message-format\ngit commit --amend -m "conventional commit message"\n`
     );
   }
 })();


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- You are allowed to push if there is at least one conventional commit on a branch
- pushes to master are exempt, but they still prompt to make sure its on purpose (version releases are non conventional commits)
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
