### PR TITLE
refactor(tab-title, tab): clean up

### DIFF
--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -65,16 +65,6 @@ export class TabNav {
   /**
    * @internal
    */
-  @State() selectedTab: TabID;
-
-  /**
-   * @internal
-   */
-  @State() selectedTabEl: HTMLCalciteTabTitleElement;
-
-  /**
-   * @internal
-   */
   @Prop({ mutable: true }) indicatorOffset: number;
 
   /**
@@ -269,13 +259,19 @@ export class TabNav {
   //
   //--------------------------------------------------------------------------
 
-  private tabNavEl: HTMLDivElement;
+  @State() selectedTab: TabID;
 
-  private activeIndicatorEl: HTMLElement;
+  @State() selectedTabEl: HTMLCalciteTabTitleElement;
 
-  private activeIndicatorContainerEl: HTMLDivElement;
+  parentTabsEl: HTMLCalciteTabsElement;
 
-  private animationActiveDuration = 0.3;
+  tabNavEl: HTMLDivElement;
+
+  activeIndicatorEl: HTMLElement;
+
+  activeIndicatorContainerEl: HTMLDivElement;
+
+  animationActiveDuration = 0.3;
 
   //--------------------------------------------------------------------------
   //
@@ -283,13 +279,13 @@ export class TabNav {
   //
   //--------------------------------------------------------------------------
 
-  private handleContainerScroll = (): void => {
+  handleContainerScroll = (): void => {
     // remove active indicator transition duration while container is scrolling to prevent wobble
     this.activeIndicatorEl.style.transitionDuration = "0s";
     this.updateOffsetPosition();
   };
 
-  private updateOffsetPosition(): void {
+  updateOffsetPosition(): void {
     const dir = getElementDir(this.el);
     const navWidth = this.activeIndicatorContainerEl?.offsetWidth;
     const tabLeft = this.selectedTabEl?.offsetLeft;
@@ -299,27 +295,27 @@ export class TabNav {
       dir !== "rtl" ? tabLeft - this.tabNavEl?.scrollLeft : offsetRight + this.tabNavEl?.scrollLeft;
   }
 
-  private updateActiveWidth(): void {
+  updateActiveWidth(): void {
     this.indicatorWidth = this.selectedTabEl?.offsetWidth;
   }
 
-  private getIndexOfTabTitle(el: HTMLCalciteTabTitleElement, tabTitles = this.tabTitles): number {
+  getIndexOfTabTitle(el: HTMLCalciteTabTitleElement, tabTitles = this.tabTitles): number {
     // In most cases, since these indexes correlate with tab contents, we want to consider all tab titles.
     // However, when doing relative index operations, it makes sense to pass in this.enabledTabTitles as the 2nd arg.
     return tabTitles.indexOf(el);
   }
 
-  private async getTabTitleById(id: TabID): Promise<HTMLCalciteTabTitleElement | null> {
+  async getTabTitleById(id: TabID): Promise<HTMLCalciteTabTitleElement | null> {
     return Promise.all(this.tabTitles.map((el) => el.getTabIdentifier())).then((ids) => {
       return this.tabTitles[ids.indexOf(id)];
     });
   }
 
-  private get tabTitles(): HTMLCalciteTabTitleElement[] {
+  get tabTitles(): HTMLCalciteTabTitleElement[] {
     return filterDirectChildren<HTMLCalciteTabTitleElement>(this.el, "calcite-tab-title");
   }
 
-  private get enabledTabTitles(): HTMLCalciteTabTitleElement[] {
+  get enabledTabTitles(): HTMLCalciteTabTitleElement[] {
     return filterDirectChildren<HTMLCalciteTabTitleElement>(
       this.el,
       "calcite-tab-title:not([disabled])"

--- a/src/components/tab-title/tab-title.tsx
+++ b/src/components/tab-title/tab-title.tsx
@@ -292,34 +292,26 @@ export class TabTitle implements InteractiveComponent {
   //--------------------------------------------------------------------------
 
   /** watches for changing text content **/
-  private mutationObserver: MutationObserver = createObserver("mutation", () =>
-    this.updateHasText()
-  );
+  mutationObserver: MutationObserver = createObserver("mutation", () => this.updateHasText());
 
-  @State() private controls: string;
+  @State() controls: string;
 
   /** determine if there is slotted text for styling purposes */
-  @State() private hasText = false;
+  @State() hasText = false;
 
-  /**
-   * @internal
-   */
-  private parentTabNavEl: HTMLCalciteTabNavElement;
+  parentTabNavEl: HTMLCalciteTabNavElement;
 
-  /**
-   * @internal
-   */
-  private parentTabsEl: HTMLCalciteTabsElement;
+  parentTabsEl: HTMLCalciteTabsElement;
 
-  private updateHasText(): void {
+  updateHasText(): void {
     this.hasText = this.el.textContent.trim().length > 0;
   }
 
-  private setupTextContentObserver(): void {
+  setupTextContentObserver(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
-  private emitActiveTab(): void {
+  emitActiveTab(): void {
     if (!this.disabled) {
       this.calciteTabsActivate.emit({
         tab: this.tab
@@ -327,10 +319,7 @@ export class TabTitle implements InteractiveComponent {
     }
   }
 
-  /**
-   * @internal
-   */
-  private guid = `calcite-tab-title-${guid()}`;
+  guid = `calcite-tab-title-${guid()}`;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -151,12 +151,11 @@ export class Tab {
   //
   //--------------------------------------------------------------------------
 
-  /**
-   * @internal
-   */
-  private guid = `calcite-tab-title-${guid()}`;
+  parentTabsEl: HTMLCalciteTabsElement;
 
-  @State() private labeledBy: string;
+  guid = `calcite-tab-title-${guid()}`;
+
+  @State() labeledBy: string;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -129,7 +129,6 @@ export class Tabs {
   //--------------------------------------------------------------------------
 
   /**
-   * @internal
    *
    * Stores an array of ids of `<calcite-tab-titles>`s to match up ARIA
    * attributes.
@@ -137,7 +136,6 @@ export class Tabs {
   @State() titles: HTMLCalciteTabTitleElement[] = [];
 
   /**
-   * @internal
    *
    * Stores an array of ids of `<calcite-tab>`s to match up ARIA attributes.
    */
@@ -150,13 +148,12 @@ export class Tabs {
   //--------------------------------------------------------------------------
 
   /**
-   * @internal
    *
    * Matches up elements from the internal `tabs` and `titles` to automatically
    * update the ARIA attributes and link `<calcite-tab>` and
    * `<calcite-tab-title>` components.
    */
-  private async registryHandler() {
+  async registryHandler(): Promise<void> {
     let tabIds;
     let titleIds;
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This splits up refactor changes from https://github.com/Esri/calcite-components/pull/4250/.