### PR TITLE
ci(screener): enable compareSVGDOM

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -12,6 +12,7 @@ module.exports = {
     }
   ],
   diffOptions: {
+    compareSVGDOM: true,
     minLayoutDimension: 1,
     minLayoutPosition: 1
   },

--- a/src/components/calcite-color-picker-swatch/resources.ts
+++ b/src/components/calcite-color-picker-swatch/resources.ts
@@ -4,6 +4,6 @@ export const CSS = {
 };
 
 export const COLORS = {
-  borderLight: "rgba(0, 0, 0, 0.3)",
+  borderLight: "rgba(0, 0, 0, 0.15)",
   borderDark: "rgba(255, 255, 255, 0.15)"
 };


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Enabling `compareSVGDOM` for testing purposes.