### PR TITLE
ci(screener): fix fetch depth when skipping screener on markdown only prs

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -10,13 +10,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: skip for markdown only prs
+        id: one
+        run: |
+          current_branch=$(git rev-parse --abbrev-ref HEAD)
+          echo "branch: $current_branch"
+          if [ "$current_branch" == "master" ]; then
+            # diff of last commit excluding md (assumes squash merge)
+            screenable_changes=$(git diff --name-only @~..@ -- . ':(exclude)*.md')
+            echo "push run"
+          else
+            # diff of branch excluding md
+            screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md')
+            echo "pr run"
+          fi
+          echo "changed files: $screenable_changes"
+          # skip if there are only md changes
+          if [ -z "$screenable_changes" ]; then
+            echo "skip screener"
+            echo "::set-output name=skip::skip"
+          else
+            echo "run screener"
+            echo "::set-output name=skip::screen"
+          fi
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-      - name: install dependencies
-        run: npm install
-      - name: run screener check
+      - if: steps.one.outputs.skip == 'screen'
+        name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
-        run: npm run test:storybook || true
+        run: |
+          npm install
+          npm run test:storybook || true
+      - if: steps.one.outputs.skip == 'skip'
+        name: skip screener
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: screener
+          description: Screener run skipped (markdown PRs)
+          state: success
+          sha: ${{github.event.pull_request.head.sha || github.sha}}


### PR DESCRIPTION
**Related Issue:** #3636

## Summary
@driskull put in a hefty PR linked above and screener was skipped when it shouldn't have been. I immediately [reverted](#3673) the skipping part of the action. After some digging it looked like the script didn't fetch enough for larger PRs. Matt helped me test on his branch and confirmed that the fix in this PR (`fetch-depth: 0` instead of `--deepen=100`) works.

https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
