### PR TITLE
docs(demos): finalize demo homepage

### DIFF
--- a/src/demos/graph.html
+++ b/src/demos/graph.html
@@ -6,35 +6,80 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Calcite Graph</title>
     <style>
-      h3 {
-        margin-top: 4rem;
+      .parent {
+        display: flex;
+        align-items: center;
+        margin: 25px 0;
+      }
+
+      .child {
+        flex: 0 0 40%;
+        margin: 0 25px;
+        color: var(--calcite-ui-text-3);
+        font-family: var(--calcite-sans-family);
+        font-size: var(--calcite-font-size-0);
+        font-weight: var(--calcite-font-weight-medium);
+        padding: 10px 0;
+      }
+
+      .right-aligned-text {
+        text-align: right;
+        flex: 0 0 15%;
       }
     </style>
     <script src="_assets/head.js"></script>
   </head>
 
   <body>
-    <h1>Calcite Graph</h1>
+    <!-- Default -->
+    <div class="parent">
+      <div class="child right-aligned-text">Default</div>
+      <div class="child">
+        <calcite-graph></calcite-graph>
+      </div>
+    </div>
 
-    <h3>Default</h3>
-    <calcite-graph></calcite-graph>
+    <!-- Custom Size -->
+    <div class="parent">
+      <div class="child right-aligned-text">Custom Size</div>
+      <div class="child">
+        <calcite-graph width="100" height="40"></calcite-graph>
+      </div>
+    </div>
 
-    <h3>Custom Size</h3>
-    <calcite-graph width="100" height="40"></calcite-graph>
+    <!-- Inherit Color -->
+    <div class="parent">
+      <div class="child right-aligned-text">Inherit Color</div>
+      <div class="child">
+        <p style="color: var(--calcite-ui-brand)">
+          <calcite-graph></calcite-graph>
+        </p>
+      </div>
+    </div>
 
-    <h3>Inherit Color</h3>
-    <p style="color: var(--calcite-ui-brand)">
-      <calcite-graph></calcite-graph>
-    </p>
+    <!-- Highlight Range -->
+    <div class="parent">
+      <div class="child right-aligned-text">Highlight Range</div>
+      <div class="child">
+        <calcite-graph class="highlight-range"></calcite-graph>
+      </div>
+    </div>
 
-    <h3>Highlight Range</h3>
-    <calcite-graph class="highlight-range"></calcite-graph>
+    <!-- Color Stops -->
+    <div class="parent">
+      <div class="child right-aligned-text">Color Stops</div>
+      <div class="child">
+        <calcite-graph class="color-stops"></calcite-graph>
+      </div>
+    </div>
 
-    <h3>Color Stops</h3>
-    <calcite-graph class="color-stops"></calcite-graph>
-
-    <h3>Highlight Range and Color Stops</h3>
-    <calcite-graph class="highlight-range color-stops"></calcite-graph>
+    <!-- Highlight Range and Color Stops -->
+    <div class="parent">
+      <div class="child right-aligned-text">Highlight Range and Color Stops</div>
+      <div class="child">
+        <calcite-graph class="highlight-range color-stops"></calcite-graph>
+      </div>
+    </div>
 
     <script>
       // Fill all graphs with the same data.

--- a/src/demos/shell/popup-config-example.html
+++ b/src/demos/shell/popup-config-example.html
@@ -8,8 +8,10 @@
 
     <script src="../_assets/head.js"></script>
 
-    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.15/"></script>
+    <script src="https://js.arcgis.com/4.23/"></script>
+    <link disabled id="jsapi-theme-dark" rel="stylesheet" href="https://js.arcgis.com/4.23/esri/themes/dark/main.css" />
+    <link id="jsapi-theme-light" rel="stylesheet" href="https://js.arcgis.com/4.23/esri/themes/light/main.css" />
+
     <style>
       html,
       body,
@@ -17,10 +19,8 @@
       .shell-container {
         position: relative;
         width: 100%;
-        height: 100%;
+        height: calc(99vh - 80px);
       }
-    </style>
-    <style>
       #viewDiv {
         padding: 0;
         margin: 0;
@@ -36,18 +36,31 @@
         LayerList,
         Zoom
       ) {
-        const webmap = new WebMap({
+        const customWebMap = new WebMap({
           portalItem: {
             id: "cc316ca9e0824970ad29ac558161d42d"
-          }
+          },
+          basemap: "gray-vector" // Overrides webmap basemap (dark-gray-vector)
         });
 
         const view = new MapView({
           container: "viewDiv",
-          map: webmap
+          map: customWebMap,
+          padding: {
+            left: 45,
+            right: 330
+          }
         });
         view.when(function () {
           view.ui.move("zoom", "bottom-right");
+        });
+        // Theme switch
+        document.getElementById("toggle-theme").addEventListener("click", (event) => {
+          const dark = document.getElementById("jsapi-theme-dark");
+          const light = document.getElementById("jsapi-theme-light");
+          dark.toggleAttribute("disabled");
+          light.toggleAttribute("disabled");
+          customWebMap.basemap = dark.hasAttribute("disabled") ? "gray-vector" : "dark-gray-vector";
         });
       });
     </script>
@@ -57,7 +70,7 @@
       <div class="shell-container">
         <calcite-shell content-behind>
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached>
-            <calcite-action-bar slot="action-bar" class="calcite-theme-dark">
+            <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Save" icon="save" indicator> </calcite-action>
                 <calcite-action icon="map" text="New"> </calcite-action>
@@ -108,7 +121,7 @@
                 <calcite-action text="Configure pop-ups" icon="popup" active> </calcite-action>
                 <calcite-action text="Configure attributes" icon="feature-details"> </calcite-action>
                 <calcite-action text="Labels" icon="label"> </calcite-action>
-                <calcite-action text="Tablew" icon="table"> </calcite-action>
+                <calcite-action text="Table" icon="table"> </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action icon="search" text="Search"></calcite-action>

--- a/src/demos/theme/auto.html
+++ b/src/demos/theme/auto.html
@@ -14,8 +14,9 @@
         }
       };
     </script>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.15/"></script>
+    <script src="https://js.arcgis.com/4.23/"></script>
+    <link disabled id="jsapi-theme-dark" rel="stylesheet" href="https://js.arcgis.com/4.23/esri/themes/dark/main.css" />
+    <link id="jsapi-theme-light" rel="stylesheet" href="https://js.arcgis.com/4.23/esri/themes/light/main.css" />
     <style>
       html,
       body,
@@ -23,7 +24,7 @@
       .shell-container {
         position: relative;
         width: 100%;
-        height: 100%;
+        height: calc(99vh - 80px);
       }
     </style>
     <style>
@@ -42,15 +43,16 @@
         LayerList,
         Zoom
       ) {
-        const webmap = new WebMap({
+        const customWebMap = new WebMap({
           portalItem: {
             id: "cc316ca9e0824970ad29ac558161d42d"
-          }
+          },
+          basemap: "gray-vector"
         });
 
         const view = new MapView({
           container: "viewDiv",
-          map: webmap
+          map: customWebMap
         });
         view.when(function () {
           const layerList = new LayerList({
@@ -60,11 +62,20 @@
           });
 
           view.ui.move("zoom", "bottom-right");
+
+          // Theme switch
+          document.getElementById("toggle-theme").addEventListener("click", (event) => {
+            const dark = document.getElementById("jsapi-theme-dark");
+            const light = document.getElementById("jsapi-theme-light");
+            dark.toggleAttribute("disabled");
+            light.toggleAttribute("disabled");
+            customWebMap.basemap = dark.hasAttribute("disabled") ? "gray-vector" : "dark-gray-vector";
+          });
         });
       });
     </script>
   </head>
-  <body class="calcite-theme-auto">
+  <body>
     <main>
       <div class="shell-container">
         <calcite-shell>

--- a/src/demos/theme/auto.html
+++ b/src/demos/theme/auto.html
@@ -47,7 +47,7 @@
           portalItem: {
             id: "cc316ca9e0824970ad29ac558161d42d"
           },
-          basemap: "gray-vector"
+          basemap: "gray-vector" // Overrides webmap basemap (dark-gray-vector)
         });
 
         const view = new MapView({

--- a/src/index.html
+++ b/src/index.html
@@ -77,6 +77,13 @@
         </div>
 
         <div>
+          <a href="/demos/animation/animation.html">
+            <calcite-action scale="s" text="Animation" alignment="start" text-enabled appearance="solid">
+            </calcite-action>
+          </a>
+        </div>
+
+        <div>
           <a href="/demos/avatar.html">
             <calcite-action scale="s" text="Avatar" alignment="start" text-enabled appearance="solid"> </calcite-action>
           </a>
@@ -160,14 +167,26 @@
         </div>
 
         <div>
-          <a href="/demos/icon.html">
-            <calcite-action scale="s" text="Icon" alignment="start" text-enabled appearance="solid"> </calcite-action>
+          <a href="/demos/graph.html">
+            <calcite-action scale="s" text="Graph" alignment="start" text-enabled appearance="solid"> </calcite-action>
+          </a>
+        </div>
+
+        <div>
+          <a href="/demos/handle/basic.html">
+            <calcite-action scale="s" text="Handle" alignment="start" text-enabled appearance="solid"> </calcite-action>
           </a>
         </div>
       </div>
 
       <!-- second column -->
       <div>
+        <div>
+          <a href="/demos/icon.html">
+            <calcite-action scale="s" text="Icon" alignment="start" text-enabled appearance="solid"> </calcite-action>
+          </a>
+        </div>
+
         <div>
           <a href="/demos/inline-editable.html">
             <calcite-action scale="s" text="Inline-editable" alignment="start" text-enabled appearance="solid">
@@ -178,6 +197,13 @@
         <div>
           <a href="/demos/input.html">
             <calcite-action scale="s" text="Input" alignment="start" text-enabled appearance="solid"> </calcite-action>
+          </a>
+        </div>
+
+        <div>
+          <a href="/demos/input-date-picker.html">
+            <calcite-action scale="s" text="Input Date Picker" alignment="start" text-enabled appearance="solid">
+            </calcite-action>
           </a>
         </div>
 
@@ -301,6 +327,12 @@
         </div>
 
         <div>
+          <a href="/demos/shell/popup-config-example.html">
+            <calcite-action scale="s" text="Shell" alignment="start" text-enabled appearance="solid"> </calcite-action>
+          </a>
+        </div>
+
+        <div>
           <a href="/demos/shell-panel/basic.html">
             <calcite-action scale="s" text="Shell Panel" alignment="start" text-enabled appearance="solid">
             </calcite-action>
@@ -343,6 +375,12 @@
         <div>
           <a href="/demos/tabs.html">
             <calcite-action scale="s" text="Tabs" alignment="start" text-enabled appearance="solid"> </calcite-action>
+          </a>
+        </div>
+
+        <div>
+          <a href="/demos/theme/auto.html">
+            <calcite-action scale="s" text="Theme" alignment="start" text-enabled appearance="solid"> </calcite-action>
           </a>
         </div>
 


### PR DESCRIPTION
**Related Issue:** #2622

## Summary
1. Added remaining demos to the demo homepage, including:
    *  graph
    * input-date-picker
    * theme
    * animation
    * handle
    * shell
2. Updated demos with shell inclusion
    * shell only spans the full window height
3. Theme switcher added to theme and shell example for the JSAPI
    * map will also switch when theme switch is enabled (light vs. dark)   
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
