### PR TITLE
build: add version to preamble

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublishOnly": "ts-node ./support/prepublish.ts",
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",
     "release:next": "npm run util:clean-tested-build && npm run util:deploy-next-from-existing-build",
-    "release:prepare": "npm run util:clean-tested-build && ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts && git add .",
+    "release:prepare": "npm ci && npm test && ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts && npm run build && git add .",
     "release:publish": "npm run util:push-tags && npm publish && ts-node ./support/releaseToGitHub.ts",
     "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm:build -- --dev --watch --serve\" \"ts-node ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
     "test": "npm run util:run-tests",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -6,6 +6,7 @@ import autoprefixer from "autoprefixer";
 import tailwindcss from "tailwindcss";
 import tailwindConfig from "./tailwind.config";
 import { generatePreactTypes } from "./support/preact";
+import { version } from "./package.json";
 
 export const create: () => Config = () => ({
   buildEs5: "prod",
@@ -122,7 +123,7 @@ export const create: () => Config = () => ({
     selector: "attribute",
     name: "calcite-hydrated"
   },
-  preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-components/blob/master/LICENSE.md for details.`,
+  preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-components/blob/master/LICENSE.md for details.\nv${version}`,
   extras: {
     scriptDataOpts: true
   }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Appends the CC version number to the preamble so users can find out which version a product is using. I had to change the `release:prepare` npm script to build after bumping the version number rather than before.

For example, in the browser dev tools for Map Viewer you can't find a version:
![image](https://user-images.githubusercontent.com/10986395/160018134-3018675a-6adf-4296-acbd-15f110d13950.png)

This PR will display the version in the preamble comment like:
```js
/*!
 * All material copyright ESRI, All Rights Reserved, unless otherwise specified.
 * See https://github.com/Esri/calcite-components/blob/master/LICENSE.md for details.
 * v1.0.0-beta.80
 */
```

### Edit
If we are worried about character/line count, I can replace `master` with the version instead, like:
```js
/*!
 * All material copyright ESRI, All Rights Reserved, unless otherwise specified.
 * See https://github.com/Esri/calcite-components/blob/v1.0.0-beta.80/LICENSE.md for details.
 */
```
However, the link won't work if the GitHub tag isn't created yet, or if there is a typo on the tag. That _shouldn't_ happen since the process is automated. Also, if we ever have to change the license, it will be automatically updated for everyone on `master`. But if we use the version tag, then people on old versions will see an old license.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
