### PR TITLE
fix(date-picker): displays appropriate last date of previous month 

### DIFF
--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -258,7 +258,7 @@ export class DatePickerMonth {
     if (day - 6 === startOfWeek) {
       return days;
     }
-    for (let i = lastDate.getDay(); i >= startOfWeek; i--) {
+    for (let i = Math.abs(lastDate.getDay() - startOfWeek); i >= 0; i--) {
       days.push(date - i);
     }
     return days;

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -206,4 +206,5 @@ export const Default = stepStory(
         knobs: [{ name: "locale", value: "bg" }]
       })
     )
+    .snapshot("bg locale")
 );

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -202,7 +202,7 @@ export const Default = stepStory(
 
     .executeScript(
       setKnobs({
-        story: "components-controls-datepicker--locale-specific",
+        story: "components-controls-datepicker--default",
         knobs: [{ name: "locale", value: "bg" }]
       })
     )

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -199,4 +199,11 @@ export const Default = stepStory(
     `
     )
     .snapshot(" set maxAsDate & minAsDate")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--locale-specific",
+        knobs: [{ name: "locale", value: "bg" }]
+      })
+    )
 );


### PR DESCRIPTION
**Related Issue:** #4283 

## Summary

This fixes the wrong last dates of previous months displayed in locales such as `bg | sk`  in `date-picker` 


### Previous :
`locale=bg`
![12052899-F939-4A99-94B2-211E7DBE2D94_4_5005_c](https://user-images.githubusercontent.com/88453586/167212076-93f65497-19bd-4d93-8e11-b00dbeb890d5.jpeg)


### After the fix:
![851FD6A6-306E-4F4B-9A60-37D35493D076_4_5005_c](https://user-images.githubusercontent.com/88453586/167212162-b6280fcc-e515-419f-bb19-b3195d9c5339.jpeg)

