### PR TITLE
chore: reorganize a11y and bug issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -63,15 +63,13 @@ body:
     attributes:
       label: Relevant Info
       description: Browser, OS, mobile, stack traces, related issues, suggestions/resources on how to fix, etc.
-      value: "Regression? Last working version: `@esri/calcite-components@1.0.0-VERSION`"
     validations:
       required: false
   - type: checkboxes
-    id: source
+    id: regression
     attributes:
-      label: Source
+      label: Regression?
+      description: Please provide the last working version in the Relevant Info section if the issue is a regression.
       options:
-        - label: CDN
-          required: false
-        - label: NPM package
+        - label: "Yes"
           required: false

--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -40,7 +40,10 @@ body:
     attributes:
       label: Reproduction Steps
       description: Clear, numbered steps for reproducing the issue using the sample provided above.
-      value: "1. "
+      placeholder: |
+        1. Open the DevTools console
+        2. Click on XYZ
+        3. ...
     validations:
       required: true
   - type: input
@@ -48,7 +51,7 @@ body:
     attributes:
       label: Reproduction Version
       description: The latest version that reproduces the issue.
-      value: "@esri/calcite-components@1.0.0-VERSION"
+      placeholder: beta.2
     validations:
       required: true
   - type: input
@@ -63,13 +66,17 @@ body:
     attributes:
       label: Relevant Info
       description: Browser, OS, mobile, stack traces, related issues, suggestions/resources on how to fix, etc.
+      placeholder: |
+        Windows 10, Chrome 97
+        `Uncaught TypeError: Cannot read property of undefined`
+        ...
     validations:
       required: false
-  - type: checkboxes
+  - type: input
     id: regression
     attributes:
       label: Regression?
-      description: Please provide the last working version in the Relevant Info section if the issue is a regression.
-      options:
-        - label: "Yes"
-          required: false
+      description: Please provide the last working version if the issue is a regression.
+      placeholder: beta.1
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -50,15 +50,13 @@ body:
     attributes:
       label: Relevant Info
       description: Browser, OS, mobile, stack traces, related issues, suggestions/resources on how to fix, etc.
-      value: "Regression? Last working version: `@esri/calcite-components@1.0.0-VERSION`"
     validations:
       required: false
   - type: checkboxes
-    id: source
+    id: regression
     attributes:
-      label: Source
+      label: Regression?
+      description: Please provide the last working version in the Relevant Info section if the issue is a regression.
       options:
-        - label: CDN
-          required: false
-        - label: NPM package
+        - label: "Yes"
           required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,7 +34,10 @@ body:
     attributes:
       label: Reproduction Steps
       description: Clear, numbered steps for reproducing the issue using the sample provided above.
-      value: "1. "
+      placeholder: |
+        1. Open the DevTools console
+        2. Click on XYZ
+        3. ...
     validations:
       required: true
   - type: input
@@ -42,7 +45,7 @@ body:
     attributes:
       label: Reproduction Version
       description: The latest version that reproduces the issue.
-      value: "@esri/calcite-components@1.0.0-VERSION"
+      placeholder: beta.2
     validations:
       required: true
   - type: textarea
@@ -50,13 +53,17 @@ body:
     attributes:
       label: Relevant Info
       description: Browser, OS, mobile, stack traces, related issues, suggestions/resources on how to fix, etc.
+      placeholder: |
+        Windows 10, Chrome 97
+        `Uncaught TypeError: Cannot read property of undefined`
+        ...
     validations:
       required: false
-  - type: checkboxes
+  - type: input
     id: regression
     attributes:
       label: Regression?
-      description: Please provide the last working version in the Relevant Info section if the issue is a regression.
-      options:
-        - label: "Yes"
-          required: false
+      description: Please provide the last working version if the issue is a regression.
+      placeholder: beta.1
+    validations:
+      required: false


### PR DESCRIPTION
**Related Issue:** NA

## Summary
- Remove the CDN vs NPM checkboxes as suggested by @jcfranco 
- Removed default values from some of the required fields and added placeholders so someone can't submit without entering something.

Bug template: https://github.com/benelan/test/issues/new?assignees=&labels=bug%2C0+-+new%2Cneeds+triage&template=bug.yml

A11y template: https://github.com/benelan/test/issues/new?assignees=&labels=a11y%2Cbug%2C0+-+new%2Cp+-+high%2Cneeds+triage&template=accessibility.yml
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
