### PR TITLE
ci: remove extra git add from release prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "ts-node ./support/prepublish.ts",
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",
     "release:next": "npm ci && npm test && npm run util:deploy-next",
-    "release:prepare": "npm ci && npm test && ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts && npm run build && git add .",
+    "release:prepare": "npm ci && npm test && ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts && npm run build",
     "release:publish": "npm run util:push-tags && npm publish && ts-node ./support/releaseToGitHub.ts",
     "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm:build -- --dev --watch --serve\" \"ts-node ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
     "test": "npm run util:run-tests",


### PR DESCRIPTION
**Related Issue:** NA

## Summary

`support/prepReleaseCommit.ts` already adds and commits the relevant files. The extra `git add .` ends up staging all of the generated readmes which we don't want to manually commit. And then ammending the release commit with changelog fixes is slightly more annoying than if the readmes weren't staged 😅 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
