### PR TITLE
fix(accordion): no longer has white background when set to transparent

### DIFF
--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -29,26 +29,13 @@
 }
 
 :host {
-  --calcite-accordion-item-background: theme("backgroundColor.foreground.1");
-}
-
-:host([appearance="minimal"]) {
-  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
-}
-:host([appearance="transparent"]) {
-  --calcite-accordion-item-border: transparent;
-  --calcite-accordion-item-background: transparent;
-}
-
-:host {
   @apply flex
     flex-col
     no-underline
     outline-none
     relative
     text-color-3;
-  background-color: var(--calcite-accordion-item-background);
-  --calcite-accordion-item-border: theme("borderColor.color.2");
+  background-color: var(--calcite-accordion-item-background, theme("backgroundColor.foreground.1"));
 }
 
 // focus styles
@@ -90,7 +77,7 @@
 :host .accordion-item-content,
 :host .accordion-item-header {
   padding: var(--calcite-accordion-item-padding);
-  border-bottom: 1px solid var(--calcite-accordion-item-border);
+  border-bottom: 1px solid var(--calcite-accordion-item-border, theme("borderColor.color.2"));
 }
 
 :host .accordion-item-header * {

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -32,10 +32,10 @@
   --calcite-accordion-item-background: theme("backgroundColor.foreground.1");
 }
 
-:host-context([appearance="minimal"]) {
+:host(.accordion-item-minimal) {
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
 }
-:host-context([appearance="transparent"]) {
+:host(.accordion-item-transparent) {
   --calcite-accordion-item-border: transparent;
   --calcite-accordion-item-background: transparent;
 }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.scss
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.scss
@@ -32,10 +32,10 @@
   --calcite-accordion-item-background: theme("backgroundColor.foreground.1");
 }
 
-:host(.accordion-item-minimal) {
+:host([appearance="minimal"]) {
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
 }
-:host(.accordion-item-transparent) {
+:host([appearance="transparent"]) {
   --calcite-accordion-item-border: transparent;
   --calcite-accordion-item-background: transparent;
 }

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -107,48 +107,41 @@ export class CalciteAccordionItem {
 
     const iconEl = <calcite-icon class="accordion-item-icon" icon={this.icon} scale="s" />;
 
-    const appearanceClasses = {
-      "accordion-item-minimal": this.appearance === "minimal",
-      "accordion-item-transparent": this.appearance === "transparent"
-    };
-
     return (
       <Host aria-expanded={this.active.toString()} tabindex="0">
-        <div class={appearanceClasses}>
+        <div
+          class={{
+            [`icon-position--${this.iconPosition}`]: true,
+            [`icon-type--${this.iconType}`]: true
+          }}
+        >
           <div
-            class={{
-              [`icon-position--${this.iconPosition}`]: true,
-              [`icon-type--${this.iconType}`]: true
-            }}
+            class={{ "accordion-item-header": true, [CSS_UTILITY.rtl]: dir === "rtl" }}
+            onClick={this.itemHeaderClickHandler}
           >
-            <div
-              class={{ "accordion-item-header": true, [CSS_UTILITY.rtl]: dir === "rtl" }}
-              onClick={this.itemHeaderClickHandler}
-            >
-              {this.icon ? iconEl : null}
-              <div class="accordion-item-header-text">
-                <span class="accordion-item-title">{this.itemTitle}</span>
-                {this.itemSubtitle ? (
-                  <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
-                ) : null}
-              </div>
-              <calcite-icon
-                class="accordion-item-expand-icon"
-                icon={
-                  this.iconType === "chevron"
-                    ? "chevronDown"
-                    : this.iconType === "caret"
-                    ? "caretDown"
-                    : this.active
-                    ? "minus"
-                    : "plus"
-                }
-                scale="s"
-              />
+            {this.icon ? iconEl : null}
+            <div class="accordion-item-header-text">
+              <span class="accordion-item-title">{this.itemTitle}</span>
+              {this.itemSubtitle ? (
+                <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
+              ) : null}
             </div>
-            <div class="accordion-item-content">
-              <slot />
-            </div>
+            <calcite-icon
+              class="accordion-item-expand-icon"
+              icon={
+                this.iconType === "chevron"
+                  ? "chevronDown"
+                  : this.iconType === "caret"
+                  ? "caretDown"
+                  : this.active
+                  ? "minus"
+                  : "plus"
+              }
+              scale="s"
+            />
+          </div>
+          <div class="accordion-item-content">
+            <slot />
           </div>
         </div>
       </Host>

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -12,7 +12,6 @@ import {
 import { getElementDir, getElementProp } from "../../utils/dom";
 
 import { CSS_UTILITY } from "../../utils/resources";
-import { AccordionAppearance } from "../calcite-accordion/interfaces";
 import { Position } from "../interfaces";
 
 /**
@@ -50,11 +49,6 @@ export class CalciteAccordionItem {
   /** optionally pass an icon to display - accepts Calcite UI icon names  */
   @Prop({ reflect: true }) icon?: string;
 
-  /**
-   * @internal
-   */
-  @Prop({ reflect: true })
-  appearance: AccordionAppearance;
   //--------------------------------------------------------------------------
   //
   //  Events

--- a/src/components/calcite-accordion-item/calcite-accordion-item.tsx
+++ b/src/components/calcite-accordion-item/calcite-accordion-item.tsx
@@ -12,6 +12,7 @@ import {
 import { getElementDir, getElementProp } from "../../utils/dom";
 
 import { CSS_UTILITY } from "../../utils/resources";
+import { AccordionAppearance } from "../calcite-accordion/interfaces";
 import { Position } from "../interfaces";
 
 /**
@@ -49,6 +50,11 @@ export class CalciteAccordionItem {
   /** optionally pass an icon to display - accepts Calcite UI icon names  */
   @Prop({ reflect: true }) icon?: string;
 
+  /**
+   * @internal
+   */
+  @Prop({ reflect: true })
+  appearance: AccordionAppearance;
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -101,41 +107,48 @@ export class CalciteAccordionItem {
 
     const iconEl = <calcite-icon class="accordion-item-icon" icon={this.icon} scale="s" />;
 
+    const appearanceClasses = {
+      "accordion-item-minimal": this.appearance === "minimal",
+      "accordion-item-transparent": this.appearance === "transparent"
+    };
+
     return (
       <Host aria-expanded={this.active.toString()} tabindex="0">
-        <div
-          class={{
-            [`icon-position--${this.iconPosition}`]: true,
-            [`icon-type--${this.iconType}`]: true
-          }}
-        >
+        <div class={appearanceClasses}>
           <div
-            class={{ "accordion-item-header": true, [CSS_UTILITY.rtl]: dir === "rtl" }}
-            onClick={this.itemHeaderClickHandler}
+            class={{
+              [`icon-position--${this.iconPosition}`]: true,
+              [`icon-type--${this.iconType}`]: true
+            }}
           >
-            {this.icon ? iconEl : null}
-            <div class="accordion-item-header-text">
-              <span class="accordion-item-title">{this.itemTitle}</span>
-              {this.itemSubtitle ? (
-                <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
-              ) : null}
+            <div
+              class={{ "accordion-item-header": true, [CSS_UTILITY.rtl]: dir === "rtl" }}
+              onClick={this.itemHeaderClickHandler}
+            >
+              {this.icon ? iconEl : null}
+              <div class="accordion-item-header-text">
+                <span class="accordion-item-title">{this.itemTitle}</span>
+                {this.itemSubtitle ? (
+                  <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
+                ) : null}
+              </div>
+              <calcite-icon
+                class="accordion-item-expand-icon"
+                icon={
+                  this.iconType === "chevron"
+                    ? "chevronDown"
+                    : this.iconType === "caret"
+                    ? "caretDown"
+                    : this.active
+                    ? "minus"
+                    : "plus"
+                }
+                scale="s"
+              />
             </div>
-            <calcite-icon
-              class="accordion-item-expand-icon"
-              icon={
-                this.iconType === "chevron"
-                  ? "chevronDown"
-                  : this.iconType === "caret"
-                  ? "caretDown"
-                  : this.active
-                  ? "minus"
-                  : "plus"
-              }
-              scale="s"
-            />
-          </div>
-          <div class="accordion-item-content">
-            <slot />
+            <div class="accordion-item-content">
+              <slot />
+            </div>
           </div>
         </div>
       </Host>

--- a/src/components/calcite-accordion/calcite-accordion.scss
+++ b/src/components/calcite-accordion/calcite-accordion.scss
@@ -33,12 +33,13 @@
   --calcite-accordion-item-background: theme("backgroundColor.foreground.1");
 }
 
-:host([appearance="minimal"]) {
-  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
-  border-color: transparent;
-}
-:host([appearance="transparent"]) {
+.accordion--transparent {
   border-color: transparent;
   --calcite-accordion-item-border: transparent;
   --calcite-accordion-item-background: transparent;
+}
+
+.accordion--minimal {
+  --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
+  border-color: transparent;
 }

--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -103,6 +103,9 @@ export default {
     notes: {
       accordion: accordionReadme,
       accordionItem: accordionItemReadme
+    },
+    backgrounds: {
+      values: [{ name: "transparent", value: "#0000ffff" }]
     }
   }
 };
@@ -272,3 +275,8 @@ export const TransparentAppearance = (): string =>
       )}
     `
   );
+
+export const TransparentBackground = TransparentAppearance.bind({});
+TransparentBackground.parameters = {
+  backgrounds: { default: "transparent" }
+};

--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -242,7 +242,7 @@ export const RTL = (): string =>
     `
   );
 
-const TransparentAppearance = (): string =>
+export const TransparentAppearance = (): string =>
   create(
     "calcite-accordion",
     createAccordionAttributes({ exceptions: ["appearance"] }).concat({
@@ -275,8 +275,3 @@ const TransparentAppearance = (): string =>
       )}
     `
   );
-
-export const TransparentBackground = TransparentAppearance.bind({});
-TransparentBackground.parameters = {
-  backgrounds: { default: "transparent" }
-};

--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -242,7 +242,7 @@ export const RTL = (): string =>
     `
   );
 
-export const TransparentAppearance = (): string =>
+const TransparentAppearance = (): string =>
   create(
     "calcite-accordion",
     createAccordionAttributes({ exceptions: ["appearance"] }).concat({

--- a/src/components/calcite-accordion/calcite-accordion.stories.ts
+++ b/src/components/calcite-accordion/calcite-accordion.stories.ts
@@ -238,3 +238,37 @@ export const RTL = (): string =>
       )}
     `
   );
+
+export const TransparentAppearance = (): string =>
+  create(
+    "calcite-accordion",
+    createAccordionAttributes({ exceptions: ["appearance"] }).concat({
+      name: "appearance",
+      value: "transparent"
+    }),
+    html`
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-1" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-2" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-3" }),
+        accordionItemContent
+      )}
+      ${create(
+        "calcite-accordion-item",
+        createAccordionItemAttributes({ group: "accordion-item-4" }).concat({
+          name: "active",
+          value: true
+        }),
+        accordionItemContent
+      )}
+    `
+  );

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -1,4 +1,14 @@
-import { Component, Element, Event, EventEmitter, h, Listen, Prop, VNode } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Listen,
+  Prop,
+  VNode,
+  Watch
+} from "@stencil/core";
 
 import { AccordionAppearance } from "./interfaces";
 import { Position, Scale } from "../interfaces";
@@ -28,6 +38,11 @@ export class CalciteAccordion {
 
   /** specify the appearance - default (containing border), or minimal (no containing border), defaults to default */
   @Prop({ reflect: true }) appearance: AccordionAppearance = "default";
+
+  @Watch("appearance")
+  updateAppearance(appearance: AccordionAppearance): void {
+    this.updateAccordionItemAppearance(appearance);
+  }
 
   /** specify the placement of the icon in the header, defaults to end */
   @Prop({ reflect: true }) iconPosition: Position = "end";
@@ -64,6 +79,10 @@ export class CalciteAccordion {
       this.items = this.sortItems(this.items);
       this.sorted = true;
     }
+  }
+
+  componentWillLoad(): void {
+    this.updateAccordionItemAppearance(this.appearance);
   }
 
   render(): VNode {
@@ -181,4 +200,13 @@ export class CalciteAccordion {
 
   private sortItems = (items: any[]): any[] =>
     items.sort((a, b) => a.position - b.position).map((a) => a.item);
+
+  private updateAccordionItemAppearance(appearance: AccordionAppearance): void {
+    const accordionItems = this.el.querySelectorAll("calcite-accordion-item");
+    if (accordionItems.length) {
+      accordionItems.forEach((item: HTMLCalciteAccordionItemElement) => {
+        item.appearance = appearance;
+      });
+    }
+  }
 }

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -86,7 +86,16 @@ export class CalciteAccordion {
   }
 
   render(): VNode {
-    return <slot />;
+    return (
+      <div
+        class={{
+          "accordion--transparent": this.appearance === "transparent",
+          "accordion--minimal": this.appearance === "minimal"
+        }}
+      >
+        <slot />
+      </div>
+    );
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/calcite-accordion/calcite-accordion.tsx
+++ b/src/components/calcite-accordion/calcite-accordion.tsx
@@ -1,15 +1,4 @@
-import {
-  Component,
-  Element,
-  Event,
-  EventEmitter,
-  h,
-  Listen,
-  Prop,
-  VNode,
-  Watch
-} from "@stencil/core";
-
+import { Component, Element, Event, EventEmitter, h, Listen, Prop, VNode } from "@stencil/core";
 import { AccordionAppearance } from "./interfaces";
 import { Position, Scale } from "../interfaces";
 
@@ -38,11 +27,6 @@ export class CalciteAccordion {
 
   /** specify the appearance - default (containing border), or minimal (no containing border), defaults to default */
   @Prop({ reflect: true }) appearance: AccordionAppearance = "default";
-
-  @Watch("appearance")
-  updateAppearance(appearance: AccordionAppearance): void {
-    this.updateAccordionItemAppearance(appearance);
-  }
 
   /** specify the placement of the icon in the header, defaults to end */
   @Prop({ reflect: true }) iconPosition: Position = "end";
@@ -79,10 +63,6 @@ export class CalciteAccordion {
       this.items = this.sortItems(this.items);
       this.sorted = true;
     }
-  }
-
-  componentWillLoad(): void {
-    this.updateAccordionItemAppearance(this.appearance);
   }
 
   render(): VNode {
@@ -209,13 +189,4 @@ export class CalciteAccordion {
 
   private sortItems = (items: any[]): any[] =>
     items.sort((a, b) => a.position - b.position).map((a) => a.item);
-
-  private updateAccordionItemAppearance(appearance: AccordionAppearance): void {
-    const accordionItems = this.el.querySelectorAll("calcite-accordion-item");
-    if (accordionItems.length) {
-      accordionItems.forEach((item: HTMLCalciteAccordionItemElement) => {
-        item.appearance = appearance;
-      });
-    }
-  }
 }


### PR DESCRIPTION
**Related Issue:** #1225 

## Summary

This fix will set the `background-color` of the `calcite-accordion` to `transparent` in FireFox & Safari.