### PR TITLE
ci: squash mergeable script os agnostic

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -13,8 +13,7 @@ then
         exit 0
     fi
     exit 1
-# disabled due to Windows error: https://github.com/Esri/calcite-components/pull/4307
-# else
-    # npm run util:check-squash-mergeable-branch
-    # exit
+else
+    npm run util:check-squash-mergeable-branch
+    exit
 fi

--- a/support/checkSquashMergeableBranch.ts
+++ b/support/checkSquashMergeableBranch.ts
@@ -14,9 +14,9 @@ This ensures a conventional commit message when PRs are squash-merged.
 
   const currentBranch = (await exec(`git rev-parse --abbrev-ref HEAD`, { encoding: "utf-8" })).trim();
 
-  const commits = (await exec(`git log --format=%B ${currentBranch} --not master | tr '\n' ';'`, { encoding: "utf-8" }))
+  const commits = (await exec(`git log --format=%B ${currentBranch} --not master`, { encoding: "utf-8" }))
     .trim()
-    .split(";")
+    .split("\n")
     .filter((commit: string) => !!commit);
 
   process.exitCode = commits.length === 1 ? (conventionalCommitRegex.test(commits[0]) ? 0 : 1) : 0;


### PR DESCRIPTION
**Related Issue:** #4307

## Summary
Makes the squash-mergeable prepush script work on Windows (Kitty tested and confirmed). It also still works on Unix:
![image](https://user-images.githubusercontent.com/10986395/160180991-2076bb55-cca4-4c26-8eaa-b610c57fb201.png)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
