### PR TITLE
revert: use postcss to ensure logical prop usage

### DIFF
--- a/.stylelintrc-postcss.json
+++ b/.stylelintrc-postcss.json
@@ -1,6 +1,0 @@
-{
-  "plugins": ["stylelint-use-logical-spec"],
-  "rules": {
-    "liberty/use-logical-spec": "always"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "storybook-rtl-addon": "0.3.3",
         "stylelint": "14.1.0",
         "stylelint-config-recommended-scss": "5.0.2",
-        "stylelint-use-logical-spec": "3.2.2",
         "tailwindcss": "1.9.6",
         "ts-jest": "27.1.1",
         "ts-node": "10.4.0",
@@ -31063,18 +31062,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/stylelint-use-logical-spec": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
-      "integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "stylelint": ">=13"
-      }
-    },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -59627,13 +59614,6 @@
           }
         }
       }
-    },
-    "stylelint-use-logical-spec": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
-      "integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
-      "dev": true,
-      "requires": {}
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "storybook-rtl-addon": "0.3.3",
     "stylelint": "14.1.0",
     "stylelint-config-recommended-scss": "5.0.2",
-    "stylelint-use-logical-spec": "3.2.2",
     "tailwindcss": "1.9.6",
     "ts-jest": "27.1.1",
     "ts-node": "10.4.0",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -5,7 +5,6 @@ import babel from "@rollup/plugin-babel";
 import autoprefixer from "autoprefixer";
 import tailwind from "tailwindcss";
 import { generatePreactTypes } from "./support/preact";
-import stylelint from "stylelint";
 
 export const create: () => Config = () => ({
   buildEs5: "prod",
@@ -100,14 +99,7 @@ export const create: () => Config = () => ({
       injectGlobalPaths: ["src/assets/styles/includes.scss"]
     }),
     postcss({
-      plugins: [
-        tailwind(),
-        autoprefixer(),
-        stylelint({
-          configFile: ".stylelintrc-postcss.json",
-          fix: true
-        })
-      ]
+      plugins: [tailwind(), autoprefixer()]
     })
   ],
   rollupPlugins: {


### PR DESCRIPTION
This reverts commit 6dbcfaf9066aea16f6da9b9433050a2b0ffb9f94.

**Related Issue:** #3688 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Reverts 6dbcfaf9066aea16f6da9b9433050a2b0ffb9f94 since it introduced visual regressions. Will fix and resubmit in a separate PR.