### PR TITLE
fix(action-bar, action-pad): allow expanding via API when expandDisabled. #4169

### DIFF
--- a/src/components/action-bar/action-bar.e2e.ts
+++ b/src/components/action-bar/action-bar.e2e.ts
@@ -42,7 +42,7 @@ describe("calcite-action-bar", () => {
       const page = await newE2EPage({
         html: html`<calcite-action-bar expanded>
           <calcite-action-group>
-            <calcite-action id="action-bar-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+            <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
           </calcite-action-group>
           <calcite-action-group>
             <calcite-action-menu label="Save and open">
@@ -53,7 +53,7 @@ describe("calcite-action-bar", () => {
       });
       await page.waitForChanges();
       const actionBar = await page.find("calcite-action-bar");
-      const actionBarAction = await page.find("#action-bar-action");
+      const actionBarAction = await page.find("#my-action");
       const menuAction = await page.find("#menu-action");
       expect(await actionBar.getProperty("expanded")).toBe(true);
       expect(await actionBarAction.getProperty("textEnabled")).toBe(true);
@@ -144,20 +144,25 @@ describe("calcite-action-bar", () => {
       expect(buttonGroup).toBeNull();
     });
 
-    it("should not modify textEnabled on actions when not expandable", async () => {
+    it("should modify textEnabled on actions when expanded and expandDisabled", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(
-        html`<calcite-action-bar expand-disabled expanded
-          ><calcite-action text="hello"></calcite-action
-        ></calcite-action-bar>`
-      );
+      await page.setContent(html`<calcite-action-bar expand-disabled expanded>
+        <calcite-action-group>
+          <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>`);
 
+      const expandAction = await page.find("calcite-action-bar >>> calcite-action");
       const action = await page.find("calcite-action");
+      const actionBar = await page.find("calcite-action-bar");
+      const group = await page.find("calcite-action-group");
 
-      const textEnabled = await action.getProperty("textEnabled");
-
-      expect(textEnabled).toBe(false);
+      expect(await actionBar.getProperty("expanded")).toBe(true);
+      expect(expandAction).toBeNull();
+      expect(action).not.toBeNull();
+      expect(await group.getProperty("expanded")).toBe(true);
+      expect(await action.getProperty("textEnabled")).toBe(true);
     });
 
     it("should modify textEnabled on actions when expanded is true and new children are added", async () => {

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -51,11 +51,7 @@ export class ActionBar implements ConditionalSlotComponent {
   @Prop({ reflect: true }) expandDisabled = false;
 
   @Watch("expandDisabled")
-  expandHandler(expandDisabled: boolean): void {
-    if (!expandDisabled) {
-      toggleChildActionText({ parent: this.el, expanded: this.expanded });
-    }
-
+  expandHandler(): void {
     this.conditionallyOverflowActions();
   }
 
@@ -66,10 +62,7 @@ export class ActionBar implements ConditionalSlotComponent {
 
   @Watch("expanded")
   expandedHandler(expanded: boolean): void {
-    if (!this.expandDisabled) {
-      toggleChildActionText({ parent: this.el, expanded });
-    }
-
+    toggleChildActionText({ parent: this.el, expanded });
     this.calciteActionBarToggle.emit();
   }
 
@@ -145,11 +138,9 @@ export class ActionBar implements ConditionalSlotComponent {
   }
 
   connectedCallback(): void {
-    const { el, expandDisabled, expanded } = this;
+    const { el, expanded } = this;
 
-    if (!expandDisabled) {
-      toggleChildActionText({ parent: el, expanded });
-    }
+    toggleChildActionText({ parent: el, expanded });
 
     this.mutationObserver?.observe(el, { childList: true, subtree: true });
 

--- a/src/components/action-pad/action-pad.e2e.ts
+++ b/src/components/action-pad/action-pad.e2e.ts
@@ -119,25 +119,32 @@ describe("calcite-action-pad", () => {
   it("should not have bottomGroup when not expandable", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-action-bar expand-disabled></calcite-action-bar>`);
+    await page.setContent(`<calcite-action-pad expand-disabled></calcite-action-pad>`);
 
-    const buttonGroup = await page.find(`calcite-action-bar >>> .${CSS.actionGroupBottom}`);
+    const buttonGroup = await page.find(`calcite-action-pad >>> .${CSS.actionGroupBottom}`);
 
     expect(buttonGroup).toBeNull();
   });
 
-  it("should not modify textEnabled on actions when not expandable", async () => {
+  it("should modify textEnabled on actions when expanded and expandDisabled", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(
-      `<calcite-action-bar expand-disabled expanded><calcite-action text="hello"></calcite-action></calcite-action-bar>`
-    );
+    await page.setContent(html`<calcite-action-pad expand-disabled expanded>
+      <calcite-action-group>
+        <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-pad>`);
 
+    const expandAction = await page.find("calcite-action-pad >>> calcite-action");
     const action = await page.find("calcite-action");
+    const actionPad = await page.find("calcite-action-pad");
+    const group = await page.find("calcite-action-group");
 
-    const textEnabled = await action.getProperty("textEnabled");
-
-    expect(textEnabled).toBe(false);
+    expect(await actionPad.getProperty("expanded")).toBe(true);
+    expect(expandAction).toBeNull();
+    expect(action).not.toBeNull();
+    expect(await group.getProperty("expanded")).toBe(true);
+    expect(await action.getProperty("textEnabled")).toBe(true);
   });
 
   it("should be accessible", async () =>

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -41,13 +41,6 @@ export class ActionPad implements ConditionalSlotComponent {
    */
   @Prop({ reflect: true }) expandDisabled = false;
 
-  @Watch("expandDisabled")
-  expandHandler(expandDisabled: boolean): void {
-    if (!expandDisabled) {
-      toggleChildActionText({ parent: this.el, expanded: this.expanded });
-    }
-  }
-
   /**
    * Indicates whether widget is expanded.
    */
@@ -55,10 +48,7 @@ export class ActionPad implements ConditionalSlotComponent {
 
   @Watch("expanded")
   expandedHandler(expanded: boolean): void {
-    if (!this.expandDisabled) {
-      toggleChildActionText({ parent: this.el, expanded });
-    }
-
+    toggleChildActionText({ parent: this.el, expanded });
     this.calciteActionPadToggle.emit();
   }
 
@@ -123,11 +113,9 @@ export class ActionPad implements ConditionalSlotComponent {
   }
 
   componentWillLoad(): void {
-    const { el, expandDisabled, expanded } = this;
+    const { el, expanded } = this;
 
-    if (!expandDisabled) {
-      toggleChildActionText({ parent: el, expanded });
-    }
+    toggleChildActionText({ parent: el, expanded });
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #4169

## Summary

fix(action-bar, action-pad): allow expanding via API when expandDisabled. #4169

Allows action-bar/action-pad to still change `expanded` state even when `expandDisabled` is true. `expandDisabled` only applies to showing the expand/collapse button at the bottom.


