### PR TITLE
fix(accordion): transparent appearance no longer has border

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -21,25 +21,23 @@
 }
 
 :host {
-  @apply border-color-2
-    relative
+  @apply relative
     block
     max-w-full
-    border
-    border-b-0
-    border-solid
     leading-6;
   --calcite-accordion-item-border: theme("borderColor.color.2");
   --calcite-accordion-item-background: theme("backgroundColor.foreground.1");
 }
 
 .accordion--transparent {
-  border-color: transparent;
   --calcite-accordion-item-border: transparent;
   --calcite-accordion-item-background: transparent;
 }
 
 .accordion--minimal {
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
-  border-color: transparent;
+}
+
+.accordion--default {
+  @apply border border-solid border-color-2 border-b-0;
 }

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -38,6 +38,6 @@
   --calcite-accordion-item-padding: var(--calcite-accordion-item-spacing-unit) 0;
 }
 
-.accordion--default {
+.accordion {
   @apply border border-solid border-color-2 border-b-0;
 }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -70,7 +70,8 @@ export class Accordion {
       <div
         class={{
           "accordion--transparent": this.appearance === "transparent",
-          "accordion--minimal": this.appearance === "minimal"
+          "accordion--minimal": this.appearance === "minimal",
+          "accordion--default": this.appearance === "default"
         }}
       >
         <slot />

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -71,7 +71,7 @@ export class Accordion {
         class={{
           "accordion--transparent": this.appearance === "transparent",
           "accordion--minimal": this.appearance === "minimal",
-          "accordion--default": this.appearance === "default"
+          accordion: this.appearance === "default"
         }}
       >
         <slot />


### PR DESCRIPTION
**Related Issue:** #4120 

## Summary

`transparent` and `minimal` appearance no longer has border in accordion