### PR TITLE
ci(action): cleanup teams release notification

### DIFF
--- a/.github/workflows/teams-release-msg.yml
+++ b/.github/workflows/teams-release-msg.yml
@@ -16,12 +16,9 @@ jobs:
               return
             }
             core.exportVariable("RELEASE_VERSION", release.tag_name);
-      - name: Wait for npm release
-        run: sleep 30m
-        shell: bash
       - name: Teams channel notification
         uses: FTsbrown/msteams-action@master
         with:
           TITLE: ${{ env.RELEASE_VERSION }}
           BODY: "🚀 <code>@esri/calcite-components@${{ env.RELEASE_VERSION }}</code> released! Check out the [changelog](https://github.com/Esri/calcite-components/blob/master/CHANGELOG.md) for more info. 🚀"
-          MS_TEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URI }}
+          MS_TEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URI_RELEASE }}

--- a/.github/workflows/teams-release-msg.yml
+++ b/.github/workflows/teams-release-msg.yml
@@ -17,7 +17,7 @@ jobs:
             }
             core.exportVariable("RELEASE_VERSION", release.tag_name);
       - name: Teams channel notification
-        uses: FTsbrown/msteams-action@master
+        uses: FTsbrown/msteams-action@v1.0.1
         with:
           TITLE: ${{ env.RELEASE_VERSION }}
           BODY: "🚀 <code>@esri/calcite-components@${{ env.RELEASE_VERSION }}</code> released! Check out the [changelog](https://github.com/Esri/calcite-components/blob/master/CHANGELOG.md#changelog) for more info. 🚀"

--- a/.github/workflows/teams-release-msg.yml
+++ b/.github/workflows/teams-release-msg.yml
@@ -20,5 +20,5 @@ jobs:
         uses: FTsbrown/msteams-action@master
         with:
           TITLE: ${{ env.RELEASE_VERSION }}
-          BODY: "🚀 <code>@esri/calcite-components@${{ env.RELEASE_VERSION }}</code> released! Check out the [changelog](https://github.com/Esri/calcite-components/blob/master/CHANGELOG.md) for more info. 🚀"
+          BODY: "🚀 <code>@esri/calcite-components@${{ env.RELEASE_VERSION }}</code> released! Check out the [changelog](https://github.com/Esri/calcite-components/blob/master/CHANGELOG.md#changelog) for more info. 🚀"
           MS_TEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URI_RELEASE }}


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Removed unnecessary 30 min delay
- Changed the name of the GH secret. Since creating this, I added another teams notification for builds with the secret `TEAMS_WEBHOOK_URI_BUILD`. So I want to specify that this secret is for release for consistency
- Added `#changelog` to the link so you don't have to scroll to find the changes
- Hardcoded the action version just incase the owner pushes breaking changes to master
    - https://github.com/marketplace/actions/ms-teams-action?version=v1.0.1
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
