### PR TITLE
ci: add ci flag and github actor to fix storybook deployment automation

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -13,9 +13,12 @@ jobs:
         with:
           node-version: lts/*
           cache: npm
-      - run: |
+      - name: Deploy storybook
+        run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           npm ci
           npm run build-storybook
-          npx storybook-to-ghpages --existing-output-dir=docs
+          npx storybook-to-ghpages --existing-output-dir=docs --ci
+        env:
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Got a [new error](https://github.com/Esri/calcite-components/runs/6243148044?check_suite_focus=true#step:4:7696) for the storybook deployment action. Trying a solution found [here](https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-579745557)
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
