### PR TITLE
fix(pick-list): only remove group if removable item is slotted as parent

### DIFF
--- a/src/components/pick-list/shared-list-logic.ts
+++ b/src/components/pick-list/shared-list-logic.ts
@@ -3,6 +3,7 @@ import { ValueList } from "../value-list/value-list";
 import { debounce } from "lodash-es";
 import { focusElement, getSlotted } from "../../utils/dom";
 import { getRoundRobinIndex } from "../../utils/array";
+import { SLOTS } from "../pick-list-group/resources";
 
 type Lists = PickList | ValueList;
 type ListItemElement<T> = T extends PickList ? HTMLCalcitePickListItemElement : HTMLCalciteValueListItemElement;
@@ -191,7 +192,7 @@ export function removeItem<T extends Lists, U extends ListItemElement<T>>(this: 
   const item = event.target as U;
   const selectedValues = this.selectedValues as Map<string, U>;
 
-  if (item.parentElement.tagName === "CALCITE-PICK-LIST-GROUP") {
+  if (item.parentElement.tagName === "CALCITE-PICK-LIST-GROUP" && item.slot === SLOTS.parentItem) {
     item.parentElement.remove();
     Array.from(item.parentElement.children).forEach((item: U) => selectedValues.delete(item.value));
   } else {


### PR DESCRIPTION
**Related Issue:** #4208 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where grouped pick list items were removed regardless if they were slotted as a group's parent item or not. 