### PR TITLE
fix(slider): Properly reset and submit form value when a range is used

### DIFF
--- a/src/components/slider/slider.e2e.ts
+++ b/src/components/slider/slider.e2e.ts
@@ -669,4 +669,6 @@ describe("calcite-slider", () => {
   });
 
   it("is form-associated", () => formAssociated("calcite-slider", { testValue: 5 }));
+
+  it("is form-associated with range", () => formAssociated("calcite-slider", { testValue: [5, 10] }));
 });

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -126,7 +126,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   @Prop() ticks?: number;
 
   /** Currently selected number (if single select) */
-  @Prop({ reflect: true, mutable: true }) value: null | number | number[] = null;
+  @Prop({ reflect: true, mutable: true }) value: null | number | number[] = 0;
 
   @Watch("value")
   valueHandler(): void {
@@ -166,11 +166,11 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   componentWillLoad(): void {
     this.isRange = !!(this.maxValue || this.maxValue === 0);
     this.tickValues = this.generateTickValues();
-    if (typeof this.value === "number") {
+    if (!Array.isArray(this.value)) {
       this.value = this.clamp(this.value);
     }
     afterConnectDefaultValueSet(this, this.value);
-    if (this.snap && typeof this.value === "number") {
+    if (this.snap && !Array.isArray(this.value)) {
       this.value = this.getClosestStep(this.value);
     }
     if (this.histogram) {
@@ -194,10 +194,10 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   render(): VNode {
     const id = this.el.id || this.guid;
+    const maxProp = Array.isArray(this.value) ? "maxValue" : "value";
+    const value = Array.isArray(this.value) ? this.maxValue : this.value;
     const min = this.minValue || this.min;
-    const max = this.maxValue || (typeof this.value === "number" && this.value);
-    const maxProp = this.isRange ? "maxValue" : "value";
-    const value = this[maxProp];
+    const max = this.maxValue || value;
     const useMinValue = this.shouldUseMinValue();
     const minInterval = this.getUnitInterval(useMinValue ? this.minValue : min) * 100;
     const maxInterval = this.getUnitInterval(max) * 100;
@@ -662,7 +662,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
         class="graph"
         colorStops={this.histogramStops}
         data={this.histogram}
-        highlightMax={this.isRange ? this.maxValue : typeof this.value === "number" && this.value}
+        highlightMax={Array.isArray(this.value) ? this.maxValue : this.value}
         highlightMin={this.isRange ? this.minValue : this.min}
         max={this.max}
         min={this.min}

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -923,7 +923,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   setMinMaxFromValue(): void {
     const { value } = this;
 
-    if (Array.isArray(value) && value.length === 2) {
+    if (Array.isArray(value)) {
       this.minValue = value[0];
       this.maxValue = value[1];
     }


### PR DESCRIPTION
**Related Issue:** #4174

## Summary

fix(slider): Properly reset and submit form value when a range is used. #4174

- Changes `value` type to allow for an array.
- The change to value is to support form resetting but also form submission. Currently, form submission wouldn't submit values for range sliders.
- We might want to update clamping/stepping for range values later