### PR TITLE
docs: consistent api refs for tree and tree-item

### DIFF
--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -25,7 +25,7 @@ import {
 
 /**
  * @slot - A slot for adding content to the item.
- * @slot children - A slot for adding nested `calcite-tree` elements.
+ * @slot children - A slot for adding nested calcite-tree elements.
  */
 @Component({
   tag: "calcite-tree-item",
@@ -47,10 +47,10 @@ export class TreeItem implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** Is the item currently selected */
+  /** Selected state of the item. */
   @Prop({ mutable: true, reflect: true }) selected = false;
 
-  /** True if the item is in an expanded state */
+  /** Expanded state of the item. */
   @Prop({ mutable: true, reflect: true }) expanded = false;
 
   @Watch("expanded")
@@ -58,35 +58,35 @@ export class TreeItem implements ConditionalSlotComponent {
     this.updateParentIsExpanded(this.el, newValue);
   }
 
-  /** @internal Is the parent of this item expanded? */
+  /** @internal Expanded state of the parent. */
   @Prop() parentExpanded = false;
 
-  /** @internal What level of depth is this item at? */
+  /** @internal Level of depth of the item. */
   @Prop({ reflect: true, mutable: true }) depth = -1;
 
   /** @internal Does this tree item have a tree inside it? */
   @Prop({ reflect: true, mutable: true }) hasChildren: boolean = null;
 
-  /** @internal Draw lines (set on parent) */
+  /** @internal Draws lines (set on parent). */
   @Prop({ reflect: true, mutable: true }) lines: boolean;
 
-  /** Display checkboxes (set on parent)
+  /** Displays checkboxes (set on parent).
    * @internal
-   * @deprecated set "ancestors" selection-mode on parent tree for checkboxes
+   * @deprecated Use "ancestors" selection-mode on parent for checkbox input.
    */
   @Prop() inputEnabled: boolean;
 
-  /** @internal Scale of the parent tree, defaults to m */
+  /** @internal Scale of the parent tree. */
   @Prop({ reflect: true, mutable: true }) scale: Scale;
 
   /**
    * @internal
    * In ancestor selection mode,
-   * show as indeterminate when only some children are selected
+   * show as indeterminate when only some children are selected.
    **/
   @Prop({ reflect: true }) indeterminate: boolean;
 
-  /** @internal Tree selection-mode (set on parent) */
+  /** @internal Tree selection-mode (set on parent). */
   @Prop({ mutable: true }) selectionMode: TreeSelectionMode;
 
   @Watch("selectionMode")

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -15,7 +15,7 @@ import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
 
 /**
- * @slot - A slot for `calcite-tree-item` elements.
+ * @slot - A slot for calcite-tree-item elements.
  */
 @Component({
   tag: "calcite-tree",
@@ -37,21 +37,21 @@ export class Tree {
   //
   //--------------------------------------------------------------------------
 
-  /** Display indentation guide lines */
+  /** Display indentation guide lines. */
   @Prop({ mutable: true, reflect: true }) lines = false;
 
   /** Display input
-   * @deprecated use "ancestors" selection-mode for checkbox input
+   * @deprecated Use "ancestors" selection-mode for checkbox input.
    */
   @Prop() inputEnabled = false;
 
-  /** @internal If this tree is nested within another tree, set to false */
+  /** @internal If this tree is nested within another tree, set to false. */
   @Prop({ reflect: true, mutable: true }) child: boolean;
 
-  /** Specify the scale of the tree, defaults to m */
+  /** Specify the scale of the tree. */
   @Prop({ mutable: true, reflect: true }) scale: Scale = "m";
 
-  /** Customize how tree selection works (single, multi, children, multi-children, ancestors)
+  /** Customize how tree selection works (single, multi, children, multi-children, ancestors).
    * @default "single"
    * @see [TreeSelectionMode](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L5)
    */
@@ -338,7 +338,7 @@ export class Tree {
   //--------------------------------------------------------------------------
 
   /**
-   * Emitted when user selects/deselects tree items. An object including an array of selected items will be passed in the event's `detail` property.
+   * Emits when the user selects/deselects tree items. An object including an array of selected items will be passed in the event's "detail" property.
    * @see [TreeSelectDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L1)
    */
   @Event() calciteTreeSelect: EventEmitter<TreeSelectDetail>;


### PR DESCRIPTION
**Related Issue:** #4442

## Summary
Part of a series of updates across components to implement a style guide across our API references for consistency.

PR includes the following components API refs:
- tree
- tree-item

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
