### PR TITLE
ci: cache npm packages to speed up actions

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org/
+          cache: npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: e2e test

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
+          cache: npm
       - if: steps.testable.outputs.skip == 'false'
         run: |
           npm install

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
+          cache: npm
       - if: steps.one.outputs.skip == 'screen'
         name: run screener check
         env:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
+          cache: npm
       - uses: fregante/setup-git-user@v1
 
       - name: run dependency-updating script

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-
+          cache: npm
       - name: generate doc
         run: |
           npm install


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Start caching the npm packages when running the checks/actions to speed things up. 
- https://github.com/actions/setup-node#caching-packages-dependencies
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
