### PR TITLE
fix(Panel): match header height and border color to Action

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.scss
+++ b/src/components/calcite-action-bar/calcite-action-bar.scss
@@ -19,7 +19,7 @@
   @apply border-0
     border-b
     border-solid
-    border-color-2;
+    border-color-3;
 }
 
 ::slotted(calcite-action-group:last-child) {

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -81,14 +81,13 @@
     border-b-color-3
     w-full;
   flex: 0 0 auto;
-  min-height: theme("spacing.12");
   z-index: 2;
 }
 
 .header-content {
   @apply overflow-hidden
     px-3
-    py-4
+    py-3.5
     flex
     flex-col;
   margin-inline-end: auto;


### PR DESCRIPTION
**Related Issue:** #3699

## Summary
Updates how header height is achieved in order to match the height to an Action when there's only a heading in the Panel's header.

Also updates border colors to match.

Of course, if there's a summary or long heading text, the alignment no longer happens.

<img width="1317" alt="Screen Shot 2021-12-29 at 9 15 22 AM" src="https://user-images.githubusercontent.com/12503298/147687518-3b01333c-c091-4501-9be8-30353756f7b8.png">



<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
