### PR TITLE
chore(browserslist): use last 2 major versions for Safari and iOS

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -2,5 +2,5 @@
 last 2 chrome versions
 last 2 edge versions
 last 2 ff versions
-last 2 safari versions
-last 2 ios versions
+last 2 safari major versions
+last 2 ios major versions


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This will better match the requirements defined in https://doc.arcgis.com/en/arcgis-online/reference/browsers.htm and https://developers.arcgis.com/javascript/latest/system-requirements/.