### PR TITLE
chore: fix squash-mergeable pattern check for single-commit branches

### DIFF
--- a/support/checkSquashMergeableBranch.ts
+++ b/support/checkSquashMergeableBranch.ts
@@ -19,7 +19,7 @@ This ensures a conventional commit message when PRs are squash-merged.
     .split(";")
     .filter((commit: string) => !!commit);
 
-  process.exitCode = commits.length === 1 ? (commits[0].test(conventionalCommitRegex) ? 0 : 1) : 0;
+  process.exitCode = commits.length === 1 ? (conventionalCommitRegex.test(commits[0]) ? 0 : 1) : 0;
 
   if (process.exitCode === 1) {
     console.log(


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue when checking single-commit branch pushes:

```
@esri/calcite-components@1.0.0-next.314 util:check-squash-mergeable-branch
ts-node --project ./tsconfig-node-scripts.json support/checkSquashMergeableBranch.ts

/Users/juan6600/dev/projects/calcite-components/support/checkSquashMergeableBranch.ts:22
  process.exitCode = commits.length === 1 ? (commits[0].test(conventionalCommitRegex) ? 0 : 1) : 0;
                                                        ^
TypeError: commits[0].test is not a function
    at runner (/Users/juan6600/dev/projects/calcite-components/support/checkSquashMergeableBranch.ts:22:57)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
error: failed to push some refs to 'github.com:Esri/calcite-components.git'

```