### PR TITLE
feat(label): add additional layout of horizontal to replace deprecate…

### DIFF
--- a/src/components/label/label.tsx
+++ b/src/components/label/label.tsx
@@ -40,8 +40,15 @@ export class Label {
   /** specify the scale of the label, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** is the wrapped element positioned inline with the label slotted text */
-  @Prop({ reflect: true }) layout: "inline" | "inline-space-between" | "default" = "default";
+  /** is the wrapped element positioned inline with the label slotted text
+   * @deprecated "inline"/"inline-space-between" layout will no longer be supported, use "horizontal"/"horizontal-space-between" instead
+   */
+  @Prop({ reflect: true }) layout:
+    | "horizontal"
+    | "horizontal-space-between"
+    | "inline"
+    | "inline-space-between"
+    | "default" = "default";
 
   /** eliminates any space around the label */
   @Prop() disableSpacing = false;


### PR DESCRIPTION
…d inline

**Related Issue:** #2188

## Summary
For easier clarity on layout prop- "inline" and "inline-space-between" will be changed to "horizontal" and "horizontal-space-between". I kept "inline"/"inline-space-between" still as an option just in case it's already been utilized and to not cause any problems. 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
