### PR TITLE
fix(combobox): fix stacking icon on very narrow combobox (#3891)

### DIFF
--- a/src/components/calcite-combobox/calcite-combobox.scss
+++ b/src/components/calcite-combobox/calcite-combobox.scss
@@ -109,7 +109,7 @@
 }
 
 .input-wrap--single {
-  @apply flex-auto overflow-hidden;
+  @apply flex-1 overflow-hidden;
 }
 
 .label {

--- a/src/components/calcite-combobox/calcite-combobox.stories.ts
+++ b/src/components/calcite-combobox/calcite-combobox.stories.ts
@@ -49,7 +49,7 @@ export const Simple = (): string => html`
 `;
 
 export const Single = (): string => html`
-  <div style="width:400px;max-width:100%;background-color:white;padding:100px">
+  <div style="width:150px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
       label="demo combobox"
       selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "single")}"
@@ -59,7 +59,7 @@ export const Single = (): string => html`
       ${boolean("disabled", false)}
       max-items="${number("max-items", 0)}"
     >
-      <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude"></calcite-combobox-item>
+      <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude" selected></calcite-combobox-item>
       <calcite-combobox-item icon="article" value="article" text-label="Article"></calcite-combobox-item>
       <calcite-combobox-item icon="attachment" value="attachment" text-label="Attachment"></calcite-combobox-item>
       <calcite-combobox-item icon="banana" value="banana" text-label="Banana"></calcite-combobox-item>


### PR DESCRIPTION
**Related Issue:** #3891

## Summary

Saw this while doing some mobile testing in another product. Using `flex-1` allows the element to scale down with no minimum, so it won't force a flex wrap.