### PR TITLE
refactor(tabs): remove commented out story that is replaced

### DIFF
--- a/src/components/calcite-tabs/calcite-tabs.stories.ts
+++ b/src/components/calcite-tabs/calcite-tabs.stories.ts
@@ -45,32 +45,6 @@ export const Simple = stepStory(
   createSteps("calcite-tabs").snapshot("simple").click("#reference-element").snapshot("horizontal scroll")
 );
 
-// export const Simple = (): string => html`
-//   <calcite-tabs
-//     layout="${select("layout", ["inline", "center"], "inline")}"
-//     position="${select("position", ["above", "below"], "above")}"
-//     scale="${select("scale", ["s", "m", "l"], "m")}"
-//   >
-//     <calcite-tab-nav slot="tab-nav">
-//       <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-//       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-//       <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-//       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-//     </calcite-tab-nav>
-
-//     <calcite-tab active>
-//       <p>Tab 1 Content</p><br />
-//       <img src="${placeholderImage({
-//         width: 1000,
-//         height: 200
-//       })}"></img>
-//     </calcite-tab>
-//     <calcite-tab><p>Tab 2 Content</p></calcite-tab>
-//     <calcite-tab><p>Tab 3 Content</p></calcite-tab>
-//     <calcite-tab><p>Tab 4 Content</p></calcite-tab>
-//   </calcite-tabs>
-// `;
-
 export const Bordered = (): string => html`
   <calcite-tabs
     layout="inline"


### PR DESCRIPTION
**Related Issue:** #3395

## Summary
I forgot to remove the commented out section for the story. There is already another story that is meant to replace the commented out story
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
