### PR TITLE
docs(readme): change loader property from isActive to active

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,12 +107,12 @@ This will provide autocomplete of component names/properties, as well as additio
 // created elements will implicitly have the correct type already
 const loader = document.createElement("calcite-loader");
 document.body.appendChild(loader);
-loader.isActive = true;
+loader.active = true;
 
 // you can also explicitly type an element using the generated types
 // the type name will always be formatted like HTML{CamelCaseComponentName}Element
 const loader = document.querySelector(".my-loader-element") as HTMLCalciteLoaderElement;
-loader.isActive = true;
+loader.active = true;
 ```
 
 ## Browser Support


### PR DESCRIPTION
**Related Issue:** NA

## Summary
fixed readme doc
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
