### PR TITLE
fix: solve regression with preact type generation

### DIFF
--- a/support/preact.ts
+++ b/support/preact.ts
@@ -34,16 +34,17 @@ declare module "preact/src/jsx" {
 }
 
 function getType({ events, tagName, componentClassName }): string {
+  const className = `Calcite${componentClassName}`;
   if (!events?.length) {
     return `
-      "${tagName}": JSX.${componentClassName} & JSXInternal.HTMLAttributes<HTML${componentClassName}Element>`;
+      "${tagName}": JSX.${className} & JSXInternal.HTMLAttributes<HTML${className}Element>`;
   } else {
     const stencilEvents = events.map(({ name }) => `"on${capitalize(name)}"`).join(" | ");
     const preactEvents = events
       .map(({ name }) => `"on${name}"?: (event: CustomEvent<any>) => void;`)
       .join("\n        ");
     return `
-      "${tagName}": Omit<JSX.${componentClassName}, ${stencilEvents}> & JSXInternal.HTMLAttributes<HTML${componentClassName}Element> & {
+      "${tagName}": Omit<JSX.${className}, ${stencilEvents}> & JSXInternal.HTMLAttributes<HTML${className}Element> & {
         ${preactEvents}
       }`;
   }


### PR DESCRIPTION
## Summary

When all the files were renamed without the `calcite` prefix, it caused the generated preact types to be incorrect. This led to a lot of typescript errors where we're using a ref pointing to these types as preact was then thinking the CalciteInput was an Input.