### PR TITLE
fix(action-pad, action-bar): toggleChange event emit only on user interaction

### DIFF
--- a/src/components/action-bar/action-bar.e2e.ts
+++ b/src/components/action-bar/action-bar.e2e.ts
@@ -104,7 +104,7 @@ describe("calcite-action-bar", () => {
       expect(bar).toHaveAttribute("expanded");
     });
 
-    it("should fire expanded event", async () => {
+    it("should not fire expanded event when expanded programmatically", async () => {
       const page = await newE2EPage();
 
       await page.setContent("<calcite-action-bar></calcite-action-bar>");
@@ -114,6 +114,22 @@ describe("calcite-action-bar", () => {
       const eventSpy = await element.spyOnEvent("calciteActionBarToggle");
 
       element.setProperty("expanded", true);
+
+      await page.waitForChanges();
+
+      expect(eventSpy).not.toHaveReceivedEvent();
+    });
+
+    it("should fire expanded event on user interaction", async () => {
+      const page = await newE2EPage();
+
+      await page.setContent("<calcite-action-bar></calcite-action-bar>");
+
+      const element = await page.find("calcite-action-bar");
+
+      const eventSpy = await element.spyOnEvent("calciteActionBarToggle");
+
+      await element.click();
 
       await page.waitForChanges();
 

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -63,7 +63,6 @@ export class ActionBar implements ConditionalSlotComponent {
   @Watch("expanded")
   expandedHandler(expanded: boolean): void {
     toggleChildActionText({ parent: this.el, expanded });
-    this.calciteActionBarToggle.emit();
   }
 
   /**
@@ -247,6 +246,7 @@ export class ActionBar implements ConditionalSlotComponent {
 
   toggleExpand = (): void => {
     this.expanded = !this.expanded;
+    this.calciteActionBarToggle.emit();
   };
 
   setExpandToggleRef = (el: HTMLCalciteActionElement): void => {

--- a/src/components/action-pad/action-pad.e2e.ts
+++ b/src/components/action-pad/action-pad.e2e.ts
@@ -85,7 +85,7 @@ describe("calcite-action-pad", () => {
       expect(pad).toHaveAttribute("expanded");
     });
 
-    it("should fire expanded event", async () => {
+    it("should fire not expanded event when expanded programmatically", async () => {
       const page = await newE2EPage();
 
       await page.setContent("<calcite-action-pad></calcite-action-pad>");
@@ -95,6 +95,23 @@ describe("calcite-action-pad", () => {
       const eventSpy = await element.spyOnEvent("calciteActionPadToggle");
 
       element.setProperty("expanded", true);
+
+      await page.waitForChanges();
+
+      expect(eventSpy).not.toHaveReceivedEvent();
+    });
+
+    it("should fire expanded event on user interaction", async () => {
+      const page = await newE2EPage();
+
+      await page.setContent("<calcite-action-pad></calcite-action-pad>");
+
+      const element = await page.find("calcite-action-pad");
+      const actionElement = await page.find("calcite-action-pad >>> calcite-action");
+
+      const eventSpy = await element.spyOnEvent("calciteActionPadToggle");
+
+      await actionElement.click();
 
       await page.waitForChanges();
 

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -49,7 +49,6 @@ export class ActionPad implements ConditionalSlotComponent {
   @Watch("expanded")
   expandedHandler(expanded: boolean): void {
     toggleChildActionText({ parent: this.el, expanded });
-    this.calciteActionPadToggle.emit();
   }
 
   /**
@@ -154,6 +153,7 @@ export class ActionPad implements ConditionalSlotComponent {
 
   toggleExpand = (): void => {
     this.expanded = !this.expanded;
+    this.calciteActionPadToggle.emit();
   };
 
   setExpandToggleRef = (el: HTMLCalciteActionElement): void => {


### PR DESCRIPTION


**Related Issue:** #2033 

## Summary

This fix will make sure `calciteActionPadToggle` & `calciteActionBarToggle` events emit only on user interaction