### PR TITLE
fix(input): correct negative values in ar and et locales

### DIFF
--- a/src/components/calcite-input/calcite-input.e2e.ts
+++ b/src/components/calcite-input/calcite-input.e2e.ts
@@ -1084,6 +1084,18 @@ describe("calcite-input", () => {
       });
   });
 
+  it(`allows negative numbers for ar locale`, async () => {
+    const value = "123";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input locale="ar" type="number"></calcite-input>`);
+    const element = await page.find("calcite-input");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, value);
+    await page.waitForChanges();
+    await page.keyboard.press("Tab");
+    expect(await element.getProperty("value")).toBe(value);
+  });
+
   it(`allows clearing value for type=number`, async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number" value="1"></calcite-input>`);

--- a/src/components/calcite-input/calcite-input.tsx
+++ b/src/components/calcite-input/calcite-input.tsx
@@ -320,16 +320,6 @@ export class CalciteInput implements LabelableComponent, FormComponent {
     this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
   }
 
-  componentShouldUpdate(newValue: string, oldValue: string, property: string): boolean {
-    if (this.type === "number" && property === "value" && newValue && !isValidNumber(newValue)) {
-      this.setValue({
-        value: oldValue
-      });
-      return false;
-    }
-    return true;
-  }
-
   //--------------------------------------------------------------------------
   //
   //  Events

--- a/src/demos/calcite-input.html
+++ b/src/demos/calcite-input.html
@@ -1350,6 +1350,14 @@
       </div>
     </div>
 
+    <!-- arabic number input  -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">arabic number input</div>
+      <div class="child-flex">
+        <calcite-input type="number" name="arabic-group" locale="ar" placeholder="arabic number input"></calcite-input>
+      </div>
+    </div>
+
     <!-- set to undefined -->
     <div class="parent-flex">
       <div class="child-flex font right-aligned-text">set to undefined</div>


### PR DESCRIPTION
**Related Issue:** #3956

## Summary
- `-123` was considered an invalid number in `ar` and `et` locales. 
- The issue started when adding the `componentShouldUpdate` lifecycle method in [this PR](https://github.com/Esri/calcite-components/pull/2036). 
- It looks like there was [no number sanitation at the time of that PR](https://github.com/Esri/calcite-components/blob/c0cc3ed5b6334282e5f7a4b415030331dae5f3c9/src/utils/number.ts). Can you think of any use cases where this method is needed @eriklharper? It seems like the new(ish) number sanitation covers it. 
- The existing tests passed locally and the functionality was the same in the demos. The test I added fails on master but passes on this branch.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
