### PR TITLE
fix(action-bar, action-pad): Remove warning when when expanding with expand tooltip #3978

### DIFF
--- a/src/components/functional/ExpandToggle.tsx
+++ b/src/components/functional/ExpandToggle.tsx
@@ -50,7 +50,7 @@ const setTooltipReference = ({
   ref?: (el: HTMLElement) => void;
 }): HTMLCalciteActionElement => {
   if (tooltip) {
-    tooltip.referenceElement = !expanded && referenceElement;
+    tooltip.referenceElement = !expanded && referenceElement ? referenceElement : null;
   }
 
   if (ref) {


### PR DESCRIPTION
**Related Issue:** #3978

## Summary

fix(action-bar, action-pad): Remove warning when when expanding with expand tooltip #3978

- This was setting referenceElement to `false` which isn incorrect.