### PR TITLE
ci(release): ensure tags are pushed when releasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "util:check-squash-mergeable-branch": "ts-node --project ./tsconfig-node-scripts.json support/checkSquashMergeableBranch.ts",
     "util:prep-next-from-existing-build": "ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts --next",
     "util:publish-next": "npm publish --tag next",
-    "util:push-tags": "git push --follow-tags",
+    "util:push-tags": "git push --atomic --follow-tags origin master",
     "util:run-tests": "npm run util:copy-icons && stencil test --no-docs --spec --e2e"
   },
   "repository": {


### PR DESCRIPTION
**Related Issue:** NA

## Summary
The last couple releases, the new tag was not pushed with the rest of the changes (package.json/readme/changelog). Adding `--atomic` to ensure the tag pushes, and if it doesn't it will give me a chance to troubleshoot.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
