### PR TITLE
fix(chip): apply --calcite-ui-icon-color to chip icon if defined

### DIFF
--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -4,7 +4,7 @@
   @apply text-n2 h-6;
   --calcite-chip-spacing-unit-l: theme("spacing.2");
   --calcite-chip-spacing-unit-s: theme("spacing.1");
-  .chip-image-container {
+  .image-container {
     @apply h-5 w-5;
   }
 }
@@ -12,7 +12,7 @@
   @apply text-n1 h-8;
   --calcite-chip-spacing-unit-l: theme("spacing.3");
   --calcite-chip-spacing-unit-s: 6px;
-  .chip-image-container {
+  .image-container {
     @apply h-6 w-6;
     padding-inline-start: theme("padding.1");
   }
@@ -22,7 +22,7 @@
   @apply text-0 h-11;
   --calcite-chip-spacing-unit-l: theme("spacing.4");
   --calcite-chip-spacing-unit-s: theme("spacing.2");
-  .chip-image-container {
+  .image-container {
     @apply h-8 w-8 pl-1;
   }
 }
@@ -97,7 +97,7 @@
 }
 
 //slotted image
-.chip-image-container {
+.image-container {
   @apply rounded-half inline-flex overflow-hidden;
 }
 
@@ -106,7 +106,7 @@
 }
 
 //icon
-.calcite-chip--icon {
+.chip-icon {
   @apply relative
     my-0
     inline-flex
@@ -150,43 +150,47 @@
   background-color: var(--calcite-ui-foreground-2);
   color: var(--calcite-ui-text-1);
   button,
-  calcite-icon {
+  .close-icon {
     color: var(--calcite-ui-text-3);
+  }
+
+  .chip-icon {
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-text-3));
   }
 }
 
 // clear
 :host([color="blue"][appearance="clear"]) {
   border-color: var(--calcite-ui-info);
-  .calcite-chip--icon {
-    color: var(--calcite-ui-info);
+  .chip-icon {
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-info));
   }
 }
 
 :host([color="red"][appearance="clear"]) {
   border-color: var(--calcite-ui-danger);
-  .calcite-chip--icon {
-    color: var(--calcite-ui-danger);
+  .chip-icon {
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-danger));
   }
 }
 
 :host([color="yellow"][appearance="clear"]) {
   border-color: var(--calcite-ui-warning);
-  .calcite-chip--icon {
-    color: var(--calcite-ui-warning);
+  .chip-icon {
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-warning));
   }
 }
 
 :host([color="green"][appearance="clear"]) {
   border-color: var(--calcite-ui-success);
-  .calcite-chip--icon {
-    color: var(--calcite-ui-success);
+  .chip-icon {
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-success));
   }
 }
 
 :host([color="grey"][appearance="clear"]) {
   border-color: var(--calcite-ui-border-1);
-  .calcite-chip--icon {
-    color: var(--calcite-ui-text-3);
+  .chip-icon {
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-text-3));
   }
 }

--- a/src/components/chip/chip.stories.ts
+++ b/src/components/chip/chip.stories.ts
@@ -105,3 +105,6 @@ export const Rtl = (): string => html`
 `;
 
 Rtl.storyName = "RTL";
+
+export const OverriddenIconColor = (): string =>
+  html`<calcite-chip icon="banana" style="--calcite-ui-icon-color: #ac9f42" dismissible>Banana</calcite-chip>`;

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -121,7 +121,7 @@ export class Chip implements ConditionalSlotComponent {
     const hasChipImage = getSlotted(el, SLOTS.image);
 
     return hasChipImage ? (
-      <div class={CSS.chipImageContainer} key="image">
+      <div class={CSS.imageContainer} key="image">
         <slot name={SLOTS.image} />
       </div>
     ) : null;
@@ -129,12 +129,7 @@ export class Chip implements ConditionalSlotComponent {
 
   render(): VNode {
     const iconEl = (
-      <calcite-icon
-        class={CSS.calciteChipIcon}
-        flipRtl={this.iconFlipRtl}
-        icon={this.icon}
-        scale="s"
-      />
+      <calcite-icon class={CSS.chipIcon} flipRtl={this.iconFlipRtl} icon={this.icon} scale="s" />
     );
 
     const closeButton = (
@@ -145,7 +140,7 @@ export class Chip implements ConditionalSlotComponent {
         onClick={this.closeClickHandler}
         ref={(el) => (this.closeButton = el)}
       >
-        <calcite-icon icon={ICONS.close} scale="s" />
+        <calcite-icon class={CSS.closeIcon} icon={ICONS.close} scale="s" />
       </button>
     );
 

--- a/src/components/chip/resources.ts
+++ b/src/components/chip/resources.ts
@@ -1,8 +1,9 @@
 export const CSS = {
   title: "title",
   close: "close",
-  chipImageContainer: "chip-image-container",
-  calciteChipIcon: "calcite-chip--icon"
+  imageContainer: "image-container",
+  chipIcon: "chip-icon",
+  closeIcon: "close-icon"
 };
 
 export const TEXT = {


### PR DESCRIPTION
**Related Issue:** #4306 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This updates chip to apply `--calcite-ui-icon-color` to the chip icon if defined. Otherwise, it will apply the icon color according to the `color`-prop.

Note: only the chip icon will be be affected and not the close icon. 

![Screen Shot 2022-04-25 at 5 52 24 PM](https://user-images.githubusercontent.com/197440/165198221-a48003e3-3eb8-4be1-a823-59b2f65decfa.png)

Also, the image container CSS class was renamed to follow changes to the icon one. I can revert this if deemed better as a separate refactor PR.