### PR TITLE
revert(input): correct negative values in ar and et locales

### DIFF
--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -797,7 +797,10 @@ describe("calcite-input", () => {
       const element = await page.find("calcite-input");
       await element.callMethod("setFocus");
       await page.waitForChanges();
-      await typeNumberValue(page, "-0.001");
+      await typeNumberValue(page, "-");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("");
+      await typeNumberValue(page, "0.001");
       await page.waitForChanges();
       expect(await element.getProperty("value")).toBe("-0.001");
     });

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1084,18 +1084,6 @@ describe("calcite-input", () => {
       });
   });
 
-  it(`allows negative numbers for ar locale`, async () => {
-    const value = "123";
-    const page = await newE2EPage();
-    await page.setContent(html`<calcite-input locale="ar" type="number"></calcite-input>`);
-    const element = await page.find("calcite-input");
-    await element.callMethod("setFocus");
-    await typeNumberValue(page, value);
-    await page.waitForChanges();
-    await page.keyboard.press("Tab");
-    expect(await element.getProperty("value")).toBe(value);
-  });
-
   it(`allows clearing value for type=number`, async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number" value="1"></calcite-input>`);

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -320,6 +320,16 @@ export class Input implements LabelableComponent, FormComponent {
     this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
   }
 
+  componentShouldUpdate(newValue: string, oldValue: string, property: string): boolean {
+    if (this.type === "number" && property === "value" && newValue && !isValidNumber(newValue)) {
+      this.setValue({
+        value: oldValue
+      });
+      return false;
+    }
+    return true;
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Events

--- a/src/demos/input.html
+++ b/src/demos/input.html
@@ -1350,14 +1350,6 @@
       </div>
     </div>
 
-    <!-- arabic number input  -->
-    <div class="parent-flex">
-      <div class="child-flex font right-aligned-text">arabic number input</div>
-      <div class="child-flex">
-        <calcite-input type="number" name="arabic-group" locale="ar" placeholder="arabic number input"></calcite-input>
-      </div>
-    </div>
-
     <!-- set to undefined -->
     <div class="parent-flex">
       <div class="child-flex font right-aligned-text">set to undefined</div>


### PR DESCRIPTION
**Related Issue:** #4063

## Summary
Reverts #4020 which is a fix for `et` and `ar` locales. That fix created a regression which effects the `en` locale, which is most of our users, and therefore takes priority. I will reopen the other issue and find a solution that does not cause this regression.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
