### PR TITLE
fix(filter): fix inconsistent text-clearing UX

### DIFF
--- a/src/components/filter/filter.e2e.ts
+++ b/src/components/filter/filter.e2e.ts
@@ -1,6 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, focusable, hidden, reflects, renders } from "../../tests/commonTests";
-import { CSS, DEBOUNCE_TIMEOUT } from "./resources";
+import { DEBOUNCE_TIMEOUT } from "./resources";
+import { CSS as INPUT_CSS } from "../input/resources";
 
 describe("calcite-filter", () => {
   it("renders", async () => renders("calcite-filter", { display: "flex" }));
@@ -73,23 +74,6 @@ describe("calcite-filter", () => {
       });
     });
 
-    it("should only display when the input has a value", async () => {
-      let button = await page.find(`calcite-filter >>> .${CSS.clearButton}`);
-
-      expect(button).toBeNull();
-
-      const filter = await page.find("calcite-filter");
-      await filter.callMethod("setFocus");
-
-      await page.keyboard.type("developer");
-      await page.waitForChanges();
-
-      button = await page.find(`calcite-filter >>> .${CSS.clearButton}`);
-
-      expect(button).not.toBeNull();
-      expect(await filter.getProperty("value")).toBe("developer");
-    });
-
     describe("clearing value", () => {
       const filterIsFocused = async (): Promise<boolean> =>
         page.evaluate(() => document.querySelector("calcite-filter") === document.activeElement);
@@ -103,9 +87,16 @@ describe("calcite-filter", () => {
 
         expect(await filter.getProperty("value")).toBe("developer");
 
-        const button = await page.find(`calcite-filter >>> .${CSS.clearButton}`);
-
-        await button.click();
+        await page.$eval(
+          "calcite-filter",
+          async (filter: HTMLCalciteFilterElement, buttonSelector: string): Promise<void> => {
+            return filter.shadowRoot
+              .querySelector("calcite-input")
+              .shadowRoot.querySelector<HTMLElement>(buttonSelector)
+              .click();
+          },
+          `.${INPUT_CSS.clearButton}`
+        );
         await page.waitForChanges();
 
         expect(await filter.getProperty("value")).toBe("");

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -214,8 +214,10 @@ export class Filter implements InteractiveComponent {
           <label>
             <calcite-input
               aria-label={this.intlLabel || TEXT.filterLabel}
+              clearable={true}
               disabled={disabled}
               icon={ICONS.search}
+              intlClear={this.intlClear || TEXT.clear}
               onCalciteInputInput={this.inputHandler}
               onKeyDown={this.keyDownHandler}
               placeholder={this.placeholder}
@@ -227,16 +229,6 @@ export class Filter implements InteractiveComponent {
               value={this.value}
             />
           </label>
-          {this.value ? (
-            <button
-              aria-label={this.intlClear || TEXT.clear}
-              class={CSS.clearButton}
-              disabled={disabled}
-              onClick={this.clear}
-            >
-              <calcite-icon icon={ICONS.close} scale={scale} />
-            </button>
-          ) : null}
         </div>
       </Fragment>
     );

--- a/src/components/filter/resources.ts
+++ b/src/components/filter/resources.ts
@@ -1,7 +1,6 @@
 export const CSS = {
   container: "container",
-  searchIcon: "search-icon",
-  clearButton: "clear-button"
+  searchIcon: "search-icon"
 };
 
 export const TEXT = {

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -5,6 +5,7 @@ import { letterKeys, numberKeys } from "../../utils/key";
 import { getDecimalSeparator, locales, localizeNumberString } from "../../utils/locale";
 import { getElementXY } from "../../tests/utils";
 import { KeyInput } from "puppeteer";
+import { TEXT } from "./resources";
 
 describe("calcite-input", () => {
   const delayFor2UpdatesInMs = 200;
@@ -441,6 +442,7 @@ describe("calcite-input", () => {
     await page.setContent(html` <calcite-input clearable value="John Doe"></calcite-input> `);
     const clearButton = await page.find("calcite-input >>> .clear-button");
     expect(clearButton).not.toBe(null);
+    expect(clearButton.getAttribute("aria-label")).toBe(TEXT.clear);
   });
 
   it("does not render clear button when clearable is requested and value is not populated", async () => {

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -14,7 +14,7 @@ import {
 } from "@stencil/core";
 import { getElementDir, getElementProp, getSlotted, setRequestedIcon } from "../../utils/dom";
 
-import { CSS, INPUT_TYPE_ICONS, SLOTS } from "./resources";
+import { CSS, INPUT_TYPE_ICONS, SLOTS, TEXT } from "./resources";
 import { InputPlacement } from "./interfaces";
 import { Position } from "../interfaces";
 import { LabelableComponent, connectLabel, disconnectLabel, getLabelText } from "../../utils/label";
@@ -26,7 +26,7 @@ import {
 } from "../../utils/locale";
 import { numberKeys } from "../../utils/key";
 import { isValidNumber, parseNumberString, sanitizeNumberString } from "../../utils/number";
-import { CSS_UTILITY, TEXT } from "../../utils/resources";
+import { CSS_UTILITY, TEXT as COMMON_TEXT } from "../../utils/resources";
 import { decimalPlaces } from "../../utils/math";
 import { createObserver } from "../../utils/observers";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
@@ -87,10 +87,15 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   @Prop({ reflect: true }) icon: string | boolean;
 
   /**
+   * A text label that will appear on the clear button for screen readers.
+   */
+  @Prop() intlClear?: string;
+
+  /**
    * string to override English loading text
    * @default "Loading"
    */
-  @Prop() intlLoading?: string = TEXT.loading;
+  @Prop() intlLoading?: string = COMMON_TEXT.loading;
 
   /** flip the icon in rtl */
   @Prop({ reflect: true }) iconFlipRtl = false;
@@ -752,6 +757,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
 
     const inputClearButton = (
       <button
+        aria-label={this.intlClear || TEXT.clear}
         class={CSS.clearButton}
         disabled={this.disabled || this.readOnly}
         onClick={this.clearInputValue}

--- a/src/components/input/resources.ts
+++ b/src/components/input/resources.ts
@@ -27,3 +27,7 @@ export const INPUT_TYPE_ICONS = {
 export const SLOTS = {
   action: "action"
 };
+
+export const TEXT = {
+  clear: "Clear value"
+};


### PR DESCRIPTION
**Related Issue:** #4376 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a UI inconsistency with `calcite-filter` by refactoring it to use `calcite-input`'s `clearable` option. 

### Noteworthy changes to `calcite-input`

* Added `intlClear` prop
* Added default aria-label text for the clear button in case ☝️ is empty cc @geospatialem 