### PR TITLE
ci(screener): integrating sauce labs without build failures

### DIFF
--- a/screener.config.js
+++ b/screener.config.js
@@ -4,17 +4,24 @@ module.exports = {
   storybookStaticDir: "./__docs-temp__",
   apiKey: process.env.SCREENER_API_KEY,
   commit: process.env.COMMIT_SHA,
-  resolution: "1024x768",
   baseBranch: "master",
   browsers: [
     {
-      browserName: "chrome"
+      browserName: "chrome",
+      version: "97.0"
     }
   ],
   diffOptions: {
     minLayoutDimension: 1,
     minLayoutPosition: 1
   },
+  sauce: {
+    username: process.env.SAUCE_ACCESS_NAME,
+    accessKey: process.env.SAUCE_ACCESS_KEY,
+    maxConcurrent: 10
+  },
   excludeRules: [/^Overview/],
-  resolution: "1920x1440"
+  resolution: "1024x768",
+  failureExitCode: 0,
+  failOnNewStates: false
 };


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

This PR is setup for testing just the Sauce Labs integration with Screener.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
