### PR TITLE
fix(button): remove extra margin when icon is empty

### DIFF
--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -62,12 +62,12 @@
 
 .icon-start-empty {
   .content {
-    margin-left: unset;
+    margin-inline-start: unset;
   }
 }
 .icon-end-empty {
   .content {
-    margin-right: unset;
+    margin-inline-end: unset;
   }
 }
 

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -70,16 +70,6 @@
     --calcite-button-content-margin: theme("margin.4");
   }
 }
-:host(:not([icon-start="undefined"])) {
-  .content {
-    margin-right: unset;
-  }
-}
-:host(:not([icon-end="undefined"])) {
-  .content {
-    margin-left: unset;
-  }
-}
 // :host(:not([icon-start])) {
 //   .content {
 //     margin-left: unset;
@@ -90,6 +80,16 @@
 //     margin-right: unset;
 //   }
 // }
+.icon-start-empty {
+  .content {
+    margin-left: unset;
+  }
+}
+.icon-end-empty {
+  .content {
+    margin-right: unset;
+  }
+}
 :host([icon-start]:not([icon-end])) {
   .calcite--rtl .content {
     margin-left: unset;

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -83,18 +83,6 @@
     --calcite-button-content-margin: theme("margin.4");
   }
 }
-:host([icon-start]:not([icon-end])) {
-  .calcite--rtl .content {
-    margin-left: unset;
-    margin-right: var(--calcite-button-content-margin);
-  }
-}
-:host([icon-end]:not([icon-start])) {
-  .calcite--rtl .content {
-    margin-right: unset;
-    margin-left: var(--calcite-button-content-margin);
-  }
-}
 
 // button width
 :host([width="auto"]) {

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -58,6 +58,17 @@
   margin-right: var(--calcite-button-content-margin);
 }
 
+.icon-start-empty {
+  .content {
+    margin-left: unset;
+  }
+}
+.icon-end-empty {
+  .content {
+    margin-right: unset;
+  }
+}
+
 :host([scale="m"]) {
   button,
   a {
@@ -68,26 +79,6 @@
   button,
   a {
     --calcite-button-content-margin: theme("margin.4");
-  }
-}
-// :host(:not([icon-start])) {
-//   .content {
-//     margin-left: unset;
-//   }
-// }
-// :host(:not([icon-end])) {
-//   .content {
-//     margin-right: unset;
-//   }
-// }
-.icon-start-empty {
-  .content {
-    margin-left: unset;
-  }
-}
-.icon-end-empty {
-  .content {
-    margin-right: unset;
   }
 }
 :host([icon-start]:not([icon-end])) {

--- a/src/components/calcite-button/calcite-button.scss
+++ b/src/components/calcite-button/calcite-button.scss
@@ -70,17 +70,26 @@
     --calcite-button-content-margin: theme("margin.4");
   }
 }
-
-:host(:not([icon-start])) {
-  .content {
-    margin-left: unset;
-  }
-}
-:host(:not([icon-end])) {
+:host(:not([icon-start="undefined"])) {
   .content {
     margin-right: unset;
   }
 }
+:host(:not([icon-end="undefined"])) {
+  .content {
+    margin-left: unset;
+  }
+}
+// :host(:not([icon-start])) {
+//   .content {
+//     margin-left: unset;
+//   }
+// }
+// :host(:not([icon-end])) {
+//   .content {
+//     margin-right: unset;
+//   }
+// }
 :host([icon-start]:not([icon-end])) {
   .calcite--rtl .content {
     margin-left: unset;

--- a/src/components/calcite-button/calcite-button.stories.ts
+++ b/src/components/calcite-button/calcite-button.stories.ts
@@ -78,6 +78,14 @@ export const WithIconStartAndIconEnd = (): string => html`
 
 WithIconStartAndIconEnd.storyName = "With icon-start and icon-end";
 
+export const WithIconStartEmpty = (): string => html` <calcite-button icon-start> Button </calcite-button>`;
+
+WithIconStartEmpty.storyName = "With icon-start set to empty";
+
+export const WithIconEndEmpty = (): string => html` <calcite-button icon-end> Button </calcite-button>`;
+
+WithIconEndEmpty.storyName = "With icon-end set to empty";
+
 export const SetWidthContainer = (): string => html`
   <div style="width: 480px; max-width: 100%; background-color: #fff">
     <calcite-button

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -150,7 +150,6 @@ export class CalciteButton implements LabelableComponent {
   render(): VNode {
     const dir = getElementDir(this.el);
     const Tag = this.childElType;
-
     const loaderNode = this.hasLoader ? (
       <div class={CSS.buttonLoader}>
         <calcite-loader
@@ -190,7 +189,12 @@ export class CalciteButton implements LabelableComponent {
     return (
       <Tag
         aria-label={getLabelText(this)}
-        class={{ [CSS_UTILITY.rtl]: dir === "rtl", [CSS.contentSlotted]: this.hasContent }}
+        class={{
+          [CSS_UTILITY.rtl]: dir === "rtl",
+          [CSS.contentSlotted]: this.hasContent,
+          "icon-start-empty": !this.iconStart,
+          "icon-end-empty": !this.iconEnd
+        }}
         disabled={this.disabled || this.loading}
         href={this.childElType === "a" && this.href}
         name={this.childElType === "button" && this.name}

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -192,8 +192,8 @@ export class CalciteButton implements LabelableComponent {
         class={{
           [CSS_UTILITY.rtl]: dir === "rtl",
           [CSS.contentSlotted]: this.hasContent,
-          "icon-start-empty": !this.iconStart,
-          "icon-end-empty": !this.iconEnd
+          [CSS.iconStartEmpty]: !this.iconStart,
+          [CSS.iconEndEmpty]: !this.iconEnd
         }}
         disabled={this.disabled || this.loading}
         href={this.childElType === "a" && this.href}

--- a/src/components/calcite-button/calcite-button.tsx
+++ b/src/components/calcite-button/calcite-button.tsx
@@ -1,10 +1,9 @@
 import "form-request-submit-polyfill/form-request-submit-polyfill";
 import { Component, Element, h, Method, Prop, Build, State, VNode, Watch } from "@stencil/core";
 import { CSS, TEXT } from "./resources";
-import { closestElementCrossShadowBoundary, getElementDir } from "../../utils/dom";
+import { closestElementCrossShadowBoundary } from "../../utils/dom";
 import { ButtonAlignment, ButtonAppearance, ButtonColor } from "./interfaces";
 import { FlipContext, Scale, Width } from "../interfaces";
-import { CSS_UTILITY } from "../../utils/resources";
 import { LabelableComponent, connectLabel, disconnectLabel, getLabelText } from "../../utils/label";
 import { createObserver } from "../../utils/observers";
 
@@ -189,7 +188,6 @@ export class CalciteButton implements LabelableComponent {
       <Tag
         aria-label={getLabelText(this)}
         class={{
-          [CSS_UTILITY.rtl]: dir === "rtl",
           [CSS.contentSlotted]: this.hasContent,
           [CSS.iconStartEmpty]: !this.iconStart,
           [CSS.iconEndEmpty]: !this.iconEnd

--- a/src/components/calcite-button/resources.ts
+++ b/src/components/calcite-button/resources.ts
@@ -6,7 +6,9 @@ export const CSS = {
   iconStart: "icon--start",
   iconEnd: "icon--end",
   loadingIn: "loading-in",
-  loadingOut: "loading-out"
+  loadingOut: "loading-out",
+  iconStartEmpty: "icon-start-empty",
+  iconEndEmpty: "icon-end-empty"
 };
 
 export const TEXT = {


### PR DESCRIPTION
**Related Issue:** #3529 

## Summary

This fix removes the `margin` added to the `.content `class when  `calcite-button` is passed with empty `icon-start | icon-end` prop

Ex:
`<calcite-button icon-end>Button</calcite-button>`