### PR TITLE
feat(ListItem): updates flex definitions on start and end content slots

### DIFF
--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -45,6 +45,11 @@
   &:focus {
     @apply focus-inset;
   }
+
+  .content-start,
+  .content-end {
+    @apply pointer-events-none;
+  }
 }
 
 .content {
@@ -73,9 +78,22 @@
   @apply text-color-3 mt-0.5;
 }
 
+.content-start {
+  @apply justify-start;
+}
+
+.content-end {
+  @apply justify-end;
+}
+
 .content-start,
 .content-end {
-  @apply pointer-events-none flex-initial;
+  @apply flex-auto;
+}
+
+.has-center-content .content-start,
+.has-center-content .content-end {
+  @apply flex-initial;
 }
 
 .actions-start,

--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -23,6 +23,8 @@
     text-color-2
     flex
     flex-auto
+    font-sans
+    font-normal
     items-stretch
     p-0;
 }

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -147,20 +147,27 @@ export class ListItem implements ConditionalSlotComponent, InteractiveComponent 
   }
 
   renderContentContainer(): VNode {
-    const { disabled, nonInteractive } = this;
-
+    const { description, disabled, label, nonInteractive } = this;
+    const hasCenterContent = !!label || !!description;
     const content = [this.renderContentStart(), this.renderContent(), this.renderContentEnd()];
 
     return !nonInteractive ? (
       <button
-        class={{ [CSS.contentContainer]: true, [CSS.contentContainerButton]: true }}
+        class={{
+          [CSS.contentContainer]: true,
+          [CSS.contentContainerButton]: true,
+          [CSS.hasCenterContent]: hasCenterContent
+        }}
         disabled={disabled}
         ref={(focusEl) => (this.focusEl = focusEl)}
       >
         {content}
       </button>
     ) : (
-      <div class={CSS.contentContainer} ref={() => (this.focusEl = null)}>
+      <div
+        class={{ [CSS.contentContainer]: true, [CSS.hasCenterContent]: hasCenterContent }}
+        ref={() => (this.focusEl = null)}
+      >
         {content}
       </div>
     );

--- a/src/components/list-item/resources.ts
+++ b/src/components/list-item/resources.ts
@@ -9,7 +9,8 @@ export const CSS = {
   label: "label",
   description: "description",
   contentEnd: "content-end",
-  actionsEnd: "actions-end"
+  actionsEnd: "actions-end",
+  hasCenterContent: "has-center-content"
 };
 
 export const SLOTS = {

--- a/src/components/list/list.stories.ts
+++ b/src/components/list/list.stories.ts
@@ -83,6 +83,34 @@ export const GroupedItems = (): string => html`
   </calcite-list>
 `;
 
+export const StartAndEndContentSlots = (): string => html`<calcite-list>
+  <calcite-list-item>
+    <calcite-action slot="actions-end" icon="ellipsis"> </calcite-action>
+    <calcite-icon icon="layers" scale="m" slot="content-start"></calcite-icon>
+    <span slot="content-start">Some value or something and a <b>thing</b>.</span>
+    <div slot="content-end" style="display: flex; justify-content: flex-end">
+      <calcite-chip class="list-chip" icon="ribbon-rosette" scale="s">Review</calcite-chip>
+      <calcite-chip class="list-chip" icon="globe" scale="s" color="green">Good</calcite-chip>
+    </div>
+  </calcite-list-item>
+  <calcite-list-item>
+    <calcite-action slot="actions-end" icon="ellipsis"> </calcite-action>
+    <calcite-icon icon="user" scale="m" slot="content-start"></calcite-icon>
+    <span slot="content-start">Some value or something and a <b>thing</b>.</span>
+    <div slot="content-end" style="display: flex; justify-content: flex-end">
+      <calcite-chip class="list-chip" icon="globe" scale="s" color="green">Good</calcite-chip>
+    </div>
+  </calcite-list-item>
+  <calcite-list-item>
+    <calcite-action slot="actions-end" icon="ellipsis"> </calcite-action>
+    <calcite-icon icon="user" scale="m" slot="content-start"></calcite-icon>
+    <span slot="content-start">Some value or something and a <b>thing</b>.</span>
+    <div slot="content-end" style="display: flex; justify-content: flex-end">
+      <calcite-chip class="list-chip" icon="bell" color="red" scale="s">Halp!</calcite-chip>
+    </div>
+  </calcite-list-item>
+</calcite-list> `;
+
 export const RichContent = (): string => html`
   <calcite-list>
     <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">

--- a/src/demos/list.html
+++ b/src/demos/list.html
@@ -200,6 +200,7 @@
         </calcite-list>
       </div>
     </div>
+
     <div class="parent">
       <div class="child right-aligned-text">grouped and nested</div>
 
@@ -227,6 +228,75 @@
               </calcite-list-item>
             </calcite-list-item-group>
           </calcite-list-item-group>
+        </calcite-list>
+      </div>
+    </div>
+
+    <!-- inline editing -->
+    <div class="parent">
+      <style>
+        .form-container {
+          width: 100%;
+          padding: 0.75rem;
+          border-inline-end: 1px solid var(--calcite-ui-border-3);
+        }
+      </style>
+      <div class="child right-aligned-text">inline editing</div>
+
+      <div class="child">
+        <calcite-list>
+          <calcite-list-item label="Jake the Dog" description="Is yellow and magical.">
+            <calcite-action slot="actions-end" icon="pencil"></calcite-action>
+          </calcite-list-item>
+
+          <calcite-list-item non-interactive>
+            <calcite-action slot="actions-end" icon="undo"> </calcite-action>
+            <calcite-action slot="actions-end" icon="check"> </calcite-action>
+            <div class="form-container" slot="content-start">
+              <calcite-input scale="s" value="Jake the Dog" scale="m" placeholder="This is an input."></calcite-input>
+            </div>
+          </calcite-list-item>
+        </calcite-list>
+      </div>
+    </div>
+
+    <!-- custom content -->
+    <div class="parent">
+      <style>
+        .list-chip {
+          margin-inline-end: 0.5rem;
+        }
+      </style>
+      <div class="child right-aligned-text">start/end content slots</div>
+      <div class="child">
+        <calcite-list>
+          <calcite-list-item>
+            <calcite-action slot="actions-end" icon="ellipsis"> </calcite-action>
+            <calcite-icon icon="layers" scale="m" slot="content-start"></calcite-icon>
+            <span slot="content-start">Some value or something and a <b>thing</b>.</span>
+            <div slot="content-end" style="display: flex; justify-content: flex-end">
+              <calcite-chip class="list-chip" icon="ribbon-rosette" scale="s">Review</calcite-chip>
+              <calcite-chip class="list-chip" icon="globe" scale="s" color="green">Good</calcite-chip>
+            </div>
+          </calcite-list-item>
+
+          <calcite-list-item>
+            <calcite-action slot="actions-end" icon="ellipsis"> </calcite-action>
+            <calcite-icon icon="user" scale="m" slot="content-start"></calcite-icon>
+            <span slot="content-start">Some value or something and a <b>thing</b>.</span>
+            <div slot="content-end" style="display: flex; justify-content: flex-end">
+              <calcite-chip class="list-chip" icon="globe" scale="s" color="green">Good</calcite-chip>
+            </div>
+          </calcite-list-item>
+
+          <calcite-list-item>
+            <calcite-action slot="actions-end" icon="ellipsis"> </calcite-action>
+            <calcite-icon icon="user" scale="m" slot="content-start"></calcite-icon>
+            <span slot="content-start">Some value or something and a <b>thing</b>.</span>
+            <div slot="content-end" style="display: flex; justify-content: flex-end">
+              <calcite-chip class="list-chip" icon="bell" color="red" scale="s">Halp!</calcite-chip>
+            </div>
+          </calcite-list-item>
         </calcite-list>
       </div>
     </div>


### PR DESCRIPTION
**Related Issue:** #4336

## Summary
When no center content is rendered, `content-end` and `content-start` slots occupy the available space in the container.

@benelan Not sure if I added the correct Milestone or not.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
