### PR TITLE
fix(popover, tooltip, combobox, dropdown, input-date-picker): display escaped poppers

### DIFF
--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -76,7 +76,6 @@ $popper-default-z-index: 900;
     @include popperAnimActive();
   }
 
-  :host([data-popper-placement][data-popper-escaped]),
   :host([data-popper-placement][data-popper-reference-hidden]) {
     @apply opacity-0 pointer-events-none;
   }

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -313,8 +313,6 @@ describe("calcite-popover", () => {
     https://popper.js.org/docs/v2/modifiers/hide/
 
     data-popper-reference-hidden: This attribute gets applied to the popper when the reference element is fully clipped and hidden from view, which causes the popper to appear to be attached to nothing.
-
-    data-popper-escaped: This attribute gets applied when the popper escapes the reference element's boundary (and so it appears detached).
     */
     const page = await newE2EPage();
 
@@ -335,20 +333,5 @@ describe("calcite-popover", () => {
 
     expect(await popover.isVisible()).toBe(false);
     expect((await popover.getComputedStyle()).pointerEvents).toBe("none");
-
-    popover.removeAttribute("data-popper-reference-hidden");
-    popover.setAttribute("data-popper-escaped", "");
-
-    await page.waitForChanges();
-
-    expect(await popover.isVisible()).toBe(false);
-    expect((await popover.getComputedStyle()).pointerEvents).toBe("none");
-
-    popover.removeAttribute("data-popper-escaped");
-
-    await page.waitForChanges();
-
-    expect(await popover.isVisible()).toBe(true);
-    expect((await popover.getComputedStyle()).pointerEvents).toBe("auto");
   });
 });


### PR DESCRIPTION
**Related Issue:** #4197

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This restores visibility for escaped poppers. Poppers with hidden reference elements will continue to be hidden.