### PR TITLE
refactor(calcite-input): simplifying logic based on comments in #3915

### DIFF
--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -203,14 +203,7 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     if (!this.internalValueChange) {
       this.setValue({
         origin: "external",
-        value:
-          newValue == null
-            ? ""
-            : this.type === "number"
-            ? isValidNumber(newValue)
-              ? newValue
-              : this.previousValue || ""
-            : newValue
+        value: newValue
       });
       this.warnAboutInvalidNumberValue(newValue);
     }
@@ -647,10 +640,10 @@ export class CalciteInput implements LabelableComponent, FormComponent {
   }
 
   private setInputValue = (newInputValue: string): void => {
-    if (this.type === "text" && !this.childEl) {
-      return;
-    }
-    if (this.type === "number" && !this.childNumberEl) {
+    if (
+      (this.type === "text" && !this.childEl) ||
+      (this.type === "number" && !this.childNumberEl)
+    ) {
       return;
     }
     this[`child${this.type === "number" ? "Number" : ""}El`].value = newInputValue;
@@ -680,7 +673,8 @@ export class CalciteInput implements LabelableComponent, FormComponent {
       this.type === "number"
         ? localizeNumberString(this.previousValue, this.locale, this.groupSeparator)
         : "";
-    const sanitizedValue = this.type === "number" ? sanitizeNumberString(value) : value;
+    const sanitizedValue =
+      value == null ? "" : this.type === "number" ? sanitizeNumberString(value) : value;
     const newValue =
       this.type === "number" && value && !sanitizedValue
         ? isValidNumber(this.previousValue)


### PR DESCRIPTION
**Related Issue:** #3003

## Summary

This PR addresses the comments in #3915 that originally fixed #3003.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
