### PR TITLE
revert(pick-list): this change was in the wrong pr branch that got merged by accident

### DIFF
--- a/src/components/pick-list/shared-list-logic.ts
+++ b/src/components/pick-list/shared-list-logic.ts
@@ -258,7 +258,6 @@ export function deselectSiblingItems<T extends Lists>(this: List<T>, item: ListI
   this.items.forEach((currentItem) => {
     if (currentItem.value !== item.value) {
       currentItem.toggleSelected(false);
-      toggleSingleSelectItemTabbing(currentItem, false);
       if (this.selectedValues.has(currentItem.value)) {
         this.selectedValues.delete(currentItem.value);
       }


### PR DESCRIPTION
this reverts commit 52f19d1

**Related Issue:** #4168

## Summary
This code change was meant for pr branch #4177 so reverting it to put this code fix at it's proper pr branch
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
