### PR TITLE
chore(action): allow primary contact to merge pr branches

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -2,9 +2,12 @@ name: Auto Merge
 on: issue_comment
 jobs:
   merge:
+    env:
+      PRIMARY_CONTACT: ${{ secrets.PRIMARY_CONTACT }}
     if: |
       github.event.issue.user.login == 'github-actions[bot]' ||
-      github.event.issue.user.login == github.actor
+      github.event.issue.user.login == github.actor ||
+      env.PRIMARY_CONTACT == github.actor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Give the primary contact (me as of now) the ability to merge PR branches by commenting. If CI stuff ever gets messed up, I'll be able to merge the branches with a fix so someone doesn't accidently install with no checks (as an example).
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
