### PR TITLE
fix: rerender components with conditional slots when slotting elements after initialization

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -1,5 +1,5 @@
-import { E2EElement, newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, focusable, hidden, reflects, renders } from "../../tests/commonTests";
+import { newE2EPage } from "@stencil/core/testing";
+import { accessible, defaults, focusable, hidden, reflects, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 import { overflowActionsDebounceInMs } from "./utils";
 import { html } from "../../tests/utils";
@@ -216,58 +216,7 @@ describe("calcite-action-bar", () => {
       }
     ));
 
-  it("honors 'expand-tooltip' slot", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-action-bar>
-        <calcite-tooltip slot="${SLOTS.expandTooltip}">Bits and bobs.</calcite-tooltip>
-        <calcite-action-group>
-          <calcite-action text="Add" icon="plus"></calcite-action>
-        </calcite-action-group>
-      </calcite-action-bar>`
-    });
-
-    await page.waitForChanges();
-
-    const tooltipManager = await page.find(`calcite-action-bar >>> calcite-tooltip-manager`);
-
-    expect(tooltipManager).toBeTruthy();
-
-    const tooltipSlot = await page.find(`calcite-action-bar >>> slot[name=${SLOTS.expandTooltip}]`);
-    expect(tooltipSlot).toBeTruthy();
-  });
-
-  it("honors conditional 'expand-tooltip' slot", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-action-bar>
-        <calcite-action-group>
-          <calcite-action text="Add" icon="plus"></calcite-action>
-        </calcite-action-group>
-      </calcite-action-bar>`
-    });
-
-    await page.waitForChanges();
-
-    let tooltipManager: E2EElement = await page.find(`calcite-action-bar >>> calcite-tooltip-manager`);
-
-    expect(tooltipManager).toBeFalsy();
-
-    await page.$eval(
-      "calcite-action-bar",
-      (actionBar, expandTooltip: string) => {
-        const tooltip = document.createElement("calcite-tooltip");
-        tooltip.slot = expandTooltip;
-        tooltip.innerHTML = "Bits and bobs.";
-        actionBar.appendChild(tooltip);
-      },
-      SLOTS.expandTooltip
-    );
-
-    await page.waitForChanges();
-
-    tooltipManager = await page.find(`calcite-action-bar >>> calcite-tooltip-manager`);
-
-    expect(tooltipManager).toBeTruthy();
-  });
+  it("has slots", () => slots("calcite-action-bar", SLOTS));
 
   it.skip("should set other 'calcite-action-group' - 'menuOpen' to false", async () => {
     const page = await newE2EPage({

--- a/src/components/calcite-action-group/calcite-action-group.e2e.ts
+++ b/src/components/calcite-action-group/calcite-action-group.e2e.ts
@@ -1,5 +1,6 @@
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, hidden, renders, slots } from "../../tests/commonTests";
 import { newE2EPage } from "@stencil/core/testing";
+import { SLOTS } from "./resources";
 
 describe("calcite-action-group", () => {
   it("renders", async () => renders("calcite-action-group", { display: "flex" }));
@@ -12,6 +13,8 @@ describe("calcite-action-group", () => {
       <calcite-action text="Add" icon="plus"></calcite-action>
     </calcite-action-group>
     `));
+
+  it("has slots", () => slots("calcite-action-group", SLOTS));
 
   it("should honor scale of expand icon", async () => {
     const page = await newE2EPage({

--- a/src/components/calcite-action-group/calcite-action-group.tsx
+++ b/src/components/calcite-action-group/calcite-action-group.tsx
@@ -4,6 +4,11 @@ import { Fragment, VNode } from "@stencil/core/internal";
 import { getSlotted } from "../../utils/dom";
 import { SLOTS as ACTION_MENU_SLOTS } from "../calcite-action-menu/resources";
 import { Columns, Layout, Scale } from "../interfaces";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding a group of `calcite-action`s.
@@ -15,7 +20,7 @@ import { Columns, Layout, Scale } from "../interfaces";
   styleUrl: "calcite-action-group.scss",
   shadow: true
 })
-export class CalciteActionGroup {
+export class CalciteActionGroup implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -64,6 +69,20 @@ export class CalciteActionGroup {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteActionGroupElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
+++ b/src/components/calcite-action-menu/calcite-action-menu.e2e.ts
@@ -1,4 +1,4 @@
-import { accessible, hidden, renders, defaults, reflects, focusable } from "../../tests/commonTests";
+import { accessible, hidden, renders, defaults, reflects, focusable, slots } from "../../tests/commonTests";
 import { newE2EPage } from "@stencil/core/testing";
 import { SLOTS, CSS } from "./resources";
 import { html } from "../../tests/utils";
@@ -22,6 +22,8 @@ describe("calcite-action-menu", () => {
       <calcite-action text="Add" icon="plus"></calcite-action>
     </calcite-action-menu>
     `));
+
+  it("has slots", () => slots("calcite-action-menu", SLOTS));
 
   it("defaults", async () =>
     defaults("calcite-action-menu", [
@@ -70,24 +72,6 @@ describe("calcite-action-menu", () => {
         value: "auto"
       }
     ]));
-
-  it("honors tooltip slot", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-menu>
-      <calcite-tooltip slot="${SLOTS.tooltip}">Bits and bobs.</calcite-tooltip>
-      <calcite-action text="Add" icon="plus"></calcite-action>
-    </calcite-action-menu>`
-    });
-
-    await page.waitForChanges();
-
-    const tooltipManager = await page.find(`calcite-action-menu >>> calcite-tooltip-manager`);
-
-    expect(tooltipManager).toBeTruthy();
-
-    const tooltipSlot = await page.find(`calcite-action-menu >>> slot[name=${SLOTS.tooltip}]`);
-    expect(tooltipSlot).toBeTruthy();
-  });
 
   it("should emit 'calciteActionMenuOpenChange' event", async () => {
     const page = await newE2EPage({

--- a/src/components/calcite-action-menu/calcite-action-menu.tsx
+++ b/src/components/calcite-action-menu/calcite-action-menu.tsx
@@ -19,6 +19,11 @@ import { Placement } from "@popperjs/core";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
 import { createObserver } from "../../utils/observers";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 const SUPPORTED_BUTTON_NAV_KEYS = ["ArrowUp", "ArrowDown"];
 const SUPPORTED_MENU_NAV_KEYS = ["ArrowUp", "ArrowDown", "End", "Home"];
@@ -33,7 +38,7 @@ const SUPPORTED_MENU_NAV_KEYS = ["ArrowUp", "ArrowDown", "End", "Home"];
   styleUrl: "calcite-action-menu.scss",
   shadow: true
 })
-export class CalciteActionMenu {
+export class CalciteActionMenu implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -43,11 +48,13 @@ export class CalciteActionMenu {
   connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.getActions();
+    connectConditionalSlotComponent(this);
   }
 
   disconnectedCallback(): void {
     this.mutationObserver?.disconnect();
     this.disconnectMenuButtonEl();
+    disconnectConditionalSlotComponent(this);
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, focusable, hidden, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, reflects, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 import { html } from "../../tests/utils";
 
@@ -173,25 +173,7 @@ describe("calcite-action-pad", () => {
       }
     ));
 
-  it("honors 'expand-tooltip' slot", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-pad>
-        <calcite-tooltip slot="${SLOTS.expandTooltip}">Bits and bobs.</calcite-tooltip>
-        <calcite-action-group>
-          <calcite-action text="Add" icon="plus"></calcite-action>
-        </calcite-action-group>
-      </calcite-action-pad>`
-    });
-
-    await page.waitForChanges();
-
-    const tooltipManager = await page.find(`calcite-action-pad >>> calcite-tooltip-manager`);
-
-    expect(tooltipManager).toBeTruthy();
-
-    const tooltipSlot = await page.find(`calcite-action-pad >>> slot[name=${SLOTS.expandTooltip}]`);
-    expect(tooltipSlot).toBeTruthy();
-  });
+  it("has slots", () => slots("calcite-action-pad", SLOTS));
 
   it("'calciteActionMenuOpenChange' event should set other 'calcite-action-group' - 'menuOpen' to false", async () => {
     const page = await newE2EPage({

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -14,6 +14,11 @@ import { Layout, Position, Scale } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../functional/CalciteExpandToggle";
 import { focusElement, getSlotted } from "../../utils/dom";
 import { CSS, TEXT, SLOTS } from "./resources";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding `calcite-action`s to the action pad.
@@ -24,7 +29,7 @@ import { CSS, TEXT, SLOTS } from "./resources";
   styleUrl: "calcite-action-pad.scss",
   shadow: true
 })
-export class CalciteActionPad {
+export class CalciteActionPad implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -108,6 +113,14 @@ export class CalciteActionPad {
   //  Lifecycle
   //
   // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   componentWillLoad(): void {
     const { el, expandDisabled, expanded } = this;

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, SLOTS, TEXT } from "./resources";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, renders, slots } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
 describe("calcite-block", () => {
@@ -31,6 +31,8 @@ describe("calcite-block", () => {
         defaultValue: false
       }
     ]));
+
+  it("has slots", () => slots("calcite-block", SLOTS));
 
   it("is accessible", async () =>
     accessible(`
@@ -218,19 +220,6 @@ describe("calcite-block", () => {
       );
       const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
       expect(collapsibleIcon).toBeNull();
-    });
-
-    it("supports a header icon", async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        `<calcite-block heading="test-heading"><div class="header-icon" slot=${SLOTS.icon} /></calcite-block>`
-      );
-
-      const icon = await page.find(`.header-icon`);
-      expect(await icon.isVisible()).toBe(true);
-
-      const iconSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.icon}]`);
-      expect(await iconSlot.isVisible()).toBe(true);
     });
 
     it("displays a status icon instead of a header icon when `status` is an accepted value", async () => {

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -160,7 +160,7 @@ export class CalciteBlock implements ConditionalSlotComponent {
     const hasIcon = getSlotted(el, SLOTS.icon) || statusIcon;
 
     const iconEl = !statusIcon ? (
-      <slot name={SLOTS.icon} />
+      <slot key="icon-slot" name={SLOTS.icon} />
     ) : (
       <calcite-icon
         class={{

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -3,6 +3,11 @@ import { CSS, HEADING_LEVEL, ICONS, SLOTS, TEXT } from "./resources";
 import { getSlotted } from "../../utils/dom";
 import { CalciteHeading, HeadingLevel } from "../functional/CalciteHeading";
 import { Status } from "../interfaces";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding content to the block.
@@ -15,7 +20,7 @@ import { Status } from "../interfaces";
   styleUrl: "calcite-block.scss",
   shadow: true
 })
-export class CalciteBlock {
+export class CalciteBlock implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -94,6 +99,20 @@ export class CalciteBlock {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-chip/calcite-chip.e2e.ts
+++ b/src/components/calcite-chip/calcite-chip.e2e.ts
@@ -1,12 +1,14 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, renders } from "../../tests/commonTests";
+import { accessible, renders, slots } from "../../tests/commonTests";
 
-import { CSS } from "./resources";
+import { CSS, SLOTS } from "./resources";
 
 describe("calcite-chip", () => {
   it("renders", async () => renders("<calcite-chip>doritos</calcite-chip>", { display: "inline-flex" }));
 
   it("is accessible", async () => accessible(`<calcite-chip>doritos</calcite-chip>`));
+
+  it("has slots", () => slots("calcite-chip", SLOTS));
 
   it("should emit event after the close button is clicked", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -121,7 +121,7 @@ export class CalciteChip implements ConditionalSlotComponent {
     const hasChipImage = getSlotted(el, SLOTS.image);
 
     return hasChipImage ? (
-      <div class={CSS.chipImageContainer}>
+      <div class={CSS.chipImageContainer} key="image">
         <slot name={SLOTS.image} />
       </div>
     ) : null;

--- a/src/components/calcite-chip/calcite-chip.tsx
+++ b/src/components/calcite-chip/calcite-chip.tsx
@@ -4,6 +4,11 @@ import { guid } from "../../utils/guid";
 import { CSS, TEXT, SLOTS, ICONS } from "./resources";
 import { ChipColor } from "./interfaces";
 import { Appearance, Scale } from "../interfaces";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding text.
@@ -14,7 +19,7 @@ import { Appearance, Scale } from "../interfaces";
   styleUrl: "calcite-chip.scss",
   shadow: true
 })
-export class CalciteChip {
+export class CalciteChip implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
   //
   //  Public Properties
@@ -54,6 +59,20 @@ export class CalciteChip {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteChipElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/calcite-list-item/calcite-list-item.e2e.ts
+++ b/src/components/calcite-list-item/calcite-list-item.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { hidden, renders, focusable } from "../../tests/commonTests";
+import { hidden, renders, focusable, slots } from "../../tests/commonTests";
 import { defaults } from "../../tests/commonTests";
-import { CSS } from "./resources";
+import { CSS, SLOTS } from "./resources";
 
 describe("calcite-list-item", () => {
   it("renders", async () => renders("calcite-list-item", { display: "flex" }));
@@ -32,6 +32,8 @@ describe("calcite-list-item", () => {
         defaultValue: undefined
       }
     ]));
+
+  it("has slots", () => slots("calcite-list-item", SLOTS));
 
   it("renders content node when label is provided", async () => {
     const page = await newE2EPage({ html: `<calcite-list-item label="test"></calcite-list-item>` });

--- a/src/components/calcite-list-item/calcite-list-item.tsx
+++ b/src/components/calcite-list-item/calcite-list-item.tsx
@@ -1,6 +1,11 @@
 import { Component, Element, Prop, h, VNode, Host, Method } from "@stencil/core";
 import { SLOTS, CSS } from "./resources";
 import { getSlotted } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
@@ -14,7 +19,7 @@ import { getSlotted } from "../../utils/dom";
   styleUrl: "calcite-list-item.scss",
   shadow: true
 })
-export class CalciteListItem {
+export class CalciteListItem implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -50,6 +55,20 @@ export class CalciteListItem {
   @Element() el: HTMLCalciteListItemElement;
 
   focusEl: HTMLButtonElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -1,9 +1,12 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { focusable, renders } from "../../tests/commonTests";
+import { focusable, renders, slots } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
+import { SLOTS } from "./resources";
 
 describe("calcite-modal properties", () => {
   it("renders", () => renders("calcite-modal", { display: "flex", visible: false }));
+
+  it("has slots", () => slots("calcite-action-bar", SLOTS));
 
   it("adds localized strings set via intl-* props", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-modal/calcite-modal.e2e.ts
+++ b/src/components/calcite-modal/calcite-modal.e2e.ts
@@ -6,7 +6,7 @@ import { SLOTS } from "./resources";
 describe("calcite-modal properties", () => {
   it("renders", () => renders("calcite-modal", { display: "flex", visible: false }));
 
-  it("has slots", () => slots("calcite-action-bar", SLOTS));
+  it("has slots", () => slots("calcite-modal", SLOTS));
 
   it("adds localized strings set via intl-* props", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -26,6 +26,11 @@ import { Scale } from "../interfaces";
 import { ModalBackgroundColor } from "./interfaces";
 import { TEXT, SLOTS, CSS, ICONS } from "./resources";
 import { createObserver } from "../../utils/observers";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 const isFocusableExtended = (el: CalciteFocusableElement): boolean => {
   return isCalciteFocusable(el) || isFocusable(el);
@@ -48,7 +53,7 @@ const getFocusableElements = (el: HTMLElement | ShadowRoot): HTMLElement[] => {
   styleUrl: "calcite-modal.scss",
   shadow: true
 })
-export class CalciteModal {
+export class CalciteModal implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
   //
   //  Element
@@ -119,11 +124,13 @@ export class CalciteModal {
   connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.updateFooterVisibility();
+    connectConditionalSlotComponent(this);
   }
 
   disconnectedCallback(): void {
     this.removeOverflowHiddenClass();
     this.mutationObserver?.disconnect();
+    disconnectConditionalSlotComponent(this);
   }
 
   render(): VNode {

--- a/src/components/calcite-modal/calcite-modal.tsx
+++ b/src/components/calcite-modal/calcite-modal.tsx
@@ -170,7 +170,7 @@ export class CalciteModal implements ConditionalSlotComponent {
 
   renderFooter(): VNode {
     return this.hasFooter ? (
-      <div class={CSS.footer}>
+      <div class={CSS.footer} key="footer">
         <span class={CSS.back}>
           <slot name={SLOTS.back} />
         </span>
@@ -189,6 +189,7 @@ export class CalciteModal implements ConditionalSlotComponent {
       <button
         aria-label={this.intlClose}
         class={CSS.close}
+        key="button"
         onClick={this.close}
         ref={(el) => (this.closeButtonEl = el)}
         title={this.intlClose}

--- a/src/components/calcite-notice/calcite-notice.e2e.ts
+++ b/src/components/calcite-notice/calcite-notice.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, focusable, renders } from "../../tests/commonTests";
+import { accessible, focusable, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 import { html } from "../../tests/utils";
 
@@ -18,6 +18,8 @@ describe("calcite-notice", () => {
     accessible(`<calcite-notice dismissible active>${noticeContent}</calcite-notice>`));
   it("is accessible with icon and close button", async () =>
     accessible(`<calcite-notice icon dismissible active>${noticeContent}</calcite-notice>`));
+
+  it("has slots", () => slots("calcite-notice", SLOTS));
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
@@ -81,19 +83,6 @@ describe("calcite-notice", () => {
     await noticeclose1.click();
     await page.waitForTimeout(animationDurationInMs);
     expect(await notice1.isVisible()).not.toBe(true);
-  });
-
-  it("allows users to slot in a trailing action", async () => {
-    const page = await newE2EPage({
-      html: html` <calcite-notice active dismissible>
-        ${noticeContent}
-        <calcite-action label="banana" icon="banana" slot=${SLOTS.actionsEnd}></calcite-action>
-      </calcite-notice>`
-    });
-
-    const actionAssignedSlot = await page.$eval("calcite-action", (action) => action.assignedSlot.name);
-
-    expect(actionAssignedSlot).toBe(SLOTS.actionsEnd);
   });
 
   describe("focusable", () => {

--- a/src/components/calcite-notice/calcite-notice.tsx
+++ b/src/components/calcite-notice/calcite-notice.tsx
@@ -14,6 +14,11 @@ import { CSS, SLOTS, TEXT } from "./resources";
 import { Scale, Width } from "../interfaces";
 import { StatusColor, StatusIcons } from "../calcite-alert/interfaces";
 import { getSlotted, setRequestedIcon } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /** Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
  * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
@@ -33,7 +38,7 @@ import { getSlotted, setRequestedIcon } from "../../utils/dom";
   styleUrl: "calcite-notice.scss",
   shadow: true
 })
-export class CalciteNotice {
+export class CalciteNotice implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
   //
   //  Element
@@ -83,6 +88,14 @@ export class CalciteNotice {
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   componentWillLoad(): void {
     this.requestedIcon = setRequestedIcon(StatusIcons, this.icon, this.color);

--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, focusable, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-panel", () => {
@@ -18,6 +18,8 @@ describe("calcite-panel", () => {
         defaultValue: undefined
       }
     ]));
+
+  it("has slots", () => slots("calcite-panel", SLOTS));
 
   it("honors dismissed prop", async () => {
     const page = await newE2EPage();
@@ -184,34 +186,6 @@ describe("calcite-panel", () => {
 
     expect(actionsContainerStart).toBeNull();
     expect(actionsContainerEnd).toBeNull();
-  });
-
-  it("should render start actions containers header-actions-start", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      `<calcite-panel>
-        <calcite-action slot=${SLOTS.headerActionsStart} text="test start"></calcite-action>
-      </calcite-panel>`
-    );
-
-    const actionsContainerStart = await page.find(`calcite-panel >>> .${CSS.headerActionsStart}`);
-
-    expect(actionsContainerStart).not.toBeNull();
-  });
-
-  it("should render end actions containers header-actions-end", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      `<calcite-panel>
-        <calcite-action slot=${SLOTS.headerActionsEnd} text="test end"></calcite-action>
-      </calcite-panel>`
-    );
-
-    const actionsContainerEnd = await page.find(`calcite-panel >>> .${CSS.headerActionsEnd}`);
-
-    expect(actionsContainerEnd).not.toBeNull();
   });
 
   it("header-content should override heading and summary properties", async () => {

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -282,7 +282,7 @@ export class CalcitePanel implements ConditionalSlotComponent {
    */
   renderHeaderSlottedContent(): VNode {
     return (
-      <div class={CSS.headerContent} key="header-content">
+      <div class={CSS.headerContent} key="slotted-header-content">
         <slot name={SLOTS.headerContent} />
       </div>
     );
@@ -381,29 +381,16 @@ export class CalcitePanel implements ConditionalSlotComponent {
     ) : null;
   }
 
-  /**
-   * Allows user to override the entire footer node.
-   */
-  renderFooterSlottedContent(): VNode {
+  renderFooterNode(): VNode {
     const { el } = this;
 
     const hasFooterSlottedContent = getSlotted(el, SLOTS.footer);
-
-    return hasFooterSlottedContent ? (
-      <footer class={CSS.footer}>
-        <slot name={SLOTS.footer} />
-      </footer>
-    ) : null;
-  }
-
-  renderFooterActions(): VNode {
-    const { el } = this;
-
     const hasFooterActions = getSlotted(el, SLOTS.footerActions);
 
-    return hasFooterActions ? (
-      <footer class={CSS.footer}>
-        <slot name={SLOTS.footerActions} />
+    return hasFooterSlottedContent || hasFooterActions ? (
+      <footer class={CSS.footer} key="footer">
+        {hasFooterSlottedContent ? <slot key="footer-slot" name={SLOTS.footer} /> : null}
+        {hasFooterActions ? <slot key="footer-actions-slot" name={SLOTS.footerActions} /> : null}
       </footer>
     ) : null;
   }
@@ -456,7 +443,7 @@ export class CalcitePanel implements ConditionalSlotComponent {
       >
         {this.renderHeaderNode()}
         {this.renderContent()}
-        {this.renderFooterSlottedContent() || this.renderFooterActions()}
+        {this.renderFooterNode()}
       </article>
     );
 

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -15,6 +15,11 @@ import { getElementDir, getSlotted } from "../../utils/dom";
 import { Scale } from "../interfaces";
 import { HeadingLevel, CalciteHeading } from "../functional/CalciteHeading";
 import { SLOTS as ACTION_MENU_SLOTS } from "../calcite-action-menu/resources";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding custom content.
@@ -31,7 +36,7 @@ import { SLOTS as ACTION_MENU_SLOTS } from "../calcite-action-menu/resources";
   styleUrl: "calcite-panel.scss",
   shadow: true
 })
-export class CalcitePanel {
+export class CalcitePanel implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -131,6 +136,20 @@ export class CalcitePanel {
   dismissButtonEl: HTMLCalciteActionElement;
 
   containerEl: HTMLElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -337,6 +337,7 @@ export class CalcitePanel implements ConditionalSlotComponent {
     return hasMenuItems ? (
       <calcite-action-menu
         flipPlacements={["top", "bottom"]}
+        key="menu"
         label={intlOptions || TEXT.options}
         open={menuOpen}
         placement="bottom-end"

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
@@ -1,7 +1,8 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS } from "./resources";
-import { accessible, defaults, renders } from "../../tests/commonTests";
+import { accessible, defaults, renders, slots } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
+import { SLOTS } from "../calcite-action-bar/resources";
 
 describe("calcite-pick-list-group", () => {
   it("renders", async () => renders("calcite-pick-list-group", { display: "block" }));
@@ -24,6 +25,8 @@ describe("calcite-pick-list-group", () => {
         defaultValue: undefined
       }
     ]));
+
+  it("has slots", () => slots("calcite-pick-list-group", SLOTS));
 
   it("should render", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.e2e.ts
@@ -1,8 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { CSS } from "./resources";
+import { CSS, SLOTS } from "./resources";
 import { accessible, defaults, renders, slots } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
-import { SLOTS } from "../calcite-action-bar/resources";
 
 describe("calcite-pick-list-group", () => {
   it("renders", async () => renders("calcite-pick-list-group", { display: "block" }));

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -3,6 +3,11 @@ import { CSS, SLOTS } from "./resources";
 import { HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
 import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../functional/CalciteHeading";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
@@ -12,7 +17,7 @@ import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../function
   styleUrl: "./calcite-pick-list-group.scss",
   shadow: true
 })
-export class CalcitePickListGroup {
+export class CalcitePickListGroup implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -37,6 +42,20 @@ export class CalcitePickListGroup {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalcitePickListGroupElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
@@ -1,5 +1,5 @@
-import { CSS } from "./resources";
-import { accessible, renders } from "../../tests/commonTests";
+import { CSS, SLOTS } from "./resources";
+import { accessible, renders, slots } from "../../tests/commonTests";
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../tests/utils";
 
@@ -25,6 +25,8 @@ describe("calcite-pick-list-item", () => {
       </calcite-pick-list>
     `);
   });
+
+  it("has slots", () => slots("calcite-pick-list-item", SLOTS));
 
   it("should toggle selected attribute when clicked", async () => {
     const page = await newE2EPage({ html: `<calcite-pick-list-item label="test"></calcite-pick-list-item>` });
@@ -124,51 +126,5 @@ describe("calcite-pick-list-item", () => {
     await removeButton.click();
 
     expect(removeEventSpy).toHaveReceivedEventTimes(1);
-  });
-
-  it("should not render actions--end if there are no end actions", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" description="example"></calcite-pick-list-item>`
-    });
-
-    const actionsNodeEnd = await page.find(`calcite-pick-list-item >>> .${CSS.actionsEnd}`);
-
-    expect(actionsNodeEnd).toBeNull();
-  });
-
-  it("should not render actions--start if there are no start actions", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" description="example"></calcite-pick-list-item>`
-    });
-
-    const actionsNodeStart = await page.find(`calcite-pick-list-item >>> .${CSS.actionsStart}`);
-
-    expect(actionsNodeStart).toBeNull();
-  });
-
-  it("should render actions--end if there are end actions", async () => {
-    const page = await newE2EPage({
-      html: `
-      <calcite-pick-list-item label="test" description="example">
-        <calcite-action text="test" slot="actions-end"></calcite-action>
-      </calcite-pick-list-item>`
-    });
-
-    const actionsNodeEnd = await page.find(`calcite-pick-list-item >>> .${CSS.actionsEnd}`);
-
-    expect(actionsNodeEnd).not.toBeNull();
-  });
-
-  it("should render actions--start if there are start actions", async () => {
-    const page = await newE2EPage({
-      html: `
-      <calcite-pick-list-item label="test" description="example">
-        <calcite-action text="test" slot="actions-start"></calcite-action>
-      </calcite-pick-list-item>`
-    });
-
-    const actionsNodeStart = await page.find(`calcite-pick-list-item >>> .${CSS.actionsStart}`);
-
-    expect(actionsNodeStart).not.toBeNull();
   });
 });

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -13,6 +13,11 @@ import {
 import { CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { ICON_TYPES } from "../calcite-pick-list/resources";
 import { getSlotted } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot actions-end - a slot for adding actions or content to the end side of the item.
@@ -23,7 +28,7 @@ import { getSlotted } from "../../utils/dom";
   styleUrl: "./calcite-pick-list-item.scss",
   shadow: true
 })
-export class CalcitePickListItem {
+export class CalcitePickListItem implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -130,6 +135,20 @@ export class CalcitePickListItem {
   private focusEl: HTMLLabelElement;
 
   shiftPressed: boolean;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-shell-center-row/calcite-shell-center-row.e2e.ts
+++ b/src/components/calcite-shell-center-row/calcite-shell-center-row.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 
 import { CSS, SLOTS } from "./resources";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, renders, slots } from "../../tests/commonTests";
 
 describe("calcite-shell-center-row", () => {
   it("renders", async () => renders("calcite-shell-center-row", { display: "flex" }));
@@ -24,6 +24,8 @@ describe("calcite-shell-center-row", () => {
       }
     ]));
 
+  it("has slots", () => slots("calcite-shell-center-row", SLOTS));
+
   it("should not render action bar container when there is no action-bar", async () => {
     const page = await newE2EPage();
 
@@ -32,23 +34,6 @@ describe("calcite-shell-center-row", () => {
     const actionBarContainer = await page.find(`calcite-shell-center-row >>> .${CSS.actionBarContainer}`);
 
     expect(actionBarContainer).toBeNull();
-  });
-
-  it("should render action bar container when there is an action-bar", async () => {
-    const page = await newE2EPage();
-
-    const pageContent = `
-    <calcite-shell-center-row>
-      <calcite-action-bar slot=${SLOTS.actionBar}>
-        <calcite-action text="hello" icon="banana"></calcite-action>
-      </calcite-action-bar>
-    </calcite-shell-center-row>
-    `;
-    await page.setContent(pageContent);
-
-    const actionBarContainer = await page.find(`calcite-shell-center-row >>> .${CSS.actionBarContainer}`);
-
-    expect(actionBarContainer).not.toBeNull();
   });
 
   it("should render action bar container first when action bar has start position", async () => {

--- a/src/components/calcite-shell-center-row/calcite-shell-center-row.tsx
+++ b/src/components/calcite-shell-center-row/calcite-shell-center-row.tsx
@@ -79,7 +79,7 @@ export class CalciteShellCenterRow implements ConditionalSlotComponent {
     const actionBar = getSlotted<HTMLCalciteActionBarElement>(el, SLOTS.actionBar);
 
     const actionBarNode = actionBar ? (
-      <div class={CSS.actionBarContainer}>
+      <div class={CSS.actionBarContainer} key="action-bar">
         <slot name={SLOTS.actionBar} />
       </div>
     ) : null;

--- a/src/components/calcite-shell-center-row/calcite-shell-center-row.tsx
+++ b/src/components/calcite-shell-center-row/calcite-shell-center-row.tsx
@@ -2,6 +2,11 @@ import { Component, Element, Prop, h, VNode, Fragment } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { Position, Scale } from "../interfaces";
 import { getSlotted } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding content to the shell panel.
@@ -12,7 +17,7 @@ import { getSlotted } from "../../utils/dom";
   styleUrl: "calcite-shell-center-row.scss",
   shadow: true
 })
-export class CalciteShellCenterRow {
+export class CalciteShellCenterRow implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -41,6 +46,20 @@ export class CalciteShellCenterRow {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteShellCenterRowElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EElement, newE2EPage } from "@stencil/core/testing";
 
 import { CSS, SLOTS } from "./resources";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, renders, slots } from "../../tests/commonTests";
 import { getElementXY } from "../../tests/utils";
 
 describe("calcite-shell-panel", () => {
@@ -24,6 +24,8 @@ describe("calcite-shell-panel", () => {
         defaultValue: "Resize"
       }
     ]));
+
+  it("has slots", () => slots("calcite-shell-panel", SLOTS));
 
   it("has a slot", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -145,7 +145,7 @@ export class CalciteShellPanel implements ConditionalSlotComponent {
     const hasHeader = getSlotted(el, SLOTS.header);
 
     return hasHeader ? (
-      <div class={CSS.contentHeader}>
+      <div class={CSS.contentHeader} key="header">
         <slot name={SLOTS.header} />
       </div>
     ) : null;
@@ -170,6 +170,7 @@ export class CalciteShellPanel implements ConditionalSlotComponent {
       <div
         class={{ [CSS.content]: true, [CSS.contentDetached]: detached }}
         hidden={collapsed}
+        key="content"
         ref={this.storeContentEl}
         style={allowResizing && contentWidth ? { width: `${contentWidth}px` } : null}
       >
@@ -188,6 +189,7 @@ export class CalciteShellPanel implements ConditionalSlotComponent {
         aria-valuemin={contentWidthMin}
         aria-valuenow={contentWidth ?? initialContentWidth}
         class={CSS.separator}
+        key="separator"
         onKeyDown={this.separatorKeyDown}
         ref={this.connectSeparator}
         role="separator"
@@ -196,7 +198,7 @@ export class CalciteShellPanel implements ConditionalSlotComponent {
       />
     ) : null;
 
-    const actionBarNode = <slot name={SLOTS.actionBar} />;
+    const actionBarNode = <slot key="action-bar" name={SLOTS.actionBar} />;
 
     const mainNodes = [actionBarNode, contentNode, separatorNode];
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -14,6 +14,11 @@ import { CSS, SLOTS, TEXT } from "./resources";
 import { Position, Scale } from "../interfaces";
 import { getSlotted, getElementDir } from "../../utils/dom";
 import { clamp } from "../../utils/math";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding content to the shell panel.
@@ -24,7 +29,7 @@ import { clamp } from "../../utils/math";
   styleUrl: "calcite-shell-panel.scss",
   shadow: true
 })
-export class CalciteShellPanel {
+export class CalciteShellPanel implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -79,7 +84,12 @@ export class CalciteShellPanel {
   //
   //--------------------------------------------------------------------------
 
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
   disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
     this.disconnectSeparator();
   }
 

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, hidden, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-shell", () => {
@@ -19,6 +19,8 @@ describe("calcite-shell", () => {
     expect(header).toBeNull();
   });
 
+  it("has slots", () => slots("calcite-shell", SLOTS));
+
   it("content node should always be present", async () => {
     const page = await newE2EPage();
 
@@ -27,26 +29,6 @@ describe("calcite-shell", () => {
     const content = await page.find(`calcite-shell >>> .${CSS.content}`);
 
     expect(content).not.toBeNull();
-  });
-
-  it("footer should be present when defined", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`<calcite-shell><div slot="${SLOTS.footer}">Footer</div></calcite-shell>`);
-
-    const footer = await page.find(`calcite-shell >>> slot[name="${SLOTS.footer}"]`);
-
-    expect(footer).not.toBeNull();
-  });
-
-  it("header should be present when defined", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`<calcite-shell><div slot="${SLOTS.header}">Header</div></calcite-shell>`);
-
-    const header = await page.find(`calcite-shell >>> slot[name="${SLOTS.header}"]`);
-
-    expect(header).not.toBeNull();
   });
 
   it("should be accessible", async () =>

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -1,6 +1,11 @@
 import { Component, Element, Prop, h, VNode, Fragment } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { getSlotted } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding content to the shell. This content will appear between any leading and trailing panels added to the shell. (eg. a map)
@@ -15,7 +20,7 @@ import { getSlotted } from "../../utils/dom";
   styleUrl: "calcite-shell.scss",
   shadow: true
 })
-export class CalciteShell {
+export class CalciteShell implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -34,6 +39,20 @@ export class CalciteShell {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteShellElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -63,7 +63,7 @@ export class CalciteShell implements ConditionalSlotComponent {
   renderHeader(): VNode {
     const hasHeader = !!getSlotted(this.el, SLOTS.header);
 
-    return hasHeader ? <slot name={SLOTS.header} /> : null;
+    return hasHeader ? <slot key="header" name={SLOTS.header} /> : null;
   }
 
   renderContent(): VNode[] {
@@ -93,7 +93,7 @@ export class CalciteShell implements ConditionalSlotComponent {
     const hasFooter = !!getSlotted(this.el, SLOTS.footer);
 
     return hasFooter ? (
-      <div class={CSS.footer}>
+      <div class={CSS.footer} key="footer">
         <slot name={SLOTS.footer} />
       </div>
     ) : null;

--- a/src/components/calcite-tile/calcite-tile.tsx
+++ b/src/components/calcite-tile/calcite-tile.tsx
@@ -1,6 +1,11 @@
 import { Component, Element, Fragment, h, Prop, VNode } from "@stencil/core";
 import { SLOTS } from "./resources";
 import { getSlotted } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot content-start - A slot for adding non-actionable elements before the tile content.
@@ -11,7 +16,7 @@ import { getSlotted } from "../../utils/dom";
   styleUrl: "calcite-tile.scss",
   shadow: true
 })
-export class CalciteTile {
+export class CalciteTile implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Private Properties
@@ -57,6 +62,20 @@ export class CalciteTile {
 
   /** The icon that appears at the top of the tile. */
   @Prop({ reflect: true }) icon?: string;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-tip/calcite-tip.e2e.ts
+++ b/src/components/calcite-tip/calcite-tip.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, hidden, renders, defaults } from "../../tests/commonTests";
-import { CSS } from "./resources";
+import { accessible, hidden, renders, defaults, slots } from "../../tests/commonTests";
+import { CSS, SLOTS } from "./resources";
 
 describe("calcite-tip", () => {
   it("renders", async () => renders("calcite-tip", { display: "flex" }));
@@ -16,6 +16,8 @@ describe("calcite-tip", () => {
     ]));
 
   it("is accessible", async () => accessible(`<calcite-tip heading="sample"><p>not dismissible</p></calcite-tip>`));
+
+  it("has slots", () => slots("calcite-tip", SLOTS));
 
   it("should remove the closeButton if nonDismissible prop is true", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -2,6 +2,11 @@ import { Component, Element, Event, EventEmitter, Prop, h, VNode, Fragment } fro
 import { CSS, ICONS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
 import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../functional/CalciteHeading";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding text and a hyperlink.
@@ -12,7 +17,7 @@ import { HeadingLevel, CalciteHeading, constrainHeadingLevel } from "../function
   styleUrl: "./calcite-tip.scss",
   shadow: true
 })
-export class CalciteTip {
+export class CalciteTip implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -55,6 +60,20 @@ export class CalciteTip {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteTipElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -139,7 +139,7 @@ export class CalciteTip implements ConditionalSlotComponent {
     const { el } = this;
 
     return getSlotted(el, SLOTS.thumbnail) ? (
-      <div class={CSS.imageFrame}>
+      <div class={CSS.imageFrame} key="thumbnail">
         <slot name={SLOTS.thumbnail} />
       </div>
     ) : null;

--- a/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
+++ b/src/components/calcite-tree-item/calcite-tree-item.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, renders, defaults } from "../../tests/commonTests";
+import { accessible, renders, defaults, slots } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
+import { SLOTS } from "./resources";
 
 describe("calcite-tree-item", () => {
   it("renders", async () => renders("calcite-tree-item", { visible: false, display: "block" }));
@@ -44,6 +45,8 @@ describe("calcite-tree-item", () => {
       },
       { propertyName: "indeterminate", defaultValue: undefined }
     ]));
+
+  it("has slots", () => slots("calcite-tree-item", SLOTS));
 
   it("should expand/collapse children when the icon is clicked, but not select/deselect group", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-tree-item/calcite-tree-item.tsx
+++ b/src/components/calcite-tree-item/calcite-tree-item.tsx
@@ -17,6 +17,11 @@ import { nodeListToArray, getElementDir, filterDirectChildren, getSlotted } from
 import { Scale } from "../interfaces";
 import { CSS, SLOTS, ICONS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot - A slot for adding content to the item.
@@ -27,7 +32,7 @@ import { CSS_UTILITY } from "../../utils/resources";
   styleUrl: "calcite-tree-item.scss",
   shadow: true
 })
-export class CalciteTreeItem {
+export class CalciteTreeItem implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
   //
   //  Element
@@ -96,6 +101,11 @@ export class CalciteTreeItem {
       const { expanded } = this.parentTreeItem;
       this.updateParentIsExpanded(this.parentTreeItem, expanded);
     }
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
   }
 
   componentWillRender(): void {

--- a/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.e2e.ts
@@ -1,5 +1,5 @@
-import { CSS as PICK_LIST_ITEM_CSS } from "../calcite-pick-list-item/resources";
-import { accessible, focusable, renders } from "../../tests/commonTests";
+import { CSS as PICK_LIST_ITEM_CSS, SLOTS } from "../calcite-pick-list-item/resources";
+import { accessible, focusable, renders, slots } from "../../tests/commonTests";
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../tests/utils";
 
@@ -25,6 +25,8 @@ describe("calcite-value-list-item", () => {
       </calcite-value-list>
     `);
   });
+
+  it("has slots", () => slots("calcite-value-list-item", SLOTS));
 
   it("is focusable", async () => focusable("calcite-value-list-item"));
 
@@ -124,31 +126,5 @@ describe("calcite-value-list-item", () => {
     await queryWrappedPickListPart(page, `.${PICK_LIST_ITEM_CSS.remove}`, "click");
 
     expect(removeEventSpy).toHaveReceivedEventTimes(1);
-  });
-
-  it("supports adding start-actions", async () => {
-    const page = await newE2EPage({
-      html: `
-      <calcite-value-list-item label="test" description="example">
-        <calcite-action text="test" slot="actions-start"></calcite-action>
-      </calcite-value-list-item>`
-    });
-
-    const actionsNodeStart = await queryWrappedPickListPart(page, `.${PICK_LIST_ITEM_CSS.actionsStart}`);
-
-    expect(actionsNodeStart).not.toBeNull();
-  });
-
-  it("supports adding end-actions", async () => {
-    const page = await newE2EPage({
-      html: `
-      <calcite-value-list-item label="test" description="example">
-        <calcite-action text="test" slot="actions-end"></calcite-action>
-      </calcite-value-list-item>`
-    });
-
-    const actionsNodeEnd = await queryWrappedPickListPart(page, `.${PICK_LIST_ITEM_CSS.actionsEnd}`);
-
-    expect(actionsNodeEnd).not.toBeNull();
   });
 });

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -16,6 +16,11 @@ import { CSS } from "../calcite-pick-list-item/resources";
 import { ICONS, SLOTS } from "./resources";
 import { SLOTS as PICK_LIST_SLOTS } from "../calcite-pick-list-item/resources";
 import { getSlotted } from "../../utils/dom";
+import {
+  ConditionalSlotComponent,
+  connectConditionalSlotComponent,
+  disconnectConditionalSlotComponent
+} from "../../utils/conditionalSlot";
 
 /**
  * @slot actions-end - A slot for adding actions or content to the end side of the item.
@@ -26,7 +31,7 @@ import { getSlotted } from "../../utils/dom";
   styleUrl: "./calcite-value-list-item.scss",
   shadow: true
 })
-export class CalciteValueListItem {
+export class CalciteValueListItem implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -100,6 +105,20 @@ export class CalciteValueListItem {
   pickListItem: HTMLCalcitePickListItemElement = null;
 
   guid = `calcite-value-list-item-${guid()}`;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    connectConditionalSlotComponent(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectConditionalSlotComponent(this);
+  }
 
   // --------------------------------------------------------------------------
   //

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -197,6 +197,7 @@ export async function slots(componentTagOrHTML: TagOrHTML, slots: Record<string,
         el.slot = slot;
 
         component.append(el);
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
       }
     },
     slotNames

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -205,13 +205,13 @@ export async function slots(componentTagOrHTML: TagOrHTML, slots: Record<string,
 
   await page.waitForChanges();
 
-  const allSlotsAssigned = await page.evaluate(() => {
-    return Array.from(document.getElementsByClassName("slotted"))
-      .map((slotted) => slotted.assignedSlot)
-      .every((assignedSlot) => !!assignedSlot);
-  });
+  const slotted = await page.evaluate(() =>
+    Array.from(document.getElementsByClassName("slotted"))
+      .filter((slotted) => slotted.assignedSlot)
+      .map((slotted) => slotted.slot)
+  );
 
-  expect(allSlotsAssigned).toBe(true);
+  expect(slotNames).toEqual(slotted);
 }
 
 async function assertLabelable({


### PR DESCRIPTION
**Related Issue:** #3686 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR updates components that were already using `getSlotted` for conditionally rendering their named slots to use the interface and utils from the `conditionalSlot.ts` util.

### Notable changes

1. Refactored the conditional slot helpers to ensure components rerender when elements are appended after initialization
2. Enhanced the `slots` test helper to help test conditional rendering
3. Refactored `calcite-panel`'s footer slot rendering to render both slots†

† **Reasoning for 3**:

* Both footer and footer-action slot rendering are identical except for the named slot (see https://github.com/Esri/calcite-components/blob/5b4793b7aae448e785fdaa06ad6824eb10cc6715/src/components/calcite-panel/calcite-panel.tsx#L387-L409)
* The usage of ☝️ (see https://github.com/Esri/calcite-components/blob/5b4793b7aae448e785fdaa06ad6824eb10cc6715/src/components/calcite-panel/calcite-panel.tsx#L459) indicates that it is invalid to slot both footer and footer-action elements, so we can render both and rely on the doc (sidebar: if both slots are identical, can we drop one in favor of the other?)
* It makes it easier to set up and use the test helper, otherwise we need a way to let the test helper know how slots are related to each other (I'd like to avoid this if possible)