### PR TITLE
docs(tooltip): use the correct component name

### DIFF
--- a/src/components/calcite-tooltip/calcite-tooltip.tsx
+++ b/src/components/calcite-tooltip/calcite-tooltip.tsx
@@ -31,7 +31,7 @@ export class CalciteTooltip {
   @Prop() label!: string;
 
   /**
-   * Offset the position of the popover away from the reference element.
+   * Offset the position of the tooltip away from the reference element.
    * @default 6
    */
   @Prop({ reflect: true }) offsetDistance = defaultOffsetDistance;
@@ -42,7 +42,7 @@ export class CalciteTooltip {
   }
 
   /**
-   * Offset the position of the popover along the reference element.
+   * Offset the position of the tooltip along the reference element.
    */
   @Prop({ reflect: true }) offsetSkidding = 0;
 


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Looks like these were copy and pasted from `popover` and the component name wasn't changed
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
