### PR TITLE
ci(screener): skip screener when a pr is only markdown changes

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -10,13 +10,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: skip for markdown only prs
+        id: one
+        run: |
+          git fetch --deepen=100
+          current_branch=$(git rev-parse --abbrev-ref HEAD)
+          screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.yml')
+          if [ -z "$screenable_changes" ]; then
+            echo "skip screener"
+            echo "::set-output name=skip::skip"
+          else
+            echo "run screener"
+            echo "::set-output name=skip::screen"
+          fi
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-      - name: install dependencies
-        run: npm install
-      - name: run screener check
+      - if: steps.one.outputs.skip == 'screen'
+        name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
-        run: npm run test:storybook || true
+        run: |
+          npm install
+          npm run test:storybook || true
+      - if: steps.one.outputs.skip == 'skip'
+        name: skip screener
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: screener
+          description: Screener run skipped (markdown PRs)
+          state: success
+          sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -15,7 +15,18 @@ jobs:
         run: |
           git fetch --deepen=100
           current_branch=$(git rev-parse --abbrev-ref HEAD)
-          screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md')
+          echo "branch: $current_branch"
+          if [ "$current_branch" == "master" ]; then
+            # diff of last commit excluding md (assumes squash merge)
+            screenable_changes=$(git diff --name-only @~..@ -- . ':(exclude)*.md')
+            echo "push run"
+          else
+            # diff of branch excluding md
+            screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md')
+            echo "pr run"
+          fi
+          echo "changed files: $screenable_changes"
+          # skip if there are only md changes
           if [ -z "$screenable_changes" ]; then
             echo "skip screener"
             echo "::set-output name=skip::skip"

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           git fetch --deepen=100
           current_branch=$(git rev-parse --abbrev-ref HEAD)
-          screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.yml')
+          screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md')
           if [ -z "$screenable_changes" ]; then
             echo "skip screener"
             echo "::set-output name=skip::skip"


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Don't run screener when the PR is only markdown changes
- We pay per # runs so this might save us some money and definitely some time

## Tests
Test Repo
- Skips on markdown only pr: https://github.com/benelan/test/pull/59
- Skips on markdown only push: https://github.com/benelan/test/runs/4414667007?check_suite_focus=true 
- Runs on non-markdown only prs: https://github.com/benelan/test/pull/60
- Runs on non-markdown only pushes: https://github.com/benelan/test/runs/4414736288?check_suite_focus=true

This PR
- [Successfully skipped screener when I changed `md` to `yml`](https://github.com/Esri/calcite-components/runs/4414152312?check_suite_focus=true)
- [Successfully ran screener when I changed it back to `md`](https://github.com/Esri/calcite-components/runs/4414250825?check_suite_focus=true)


## Questions
- Any other file types that don't require screener runs?
- Should we do this on the e2e build action as well?

<!--
Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
