### PR TITLE
fix(input): Allow "" to clear a number input

### DIFF
--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -986,6 +986,15 @@ describe("calcite-input", () => {
       await page.waitForChanges();
       expect(await input.getProperty("value")).toBe("1.008");
     });
+
+    it("allows clearing value with an empty string", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input type="number" value="1"></calcite-input>`);
+      const input = await page.find("calcite-input");
+      input.setProperty("value", "");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("");
+    });
   });
 
   describe("number locale support", () => {

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -204,7 +204,7 @@ export class Input implements LabelableComponent, FormComponent {
       this.setValue({
         origin: "external",
         value:
-          newValue == null
+          newValue == null || newValue == ""
             ? ""
             : this.type === "number"
             ? isValidNumber(newValue)


### PR DESCRIPTION
**Related Issue:** # none

## Summary

After the changes in https://github.com/Esri/calcite-components/pull/3915, setting `element.value = ''` will no longer clear a `<calcite-input type="number">` that previously had a numerical value.  Setting `element.value = null` does clear the input, but that gives us TS errors since we build with `strictNullChecks: true`.

I added a failing test for this case, and then fixed it with a small change to the input component.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
