### PR TITLE
fix(button): no longer render loader when width set to half or full

### DIFF
--- a/src/components/calcite-button/calcite-button.e2e.ts
+++ b/src/components/calcite-button/calcite-button.e2e.ts
@@ -292,6 +292,15 @@ describe("calcite-button", () => {
     expect(loader).not.toBeNull();
   });
 
+  it("should not render loader with an icon-start ,width set to half and aligned space-between", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-button icon-start='plus' width='half' , alignment='space-between'>Continue</calcite-button>`
+    );
+    const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
+    expect(loader).toBeNull();
+  });
+
   it("hascontent class is present on rendered child when content (as text) is present", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-button>Continue</calcite-button>`);

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -151,7 +151,7 @@ export class CalciteButton implements LabelableComponent {
     const dir = getElementDir(this.el);
     const Tag = this.childElType;
 
-    const loader = this.hasLoader ? (
+    const loaderNode = this.hasLoader ? (
       <div class={CSS.buttonLoader}>
         <calcite-loader
           active
@@ -201,7 +201,7 @@ export class CalciteButton implements LabelableComponent {
         target={this.childElType === "a" && this.target}
         type={this.childElType === "button" && this.type}
       >
-        {loader}
+        {loaderNode}
         {this.iconStart ? iconStartEl : null}
         {this.hasContent ? contentEl : null}
         {this.iconEnd ? iconEndEl : null}

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -151,19 +151,17 @@ export class CalciteButton implements LabelableComponent {
     const dir = getElementDir(this.el);
     const Tag = this.childElType;
 
-    const loader = (
+    const loader = this.hasLoader ? (
       <div class={CSS.buttonLoader}>
-        {this.hasLoader ? (
-          <calcite-loader
-            active
-            class={this.loading ? CSS.loadingIn : CSS.loadingOut}
-            inline
-            label={this.intlLoading}
-            scale="m"
-          />
-        ) : null}
+        <calcite-loader
+          active
+          class={this.loading ? CSS.loadingIn : CSS.loadingOut}
+          inline
+          label={this.intlLoading}
+          scale="m"
+        />
       </div>
-    );
+    ) : null;
 
     const iconStartEl = (
       <calcite-icon


### PR DESCRIPTION


**Related Issue:** #3533 

## Summary

This fixes the spaced occupied by `<div>` wrapper of `calcite-loader` in button when width is set to `half | full` and `alignment = space-between | icon-start-space-between | icon-end-space-between`