### PR TITLE
fix(input): correctly de-localize negative numbers in ar and et

### DIFF
--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1075,6 +1075,18 @@ describe("calcite-input", () => {
       });
   });
 
+  it(`allows negative, decimal numbers for et locale`, async () => {
+    const value = "-1,5";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input locale="et" type="number"></calcite-input>`);
+    const element = await page.find("calcite-input");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, value);
+    await page.waitForChanges();
+    await page.keyboard.press("Tab");
+    expect(await element.getProperty("value")).toBe("-1.5");
+  });
+
   it(`allows clearing value for type=number`, async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number" value="1"></calcite-input>`);

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -501,7 +501,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
     } else {
       this.setValue({
         nativeEvent,
-        value: delocalizeNumberString(value, this.locale)
+        value: delocalizedValue
       });
     }
   };

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -52,6 +52,8 @@ export const locales = [
   "zh-TW"
 ];
 
+const localesNegativeCharacters = ["−", "-", "﹣", "－"];
+
 function createLocaleNumberFormatter(locale: string): Intl.NumberFormat {
   return new Intl.NumberFormat(locale, {
     minimumFractionDigits: 0,
@@ -67,6 +69,9 @@ export function delocalizeNumberString(numberString: string, locale: string): st
 
       const splitNumberString = nonExpoNumString.split("");
       const decimalIndex = splitNumberString.lastIndexOf(decimalSeparator);
+      if (localesNegativeCharacters.includes(splitNumberString[0])) {
+        splitNumberString[0] = "-";
+      }
 
       const delocalizedNumberString = splitNumberString
         .map((value, index) => {

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -52,8 +52,6 @@ export const locales = [
   "zh-TW"
 ];
 
-const localesNegativeCharacters = ["−", "-", "﹣", "－"];
-
 function createLocaleNumberFormatter(locale: string): Intl.NumberFormat {
   return new Intl.NumberFormat(locale, {
     minimumFractionDigits: 0,
@@ -66,12 +64,10 @@ export function delocalizeNumberString(numberString: string, locale: string): st
     if (nonExpoNumString) {
       const groupSeparator = getGroupSeparator(locale);
       const decimalSeparator = getDecimalSeparator(locale);
+      const minusSign = getMinusSign(locale);
 
       const splitNumberString = nonExpoNumString.split("");
       const decimalIndex = splitNumberString.lastIndexOf(decimalSeparator);
-      if (localesNegativeCharacters.includes(splitNumberString[0])) {
-        splitNumberString[0] = "-";
-      }
 
       const delocalizedNumberString = splitNumberString
         .map((value, index) => {
@@ -81,7 +77,8 @@ export function delocalizeNumberString(numberString: string, locale: string): st
           return value;
         })
         .reduce((string, part) => string + part)
-        .replace(decimalSeparator, ".");
+        .replace(decimalSeparator, ".")
+        .replace(minusSign, "-");
 
       return isNaN(Number(delocalizedNumberString)) ? nonExpoNumString : delocalizedNumberString;
     }
@@ -101,6 +98,13 @@ export function getDecimalSeparator(locale: string): string {
   const parts = formatter.formatToParts(1234567.8);
   const value = parts.find((part) => part.type === "decimal").value;
   return value.trim().length === 0 ? " " : value;
+}
+
+export function getMinusSign(locale: string): string {
+  const formatter = createLocaleNumberFormatter(locale);
+  const parts = formatter.formatToParts(-1234567.8);
+  const value = parts.find((part) => part.type === "minusSign").value;
+  return value.trim().length === 0 ? "-" : value;
 }
 
 export function localizeNumberString(numberString: string, locale: string, displayGroupSeparator = false): string {

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -24,7 +24,7 @@ export function parseNumberString(numberString?: string): string {
         return numberKeys.includes(value);
       })
       .reduce((string, part) => string + part);
-    return isValidNumber(result) ? Number(result).toString() : null;
+    return isValidNumber(result) ? Number(result).toString() : "";
   });
 }
 


### PR DESCRIPTION
**Related Issue:** #4040 #3956

## Summary
The negative character is different in some locales, and it was not being delocalized, which caused the number to be invalid.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
