### PR TITLE
fix(fab, color-picker, inline-editable, split-button): Set calcite button type

### DIFF
--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -163,6 +163,16 @@ describe("calcite-color-picker", () => {
       }
     ]));
 
+  it(`should set all internal calcite-button types to 'button'`, async () => {
+    const page = await newE2EPage({
+      html: "<calcite-color-picker></calcite-color-picker>"
+    });
+
+    const buttons = await page.findAll("calcite-color-picker >>> calcite-button");
+
+    buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
+  });
+
   it("emits event when value changes", async () => {
     const page = await newE2EPage({
       html: "<calcite-color-picker></calcite-color-picker>"

--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -170,6 +170,8 @@ describe("calcite-color-picker", () => {
 
     const buttons = await page.findAll("calcite-color-picker >>> calcite-button");
 
+    expect(buttons).toHaveLength(2);
+
     buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
   });
 

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -851,6 +851,7 @@ export class ColorPicker {
                   label={intlDeleteColor}
                   onClick={this.deleteColor}
                   scale={hexInputScale}
+                  type="button"
                 />
                 <calcite-button
                   appearance="transparent"
@@ -861,6 +862,7 @@ export class ColorPicker {
                   label={intlSaveColor}
                   onClick={this.saveColor}
                   scale={hexInputScale}
+                  type="button"
                 />
               </div>
             </div>

--- a/src/components/fab/fab.e2e.ts
+++ b/src/components/fab/fab.e2e.ts
@@ -20,6 +20,16 @@ describe("calcite-fab", () => {
       }
     ]));
 
+  it(`should set all internal calcite-button types to 'button'`, async () => {
+    const page = await newE2EPage({
+      html: "<calcite-fab></calcite-fab>"
+    });
+
+    const buttons = await page.findAll("calcite-fab >>> calcite-button");
+
+    buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
+  });
+
   it("should have visible text when text is enabled", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-fab text="hello world" text-enabled></calcite-fab>`);

--- a/src/components/fab/fab.e2e.ts
+++ b/src/components/fab/fab.e2e.ts
@@ -27,6 +27,8 @@ describe("calcite-fab", () => {
 
     const buttons = await page.findAll("calcite-fab >>> calcite-button");
 
+    expect(buttons).toHaveLength(1);
+
     buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
   });
 

--- a/src/components/fab/fab.tsx
+++ b/src/components/fab/fab.tsx
@@ -109,6 +109,7 @@ export class Fab {
         round={true}
         scale={scale}
         title={title}
+        type="button"
         width="auto"
       >
         {this.textEnabled ? this.text : null}

--- a/src/components/inline-editable/inline-editable.e2e.ts
+++ b/src/components/inline-editable/inline-editable.e2e.ts
@@ -36,12 +36,14 @@ describe("calcite-inline-editable", () => {
 
     it(`should set all internal calcite-button types to 'button'`, async () => {
       const page = await newE2EPage({
-        html: html`<calcite-inline-editable>
+        html: html`<calcite-inline-editable controls editing-enabled>
           <calcite-input />
         </calcite-inline-editable>`
       });
 
       const buttons = await page.findAll("calcite-inline-editable >>> calcite-button");
+
+      expect(buttons).toHaveLength(3);
 
       buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
     });

--- a/src/components/inline-editable/inline-editable.e2e.ts
+++ b/src/components/inline-editable/inline-editable.e2e.ts
@@ -34,6 +34,18 @@ describe("calcite-inline-editable", () => {
       expect(element).not.toHaveAttribute("loading");
     });
 
+    it(`should set all internal calcite-button types to 'button'`, async () => {
+      const page = await newE2EPage({
+        html: html`<calcite-inline-editable>
+          <calcite-input />
+        </calcite-inline-editable>`
+      });
+
+      const buttons = await page.findAll("calcite-inline-editable >>> calcite-button");
+
+      buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
+    });
+
     it("uses a wrapping label's scale when none are provided", async () => {
       page = await newE2EPage();
       await page.setContent(`

--- a/src/components/inline-editable/inline-editable.tsx
+++ b/src/components/inline-editable/inline-editable.tsx
@@ -132,6 +132,7 @@ export class InlineEditable implements LabelableComponent {
               opacity: this.editingEnabled ? "0" : "1",
               width: this.editingEnabled ? "0" : "inherit"
             }}
+            type="button"
           />
           {this.shouldShowControls && [
             <div class={CSS.cancelEditingButtonWrapper}>
@@ -145,6 +146,7 @@ export class InlineEditable implements LabelableComponent {
                 onClick={this.cancelEditingHandler}
                 ref={(el) => (this.cancelEditingButton = el)}
                 scale={this.scale}
+                type="button"
               />
             </div>,
             <calcite-button
@@ -157,6 +159,7 @@ export class InlineEditable implements LabelableComponent {
               loading={this.loading}
               onClick={this.confirmChangesHandler}
               scale={this.scale}
+              type="button"
             />
           ]}
         </div>

--- a/src/components/split-button/split-button.e2e.ts
+++ b/src/components/split-button/split-button.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, renders, defaults } from "../../tests/commonTests";
+import { html } from "../../tests/utils";
 import { CSS } from "./resources";
 
 describe("calcite-split-button", () => {
@@ -61,6 +62,16 @@ describe("calcite-split-button", () => {
     expect(element).toEqualAttribute("color", "blue");
     expect(element).toEqualAttribute("dropdown-icon-type", "chevron");
     expect(element).toEqualAttribute("width", "auto");
+  });
+
+  it(`should set all internal calcite-button types to 'button'`, async () => {
+    const page = await newE2EPage({
+      html: html`<calcite-split-button primary-text="primary action"></calcite-split-button>`
+    });
+
+    const buttons = await page.findAll("calcite-split-button >>> calcite-button");
+
+    buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
   });
 
   it("renders requested props when valid props are provided", async () => {

--- a/src/components/split-button/split-button.e2e.ts
+++ b/src/components/split-button/split-button.e2e.ts
@@ -71,6 +71,8 @@ describe("calcite-split-button", () => {
 
     const buttons = await page.findAll("calcite-split-button >>> calcite-button");
 
+    expect(buttons).toHaveLength(2);
+
     buttons.forEach(async (button) => expect(await button.getProperty("type")).toBe("button"));
   });
 

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -93,6 +93,7 @@ export class SplitButton {
           onClick={this.calciteSplitButtonPrimaryClickHandler}
           scale={this.scale}
           splitChild={"primary"}
+          type="button"
           width={buttonWidth}
         >
           {this.primaryText}
@@ -117,6 +118,7 @@ export class SplitButton {
             scale={this.scale}
             slot="dropdown-trigger"
             splitChild={"secondary"}
+            type="button"
           />
           <slot />
         </calcite-dropdown>


### PR DESCRIPTION
**Related Issue:** #4007

## Summary

fix(fab, color-picker, inline-editable, split-button): Set calcite button type. #4007

- Make sure button types are "button" so forms don't submit.