### PR TITLE
build: remove unnecessary numeric separator plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,11 @@
     "sortablejs": "1.15.0"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-numeric-separator": "7.16.7",
     "@babel/preset-react": "7.16.7",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.1",
     "@esri/calcite-ui-icons": "3.18.7",
     "@esri/eslint-plugin-calcite-components": "0.1.4",
-    "@rollup/plugin-babel": "5.3.1",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",
     "@stencil/sass": "1.5.2",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,7 +1,6 @@
 import { Config } from "@stencil/core";
 import { postcss } from "@stencil/postcss";
 import { sass } from "@stencil/sass";
-import babel from "@rollup/plugin-babel";
 import autoprefixer from "autoprefixer";
 import tailwindcss from "tailwindcss";
 import tailwindConfig from "./tailwind.config";
@@ -104,15 +103,6 @@ export const create: () => Config = () => ({
       plugins: [tailwindcss(tailwindConfig), autoprefixer()]
     })
   ],
-  rollupPlugins: {
-    after: [
-      babel({
-        babelHelpers: "bundled",
-        include: [/\/color\//],
-        plugins: ["@babel/plugin-proposal-numeric-separator"]
-      })
-    ]
-  },
   testing: {
     moduleNameMapper: {
       "^/assets/(.*)$": "<rootDir>/src/tests/iconPathDataStub.ts"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

https://github.com/Esri/calcite-components/pull/4381 bumped color to version 4.2.3, which [removed `numeric separators`](https://github.com/Qix-/color/releases/tag/4.2.3), so we can drop the `@babel/plugin-proposal-numeric-separator` rollup plugin (introduced in https://github.com/Esri/calcite-components/pull/2822/).
