### PR TITLE
chore(ci): remove obsolete check for valid new issues

### DIFF
--- a/.github/need-info.yml
+++ b/.github/need-info.yml
@@ -3,13 +3,6 @@ labelsToCheck:
   - bug
 commentHeader: "More information is required to proceed with this issue:"
 requiredItems:
-  - response: "- Copy the appropriate [issue template](https://github.com/Esri/calcite-components/issues/new/choose) format and paste it into a comment, providing all of the requested items"
-    requireAll: true
-    content:
-      - "### Actual Behavior"
-      - "### Expected Behavior"
-      - "### Reproduction Steps and Sample"
-      - "### Relevant Info"
   - response: "- Provide a [codepen](https://codepen.io/pen?template=RwgrjEx), [codesandbox](https://codesandbox.io/s/calcite-template-p95kp?file=/src/App.js), or [jsbin](https://jsbin.com/zocobeqopu/edit?html,css,js,output) that reproduces the issue. Alternatively, a [documentation](https://developers.arcgis.com/calcite-design-system/components/) sample can be used if the issue is reproducible."
     requireAll: false
     content:


### PR DESCRIPTION
**Related Issue:** #3893

## Summary
The new issue template format installed in the PR linked above can mark sections as required. Therefore we no longer need to check to see if all sections are included
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
