### PR TITLE
fix(value-list): emit list order change event when value list items are reordered via the keyboard

### DIFF
--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -85,6 +85,7 @@ describe("calcite-value-list", () => {
 
     it("works using a mouse", async () => {
       const page = await createSimpleValueList();
+      const listOrderChangeSpy = await page.spyOnEvent("calciteListOrderChange");
 
       await dragAndDrop(
         page,
@@ -101,10 +102,12 @@ describe("calcite-value-list", () => {
       const [first, second] = await page.findAll("calcite-value-list-item");
       expect(await first.getProperty("value")).toBe("two");
       expect(await second.getProperty("value")).toBe("one");
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(1);
     });
 
     it("works using a keyboard", async () => {
       const page = await createSimpleValueList();
+      const listOrderChangeSpy = await page.spyOnEvent("calciteListOrderChange");
 
       await page.keyboard.press("Tab");
       await page.keyboard.press("Space");
@@ -122,12 +125,18 @@ describe("calcite-value-list", () => {
       }
 
       await assertKeyboardMove("down", ["two", "one", "three"]);
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(1);
       await assertKeyboardMove("down", ["two", "three", "one"]);
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(2);
       await assertKeyboardMove("down", ["one", "two", "three"]);
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(3);
 
       await assertKeyboardMove("up", ["two", "three", "one"]);
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(4);
       await assertKeyboardMove("up", ["two", "one", "three"]);
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(5);
       await assertKeyboardMove("up", ["one", "two", "three"]);
+      expect(listOrderChangeSpy).toHaveReceivedEventTimes(6);
     });
 
     it("supports dragging items between lists", async () => {

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -185,6 +185,10 @@ export class CalciteValueList<
   //
   // --------------------------------------------------------------------------
 
+  getItems(): ItemElement[] {
+    return Array.from(this.el.querySelectorAll<ItemElement>("calcite-value-list-item"));
+  }
+
   setUpItems(): void {
     setUpItems.call(this, "calcite-value-list-item");
   }
@@ -253,13 +257,15 @@ export class CalciteValueList<
       return;
     }
 
-    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {
+    const { items } = this;
+
+    if ((event.key !== "ArrowUp" && event.key !== "ArrowDown") || items.length <= 1) {
       return;
     }
 
     event.preventDefault();
 
-    const { el, items } = this;
+    const { el } = this;
     const moveOffset = event.key === "ArrowDown" ? 1 : -1;
     const currentIndex = items.indexOf(item);
     const nextIndex = getRoundRobinIndex(currentIndex + moveOffset, items.length);
@@ -274,6 +280,9 @@ export class CalciteValueList<
           : itemAtNextIndex;
       el.insertBefore(item, insertionReferenceItem);
     }
+
+    this.items = this.getItems();
+    this.calciteListOrderChange.emit(this.items);
 
     requestAnimationFrame(() => handleElement.focus());
     item.handleActivated = true;


### PR DESCRIPTION
**Related Issue:** #3685

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

The value list was only emitting order change events when reordered with the mouse (via SortableJS). This PR adds the eventing logic when reordered via keyboard. 

Note that the event be emitted as each item is moved with the up/down keys.