### PR TITLE
test(dropdown): correct logical errors in the test

### DIFF
--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -640,8 +640,8 @@ describe("calcite-dropdown", () => {
     expect(await dropdownWrapper.isVisible()).toBe(false);
   });
 
-  describe("opens the dropdown with click, enter, or space", () => {
-    it.skip("opens when dropdown-trigger is a button", async () => {
+  describe("toggles the dropdown with click, enter, or space", () => {
+    it("toggles when dropdown-trigger is a button", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-dropdown>
@@ -656,25 +656,30 @@ describe("calcite-dropdown", () => {
       const trigger = await element.find("calcite-button[slot='dropdown-trigger']");
       const dropdownWrapper = await page.find(`calcite-dropdown >>> .calcite-dropdown-wrapper`);
       const calciteDropdownOpen = await element.spyOnEvent("calciteDropdownOpen");
+      const calciteDropdownClose = await element.spyOnEvent("calciteDropdownClose");
 
       expect(await dropdownWrapper.isVisible()).toBe(false);
       await trigger.click();
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
+      await page.waitForChanges();
+      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
 
       await trigger.focus();
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(false);
-      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
+      await page.waitForChanges();
+      expect(calciteDropdownClose).toHaveReceivedEventTimes(1);
 
       await page.keyboard.press("Enter");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
-      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
+      await page.waitForChanges();
+      expect(calciteDropdownOpen).toHaveReceivedEventTimes(2);
     });
 
-    it.skip("opens when dropdown-trigger is an action", async () => {
+    it("toggle when dropdown-trigger is an action", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-dropdown>
@@ -689,22 +694,27 @@ describe("calcite-dropdown", () => {
       const trigger = await element.find("calcite-action[slot='dropdown-trigger'] >>> button");
       const dropdownWrapper = await page.find(`calcite-dropdown >>> .calcite-dropdown-wrapper`);
       const calciteDropdownOpen = await element.spyOnEvent("calciteDropdownOpen");
+      const calciteDropdownClose = await element.spyOnEvent("calciteDropdownClose");
 
       expect(await dropdownWrapper.isVisible()).toBe(false);
       await trigger.click();
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
+      await page.waitForChanges();
+      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
 
       await trigger.focus();
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(false);
-      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
+      await page.waitForChanges();
+      expect(calciteDropdownClose).toHaveReceivedEventTimes(1);
 
       await page.keyboard.press("Enter");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
-      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
+      await page.waitForChanges();
+      expect(calciteDropdownOpen).toHaveReceivedEventTimes(2);
     });
   });
 

--- a/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
+++ b/src/components/calcite-dropdown/calcite-dropdown.e2e.ts
@@ -657,26 +657,33 @@ describe("calcite-dropdown", () => {
       const dropdownWrapper = await page.find(`calcite-dropdown >>> .calcite-dropdown-wrapper`);
       const calciteDropdownOpen = await element.spyOnEvent("calciteDropdownOpen");
       const calciteDropdownClose = await element.spyOnEvent("calciteDropdownClose");
+      let waitForCalciteDropdownOpen = page.waitForEvent("calciteDropdownOpen");
+      const waitForCalciteDropdownClose = page.waitForEvent("calciteDropdownClose");
 
       expect(await dropdownWrapper.isVisible()).toBe(false);
       await trigger.click();
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
-      await page.waitForChanges();
+      await waitForCalciteDropdownOpen;
       expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
+      expect(calciteDropdownClose).toHaveReceivedEventTimes(0);
 
       await trigger.focus();
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(false);
-      await page.waitForChanges();
+      await waitForCalciteDropdownClose;
+      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
       expect(calciteDropdownClose).toHaveReceivedEventTimes(1);
+
+      waitForCalciteDropdownOpen = page.waitForEvent("calciteDropdownOpen");
 
       await page.keyboard.press("Enter");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
-      await page.waitForChanges();
+      await waitForCalciteDropdownOpen;
       expect(calciteDropdownOpen).toHaveReceivedEventTimes(2);
+      expect(calciteDropdownClose).toHaveReceivedEventTimes(1);
     });
 
     it("toggle when dropdown-trigger is an action", async () => {
@@ -695,26 +702,33 @@ describe("calcite-dropdown", () => {
       const dropdownWrapper = await page.find(`calcite-dropdown >>> .calcite-dropdown-wrapper`);
       const calciteDropdownOpen = await element.spyOnEvent("calciteDropdownOpen");
       const calciteDropdownClose = await element.spyOnEvent("calciteDropdownClose");
+      let waitForCalciteDropdownOpen = page.waitForEvent("calciteDropdownOpen");
+      const waitForCalciteDropdownClose = page.waitForEvent("calciteDropdownClose");
 
       expect(await dropdownWrapper.isVisible()).toBe(false);
       await trigger.click();
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
-      await page.waitForChanges();
+      await waitForCalciteDropdownOpen;
       expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
+      expect(calciteDropdownClose).toHaveReceivedEventTimes(0);
 
       await trigger.focus();
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(false);
-      await page.waitForChanges();
+      await waitForCalciteDropdownClose;
+      expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
       expect(calciteDropdownClose).toHaveReceivedEventTimes(1);
+
+      waitForCalciteDropdownOpen = page.waitForEvent("calciteDropdownOpen");
 
       await page.keyboard.press("Enter");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(true);
-      await page.waitForChanges();
+      await waitForCalciteDropdownOpen;
       expect(calciteDropdownOpen).toHaveReceivedEventTimes(2);
+      expect(calciteDropdownClose).toHaveReceivedEventTimes(1);
     });
   });
 


### PR DESCRIPTION
**Related Issue:** #3936

## Summary

This was flaking for 2 reasons:

- the event open/close fires after transition ends, so I needed to check for it in the right sequence and preceded with await page.waitForChanges();
- in the open position it fires calciteDropdownOpen, and in close: calciteDropdownClose; had to check for both