### PR TITLE
fix(tile): match content-start spacing when dir set to rtl

### DIFF
--- a/src/components/tile/tile.scss
+++ b/src/components/tile/tile.scss
@@ -38,11 +38,11 @@
     @apply bg-foreground-1 flex items-center;
 
     &:first-child {
-      @apply pr-3;
+      padding-inline: 0 0.75rem;
     }
 
     &:last-child {
-      @apply pl-3;
+      padding-inline: 0.75rem 0;
     }
   }
 

--- a/src/components/tile/tile.stories.ts
+++ b/src/components/tile/tile.stories.ts
@@ -77,4 +77,15 @@ export const LargeTile = (): string => html`
   </calcite-tile>
 `;
 
+export const ContentStartRTL = (): string => html`
+  <calcite-tile
+    description="${text("description", "polygon layer")}"
+    heading="${text("heading", "Percent of population that carpool to work")}"
+    dir="rtl"
+  >
+    <calcite-icon scale="s" slot="content-start" icon="polygon"></calcite-icon>
+    <calcite-icon scale="s" slot="content-end" icon="launch"></calcite-icon>
+  </calcite-tile>
+`;
+
 export const disabled = (): string => html`<calcite-tile heading="Heading" disabled></calcite-tile>`;


### PR DESCRIPTION
**Related Issue:** #4240 

## Summary

Fixes padding space for `content-start` slotted items when `dir=rtl`