### PR TITLE
chore: remove tslint from recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "stylelint.vscode-stylelint",
     "esbenp.prettier-vscode",
     "bradlc.vscode-tailwindcss",
-    "ms-vscode.vscode-typescript-tslint-plugin",
     "visualstudioexptteam.vscodeintellicode"
   ]
 }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Unrecommending deprecated extension  :grimacing: