### PR TITLE
fix(combobox, dropdown, input-date-picker, popover, tooltip): disable scroll event listeners for hidden poppers

### DIFF
--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { renders, hidden, accessible, defaults, labelable, formAssociated } from "../../tests/commonTests";
+import { renders, hidden, accessible, defaults, labelable, formAssociated, popperOwner } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 import { TEXT } from "./resources";
 
@@ -945,5 +945,16 @@ describe("calcite-combobox", () => {
         <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
       </calcite-combobox>`,
       { testValue: "two" }
+    ));
+
+  it("owns a popper", () =>
+    popperOwner(
+      html` <calcite-combobox>
+        <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
+        <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two" selected></calcite-combobox-item>
+        <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+      </calcite-combobox>`,
+      "active",
+      { shadowPopperSelector: ".popper-container" }
     ));
 });

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -446,12 +446,12 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   };
 
   private toggleCloseEnd = (): void => {
-    this.active = true;
+    this.active = false;
     this.el.removeEventListener("calciteComboboxClose", this.toggleCloseEnd);
   };
 
   private toggleOpenEnd = (): void => {
-    this.active = false;
+    this.active = true;
     this.el.removeEventListener("calciteComboboxOpen", this.toggleOpenEnd);
   };
 
@@ -499,11 +499,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
 
   setInactiveIfNotContained = (event: Event): void => {
     const composedPath = event.composedPath();
-    if (
-      (!this.active && !this.open) ||
-      composedPath.includes(this.el) ||
-      composedPath.includes(this.referenceEl)
-    ) {
+    if (!this.active || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
       return;
     }
 
@@ -521,7 +517,6 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
     }
 
     this.active = false;
-    this.open = false;
   };
 
   setMenuEl = (el: HTMLDivElement): void => {
@@ -1026,7 +1021,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
         ref={setMenuEl}
       >
         <div class={classes} onTransitionEnd={this.transitionEnd} ref={setListContainerEl}>
-          <ul class={{ list: true, "list--hide": active }}>
+          <ul class={{ list: true, "list--hide": !active }}>
             <slot />
           </ul>
         </div>
@@ -1065,7 +1060,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
       <Host onKeyDown={this.keydownHandler}>
         <div
           aria-autocomplete="list"
-          aria-expanded={open.toString()}
+          aria-expanded={active.toString()}
           aria-haspopup="listbox"
           aria-labelledby={`${labelUidPrefix}${guid}`}
           aria-owns={`${listboxUidPrefix}${guid}`}

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -1,5 +1,5 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, renders } from "../../tests/commonTests";
+import { accessible, defaults, popperOwner, renders } from "../../tests/commonTests";
 import dedent from "dedent";
 import { html } from "../../tests/utils";
 
@@ -1010,4 +1010,20 @@ describe("calcite-dropdown", () => {
 
     expect(dropdownContentHeight.height).toBe("0px");
   });
+
+  it("owns a popper", () =>
+    popperOwner(
+      html` <calcite-dropdown>
+        <calcite-button slot="dropdown-trigger">Open</calcite-button>
+        <calcite-dropdown-group selection-mode="single">
+          <calcite-dropdown-item id="item-1" active>1</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>`,
+      "active",
+      {
+        shadowPopperSelector: ".calcite-dropdown-wrapper"
+      }
+    ));
 });

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -379,7 +379,12 @@ export class Dropdown {
       fallbackPlacements: ["top-start", "top", "top-end", "bottom-start", "bottom", "bottom-end"]
     };
 
-    return [flipModifier];
+    const eventListenerModifier: Partial<StrictModifiers> = {
+      name: "eventListeners",
+      enabled: this.active
+    };
+
+    return [flipModifier, eventListenerModifier];
   }
 
   createPopper(): void {

--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { defaults, formAssociated, labelable, renders } from "../../tests/commonTests";
+import { defaults, formAssociated, labelable, popperOwner, renders } from "../../tests/commonTests";
 import { html } from "../../tests/utils";
 
 const animationDurationInMs = 200;
@@ -166,4 +166,11 @@ describe("calcite-input-date-picker", () => {
     );
     expect(minDateAsTime).toEqual(new Date(minDateString).getTime());
   });
+
+  it("owns a popper", () =>
+    popperOwner(
+      `<calcite-input-date-picker value="2022-11-27" min="2022-11-15" max="2024-11-15"></calcite-input-date-picker>`,
+      "active",
+      { shadowPopperSelector: ".menu-container" }
+    ));
 });

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -563,7 +563,12 @@ export class InputDatePicker implements LabelableComponent, FormComponent {
       fallbackPlacements: ["top-start", "top", "top-end", "bottom-start", "bottom", "bottom-end"]
     };
 
-    return [flipModifier];
+    const eventListenerModifier: Partial<StrictModifiers> = {
+      name: "eventListeners",
+      enabled: this.active
+    };
+
+    return [flipModifier, eventListenerModifier];
   }
 
   createPopper(): void {

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, popperOwner, renders } from "../../tests/commonTests";
 
 import { CSS, POPOVER_REFERENCE } from "./resources";
 
@@ -351,4 +351,10 @@ describe("calcite-popover", () => {
     expect(await popover.isVisible()).toBe(true);
     expect((await popover.getComputedStyle()).pointerEvents).toBe("auto");
   });
+
+  it("owns a popper", () =>
+    popperOwner(
+      `<calcite-popover placement="auto" reference-element="ref" open>content</calcite-popover><div id="ref">referenceElement</div>`,
+      "open"
+    ));
 });

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -345,7 +345,12 @@ export class Popover {
       }
     };
 
-    return [arrowModifier, flipModifier, offsetModifier];
+    const eventListenerModifier: Partial<StrictModifiers> = {
+      name: "eventListeners",
+      enabled: this.open
+    };
+
+    return [arrowModifier, flipModifier, offsetModifier, eventListenerModifier];
   }
 
   createPopper(): void {

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { TOOLTIP_DELAY_MS, TOOLTIP_REFERENCE } from "../tooltip/resources";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, popperOwner, renders } from "../../tests/commonTests";
 
 describe("calcite-tooltip", () => {
   it("renders", async () => {
@@ -248,4 +248,10 @@ describe("calcite-tooltip", () => {
     expect(id).toEqual(userDefinedId);
     expect(referenceId).toEqual(userDefinedId);
   });
+
+  it("owns a popper", () =>
+    popperOwner(
+      `<calcite-tooltip reference-element="ref">content</calcite-tooltip><div id="ref">referenceElement</div>`,
+      "open"
+    ));
 });

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -228,7 +228,12 @@ export class Tooltip {
       }
     };
 
-    return [arrowModifier, offsetModifier];
+    const eventListenerModifier: Partial<StrictModifiers> = {
+      name: "eventListeners",
+      enabled: this.open
+    };
+
+    return [arrowModifier, offsetModifier, eventListenerModifier];
   }
 
   createPopper(): void {

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -592,3 +592,84 @@ export async function formAssociated(componentTagOrHtml: TagOrHTML, options: For
     }
   }
 }
+
+/**
+ * This helper will test if a popper-owning component has configured the popper correctly.
+ *
+ * At the moment, this only tests if the scroll event listeners are only active when the popper is displayed.
+ *
+ * @param componentTagOrHTML - The component tag or HTML used to test label support.
+ * @param togglePropName - The component property that toggles the popper
+ * @param options - the popper owner test configuration
+ */
+export async function popperOwner(
+  componentTagOrHTML: TagOrHTML,
+  togglePropName: string,
+  options?: {
+    /**
+     * Use this to specify the selector in the shadow DOM for the popper element.
+     */
+    shadowPopperSelector?: string;
+  }
+): Promise<void> {
+  const page = await simplePageSetup(componentTagOrHTML);
+
+  const scrollablePageSizeInPx = 2400;
+  await page.addStyleTag({
+    content: `body { 
+      height: ${scrollablePageSizeInPx}px; 
+      width: ${scrollablePageSizeInPx}px; 
+    }`
+  });
+  await page.waitForChanges();
+
+  const tag = getTag(componentTagOrHTML);
+  const component = await page.find(tag);
+
+  async function getTransform(): Promise<string> {
+    // need to get the style attribute from the browser context since the E2E element returns null
+    return page.$eval(
+      tag,
+      (component: HTMLElement, shadowSelector: string): string => {
+        const popperEl = shadowSelector ? component.shadowRoot.querySelector<HTMLElement>(shadowSelector) : component;
+
+        return popperEl.getAttribute("style");
+      },
+      options?.shadowPopperSelector
+    );
+  }
+
+  async function scrollTo(x: number, y: number): Promise<void> {
+    await page.evaluate((x: number, y: number) => document.firstElementChild.scrollTo(x, y), x, y);
+  }
+
+  component.setProperty(togglePropName, false);
+  await page.waitForChanges();
+
+  const initialClosedTransform = await getTransform();
+
+  await scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
+  await page.waitForChanges();
+
+  expect(await getTransform()).toBe(initialClosedTransform);
+
+  await scrollTo(0, 0);
+  await page.waitForChanges();
+
+  expect(await getTransform()).toBe(initialClosedTransform);
+
+  component.setProperty(togglePropName, true);
+  await page.waitForChanges();
+
+  const initialOpenTransform = await getTransform();
+
+  await scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
+  await page.waitForChanges();
+
+  expect(await getTransform()).not.toBe(initialOpenTransform);
+
+  await scrollTo(0, 0);
+  await page.waitForChanges();
+
+  expect(await getTransform()).toBe(initialOpenTransform);
+}


### PR DESCRIPTION
**Related Issue:** #3727 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR updates all popper-owning components to toggle the `eventListeners` modifier based on the popper's visibility (as suggested [here](https://popper.js.org/docs/v2/tutorial/#performance)). 

This also cleans up some internals for combobox. It seemed to have multiple state props based on `active`. 