### PR TITLE
fix(input-date-picker): fix issue where clicking on the date picker would immediately close it

### DIFF
--- a/src/components/input-date-picker/input-date-picker.scss
+++ b/src/components/input-date-picker/input-date-picker.scss
@@ -94,6 +94,10 @@
 
 @include popperElemAnim(".menu-container");
 
+:host([active]) .menu-container {
+  @include popperWrapperActive();
+}
+
 .menu-container--active {
   @include popperElemAnim(".menu-container");
 }


### PR DESCRIPTION
cc @jcfranco

**Related Issue:** #2655 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression introduced by https://github.com/Esri/calcite-components/commit/083d283caf719eed91cb1f5bd71b4584864b5e61 (see https://github.com/Esri/calcite-components/commit/083d283caf719eed91cb1f5bd71b4584864b5e61#r68872701).