### PR TITLE
fix(input): correctly delocalize numbers with group separators

### DIFF
--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -33,5 +33,11 @@ describe("localizeNumberString and delocalizeNumberString", () => {
         const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
         expect(delocalizedNumberString).toBe(numberString);
       });
+      it(`numbers with group separators localize and delocalize in "${locale}"`, () => {
+        const numberString = "12,345,678.9";
+        const localizedNumberString = localizeNumberString(numberString, locale, true);
+        const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
+        expect(delocalizedNumberString).toBe("12345678.9");
+      });
     });
 });

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -33,6 +33,7 @@ describe("localizeNumberString and delocalizeNumberString", () => {
         const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
         expect(delocalizedNumberString).toBe(numberString);
       });
+
       it(`numbers with group separators localize and delocalize in "${locale}"`, () => {
         const numberString = "1,234";
         const localizedNumberString = localizeNumberString(numberString, locale, true);

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -21,7 +21,7 @@ describe("localizeNumberString and delocalizeNumberString", () => {
       });
 
       it(`floating point numbers localize and delocalize in "${locale}"`, () => {
-        const numberString = "1.05";
+        const numberString = "4.321";
         const localizedNumberString = localizeNumberString(numberString, locale);
         const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
         expect(delocalizedNumberString).toBe(numberString);
@@ -34,6 +34,13 @@ describe("localizeNumberString and delocalizeNumberString", () => {
         expect(delocalizedNumberString).toBe(numberString);
       });
       it(`numbers with group separators localize and delocalize in "${locale}"`, () => {
+        const numberString = "1,234";
+        const localizedNumberString = localizeNumberString(numberString, locale, true);
+        const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);
+        expect(delocalizedNumberString).toBe("1234");
+      });
+
+      it(`floating point numbers with group separators localize and delocalize in "${locale}"`, () => {
         const numberString = "12,345,678.9";
         const localizedNumberString = localizeNumberString(numberString, locale, true);
         const delocalizedNumberString = delocalizeNumberString(localizedNumberString, locale);

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -53,6 +53,10 @@ export const locales = [
   "zh-TW"
 ];
 
+const allDecimalsExceptLast = new RegExp(`[.](?=.*[.])`, "g");
+const everythingExceptNumbersDecimalsAndMinusSigns = new RegExp("[^0-9-.]", "g");
+const defaultGroupSeparator = new RegExp(",", "g");
+
 function createLocaleNumberFormatter(locale: string): Intl.NumberFormat {
   return new Intl.NumberFormat(locale, {
     minimumFractionDigits: 0,
@@ -62,8 +66,6 @@ function createLocaleNumberFormatter(locale: string): Intl.NumberFormat {
 
 export function delocalizeNumberString(numberString: string, locale: string): string {
   return sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string => {
-    const allDecimalsExceptLast = new RegExp(`[.](?=.*[.])`, "g");
-    const everythingExceptNumbersDecimalsAndMinusSigns = new RegExp("[^0-9-.]", "g");
     const delocalizedNumberString = nonExpoNumString
       .replace(getMinusSign(locale), "-")
       .replace(getGroupSeparator(locale), "")
@@ -78,28 +80,25 @@ export function delocalizeNumberString(numberString: string, locale: string): st
 export function getGroupSeparator(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
   const parts = formatter.formatToParts(1234567);
-  const value = parts.find((part) => part.type === "group")?.value;
-  return value ? value.trim() : "";
+  return parts.find((part) => part.type === "group").value;
 }
 
 export function getDecimalSeparator(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
   const parts = formatter.formatToParts(1.1);
-  const value = parts.find((part) => part.type === "decimal")?.value;
-  return value ? value.trim() : "";
+  return parts.find((part) => part.type === "decimal").value;
 }
 
 export function getMinusSign(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
   const parts = formatter.formatToParts(-9);
-  const value = parts.find((part) => part.type === "minusSign")?.value;
-  return value ? value.trim() : "";
+  return parts.find((part) => part.type === "minusSign").value;
 }
 
 export function localizeNumberString(numberString: string, locale: string, displayGroupSeparator = false): string {
   return sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string => {
     if (nonExpoNumString) {
-      const number = Number(sanitizeDecimalString(nonExpoNumString.replace(/,/g, "")));
+      const number = Number(sanitizeDecimalString(nonExpoNumString.replace(defaultGroupSeparator, "")));
       if (!isNaN(number)) {
         const formatter = createLocaleNumberFormatter(locale);
         const parts = formatter.formatToParts(number);

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,4 +1,5 @@
 import { sanitizeDecimalString, sanitizeExponentialNumberString } from "./number";
+import { isValidNumber } from "./number";
 
 export const locales = [
   "ar",
@@ -61,17 +62,14 @@ function createLocaleNumberFormatter(locale: string): Intl.NumberFormat {
 
 export function delocalizeNumberString(numberString: string, locale: string): string {
   return sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string => {
-    if (nonExpoNumString) {
-      const allDecimalsExceptLast = new RegExp(`[.](?=.*[.])`, "g");
-      const delocalizedNumberString = nonExpoNumString
-        .replace(getDecimalSeparator(locale), ".")
-        .replace(getMinusSign(locale), "-")
-        .replace(allDecimalsExceptLast, "")
-        .replace(/[^0-9\-\.]/g, ""); // remove everything except numbers, minus signs, and decimals
+    const allDecimalsExceptLast = new RegExp(`[.](?=.*[.])`, "g");
+    const delocalizedNumberString = nonExpoNumString
+      .replace(getDecimalSeparator(locale), ".")
+      .replace(getMinusSign(locale), "-")
+      .replace(allDecimalsExceptLast, "")
+      .replace(/[^0-9\-\.]/g, ""); // remove everything except numbers, minus signs, and decimals
 
-      return isNaN(Number(delocalizedNumberString)) ? delocalizedNumberString : delocalizedNumberString;
-    }
-    return nonExpoNumString;
+    return isValidNumber(delocalizedNumberString) ? delocalizedNumberString : nonExpoNumString;
   });
 }
 

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -80,7 +80,9 @@ export function delocalizeNumberString(numberString: string, locale: string): st
 export function getGroupSeparator(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
   const parts = formatter.formatToParts(1234567);
-  return parts.find((part) => part.type === "group").value;
+  const value = parts.find((part) => part.type === "group").value;
+  // there are whitespace group characters that doesn't render correctly
+  return value.trim().length === 0 ? " " : value;
 }
 
 export function getDecimalSeparator(locale: string): string {

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -63,11 +63,13 @@ function createLocaleNumberFormatter(locale: string): Intl.NumberFormat {
 export function delocalizeNumberString(numberString: string, locale: string): string {
   return sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string => {
     const allDecimalsExceptLast = new RegExp(`[.](?=.*[.])`, "g");
+    const everythingExceptNumbersDecimalsAndMinusSigns = new RegExp("[^0-9-.]", "g");
     const delocalizedNumberString = nonExpoNumString
-      .replace(getDecimalSeparator(locale), ".")
       .replace(getMinusSign(locale), "-")
+      .replace(getGroupSeparator(locale), "")
+      .replace(getDecimalSeparator(locale), ".")
       .replace(allDecimalsExceptLast, "")
-      .replace(/[^0-9\-\.]/g, ""); // remove everything except numbers, minus signs, and decimals
+      .replace(everythingExceptNumbersDecimalsAndMinusSigns, "");
 
     return isValidNumber(delocalizedNumberString) ? delocalizedNumberString : nonExpoNumString;
   });
@@ -97,7 +99,7 @@ export function getMinusSign(locale: string): string {
 export function localizeNumberString(numberString: string, locale: string, displayGroupSeparator = false): string {
   return sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string => {
     if (nonExpoNumString) {
-      const number = Number(sanitizeDecimalString(nonExpoNumString));
+      const number = Number(sanitizeDecimalString(nonExpoNumString.replace(/,/g, "")));
       if (!isNaN(number)) {
         const formatter = createLocaleNumberFormatter(locale);
         const parts = formatter.formatToParts(number);

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -81,7 +81,7 @@ export function getGroupSeparator(locale: string): string {
   const formatter = createLocaleNumberFormatter(locale);
   const parts = formatter.formatToParts(1234567);
   const value = parts.find((part) => part.type === "group").value;
-  // there are whitespace group characters that doesn't render correctly
+  // change whitespace group characters that don't render correctly
   return value.trim().length === 0 ? " " : value;
 }
 


### PR DESCRIPTION
**Related Issue:** #3956

## Summary
When adding the locale spec tests in the PR above, the group separators were not working properly for a lot of locales (33 failed tests if I remember correctly). I fixed and cleaned up the locale utils, so now everything is passing.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
