### PR TITLE
ci: fix markdown PR check skipping logic

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           # diff of branch excluding md
-          testable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.(md|mdx)')
+          testable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md*')
           echo "changed files: $testable_changes"
           # skip if there are only md changes
           if [ -z "$testable_changes" ]; then

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -19,11 +19,11 @@ jobs:
           echo "branch: $current_branch"
           if [ "$current_branch" == "master" ]; then
             # diff of last commit excluding md (assumes squash merge)
-            screenable_changes=$(git diff --name-only @~..@ -- . ':(exclude)*.(md|mdx)')
+            screenable_changes=$(git diff --name-only @~..@ -- . ':(exclude)*.md*')
             echo "push run"
           else
             # diff of branch excluding md
-            screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.(md|mdx)')
+            screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md*')
             echo "pr run"
           fi
           echo "changed files: $screenable_changes"


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Mixed up my regex and glob pattern matching. It didn't break anything other than running screener/e2e on my markdown-only PR
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
