### PR TITLE
ci: add current milestone when pr merged

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -14,7 +14,3 @@ jobs:
       - uses: srvaroa/labeler@v0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  milestone:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: benelan/milestone-action@v1.1.1

--- a/.github/workflows/pr-milestone.yml
+++ b/.github/workflows/pr-milestone.yml
@@ -1,0 +1,11 @@
+name: PR Merged
+on:
+  pull_request:
+    branches: [master]
+    types: [closed]
+jobs:
+  milestone:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benelan/milestone-action@v1.3.0


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Right now the current milestone is being added when the PR is opened. We need everything in a past-due milestone to be closed before we can close the milestone. Stale PRs are making it harder to close milestones. So it will be better to add PRs to milestones when they are merged, rather than opened.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
