### PR TITLE
test(color-picker): import getElementXY from util

### DIFF
--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -4,27 +4,10 @@ import { CSS, DEFAULT_COLOR, DEFAULT_STORAGE_KEY_PREFIX, DIMENSIONS, TEXT } from
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing";
 import { ColorValue } from "./interfaces";
 import SpyInstance = jest.SpyInstance;
-import { GlobalTestProps, selectText } from "../../tests/utils";
+import { GlobalTestProps, selectText, getElementXY } from "../../tests/utils";
 
 describe("calcite-color-picker", () => {
   let consoleSpy: SpyInstance;
-
-  async function getElementXY(
-    page: E2EPage,
-    elementSelector: string,
-    shadowSelector?: string
-  ): Promise<[number, number]> {
-    return page.evaluate(
-      ([elementSelector, shadowSelector]): [number, number] => {
-        const element = document.querySelector(elementSelector);
-        const measureTarget = shadowSelector ? element.shadowRoot.querySelector(shadowSelector) : element;
-        const { x, y } = measureTarget.getBoundingClientRect();
-
-        return [x, y];
-      },
-      [elementSelector, shadowSelector]
-    );
-  }
 
   beforeEach(
     () =>


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Getting rid of duplicate code
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
