### PR TITLE
fix(input): set value to empty string instead of null or undefined

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -288,7 +288,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
       if (isValidNumber(this.value)) {
         this.localizedValue = localizeNumberString(this.value, this.locale, this.groupSeparator);
       } else {
-        this.value = undefined;
+        this.value = "";
       }
     }
     connectLabel(this);
@@ -603,7 +603,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   private setValue = (value: string, nativeEvent?: any, committing = false): void => {
     const previousValue = this.value;
 
-    this.value = this.type === "number" ? sanitizeNumberString(value) : value;
+    this.value = value; //= this.type === "number" ? sanitizeNumberString(value) : value;
 
     if (this.type === "number") {
       this.setLocalizedValue(this.value);

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -603,7 +603,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   private setValue = (value: string, nativeEvent?: any, committing = false): void => {
     const previousValue = this.value;
 
-    this.value = value; //= this.type === "number" ? sanitizeNumberString(value) : value;
+    this.value = this.type === "number" ? sanitizeNumberString(value) : value;
 
     if (this.type === "number") {
       this.setLocalizedValue(this.value);

--- a/src/utils/number.spec.ts
+++ b/src/utils/number.spec.ts
@@ -21,7 +21,7 @@ describe("isValidNumber", () => {
 describe("parseNumberString", () => {
   it("returns null for string values that can't compute to a number", () => {
     expect(parseNumberString()).toBe("");
-    expect(parseNumberString("")).toBe("");
+    expect(parseNumberString(null)).toBe("");
     expect(parseNumberString(undefined)).toBe("");
     expect(parseNumberString("")).toBe("");
     expect(parseNumberString("text only")).toBe("");

--- a/src/utils/number.spec.ts
+++ b/src/utils/number.spec.ts
@@ -20,17 +20,17 @@ describe("isValidNumber", () => {
 
 describe("parseNumberString", () => {
   it("returns null for string values that can't compute to a number", () => {
-    expect(parseNumberString()).toBe(null);
-    expect(parseNumberString("")).toBe(null);
-    expect(parseNumberString(undefined)).toBe(null);
-    expect(parseNumberString(null)).toBe(null);
-    expect(parseNumberString("text only")).toBe(null);
+    expect(parseNumberString()).toBe("");
+    expect(parseNumberString("")).toBe("");
+    expect(parseNumberString(undefined)).toBe("");
+    expect(parseNumberString("")).toBe("");
+    expect(parseNumberString("text only")).toBe("");
 
     const lettersAndSymbols = "kjas;lkjwo;aiej(*&,asd;flkj-";
     const lettersAndSymbolsWithLeadingNegativeSign = "-ASDF(*^LKJihsdf*&^";
 
-    expect(parseNumberString(lettersAndSymbols)).toBe(null);
-    expect(parseNumberString(lettersAndSymbolsWithLeadingNegativeSign)).toBe(null);
+    expect(parseNumberString(lettersAndSymbols)).toBe("");
+    expect(parseNumberString(lettersAndSymbolsWithLeadingNegativeSign)).toBe("");
   });
 
   it("returns valid number string for string values that compute to a valid number", () => {

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -6,7 +6,7 @@ export function isValidNumber(numberString: string): boolean {
 
 export function parseNumberString(numberString?: string): string {
   if (!numberString || !stringContainsNumbers(numberString)) {
-    return null;
+    return "";
   }
   let containsDecimal = false;
   const result = numberString


### PR DESCRIPTION
**Related Issue:** #3627

## Summary
- The PR linked above moved to use an empty string for the value instead of `null`. I made the same change for pasting invalid numbers.


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
