### PR TITLE
fix(input): ensure input's value is an empty string when cleared or set to null/undefined

### DIFF
--- a/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
+++ b/src/components/calcite-color-picker/calcite-color-picker.e2e.ts
@@ -977,15 +977,15 @@ describe("calcite-color-picker", () => {
 
           await rgbModeButton.click();
 
-          expect(await rInput.getProperty("value")).toBeUndefined();
-          expect(await gInput.getProperty("value")).toBeUndefined();
-          expect(await bInput.getProperty("value")).toBeUndefined();
+          expect(await rInput.getProperty("value")).toBe("");
+          expect(await gInput.getProperty("value")).toBe("");
+          expect(await bInput.getProperty("value")).toBe("");
 
           await hsvModeButton.click();
 
-          expect(await hInput.getProperty("value")).toBeUndefined();
-          expect(await sInput.getProperty("value")).toBeUndefined();
-          expect(await vInput.getProperty("value")).toBeUndefined();
+          expect(await hInput.getProperty("value")).toBe("");
+          expect(await sInput.getProperty("value")).toBe("");
+          expect(await vInput.getProperty("value")).toBe("");
         });
 
         describe("clearing color via supporting inputs", () => {
@@ -1017,8 +1017,8 @@ describe("calcite-color-picker", () => {
             await clearAndEnterHexOrChannelValue(page, rInput, "");
 
             // clearing one clears the rest
-            expect(await gInput.getProperty("value")).toBeUndefined();
-            expect(await bInput.getProperty("value")).toBeUndefined();
+            expect(await gInput.getProperty("value")).toBe("");
+            expect(await bInput.getProperty("value")).toBe("");
 
             expect(await picker.getProperty("value")).toBeNull();
           });
@@ -1040,8 +1040,8 @@ describe("calcite-color-picker", () => {
             await clearAndEnterHexOrChannelValue(page, hInput, "");
 
             // clearing one clears the rest
-            expect(await sInput.getProperty("value")).toBeUndefined();
-            expect(await vInput.getProperty("value")).toBeUndefined();
+            expect(await sInput.getProperty("value")).toBe("");
+            expect(await vInput.getProperty("value")).toBe("");
 
             expect(await picker.getProperty("value")).toBeNull();
           });

--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -521,7 +521,7 @@ describe("calcite-input", () => {
 
     const calciteInputInput = await page.spyOnEvent("calciteInputInput");
     const element = await page.find("calcite-input");
-    expect(await element.getProperty("value")).toBeUndefined();
+    expect(await element.getProperty("value")).toBe("");
     await element.callMethod("setFocus");
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("a");
@@ -642,7 +642,7 @@ describe("calcite-input", () => {
     await element.callMethod("setFocus");
     await page.keyboard.press("Escape");
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBeNull();
+    expect(await element.getProperty("value")).toBe("");
   });
 
   it("when clearable is requested, value is cleared on clear button click", async () => {
@@ -656,7 +656,7 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("John Doe");
     await clearButton.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBeNull();
+    expect(await element.getProperty("value")).toBe("");
   });
 
   it("when clearable is requested and clear button is clicked, event is received", async () => {
@@ -671,7 +671,7 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("John Doe");
     await clearButton.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBeNull();
+    expect(await element.getProperty("value")).toBe("");
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
@@ -688,7 +688,7 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBeNull();
+    expect(await element.getProperty("value")).toBe("");
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
@@ -705,7 +705,7 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await clearButton.click();
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBeNull();
+    expect(await element.getProperty("value")).toBe("");
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
@@ -722,7 +722,7 @@ describe("calcite-input", () => {
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
-    expect(await element.getProperty("value")).toBeNull();
+    expect(await element.getProperty("value")).toBe("");
     expect(calciteInputInput).toHaveReceivedEventTimes(1);
   });
 
@@ -886,7 +886,7 @@ describe("calcite-input", () => {
         html: `<calcite-input></calcite-input>`
       });
       const input = await page.find("calcite-input");
-      expect(await input.getProperty("value")).toBeUndefined();
+      expect(await input.getProperty("value")).toBe("");
     });
 
     it(`initial value is of type string when initially set to ""`, async () => {
@@ -902,10 +902,10 @@ describe("calcite-input", () => {
       await input.setProperty("value", null);
       await page.waitForChanges();
 
-      expect(await input.getProperty("value")).toBeNull();
+      expect(await input.getProperty("value")).toBe("");
     });
 
-    it(`when value is programmatically set to null, value is null`, async () => {
+    it(`when value is programmatically set to null, value is ""`, async () => {
       const page = await newE2EPage({
         html: `<calcite-input></calcite-input>`
       });
@@ -916,7 +916,7 @@ describe("calcite-input", () => {
 
       const value = await input.getProperty("value");
 
-      expect(value).toBeNull();
+      expect(value).toBe("");
     });
 
     it(`when value is programmatically set to "", value's type is string`, async () => {
@@ -1199,28 +1199,6 @@ describe("calcite-input", () => {
         });
       });
 
-    it(`disallows setting value to undefined on initial load.`, async () => {
-      const page = await newE2EPage({
-        html: `<calcite-input type="number" value="undefined"></calcite-input>`
-      });
-      const calciteInput = await page.find("calcite-input");
-      const input = await page.find("calcite-input >>> input");
-
-      expect(await calciteInput.getProperty("value")).toBeFalsy();
-      expect(await input.getProperty("value")).toBeFalsy();
-    });
-
-    it(`disallows setting value to null on initial load.`, async () => {
-      const page = await newE2EPage({
-        html: `<calcite-input type="number" value="null"></calcite-input>`
-      });
-      const calciteInput = await page.find("calcite-input");
-      const input = await page.find("calcite-input >>> input");
-
-      expect(await calciteInput.getProperty("value")).toBeFalsy();
-      expect(await input.getProperty("value")).toBeFalsy();
-    });
-
     it(`disallows setting text value on initial load.`, async () => {
       const page = await newE2EPage({
         html: `<calcite-input type="number" value="i am a text value"></calcite-input>`
@@ -1228,8 +1206,8 @@ describe("calcite-input", () => {
       const calciteInput = await page.find("calcite-input");
       const input = await page.find("calcite-input >>> input");
 
-      expect(await calciteInput.getProperty("value")).toBeFalsy();
-      expect(await input.getProperty("value")).toBeFalsy();
+      expect(await calciteInput.getProperty("value")).toBe("");
+      expect(await input.getProperty("value")).toBe("");
     });
 
     it(`allows setting value to undefined after initial load.`, async () => {
@@ -1264,8 +1242,8 @@ describe("calcite-input", () => {
       calciteInput.setProperty("value", null);
       await page.waitForChanges();
 
-      expect(await calciteInput.getProperty("value")).toBeFalsy();
-      expect(await input.getProperty("value")).toBeFalsy();
+      expect(await calciteInput.getProperty("value")).toBe("");
+      expect(await input.getProperty("value")).toBe("");
     });
 
     it(`disallows setting text value after initial load.`, async () => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -195,10 +195,15 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     | "week" = "text";
 
   /** input value */
-  @Prop({ mutable: true }) value: string;
+  @Prop({ mutable: true }) value = "";
 
   @Watch("value")
   valueWatcher(newValue: string): void {
+    if (newValue == null) {
+      this.value = "";
+      return;
+    }
+
     if (
       this.type === "number" &&
       this.localizedValue !== localizeNumberString(newValue, this.locale)
@@ -239,7 +244,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   private childNumberEl?: HTMLInputElement;
 
   get isClearable(): boolean {
-    return !this.isTextarea && (this.clearable || this.type === "search") && this.value?.length > 0;
+    return !this.isTextarea && (this.clearable || this.type === "search") && this.value.length > 0;
   }
 
   get isTextarea(): boolean {
@@ -406,7 +411,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   }
 
   private clearInputValue = (nativeEvent: KeyboardEvent | MouseEvent): void => {
-    this.setValue(null, nativeEvent, true);
+    this.setValue("", nativeEvent, true);
   };
 
   private inputBlurHandler = () => {
@@ -607,7 +612,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     }
 
     if (nativeEvent) {
-      if (this.type === "number" && value?.endsWith(".")) {
+      if (this.type === "number" && value.endsWith(".")) {
         return;
       }
 


### PR DESCRIPTION
**Related Issue:** #3381

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adjusts the approach taken for https://github.com/Esri/calcite-components/issues/2060 where value would support being cleared with `null`/`undefined`. `value` will now be a string to make it easier for end-users and align with expectations when compared to `<input>`. 