### PR TITLE
docs: consistent api refs for value-list and value-list-item

### DIFF
--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -24,8 +24,8 @@ import {
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot actions-end - A slot that adds actions or content to the end side of the item.
- * @slot actions-start - A slot that adds actions or content to the start side of the item.
+ * @slot actions-end - A slot for adding actions or content to the end side of the item.
+ * @slot actions-start - A slot for adding actions or content to the start side of the item.
  */
 @Component({
   tag: "calcite-value-list-item",
@@ -86,7 +86,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   @Prop({ reflect: true }) removable = false;
 
   /**
-   * When true, pre-select's the list item. Toggles when an item is checked/unchecked.
+   * When true, preselects the list item. Toggles when an item is checked/unchecked.
    */
   @Prop({ reflect: true, mutable: true }) selected = false;
 

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -24,8 +24,8 @@ import {
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot actions-end - A slot for adding actions or content to the end side of the item.
- * @slot actions-start - A slot for adding actions or content to the start side of the item.
+ * @slot actions-end - A slot that adds actions or content to the end side of the item.
+ * @slot actions-start - A slot that adds actions or content to the start side of the item.
  */
 @Component({
   tag: "calcite-value-list-item",
@@ -40,17 +40,17 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   // --------------------------------------------------------------------------
 
   /**
-   * An optional description for this item. Will appear below the label text.
+   * An optional description for the list item that displays below the label text.
    */
   @Prop({ reflect: true }) description?: string;
 
   /**
-   * When true, the item cannot be clicked and is visually muted
+   * When true, the list item cannot be clicked and is visually muted.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * @internal When false, the item cannot be deselected by user interaction.
+   * @internal When false, the list item cannot be deselected by user interaction.
    */
   @Prop() disableDeselect = false;
 
@@ -60,7 +60,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   @Prop({ reflect: true }) nonInteractive = false;
 
   /**
-   * @internal - stores the activated state of the drag handle.
+   * @internal - Stores the activated state of the drag handle.
    */
   @Prop({ mutable: true }) handleActivated? = false;
 
@@ -71,27 +71,27 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   @Prop({ reflect: true }) icon?: ICON_TYPES | null = null;
 
   /**
-   * The main label for this item. Appears next to the icon.
+   * The main label for the list item. Appears next to the icon.
    */
   @Prop({ reflect: true }) label!: string;
 
   /**
-   * Used to provide additional metadata to an item, primarily used when the parent list has a filter.
+   * Provides additional metadata to a list item. Primary use is for a filter on the parent list.
    */
   @Prop() metadata?: Record<string, unknown>;
 
   /**
-   * Set this to true to display a remove action that removes the item from the list.
+   * When true, adds an action to remove the list item.
    */
   @Prop({ reflect: true }) removable = false;
 
   /**
-   * Set this to true to pre-select an item. Toggles when an item is checked/unchecked.
+   * When true, pre-select's the list item. Toggles when an item is checked/unchecked.
    */
   @Prop({ reflect: true, mutable: true }) selected = false;
 
   /**
-   * The item's associated value.
+   * The list item's associated value.
    */
   @Prop() value!: any;
 
@@ -132,7 +132,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   // --------------------------------------------------------------------------
 
   /**
-   * Used to toggle the selection state. By default this won't trigger an event.
+   * Toggle the selection state. By default this won't trigger an event.
    * The first argument allows the value to be coerced, rather than swapping values.
    */
   @Method()
@@ -140,7 +140,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
     this.pickListItem.toggleSelected(coerce);
   }
 
-  /** Sets focus on the component. */
+  /** Set focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
     this.pickListItem?.setFocus();
@@ -153,7 +153,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted whenever the remove button is pressed.
+   * Emits when the remove button is pressed.
    */
   @Event() calciteListItemRemove: EventEmitter<void>; // wrapped pick-list-item emits this
 

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -38,8 +38,8 @@ import { createObserver } from "../../utils/observers";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot for adding `calcite-value-list-item` elements. Items are displayed as a vertical list.
- * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
+ * @slot - A slot that adds calcite-value-list-item elements. List items are displayed as a vertical list.
+ * @slot menu-actions - A slot that adds a button and menu combination for performing actions, such as sorting.
  */
 @Component({
   tag: "calcite-value-list",
@@ -57,22 +57,22 @@ export class ValueList<
   // --------------------------------------------------------------------------
 
   /**
-   * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
+   * When true, prevents user interaction. This state shows list items with lower opacity and grayed out.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * When true, the items will be sortable via drag and drop.
+   * When true, list items are sortable via a draggable button.
    */
   @Prop({ reflect: true }) dragEnabled = false;
 
   /**
-   * When true, an input appears at the top of the list that can be used by end users to filter items in the list.
+   * When true, an input appears at the top of the list that can be used by end users to filter list items.
    */
   @Prop({ reflect: true }) filterEnabled = false;
 
   /**
-   * Placeholder text for the filter input field.
+   * Placeholder text for the filter's input field.
    */
   @Prop({ reflect: true }) filterPlaceholder: string;
 
@@ -89,15 +89,15 @@ export class ValueList<
   @Prop({ reflect: true }) loading = false;
 
   /**
-   * Multiple Works similar to standard radio buttons and checkboxes.
-   * When true, a user can select multiple items at a time.
-   * When false, only a single item can be selected at a time
-   * and selecting a new item will deselect any other selected items.
+   * Similar to standard radio buttons and checkboxes.
+   * When true, a user can select multiple list items at a time.
+   * When false, only a single list item can be selected at a time,
+   * and selecting a new list item will deselect any other selected list items.
    */
   @Prop({ reflect: true }) multiple = false;
 
   /**
-   * When true and single-selection is enabled, the selection will change when navigating items via the keyboard.
+   * When true and single-selection is enabled, the selection changes when navigating list items via the keyboard.
    */
   @Prop() selectionFollowsFocus = false;
 
@@ -156,12 +156,12 @@ export class ValueList<
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when any of the item selections have changed.
+   * Emits when any of the list item selections have changed.
    */
   @Event() calciteListChange: EventEmitter<Map<string, HTMLCalciteValueListItemElement>>;
 
   /**
-   * Emitted when the order of the list has changed.
+   * Emits when the order of the list has changed.
    */
   @Event() calciteListOrderChange: EventEmitter<any[]>;
 

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -38,8 +38,8 @@ import { createObserver } from "../../utils/observers";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot that adds calcite-value-list-item elements. List items are displayed as a vertical list.
- * @slot menu-actions - A slot that adds a button and menu combination for performing actions, such as sorting.
+ * @slot - A slot for adding calcite-value-list-item elements. List items are displayed as a vertical list.
+ * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
 @Component({
   tag: "calcite-value-list",
@@ -57,7 +57,7 @@ export class ValueList<
   // --------------------------------------------------------------------------
 
   /**
-   * When true, prevents user interaction. This state shows list items with lower opacity and grayed out.
+   * When true, prevents user interaction. This state shows list items grayed out and with lower opacity.
    */
   @Prop({ reflect: true }) disabled = false;
 


### PR DESCRIPTION
**Related Issue:** #4442

## Summary
First of a series of updates across components to implement a style guide across our API references for consistency.

PR includes the following components API refs:
* value-list
* value-list-item

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
