### PR TITLE
ci: allow primary and secondary contacts to merge on all prs

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -12,10 +12,7 @@ jobs:
           PRIMARY_CONTACT: ${{secrets.PRIMARY_CONTACT}}
           SECONDARY_CONTACTS: ${{secrets.SECONDARY_CONTACTS}}
         with:
-          script: |
-            const { PRIMARY_CONTACT, SECONDARY_CONTACTS } = process.env
-            const contacts = [...SECONDARY_CONTACTS.split(",").map(c => c.trim()), PRIMARY_CONTACT]
-            return contacts.includes(context.actor)
+          script: return [...process.env.SECONDARY_CONTACTS.split(",").map(c => c.trim()), process.env.PRIMARY_CONTACT].includes(context.actor)
       - name: merge
         uses: Goobles/gh-actions-merge-command@v1
         if: |

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -24,4 +24,4 @@ jobs:
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -2,17 +2,29 @@ name: Auto Merge
 on: issue_comment
 jobs:
   merge:
-    if: |
-      github.event.issue.user.login == 'github-actions[bot]' ||
-      github.event.issue.user.login == github.actor
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: validate user permissions
+        uses: actions/github-script@v5
+        id: permission
+        env:
+          PRIMARY_CONTACT: ${{secrets.PRIMARY_CONTACT}}
+          SECONDARY_CONTACTS: ${{secrets.SECONDARY_CONTACTS}}
+        with:
+          script: |
+            const { PRIMARY_CONTACT, SECONDARY_CONTACTS } = process.env
+            const contacts = [...SECONDARY_CONTACTS.split(",").map(c => c.trim()), PRIMARY_CONTACT]
+            return contacts.includes(context.actor)
       - name: merge
         uses: Goobles/gh-actions-merge-command@v1
+        if: |
+          github.event.issue.user.login == 'github-actions[bot]' ||
+          github.event.issue.user.login == github.actor ||
+          steps.permission.outputs.result == 'true'
         with:
           allow_ff: false
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com
         env:
-          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Allows the users in the `PRIMARY_CONTACT` (a single user name) and `SECONDARY_CONTACTS` (comma separated usernames) github secrets to use the merge action on all PRs
- Important for situations like getting screener working on all the PRs again
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
