### PR TITLE
fix(option): update label and value when character data changes

### DIFF
--- a/src/components/calcite-option/calcite-option.e2e.ts
+++ b/src/components/calcite-option/calcite-option.e2e.ts
@@ -56,5 +56,16 @@ describe("calcite-option", () => {
 
     expect(await option.getProperty("label")).toBe(alternateLabel);
     expect(await option.getProperty("value")).toBe(alternateLabel);
+
+    const charDataUpdateLabel = "tres";
+    await page.evaluate((updatedText: string): void => {
+      // Ember and possibly other frameworks use Text node APIs to update contents
+      const option = document.querySelector<HTMLCalciteOptionElement>("calcite-option");
+      const textNode = option.childNodes[0] as Text;
+      textNode.replaceData(0, textNode.length, updatedText);
+    }, charDataUpdateLabel);
+
+    expect(await option.getProperty("label")).toBe(charDataUpdateLabel);
+    expect(await option.getProperty("value")).toBe(charDataUpdateLabel);
   });
 });

--- a/src/components/calcite-option/calcite-option.tsx
+++ b/src/components/calcite-option/calcite-option.tsx
@@ -114,8 +114,10 @@ export class CalciteOption {
   connectedCallback(): void {
     this.ensureTextContentDependentProps();
     this.mutationObserver?.observe(this.el, {
+      attributeFilter: ["label", "value"],
+      characterData: true,
       childList: true,
-      attributeFilter: ["label", "value"]
+      subtree: true
     });
   }
 


### PR DESCRIPTION
**Related Issue:** #3242 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This updates `calcite-option'`s observer to cover changes to character data, which is used by Ember and possibly other frameworks. 