### PR TITLE
fix(dropdown-item): ensure dropdown items are initialized properly

### DIFF
--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -98,12 +98,12 @@ export class DropdownItem {
   //
   //--------------------------------------------------------------------------
 
+  componentWillLoad(): void {
+    this.initialize();
+  }
+
   connectedCallback(): void {
-    this.selectionMode = getElementProp(this.el, "selection-mode", "single");
-    this.parentDropdownGroupEl = this.el.closest("calcite-dropdown-group");
-    if (this.selectionMode === "none") {
-      this.active = false;
-    }
+    this.initialize();
   }
 
   render(): VNode {
@@ -267,6 +267,14 @@ export class DropdownItem {
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private initialize(): void {
+    this.selectionMode = getElementProp(this.el, "selection-mode", "single");
+    this.parentDropdownGroupEl = this.el.closest("calcite-dropdown-group");
+    if (this.selectionMode === "none") {
+      this.active = false;
+    }
+  }
 
   private determineActiveItem(): void {
     switch (this.selectionMode) {


### PR DESCRIPTION
**Related Issue:** #4215 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue that shows up in the custom-elements output target where a dropdown item is initialized before its ancestors are ready. I am not sure if it's possible to cover this in our automated test suite. I'll have to investigate.

I'll create a separate issue to go over our components to identify similar cases.