### PR TITLE
revert: allow primary contact to merge pr branches

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -2,12 +2,9 @@ name: Auto Merge
 on: issue_comment
 jobs:
   merge:
-    env:
-      PRIMARY_CONTACT: ${{ secrets.PRIMARY_CONTACT }}
     if: |
       github.event.issue.user.login == 'github-actions[bot]' ||
-      github.event.issue.user.login == github.actor ||
-      env.PRIMARY_CONTACT == github.actor
+      github.event.issue.user.login == github.actor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
**Related Issue:** #3823

## Summary
Reverting PR that broke the merge action.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
