### PR TITLE
refactor: use window or global when calling global interval or timeout methods

### DIFF
--- a/src/components/calcite-alert/calcite-alert.tsx
+++ b/src/components/calcite-alert/calcite-alert.tsx
@@ -316,7 +316,7 @@ export class CalciteAlert {
 
   /** emit the opened alert and the queue */
   private openAlert(): void {
-    clearTimeout(this.queueTimeout);
+    window.clearTimeout(this.queueTimeout);
     this.queueTimeout = window.setTimeout(() => (this.queued = false), 300);
     this.calciteAlertOpen.emit({
       el: this.el,

--- a/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
+++ b/src/components/calcite-date-picker/calcite-date-picker.e2e.ts
@@ -100,7 +100,7 @@ describe("calcite-date-picker", () => {
     const date = await page.find("calcite-date-picker");
     // have to wait for transition
     const changedEvent = await page.spyOnEvent("calciteDatePickerRangeChange");
-    await new Promise((res) => setTimeout(() => res(true), 200));
+    await new Promise((res) => global.setTimeout(() => res(true), 200));
     expect(changedEvent).toHaveReceivedEventTimes(0);
     const start1 = await date.getProperty("start");
     const end1 = await date.getProperty("end");

--- a/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
+++ b/src/components/calcite-inline-editable/calcite-inline-editable.e2e.ts
@@ -266,7 +266,7 @@ describe("calcite-inline-editable", () => {
 
     it("disables editing when afterConfirm resolves successfully", async () => {
       const element = await page.find("calcite-inline-editable");
-      const afterConfirm: () => Promise<void> = () => new Promise((resolve) => setTimeout(resolve, 100));
+      const afterConfirm: () => Promise<void> = () => new Promise((resolve) => global.setTimeout(resolve, 100));
       // https://github.com/ionic-team/stencil/issues/1174
       await page.exposeFunction("afterConfirm", afterConfirm);
       await page.$eval("calcite-inline-editable", (el: HTMLCalciteInlineEditableElement) => {
@@ -291,7 +291,7 @@ describe("calcite-inline-editable", () => {
 
     it("does not disable editing when afterConfirm resolves unsuccessfully", async () => {
       const element = await page.find("calcite-inline-editable");
-      const afterConfirm: () => Promise<void> = () => new Promise((_resolve, reject) => setTimeout(reject, 100));
+      const afterConfirm: () => Promise<void> = () => new Promise((_resolve, reject) => global.setTimeout(reject, 100));
       // https://github.com/ionic-team/stencil/issues/1174
       await page.exposeFunction("afterConfirm", afterConfirm);
       await page.$eval("calcite-inline-editable", (el: HTMLCalciteInlineEditableElement) => {

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -533,7 +533,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
 
     let firstValueNudge = true;
-    this.nudgeNumberValueIntervalId = setInterval(() => {
+    this.nudgeNumberValueIntervalId = window.setInterval(() => {
       if (firstValueNudge) {
         firstValueNudge = false;
         return;
@@ -544,7 +544,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   };
 
   private numberButtonMouseUpAndMouseOutHandler = (): void => {
-    clearInterval(this.nudgeNumberValueIntervalId);
+    window.clearInterval(this.nudgeNumberValueIntervalId);
   };
 
   private numberButtonMouseDownHandler = (event: MouseEvent): void => {
@@ -628,7 +628,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   };
 
   private inputKeyUpHandler = (): void => {
-    clearInterval(this.nudgeNumberValueIntervalId);
+    window.clearInterval(this.nudgeNumberValueIntervalId);
   };
 
   // --------------------------------------------------------------------------

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -96,7 +96,7 @@ export async function dragAndDrop(
     dragStart.dispatchEvent(new PointerEvent("pointerdown", dragStartInitializer));
     dragStart.dispatchEvent(new DragEvent("dragstart", dragStartInitializer));
 
-    await new Promise((resolve) => global.setTimeout(resolve, 2000));
+    await new Promise((resolve) => window.setTimeout(resolve, 2000));
 
     dragEnd.dispatchEvent(new MouseEvent("dragenter", dragEndInitializer));
     dragStart.dispatchEvent(new DragEvent("dragend", dragEndInitializer));

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -96,7 +96,7 @@ export async function dragAndDrop(
     dragStart.dispatchEvent(new PointerEvent("pointerdown", dragStartInitializer));
     dragStart.dispatchEvent(new DragEvent("dragstart", dragStartInitializer));
 
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await new Promise((resolve) => global.setTimeout(resolve, 2000));
 
     dragEnd.dispatchEvent(new MouseEvent("dragenter", dragEndInitializer));
     dragStart.dispatchEvent(new DragEvent("dragend", dragEndInitializer));


### PR DESCRIPTION
**Related Issue:** #1004

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR eliminates the ambiguity of global timeout and interval methods. This is needed for to avoid mismatching types since `@types/node/globals.d.ts` is getting pulled in automatically from `jest` dependencies.