### PR TITLE
fix(form): keep track of bound form reset event handlers to plug memory leak

### DIFF
--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -147,6 +147,7 @@ export function connectForm<T>(component: FormComponent<T>): void {
 
   const boundOnFormReset = (component.onFormReset || onFormReset).bind(component);
   form.addEventListener("reset", boundOnFormReset);
+  onFormResetMap.set(component.el, boundOnFormReset);
   formComponentSet.add(el);
 }
 


### PR DESCRIPTION
**Related Issue:** #4500

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR adds a missing line to keep track of the bound reset method when a form control is added. This led to increased form reset event handlers being added and never removed.