### PR TITLE
fix(combobox, filter): only test regex on string properties when filtering

### DIFF
--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -61,6 +61,33 @@ describe("calcite-combobox", () => {
 
   it("can be disabled", () => disabled("calcite-combobox"));
 
+  it("filtering does not match property with value of undefined", async () => {
+    const page = await newE2EPage({
+      html: html`
+        <calcite-combobox id="myCombobox">
+          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
+          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
+          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
+          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+        </calcite-combobox>
+      `
+    });
+
+    const combobox = await page.find("calcite-combobox");
+    const input = await page.find("calcite-combobox >>> input");
+    const items = await page.findAll("calcite-combobox-item");
+    await combobox.click();
+    await page.waitForChanges();
+
+    await input.type("undefined");
+    await page.waitForChanges();
+
+    expect(await items[0].isVisible()).toBe(false);
+    expect(await items[1].isVisible()).toBe(false);
+    expect(await items[2].isVisible()).toBe(false);
+    expect(await items[3].isVisible()).toBe(false);
+  });
+
   it("should filter the items in listbox when typing into the input", async () => {
     const page = await newE2EPage({
       html: html`

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -151,14 +151,14 @@ export class Filter implements InteractiveComponent {
     const find = (input: object, RE: RegExp): any => {
       let found = false;
       forIn(input, (val) => {
-        if (typeof val === "function") {
+        if (typeof val === "function" || val == null /* intentional == to catch undefined */) {
           return;
         }
         if (Array.isArray(val) || (typeof val === "object" && val !== null)) {
           if (find(val, RE)) {
             found = true;
           }
-        } else if (typeof val === "string" && RE.test(val)) {
+        } else if (RE.test(val)) {
           found = true;
         }
       });

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -158,7 +158,7 @@ export class Filter implements InteractiveComponent {
           if (find(val, RE)) {
             found = true;
           }
-        } else if (RE.test(val)) {
+        } else if (typeof val === "string" && RE.test(val)) {
           found = true;
         }
       });

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -23,7 +23,7 @@ export const filter = (data: Array<object>, value: string): Array<any> => {
         if (find(val, RE)) {
           found = true;
         }
-      } else if (RE.test(val)) {
+      } else if (typeof val === "string" && RE.test(val)) {
         found = true;
       }
     });

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -16,14 +16,14 @@ export const filter = (data: Array<object>, value: string): Array<any> => {
     let found = false;
 
     forIn(input, (val) => {
-      if (typeof val === "function") {
+      if (typeof val === "function" || val == null /* intentional == to catch undefined */) {
         return;
       }
       if (Array.isArray(val) || (typeof val === "object" && val !== null)) {
         if (find(val, RE)) {
           found = true;
         }
-      } else if (typeof val === "string" && RE.test(val)) {
+      } else if (RE.test(val)) {
         found = true;
       }
     });


### PR DESCRIPTION
**Related Issue:** #4348

## Summary
It was matching the `constant` attribute's `undefined` default value. 
```js
/u/.test(undefined) === true
```
Fixing it this way also works for `calcite-filter`, rather than only filtering based on `label` and `value` properties (relevant for #4425)
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
