### PR TITLE
docs(internal): add section about test helpers and utilities

### DIFF
--- a/conventions/Testing.md
+++ b/conventions/Testing.md
@@ -1,4 +1,4 @@
-## Tests
+# Tests
 
 Components should have an automated test for any incoming features or bug fixes. Make sure all tests pass as PRs will not be allowed to merge if there is a single test failure.
 
@@ -6,9 +6,25 @@ We encourage writing expressive test cases and code that indicates intent. Use c
 
 Please see Stencil's doc for more info on [end-to-end](https://stenciljs.com/docs/end-to-end-testing) testing. See one of our test examples [here](https://github.com/Esri/calcite-components/blob/master/src/components/block/block.e2e.ts).
 
-### Writing Tests
+## Writing Tests
 
-#### Prevent logging unnecessary messaging in the build
+### Helpers and utilities
+
+There are helpers and utilities to make testing common workflows easier. [`commonTests.ts`](https://github.com/Esri/calcite-components/blob/master/src/tests/commonTests.ts) contains common tests that you can import and use for your component. For example, every component should have an [`accessible`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/tests/commonTests.ts#L48-L62) test. To use the test in your component, import the helper and assert that the component is accessible.
+
+```js
+import { accessible } from "../../tests/commonTests";
+
+it("is accessible", async () => accessible(`<calcite-example>${content}</calcite-example>`));
+```
+
+Here is an example of the helper test usage in [`accordion.e2e.ts`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/accordion/accordion.e2e.ts#L16).
+
+There are many more useful, common tests that you should use in specific scenarios. In most IDEs or text editors, you can search the function name of a common test to find usage examples in component's end-to-end test files.
+
+In addition to the common tests, there are also test utilities in [`utils.ts`](https://github.com/Esri/calcite-components/blob/master/src/tests/utils.ts). These utilities are created to avoid duplicate code in component end-to-end test files. If you find yourself creating the same test function for different components, then it should be moved to `utils.ts`. A good example is [`getElementXY`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/tests/utils.ts#L124-L139). Determining the screen location of an element can be very important when testing interactive components. Here are some end-to-end tests where the utility is used in [`color-picker.e2e.ts`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/color-picker/color-picker.e2e.ts#L232-L236), [`input-e2e.ts`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/input/input.e2e.ts#L289-L293), [`shell-panel.e2e.ts`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/shell-panel/shell-panel.e2e.ts#L381), and [`slider.e2e.ts`](https://github.com/Esri/calcite-components/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/slider/slider.e2e.ts#L176).
+
+### Prevent unnecessary logging in the build
 
 **This is only necessary if a component's test will produce a lot of console messages in a test run.**
 
@@ -16,7 +32,7 @@ As a best practice when writing tests, prevent emitting console warnings by stub
 
 Console warnings can end up polluting the build output messaging that makes it more difficult to identify real issues. By stubbing `console.warn`, you can prevent warning messages from displaying in the build. See [`color.e2e`](https://github.com/Esri/calcite-components/blob/af0c6cb/src/components/color/color.e2e.ts#L9-L17) for an example.
 
-### Unstable Tests
+## Unstable Tests
 
 If you notice that a test fails intermittently during local or CI test runs, it is unstable and must be skipped to avoid holding up test runs, builds and deployments.
 


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Add a short section about commonTests and utils.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
