### PR TITLE
ci: disable merge squash prepush due to windows error

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -13,7 +13,7 @@ then
         exit 0
     fi
     exit 1
-else
-    npm run util:check-squash-mergeable-branch
-    exit
+# else
+    # npm run util:check-squash-mergeable-branch
+    # exit
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -13,6 +13,7 @@ then
         exit 0
     fi
     exit 1
+# disabled due to Windows error: https://github.com/Esri/calcite-components/pull/4307
 # else
     # npm run util:check-squash-mergeable-branch
     # exit


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Kitty ran into an error pushing due to the prepush hook which ensures conventional commits. 
![2a8c01f3-027d-4a7d-9b20-0da2abba3486](https://user-images.githubusercontent.com/10986395/160176410-c76d3cb1-7074-413e-bc1c-bb29978dd241.jpg)

Relevant bit:
`Error: Command failed: git log --format=%B geospatialem/test --not master | tr '`

It looks like its an issue due to Windows. I disabled the hook so she can push and I'll work on making it OS agnostic.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
