### PR TITLE
ci(release): don't update cdn versions in readme on next releases

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -112,10 +112,10 @@ async function runStandardVersion(next: boolean, standardVersionOptions: Options
   if (next) {
     await appendUnreleasedNotesToChangelog();
     await exec(`git add ${changelogPath}`);
+  } else {
+    await updateReadmeCdnUrls(standardVersionOptions.releaseAs);
+    await exec(`git add ${readmePath}`);
   }
-
-  await updateReadmeCdnUrls(standardVersionOptions.releaseAs);
-  await exec(`git add ${readmePath}`);
 
   await standardVersion(standardVersionOptions);
 }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Right now the README is updated with `next` versions. From a product standpoint, the `next` versions should not be the recommended version in our project README. The people who need to use `next` will know how to do so, but the general public should use the `beta` versions.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
