### PR TITLE
test(input): when both 'ArrowUp' and 'ArrowDown' are pressed at the same time most recently pressed key takes over

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -686,20 +686,16 @@ describe("calcite-input", () => {
     expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
   });
 
-  it.skip("when both 'ArrowUp' and 'ArrowDown' are pressed at the same time most recently pressed key takes over", async () => {
+  it("when both 'ArrowUp' and 'ArrowDown' are pressed at the same time most recently pressed key takes over", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number" value="0"></calcite-input>`);
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
 
-    await page.keyboard.down("ArrowUp");
-    await page.waitForChanges();
-    expect(await element.getProperty("value")).toBe("1");
-    await page.keyboard.down("ArrowDown");
+    const arrowUpDown = page.keyboard.down("ArrowUp");
+    const arrowDownDown = page.keyboard.down("ArrowDown");
+    await Promise.all([arrowUpDown, arrowDownDown]);
     await page.waitForTimeout(delayFor2UpdatesInMs);
-    await page.keyboard.up("ArrowUp");
-    await page.keyboard.up("ArrowDown");
-    await page.waitForChanges();
     expect(await element.getProperty("value")).toBe("-1");
   });
 


### PR DESCRIPTION
**Related Issue:** #3938

## Summary
Simplify test to have a consistent result. 


Test error
FAIL src/components/calcite-input/calcite-input.e2e.ts (402.713 s)
  ● calcite-input › when both 'ArrowUp' and 'ArrowDown' are pressed at the same time most recently pressed key takes over

    expect(received).toBe(expected) // Object.is equality

    Expected: "1"
    Received: "2"

      695 |     await page.keyboard.down("ArrowUp");
      696 |     await page.waitForChanges();
    > 697 |     expect(await element.getProperty("value")).toBe("1");
          |                                                ^
      698 |     await page.keyboard.down("ArrowDown");
      699 |     await page.waitForTimeout(delayFor2UpdatesInMs);
      700 |     await page.keyboard.up("ArrowUp");

      at Object.<anonymous> (src/components/calcite-input/calcite-input.e2e.ts:697:48)
