### PR TITLE
build: use postcss to ensure CSS logical prop usage

### DIFF
--- a/.stylelintrc-postcss.json
+++ b/.stylelintrc-postcss.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["stylelint-use-logical-spec"],
+  "rules": {
+    "liberty/use-logical-spec": "always"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "storybook-rtl-addon": "0.3.3",
         "stylelint": "14.1.0",
         "stylelint-config-recommended-scss": "5.0.2",
+        "stylelint-use-logical-spec": "3.2.2",
         "tailwindcss": "1.9.6",
         "ts-jest": "27.1.0",
         "ts-node": "10.4.0",
@@ -33380,6 +33381,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/stylelint-use-logical-spec": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
+      "integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": ">=13"
+      }
+    },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -63616,6 +63629,13 @@
           }
         }
       }
+    },
+    "stylelint-use-logical-spec": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
+      "integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
+      "dev": true,
+      "requires": {}
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "storybook-rtl-addon": "0.3.3",
     "stylelint": "14.1.0",
     "stylelint-config-recommended-scss": "5.0.2",
+    "stylelint-use-logical-spec": "3.2.2",
     "tailwindcss": "1.9.6",
     "ts-jest": "27.1.0",
     "ts-node": "10.4.0",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -5,6 +5,7 @@ import babel from "@rollup/plugin-babel";
 import autoprefixer from "autoprefixer";
 import tailwind from "tailwindcss";
 import { generatePreactTypes } from "./support/preact";
+import stylelint from "stylelint";
 
 export const create: () => Config = () => ({
   buildEs5: "prod",
@@ -99,7 +100,14 @@ export const create: () => Config = () => ({
       injectGlobalPaths: ["src/assets/styles/includes.scss"]
     }),
     postcss({
-      plugins: [tailwind(), autoprefixer()]
+      plugins: [
+        tailwind(),
+        autoprefixer(),
+        stylelint({
+          configFile: ".stylelintrc-postcss.json",
+          fix: true
+        })
+      ]
     })
   ],
   rollupPlugins: {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This wires up postcss + stylelint + https://www.npmjs.com/package/stylelint-use-logical-spec to ensure the CSS output uses [logical props](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties). 

Note that this is using the default configuration and will transform all properties that have a logical equivalent. We can tweak this if we need to prevent some properties from being transformed.
