### PR TITLE
fix(radio-button): show selection in high contrast

### DIFF
--- a/src/components/calcite-radio-button/calcite-radio-button.scss
+++ b/src/components/calcite-radio-button/calcite-radio-button.scss
@@ -82,4 +82,17 @@
   }
 }
 
+@media (forced-colors: active) {
+  :host([checked]),
+  :host([checked][disabled]) {
+    .radio::after {
+      content: "";
+      width: 1rem;
+      height: 1rem;
+      background-color: windowText;
+      display: block;
+    }
+  }
+}
+
 @include hidden-form-input();


### PR DESCRIPTION
**Related Issue:** #3875 

## Summary
cherry picked the commit from the external PR linked above so that all of the CI runs correctly.

---

Produces following UI on browsers with OS in high contrast mode.

Firefox 95
<img width="964" alt="Screen Shot 2022-01-07 at 8 10 37 AM" src="https://user-images.githubusercontent.com/142636/148555833-a709af1b-a905-4e1d-ab05-1bbc12e0e144.png">

Chrome 97
<img width="964" alt="Screen Shot 2022-01-07 at 8 12 34 AM" src="https://user-images.githubusercontent.com/142636/148556090-aa5e9b92-2fdb-46c9-b9ba-4a254a62c331.png">

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
