### PR TITLE
fix(value-list): include ordered values in list order change event payload

### DIFF
--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -103,6 +103,7 @@ describe("calcite-value-list", () => {
       expect(await first.getProperty("value")).toBe("two");
       expect(await second.getProperty("value")).toBe("one");
       expect(listOrderChangeSpy).toHaveReceivedEventTimes(1);
+      expect(listOrderChangeSpy).toHaveReceivedEventDetail(["two", "one", "three"]);
     });
 
     it("works using a keyboard", async () => {
@@ -113,6 +114,8 @@ describe("calcite-value-list", () => {
       await page.keyboard.press("Space");
       await page.waitForChanges();
 
+      let totalMoves = 0;
+
       async function assertKeyboardMove(direction: "down" | "up", expectedValueOrder: string[]): Promise<void> {
         const arrowKey = `Arrow${(direction.charAt(0).toUpperCase() + direction.slice(1)) as "Down" | "Up"}` as const;
         await page.keyboard.press(arrowKey);
@@ -122,21 +125,18 @@ describe("calcite-value-list", () => {
         for (let i = 0; i < itemsAfter.length; i++) {
           expect(await itemsAfter[i].getProperty("value")).toBe(expectedValueOrder[i]);
         }
+
+        expect(listOrderChangeSpy).toHaveReceivedEventTimes(++totalMoves);
+        expect(listOrderChangeSpy).toHaveReceivedEventDetail(expectedValueOrder);
       }
 
       await assertKeyboardMove("down", ["two", "one", "three"]);
-      expect(listOrderChangeSpy).toHaveReceivedEventTimes(1);
       await assertKeyboardMove("down", ["two", "three", "one"]);
-      expect(listOrderChangeSpy).toHaveReceivedEventTimes(2);
       await assertKeyboardMove("down", ["one", "two", "three"]);
-      expect(listOrderChangeSpy).toHaveReceivedEventTimes(3);
 
       await assertKeyboardMove("up", ["two", "three", "one"]);
-      expect(listOrderChangeSpy).toHaveReceivedEventTimes(4);
       await assertKeyboardMove("up", ["two", "one", "three"]);
-      expect(listOrderChangeSpy).toHaveReceivedEventTimes(5);
       await assertKeyboardMove("up", ["one", "two", "three"]);
-      expect(listOrderChangeSpy).toHaveReceivedEventTimes(6);
     });
 
     it("supports dragging items between lists", async () => {

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -151,12 +151,12 @@ export class CalciteValueList<
   /**
    * Emitted when any of the item selections have changed.
    */
-  @Event() calciteListChange: EventEmitter;
+  @Event() calciteListChange: EventEmitter<void>;
 
   /**
    * Emitted when the order of the list has changed.
    */
-  @Event() calciteListOrderChange: EventEmitter;
+  @Event() calciteListOrderChange: EventEmitter<any[]>;
 
   @Listen("calciteListItemRemove")
   calciteListItemRemoveHandler(event: CustomEvent<void>): void {
@@ -282,7 +282,7 @@ export class CalciteValueList<
     }
 
     this.items = this.getItems();
-    this.calciteListOrderChange.emit(this.items);
+    this.calciteListOrderChange.emit(this.items.map(({ value }) => value));
 
     requestAnimationFrame(() => handleElement.focus());
     item.handleActivated = true;


### PR DESCRIPTION
**Related Issue:** #3685 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a bug introduced by #3816 where the event payload when reordering items via the keyboard included the list elements instead of the ordered values.

cc @jmanke