### PR TITLE
docs(block): update props desc and values

### DIFF
--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -55,14 +55,14 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   @Prop() headingLevel: HeadingLevel;
 
   /**
-   * Tooltip used for the toggle when expanded.
+   * Aria-label for collapsing the toggle and tooltip used for the toggle when expanded.
    */
-  @Prop() intlCollapse?: string;
+  @Prop() intlCollapse?: string = TEXT.collapse;
 
   /**
-   * Tooltip used for the toggle when collapsed.
+   * Aria-label for expanding the toggle and tooltip used for the toggle when collapsed.
    */
-  @Prop() intlExpand?: string;
+  @Prop() intlExpand?: string = TEXT.expand;
 
   /** string to override English loading text
    * @default "Loading"


### PR DESCRIPTION
**Related Issue:** #4460

## Summary
* Update props and attrs for `intlCollapse` and `intlExpand` to include default values.
* Add supporting text to provide context with aria-label

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
