### PR TITLE
docs(panel, shell-panel-shell-center-row): fix heightScale typo

### DIFF
--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -84,9 +84,9 @@ export class Panel implements ConditionalSlotComponent {
   @Prop() intlBack?: string;
 
   /**
-   * Specifies the maxiumum height of the panel.
+   * Specifies the maximum height of the panel.
    */
-  @Prop({ reflect: true }) heightScale: Scale;
+  @Prop({ reflect: true }) heightScale?: Scale;
 
   /**
    * This sets width of the panel.

--- a/src/components/shell-center-row/shell-center-row.tsx
+++ b/src/components/shell-center-row/shell-center-row.tsx
@@ -30,7 +30,7 @@ export class ShellCenterRow implements ConditionalSlotComponent {
   @Prop({ reflect: true }) detached = false;
 
   /**
-   * Specifies the maxiumum height of the row.
+   * Specifies the maximum height of the row.
    */
   @Prop({ reflect: true }) heightScale: Scale = "s";
 

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -52,7 +52,7 @@ export class ShellPanel implements ConditionalSlotComponent {
   @Prop({ reflect: true }) detached = false;
 
   /**
-   * Specifies the maxiumum height of the contents when detached.
+   * Specifies the maximum height of the contents when detached.
    */
   @Prop({ reflect: true }) detachedHeightScale: Scale = "l";
 


### PR DESCRIPTION
**Related Issue:** https://community.esri.com/t5/calcite-design-system-questions/calcite-panel-heightscale-optional-or-not/td-p/1137264

## Summary
- Fixes typo and sets heightScale to optional when for `panel` where there is no default
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
