### PR TITLE
fix(select): ensure selecting item programmatically is reflected in selectedOption

### DIFF
--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -62,11 +62,22 @@ describe("calcite-select", () => {
       await internalSelect.asElement().select("dos");
       await page.waitForChanges();
 
-      const selected = await page.findAll("calcite-option[selected]");
+      let selected = await page.findAll("calcite-option[selected]");
 
       await assertSelectedOption(page, selected[0]);
       expect(selected.length).toBe(1);
       expect(selected[0].innerText).toBe("dos");
+      expect(spy).toHaveReceivedEventTimes(1);
+
+      const [, , lastOption] = await page.findAll("calcite-option");
+      await lastOption.setProperty("selected", true);
+      await page.waitForChanges();
+
+      selected = await page.findAll("calcite-option[selected]");
+
+      await assertSelectedOption(page, selected[0]);
+      expect(selected.length).toBe(1);
+      expect(selected[0].innerText).toBe("tres");
       expect(spy).toHaveReceivedEventTimes(1);
     });
 
@@ -166,11 +177,23 @@ describe("calcite-select", () => {
       await internalSelect.asElement().select("c");
       await page.waitForChanges();
 
-      const selected = await page.findAll("calcite-option[selected]");
+      let selected = await page.findAll("calcite-option[selected]");
 
       await assertSelectedOption(page, selected[0]);
       expect(selected.length).toBe(1);
       expect(selected[0].innerText).toBe("c");
+      expect(spy).toHaveReceivedEventTimes(1);
+
+      const [, , lastNumberOption] = await page.findAll("calcite-option-group[label='numbers'] calcite-option");
+      console.log(lastNumberOption.innerHTML);
+      await lastNumberOption.setProperty("selected", true);
+      await page.waitForChanges();
+
+      selected = await page.findAll("calcite-option[selected]");
+
+      await assertSelectedOption(page, selected[0]);
+      expect(selected.length).toBe(1);
+      expect(selected[0].innerText).toBe("3");
       expect(spy).toHaveReceivedEventTimes(1);
     });
 

--- a/src/components/calcite-select/calcite-select.e2e.ts
+++ b/src/components/calcite-select/calcite-select.e2e.ts
@@ -69,7 +69,7 @@ describe("calcite-select", () => {
       expect(selected[0].innerText).toBe("dos");
       expect(spy).toHaveReceivedEventTimes(1);
 
-      const [, , lastOption] = await page.findAll("calcite-option");
+      const lastOption = await page.find("calcite-option:last-child");
       await lastOption.setProperty("selected", true);
       await page.waitForChanges();
 
@@ -184,8 +184,7 @@ describe("calcite-select", () => {
       expect(selected[0].innerText).toBe("c");
       expect(spy).toHaveReceivedEventTimes(1);
 
-      const [, , lastNumberOption] = await page.findAll("calcite-option-group[label='numbers'] calcite-option");
-      console.log(lastNumberOption.innerHTML);
+      const lastNumberOption = await page.find("calcite-option-group[label='numbers'] calcite-option:last-child");
       await lastNumberOption.setProperty("selected", true);
       await page.waitForChanges();
 

--- a/src/components/calcite-select/calcite-select.tsx
+++ b/src/components/calcite-select/calcite-select.tsx
@@ -200,6 +200,7 @@ export class CalciteSelect implements LabelableComponent, FormComponent {
 
     if (isOption(optionOrGroup) && optionOrGroup.selected) {
       this.deselectAllExcept(optionOrGroup);
+      this.selectedOption = optionOrGroup;
     }
   }
 
@@ -274,7 +275,7 @@ export class CalciteSelect implements LabelableComponent, FormComponent {
     });
 
     if (futureSelected) {
-      requestAnimationFrame(() => (this.selectedOption = futureSelected));
+      this.selectedOption = futureSelected;
     }
   }
 


### PR DESCRIPTION
**Related Issue:** #3239 #3241 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This improves `calcite-select` to update `selectedOption` as soon as there is an internal change to selection.

**Note:** this change causes `stencil The state/prop "value" changed during rendering. This can potentially lead to infinite-loops and other bugs.` warnings to display in the dev build when the component initializes, but it is expected as `value` and `selectedOption` (read-only) are technically not used for rendering.