### PR TITLE
test: remove unnecessary polyfill

### DIFF
--- a/src/utils/label.spec.ts
+++ b/src/utils/label.spec.ts
@@ -15,25 +15,6 @@ describe("label", () => {
 
   describe("connectLabel/disconnectLabel", () => {
     describe("wires up the associated label", () => {
-      beforeEach(() => {
-        // we polyfill composedPath since Stencil's MockEvent does not support it: https://github.com/ionic-team/stencil/blob/main/src/mock-doc/event.ts#L5-L40
-        CustomEvent.prototype.composedPath = function () {
-          // based on https://gist.github.com/rockinghelvetica/00b9f7b5c97a16d3de75ba99192ff05c
-          if (this.path) {
-            return this.path;
-          }
-          let target = this.target;
-
-          this.path = [];
-          while (target.parentNode !== null) {
-            this.path.push(target);
-            target = target.parentNode;
-          }
-          this.path.push(document, window);
-          return this.path;
-        };
-      });
-
       /**
        * This util helps simulate calcite-label's behavior since we cannot use the component here
        */


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

https://github.com/ionic-team/stencil/blob/main/CHANGELOG.md#-2130-2022-01-24 added support for  `MockEvent#composedPath()`, so no need for our polyfill anymore.