### PR TITLE
fix(checkbox,radio-button): prevents disabled checkboxes and radio-buttons from receiving keyboard or mouse focus

### DIFF
--- a/src/components/calcite-checkbox/calcite-checkbox.tsx
+++ b/src/components/calcite-checkbox/calcite-checkbox.tsx
@@ -213,7 +213,7 @@ export class CalciteCheckbox implements LabelableComponent, CheckableFormCompome
           onFocus={this.onToggleFocus}
           ref={(toggleEl) => (this.toggleEl = toggleEl)}
           role="checkbox"
-          tabIndex={0}
+          tabIndex={this.disabled ? undefined : 0}
         >
           <svg class="check-svg" viewBox="0 0 16 16">
             <path d={this.getPath()} />

--- a/src/components/calcite-radio-button/calcite-radio-button.scss
+++ b/src/components/calcite-radio-button/calcite-radio-button.scss
@@ -10,7 +10,7 @@
 }
 
 :host([hovered]),
-:host(:not([checked])[focused]) {
+:host(:not([checked])[focused]:not([disabled])) {
   .radio {
     box-shadow: inset 0 0 0 2px var(--calcite-ui-brand);
   }
@@ -51,7 +51,7 @@
     box-shadow: inset 0 0 0 4px var(--calcite-ui-brand);
   }
 }
-:host([scale="s"][focused][checked]) {
+:host([scale="s"][focused][checked]:not([disabled])) {
   .radio {
     box-shadow: inset 0 0 0 4px var(--calcite-ui-brand), 0 0 0 2px var(--calcite-ui-foreground-1),
       0 0 0 4px var(--calcite-ui-brand);
@@ -63,7 +63,7 @@
     box-shadow: inset 0 0 0 5px var(--calcite-ui-brand);
   }
 }
-:host([scale="m"][focused][checked]) {
+:host([scale="m"][focused][checked]:not([disabled])) {
   .radio {
     box-shadow: inset 0 0 0 5px var(--calcite-ui-brand), 0 0 0 2px var(--calcite-ui-foreground-1),
       0 0 0 4px var(--calcite-ui-brand);
@@ -75,7 +75,7 @@
     box-shadow: inset 0 0 0 6px var(--calcite-ui-brand);
   }
 }
-:host([scale="l"][focused][checked]) {
+:host([scale="l"][focused][checked]:not([disabled])) {
   .radio {
     box-shadow: inset 0 0 0 6px var(--calcite-ui-brand), 0 0 0 2px var(--calcite-ui-foreground-1),
       0 0 0 4px var(--calcite-ui-brand);

--- a/src/components/calcite-radio-button/calcite-radio-button.tsx
+++ b/src/components/calcite-radio-button/calcite-radio-button.tsx
@@ -131,7 +131,9 @@ export class CalciteRadioButton implements LabelableComponent, CheckableFormComp
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    focusElement(this.containerEl);
+    if (!this.disabled) {
+      focusElement(this.containerEl);
+    }
   }
 
   //--------------------------------------------------------------------------
@@ -235,6 +237,13 @@ export class CalciteRadioButton implements LabelableComponent, CheckableFormComp
         otherRadioButton.focused = false;
       }
     });
+  }
+
+  private getTabIndex(): number | undefined {
+    if (this.disabled) {
+      return undefined;
+    }
+    return this.checked || this.isDefaultSelectable() ? 0 : -1;
   }
 
   //--------------------------------------------------------------------------
@@ -352,8 +361,10 @@ export class CalciteRadioButton implements LabelableComponent, CheckableFormComp
   };
 
   private onContainerFocus = (): void => {
-    this.focused = true;
-    this.calciteInternalRadioButtonFocus.emit();
+    if (!this.disabled) {
+      this.focused = true;
+      this.calciteInternalRadioButtonFocus.emit();
+    }
   };
 
   //--------------------------------------------------------------------------
@@ -373,7 +384,7 @@ export class CalciteRadioButton implements LabelableComponent, CheckableFormComp
   }
 
   componentDidLoad(): void {
-    if (this.focused) {
+    if (this.focused && !this.disabled) {
       this.setFocus();
     }
   }
@@ -390,6 +401,7 @@ export class CalciteRadioButton implements LabelableComponent, CheckableFormComp
   // --------------------------------------------------------------------------
 
   render(): VNode {
+    const tabIndex = this.getTabIndex();
     return (
       <Host onClick={this.clickHandler} onKeyDown={this.handleKeyDown}>
         <div
@@ -400,7 +412,7 @@ export class CalciteRadioButton implements LabelableComponent, CheckableFormComp
           onFocus={this.onContainerFocus}
           ref={this.setContainerEl}
           role="radio"
-          tabIndex={this.checked || this.isDefaultSelectable() ? 0 : -1}
+          tabIndex={tabIndex}
         >
           <div class="radio" />
         </div>


### PR DESCRIPTION
**Related Issue:** #3783

## Summary

This pr fixes checkbox and radio-button so that they no longer allow focusing when disabled.  Testing for this change will be covered with Screener visual snapshots in this PR: https://github.com/Esri/calcite-components/pull/3571

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
