### PR TITLE
fix(slider): aria-role is assigned to appropriate element

### DIFF
--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -18,7 +18,7 @@ export const SingleValue = (): string => html`
     max="${number("max", 100)}"
     value="${number("value", 50)}"
     step="${number("step", 1)}"
-    min-label="${text("label", "Temperature")}"
+    min-label="${text("min-label", "Temperature")}"
     ${boolean("disabled", false)}
     ${boolean("label-handles", false)}
     ${boolean("label-ticks", false)}

--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -18,7 +18,7 @@ export const SingleValue = (): string => html`
     max="${number("max", 100)}"
     value="${number("value", 50)}"
     step="${number("step", 1)}"
-    label="${text("label", "Temperature")}"
+    min-label="${text("label", "Temperature")}"
     ${boolean("disabled", false)}
     ${boolean("label-handles", false)}
     ${boolean("label-ticks", false)}

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -221,7 +221,6 @@ export class Slider implements LabelableComponent, FormComponent {
         aria-valuemax={this.max}
         aria-valuemin={this.min}
         aria-valuenow={value}
-        // disabled={this.disabled}
         class={{
           thumb: true,
           "thumb--value": true,

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -189,7 +189,8 @@ export class Slider implements LabelableComponent, FormComponent {
     const rightThumbOffset = `${mirror ? maxInterval : 100 - maxInterval}%`;
 
     const handle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -200,37 +201,39 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle" />
-      </button>
+      </div>
     );
 
     const labeledHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
         aria-valuemin={this.min}
         aria-valuenow={value}
+        // disabled={this.disabled}
         class={{
           thumb: true,
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <span aria-hidden="true" class="handle__label handle__label--value">
           {value ? value.toLocaleString() : value}
@@ -242,11 +245,12 @@ export class Slider implements LabelableComponent, FormComponent {
           {value ? value.toLocaleString() : value}
         </span>
         <div class="handle" />
-      </button>
+      </div>
     );
 
     const histogramLabeledHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -257,13 +261,13 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--value": true,
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle" />
         <span aria-hidden="true" class="handle__label handle__label--value">
@@ -275,11 +279,12 @@ export class Slider implements LabelableComponent, FormComponent {
         <span aria-hidden="true" class="handle__label handle__label--value transformed">
           {value ? value.toLocaleString() : value}
         </span>
-      </button>
+      </div>
     );
 
     const preciseHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -291,21 +296,22 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle" />
         <div class="handle-extension" />
-      </button>
+      </div>
     );
 
     const histogramPreciseHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -317,21 +323,22 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle-extension" />
         <div class="handle" />
-      </button>
+      </div>
     );
 
     const labeledPreciseHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -343,13 +350,13 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <span aria-hidden="true" class="handle__label handle__label--value">
           {value ? value.toLocaleString() : value}
@@ -362,11 +369,12 @@ export class Slider implements LabelableComponent, FormComponent {
         </span>
         <div class="handle" />
         <div class="handle-extension" />
-      </button>
+      </div>
     );
 
     const histogramLabeledPreciseHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.isRange ? this.maxLabel : this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -378,13 +386,13 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--active": this.lastDragProp !== "minMaxValue" && this.dragProp === maxProp,
           "thumb--precise": true
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={() => this.dragStart(maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle-extension" />
         <div class="handle" />
@@ -397,11 +405,12 @@ export class Slider implements LabelableComponent, FormComponent {
         <span aria-hidden="true" class="handle__label handle__label--value transformed">
           {value ? value.toLocaleString() : value}
         </span>
-      </button>
+      </div>
     );
 
     const minHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -412,20 +421,21 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue"
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={() => this.dragStart("minValue")}
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle" />
-      </button>
+      </div>
     );
 
     const minLabeledHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -436,13 +446,13 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue"
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={() => this.dragStart("minValue")}
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
+        tabIndex={0}
       >
         <span aria-hidden="true" class="handle__label handle__label--minValue">
           {this.minValue && this.minValue.toLocaleString()}
@@ -454,11 +464,12 @@ export class Slider implements LabelableComponent, FormComponent {
           {this.minValue && this.minValue.toLocaleString()}
         </span>
         <div class="handle" />
-      </button>
+      </div>
     );
 
     const minHistogramLabeledHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -469,13 +480,13 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--minValue": true,
           "thumb--active": this.dragProp === "minValue"
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={() => this.dragStart("minValue")}
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle" />
         <span aria-hidden="true" class="handle__label handle__label--minValue">
@@ -487,11 +498,12 @@ export class Slider implements LabelableComponent, FormComponent {
         <span aria-hidden="true" class="handle__label handle__label--minValue transformed">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-      </button>
+      </div>
     );
 
     const minPreciseHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -503,21 +515,22 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--active": this.dragProp === "minValue",
           "thumb--precise": true
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={() => this.dragStart("minValue")}
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle-extension" />
         <div class="handle" />
-      </button>
+      </div>
     );
 
     const minLabeledPreciseHandle = (
-      <button
+      <div
+        aria-disabled={this.disabled}
         aria-label={this.minLabel}
         aria-orientation="horizontal"
         aria-valuemax={this.max}
@@ -529,13 +542,13 @@ export class Slider implements LabelableComponent, FormComponent {
           "thumb--active": this.dragProp === "minValue",
           "thumb--precise": true
         }}
-        disabled={this.disabled}
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={() => this.dragStart("minValue")}
-        ref={(el) => (this.minHandle = el as HTMLButtonElement)}
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
+        tabIndex={0}
       >
         <div class="handle-extension" />
         <div class="handle" />
@@ -548,7 +561,7 @@ export class Slider implements LabelableComponent, FormComponent {
         <span aria-hidden="true" class="handle__label handle__label--minValue transformed">
           {this.minValue && this.minValue.toLocaleString()}
         </span>
-      </button>
+      </div>
     );
 
     return (
@@ -861,9 +874,9 @@ export class Slider implements LabelableComponent, FormComponent {
 
   private lastDragPropValue: number;
 
-  private minHandle: HTMLButtonElement;
+  private minHandle: HTMLDivElement;
 
-  private maxHandle: HTMLButtonElement;
+  private maxHandle: HTMLDivElement;
 
   private trackEl: HTMLDivElement;
 
@@ -1066,13 +1079,13 @@ export class Slider implements LabelableComponent, FormComponent {
     return num;
   }
 
-  private getClosestHandle(valueX: number): HTMLButtonElement {
+  private getClosestHandle(valueX: number): HTMLDivElement {
     return this.getDistanceX(this.maxHandle, valueX) > this.getDistanceX(this.minHandle, valueX)
       ? this.minHandle
       : this.maxHandle;
   }
 
-  private getDistanceX(el: HTMLButtonElement, valueX: number): number {
+  private getDistanceX(el: HTMLDivElement, valueX: number): number {
     return Math.abs(el.getBoundingClientRect().left - valueX);
   }
 
@@ -1246,9 +1259,8 @@ export class Slider implements LabelableComponent, FormComponent {
       return;
     }
 
-    const minHandle: HTMLButtonElement | null =
-      this.el.shadowRoot.querySelector(".thumb--minValue");
-    const maxHandle: HTMLButtonElement | null = this.el.shadowRoot.querySelector(".thumb--value");
+    const minHandle: HTMLDivElement | null = this.el.shadowRoot.querySelector(".thumb--minValue");
+    const maxHandle: HTMLDivElement | null = this.el.shadowRoot.querySelector(".thumb--value");
 
     const minTickLabel: HTMLSpanElement | null =
       this.el.shadowRoot.querySelector(".tick__label--min");
@@ -1309,22 +1321,22 @@ export class Slider implements LabelableComponent, FormComponent {
   }
 
   /**
-   * Returns a boolean value representing if the minLabel span element is obscured (being overlapped) by the given handle button element.
+   * Returns a boolean value representing if the minLabel span element is obscured (being overlapped) by the given handle div element.
    * @param minLabel
    * @param handle
    */
-  private isMinTickLabelObscured(minLabel: HTMLSpanElement, handle: HTMLButtonElement): boolean {
+  private isMinTickLabelObscured(minLabel: HTMLSpanElement, handle: HTMLDivElement): boolean {
     const minLabelBounds = minLabel.getBoundingClientRect();
     const handleBounds = handle.getBoundingClientRect();
     return intersects(minLabelBounds, handleBounds);
   }
 
   /**
-   * Returns a boolean value representing if the maxLabel span element is obscured (being overlapped) by the given handle button element.
+   * Returns a boolean value representing if the maxLabel span element is obscured (being overlapped) by the given handle div element.
    * @param maxLabel
    * @param handle
    */
-  private isMaxTickLabelObscured(maxLabel: HTMLSpanElement, handle: HTMLButtonElement): boolean {
+  private isMaxTickLabelObscured(maxLabel: HTMLSpanElement, handle: HTMLDivElement): boolean {
     const maxLabelBounds = maxLabel.getBoundingClientRect();
     const handleBounds = handle.getBoundingClientRect();
     return intersects(maxLabelBounds, handleBounds);

--- a/src/demos/slider.html
+++ b/src/demos/slider.html
@@ -51,9 +51,33 @@
       <div class="child right-aligned-text">disabled</div>
 
       <div class="child">
-        <calcite-slider scale="s" min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
-        <calcite-slider scale="m" min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
-        <calcite-slider scale="l" min="0" max="100" value="40" step="1" label="Temperature" disabled></calcite-slider>
+        <calcite-slider
+          scale="s"
+          min="0"
+          max="100"
+          value="40"
+          step="1"
+          min-label="Temperature"
+          disabled
+        ></calcite-slider>
+        <calcite-slider
+          scale="m"
+          min="0"
+          max="100"
+          value="40"
+          step="1"
+          min-label="Temperature"
+          disabled
+        ></calcite-slider>
+        <calcite-slider
+          scale="l"
+          min="0"
+          max="100"
+          value="40"
+          step="1"
+          min-label="Temperature"
+          disabled
+        ></calcite-slider>
       </div>
 
       <div class="child">
@@ -187,7 +211,7 @@
           max="100000"
           value="100000"
           step="1000.12"
-          label="Temperature"
+          min-label="Temperature"
           precise
           label-handles
         >
@@ -201,7 +225,7 @@
           max="100000"
           value="100000"
           step="1000.12"
-          label="Temperature"
+          min-label="Temperature"
           precise
           label-handles
         >
@@ -363,7 +387,16 @@
       <div class="child right-aligned-text">ticks with precise labeled handle and a decimal step</div>
 
       <div class="child">
-        <calcite-slider min="0" max="100" value="60" step="10.12" ticks="10" label="Temperature" label-handles precise>
+        <calcite-slider
+          min="0"
+          max="100"
+          value="60"
+          step="10.12"
+          ticks="10"
+          min-label="Temperature"
+          label-handles
+          precise
+        >
         </calcite-slider>
       </div>
 
@@ -375,7 +408,7 @@
           value="60"
           step="10.12"
           ticks="10"
-          label="Temperature"
+          min-label="Temperature"
           label-handles
           precise
         >
@@ -666,7 +699,7 @@
           label-handles
           label-ticks
           precise
-          label="Temperature"
+          min-label="Temperature"
         ></calcite-slider>
       </div>
 
@@ -681,7 +714,7 @@
           label-handles
           label-ticks
           precise
-          label="Temperature"
+          min-label="Temperature"
         ></calcite-slider>
       </div>
     </div>
@@ -1812,7 +1845,7 @@
           max-value="80000"
           step="10000.12"
           ticks="10000"
-          label="Temperature"
+          min-label="Temperature"
           precise
           label-handles
           label-ticks
@@ -1828,7 +1861,7 @@
           max-value="80000"
           step="10000.12"
           ticks="10000"
-          label="Temperature"
+          min-label="Temperature"
           precise
           label-handles
           label-ticks
@@ -2929,7 +2962,14 @@
       <div class="child right-aligned-text">Event listener</div>
 
       <div class="child">
-        <calcite-slider id="sliderEvents" min="0" max="100" value="50" step="1" label="Temperature"></calcite-slider>
+        <calcite-slider
+          id="sliderEvents"
+          min="0"
+          max="100"
+          value="50"
+          step="1"
+          min-label="Temperature"
+        ></calcite-slider>
         <p>Current slider value is: <span id="sliderEventDisplay"></span></p>
       </div>
     </div>


### PR DESCRIPTION
**Related Issue:** #1156 

## Summary

This fix will assign the `aria-role=slider` to appropriate element `div` and enable the screen readers to identify slider. 

