### PR TITLE
fix(panel): the panel is now dismissed on escape keydown and not keyu…

### DIFF
--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -172,7 +172,7 @@ export class CalcitePanel {
     this.backButtonEl = node;
   };
 
-  panelKeyUpHandler = (event: KeyboardEvent): void => {
+  panelKeyDownHandler = (event: KeyboardEvent): void => {
     if (event.key === "Escape") {
       this.dismiss();
     }
@@ -424,7 +424,7 @@ export class CalcitePanel {
   }
 
   render(): VNode {
-    const { dismissed, disabled, dismissible, el, loading, panelKeyUpHandler } = this;
+    const { dismissed, disabled, dismissible, el, loading, panelKeyDownHandler } = this;
 
     const rtl = getElementDir(el) === "rtl";
 
@@ -436,7 +436,7 @@ export class CalcitePanel {
           [CSS_UTILITY.rtl]: rtl
         }}
         hidden={dismissible && dismissed}
-        onKeyUp={panelKeyUpHandler}
+        onKeyDown={panelKeyDownHandler}
         ref={this.setContainerRef}
         tabIndex={dismissible ? 0 : -1}
       >


### PR DESCRIPTION
…p for consistency

**Related Issue:** #3500

## Summary

Since other components like dropdown and combobox are closed on escape keydown, this needs to follow the same behavior for consistency and to make it simpler to stop propagation of keyup event in case we have a nested component that closes on keydown.
