### PR TITLE
ci(screener): updating to Chrome latest

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -9,7 +9,7 @@ module.exports = {
   browsers: [
     {
       browserName: "chrome",
-      version: "latest"
+      version: "97"
     }
   ],
   diffOptions: {

--- a/screener.config.js
+++ b/screener.config.js
@@ -9,7 +9,7 @@ module.exports = {
   browsers: [
     {
       browserName: "chrome",
-      version: "89.0"
+      version: "latest"
     }
   ],
   diffOptions: {

--- a/screener.config.js
+++ b/screener.config.js
@@ -9,7 +9,7 @@ module.exports = {
   browsers: [
     {
       browserName: "chrome",
-      version: "87.0"
+      version: "89.0"
     }
   ],
   diffOptions: {


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
