### PR TITLE
fix(color-picker-swatch): double the alpha value on the border when theme is light to make it a bit more pronounced

### DIFF
--- a/src/components/calcite-color-picker-swatch/resources.ts
+++ b/src/components/calcite-color-picker-swatch/resources.ts
@@ -4,6 +4,6 @@ export const CSS = {
 };
 
 export const COLORS = {
-  borderLight: "rgba(0, 0, 0, 0.15)",
+  borderLight: "rgba(0, 0, 0, 0.3)",
   borderDark: "rgba(255, 255, 255, 0.15)"
 };


### PR DESCRIPTION
**Related Issue:** #3160

## Summary

Double the alpha value on the border when theme is light to make it a bit more pronounced.
