### PR TITLE
fix(color-picker): setting value programmatically twice or more in a row will no longer emit change/input events

### DIFF
--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -490,7 +490,7 @@ describe("calcite-color-picker", () => {
     // set to corner right value that's not red (first value)
     picker.setProperty("value", "#ff0");
     await page.waitForChanges();
-    expect(spy).toHaveReceivedEventTimes(++changes);
+    expect(spy).toHaveReceivedEventTimes(changes);
 
     // clicking on color slider to set hue
     const colorsToSample = 7;

--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -179,9 +179,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("emits event when value changes via user interaction and not programmatically", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
     const picker = await page.find("calcite-color-picker");
     const changeSpy = await picker.spyOnEvent("calciteColorPickerChange");
     const inputSpy = await picker.spyOnEvent("calciteColorPickerInput");
@@ -249,7 +248,7 @@ describe("calcite-color-picker", () => {
 
     // change by dragging hue slider thumb
     const [hueScopeX, hueScopeY] = await getElementXY(page, "calcite-color-picker", `.${CSS.hueScope}`);
-    const previousInputEventLength = inputSpy.length;
+    let previousInputEventLength = inputSpy.length;
 
     await page.mouse.move(hueScopeX + thumbRadius, hueScopeY + thumbRadius);
     await page.mouse.down();
@@ -259,6 +258,17 @@ describe("calcite-color-picker", () => {
 
     expect(changeSpy).toHaveReceivedEventTimes(7);
     expect(inputSpy.length).toBeGreaterThan(previousInputEventLength + 1); // input event fires more than once
+
+    previousInputEventLength = inputSpy.length;
+
+    // this portion covers an odd scenario where setting twice would cause the component to emit
+    picker.setProperty("value", "colorFieldCenterValueHex");
+    await page.waitForChanges();
+    picker.setProperty("value", "#fff");
+    await page.waitForChanges();
+
+    expect(changeSpy).toHaveReceivedEventTimes(7);
+    expect(inputSpy.length).toBe(previousInputEventLength);
   });
 
   it("does not emit on initialization", async () => {

--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -524,8 +524,9 @@ describe("calcite-color-picker", () => {
     // clicking on the slider when the color won't change by hue adjustments
 
     picker.setProperty("value", "#000");
-    changes++;
     await page.waitForChanges();
+    expect(spy).toHaveReceivedEventTimes(changes);
+
     x = 0;
 
     type TestWindow = GlobalTestProps<{

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -95,7 +95,7 @@ export class ColorPicker implements InteractiveComponent {
   @Watch("format")
   handleFormatChange(format: ColorPicker["format"]): void {
     this.setMode(format);
-    this.internalColorSet(this.color, false);
+    this.internalColorSet(this.color, false, "internal");
   }
 
   /** When true, hides the hex input */
@@ -255,7 +255,7 @@ export class ColorPicker implements InteractiveComponent {
       return;
     }
 
-    if (this.internalColorUpdateContext === "internal") {
+    if (this.internalColorUpdateContext === "user-interaction") {
       this.calciteColorPickerInput.emit();
 
       if (!dragging) {
@@ -268,7 +268,7 @@ export class ColorPicker implements InteractiveComponent {
     const colorChanged = !colorEqual(color, this.color);
 
     if (modeChanged || colorChanged) {
-      this.internalColorSet(color);
+      this.internalColorSet(color, true, "internal");
     }
   }
   //--------------------------------------------------------------------------
@@ -293,7 +293,7 @@ export class ColorPicker implements InteractiveComponent {
 
   private hueScopeNode: HTMLDivElement;
 
-  private internalColorUpdateContext: "internal" | "initial" | null = null;
+  private internalColorUpdateContext: "internal" | "initial" | "user-interaction" | null = null;
 
   private previousColor: InternalColor | null;
 
@@ -1036,7 +1036,7 @@ export class ColorPicker implements InteractiveComponent {
   private internalColorSet(
     color: Color | null,
     skipEqual = true,
-    context: ColorPicker["internalColorUpdateContext"] = "internal"
+    context: ColorPicker["internalColorUpdateContext"] = "user-interaction"
   ): void {
     if (skipEqual && colorEqual(color, this.color)) {
       return;


### PR DESCRIPTION
**Related Issue:** #2033 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes an issue where setting `value` more than once would emit. Specifically, it would emit on even `value` sets.  