### PR TITLE
fix(switch): add back outline offset on focus

### DIFF
--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -53,10 +53,6 @@
   @apply focus-base w-auto;
 }
 
-:host(:focus) {
-  @apply focus-outset;
-}
-
 .track {
   @apply relative
     inline-block
@@ -117,9 +113,8 @@
   }
 }
 
-//fix focus outline color
-.container:focus-visible {
-  outline-color: var(--calcite-ui-brand);
+.container:focus {
+  @apply focus-outset;
 }
 
 @include hidden-form-input();


### PR DESCRIPTION
**Related Issue:** #3694 

## Summary
 
- Fixes `outlines-offset` for `calcite-switch` on focus with pointer or keyboard .
- Outline appears when toggled by itself or using `calcite-label`