### PR TITLE
feat(input-date-picker): add calciteInputDatePickerChange event

### DIFF
--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.e2e.ts
@@ -17,92 +17,90 @@ describe("calcite-input-date-picker", () => {
 
   it("is labelable", async () => labelable("calcite-input-date-picker"));
 
-  it("fires a calciteDatePickerChange event on change", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-input-date-picker></calcite-input-date-picker>");
-    const input = (
-      await page.waitForFunction(() =>
-        document
-          .querySelector("calcite-input-date-picker")
-          .shadowRoot.querySelector("calcite-input")
-          .shadowRoot.querySelector("input")
-      )
-    ).asElement();
-    await input.focus();
-    await page.waitForChanges();
-    const changedEvent = await page.spyOnEvent("calciteDatePickerChange");
-    await page.waitForTimeout(animationDurationInMs);
-    const wrapper = (
-      await page.waitForFunction(() =>
-        document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(".calendar-picker-wrapper")
-      )
-    ).asElement();
-    expect(await wrapper.isIntersectingViewport()).toBe(true);
+  describe("event emitting when the value changes", () => {
+    it("emits when configured for single date", async () => {
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input-date-picker></calcite-input-date-picker>");
+      const input = await page.find("calcite-input-date-picker");
+      await input.callMethod("setFocus");
+      await page.waitForChanges();
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+      const deprecatedChangeEvent = await page.spyOnEvent("calciteDatePickerChange");
+      await page.waitForTimeout(animationDurationInMs);
+      const wrapper = (
+        await page.waitForFunction(() =>
+          document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(".calendar-picker-wrapper")
+        )
+      ).asElement();
+      expect(await wrapper.isIntersectingViewport()).toBe(true);
 
-    await input.press("3");
-    await input.press("/");
-    await input.press("7");
-    await input.press("/");
-    await input.press("2");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(1);
-    await input.press("0");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(2);
-    await input.press("2");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(3);
-    await input.press("0");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(4);
-    const element = await page.find("calcite-input-date-picker");
-    expect(await element.getProperty("value")).toBe("2020-03-07");
-    expect(await element.getProperty("valueAsDate")).toBeDefined();
-  });
+      await input.press("3");
+      await input.press("/");
+      await input.press("7");
+      await input.press("/");
+      await input.press("2");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(1);
+      await input.press("0");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(2);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(2);
+      await input.press("2");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(3);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(3);
+      await input.press("0");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(4);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(4);
+      const element = await page.find("calcite-input-date-picker");
+      expect(await element.getProperty("value")).toBe("2020-03-07");
+      expect(await element.getProperty("valueAsDate")).toBeDefined();
+    });
 
-  it("fires a calciteDatePickerRangeChange event on change", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-input-date-picker range></calcite-input-date-picker>");
-    const input = (
-      await page.waitForFunction(() =>
-        document
-          .querySelector("calcite-input-date-picker")
-          .shadowRoot.querySelector("calcite-input")
-          .shadowRoot.querySelector("input")
-      )
-    ).asElement();
-    await input.focus();
-    await page.waitForChanges();
-    const changedEvent = await page.spyOnEvent("calciteDatePickerRangeChange");
-    await page.waitForTimeout(animationDurationInMs);
-    const wrapper = (
-      await page.waitForFunction(() =>
-        document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(".calendar-picker-wrapper")
-      )
-    ).asElement();
-    expect(await wrapper.isIntersectingViewport()).toBe(true);
+    it("emits when configured for date range", async () => {
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input-date-picker range></calcite-input-date-picker>");
+      const input = await page.find("calcite-input-date-picker");
+      await input.callMethod("setFocus");
+      await page.waitForChanges();
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+      const deprecatedChangeEvent = await page.spyOnEvent("calciteDatePickerRangeChange");
+      await page.waitForTimeout(animationDurationInMs);
+      const wrapper = (
+        await page.waitForFunction(() =>
+          document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(".calendar-picker-wrapper")
+        )
+      ).asElement();
+      expect(await wrapper.isIntersectingViewport()).toBe(true);
 
-    await input.press("3");
-    await input.press("/");
-    await input.press("7");
-    await input.press("/");
-    await input.press("2");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(1);
-    await input.press("0");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(2);
-    await input.press("2");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(3);
-    await input.press("0");
-    await page.waitForChanges();
-    expect(changedEvent).toHaveReceivedEventTimes(4);
-    const element = await page.find("calcite-input-date-picker");
-    element.setProperty("end", "2020-03-05");
-    await page.waitForChanges();
-    expect(await element.getProperty("start")).toBe("2020-03-07");
-    expect(await element.getProperty("startAsDate")).toBeDefined();
+      await input.press("3");
+      await input.press("/");
+      await input.press("7");
+      await input.press("/");
+      await input.press("2");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(1);
+      await input.press("0");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(2);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(2);
+      await input.press("2");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(3);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(3);
+      await input.press("0");
+      await page.waitForChanges();
+      expect(changeEvent).toHaveReceivedEventTimes(4);
+      expect(deprecatedChangeEvent).toHaveReceivedEventTimes(4);
+      const element = await page.find("calcite-input-date-picker");
+      element.setProperty("end", "2020-03-05");
+      await page.waitForChanges();
+      expect(await element.getProperty("start")).toBe("2020-03-07");
+      expect(await element.getProperty("startAsDate")).toBeDefined();
+    });
   });
 
   it("should clear active date properly when deleted via keyboard", async () => {

--- a/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
+++ b/src/components/calcite-input-date-picker/calcite-input-date-picker.tsx
@@ -194,6 +194,12 @@ export class CalciteInputDatePicker implements LabelableComponent, FormComponent
   //
   //--------------------------------------------------------------------------
 
+  @Listen("calciteDatePickerChange")
+  @Listen("calciteDatePickerRangeChange")
+  handleDateOrRangeChange(): void {
+    this.calciteInputDatePickerChange.emit();
+  }
+
   @Listen("calciteDaySelect")
   calciteDaySelectHandler(): void {
     if (this.shouldFocusRangeStart() || this.shouldFocusRangeEnd()) {
@@ -210,14 +216,23 @@ export class CalciteInputDatePicker implements LabelableComponent, FormComponent
   //--------------------------------------------------------------------------
   /**
    * Trigger calcite date change when a user changes the date.
+   *
+   * @deprecated use `calciteInputDatePickerChange` instead.
    */
   @Event() calciteDatePickerChange: EventEmitter<Date>;
 
   /**
    * Trigger calcite date change when a user changes the date range.
    * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-date-picker/interfaces.ts#L1)
+   *
+   * @deprecated use `calciteInputDatePickerChange` instead.
    */
   @Event() calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
+
+  /**
+   * This event fires when the input date picker value changes.
+   */
+  @Event() calciteInputDatePickerChange: EventEmitter<void>;
 
   /**
    * @internal


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Stems from https://github.com/Esri/calcite-components/issues/3659.

This introduces an `calciteInputDatePickerChange` event and deprecates the use of `calciteDatePickerChange` and `calciteDatePickerRangeChange` from that component since they should be considered internal. 