### PR TITLE
fix(combobox): Align with dropdown logic and repositioning

### DIFF
--- a/.storybook/helpers.ts
+++ b/.storybook/helpers.ts
@@ -3,6 +3,7 @@ import { boolean as booleanKnob } from "@storybook/addon-knobs";
 import { Steps } from "screener-storybook/src/screener";
 import { THEMES } from "../src/utils/resources";
 import { ThemeName } from "../src/components/interfaces";
+import { Parameters } from "@storybook/api";
 
 // we can get all unique icon names from all size 16 non-filled icons.
 export const iconNames = Object.keys(icons)
@@ -21,6 +22,7 @@ export const boolean = (prop, value, standalone = true) => {
 export interface Story {
   (): string;
   decorators?: ((Story: Story) => DocumentFragment)[];
+  parameters?: Parameters;
 }
 
 export const setKnobs = ({ story, knobs }: { story: string; knobs: { name: string; value: string }[] }) => {

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -1,5 +1,5 @@
 import { select, number, text } from "@storybook/addon-knobs";
-import { boolean } from "../../../.storybook/helpers";
+import { boolean, createSteps, stepStory } from "../../../.storybook/helpers";
 
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
@@ -217,3 +217,31 @@ export const Rtl = (): string => html`
 `;
 
 Rtl.storyName = "RTL";
+
+export const FlipPositioning = stepStory(
+  (): string => html`
+    <div style="overflow: auto; height: 600px; width: 500px;">
+      <div style="height: 400px;"></div>
+      <calcite-combobox
+        placeholder="${text("placeholder", "placeholder")}"
+        label="${text("label (for screen readers)", "demo")}"
+        selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
+        scale="${select("scale", ["s", "m", "l"], "m")}"
+        ${boolean("disabled", false)}
+        ${boolean("allow-custom-values", false)}
+      >
+        <calcite-combobox-item value="Trees" text-label="Trees">
+          <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Flowers" text-label="Flowers">
+          <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+          <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+          <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+        </calcite-combobox-item>
+      </calcite-combobox>
+    </div>
+  `,
+  createSteps("calcite-combobox").snapshot("Default").click("calcite-combobox").snapshot("Open")
+);

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -220,8 +220,7 @@ Rtl.storyName = "RTL";
 
 export const FlipPositioning = stepStory(
   (): string => html`
-    <div style="overflow: auto; height: 600px; width: 500px;">
-      <div style="height: 400px;"></div>
+    <div style="position: absolute; bottom: 10px; left: 10px;">
       <calcite-combobox
         max-items="${number("max-items", 6)}"
         placeholder="${text("placeholder", "placeholder")}"
@@ -254,3 +253,6 @@ export const FlipPositioning = stepStory(
   `,
   createSteps("calcite-combobox").snapshot("Default").click("calcite-combobox").snapshot("Open")
 );
+FlipPositioning.parameters = {
+  layout: "fullscreen"
+};

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -223,6 +223,7 @@ export const FlipPositioning = stepStory(
     <div style="overflow: auto; height: 600px; width: 500px;">
       <div style="height: 400px;"></div>
       <calcite-combobox
+        max-items="${number("max-items", 6)}"
         placeholder="${text("placeholder", "placeholder")}"
         label="${text("label (for screen readers)", "demo")}"
         selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
@@ -240,6 +241,14 @@ export const FlipPositioning = stepStory(
           <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
           <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
         </calcite-combobox-item>
+        <calcite-combobox-item value="Animals" text-label="Animals">
+          <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+          <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+          <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+        <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+        <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
       </calcite-combobox>
     </div>
   `,

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -89,13 +89,9 @@ export class Combobox implements LabelableComponent, FormComponent {
       this.open = false;
     } else if (!oldValue && newValue) {
       this.el.addEventListener("calciteComboboxOpen", this.toggleOpenEnd);
-      // give the combobox height, then reposition prior to opening
-      requestAnimationFrame(() => {
-        this.setMaxScrollerHeight();
-        this.open = true;
-      });
+      this.open = true;
     }
-    this.setMaxScrollerHeight();
+    this.reposition();
   }
 
   /** Disable combobox input */

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -91,12 +91,10 @@ export class Combobox implements LabelableComponent, FormComponent {
       this.el.addEventListener("calciteComboboxOpen", this.toggleOpenEnd);
       // give the combobox height, then reposition prior to opening
       requestAnimationFrame(() => {
-        this.reposition();
         this.setMaxScrollerHeight();
         this.open = true;
       });
     }
-    this.reposition();
     this.setMaxScrollerHeight();
   }
 
@@ -288,6 +286,7 @@ export class Combobox implements LabelableComponent, FormComponent {
 
   disconnectedCallback(): void {
     this.mutationObserver?.disconnect();
+    this.resizeObserver?.disconnect();
     this.destroyPopper();
     disconnectLabel(this);
     disconnectForm(this);
@@ -336,9 +335,6 @@ export class Combobox implements LabelableComponent, FormComponent {
 
   @State() open = this.active;
 
-  /** specifies the item wrapper height; it is updated when maxItems is > 0  **/
-  @State() maxScrollerHeight = 0;
-
   /** when search text is cleared, reset active to  */
   @Watch("text")
   textHandler(): void {
@@ -350,6 +346,8 @@ export class Combobox implements LabelableComponent, FormComponent {
   data: ItemData[];
 
   mutationObserver = createObserver("mutation", () => this.updateItems());
+
+  resizeObserver = createObserver("resize", () => this.setMaxScrollerHeight());
 
   private guid = guid();
 
@@ -465,9 +463,16 @@ export class Combobox implements LabelableComponent, FormComponent {
   };
 
   setMaxScrollerHeight = (): void => {
-    if (this.active) {
-      this.maxScrollerHeight = this.getMaxScrollerHeight(this.getCombinedItems());
+    const { active, listContainerEl } = this;
+
+    if (!listContainerEl || !active) {
+      return;
     }
+
+    this.reposition();
+    const maxScrollerHeight = this.getMaxScrollerHeight();
+    listContainerEl.style.maxHeight = maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "";
+    this.reposition();
   };
 
   calciteChipDismissHandler = (
@@ -525,6 +530,7 @@ export class Combobox implements LabelableComponent, FormComponent {
   };
 
   setListContainerEl = (el: HTMLDivElement): void => {
+    this.resizeObserver.observe(el);
     this.listContainerEl = el;
   };
 
@@ -569,19 +575,26 @@ export class Combobox implements LabelableComponent, FormComponent {
     this.popper = null;
   }
 
-  private getMaxScrollerHeight(items: ComboboxChildElement[]): number {
+  private getMaxScrollerHeight(): number {
+    const items = this.getCombinedItems().filter((item) => !item.hidden);
+
     const { maxItems } = this;
+
     let itemsToProcess = 0;
     let maxScrollerHeight = 0;
-    items.forEach((item) => {
-      if (itemsToProcess < maxItems && maxItems > 0) {
-        const height = this.calculateSingleItemHeight(item);
-        if (height > 0) {
-          maxScrollerHeight += height;
-          itemsToProcess++;
+
+    if (items.length > maxItems) {
+      items.forEach((item) => {
+        if (itemsToProcess < maxItems && maxItems > 0) {
+          const height = this.calculateSingleItemHeight(item);
+          if (height > 0) {
+            maxScrollerHeight += height;
+            itemsToProcess++;
+          }
         }
-      }
-    });
+      });
+    }
+
     return maxScrollerHeight;
   }
 
@@ -987,27 +1000,20 @@ export class Combobox implements LabelableComponent, FormComponent {
   }
 
   renderPopperContainer(): VNode {
-    const { active, maxScrollerHeight, setMenuEl, setListContainerEl, hideList, open } = this;
+    const { active, setMenuEl, setListContainerEl, hideList, open } = this;
     const classes = {
       "list-container": true,
       [PopperCSS.animation]: true,
       [PopperCSS.animationActive]: active
     };
-    const style = {
-      maxHeight: maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : ""
-    };
+
     return (
       <div
         aria-hidden="true"
         class={{ "popper-container": true, "popper-container--active": open }}
         ref={setMenuEl}
       >
-        <div
-          class={classes}
-          onTransitionEnd={this.transitionEnd}
-          ref={setListContainerEl}
-          style={style}
-        >
+        <div class={classes} onTransitionEnd={this.transitionEnd} ref={setListContainerEl}>
           <ul class={{ list: true, "list--hide": hideList }}>
             <slot />
           </ul>


### PR DESCRIPTION
**Related Issue:** #3868

## Summary

fix(combobox): Align with dropdown logic and repositioning. #3868

- Makes sure when a combobox is placed at the bottom of a page that when it opens it opens "top".
- Adds screenshot test via story
- Refactors positioning and maxItems logic to be in sync with dropdown. (uses resizeObserver)
- Fixes issue where maxItem height was being applied when items where less than maxItems.