### PR TITLE
ci(screener): ignore overview stories

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -20,5 +20,6 @@ module.exports = {
     username: process.env.SAUCE_ACCESS_NAME,
     accessKey: process.env.SAUCE_ACCESS_KEY,
     maxConcurrent: 10
-  }
+  },
+  excludeRules: [/^Overview/]
 };


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

This PR updates the screener config to ignore the "Overview" stories.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
