### PR TITLE
build(action): ensure PR title is not truncated

### DIFF
--- a/.github/workflows/pr-untruncated.yml
+++ b/.github/workflows/pr-untruncated.yml
@@ -4,7 +4,7 @@ jobs:
   semantic:
     runs-on: ubuntu-latest
     steps:
-      - uses: deepakputhraya/action-pr-title@1.0.2
+      - uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           regex: "^[^…]+$"
         env:

--- a/.github/workflows/pr-untruncated.yml
+++ b/.github/workflows/pr-untruncated.yml
@@ -1,0 +1,11 @@
+name: PR title is not truncated (...)
+on: pull_request
+jobs:
+  semantic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-pr-title@1.0.2
+        with:
+          regex: "^[^…]+$"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This adds an action to avoid truncated PR titles. When a commit title is too long, GitHub truncates it when a PR is created. This can lead to incomplete changelog entries ([example](https://github.com/Esri/calcite-components/blob/master/CHANGELOG.md?plain=1#L113)). 