### PR TITLE
fix(input): input event fires when number ends with a decimal

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1429,6 +1429,23 @@ describe("calcite-input", () => {
       }
     });
 
+    it("input event fires when number ends with a decimal", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+      <calcite-input type="number" value="1.2"></calcite-input>
+      `);
+
+      const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+      const element = await page.find("calcite-input");
+      expect(await element.getProperty("value")).toBe("1.2");
+      await element.callMethod("setFocus");
+
+      await page.keyboard.press("Backspace");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("1");
+      expect(calciteInputInput).toHaveReceivedEventTimes(1);
+    });
+
     describe("when slotted in calcite-inline-editable", () => {
       it("should render text input with inline classes and editingEnabled prop", async () => {
         const page = await newE2EPage({

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -611,7 +611,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
 
     if (nativeEvent) {
       if (this.type === "number" && value.endsWith(".")) {
-        return;
+        value = value.slice(0, -1);
       }
 
       const calciteInputInputEvent = this.calciteInputInput.emit({


### PR DESCRIPTION
**Related Issue:** #2538

## Summary
- `calciteInputInput` wasn't firing when the last character was a decimal.

Edit:
With these changes the functionality will be

Type "1" -> event fires w/ "1"
Type "." -> event fires w/ "1"
Type "2" -> event fires w/ "1.2"
Delete "2" -> event fires w/ "1"
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
