### PR TITLE
docs: consistent api styles

### DIFF
--- a/src/components/list-item-group/list-item-group.tsx
+++ b/src/components/list-item-group/list-item-group.tsx
@@ -4,7 +4,7 @@ import { HEADING_LEVEL } from "./resources";
 import { HeadingLevel, Heading, constrainHeadingLevel } from "../functional/Heading";
 
 /**
- * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
+ * @slot - A slot for adding calcite-list-item and calcite-list-item-group elements.
  */
 @Component({
   tag: "calcite-list-item-group",
@@ -19,13 +19,13 @@ export class ListItemGroup {
   // --------------------------------------------------------------------------
 
   /**
-   * The title used for all nested `calcite-list-item` rows.
+   * The title for all nested calcite-list-item rows.
    *
    */
   @Prop({ reflect: true }) heading: string;
 
   /**
-   * Number at which section headings should start for this component.
+   * Number at which section headings should start for the group.
    */
   @Prop() headingLevel: HeadingLevel;
 

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -9,11 +9,11 @@ import {
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
- * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the list item.
+ * @slot - A slot for adding calcite-list-item and calcite-list-item-group elements.
+ * @slot actions-start - A slot for adding actionable calcite-action elements before the content of the list item.
  * @slot content-start - A slot for adding non-actionable elements before the label and description of the list item.
  * @slot content-end - A slot for adding non-actionable elements after the label and description of the list item.
- * @slot actions-end - A slot for adding actionable `calcite-action` elements after the content of the list item.
+ * @slot actions-end - A slot for adding actionable calcite-action elements after the content of the list item.
  */
 @Component({
   tag: "calcite-list-item",
@@ -33,17 +33,17 @@ export class ListItem implements ConditionalSlotComponent, InteractiveComponent 
   @Prop({ reflect: true }) nonInteractive = false;
 
   /**
-   * An optional description for this item.  This will appear below the label text.
+   * An optional description for the list item. Displays below the label text.
    */
   @Prop() description: string;
 
   /**
-   * When true, disabled prevents interaction.
+   * When true, prevents user interaction.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The label text of the list item. This will appear above the description text.
+   * The label text of the list item. Displays above the description text.
    */
   @Prop() label: string;
 

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -5,7 +5,7 @@ import { InteractiveComponent, updateHostInteraction } from "../../utils/interac
 
 /**
  * A general purpose list that enables users to construct list items that conform to Calcite styling.
- * @slot - A slot for adding `calcite-list-item` elements.
+ * @slot - A slot for adding calcite-list-item elements.
  */
 @Component({
   tag: "calcite-list",
@@ -20,12 +20,12 @@ export class List implements InteractiveComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * When true, disabled prevents user interaction.
+   * When true, prevents user interaction.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * Number at which section headings should start for this component.
+   * Number at which section headings should start for the list.
    */
   @Prop() headingLevel: HeadingLevel;
 

--- a/src/components/loader/loader.scss
+++ b/src/components/loader/loader.scss
@@ -3,9 +3,9 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-loader-font-size: when type is determinate, the font-size of the loader percentage
- * @prop --calcite-loader-size: the width and height of a non-inline loader
- * @prop --calcite-loader-size-inline: the width and height of an inline loader
+ * @prop --calcite-loader-font-size: When type is determinate, the font-size of the loader percentage.
+ * @prop --calcite-loader-size: The width and height of a non-inline loader.
+ * @prop --calcite-loader-size-inline: The width and height of an inline loader.
  */
 
 $stroke-width: 3;

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -20,7 +20,7 @@ export class Loader {
   //  Properties
   //
   //--------------------------------------------------------------------------
-  /** Indicates whether the loader is active. */
+  /** When true, the loader is active. */
   @Prop({ reflect: true }) active = false;
 
   /** When true, displays smaller and appears to the left of the text. */

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -41,7 +41,7 @@ export class Loader {
   /** Text that displays under the loading indicator. */
   @Prop() text? = "";
 
-  /** Disable spacing around the loader. */
+  /** Disables spacing around the loader. */
   @Prop() noPadding = false;
 
   //--------------------------------------------------------------------------

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -20,28 +20,28 @@ export class Loader {
   //  Properties
   //
   //--------------------------------------------------------------------------
-  /** Show the loader */
+  /** Indicates whether the loader is active. */
   @Prop({ reflect: true }) active = false;
 
-  /** Inline loaders are smaller and will appear to the left of the text */
+  /** When true, displays smaller and appears to the left of the text. */
   @Prop({ reflect: true }) inline = false;
 
-  /** Accessible name for the component */
+  /** Accessible name for the loader. */
   @Prop() label!: string;
 
-  /** Speficy the scale of the loader. Defaults to "m" */
+  /** Specify the scale of the loader. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** Use indeterminate if finding actual progress value is impossible */
+  /** Use indeterminate if finding actual progress value is impossible. */
   @Prop({ reflect: true }) type: "indeterminate" | "determinate";
 
-  /** Percent complete of 100, only valid for determinate indicators */
+  /** Valid only for determinate indicators. Percent complete of 100. */
   @Prop() value = 0;
 
-  /** Text which should appear under the loading indicator (optional) */
-  @Prop() text = "";
+  /** Text that displays under the loading indicator. */
+  @Prop() text? = "";
 
-  /** Turn off spacing around the loader */
+  /** Disable spacing around the loader. */
   @Prop() noPadding = false;
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #4442 

## Summary
API styling throughout all CC. This PR includes updates to list (and its children components) and loader.

1. related list components
    - list
    - list-item-group
    - list-item
4. loader
    - Includes styling docs

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
