### PR TITLE
fix(tabs): update active tab styling on resize

### DIFF
--- a/src/components/tab-nav/tab-nav.e2e.ts
+++ b/src/components/tab-nav/tab-nav.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { renders, accessible } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-tab-nav", () => {
   const tabNavHtml = "<calcite-tab-nav></calcite-tab-nav>";
@@ -8,34 +9,46 @@ describe("calcite-tab-nav", () => {
 
   it("is accessible", async () => await accessible(tabNavHtml));
 
-  it("has its active indicator positioned from left if LTR", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-tab-nav>
-        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      </calcite-tab-nav>`);
-    const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
-    const style = await element.getComputedStyle();
-    expect(style["left"]).toBe("0px");
-    expect(style["right"]).not.toBe("0px");
-  });
+  describe("active indicator", () => {
+    const tabTitles = html`
+      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+      <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+    `;
 
-  it("has its active indicator positioned from right if RTL", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-tab-nav dir='rtl'>
-        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-        <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-      </calcite-tab-nav>`);
-    const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
-    const style = await element.getComputedStyle();
-    expect(style["right"]).toBe("0px");
-    expect(style["left"]).not.toBe("0px");
+    it("has its active indicator positioned from left if LTR", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-tab-nav>${tabTitles}</calcite-tab-nav>`);
+      const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
+      const style = await element.getComputedStyle();
+      expect(style["left"]).toBe("0px");
+      expect(style["right"]).not.toBe("0px");
+      expect(style["width"]).not.toBe("0px");
+    });
+
+    it("has its active indicator positioned from right if RTL", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-tab-nav dir='rtl'>${tabTitles}</calcite-tab-nav>`);
+      const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
+      const style = await element.getComputedStyle();
+      expect(style["right"]).toBe("0px");
+      expect(style["left"]).not.toBe("0px");
+      expect(style["width"]).not.toBe("0px");
+    });
+
+    it("updates position when made visible", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-tab-nav hidden>${tabTitles}</calcite-tab-nav>`);
+      const tabNav = await page.find("calcite-tab-nav");
+      const indicator = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
+
+      tabNav.setProperty("hidden", false);
+      await page.waitForChanges();
+
+      const style = await indicator.getComputedStyle();
+      expect(style["width"]).not.toBe("0px");
+    });
   });
 
   describe("scale property", () => {

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -110,7 +110,7 @@ export class TabNav {
   }
 
   disconnectedCallback(): void {
-    this.resizeObserver?.unobserve(this.el);
+    this.resizeObserver?.disconnect();
   }
 
   componentWillLoad(): void {

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -16,6 +16,7 @@ import { getElementDir, filterDirectChildren } from "../../utils/dom";
 import { TabID, TabLayout } from "../tabs/interfaces";
 import { TabPosition } from "../tabs/interfaces";
 import { Scale } from "../interfaces";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-tab-title`s.
@@ -105,6 +106,11 @@ export class TabNav {
 
   connectedCallback(): void {
     this.parentTabsEl = this.el.closest("calcite-tabs");
+    this.resizeObserver?.observe(this.el);
+  }
+
+  disconnectedCallback(): void {
+    this.resizeObserver?.unobserve(this.el);
   }
 
   componentWillLoad(): void {
@@ -179,13 +185,6 @@ export class TabNav {
   //  Event Listeners
   //
   //--------------------------------------------------------------------------
-
-  @Listen("resize", { target: "window" }) resizeHandler(): void {
-    // remove active indicator transition duration during resize to prevent wobble
-    this.activeIndicatorEl.style.transitionDuration = "0s";
-    this.updateActiveWidth();
-    this.updateOffsetPosition();
-  }
 
   @Listen("calciteTabsFocusPrevious") focusPreviousTabHandler(e: CustomEvent): void {
     const currentIndex = this.getIndexOfTabTitle(
@@ -278,6 +277,13 @@ export class TabNav {
   activeIndicatorContainerEl: HTMLDivElement;
 
   animationActiveDuration = 0.3;
+
+  resizeObserver = createObserver("resize", () => {
+    // remove active indicator transition duration during resize to prevent wobble
+    this.activeIndicatorEl.style.transitionDuration = "0s";
+    this.updateActiveWidth();
+    this.updateOffsetPosition();
+  });
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #2885 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This modifies `tabs` to use a resize observer instead of relying on the window being resized to recompute the active tab underline. Previously, it would not update the active tab styling when initially hidden.