### PR TITLE
fix(Block): only render title node when heading or summary is used

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -34,10 +34,6 @@
   grid-template-areas: "handle header control menu";
   grid-column: header-start / menu-end;
   grid-row: 1 / 2;
-
-  & > .header {
-    @apply py-3 px-0;
-  }
 }
 
 .toggle {
@@ -47,8 +43,7 @@
     font-inherit
     items-center
     m-0
-    py-3
-    px-0
+    p-0
     border-none
     cursor-pointer
     focus-base;
@@ -74,8 +69,7 @@ calcite-handle {
 
 .title {
   @apply m-0;
-  padding-inline: 0.75rem;
-  padding-block: 0px;
+  padding: theme("spacing.3");
 }
 
 .header .title .heading {
@@ -99,8 +93,9 @@ calcite-handle {
 }
 
 .icon {
-  margin-inline-start: 0.75rem;
+  margin-inline-start: theme("spacing.3");
   margin-inline-end: 0px;
+  margin-block: theme("spacing.3");
 }
 
 .status-icon.valid {
@@ -129,12 +124,14 @@ calcite-handle {
 
 .toggle-icon {
   @apply self-center
+  justify-self-end
   text-color-3
   transition-color
   duration-150
-  ease-in-out;
-  margin-inline-end: 1rem;
-  margin-inline-start: 0px;
+  ease-in-out
+  my-3;
+  margin-inline-end: theme("spacing.4");
+  margin-inline-start: auto;
 }
 
 .toggle:hover .toggle-icon {

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -158,32 +158,28 @@ export class CalciteBlock {
     return hasIcon ? <div class={CSS.icon}>{iconEl}</div> : null;
   }
 
+  renderTitle(): VNode {
+    const { heading, headingLevel, summary } = this;
+    return heading || summary ? (
+      <div class={CSS.title}>
+        <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
+          {heading}
+        </CalciteHeading>
+        {summary ? <div class={CSS.summary}>{summary}</div> : null}
+      </div>
+    ) : null;
+  }
+
   render(): VNode {
-    const {
-      collapsible,
-      disabled,
-      el,
-      heading,
-      intlCollapse,
-      intlExpand,
-      loading,
-      open,
-      summary,
-      intlLoading,
-      headingLevel
-    } = this;
+    const { collapsible, disabled, el, intlCollapse, intlExpand, loading, open, intlLoading } =
+      this;
 
     const toggleLabel = open ? intlCollapse || TEXT.collapse : intlExpand || TEXT.expand;
 
     const headerContent = (
       <header class={CSS.header}>
         {this.renderIcon()}
-        <div class={CSS.title}>
-          <CalciteHeading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
-            {heading}
-          </CalciteHeading>
-          {summary ? <div class={CSS.summary}>{summary}</div> : null}
-        </div>
+        {this.renderTitle()}
       </header>
     );
 


### PR DESCRIPTION
**Related Issue:** #3684

## Summary
Only render `.title` node is **heading** or **summary** is used.
Also adds some styles for some edge cases, e.g. for 
- collapsible but without heading and summary
- icon without heading and summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
