### PR TITLE
fix(slider): prevent parent word-break from breaking labels

### DIFF
--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -39,7 +39,7 @@
 }
 
 .container {
-  @apply relative block;
+  @apply relative block break-normal;
   padding: calc(var(--calcite-slider-handle-size) * 0.5);
   margin: calc(var(--calcite-slider-handle-size) * 0.5) 0;
   --calcite-slider-full-handle-height: calc(

--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -283,3 +283,16 @@ HistogramDark.storyName = "Histogram Dark theme";
 HistogramDark.parameters = { themes: themesDarkDefault };
 
 export const disabled = (): string => html`<calcite-slider disabled value="5"></calcite-slider>`;
+
+export const wordBreakDoesNotAffectLabels = (): string =>
+  html`<calcite-slider
+    min="-100"
+    max="100"
+    min-value="-100"
+    max-value="100"
+    step="10"
+    ticks="10"
+    label-handles
+    label-ticks
+    style="word-break: break-all"
+  ></calcite-slider>`;


### PR DESCRIPTION
**Related Issue:** #4126 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR sets `word-break` on the main container to prevent inheriting a value that could mess up the labels.