### PR TITLE
fix(tree-item): Pressing right arrow key focuses first child when the tree-item contains an expanded subtree

### DIFF
--- a/src/components/tree-item/tree-item.e2e.ts
+++ b/src/components/tree-item/tree-item.e2e.ts
@@ -292,4 +292,59 @@ describe("calcite-tree-item", () => {
     expect(checkbox).not.toHaveAttribute("checked");
     expect(isVisible).toBe(true);
   });
+
+  it("right arrow key expands subtree and left arrow collapses it", async () => {
+    const page = await newE2EPage({
+      html: `
+        <calcite-tree>
+          <calcite-tree-item id="cables">
+            Cables
+            <calcite-tree slot="children">
+              <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
+              <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+    `
+    });
+
+    await page.keyboard.press("Tab");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
+    expect(await page.evaluate(() => (document.activeElement as HTMLCalciteTreeItemElement).expanded)).toBe(false);
+
+    await page.keyboard.press("ArrowRight");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
+    expect(await page.evaluate(() => (document.activeElement as HTMLCalciteTreeItemElement).expanded)).toBe(true);
+
+    await page.keyboard.press("ArrowLeft");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
+    expect(await page.evaluate(() => (document.activeElement as HTMLCalciteTreeItemElement).expanded)).toBe(false);
+  });
+
+  it("right arrow key focuses first item in expanded subtree", async () => {
+    const page = await newE2EPage({
+      html: `
+        <calcite-tree>
+          <calcite-tree-item id="cables" expanded>
+            Cables
+            <calcite-tree slot="children">
+              <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
+              <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+    `
+    });
+
+    await page.keyboard.press("Tab");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
+
+    await page.keyboard.press("ArrowRight");
+
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("xlr");
+  });
 });

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -345,7 +345,8 @@ export class TreeItem implements ConditionalSlotComponent {
 
         // When focus is on a open node, moves focus to the first child node.
         if (this.hasChildren && this.expanded) {
-          this.el.querySelector("calcite-tree-item").focus();
+          this.el.querySelector("calcite-tree-item")?.focus();
+          e.stopPropagation();
           break;
         }
 


### PR DESCRIPTION
**Related Issue:** #3123

## Summary

This is a partial fix for #3123 that restores the correct right arrow key behavior.  The fix now focuses the first child in an expanded subtree.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
