### PR TITLE
refactor(button,link): remove childElType as state

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -49,11 +49,6 @@ export class Button implements LabelableComponent {
   /** optionally pass a href - used to determine if the component should render as a button or an anchor */
   @Prop({ reflect: true }) href?: string;
 
-  @Watch("href")
-  hrefHandler(href: string): void {
-    this.childElType = href ? "a" : "button";
-  }
-
   /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;
 
@@ -121,7 +116,6 @@ export class Button implements LabelableComponent {
   //--------------------------------------------------------------------------
 
   connectedCallback(): void {
-    this.childElType = this.href ? "a" : "button";
     this.hasLoader = this.loading;
     this.setupTextContentObserver();
     connectLabel(this);
@@ -140,14 +134,15 @@ export class Button implements LabelableComponent {
   componentWillLoad(): void {
     if (Build.isBrowser) {
       this.updateHasContent();
-      if (this.childElType === "button" && !this.type) {
+      if (!this.href && !this.type) {
         this.type = "submit";
       }
     }
   }
 
   render(): VNode {
-    const Tag = this.childElType;
+    const childEl = this.href ? "a" : "button";
+    const Tag = childEl;
     const loaderNode = this.hasLoader ? (
       <div class={CSS.buttonLoader}>
         <calcite-loader
@@ -193,14 +188,14 @@ export class Button implements LabelableComponent {
           [CSS.iconEndEmpty]: !this.iconEnd
         }}
         disabled={this.disabled || this.loading}
-        href={this.childElType === "a" && this.href}
-        name={this.childElType === "button" && this.name}
+        href={childEl === "a" && this.href}
+        name={childEl === "button" && this.name}
         onClick={this.handleClick}
         ref={(el) => (this.childEl = el)}
-        rel={this.childElType === "a" && this.rel}
+        rel={childEl === "a" && this.rel}
         tabIndex={this.disabled || this.loading ? -1 : null}
-        target={this.childElType === "a" && this.target}
-        type={this.childElType === "button" && this.type}
+        target={childEl === "a" && this.target}
+        type={childEl === "button" && this.type}
       >
         {loaderNode}
         {this.iconStart ? iconStartEl : null}
@@ -238,9 +233,6 @@ export class Button implements LabelableComponent {
   /** the rendered child element */
   private childEl?: HTMLElement;
 
-  /** the node type of the rendered child element */
-  @State() childElType?: "a" | "button" = "button";
-
   /** determine if there is slotted content for styling purposes */
   @State() private hasContent = false;
 
@@ -272,9 +264,9 @@ export class Button implements LabelableComponent {
 
   // act on a requested or nearby form based on type
   private handleClick = (): void => {
-    const { childElType, formEl, type } = this;
+    const { formEl, type } = this;
     // this.type refers to type attribute, not child element type
-    if (childElType === "button" && type !== "button") {
+    if (!this.href && type !== "button") {
       if (type === "submit") {
         formEl?.requestSubmit();
       } else if (type === "reset") {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -141,8 +141,8 @@ export class Button implements LabelableComponent {
   }
 
   render(): VNode {
-    const childEl = this.href ? "a" : "button";
-    const Tag = childEl;
+    const childElType = this.href ? "a" : "button";
+    const Tag = childElType;
     const loaderNode = this.hasLoader ? (
       <div class={CSS.buttonLoader}>
         <calcite-loader
@@ -188,14 +188,14 @@ export class Button implements LabelableComponent {
           [CSS.iconEndEmpty]: !this.iconEnd
         }}
         disabled={this.disabled || this.loading}
-        href={childEl === "a" && this.href}
-        name={childEl === "button" && this.name}
+        href={childElType === "a" && this.href}
+        name={childElType === "button" && this.name}
         onClick={this.handleClick}
         ref={(el) => (this.childEl = el)}
-        rel={childEl === "a" && this.rel}
+        rel={childElType === "a" && this.rel}
         tabIndex={this.disabled || this.loading ? -1 : null}
-        target={childEl === "a" && this.target}
-        type={childEl === "button" && this.type}
+        target={childElType === "a" && this.target}
+        type={childElType === "button" && this.type}
       >
         {loaderNode}
         {this.iconStart ? iconStartEl : null}

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, Method, Prop, State, VNode, Watch } from "@stencil/core";
+import { Component, Element, h, Host, Method, Prop, VNode } from "@stencil/core";
 import { focusElement, getElementDir } from "../../utils/dom";
 import { FlipContext } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
@@ -64,7 +64,7 @@ export class Link {
   render(): VNode {
     const { download, el } = this;
     const dir = getElementDir(el);
-    const childEl = this.href ? "a" : "span";
+    const childElType = this.href ? "a" : "span";
     const iconStartEl = (
       <calcite-icon
         class="calcite-link--icon icon-start"
@@ -83,9 +83,9 @@ export class Link {
       />
     );
 
-    const Tag = childEl;
-    const role = childEl === "span" ? "link" : null;
-    const tabIndex = this.disabled ? -1 : childEl === "span" ? 0 : null;
+    const Tag = childElType;
+    const role = childElType === "span" ? "link" : null;
+    const tabIndex = this.disabled ? -1 : childElType === "span" ? 0 : null;
 
     return (
       <Host role="presentation">

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -40,11 +40,6 @@ export class Link {
   /** optionally pass a href - used to determine if the component should render as a link or an anchor */
   @Prop({ reflect: true }) href?: string;
 
-  @Watch("href")
-  hrefHandler(href: string): void {
-    this.childElType = href ? "a" : "span";
-  }
-
   /** optionally pass an icon to display at the end of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconEnd?: string;
 
@@ -66,14 +61,10 @@ export class Link {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
-    this.childElType = this.href ? "a" : "span";
-  }
-
   render(): VNode {
     const { download, el } = this;
     const dir = getElementDir(el);
-
+    const childEl = this.href ? "a" : "span";
     const iconStartEl = (
       <calcite-icon
         class="calcite-link--icon icon-start"
@@ -92,9 +83,9 @@ export class Link {
       />
     );
 
-    const Tag = this.childElType;
-    const role = this.childElType === "span" ? "link" : null;
-    const tabIndex = this.disabled ? -1 : this.childElType === "span" ? 0 : null;
+    const Tag = childEl;
+    const role = childEl === "span" ? "link" : null;
+    const tabIndex = this.disabled ? -1 : childEl === "span" ? 0 : null;
 
     return (
       <Host role="presentation">
@@ -140,9 +131,6 @@ export class Link {
 
   /** the rendered child element */
   private childEl: HTMLAnchorElement | HTMLSpanElement;
-
-  /** the node type of the rendered child element */
-  @State() childElType: "a" | "span" = "span";
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #3284 

### Summary

This will remove the existing `childElType` state in `button` & `link` components and determine the `type` in render method.

