### PR TITLE
fix(switch): switch no longer has black outline when toggled with label

### DIFF
--- a/src/components/calcite-label/calcite-label.stories.ts
+++ b/src/components/calcite-label/calcite-label.stories.ts
@@ -1,6 +1,7 @@
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { html } from "../../tests/utils";
+import { createSteps } from "../../../.storybook/helpers";
 
 export default {
   title: "Components/Label",
@@ -215,3 +216,9 @@ export const WrappingComponentsOtherThanInputRTL = (): string => html`
     </calcite-label>
   </div>
 `;
+
+createSteps(`<calcite-label layout="inline">
+Toggle theme
+<calcite-switch id="theme-switch"></calcite-switch> </calcite-label>`)
+  .click("calcite-label")
+  .snapshot("Toggle switch with label");

--- a/src/components/calcite-label/calcite-label.stories.ts
+++ b/src/components/calcite-label/calcite-label.stories.ts
@@ -2,7 +2,6 @@ import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { html } from "../../tests/utils";
 import { createSteps, stepStory } from "../../../.storybook/helpers";
-import { createComponentHTML as create } from "../../../.storybook/utils";
 export default {
   title: "Components/Label",
 

--- a/src/components/calcite-label/calcite-label.stories.ts
+++ b/src/components/calcite-label/calcite-label.stories.ts
@@ -1,8 +1,8 @@
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { html } from "../../tests/utils";
-import { createSteps } from "../../../.storybook/helpers";
-
+import { createSteps, stepStory } from "../../../.storybook/helpers";
+import { createComponentHTML as create } from "../../../.storybook/utils";
 export default {
   title: "Components/Label",
 
@@ -217,8 +217,10 @@ export const WrappingComponentsOtherThanInputRTL = (): string => html`
   </div>
 `;
 
-createSteps(`<calcite-label layout="inline">
-Toggle theme
-<calcite-switch id="theme-switch"></calcite-switch> </calcite-label>`)
-  .click("calcite-label")
-  .snapshot("Toggle switch with label");
+export const toggleSwitchWithLabel = stepStory(
+  (): string => html`<calcite-label layout="inline">
+    Toggle theme
+    <calcite-switch id="theme-switch"></calcite-switch>
+  </calcite-label>`,
+  createSteps("calcite-label").click("calcite-label").snapshot("Toggle switch with label")
+);

--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -117,4 +117,9 @@
   }
 }
 
+//fix focus outline color
+.container:focus-visible {
+  outline-color: var(--calcite-ui-brand);
+}
+
 @include hidden-form-input();


### PR DESCRIPTION
**Related Issue:** #3694 

## Summary

Fixes `outline` of `calcite-switch` when toggled  with `calcite-label`  which currently is set to `black` by Chrome and edge browsers.