### PR TITLE
docs(readme): remove sketch info until it is up to date

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,6 @@
 
 Shared Web Components for Esri's Calcite Design Systems. To see the components in action, [view the documentation](https://developers.arcgis.com/calcite-design-system/components/).
 
-## Sketch library
-
-All of the Calcite Components are available in the [calcite-sketch-library](https://github.com/Esri/calcite-sketch-libraries) with all variations and sizes.
-
 ## Installation
 
 The simplest way to set up the components in your project is to add the following tags in the head of your HTML document:


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Our sketch UI kit is super far behind the components, so I'm removing it from the README until it is updated. People will be really frustrated if they take the time to design something and it is completely different in the component library. 

We may want to add a disclaimer notice in the dev docs until figma/sketch gets caught up. Thoughts @macandcheese @jcfranco ?
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
