### PR TITLE
fix(input): sanitize extra dashes and leading zeros from number input value

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -975,23 +975,6 @@ describe("calcite-input", () => {
       expect(await page.evaluate(() => document.activeElement.getAttribute("label"))).toEqual("one");
     });
 
-    it.skip("allows typing redundant zeros", async () => {
-      const page = await newE2EPage({
-        html: `
-          <calcite-input type="number"></calcite-input>
-        `
-      });
-      const calciteInput = await page.find("calcite-input");
-      calciteInput.callMethod("setFocus");
-      await page.keyboard.press("0");
-      await page.keyboard.press("0");
-      await page.keyboard.press("0");
-      await page.keyboard.press("0");
-      await page.waitForChanges();
-
-      expect(await calciteInput.getProperty("value")).toBe("00000");
-    });
-
     it.skip("typing zero and then a non-zero number sets and emits the non-zero number", async () => {
       const page = await newE2EPage({
         html: `
@@ -1444,6 +1427,46 @@ describe("calcite-input", () => {
       await page.waitForChanges();
       expect(await element.getProperty("value")).toBe("1");
       expect(calciteInputInput).toHaveReceivedEventTimes(1);
+    });
+
+    it("sanitize leading zeros from number input value", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+      <calcite-input type="number"></calcite-input>
+      `);
+
+      const element = await page.find("calcite-input");
+      await element.callMethod("setFocus");
+      await page.keyboard.type("0000000");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("0");
+
+      await page.keyboard.type("1");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("1");
+
+      await page.keyboard.type("0000000");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("10000000");
+    });
+
+    it("sanitize extra dashes from number input value", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-input type="number"></calcite-input>`);
+
+      const element = await page.find("calcite-input");
+      await element.callMethod("setFocus");
+
+      await page.keyboard.type("1--2---3");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("123");
+
+      await page.keyboard.press("ArrowLeft");
+      await page.keyboard.press("ArrowLeft");
+      await page.keyboard.press("ArrowLeft");
+      await page.keyboard.type("----");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("-123");
     });
 
     describe("when slotted in calcite-inline-editable", () => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -610,8 +610,8 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     }
 
     if (nativeEvent) {
-      if (this.type === "number" && value.endsWith(".")) {
-        value = value.slice(0, -1);
+      if (this.type === "number") {
+        value = sanitizeNumberString(value);
       }
 
       const calciteInputInputEvent = this.calciteInputInput.emit({

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -1418,4 +1418,7 @@
       </div>
     </div>
   </body>
+  <script>
+    document.addEventListener("calciteInputInput", ({ detail }) => console.log(`input: ${detail.value}`));
+  </script>
 </html>

--- a/src/utils/number.spec.ts
+++ b/src/utils/number.spec.ts
@@ -1,4 +1,4 @@
-import { isValidNumber, parseNumberString } from "./number";
+import { isValidNumber, parseNumberString, sanitizeNumberString } from "./number";
 
 describe("isValidNumber", () => {
   it("returns false for string values that can't compute to a number", () => {
@@ -51,5 +51,23 @@ describe("parseNumberString", () => {
     expect(parseNumberString(stringWithLettersAndDecimal)).toBe("123123.2324234");
     expect(parseNumberString(stringWithLettersDecimalAndNonLeadingNegativeSign)).toBe("123123.2324234");
     expect(parseNumberString(stringWithLettersDecimalAndLeadingNegativeSign)).toBe("-123123.2324234");
+  });
+});
+
+describe("sanitizeNumberString", () => {
+  it("sanitizes leading zeros, multiple dashes, and trailing decimals", () => {
+    const stringWithMultipleDashes = "1--2-34----";
+    const negativeStringWithMultipleDashes = "---1--23--4---";
+    const stringWithLeadingZeros = "0000000";
+    const stringWithoutLeadingZeros = "10000000";
+    const stringWithTrailingDecimal = "123.";
+    const stringWithDecimal = "123.45";
+
+    expect(sanitizeNumberString(stringWithMultipleDashes)).toBe("1234");
+    expect(sanitizeNumberString(negativeStringWithMultipleDashes)).toBe("-1234");
+    expect(sanitizeNumberString(stringWithLeadingZeros)).toBe("0");
+    expect(sanitizeNumberString(stringWithoutLeadingZeros)).toBe("10000000");
+    expect(sanitizeNumberString(stringWithTrailingDecimal)).toBe("123");
+    expect(sanitizeNumberString(stringWithDecimal)).toBe("123.45");
   });
 });

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -29,8 +29,18 @@ export function sanitizeDecimalString(decimalString: string): string {
   return decimalString?.endsWith(".") ? decimalString.replace(".", "") : decimalString;
 }
 
+export function sanitizeNegativeString(negativeString: string): string {
+  return negativeString.charAt(0) + negativeString.substring(1).replace(/-/g, "");
+}
+
+export function sanitizeLeadingZeroString(zeroString: string): string {
+  return zeroString.replace(/^0+$/, "0");
+}
+
 export function sanitizeNumberString(value: string): string {
-  return value ? Number(sanitizeDecimalString(value)).toString() : value;
+  return value
+    ? Number(sanitizeNegativeString(sanitizeDecimalString(sanitizeLeadingZeroString(value)))).toString()
+    : value;
 }
 
 function stringContainsNumbers(string: string): boolean {


### PR DESCRIPTION
**Related Issue:** #3053

## Summary
- Sanitize leading zeros, e.g. `000000` and extra dashes, e.g. `-22----4-` which were being emitted and used for the value.
    - The zero example is now `0`, however it will still display all of the zeros in the input until a different number is entered. We are trying not to restrict the ability to type stuff (cc @eriklharper)
    - The extra dashes example is now `-224`. Same idea, you can type them but they are sanitized out of the value. Then typing another number removes the extra dashes from the displayed number as well.
- Removed a skipped test which is no longer valid after these changes
- Added a test for the zeros and a test for the dashes 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
