### PR TITLE
fix(popover-manager): Prevents auto closing when dragging outside of popover

### DIFF
--- a/src/components/popover-manager/popover-manager.tsx
+++ b/src/components/popover-manager/popover-manager.tsx
@@ -78,8 +78,8 @@ export class PopoverManager {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("click", { target: "window", capture: true })
-  closeOpenPopovers(event: Event): void {
+  @Listen("pointerdown", { target: "window", capture: true })
+  pointerDownHandler(event: Event): void {
     const { autoClose, el } = this;
     const popoverSelector = "calcite-popover";
     const composedPath = event.composedPath();


### PR DESCRIPTION
**Related Issue:** #4071

## Summary

fix(popover-manager): Prevents auto closing when dragging outside of popover. (#4071)