### PR TITLE
fix(date-picker): update utils locale to get the lang code if regional code is not found

### DIFF
--- a/src/components/calcite-date-picker/utils.spec.ts
+++ b/src/components/calcite-date-picker/utils.spec.ts
@@ -28,6 +28,13 @@ describe("utils", () => {
       expect(requestCache).toHaveProperty("en");
     });
 
+    it("falls to lang code locale if regional code is not found", async () => {
+      const locale = "pt-BR";
+
+      await getLocaleData(locale);
+      expect(requestCache).toHaveProperty("pt");
+    });
+
     it("fetches locale with conventional-cased lang code", async () => {
       const locale = "es";
 

--- a/src/components/calcite-date-picker/utils.spec.ts
+++ b/src/components/calcite-date-picker/utils.spec.ts
@@ -29,7 +29,7 @@ describe("utils", () => {
     });
 
     it("falls to lang code locale if regional code is not found", async () => {
-      const locale = "pt-BR";
+      const locale = "pt-UnsupportedRegion";
 
       await getLocaleData(locale);
       expect(requestCache).toHaveProperty("pt");

--- a/src/components/calcite-date-picker/utils.ts
+++ b/src/components/calcite-date-picker/utils.ts
@@ -42,8 +42,9 @@ function getSupportedLocale(lang = "") {
 
   if (lang.includes("-")) {
     lang = lang.replace(/(\w+)-(\w+)/, (_match, language, region) => `${language}-${region.toUpperCase()}`);
+
     if (!locales.includes(lang)) {
-      return locales.includes(lang.split("-")[0]) ? lang.split("-")[0] : "en";
+      lang = lang.split("-")[0];
     }
   }
   return locales.includes(lang) ? lang : "en";

--- a/src/components/calcite-date-picker/utils.ts
+++ b/src/components/calcite-date-picker/utils.ts
@@ -42,6 +42,9 @@ function getSupportedLocale(lang = "") {
 
   if (lang.includes("-")) {
     lang = lang.replace(/(\w+)-(\w+)/, (_match, language, region) => `${language}-${region.toUpperCase()}`);
+    if (!locales.includes(lang)) {
+      return locales.includes(lang.split("-")[0]) ? lang.split("-")[0] : "en";
+    }
   }
   return locales.includes(lang) ? lang : "en";
 }


### PR DESCRIPTION
**Related Issue:** #3965 

## Summary
When a specific file cannot be found if a locale with regional code does not exist, then the date picker will seek for just the basic lang code instead.
For example: `pt-BR` -> `pt`
Before
<img width="200" alt="Screen Shot 2022-01-20 at 3 19 40 PM" src="https://user-images.githubusercontent.com/25360903/150437733-bfe72837-e379-4794-82ff-847b030c513c.png">
After
<img width="200" alt="Screen Shot 2022-01-20 at 3 21 21 PM" src="https://user-images.githubusercontent.com/25360903/150437736-2ee96636-5e38-4e59-a086-4f7ae300a228.png">

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
