### PR TITLE
fix(combobox): balance the margin to be equal on vertical chip sides

### DIFF
--- a/src/components/combobox/combobox.scss
+++ b/src/components/combobox/combobox.scss
@@ -173,7 +173,7 @@
 }
 
 .chip {
-  margin-block: calc(var(--calcite-combobox-item-spacing-unit-s) / 2) 0;
+  margin-block: calc(var(--calcite-combobox-item-spacing-unit-s) / 2);
   margin-inline: 0 var(--calcite-combobox-item-spacing-unit-s);
   max-width: 100%;
 }


### PR DESCRIPTION
**Related Issue:** #3890 

## Summary
The margin on the vertical sides of the chip in combobox was not even.

Before
<img width="400" alt="Screen Shot 2022-02-07 at 11 48 34 AM" src="https://user-images.githubusercontent.com/25360903/152860912-129065aa-6713-46fe-9cf0-0ea31f191f40.png">
After
<img width="400" alt="Screen Shot 2022-02-07 at 11 46 46 AM" src="https://user-images.githubusercontent.com/25360903/152860909-f7b09ae7-c2f4-4c44-9a40-74062fa31c0c.png">

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
