### PR TITLE
fix(card): Checkbox label should be visible and accessible

### DIFF
--- a/src/components/card/card.e2e.ts
+++ b/src/components/card/card.e2e.ts
@@ -69,9 +69,9 @@ describe("calcite-card", () => {
       </calcite-card>
     `);
 
-    const thumbContainer = await page.find(`calcite-card >>> .${CSS.checkboxWrapper}`);
+    const checkbox = await page.find(`calcite-card >>> calcite-checkbox`);
 
-    expect(thumbContainer).not.toBeNull();
+    expect(checkbox).not.toBeNull();
   });
 
   describe("when a card is selectable", () => {
@@ -88,7 +88,7 @@ describe("calcite-card", () => {
       </div>
       `);
       const card = await page.find("calcite-card");
-      const checkbox = await page.find(`calcite-card >>> .${CSS.checkboxWrapper} calcite-checkbox`);
+      const checkbox = await page.find(`calcite-card >>> calcite-checkbox`);
       const cardSelectSpy = await card.spyOnEvent("calciteCardSelect");
       const clickSpy = await card.spyOnEvent("calciteCardSelect");
       await checkbox.click();

--- a/src/components/card/card.e2e.ts
+++ b/src/components/card/card.e2e.ts
@@ -15,6 +15,7 @@ describe("calcite-card", () => {
   it("is accessible when selectable", async () =>
     accessible(`
       <calcite-card selectable>
+        <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
         <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>`));
 

--- a/src/components/card/card.e2e.ts
+++ b/src/components/card/card.e2e.ts
@@ -15,7 +15,6 @@ describe("calcite-card", () => {
   it("is accessible when selectable", async () =>
     accessible(`
       <calcite-card selectable>
-        <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
         <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>`));
 

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -104,9 +104,3 @@
 .thumbnail-wrapper {
   @apply text-0-wrap;
 }
-
-.checkbox-wrapper {
-  @apply absolute m-0 p-0;
-  top: theme("spacing.2");
-  inset-inline-end: theme("spacing.2");
-}

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -54,16 +54,6 @@ export class Card implements ConditionalSlotComponent {
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
-  /** string to override English select text for checkbox when selectable is true
-   * @default "Select"
-   */
-  @Prop({ reflect: false }) intlSelect: string = TEXT.select;
-
-  /** string to override English deselect text for checkbox when selectable is true
-   * @default "Deselect"
-   */
-  @Prop({ reflect: false }) intlDeselect: string = TEXT.deselect;
-
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -96,7 +86,6 @@ export class Card implements ConditionalSlotComponent {
           </div>
         ) : null}
         <section aria-busy={this.loading.toString()} class={{ [CSS.container]: true }}>
-          {this.selectable ? this.renderCheckbox() : null}
           {this.renderThumbnail()}
           {this.renderHeader()}
           <div class="card-content">
@@ -146,17 +135,20 @@ export class Card implements ConditionalSlotComponent {
     ) : null;
   }
 
-  private renderCheckbox(): VNode {
-    const checkboxLabel = this.selected ? this.intlDeselect : this.intlSelect;
+  private renderTitle(): VNode {
+    const titleSlotNode = <slot key="title-slot" name={SLOTS.title} />;
 
-    return (
+    return this.selectable ? (
       <calcite-label
-        class={CSS.checkboxWrapper}
+        layout="inline"
         onClick={this.cardSelectClick}
         onKeyDown={this.cardSelectKeyDown}
       >
-        <calcite-checkbox checked={this.selected} label={checkboxLabel} />
+        <calcite-checkbox checked={this.selected} />
+        {titleSlotNode}
       </calcite-label>
+    ) : (
+      titleSlotNode
     );
   }
 
@@ -168,7 +160,7 @@ export class Card implements ConditionalSlotComponent {
 
     return hasHeader ? (
       <header class={CSS.header}>
-        <slot name={SLOTS.title} />
+        {this.renderTitle()}
         <slot name={SLOTS.subtitle} />
       </header>
     ) : null;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -140,6 +140,7 @@ export class Card implements ConditionalSlotComponent {
 
     return this.selectable ? (
       <calcite-label
+        disableSpacing={true}
         layout="inline"
         onClick={this.cardSelectClick}
         onKeyDown={this.cardSelectKeyDown}

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -153,10 +153,10 @@ export class Card implements ConditionalSlotComponent {
   }
 
   private renderHeader(): VNode {
-    const { el } = this;
+    const { el, selectable } = this;
     const title = getSlotted(el, SLOTS.title);
     const subtitle = getSlotted(el, SLOTS.subtitle);
-    const hasHeader = title || subtitle;
+    const hasHeader = title || subtitle || selectable;
 
     return hasHeader ? (
       <header class={CSS.header}>

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -54,6 +54,18 @@ export class Card implements ConditionalSlotComponent {
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
+  /** string to override English select text for checkbox when selectable is true
+   * @default "Select"
+   * @deprecated the "title" slot content will be used instead.
+   */
+  @Prop({ reflect: false }) intlSelect: string = TEXT.select;
+
+  /** string to override English deselect text for checkbox when selectable is true
+   * @default "Deselect"
+   * @deprecated the "title" slot content will be used instead.
+   */
+  @Prop({ reflect: false }) intlDeselect: string = TEXT.deselect;
+
   //--------------------------------------------------------------------------
   //
   //  Events
@@ -136,11 +148,11 @@ export class Card implements ConditionalSlotComponent {
   }
 
   private renderTitle(): VNode {
-    const { selectable, selected } = this;
+    const { selectable, selected, intlSelect, intlDeselect } = this;
 
     const titleSlotNode = (
       <slot key="title-slot" name={SLOTS.title}>
-        {selectable ? TEXT.select : ""}
+        {selectable ? (selected ? intlDeselect : intlSelect) : ""}
       </slot>
     );
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -136,16 +136,22 @@ export class Card implements ConditionalSlotComponent {
   }
 
   private renderTitle(): VNode {
-    const titleSlotNode = <slot key="title-slot" name={SLOTS.title} />;
+    const { selectable, selected } = this;
 
-    return this.selectable ? (
+    const titleSlotNode = (
+      <slot key="title-slot" name={SLOTS.title}>
+        {selectable ? TEXT.select : ""}
+      </slot>
+    );
+
+    return selectable ? (
       <calcite-label
         disableSpacing={true}
         layout="inline"
         onClick={this.cardSelectClick}
         onKeyDown={this.cardSelectKeyDown}
       >
-        <calcite-checkbox checked={this.selected} />
+        <calcite-checkbox checked={selected} />
         {titleSlotNode}
       </calcite-label>
     ) : (

--- a/src/components/card/resources.ts
+++ b/src/components/card/resources.ts
@@ -4,8 +4,7 @@ export const CSS = {
   footer: "footer",
   title: "title",
   subtitle: "subtitle",
-  thumbnailWrapper: "thumbnail-wrapper",
-  checkboxWrapper: "checkbox-wrapper"
+  thumbnailWrapper: "thumbnail-wrapper"
 };
 
 export const SLOTS = {
@@ -17,7 +16,5 @@ export const SLOTS = {
 };
 
 export const TEXT = {
-  select: "Select",
-  deselect: "Deselect",
   loading: "Loading"
 };

--- a/src/components/card/resources.ts
+++ b/src/components/card/resources.ts
@@ -16,5 +16,6 @@ export const SLOTS = {
 };
 
 export const TEXT = {
-  loading: "Loading"
+  loading: "Loading",
+  select: "Select"
 };

--- a/src/components/card/resources.ts
+++ b/src/components/card/resources.ts
@@ -16,6 +16,7 @@ export const SLOTS = {
 };
 
 export const TEXT = {
-  loading: "Loading",
-  select: "Select"
+  select: "Select",
+  deselect: "Deselect",
+  loading: "Loading"
 };


### PR DESCRIPTION
**Related Issue:** #2426

## Summary

fix(card): Checkbox label should be visible and accessible. (#2426)

- Moves checkbox next to the title and surrounds it with a label for accessibility.
- Current use of "Select"/"Deselect" doesn't meet a11y guidelines as the labels are not useful.

<img width="361" alt="image" src="https://user-images.githubusercontent.com/1231455/164557416-358970df-9927-4524-ad93-d6fe9b56b58e.png">


<img width="731" alt="image" src="https://user-images.githubusercontent.com/1231455/164557373-b5591e00-4ff6-4369-b595-6ba13c1b5313.png">


