### PR TITLE
fix(date-picker): set correct first day of week for all locales

### DIFF
--- a/src/components/date-picker/assets/date-picker/nls/bs.json
+++ b/src/components/date-picker/assets/date-picker/nls/bs.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD. MM. YYYY.",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD. MM. YYYY.",
   "days": {
     "abbreviated": ["ned", "pon", "uto", "sri", "čet", "pet", "sub"],

--- a/src/components/date-picker/assets/date-picker/nls/ca.json
+++ b/src/components/date-picker/assets/date-picker/nls/ca.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "abbreviated": ["dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds."],

--- a/src/components/date-picker/assets/date-picker/nls/cs.json
+++ b/src/components/date-picker/assets/date-picker/nls/cs.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["ne", "po", "út", "st", "čt", "pá", "so"],

--- a/src/components/date-picker/assets/date-picker/nls/da.json
+++ b/src/components/date-picker/assets/date-picker/nls/da.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["søn.", "man.", "tir.", "ons.", "tor.", "fre.", "lør."],

--- a/src/components/date-picker/assets/date-picker/nls/de.json
+++ b/src/components/date-picker/assets/date-picker/nls/de.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["So.", "Mo.", "Di.", "Mi.", "Do.", "Fr.", "Sa."],

--- a/src/components/date-picker/assets/date-picker/nls/el.json
+++ b/src/components/date-picker/assets/date-picker/nls/el.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "abbreviated": ["Κυρ", "Δευ", "Τρί", "Τετ", "Πέμ", "Παρ", "Σάβ"],

--- a/src/components/date-picker/assets/date-picker/nls/en-AU.json
+++ b/src/components/date-picker/assets/date-picker/nls/en-AU.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "narrow": ["Su.", "M.", "Tu.", "W.", "Th.", "F.", "Sa."],

--- a/src/components/date-picker/assets/date-picker/nls/es.json
+++ b/src/components/date-picker/assets/date-picker/nls/es.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "abbreviated": ["dom.", "lun.", "mar.", "mié.", "jue.", "vie.", "sáb."],

--- a/src/components/date-picker/assets/date-picker/nls/et.json
+++ b/src/components/date-picker/assets/date-picker/nls/et.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["P", "E", "T", "K", "N", "R", "L"],

--- a/src/components/date-picker/assets/date-picker/nls/fi.json
+++ b/src/components/date-picker/assets/date-picker/nls/fi.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["su", "ma", "ti", "ke", "to", "pe", "la"],

--- a/src/components/date-picker/assets/date-picker/nls/fr.json
+++ b/src/components/date-picker/assets/date-picker/nls/fr.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "abbreviated": ["dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam."],

--- a/src/components/date-picker/assets/date-picker/nls/hr.json
+++ b/src/components/date-picker/assets/date-picker/nls/hr.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD. MM. YYYY.",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD. MM. YYYY.",
   "days": {
     "abbreviated": ["ned", "pon", "uto", "sri", "čet", "pet", "sub"],

--- a/src/components/date-picker/assets/date-picker/nls/hu.json
+++ b/src/components/date-picker/assets/date-picker/nls/hu.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "YYYY. MM. DD.",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "YYYY. MM. DD.",
   "days": {
     "abbreviated": ["V", "H", "K", "Sze", "Cs", "P", "Szo"],

--- a/src/components/date-picker/assets/date-picker/nls/it.json
+++ b/src/components/date-picker/assets/date-picker/nls/it.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "abbreviated": ["dom", "lun", "mar", "mer", "gio", "ven", "sab"],

--- a/src/components/date-picker/assets/date-picker/nls/lt.json
+++ b/src/components/date-picker/assets/date-picker/nls/lt.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "-",
   "unitOrder": "YYYY-MM-DD",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "YYYY-MM-DD",
   "days": {
     "abbreviated": ["sk", "pr", "an", "tr", "kt", "pn", "št"],

--- a/src/components/date-picker/assets/date-picker/nls/lv.json
+++ b/src/components/date-picker/assets/date-picker/nls/lv.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["svētd.", "pirmd.", "otrd.", "trešd.", "ceturtd.", "piektd.", "sestd."],

--- a/src/components/date-picker/assets/date-picker/nls/mk.json
+++ b/src/components/date-picker/assets/date-picker/nls/mk.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["нед.", "пон.", "вт.", "сре.", "чет.", "пет.", "саб."],

--- a/src/components/date-picker/assets/date-picker/nls/nb.json
+++ b/src/components/date-picker/assets/date-picker/nls/nb.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["søn.", "man.", "tir.", "ons.", "tor.", "fre.", "lør."],

--- a/src/components/date-picker/assets/date-picker/nls/nl.json
+++ b/src/components/date-picker/assets/date-picker/nls/nl.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "-",
   "unitOrder": "DD-MM-YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD-MM-YYYY",
   "days": {
     "abbreviated": ["zo", "ma", "di", "wo", "do", "vr", "za"],

--- a/src/components/date-picker/assets/date-picker/nls/pl.json
+++ b/src/components/date-picker/assets/date-picker/nls/pl.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["niedz.", "pon.", "wt.", "śr.", "czw.", "pt.", "sob."],

--- a/src/components/date-picker/assets/date-picker/nls/ro.json
+++ b/src/components/date-picker/assets/date-picker/nls/ro.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["dum.", "lun.", "mar.", "mie.", "joi", "vin.", "sâm."],

--- a/src/components/date-picker/assets/date-picker/nls/ru.json
+++ b/src/components/date-picker/assets/date-picker/nls/ru.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["пн", "вт", "ср", "чт", "пт", "сб", "вс"],

--- a/src/components/date-picker/assets/date-picker/nls/sl.json
+++ b/src/components/date-picker/assets/date-picker/nls/sl.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD. MM. YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD. MM. YYYY",
   "days": {
     "abbreviated": ["ned.", "pon.", "tor.", "sre.", "čet.", "pet.", "sob."],

--- a/src/components/date-picker/assets/date-picker/nls/sr.json
+++ b/src/components/date-picker/assets/date-picker/nls/sr.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY.",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY.",
   "days": {
     "abbreviated": ["нед", "пон", "уто", "сре", "чет", "пет", "суб"],

--- a/src/components/date-picker/assets/date-picker/nls/sv.json
+++ b/src/components/date-picker/assets/date-picker/nls/sv.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "-",
   "unitOrder": "YYYY-MM-DD",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "YYYY-MM-DD",
   "days": {
     "abbreviated": ["sön", "mån", "tis", "ons", "tors", "fre", "lör"],

--- a/src/components/date-picker/assets/date-picker/nls/tr.json
+++ b/src/components/date-picker/assets/date-picker/nls/tr.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["Paz", "Pzt", "Sal", "Çar", "Per", "Cum", "Cmt"],

--- a/src/components/date-picker/assets/date-picker/nls/uk.json
+++ b/src/components/date-picker/assets/date-picker/nls/uk.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": ".",
   "unitOrder": "DD.MM.YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD.MM.YYYY",
   "days": {
     "abbreviated": ["нд", "пн", "вт", "ср", "чт", "пт", "сб"],

--- a/src/components/date-picker/assets/date-picker/nls/vi.json
+++ b/src/components/date-picker/assets/date-picker/nls/vi.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "DD/MM/YYYY",
   "days": {
     "abbreviated": ["CN", "Th 2", "Th 3", "Th 4", "Th 5", "Th 6", "Th 7"],


### PR DESCRIPTION
**Related Issue:** #4075 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Sets the first day of the week according to https://olga8614.github.io/calendars/ for the following locales:

BS, CA, CS, DA, DE, EL, ES, ET, FI, FR, HR, HU, IT, LT, LV, NB, NL, PL, RO, SL, SR, SV, TR, UK, VI

MK (missing from issue) was updated following https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/weekData.json#L153