### PR TITLE
refactor(slider): remove drag event listeners on component disconnected

### DIFF
--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -146,6 +146,9 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   disconnectedCallback(): void {
     disconnectLabel(this);
     disconnectForm(this);
+    document.removeEventListener("pointermove", this.dragUpdate);
+    document.removeEventListener("pointerup", this.dragEnd);
+    document.removeEventListener("pointercancel", this.dragEnd);
   }
 
   componentWillLoad(): void {
@@ -971,10 +974,6 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   }
 
   private dragEnd = (event: PointerEvent): void => {
-    document.removeEventListener("pointermove", this.dragUpdate);
-    document.removeEventListener("pointerup", this.dragEnd);
-    document.removeEventListener("pointercancel", this.dragEnd);
-
     this.focusActiveHandle(event.clientX);
     if (this.lastDragPropValue != this[this.dragProp]) {
       this.emitChange();

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -146,7 +146,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   disconnectedCallback(): void {
     disconnectLabel(this);
     disconnectForm(this);
-    this.removeEventListeners();
+    this.removeDragListeners();
   }
 
   componentWillLoad(): void {
@@ -972,7 +972,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   }
 
   private dragEnd = (event: PointerEvent): void => {
-    this.removeEventListeners();
+    this.removeDragListeners();
     this.focusActiveHandle(event.clientX);
     if (this.lastDragPropValue != this[this.dragProp]) {
       this.emitChange();
@@ -984,7 +984,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     this.minMaxValueRange = null;
   };
 
-  private removeEventListeners() {
+  private removeDragListeners() {
     document.removeEventListener("pointermove", this.dragUpdate);
     document.removeEventListener("pointerup", this.dragEnd);
     document.removeEventListener("pointercancel", this.dragEnd);

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -974,6 +974,9 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   }
 
   private dragEnd = (event: PointerEvent): void => {
+    document.removeEventListener("pointermove", this.dragUpdate);
+    document.removeEventListener("pointerup", this.dragEnd);
+    document.removeEventListener("pointercancel", this.dragEnd);
     this.focusActiveHandle(event.clientX);
     if (this.lastDragPropValue != this[this.dragProp]) {
       this.emitChange();

--- a/src/components/calcite-slider/calcite-slider.tsx
+++ b/src/components/calcite-slider/calcite-slider.tsx
@@ -146,9 +146,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   disconnectedCallback(): void {
     disconnectLabel(this);
     disconnectForm(this);
-    document.removeEventListener("pointermove", this.dragUpdate);
-    document.removeEventListener("pointerup", this.dragEnd);
-    document.removeEventListener("pointercancel", this.dragEnd);
+    this.removeEventListeners();
   }
 
   componentWillLoad(): void {
@@ -974,9 +972,7 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
   }
 
   private dragEnd = (event: PointerEvent): void => {
-    document.removeEventListener("pointermove", this.dragUpdate);
-    document.removeEventListener("pointerup", this.dragEnd);
-    document.removeEventListener("pointercancel", this.dragEnd);
+    this.removeEventListeners();
     this.focusActiveHandle(event.clientX);
     if (this.lastDragPropValue != this[this.dragProp]) {
       this.emitChange();
@@ -987,6 +983,12 @@ export class CalciteSlider implements LabelableComponent, FormComponent {
     this.maxValueDragRange = null;
     this.minMaxValueRange = null;
   };
+
+  private removeEventListeners() {
+    document.removeEventListener("pointermove", this.dragUpdate);
+    document.removeEventListener("pointerup", this.dragEnd);
+    document.removeEventListener("pointercancel", this.dragEnd);
+  }
 
   /**
    * Set the prop value if changed at the component level


### PR DESCRIPTION
**Related Issue:** #[1955](https://github.com/Esri/calcite-components/issues/1955)

## Summary

All `EventListeners` added  will be removed once DOM it is disconnected via lifecycle method `disconnectedCallback( )`