### PR TITLE
fix(popover): close button no longer partially hidden

### DIFF
--- a/src/components/calcite-popover/calcite-popover.scss
+++ b/src/components/calcite-popover/calcite-popover.scss
@@ -67,6 +67,7 @@
   flex-col
   flex-no-wrap
   self-center
+  overflow-hidden
   h-full
   w-full;
 }


### PR DESCRIPTION
**Related Issue:** #2720 

## Summary
I was unable to reproduce this issue locally or on a codepen so I'm not sure if this resolves the issue. @driskull how did you repro and find this solution?
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
