### PR TITLE
chore: modify test template

### DIFF
--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -53,8 +53,8 @@ body:
   - type: input
     id: pr
     attributes:
-      label: Skipped In (if applicable)
-      description: Which PR skipped the unstable test(s), if applicable?
+      label: PR skipped, if applicable
+      description: Which PR skipped the unstable test(s)?
       value: "#"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,5 +1,5 @@
-name: Unstable Test
-description: Associate issue for an unstable test that was skipped
+name: Test
+description: Associate issue for a test (e.g., a new test, an unstable test that was skipped, Screener, etc.)
 labels: ["testing", "0 - new", "p - high"]
 body:
   - type: markdown
@@ -8,23 +8,31 @@ body:
         - Please [check for existing issues](https://github.com/Esri/calcite-components/issues) to avoid duplicates. If someone has already opened an issue for what you are experiencing, please add a 👍 reaction to the existing issue instead of creating a new one.
         - For support, please check the [community forum](https://developers.arcgis.com/calcite-design-system/community/).
   - type: input
+    id: type
+    attributes:
+      label: Test type
+      description: What type of test is being requested?
+      placeholder: "e.g., new test, unstable test, Screener, etc."
+    validations:
+      required: true
+  - type: input
     id: component
     attributes:
-      label: Which Component
+      label: Which Component(s)
     validations:
       required: true
   - type: textarea
     id: tests
     attributes:
-      label: Which Tests(s)
-      description: List the unstable test(s) or suite(s).
+      label: Unstable Tests
+      description: List the unstable test(s) or suite(s), if applicable
       placeholder: "calcite-foo a11y check › setFocus › can focus some button"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: error
     attributes:
-      label: Test error
+      label: Test error, if applicable
       description: Copy and paste the error stack trace.
       placeholder: |
         FAIL src/components/calcite-foo/calcite-foo.e2e.ts (32.825 s)
@@ -41,15 +49,15 @@ body:
             at Object.focusable (src/tests/commonTests.ts:167:108)
                 at runMicrotasks (<anonymous>)
     validations:
-      required: true
+      required: false
   - type: input
     id: pr
     attributes:
-      label: Skipped In
-      description: Which PR skipped the unstable test(s)?
+      label: Skipped In (if applicable)
+      description: Which PR skipped the unstable test(s), if applicable?
       value: "#"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: info
     attributes:


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Modify the unstable test template to fit all test cases including new, unstable tests, or Screener. 

- Renamed the template to "test.yml" for its new use
- All original content remains, but some fields are now optional
- An additional section was added to the top of the template indicating the type of test being requested

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
