### PR TITLE
fix(input): negative numbers delocalize correctly in ar locale

### DIFF
--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1087,6 +1087,18 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("-1.5");
   });
 
+  it(`allows negative, decimal numbers for ar locale`, async () => {
+    const value = "-0001.0001";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input locale="ar" type="number"></calcite-input>`);
+    const element = await page.find("calcite-input");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, value);
+    await page.waitForChanges();
+    await page.keyboard.press("Tab");
+    expect(await element.getProperty("value")).toBe("-1.0001");
+  });
+
   it(`allows clearing value for type=number`, async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number" value="1"></calcite-input>`);

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1075,18 +1075,6 @@ describe("calcite-input", () => {
       });
   });
 
-  it(`allows negative, decimal numbers for et locale`, async () => {
-    const value = "-1,5";
-    const page = await newE2EPage();
-    await page.setContent(html`<calcite-input locale="et" type="number"></calcite-input>`);
-    const element = await page.find("calcite-input");
-    await element.callMethod("setFocus");
-    await typeNumberValue(page, value);
-    await page.waitForChanges();
-    await page.keyboard.press("Tab");
-    expect(await element.getProperty("value")).toBe("-1.5");
-  });
-
   it(`allows negative, decimal numbers for ar locale`, async () => {
     const value = "-0001.0001";
     const page = await newE2EPage();

--- a/src/demos/input.html
+++ b/src/demos/input.html
@@ -1381,11 +1381,11 @@
       </div>
     </div>
 
-    <!-- french -->
+    <!-- arabic -->
     <div class="parent-flex">
-      <div class="child-flex font right-aligned-text">french</div>
+      <div class="child-flex font right-aligned-text">arabic</div>
       <div class="child-flex">
-        <calcite-input type="number" locale="fr" name="french" value="1234.56" step="0.01"></calcite-input>
+        <calcite-input type="number" locale="ar" name="arabic"></calcite-input>
       </div>
     </div>
 

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,0 +1,30 @@
+import { delocalizeNumberString, localizeNumberString, locales } from "./locale";
+
+const localesWithIssues = ["ar"];
+
+describe("localizeNumberString and delocalizeNumberString", () => {
+  locales
+    .filter((locale) => !localesWithIssues.includes(locale))
+    .forEach((locale) => {
+      it(`integers localize and delocalize in "${locale}"`, () => {
+        const numberString = "555";
+        const localizedNumberString = localizeNumberString(numberString, locale);
+        const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
+        expect(delocalizedNumberString).toBe(numberString);
+      });
+
+      it(`negative numbers localize and delocalize in "${locale}"`, () => {
+        const numberString = "-123";
+        const localizedNumberString = localizeNumberString(numberString, locale);
+        const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
+        expect(delocalizedNumberString).toBe(numberString);
+      });
+
+      it(`floating point numbers localize and delocalize in "${locale}"`, () => {
+        const numberString = "1.05";
+        const localizedNumberString = localizeNumberString(numberString, locale);
+        const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
+        expect(delocalizedNumberString).toBe(numberString);
+      });
+    });
+});

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,6 +1,6 @@
 import { delocalizeNumberString, localizeNumberString, locales } from "./locale";
 
-const localesWithIssues = ["ar"];
+const localesWithIssues = ["ar"]; // arabic has different numeral characters
 
 describe("localizeNumberString and delocalizeNumberString", () => {
   locales
@@ -22,6 +22,13 @@ describe("localizeNumberString and delocalizeNumberString", () => {
 
       it(`floating point numbers localize and delocalize in "${locale}"`, () => {
         const numberString = "1.05";
+        const localizedNumberString = localizeNumberString(numberString, locale);
+        const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
+        expect(delocalizedNumberString).toBe(numberString);
+      });
+
+      it(`exponential numbers localize and delocalize in "${locale}"`, () => {
+        const numberString = "2.5e-3";
         const localizedNumberString = localizeNumberString(numberString, locale);
         const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
         expect(delocalizedNumberString).toBe(numberString);

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -78,7 +78,8 @@ export function delocalizeNumberString(numberString: string, locale: string): st
         })
         .reduce((string, part) => string + part)
         .replace(decimalSeparator, ".")
-        .replace(minusSign, "-");
+        .replace(minusSign, "-")
+        .replace(/[^0-9\-\e\.]/g, ""); // remove everything except numbers, "e", "-", and "."
 
       return isNaN(Number(delocalizedNumberString)) ? nonExpoNumString : delocalizedNumberString;
     }
@@ -95,7 +96,7 @@ export function getGroupSeparator(locale: string): string {
 
 export function getDecimalSeparator(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
-  const parts = formatter.formatToParts(1234567.8);
+  const parts = formatter.formatToParts(-1234567.8);
   const value = parts.find((part) => part.type === "decimal").value;
   return value.trim().length === 0 ? " " : value;
 }

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -79,7 +79,7 @@ export function delocalizeNumberString(numberString: string, locale: string): st
         .reduce((string, part) => string + part)
         .replace(decimalSeparator, ".")
         .replace(minusSign, "-")
-        .replace(/[^0-9\-\e\.]/g, ""); // remove everything except numbers, "e", "-", and "."
+        .replace(/[^0-9\-\.]/g, ""); // remove everything except numbers, "-", and "."
 
       return isNaN(Number(delocalizedNumberString)) ? nonExpoNumString : delocalizedNumberString;
     }
@@ -96,7 +96,7 @@ export function getGroupSeparator(locale: string): string {
 
 export function getDecimalSeparator(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
-  const parts = formatter.formatToParts(-1234567.8);
+  const parts = formatter.formatToParts(1234567.8);
   const value = parts.find((part) => part.type === "decimal").value;
   return value.trim().length === 0 ? " " : value;
 }


### PR DESCRIPTION
**Related Issue:** #3956 

## Summary
It was adding a weird character which doesn't get logged in the dev tools console but does log in the codepen console.
https://codepen.io/benesri/pen/RwxYKWv?editors=0011
![image](https://user-images.githubusercontent.com/10986395/163091988-015b2817-d4f7-4204-9018-6f45ca2fe06a.png)

Is it Friday yet? lol

From [`formatToParts` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts):
![image](https://user-images.githubusercontent.com/10986395/163085591-b5f64db4-cd36-489e-bb39-089f6ed710a1.png)


- To fix the issue I stripped everything except numbers, hyphens, and decimals. 
- I also added locale spec tests since we didn't have any. I removed the `et` negative/decimal e2e test because it is covered in the locale spec ones.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
