### PR TITLE
fix(popover-manager, tooltip-manager): Misalignment of tooltips in FireFox #3900

### DIFF
--- a/src/components/popover-manager/popover-manager.e2e.ts
+++ b/src/components/popover-manager/popover-manager.e2e.ts
@@ -9,7 +9,7 @@ describe("calcite-popover-manager", () => {
     accessible(`<calcite-popover-manager>
   <calcite-popover reference-element="ref">Content</calcite-popover>
   <div id="ref">Button</div>
-<calcite-popover-manager>`));
+</calcite-popover-manager>`));
 
   it("honors hidden attribute", async () => hidden("calcite-popover-manager"));
 
@@ -25,6 +25,14 @@ describe("calcite-popover-manager", () => {
       }
     ]));
 
+  it("should be positioned relative", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-popover-manager></calcite-popover-manager>`);
+    await page.waitForChanges();
+    const manager = await page.find("calcite-popover-manager");
+    expect((await manager.getComputedStyle()).position).toBe("relative");
+  });
+
   it("should open popovers", async () => {
     const page = await newE2EPage();
 
@@ -33,7 +41,7 @@ describe("calcite-popover-manager", () => {
       <calcite-popover-manager>
         <calcite-popover reference-element="ref">Content</calcite-popover>
         <div id="ref">Button</div>
-      <calcite-popover-manager>
+      </calcite-popover-manager>
       `
     );
 
@@ -60,7 +68,7 @@ describe("calcite-popover-manager", () => {
       <calcite-popover-manager>
         <calcite-popover reference-element="ref">Content</calcite-popover>
         <div id="ref"><span>Button</span></div>
-      <calcite-popover-manager>
+      </calcite-popover-manager>
       `
     );
 
@@ -88,7 +96,7 @@ describe("calcite-popover-manager", () => {
       <calcite-popover-manager>
         <calcite-popover reference-element="ref" open>Content</calcite-popover>
         <div id="ref">Button</div>
-      <calcite-popover-manager>
+      </calcite-popover-manager>
       `
     );
 
@@ -116,7 +124,7 @@ describe("calcite-popover-manager", () => {
           <div id="insideNode">Inside node</div>
         </calcite-popover>
         <div id="ref">Button</div>
-      <calcite-popover-manager>
+      </calcite-popover-manager>
       `
     );
 

--- a/src/components/popover-manager/popover-manager.scss
+++ b/src/components/popover-manager/popover-manager.scss
@@ -1,3 +1,3 @@
 :host {
-  @apply block;
+  @apply block relative;
 }

--- a/src/components/tooltip-manager/tooltip-manager.e2e.ts
+++ b/src/components/tooltip-manager/tooltip-manager.e2e.ts
@@ -25,6 +25,14 @@ describe("calcite-tooltip-manager", () => {
       }
     ]));
 
+  it("should be positioned relative", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-tooltip-manager></calcite-tooltip-manager>`);
+    await page.waitForChanges();
+    const manager = await page.find("calcite-tooltip-manager");
+    expect((await manager.getComputedStyle()).position).toBe("relative");
+  });
+
   it("should honor tooltips on mouseover/mouseout", async () => {
     const page = await newE2EPage();
 

--- a/src/components/tooltip-manager/tooltip-manager.scss
+++ b/src/components/tooltip-manager/tooltip-manager.scss
@@ -1,3 +1,3 @@
 :host {
-  @apply block;
+  @apply block relative;
 }


### PR DESCRIPTION
**Related Issue:** #3900

## Summary

fix(popover-manager, tooltip-manager): Misalignment of tooltips in FireFox #3900

Firefox needs manager components to be positioned relative. Tried positioning shadow dom container as relative but that didn't do anything.