### PR TITLE
refactor(pick-list, value-list): add proper types to list change event payload

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -137,7 +137,7 @@ export class CalcitePickList<
   /**
    * Emitted when any of the item selections have changed.
    */
-  @Event() calciteListChange: EventEmitter;
+  @Event() calciteListChange: EventEmitter<Map<string, HTMLCalcitePickListItemElement>>;
 
   @Listen("calciteListItemRemove")
   calciteListItemRemoveHandler(event: CustomEvent<void>): void {

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -151,7 +151,7 @@ export function keyDownHandler<T extends Lists>(this: List<T>, event: KeyboardEv
 }
 
 export function internalCalciteListChangeEvent<T extends Lists>(this: List<T>): void {
-  this.calciteListChange.emit(this.selectedValues);
+  this.calciteListChange.emit(this.selectedValues as any);
 }
 
 export function removeItem<T extends Lists, U extends ListItemElement<T>>(this: List<T>, event: CustomEvent): void {

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -151,7 +151,7 @@ export class CalciteValueList<
   /**
    * Emitted when any of the item selections have changed.
    */
-  @Event() calciteListChange: EventEmitter<void>;
+  @Event() calciteListChange: EventEmitter<Map<string, HTMLCalciteValueListItemElement>>;
 
   /**
    * Emitted when the order of the list has changed.


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Types the list change event payload for both pick and value lists. I had to use `any` for the shared implementation since it requires some advanced TS-fu. I'll create a follow-up issue for that.