### PR TITLE
fix(input): restrict typing more than two hyphens

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -495,8 +495,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
       "Delete",
       "Enter",
       "Escape",
-      "Tab",
-      "-"
+      "Tab"
     ];
     if (event.altKey || event.ctrlKey || event.metaKey) {
       return;
@@ -522,6 +521,15 @@ export class CalciteInput implements LabelableComponent, FormComponent {
         return;
       }
       if (this.value && !/[eE]/.test(this.childNumberEl.value)) {
+        return;
+      }
+    }
+
+    if (event.key === "-") {
+      if (!this.value && !this.childNumberEl.value) {
+        return;
+      }
+      if (this.value && this.childNumberEl.value.split("-").length <= 2) {
         return;
       }
     }


### PR DESCRIPTION
**Related Issue:** #3053

## Summary
Restricts typing more than two hyphens, which is how native input does it.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
