### PR TITLE
chore: add tools to a11y issue template's relevant info section

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -65,9 +65,9 @@ body:
     id: relevant
     attributes:
       label: Relevant Info
-      description: Browser, OS, mobile, stack traces, related issues, suggestions/resources on how to fix, etc.
+      description: Browser, OS, tools, mobile, stack traces, related issues, suggestions/resources on how to fix, etc.
       placeholder: |
-        Windows 10, Chrome 97
+        Windows 10, Chrome 97, JAWS, NVDA, VoiceOver, Dragon
         `Uncaught TypeError: Cannot read property of undefined`
         ...
     validations:


### PR DESCRIPTION
**Related Issue:** NA

## Summary  
Add examples of tools to the a11y issue template's `relevant` section including JAWS, NVDA, VoiceOver, and Dragon, if applicable. 

The addition could help diagnose a11y issues, and provide more context to the experienced behavior.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
