### PR TITLE
ci: change the gh secrets with usernames for clarity

### DIFF
--- a/.github/workflows/assign-for-verification.yml
+++ b/.github/workflows/assign-for-verification.yml
@@ -8,19 +8,13 @@ jobs:
     steps:
       - uses: actions/github-script@v4
         env:
-          PRIMARY_CONTACT: ${{secrets.PRIMARY_CONTACT}}
-          SECONDARY_CONTACTS: ${{secrets.SECONDARY_CONTACTS}}
+          ISSUE_VERIFIERS: ${{secrets.ISSUE_VERIFIERS}}
         with:
           script: |
-            const { PRIMARY_CONTACT, SECONDARY_CONTACTS } = process.env
-            const { label, sender } = context.payload;
-            if (sender && label && label.name === "3 - installed") {
-              const secondaryArr = SECONDARY_CONTACTS.split(",").map(c => c.trim());
-              const secondaryContact = secondaryArr[Math.floor(Math.random() * secondaryArr.length)];
-              const assignees =
-                sender.login !== PRIMARY_CONTACT
-                  ? [PRIMARY_CONTACT]
-                  : [secondaryContact]
+            const { ISSUE_VERIFIERS } = process.env;
+            const { label } = context.payload;
+            if (label && label.name === "3 - installed") {
+              const assignees = ISSUE_VERIFIERS.split(",").map(v => v.trim());
               await github.issues.update({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,

--- a/.github/workflows/need-info-close.yml
+++ b/.github/workflows/need-info-close.yml
@@ -13,4 +13,4 @@ jobs:
           days-before-issue-close: 5
           remove-stale-when-updated: false
           stale-issue-label: "incomplete issue report"
-          close-issue-message: "This issue has been automatically closed due to missing information. We will reopen the issue if the information is provided and `${{secrets.PRIMARY_CONTACT}}` is mentioned in the comment."
+          close-issue-message: "This issue has been automatically closed due to missing information. We will reopen the issue if the information is provided."

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -9,10 +9,9 @@ jobs:
         uses: actions/github-script@v5
         id: permission
         env:
-          PRIMARY_CONTACT: ${{secrets.PRIMARY_CONTACT}}
-          SECONDARY_CONTACTS: ${{secrets.SECONDARY_CONTACTS}}
+          PRIMARY_MAINTAINERS: ${{secrets.PRIMARY_MAINTAINERS}}
         with:
-          script: return [...process.env.SECONDARY_CONTACTS.split(",").map(c => c.trim()), process.env.PRIMARY_CONTACT].includes(context.actor)
+          script: return process.env.PRIMARY_MAINTAINERS.split(",").map(m => m.trim()).includes(context.actor)
       - name: merge
         uses: Goobles/gh-actions-merge-command@v1
         if: |


### PR DESCRIPTION
**Related Issue:** NA

## Summary
I changed the names of some GitHub secrets. I also slightly changed the functionality of the issue verification action.

### Issue verification
- The GH Secret for issue verifiers is now `ISSUE_VERIFIERS` (previously `PRIMARY_CONTACT` and `SECONDARY_CONTACTS`). 
- The secret still takes a comma separated list of usernames (currently me and @geospatialem). 
- It now assigns all verifications to everyone on the list, and they can verify any of them when they have the time. I can switch it back to randomly assigning again if people prefer, but I want to wait until Kitty has more practice verifying enhancements (which don't have repro samples).

### PR Merge
- The GH Secret for merging anyone's PR with a comment is now `PRIMARY_MAINTAINERS`  (previously `PRIMARY_CONTACT` and `SECONDARY_CONTACTS`). 
- The secret still takes a comma separated list of usernames (currently me and @jcfranco and @eriklharper). 
- Everyone can still use this action on their own PR, or on any auto-generated PRs
- The secret is mainly used to fix screener issues, and is probably obsolete due to GitHub's built in button.


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
