### PR TITLE
chore(action): install cached packages on all check runs

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           node-version: lts/*
           cache: npm
+      - run: npm install
       - if: steps.testable.outputs.skip == 'false'
-        run: |
-          npm install
-          npm test
+        run: npm test

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           node-version: lts/*
           cache: npm
+      - run: npm install
       - if: steps.one.outputs.skip == 'screen'
         name: run screener check
         env:
@@ -46,9 +47,7 @@ jobs:
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
           SAUCE_ACCESS_NAME: ${{ secrets.SAUCE_ACCESS_NAME}}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: |
-          npm install
-          npm run test:storybook || true
+        run: npm run test:storybook || true
       - if: steps.one.outputs.skip == 'skip'
         name: skip screener
         uses: Sibz/github-status-action@v1


### PR DESCRIPTION
**Related Issue:** #3934

## Summary
The e2e and screener checks are set up to skip installing deps and running the tests on markdown-only PRs. I then ended up caching the npm deps for all actions. Apparently if you cache the deps and the action run doesn't install any, it throws an error on clean up: https://github.com/actions/setup-node/issues/317#issuecomment-912336228

- I moved the install outside of the conditional. 
- Performance on all PRs that have non-markdown changes won't change
- Markdown only PRs shouldn't be too bad since the packages are cached
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
