### PR TITLE
build(deps): change form-request-submit-polyfill to be a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@stencil/core": "2.12.0",
         "@types/color": "3.0.2",
         "color": "4.1.0",
+        "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.14.0"
       },
@@ -66,7 +67,6 @@
         "eslint-plugin-prettier": "4.0.0",
         "eslint-plugin-react": "7.27.1",
         "eslint-plugin-unicorn": "39.0.0",
-        "form-request-submit-polyfill": "2.0.0",
         "gh-release": "6.0.1",
         "git-semver-tags": "4.1.1",
         "husky": "7.0.4",
@@ -16910,8 +16910,7 @@
     "node_modules/form-request-submit-polyfill": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
-      "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ==",
-      "dev": true
+      "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
     },
     "node_modules/format": {
       "version": "0.2.2",
@@ -48391,8 +48390,7 @@
     "form-request-submit-polyfill": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
-      "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ==",
-      "dev": true
+      "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
     },
     "format": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@stencil/core": "2.12.0",
     "@types/color": "3.0.2",
     "color": "4.1.0",
+    "form-request-submit-polyfill": "2.0.0",
     "lodash-es": "4.17.21",
     "sortablejs": "1.14.0"
   },
@@ -115,7 +116,6 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.27.1",
     "eslint-plugin-unicorn": "39.0.0",
-    "form-request-submit-polyfill": "2.0.0",
     "gh-release": "6.0.1",
     "git-semver-tags": "4.1.1",
     "husky": "7.0.4",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This should fix build issues for projects bundling `calcite-components`. cc @ffaubry 