### PR TITLE
ci(screener): static storybook build

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -48,7 +48,7 @@ jobs:
           SAUCE_ACCESS_NAME: ${{ secrets.SAUCE_ACCESS_NAME}}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: |
-          build-storybook
+          npm run build-storybook
           npm run test:storybook || true
       - if: steps.one.outputs.skip == 'skip'
         name: skip screener

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -47,7 +47,9 @@ jobs:
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
           SAUCE_ACCESS_NAME: ${{ secrets.SAUCE_ACCESS_NAME}}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: npm run test:storybook || true
+        run: |
+          build-storybook
+          npm run test:storybook || true
       - if: steps.one.outputs.skip == 'skip'
         name: skip screener
         uses: Sibz/github-status-action@v1

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -57,5 +57,5 @@ export const parameters = {
 };
 
 if (typeof window === "object") {
-  window.__screener_storybook__ = require("@storybook/react").getStorybook;
+  window.__screener_storybook__ = require("@storybook/html").getStorybook;
 }

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -55,3 +55,7 @@ export const parameters = {
     }
   }
 };
+
+if (typeof window === "object") {
+  window.__screener_storybook__ = require("@storybook/react").getStorybook;
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "npm run util:copy-icons && stencil build",
+    "build-storybook": "build-storybook",
     "build:watch": "npm run util:copy-icons && stencil build --watch",
     "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch",
     "deps:update": "updtr --exclude chalk typescript @types/jest jest jest-cli puppeteer && npm audit fix",

--- a/screener.config.js
+++ b/screener.config.js
@@ -22,5 +22,6 @@ module.exports = {
     maxConcurrent: 10
   },
   excludeRules: [/^Overview/],
-  resolution: "1920x1440"
+  resolution: "1920x1440",
+  storybookStaticBuildDir: "storybook-static"
 };


### PR DESCRIPTION
**Related Issue:** #

## Summary

This PR turns on Screener's static storybook build option so that it doesn't have to start up the Storybook Dev Server to run the visual tests.  The hope is this will resolve ngrok server failures and also speed up the tests.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
