### PR TITLE
fix(switch): provide a selected color to track element (#3987)

### DIFF
--- a/src/components/calcite-switch/calcite-switch.scss
+++ b/src/components/calcite-switch/calcite-switch.scss
@@ -113,6 +113,14 @@
   }
 }
 
+@media (forced-colors: active) {
+  :host([checked]) {
+    .track {
+      background-color: canvasText;
+    }
+  }
+}
+
 .container:focus {
   @apply focus-outset;
 }


### PR DESCRIPTION
* Use canvasText system color to show selected state of switch control. This color matches the normal text color, outlines, and borders in high contrast mode

**Related Issue:** #3987

## Summary
Fix provides a color to the switch track when the control is selected.
![high contrast switch with canvasText color](https://user-images.githubusercontent.com/142636/150838935-54b34df3-ce56-4991-a6c5-d5552caeebbb.png)


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
