### PR TITLE
fix(popover, tooltip, combobox, dropdown, input-date-picker): Hide popover when the reference element or popover is out of view.

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -78,7 +78,7 @@ $popper-default-z-index: 900;
 
   :host([data-popper-escaped]),
   :host([data-popper-reference-hidden]) {
-    @apply opacity-0 pointer-events-none;
+    @apply opacity-0 pointer-events-none !important;
   }
 }
 

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -76,9 +76,9 @@ $popper-default-z-index: 900;
     @include popperAnimActive();
   }
 
-  :host([data-popper-escaped]),
-  :host([data-popper-reference-hidden]) {
-    @apply opacity-0 pointer-events-none !important;
+  :host([data-popper-placement][data-popper-escaped]),
+  :host([data-popper-placement][data-popper-reference-hidden]) {
+    @apply opacity-0 pointer-events-none;
   }
 }
 

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -75,6 +75,10 @@ $popper-default-z-index: 900;
   :host([data-popper-placement]) .calcite-popper-anim--active {
     @include popperAnimActive();
   }
+
+  :host([data-popper-reference-hidden]) {
+    opacity: 0;
+  }
 }
 
 @mixin popperContainer($zIndex: $popper-default-z-index) {

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -76,8 +76,9 @@ $popper-default-z-index: 900;
     @include popperAnimActive();
   }
 
+  :host([data-popper-escaped]),
   :host([data-popper-reference-hidden]) {
-    opacity: 0;
+    @apply opacity-0 pointer-events-none;
   }
 }
 

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -319,12 +319,14 @@ describe("calcite-popover", () => {
     const popover = await page.find("calcite-popover");
 
     expect(await popover.isVisible()).toBe(true);
+    expect((await popover.getComputedStyle()).pointerEvents).toBe("auto");
 
     popover.setAttribute("data-popper-reference-hidden", "");
 
     await page.waitForChanges();
 
     expect(await popover.isVisible()).toBe(false);
+    expect((await popover.getComputedStyle()).pointerEvents).toBe("none");
 
     popover.removeAttribute("data-popper-reference-hidden");
     popover.setAttribute("data-popper-escaped", "");
@@ -332,11 +334,13 @@ describe("calcite-popover", () => {
     await page.waitForChanges();
 
     expect(await popover.isVisible()).toBe(false);
+    expect((await popover.getComputedStyle()).pointerEvents).toBe("none");
 
     popover.removeAttribute("data-popper-escaped");
 
     await page.waitForChanges();
 
     expect(await popover.isVisible()).toBe(true);
+    expect((await popover.getComputedStyle()).pointerEvents).toBe("auto");
   });
 });

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -325,5 +325,18 @@ describe("calcite-popover", () => {
     await page.waitForChanges();
 
     expect(await popover.isVisible()).toBe(false);
+
+    popover.removeAttribute("data-popper-reference-hidden");
+    popover.setAttribute("data-popper-escaped", "");
+
+    await page.waitForChanges();
+
+    expect(await popover.isVisible()).toBe(false);
+
+    popover.removeAttribute("data-popper-escaped");
+
+    await page.waitForChanges();
+
+    expect(await popover.isVisible()).toBe(true);
   });
 });

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -308,6 +308,14 @@ describe("calcite-popover", () => {
   });
 
   it("should not be visible if reference is hidden", async () => {
+    /*
+    Hide modifier
+    https://popper.js.org/docs/v2/modifiers/hide/
+
+    data-popper-reference-hidden: This attribute gets applied to the popper when the reference element is fully clipped and hidden from view, which causes the popper to appear to be attached to nothing.
+
+    data-popper-escaped: This attribute gets applied when the popper escapes the reference element's boundary (and so it appears detached).
+    */
     const page = await newE2EPage();
 
     await page.setContent(

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -306,4 +306,24 @@ describe("calcite-popover", () => {
     expect(id).toEqual(userDefinedId);
     expect(referenceId).toEqual(userDefinedId);
   });
+
+  it("should not be visible if reference is hidden", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<calcite-popover placement="auto" reference-element="ref" open>content</calcite-popover><div id="ref">referenceElement</div>`
+    );
+
+    await page.waitForChanges();
+
+    const popover = await page.find("calcite-popover");
+
+    expect(await popover.isVisible()).toBe(true);
+
+    popover.setAttribute("data-popper-reference-hidden", "");
+
+    await page.waitForChanges();
+
+    expect(await popover.isVisible()).toBe(false);
+  });
 });


### PR DESCRIPTION
**Related Issue:** None

## Summary

fix(popover, tooltip, combobox, dropdown, input-date-picker): Hide popover that escapes reference element's boundary (and so it appears detached) or when the reference element is fully clipped and hidden from view.

- Hides popover that escapes reference element's boundary (and so it appears detached)
- Hides popover when the reference element is fully clipped and hidden from view.
- Demo: https://popper.js.org/docs/v2/modifiers/hide/#demo

### Hide modifier

https://popper.js.org/docs/v2/modifiers/hide/

data-popper-reference-hidden: This attribute gets applied to the popper when the reference element is fully clipped and hidden from view, which causes the popper to appear to be attached to nothing.

data-popper-escaped: This attribute gets applied when the popper escapes the reference element's boundary (and so it appears detached).

### Gif

![Feb-15-2022 13-22-02](https://user-images.githubusercontent.com/1231455/154151717-45f58379-b031-4aea-8ec2-9a4d3f1fbc03.gif)

