### PR TITLE
refactor(dom): Allow multiple slot names in getSlotted utility.

### DIFF
--- a/src/utils/dom.spec.ts
+++ b/src/utils/dom.spec.ts
@@ -85,6 +85,7 @@ describe("dom", () => {
 
   describe("getSlotted()", () => {
     const testSlotName = "test";
+    const testSlotName2 = "test2";
 
     function getTestComponent(): HTMLElement {
       return document.body.querySelector("slot-test");
@@ -98,7 +99,7 @@ describe("dom", () => {
         }
 
         connectedCallback(): void {
-          this.shadowRoot.innerHTML = `<slot name="${testSlotName}"></slot>`;
+          this.shadowRoot.innerHTML = `<slot name="${testSlotName}"></slot><slot name="${testSlotName2}"></slot>`;
         }
       }
 
@@ -115,6 +116,7 @@ describe("dom", () => {
           <span>🙂</span>
         </h2>
         <h2 slot=${testSlotName}><span>😂</span></h2>
+        <h3 slot=${testSlotName2}><span>😂</span></h3>
       </slot-test>
     `;
     });
@@ -122,6 +124,9 @@ describe("dom", () => {
     describe("single slotted", () => {
       it("returns elements with matching slot name", () =>
         expect(getSlotted(getTestComponent(), testSlotName)).toBeTruthy());
+
+      it("returns elements with matching slot names", () =>
+        expect(getSlotted(getTestComponent(), [testSlotName, testSlotName2])).toBeTruthy());
 
       it("returns null when no results", () => expect(getSlotted(getTestComponent(), "non-existent-slot")).toBeNull());
 
@@ -177,6 +182,9 @@ describe("dom", () => {
     describe("multiple slotted", () => {
       it("returns elements with matching slot name", () =>
         expect(getSlotted(getTestComponent(), testSlotName, { all: true })).toHaveLength(2));
+
+      it("returns elements with matching slot names", () =>
+        expect(getSlotted(getTestComponent(), [testSlotName, testSlotName2], { all: true })).toHaveLength(3));
 
       it("returns empty list when no results", () =>
         expect(getSlotted(getTestComponent(), "non-existent-slot", { all: true })).toHaveLength(0));

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -137,20 +137,22 @@ interface GetSlottedOptions {
 
 export function getSlotted<T extends Element = Element>(
   element: Element,
-  slotName: string,
+  slotName: string | string[],
   options: GetSlottedOptions & { all: true }
 ): T[];
 export function getSlotted<T extends Element = Element>(
   element: Element,
-  slotName: string,
+  slotName: string | string[],
   options?: GetSlottedOptions
 ): T | null;
 export function getSlotted<T extends Element = Element>(
   element: Element,
-  slotName: string,
+  slotName: string | string[],
   options?: GetSlottedOptions
 ): (T | null) | T[] {
-  const slotSelector = `[slot="${slotName}"]`;
+  const slotSelector = Array.isArray(slotName)
+    ? slotName.map((name) => `[slot="${name}"]`).join(",")
+    : `[slot="${slotName}"]`;
 
   if (options?.all) {
     return queryMultiple<T>(element, slotSelector, options);


### PR DESCRIPTION
**Related Issue:** None

## Summary

refactor(dom): Allow multiple slot names in getSlotted utility.

Allows usage of utility in `calcite-modal`...

```
this.hasFooter = !!this.el.querySelector(
      `[slot=${SLOTS.back}], [slot=${SLOTS.secondary}], [slot=${SLOTS.primary}]`
    );
```