### PR TITLE
fix(tooltip-manager): Don't close tooltips on click. (#4294)

### DIFF
--- a/src/components/tooltip-manager/tooltip-manager.e2e.ts
+++ b/src/components/tooltip-manager/tooltip-manager.e2e.ts
@@ -332,39 +332,4 @@ describe("calcite-tooltip-manager", () => {
 
     expect(await hoverTip.getProperty("open")).toBe(true);
   });
-
-  it("should close hovered tooltip when clicked", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      html`
-        <calcite-tooltip-manager>
-          <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
-          <button id="ref">Button</button>
-        </calcite-tooltip-manager>
-      `
-    );
-
-    await page.waitForChanges();
-
-    const tooltip = await page.find("calcite-tooltip");
-
-    expect(await tooltip.getProperty("open")).toBe(false);
-
-    const referenceElement = await page.find("#ref");
-
-    await referenceElement.hover();
-
-    await page.waitForTimeout(TOOLTIP_DELAY_MS);
-
-    await page.waitForChanges();
-
-    expect(await tooltip.getProperty("open")).toBe(true);
-
-    await referenceElement.click();
-
-    await page.waitForChanges();
-
-    expect(await tooltip.getProperty("open")).toBe(false);
-  });
 });

--- a/src/components/tooltip-manager/tooltip-manager.tsx
+++ b/src/components/tooltip-manager/tooltip-manager.tsx
@@ -219,13 +219,7 @@ export class TooltipManager {
 
   @Listen("click", { capture: true })
   clickHandler(event: MouseEvent): void {
-    const clickedTooltip = this.queryTooltip(event.composedPath());
-
-    this.clickedTooltip = clickedTooltip;
-
-    if (clickedTooltip) {
-      this.toggleTooltip(clickedTooltip, false);
-    }
+    this.clickedTooltip = this.queryTooltip(event.composedPath());
   }
 
   @Listen("focus", { capture: true })


### PR DESCRIPTION
**Related Issue:** #4294

## Summary

fix(tooltip-manager): Don't close tooltips on click. (#4294)