### PR TITLE
fix(radio-group): fix issue caused by radio group emitting change events from internal/programmatic changes

### DIFF
--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.e2e.ts
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.e2e.ts
@@ -18,19 +18,6 @@ describe("calcite-radio-group-item", () => {
     expect(checked).toBe(false);
   });
 
-  it("emits when checked", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-radio-group-item value='test-value'></calcite-radio-group-item>");
-    const element = await page.find("calcite-radio-group-item");
-    const spy = await element.spyOnEvent("calciteRadioGroupItemChange");
-
-    await element.setProperty("checked", true);
-    await page.waitForChanges();
-    await element.setProperty("checked", false);
-    await page.waitForChanges();
-    expect(spy).toHaveReceivedEventTimes(2);
-  });
-
   it("supports value, label and checked", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-radio-group-item value='test-value' checked>test-label</calcite-radio-group-item>");

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -1,4 +1,15 @@
-import { Component, h, Prop, Element, Host, Watch, State, VNode } from "@stencil/core";
+import {
+  Component,
+  h,
+  Prop,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Watch,
+  State,
+  VNode
+} from "@stencil/core";
 import { getElementDir, getElementProp } from "../../utils/dom";
 import { RadioAppearance } from "../calcite-radio-group/interfaces";
 import { Position, Layout, Scale } from "../interfaces";
@@ -31,6 +42,7 @@ export class CalciteRadioGroupItem {
 
   @Watch("checked")
   protected handleCheckedChange(): void {
+    this.calciteRadioGroupItemChange.emit();
     this.syncToExternalInput();
   }
 
@@ -114,6 +126,19 @@ export class CalciteRadioGroupItem {
       </Host>
     );
   }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  //--------------------------------------------------------------------------
+
+  /**
+   * Fires when the item has been selected.
+   * @internal
+   */
+  @Event()
+  calciteRadioGroupItemChange: EventEmitter;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
+++ b/src/components/calcite-radio-group-item/calcite-radio-group-item.tsx
@@ -1,15 +1,4 @@
-import {
-  Component,
-  Event,
-  h,
-  EventEmitter,
-  Prop,
-  Element,
-  Host,
-  Watch,
-  State,
-  VNode
-} from "@stencil/core";
+import { Component, h, Prop, Element, Host, Watch, State, VNode } from "@stencil/core";
 import { getElementDir, getElementProp } from "../../utils/dom";
 import { RadioAppearance } from "../calcite-radio-group/interfaces";
 import { Position, Layout, Scale } from "../interfaces";
@@ -42,7 +31,6 @@ export class CalciteRadioGroupItem {
 
   @Watch("checked")
   protected handleCheckedChange(): void {
-    this.calciteRadioGroupItemChange.emit();
     this.syncToExternalInput();
   }
 
@@ -126,19 +114,6 @@ export class CalciteRadioGroupItem {
       </Host>
     );
   }
-
-  //--------------------------------------------------------------------------
-  //
-  //  Events
-  //
-  //--------------------------------------------------------------------------
-
-  /**
-   * Fires when the item has been selected.
-   * @internal
-   */
-  @Event()
-  calciteRadioGroupItemChange: EventEmitter;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
+++ b/src/components/calcite-radio-group/calcite-radio-group.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { focusable, formAssociated, labelable } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
@@ -57,7 +57,14 @@ describe("calcite-radio-group", () => {
     expect(selectedValue).toBe("3");
   });
 
-  it("fires change event, passing selected item", async () => {
+  it("allows items to be selected", async () => {
+    async function getSelectedItemValue(page: E2EPage): Promise<string> {
+      return page.$eval(
+        "calcite-radio-group",
+        (radioGroup: HTMLCalciteRadioGroupElement) => radioGroup.selectedItem.value
+      );
+    }
+
     const page = await newE2EPage();
     await page.setContent(
       `<calcite-radio-group>
@@ -69,10 +76,73 @@ describe("calcite-radio-group", () => {
     const element = await page.find("calcite-radio-group");
     const eventSpy = await element.spyOnEvent("calciteRadioGroupChange");
     expect(eventSpy).not.toHaveReceivedEvent();
-    const item = await page.find("calcite-radio-group-item");
-    await item.click();
-    expect(eventSpy).toHaveReceivedEvent();
+    const [first, second, third] = await page.findAll("calcite-radio-group-item");
+
+    await first.click();
+    expect(eventSpy).toHaveReceivedEventTimes(1);
     expect(eventSpy).toHaveReceivedEventDetail("1");
+    expect(await getSelectedItemValue(page)).toBe("1");
+
+    // does not emit from programmatic changes
+    third.setProperty("checked", true);
+    await page.waitForChanges();
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+    expect(await getSelectedItemValue(page)).toBe("3");
+
+    await second.click();
+    expect(eventSpy).toHaveReceivedEventTimes(2);
+    expect(eventSpy).toHaveReceivedEventDetail("2");
+    expect(await getSelectedItemValue(page)).toBe("2");
+  });
+
+  it("does not emit extraneous events (edge case from #3210)", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-radio-group>
+          <calcite-radio-group-item value="1">one</calcite-radio-group-item>
+          <calcite-radio-group-item value="2">two</calcite-radio-group-item>
+        </calcite-radio-group>`
+    );
+
+    const timesCalled = await page.evaluate(async () => {
+      let calls = 0;
+
+      const radioGroup = document.querySelector("calcite-radio-group");
+
+      const waitForFrame = async () => await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      document.addEventListener("calciteRadioGroupChange", () => calls++);
+
+      let [first, second] = Array.from(document.querySelectorAll("calcite-radio-group-item"));
+
+      first.checked = true;
+      await waitForFrame();
+
+      second.click();
+      await waitForFrame();
+
+      radioGroup.remove();
+      await waitForFrame();
+
+      document.body.innerHTML = `
+      <calcite-radio-group>
+          <calcite-radio-group-item value="1">one</calcite-radio-group-item>
+          <calcite-radio-group-item value="2">two</calcite-radio-group-item>
+        </calcite-radio-group>
+      `;
+
+      [first, second] = Array.from(document.querySelectorAll("calcite-radio-group-item"));
+
+      second.checked = true;
+      await waitForFrame();
+
+      first.click();
+      await waitForFrame();
+
+      return calls;
+    });
+
+    expect(timesCalled).toBe(2);
   });
 
   describe("keyboard navigation", () => {

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -111,7 +111,7 @@ export class CalciteRadioGroup implements LabelableComponent, FormComponent {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
+  componentWillLoad(): void {
     const items = this.getItems();
     const lastChecked = Array.from(items)
       .filter((item) => item.checked)
@@ -122,7 +122,9 @@ export class CalciteRadioGroup implements LabelableComponent, FormComponent {
     } else if (items[0]) {
       items[0].tabIndex = 0;
     }
+  }
 
+  connectedCallback(): void {
     connectLabel(this);
     connectForm(this);
   }
@@ -155,7 +157,6 @@ export class CalciteRadioGroup implements LabelableComponent, FormComponent {
 
   @Listen("calciteRadioGroupItemChange")
   protected handleSelected(event: Event): void {
-    // only fire after initial setup to prevent semi-infinite loops
     event.stopPropagation();
     event.preventDefault();
     this.selectItem(event.target as HTMLCalciteRadioGroupItemElement);

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -111,12 +111,17 @@ export class CalciteRadioGroup implements LabelableComponent, FormComponent {
   //
   //--------------------------------------------------------------------------
 
-  componentWillLoad(): void {
-    this.selectInitialItem();
-  }
-
   connectedCallback(): void {
-    this.selectInitialItem();
+    const items = this.getItems();
+    const lastChecked = Array.from(items)
+      .filter((item) => item.checked)
+      .pop();
+
+    if (lastChecked) {
+      this.selectItem(lastChecked);
+    } else if (items[0]) {
+      items[0].tabIndex = 0;
+    }
 
     connectLabel(this);
     connectForm(this);
@@ -251,19 +256,6 @@ export class CalciteRadioGroup implements LabelableComponent, FormComponent {
 
   onLabelClick(): void {
     this.setFocus();
-  }
-
-  private selectInitialItem(): void {
-    const items = this.getItems();
-    const lastChecked = Array.from(items)
-      .filter((item) => item.checked)
-      .pop();
-
-    if (lastChecked) {
-      this.selectItem(lastChecked);
-    } else if (items[0]) {
-      items[0].tabIndex = 0;
-    }
   }
 
   private getItems(): NodeListOf<HTMLCalciteRadioGroupItemElement> {

--- a/src/components/calcite-radio-group/calcite-radio-group.tsx
+++ b/src/components/calcite-radio-group/calcite-radio-group.tsx
@@ -1,22 +1,22 @@
 import {
-  Build,
   Component,
-  Element,
   Event,
-  EventEmitter,
   h,
-  Host,
+  EventEmitter,
   Listen,
-  Method,
+  Element,
   Prop,
-  VNode,
-  Watch
+  Watch,
+  Host,
+  Build,
+  Method,
+  VNode
 } from "@stencil/core";
 
 import { getElementDir } from "../../utils/dom";
 import { getKey } from "../../utils/key";
 import { Layout, Scale, Width } from "../interfaces";
-import { connectLabel, disconnectLabel, LabelableComponent } from "../../utils/label";
+import { LabelableComponent, connectLabel, disconnectLabel } from "../../utils/label";
 import { connectForm, disconnectForm, FormComponent, HiddenFormInputSlot } from "../../utils/form";
 import { RadioAppearance } from "./interfaces";
 


### PR DESCRIPTION
**Related Issue:** #3120 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where multiple  `calcite-radio-group` change events would fire from internal changes.