### PR TITLE
fix(date-picker, input-date-picker): update pt-BR and pt-PT localization files

### DIFF
--- a/src/components/calcite-date-picker/assets/calcite-date-picker/nls/pt-BR.json
+++ b/src/components/calcite-date-picker/assets/calcite-date-picker/nls/pt-BR.json
@@ -5,7 +5,7 @@
   "weekStart": 7,
   "placeholder": "DD/MM/YYYY",
   "days": {
-    "abbreviated": ["domingo", "segunda", "terça", "quarta", "quinta", "sexta", "sábado"],
+    "abbreviated": ["dom.", "seg.", "ter.", "qua.", "qui.", "sex.", "sáb."],
     "narrow": ["D", "S", "T", "Q", "Q", "S", "S"],
     "wide": ["domingo", "segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado"]
   },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Stemmed from https://github.com/Esri/calcite-components/issues/3925#issuecomment-1018028342. This PR adds `pt-BR.json` and updates some entries `pt-PT.json` per the CLDR locale dataset.

One thing I did notice was that `unitOrder` and `placeholder` from our files are different from the CLDR data. 

### Current

```json
{
    "default-calendar": "gregorian",
    "separator": "/",
    "unitOrder": "DD/MM/YYYY",
    "weekStart": 7,
    "placeholder": "DD/MM/YYYY",
    ...
}
```

### CLDR

```json
{
    "default-calendar": "gregorian",
    "separator": "/",
    "unitOrder": "dd/MM/yy",
    "weekStart": 7,
    "placeholder": "dd/MM/yy",
    ...
}
```

Worth noting that aside from Bulgaria (bg), all other locale files use the `MM`, `DD` and `YYYY` tokens. 

I kept the previous versions since that's what is being used by the input date picker component. Having said this, which version should we be using from the input date picker perspective? If it's the `MM`, `DD`, `YYYY` version, is this something that we need to maintain here or should this be coming from the source localization files? cc @raje9276 @paulcpederson

