### PR TITLE
chore: pin node 16 and npm 8 for volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,9 @@
     "workbox-build": "6.4.2",
     "yargs": "17.3.1"
   },
-  "license": "SEE LICENSE IN copyright.txt"
+  "license": "SEE LICENSE IN copyright.txt",
+  "volta": {
+    "node": "16.13.2",
+    "npm": "8.3.1"
+  }
 }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Pinning node16 / npm8 for volta users
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
