### PR TITLE
style: lint code with new jsdoc plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,8 @@
     "curly": "error",
     "jest/expect-expect": "off",
     "jest/no-export": "warn",
+    "jsdoc/require-jsdoc": "off",
+    "jsdoc/check-tag-names": "off",
     "lines-between-class-members": ["error", "always"],
     "no-multiple-empty-lines": ["error", { "max": 1 }],
     "no-unneeded-ternary": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "plugin:@stencil/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:jest/recommended",
+    "plugin:jsdoc/recommended",
     "prettier"
   ],
   "ignorePatterns": ["dist", "docs", "www"],
@@ -16,7 +17,15 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
-  "plugins": ["@esri/calcite-components", "@typescript-eslint", "eslint-plugin-react", "jest", "prettier", "unicorn"],
+  "plugins": [
+    "@esri/calcite-components",
+    "@typescript-eslint",
+    "eslint-plugin-react",
+    "jest",
+    "jsdoc",
+    "prettier",
+    "unicorn"
+  ],
   "rules": {
     "@stencil/decorators-context": "off",
     "@stencil/decorators-style": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint": "8.15.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-jest": "26.1.5",
+        "eslint-plugin-jsdoc": "39.2.9",
         "eslint-plugin-prettier": "4.0.0",
         "eslint-plugin-react": "7.29.4",
         "eslint-plugin-unicorn": "42.0.0",
@@ -2188,6 +2189,20 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
+      "integrity": "sha512-4yKy5t+/joLihG+ei6CCU6sc08sjUdEdXCQ2U+9h9VP13EiqHQ4YMgDC18ys/AsLdJDBX3KRx/AWY6PR7hn52Q==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -9773,6 +9788,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
@@ -13915,6 +13939,39 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "39.2.9",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.9.tgz",
+      "integrity": "sha512-gaPYJT94rWlWyQcisQyyEJHtLaaJqN4baFlLCEr/LcXVibS9wzQTL2dskqk327ggwqQopR+Xecu2Lng1IJ9Ypw==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.29.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -19877,6 +19934,15 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz",
+      "integrity": "sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsdom": {
@@ -27288,9 +27354,9 @@
       "dev": true
     },
     "node_modules/spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -33489,6 +33555,17 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
+      "integrity": "sha512-4yKy5t+/joLihG+ei6CCU6sc08sjUdEdXCQ2U+9h9VP13EiqHQ4YMgDC18ys/AsLdJDBX3KRx/AWY6PR7hn52Q==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.0.1"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -39386,6 +39463,12 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
@@ -42707,6 +42790,29 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "39.2.9",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.9.tgz",
+      "integrity": "sha512-gaPYJT94rWlWyQcisQyyEJHtLaaJqN4baFlLCEr/LcXVibS9wzQTL2dskqk327ggwqQopR+Xecu2Lng1IJ9Ypw==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.29.0",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.7",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-prettier": {
@@ -47244,6 +47350,12 @@
           }
         }
       }
+    },
+    "jsdoc-type-pratt-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz",
+      "integrity": "sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==",
+      "dev": true
     },
     "jsdom": {
       "version": "16.4.0",
@@ -52984,9 +53096,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint": "8.15.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "26.1.5",
+    "eslint-plugin-jsdoc": "39.2.9",
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-unicorn": "42.0.0",

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -37,8 +37,10 @@ export class Accordion {
   /** specify the scale of accordion, defaults to m */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** specify the selection mode - multi (allow any number of open items), single (allow one open item),
-   * or single-persist (allow and require one open item), defaults to multi */
+  /**
+   * specify the selection mode - multi (allow any number of open items), single (allow one open item),
+   * or single-persist (allow and require one open item), defaults to multi
+   */
   @Prop({ reflect: true }) selectionMode: "multi" | "single" | "single-persist" = "multi";
 
   //--------------------------------------------------------------------------

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -165,6 +165,7 @@ export class ActionBar implements ConditionalSlotComponent {
 
   /**
    * Overflows actions that won't fit into menus.
+   *
    * @internal
    */
   @Method()
@@ -172,7 +173,11 @@ export class ActionBar implements ConditionalSlotComponent {
     this.resize(this.el.clientHeight);
   }
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param focusId
+   */
   @Method()
   async setFocus(focusId?: "expand-toggle"): Promise<void> {
     if (focusId === "expand-toggle") {

--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -102,6 +102,7 @@ export class ActionMenu implements ConditionalSlotComponent {
 
   /**
    * Determines where the component will be positioned relative to the referenceElement.
+   *
    * @see [PopperPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/popper.ts#L25)
    */
   @Prop({ reflect: true }) placement: PopperPlacement = "auto";

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -123,7 +123,11 @@ export class ActionPad implements ConditionalSlotComponent {
   //
   // --------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param focusId
+   */
   @Method()
   async setFocus(focusId?: "expand-toggle"): Promise<void> {
     if (focusId === "expand-toggle") {

--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -67,7 +67,9 @@ export class Action implements InteractiveComponent {
    */
   @Prop({ reflect: true }) indicator = false;
 
-  /** string to override English loading text
+  /**
+   * string to override English loading text
+   *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
@@ -105,6 +107,7 @@ export class Action implements InteractiveComponent {
 
   /**
    * Emitted when the action has been clicked.
+   *
    * @deprecated use onClick instead.
    */
   @Event() calciteActionClick: EventEmitter;

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -17,7 +17,8 @@ import { DURATIONS, SLOTS, TEXT } from "./resources";
 import { Scale } from "../interfaces";
 import { AlertDuration, AlertPlacement, StatusColor, StatusIcons } from "./interfaces";
 
-/** Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
+/**
+ * Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
  * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided.
  */
 
@@ -70,11 +71,15 @@ export class Alert {
   /** Color for the alert (will apply to top border and icon) */
   @Prop({ reflect: true }) color: StatusColor = "blue";
 
-  /** when used as a boolean set to true, show a default recommended icon. You can
-   * also pass a calcite-ui-icon name to this prop to display a requested icon */
+  /**
+   * when used as a boolean set to true, show a default recommended icon. You can
+   * also pass a calcite-ui-icon name to this prop to display a requested icon
+   */
   @Prop({ reflect: true }) icon: string | boolean;
 
-  /** string to override English close text
+  /**
+   * string to override English close text
+   *
    * @default "Close"
    */
   @Prop() intlClose: string = TEXT.intlClose;

--- a/src/components/avatar/utils.ts
+++ b/src/components/avatar/utils.ts
@@ -4,6 +4,8 @@ import { hexToRGB } from "../color-picker/utils";
 /**
  * Convert a string to a valid hex by hashing its contents
  * and using the hash as a seed for three distinct color values
+ *
+ * @param str
  */
 export function stringToHex(str: string): string {
   let hash = 0;
@@ -21,6 +23,8 @@ export function stringToHex(str: string): string {
 
 /**
  * Find the hue of a color given the separate RGB color channels
+ *
+ * @param rgb
  */
 export function rgbToHue(rgb: RGB): number {
   let { r, g, b } = rgb;
@@ -53,6 +57,7 @@ export function rgbToHue(rgb: RGB): number {
 
 /**
  * For a hex color, find the hue
+ *
  * @param hex {string} - form of "#------"
  */
 export function hexToHue(hex: string): number {

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -56,22 +56,28 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
 
   /**
    * Aria-label for collapsing the toggle and tooltip used for the toggle when expanded.
+   *
    * @default "Collapse"
    */
   @Prop() intlCollapse?: string = TEXT.collapse;
 
   /**
    * Aria-label for expanding the toggle and tooltip used for the toggle when collapsed.
+   *
    * @default "Expand"
    */
   @Prop() intlExpand?: string = TEXT.expand;
 
-  /** string to override English loading text
+  /**
+   * string to override English loading text
+   *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
-  /** Text string used for the actions menu
+  /**
+   * Text string used for the actions menu
+   *
    * @default "Options"
    */
   @Prop() intlOptions?: string = TEXT.options;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -60,7 +60,9 @@ export class Button implements LabelableComponent, InteractiveComponent, FormOwn
   /** optionally pass an icon to display at the start of a button - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconStart?: string;
 
-  /** string to override English loading text
+  /**
+   * string to override English loading text
+   *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
@@ -230,7 +232,7 @@ export class Button implements LabelableComponent, InteractiveComponent, FormOwn
 
   labelEl: HTMLCalciteLabelElement;
 
-  /** watches for changing text content **/
+  /** watches for changing text content */
   private mutationObserver = createObserver("mutation", () => this.updateHasContent());
 
   /** the rendered child element */

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -7,7 +7,8 @@ import {
   ConditionalSlotComponent
 } from "../../utils/conditionalSlot";
 
-/** Cards do not include a grid or bounding container
+/**
+ * Cards do not include a grid or bounding container
  * - cards will expand to fit the width of their container
  */
 
@@ -49,17 +50,23 @@ export class Card implements ConditionalSlotComponent {
   /** Indicates whether the card is selectable. */
   @Prop({ reflect: true }) selectable = false;
 
-  /** string to override English loading text
+  /**
+   * string to override English loading text
+   *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
-  /** string to override English select text for checkbox when selectable is true
+  /**
+   * string to override English select text for checkbox when selectable is true
+   *
    * @default "Select"
    */
   @Prop({ reflect: false }) intlSelect: string = TEXT.select;
 
-  /** string to override English deselect text for checkbox when selectable is true
+  /**
+   * string to override English deselect text for checkbox when selectable is true
+   *
    * @default "Deselect"
    */
   @Prop({ reflect: false }) intlDeselect: string = TEXT.deselect;

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -48,6 +48,7 @@ export class Checkbox implements LabelableComponent, CheckableFormCompoment, Int
 
   /**
    * The hovered state of the checkbox.
+   *
    * @internal
    */
   @Prop({ reflect: true, mutable: true }) hovered = false;
@@ -56,11 +57,12 @@ export class Checkbox implements LabelableComponent, CheckableFormCompoment, Int
    * True if the checkbox is initially indeterminate,
    * which is independent from its checked state
    * https://css-tricks.com/indeterminate-checkboxes/
-   * */
+   */
   @Prop({ reflect: true, mutable: true }) indeterminate = false;
 
   /**
    * The label of the checkbox input
+   *
    * @internal
    */
   @Prop() label?: string;

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -35,7 +35,9 @@ export class Chip implements ConditionalSlotComponent {
   /** Optionally show a button the user can click to dismiss the chip */
   @Prop({ reflect: true }) dismissible = false;
 
-  /** Aria label for the "x" button
+  /**
+   * Aria label for the "x" button
+   *
    * @default "Close"
    */
   @Prop() dismissLabel?: string = TEXT.close;

--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -74,12 +74,14 @@ export class ColorPickerHexInput {
 
   /**
    * Label used for the hex input.
+   *
    * @default "Hex"
    */
   @Prop() intlHex = TEXT.hex;
 
   /**
    * Label used for the hex input when there is no color selected.
+   *
    * @default "No color"
    */
   @Prop() intlNoColor = TEXT.noColor;

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -88,6 +88,7 @@ export class ColorPicker implements InteractiveComponent {
    * The format of the value property.
    *
    * When "auto", the format will be inferred from `value` when set.
+   *
    * @default "auto"
    */
   @Prop() format: Format = defaultFormat;
@@ -107,98 +108,135 @@ export class ColorPicker implements InteractiveComponent {
   /** When true, hides the saved colors section */
   @Prop() hideSaved = false;
 
-  /** Label used for the blue channel
+  /**
+   * Label used for the blue channel
+   *
    * @default "B"
    */
   @Prop() intlB = TEXT.b;
 
-  /** Label used for the blue channel description
+  /**
+   * Label used for the blue channel description
+   *
    * @default "Blue"
    */
   @Prop() intlBlue = TEXT.blue;
 
-  /** Label used for the delete color button.
+  /**
+   * Label used for the delete color button.
+   *
    * @default "Delete color"
    */
   @Prop() intlDeleteColor = TEXT.deleteColor;
 
-  /** Label used for the green channel
+  /**
+   * Label used for the green channel
+   *
    * @default "G"
    */
   @Prop() intlG = TEXT.g;
 
-  /** Label used for the green channel description
+  /**
+   * Label used for the green channel description
+   *
    * @default "Green"
    */
   @Prop() intlGreen = TEXT.green;
 
-  /** Label used for the hue channel
+  /**
+   * Label used for the hue channel
+   *
    * @default "H"
    */
   @Prop() intlH = TEXT.h;
 
-  /** Label used for the HSV mode
+  /**
+   * Label used for the HSV mode
+   *
    * @default "HSV"
    */
   @Prop() intlHsv = TEXT.hsv;
 
-  /** Label used for the hex input
+  /**
+   * Label used for the hex input
+   *
    * @default "Hex"
    */
   @Prop() intlHex = TEXT.hex;
 
-  /** Label used for the hue channel description
+  /**
+   * Label used for the hue channel description
+   *
    * @default "Hue"
    */
   @Prop() intlHue = TEXT.hue;
 
   /**
    * Label used for the hex input when there is no color selected.
+   *
    * @default "No color"
    */
   @Prop() intlNoColor = TEXT.noColor;
 
-  /** Label used for the red channel
+  /**
+   * Label used for the red channel
+   *
    * @default "R"
    */
   @Prop() intlR = TEXT.r;
 
-  /** Label used for the red channel description
+  /**
+   * Label used for the red channel description
+   *
    * @default "Red"
    */
   @Prop() intlRed = TEXT.red;
 
-  /** Label used for the RGB mode
+  /**
+   * Label used for the RGB mode
+   *
    * @default "RGB"
    */
   @Prop() intlRgb = TEXT.rgb;
 
-  /** Label used for the saturation channel
+  /**
+   * Label used for the saturation channel
+   *
    * @default "S"
    */
   @Prop() intlS = TEXT.s;
 
-  /** Label used for the saturation channel description
+  /**
+   * Label used for the saturation channel description
+   *
    * @default "Saturation"
    */
   @Prop() intlSaturation = TEXT.saturation;
 
-  /** Label used for the save color button.
+  /**
+   * Label used for the save color button.
+   *
    * @default "Save color"
    */
   @Prop() intlSaveColor = TEXT.saveColor;
 
-  /** Label used for the saved colors section
+  /**
+   * Label used for the saved colors section
+   *
    * @default "Saved"
    */
   @Prop() intlSaved = TEXT.saved;
 
-  /** Label used for the value channel
+  /**
+   * Label used for the value channel
+   *
    * @default "V"
    */
   @Prop() intlV = TEXT.v;
 
-  /** Label used for the
+  /**
+   * Label used for the
+   *
    * @default "Value"
    */
   @Prop() intlValue = TEXT.value;
@@ -225,6 +263,7 @@ export class ColorPicker implements InteractiveComponent {
    * a RGB, HSL or HSV object.
    *
    * The type will be preserved as the color is updated.
+   *
    * @default "#007ac2"
    * @see [ColorValue](https://github.com/Esri/calcite-components/blob/master/src/components/color-picker/interfaces.ts#L10)
    */

--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -122,6 +122,8 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   /**
    * Used to toggle the selection state. By default this won't trigger an event.
    * The first argument allows the value to be coerced, rather than swapping values.
+   *
+   * @param coerce
    */
   @Method()
   async toggleSelected(coerce?: boolean): Promise<void> {

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -132,7 +132,8 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
    */
   @Prop() required = false;
 
-  /** specify the selection mode
+  /**
+   * specify the selection mode
    * - multi: allow any number of selected items (default)
    * - single: only one selection)
    * - ancestors: like multi, but show ancestors of selected items as selected, only deepest children shown in chips
@@ -160,7 +161,9 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
     }
   }
 
-  /** string to override the English "Remove tag" text for when an item is selected.
+  /**
+   * string to override the English "Remove tag" text for when an item is selected.
+   *
    * @default "Remove tag"
    */
   @Prop({ reflect: false }) intlRemoveTag: string = TEXT.removeTag;
@@ -235,6 +238,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
 
   /**
    * Called when the selected items set changes
+   *
    * @deprecated use calciteComboboxChange instead
    */
   @Event() calciteLookupChange: EventEmitter<HTMLCalciteComboboxItemElement[]>;
@@ -250,17 +254,19 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
     text: string;
   }>;
 
-  /** Called when a selected item in the combobox is dismissed via its chip **/
+  /** Called when a selected item in the combobox is dismissed via its chip */
   @Event() calciteComboboxChipDismiss: EventEmitter;
 
   /**
    * Fired when the combobox is opened
+   *
    * @internal
    */
   @Event() calciteComboboxOpen: EventEmitter;
 
   /**
    *  Fired when the combobox is closed
+   *
    * @internal
    */
   @Event() calciteComboboxClose: EventEmitter;

--- a/src/components/date-picker-day/date-picker-day.tsx
+++ b/src/components/date-picker-day/date-picker-day.tsx
@@ -113,6 +113,7 @@ export class DatePickerDay implements InteractiveComponent {
 
   /**
    * Emitted when user hovers over a day
+   *
    * @internal
    */
   @Event() calciteInternalDayHover: EventEmitter;

--- a/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -210,6 +210,8 @@ export class DatePickerMonthHeader {
   //--------------------------------------------------------------------------
   /**
    * Increment year on UP/DOWN keys
+   *
+   * @param e
    */
   private onYearKey = (e: KeyboardEvent): void => {
     const localizedYear = (e.target as HTMLInputElement).value;
@@ -288,6 +290,11 @@ export class DatePickerMonthHeader {
   /**
    * Parse localized year string from input,
    * set to active if in range
+   *
+   * @param root0
+   * @param root0.localizedYear
+   * @param root0.commit
+   * @param root0.offset
    */
   private setYear({
     localizedYear,

--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -77,6 +77,7 @@ export class DatePickerMonth {
 
   /**
    * Event emitted when user hovers the date.
+   *
    * @internal
    */
   @Event() calciteInternalDatePickerHover: EventEmitter;
@@ -229,6 +230,8 @@ export class DatePickerMonth {
   //--------------------------------------------------------------------------
   /**
    * Add n months to the current month
+   *
+   * @param step
    */
   private addMonths(step: number) {
     const nextDate = new Date(this.activeDate);
@@ -239,6 +242,8 @@ export class DatePickerMonth {
 
   /**
    * Add n days to the current date
+   *
+   * @param step
    */
   private addDays(step = 0) {
     const nextDate = new Date(this.activeDate);
@@ -249,6 +254,10 @@ export class DatePickerMonth {
 
   /**
    * Get dates for last days of the previous month
+   *
+   * @param month
+   * @param year
+   * @param startOfWeek
    */
   private getPrevMonthdays(month: number, year: number, startOfWeek: number): number[] {
     const lastDate = new Date(year, month, 0);
@@ -266,6 +275,9 @@ export class DatePickerMonth {
 
   /**
    * Get dates for the current month
+   *
+   * @param month
+   * @param year
    */
   private getCurrentMonthDays(month: number, year: number): number[] {
     const num = new Date(year, month + 1, 0).getDate();
@@ -278,6 +290,10 @@ export class DatePickerMonth {
 
   /**
    * Get dates for first days of the next month
+   *
+   * @param month
+   * @param year
+   * @param startOfWeek
    */
   private getNextMonthDays(month: number, year: number, startOfWeek: number): number[] {
     const endDay = new Date(year, month + 1, 0).getDay();
@@ -293,6 +309,8 @@ export class DatePickerMonth {
 
   /**
    * Determine if the date is in between the start and end dates
+   *
+   * @param date
    */
   private betweenSelectedRange(date: Date): boolean {
     return !!(
@@ -306,6 +324,8 @@ export class DatePickerMonth {
 
   /**
    * Determine if the date should be in selected state
+   *
+   * @param date
    */
   private isSelected(date: Date): boolean {
     return !!(
@@ -317,6 +337,8 @@ export class DatePickerMonth {
 
   /**
    * Determine if the date is the start of the date range
+   *
+   * @param date
    */
   private isStartOfRange(date: Date): boolean {
     return !!(
@@ -354,6 +376,12 @@ export class DatePickerMonth {
 
   /**
    * Render calcite-date-picker-day
+   *
+   * @param active
+   * @param day
+   * @param date
+   * @param currentMonth
+   * @param ref
    */
   private renderDateDay(
     active: boolean,

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -60,12 +60,14 @@ export class DatePicker {
 
   /**
    * Selected start date as full date object
+   *
    * @deprecated use valueAsDate instead
    */
   @Prop({ mutable: true }) startAsDate?: Date;
 
   /**
    * Selected end date as full date object
+   *
    * @deprecated use valueAsDate instead
    */
   @Prop({ mutable: true }) endAsDate?: Date;
@@ -105,17 +107,23 @@ export class DatePicker {
     }
   }
 
-  /** Localized string for "previous month" (used for aria label)
+  /**
+   * Localized string for "previous month" (used for aria label)
+   *
    * @default "Previous month"
    */
   @Prop() intlPrevMonth?: string = TEXT.prevMonth;
 
-  /** Localized string for "next month" (used for aria label)
+  /**
+   * Localized string for "next month" (used for aria label)
+   *
    * @default "Next month"
    */
   @Prop() intlNextMonth?: string = TEXT.nextMonth;
 
-  /** Localized string for "year" (used for aria label)
+  /**
+   * Localized string for "year" (used for aria label)
+   *
    * @default "Year"
    */
   @Prop() intlYear?: string = TEXT.year;
@@ -131,12 +139,14 @@ export class DatePicker {
 
   /**
    * Selected start date
+   *
    * @deprecated use value instead
    */
   @Prop({ mutable: true }) start?: string;
 
   /**
    * Selected end date
+   *
    * @deprecated use value instead
    */
   @Prop({ mutable: true }) end?: string;
@@ -156,6 +166,7 @@ export class DatePicker {
 
   /**
    * Trigger calcite date change when a user changes the date range.
+   *
    * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/date-picker/interfaces.ts#L1)
    */
   @Event() calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
@@ -408,6 +419,12 @@ export class DatePicker {
 
   /**
    * Render calcite-date-picker-month-header and calcite-date-picker-month
+   *
+   * @param activeDate
+   * @param maxDate
+   * @param minDate
+   * @param date
+   * @param endDate
    */
   private renderCalendar(
     activeDate: Date,
@@ -452,6 +469,9 @@ export class DatePicker {
 
   /**
    * Update date instance of start if valid
+   *
+   * @param startDate
+   * @param emit
    */
   private setStartAsDate(startDate: Date, emit?: boolean): void {
     this.startAsDate = startDate;
@@ -466,6 +486,9 @@ export class DatePicker {
 
   /**
    * Update date instance of end if valid
+   *
+   * @param endDate
+   * @param emit
    */
   private setEndAsDate(endDate: Date, emit?: boolean): void {
     this.endAsDate = endDate;
@@ -511,6 +534,8 @@ export class DatePicker {
 
   /**
    * Event handler for when the selected date changes
+   *
+   * @param e
    */
   private monthDateChange = (e: CustomEvent<Date>): void => {
     const date = new Date(e.detail);
@@ -564,6 +589,10 @@ export class DatePicker {
 
   /**
    * Get an active date using the value, or current date as default
+   *
+   * @param value
+   * @param min
+   * @param max
    */
   private getActiveDate(value: Date | null, min: Date | null, max: Date | null): Date {
     return dateFromRange(this.activeDate, min, max) || value || dateFromRange(new Date(), min, max);

--- a/src/components/date-picker/utils.ts
+++ b/src/components/date-picker/utils.ts
@@ -3,6 +3,7 @@ import { locales } from "../../utils/locale";
 
 /**
  * Translation resource data structure
+ *
  * @private
  */
 export interface DateLocaleData {
@@ -31,6 +32,8 @@ export interface DateLocaleData {
 /**
  * Get supported locale code from raw user input
  * Exported for testing purposes.
+ *
+ * @param lang
  * @private
  */
 function getSupportedLocale(lang = "") {
@@ -53,6 +56,7 @@ function getSupportedLocale(lang = "") {
 /**
  * CLDR cache.
  * Exported for testing purposes.
+ *
  * @private
  */
 export const translationCache: Record<string, DateLocaleData> = {};
@@ -60,12 +64,15 @@ export const translationCache: Record<string, DateLocaleData> = {};
 /**
  * CLDR request cache.
  * Exported for testing purposes.
+ *
  * @private
  */
 export const requestCache: Record<string, Promise<DateLocaleData>> = {};
 
 /**
  * Fetch calendar data for a given locale from list of supported languages
+ *
+ * @param lang
  * @public
  */
 export async function getLocaleData(lang: string): Promise<DateLocaleData> {

--- a/src/components/dropdown-group/dropdown-group.tsx
+++ b/src/components/dropdown-group/dropdown-group.tsx
@@ -39,8 +39,10 @@ export class DropdownGroup {
   /** optionally set a group title for display */
   @Prop({ reflect: true }) groupTitle?: string;
 
-  /** specify the selection mode - multi (allow any number of (or no) active items), single (allow and require one active item),
-   none (no active items), defaults to single */
+  /**
+    specify the selection mode - multi (allow any number of (or no) active items), single (allow and require one active item),
+   none (no active items), defaults to single
+   */
   @Prop({ reflect: true }) selectionMode: SelectionMode = "single";
 
   /**

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -44,6 +44,9 @@ describe("calcite-dropdown", () => {
 
   /**
    * Test helper for selected calcite-dropdown items. Expects items to have IDs to test against.
+   *
+   * @param page
+   * @param expectedItemIds
    */
   async function assertSelectedItems(page: E2EPage, expectedItemIds: string[]): Promise<void> {
     const selectedItemIds = await page.evaluate(() => {

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -97,7 +97,7 @@ export class Dropdown implements InteractiveComponent {
   /**
    specify the maximum number of calcite-dropdown-items to display before showing the scroller, must be greater than 0 -
    this value does not include groupTitles passed to calcite-dropdown-group
-  */
+   */
   @Prop() maxItems = 0;
 
   @Watch("maxItems")
@@ -110,6 +110,7 @@ export class Dropdown implements InteractiveComponent {
 
   /**
    * Determines where the dropdown will be positioned relative to the button.
+   *
    * @default "bottom-leading"
    */
   @Prop({ reflect: true }) placement: MenuPlacement = defaultMenuPlacement;
@@ -231,13 +232,13 @@ export class Dropdown implements InteractiveComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** fires when a dropdown item has been selected or deselected **/
+  /** fires when a dropdown item has been selected or deselected */
   @Event() calciteDropdownSelect: EventEmitter<void>;
 
-  /** fires when a dropdown has been opened **/
+  /** fires when a dropdown has been opened */
   @Event() calciteDropdownOpen: EventEmitter<void>;
 
-  /** fires when a dropdown has been closed **/
+  /** fires when a dropdown has been closed */
   @Event() calciteDropdownClose: EventEmitter<void>;
 
   @Listen("click", { target: "window" })

--- a/src/components/fab/fab.tsx
+++ b/src/components/fab/fab.tsx
@@ -34,6 +34,7 @@ export class Fab implements InteractiveComponent {
 
   /**
    * The name of the icon to display. The value of this property must match the icon name from https://esri.github.io/calcite-ui-icons/.
+   *
    * @default "plus"
    */
   @Prop() icon?: string = ICONS.plus;

--- a/src/components/graph/util.ts
+++ b/src/components/graph/util.ts
@@ -4,6 +4,10 @@ import { Point, DataSeries, Graph, TranslateOptions, Translator, Extent } from "
  * Calculate slope of the tangents
  * uses Steffen interpolation as it's monotonic
  * http://jrwalsh1.github.io/posts/interpolations/
+ *
+ * @param p0
+ * @param p1
+ * @param p2
  */
 function slope(p0: Point, p1: Point, p2: Point): number {
   const dx = p1[0] - p0[0];
@@ -18,6 +22,10 @@ function slope(p0: Point, p1: Point, p2: Point): number {
 
 /**
  * Calculate slope for just one tangent (single-sided)
+ *
+ * @param p0
+ * @param p1
+ * @param m
  */
 function slopeSingle(p0: Point, p1: Point, m: number): number {
   const dx = p1[0] - p0[0];
@@ -31,6 +39,12 @@ function slopeSingle(p0: Point, p1: Point, m: number): number {
  *
  * Translates Hermite Spline to Beziér curve:
  * stackoverflow.com/questions/42574940/
+ *
+ * @param p0
+ * @param p1
+ * @param m0
+ * @param m1
+ * @param t
  */
 function bezier(p0: Point, p1: Point, m0: number, m1: number, t: Translator): string {
   const [x0, y0] = p0;
@@ -45,6 +59,12 @@ function bezier(p0: Point, p1: Point, m0: number, m1: number, t: Translator): st
 /**
  * Generate a function which will translate a point
  * from the data coordinate space to svg viewbox oriented pixels
+ *
+ * @param root0
+ * @param root0.width
+ * @param root0.height
+ * @param root0.min
+ * @param root0.max
  */
 export function translate({ width, height, min, max }: TranslateOptions): Translator {
   const rangeX = max[0] - min[0];
@@ -58,6 +78,8 @@ export function translate({ width, height, min, max }: TranslateOptions): Transl
 
 /**
  * Get the min and max values from the dataset
+ *
+ * @param data
  */
 export function range(data: DataSeries): Extent {
   const [startX, startY] = data[0];
@@ -75,6 +97,12 @@ export function range(data: DataSeries): Extent {
 /**
  * Generate drawing commands for an area graph
  * returns a string can can be passed directly to a path element's `d` attribute
+ *
+ * @param root0
+ * @param root0.data
+ * @param root0.min
+ * @param root0.max
+ * @param root0.t
  */
 export function area({ data, min, max, t }: Graph): string {
   if (data.length === 0) {

--- a/src/components/handle/handle.tsx
+++ b/src/components/handle/handle.tsx
@@ -15,7 +15,7 @@ export class Handle {
   // --------------------------------------------------------------------------
 
   /**
-   * @internal - stores the activated state of the drag handle.
+   * @internal
    */
   @Prop({ mutable: true, reflect: true }) activated = false;
 

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -10,6 +10,7 @@ export interface FetchIconProps {
 /**
  * Icon data cache.
  * Exported for testing purposes.
+ *
  * @private
  */
 export const iconCache: Record<string, CalciteIconPath> = {};
@@ -17,6 +18,7 @@ export const iconCache: Record<string, CalciteIconPath> = {};
 /**
  * Icon request cache.
  * Exported for testing purposes.
+ *
  * @private
  */
 export const requestCache: Record<string, Promise<CalciteIconPath>> = {};
@@ -55,6 +57,8 @@ export async function fetchIcon({ icon, scale }: FetchIconProps): Promise<Calcit
 /**
  * Normalize the icon name to match the path data module exports.
  * Exported for testing purposes.
+ *
+ * @param name
  * @private
  */
 export function normalizeIconName(name: string): string {

--- a/src/components/inline-editable/inline-editable.tsx
+++ b/src/components/inline-editable/inline-editable.tsx
@@ -69,17 +69,23 @@ export class InlineEditable implements InteractiveComponent, LabelableComponent 
   /** specify whether save/cancel controls should be displayed when editingEnabled is true, defaults to false */
   @Prop({ reflect: true }) controls = false;
 
-  /** specify text to be user for the enable editing button's aria-label, defaults to `Click to edit`
+  /**
+   * specify text to be user for the enable editing button's aria-label, defaults to `Click to edit`
+   *
    * @default "Click to edit"
    */
   @Prop({ reflect: true }) intlEnableEditing = TEXT.intlEnablingEditing;
 
-  /** specify text to be user for the cancel editing button's aria-label, defaults to `Cancel`
+  /**
+   * specify text to be user for the cancel editing button's aria-label, defaults to `Cancel`
+   *
    * @default "Cancel"
    */
   @Prop({ reflect: true }) intlCancelEditing = TEXT.intlCancelEditing;
 
-  /** specify text to be user for the confirm changes button's aria-label, defaults to `Save`
+  /**
+   * specify text to be user for the confirm changes button's aria-label, defaults to `Save`
+   *
    * @default "Save"
    */
   @Prop({ reflect: true }) intlConfirmChanges = TEXT.intlConfirmChanges;

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -119,12 +119,14 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Selected start date as full date object
+   *
    * @deprecated use valueAsDate instead
    */
   @Prop({ mutable: true }) startAsDate?: Date;
 
   /**
    * Selected end date as full date object
+   *
    * @deprecated use valueAsDate instead
    */
   @Prop({ mutable: true }) endAsDate?: Date;
@@ -173,17 +175,23 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
    */
   @Prop() name: string;
 
-  /** Localized string for "previous month" (used for aria label)
+  /**
+   * Localized string for "previous month" (used for aria label)
+   *
    * @default "Previous month"
    */
   @Prop() intlPrevMonth?: string = TEXT.prevMonth;
 
-  /** Localized string for "next month" (used for aria label)
+  /**
+   * Localized string for "next month" (used for aria label)
+   *
    * @default "Next month"
    */
   @Prop() intlNextMonth?: string = TEXT.nextMonth;
 
-  /** Localized string for "year" (used for aria label)
+  /**
+   * Localized string for "year" (used for aria label)
+   *
    * @default "Year"
    */
   @Prop() intlYear?: string = TEXT.year;
@@ -196,6 +204,7 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Determines where the date-picker component will be positioned relative to the input.
+   *
    * @default "bottom-leading"
    */
   @Prop({ reflect: true }) placement: MenuPlacement = defaultMenuPlacement;
@@ -212,12 +221,14 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Selected start date
+   *
    * @deprecated use value instead
    */
   @Prop({ mutable: true }) start?: string;
 
   /**
    * Selected end date
+   *
    * @deprecated use value instead
    */
   @Prop({ mutable: true }) end?: string;
@@ -266,8 +277,8 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Trigger calcite date change when a user changes the date range.
-   * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-date-picker/interfaces.ts#L1)
    *
+   * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-date-picker/interfaces.ts#L1)
    * @deprecated use `calciteInputDatePickerChange` instead.
    */
   @Event() calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
@@ -723,6 +734,8 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * If inputted string is a valid date, update value/active
+   *
+   * @param value
    */
   private input(value: string): void {
     const date = this.getDateFromInput(value);
@@ -769,6 +782,8 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Clean up invalid date from input on blur
+   *
+   * @param target
    */
   private blur(target: HTMLCalciteInputElement): void {
     const { locale, focusedInput, endAsDate, range, startAsDate, valueAsDate } = this;
@@ -788,6 +803,8 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Event handler for when the selected date changes
+   *
+   * @param event
    */
   handleDateChange = (event: CustomEvent<Date>): void => {
     if (this.range) {
@@ -836,6 +853,8 @@ export class InputDatePicker implements LabelableComponent, FormComponent, Inter
   /**
    * Find a date from input string
    * return false if date is invalid, or out of range
+   *
+   * @param value
    */
   private getDateFromInput(value: string): Date | false {
     if (!this.localeData) {

--- a/src/components/input-message/input-message.tsx
+++ b/src/components/input-message/input-message.tsx
@@ -29,8 +29,10 @@ export class InputMessage {
   /** Indicates whether the message is displayed. */
   @Prop({ reflect: true }) active = false;
 
-  /** when used as a boolean set to true, show a default icon based on status. You can
-   * also pass a calcite-ui-icon name to this prop to display a custom icon */
+  /**
+   * when used as a boolean set to true, show a default icon based on status. You can
+   * also pass a calcite-ui-icon name to this prop to display a custom icon
+   */
   @Prop({ reflect: true }) icon: boolean | string;
 
   /** specify the scale of the input, defaults to m */
@@ -39,7 +41,9 @@ export class InputMessage {
   /** specify the status of the input field, determines message and icons */
   @Prop({ reflect: true, mutable: true }) status: Status = "idle";
 
-  /** specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input)
+  /**
+   * specify the appearance of any slotted message - default (displayed under input), or floating (positioned absolutely under input)
+   *
    * @deprecated "floating" type is no longer supported
    */
   @Prop({ reflect: true }) type: "default";

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -107,6 +107,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * BCP 47 language tag for desired language and country format
+   *
    * @internal
    */
   @Prop({ attribute: "lang", mutable: true }) locale: string =
@@ -132,6 +133,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
 
   /**
    * Determines where the popover will be positioned relative to the input.
+   *
    * @see [PopperPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/popper.ts#L25)
    */
   @Prop({ reflect: true }) placement: PopperPlacement = "auto";

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -12,6 +12,9 @@ describe("calcite-input", () => {
 
   /**
    * This helper wraps number typing to work around test instability
+   *
+   * @param page
+   * @param numberAsText
    */
   async function typeNumberValue(page: E2EPage, numberAsText: string): Promise<void> {
     await page.keyboard.type(numberAsText, numberAsText.length > 1 ? { delay: 100 } : undefined);

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -69,9 +69,11 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   /** should the input autofocus */
   @Prop() autofocus = false;
 
-  /** optionally display a clear button that displays when field has a value
+  /**
+   * optionally display a clear button that displays when field has a value
    * shows by default for search, time, date
-   * will not display for type="textarea" */
+   * will not display for type="textarea"
+   */
   @Prop({ reflect: true }) clearable = false;
 
   /** is the input disabled  */
@@ -88,9 +90,11 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   /** when true, the component will not be visible */
   @Prop() hidden = false;
 
-  /** when used as a boolean set to true, show a default recommended icon for certain
+  /**
+   * when used as a boolean set to true, show a default recommended icon for certain
    * input types (tel, password, email, date, time, search). You can also pass a
-   * calcite-ui-icon name to this prop to display a requested icon for any input type */
+   * calcite-ui-icon name to this prop to display a requested icon for any input type
+   */
   @Prop({ reflect: true }) icon: string | boolean;
 
   /**
@@ -100,6 +104,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
 
   /**
    * string to override English loading text
+   *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = COMMON_TEXT.loading;
@@ -118,6 +123,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
 
   /**
    * Toggles locale formatting for numbers.
+   *
    * @internal
    */
   @Prop() localeFormat = false;
@@ -142,6 +148,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
 
   /**
    * Maximum length of text input.
+   *
    * @deprecated use maxLength instead
    */
   @Prop({ reflect: true }) maxlength?: number;
@@ -179,10 +186,12 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   /** input step */
   @Prop({ reflect: true }) step?: number | "any";
 
-  /** optionally add suffix  **/
+  /** optionally add suffix  */
   @Prop() suffixText?: string;
 
-  /** @internal adds inline styles for text input when slotted in calcite-inline-editable */
+  /**
+   * @internal
+   */
   @Prop({ mutable: true, reflect: true }) editingEnabled = false;
 
   /**

--- a/src/components/label/label.tsx
+++ b/src/components/label/label.tsx
@@ -31,6 +31,7 @@ export class Label {
 
   /**
    * specify the status of the label and any child input / input messages
+   *
    * @deprecated set directly on child element instead
    */
   @Prop({ reflect: true }) status: Status = "idle";

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -32,7 +32,8 @@ export class Link implements InteractiveComponent {
   /** is the link disabled  */
   @Prop({ reflect: true }) disabled = false;
 
-  /** Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:
+  /**
+   * Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:
    * Without a value, the browser will suggest a filename/extension
    * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
    */

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -5,6 +5,7 @@ import { InteractiveComponent, updateHostInteraction } from "../../utils/interac
 
 /**
  * A general purpose list that enables users to construct list items that conform to Calcite styling.
+ *
  * @slot - A slot for adding calcite-list-item elements.
  */
 @Component({

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -106,6 +106,8 @@ export class Loader {
 
   /**
    * Return the proper sizes based on the scale property
+   *
+   * @param scale
    */
   private getSize(scale: string) {
     return {

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -99,8 +99,10 @@ export class Modal implements ConditionalSlotComponent {
   /** Set the modal to always be fullscreen (overrides width) */
   @Prop({ reflect: true }) fullscreen: boolean;
 
-  /** Adds a color bar at the top for visual impact,
-   * Use color to add importance to destructive/workflow dialogs. */
+  /**
+   * Adds a color bar at the top for visual impact,
+   * Use color to add importance to destructive/workflow dialogs.
+   */
   @Prop({ reflect: true }) color?: "red" | "blue";
 
   /** Background color of modal content */
@@ -284,6 +286,8 @@ export class Modal implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
   /**
    * Focus first interactive element
+   *
+   * @param el
    * @deprecated use `setFocus` instead.
    */
   @Method()
@@ -300,6 +304,8 @@ export class Modal implements ConditionalSlotComponent {
    *
    * By default, will try to focus on any focusable content. If there is none, it will focus on the close button.
    * If you want to focus on the close button, you can use the `close-button` focus ID.
+   *
+   * @param focusId
    */
   @Method()
   async setFocus(focusId?: "close-button"): Promise<void> {
@@ -310,7 +316,12 @@ export class Modal implements ConditionalSlotComponent {
     );
   }
 
-  /** Set the scroll top of the modal content */
+  /**
+   * Set the scroll top of the modal content
+   *
+   * @param top
+   * @param left
+   */
   @Method()
   async scrollContent(top = 0, left = 0): Promise<void> {
     if (this.modalContent) {

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -20,7 +20,8 @@ import {
   disconnectConditionalSlotComponent
 } from "../../utils/conditionalSlot";
 
-/** Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
+/**
+ * Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
  * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
  * They are optionally dismissible - useful for keeping track of whether or not a user has dismissed the notice. You can also choose not
  * to display a notice on page load and set the "active" attribute as needed to contextually provide inline messaging to users.
@@ -62,11 +63,15 @@ export class Notice implements ConditionalSlotComponent {
   /** Optionally show a button the user can click to dismiss the notice */
   @Prop({ reflect: true }) dismissible = false;
 
-  /** when used as a boolean set to true, show a default recommended icon. You can
-   * also pass a calcite-ui-icon name to this prop to display a requested icon */
+  /**
+   * when used as a boolean set to true, show a default recommended icon. You can
+   * also pass a calcite-ui-icon name to this prop to display a requested icon
+   */
   @Prop({ reflect: true }) icon: string | boolean;
 
-  /** String for the close button.
+  /**
+   * String for the close button.
+   *
    * @default "Close"
    */
   @Prop({ reflect: false }) intlClose: string = TEXT.close;

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -40,12 +40,16 @@ export class Pagination {
   /** total number of items */
   @Prop() total = 0;
 
-  /** Used as an accessible label (aria-label) for the next button
+  /**
+   * Used as an accessible label (aria-label) for the next button
+   *
    * @default "Next"
    */
   @Prop() textLabelNext: string = TEXT.nextLabel;
 
-  /** Used as an accessible label (aria-label) of the previous button
+  /**
+   * Used as an accessible label (aria-label) of the previous button
+   *
    * @default "Previous"
    */
   @Prop() textLabelPrevious: string = TEXT.previousLabel;
@@ -68,12 +72,14 @@ export class Pagination {
 
   /**
    * Emitted whenever the selected page changes.
+   *
    * @deprecated use calcitePaginationChange instead
    */
   @Event() calcitePaginationUpdate: EventEmitter<PaginationDetail>;
 
   /**
    * Emitted whenever the selected page changes.
+   *
    * @see [PaginationDetail](https://github.com/Esri/calcite-components/blob/master/src/components/pagination/calcite-pagination.tsx#L18)
    */
   @Event() calcitePaginationChange: EventEmitter<PaginationDetail>;

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -181,6 +181,7 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
 
   /**
    * Emitted when the close button has been clicked.
+   *
    * @deprecated use calcitePanelDismiss instead.
    */
   @Event() calcitePanelDismissedChange: EventEmitter;
@@ -252,7 +253,11 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
   //
   // --------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param focusId
+   */
   @Method()
   async setFocus(focusId?: "dismiss-button" | "back-button"): Promise<void> {
     if (focusId === "dismiss-button") {
@@ -268,7 +273,8 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
     this.containerEl?.focus();
   }
 
-  /** Scrolls panel content to a particular set of coordinates.
+  /**
+   * Scrolls panel content to a particular set of coordinates.
    *
    * ```
    *   myCalcitePanel.scrollContentTo({
@@ -277,6 +283,8 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
    *     behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    *   });
    * ```
+   *
+   * @param options
    */
   @Method()
   async scrollContentTo(options?: ScrollToOptions): Promise<void> {

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -57,12 +57,13 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   @Prop() disableDeselect = false;
 
   /**
-   * @internal When true, the item cannot be selected by user interaction.
+   * @internal
    */
   @Prop({ reflect: true }) nonInteractive = false;
 
   /**
    * Determines the icon SVG symbol that will be shown. Options are circle, square, grip or null.
+   *
    * @see [ICON_TYPES](https://github.com/Esri/calcite-components/blob/master/src/components/pick-list/resources.ts#L5)
    */
   @Prop({ reflect: true }) icon?: ICON_TYPES | null = null;
@@ -111,6 +112,7 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
 
   /**
    * Used as an accessible label (aria-label) for the "remove item" action. Only applicable if removable is true.
+   *
    * @default "Remove"
    */
   @Prop({ reflect: true }) intlRemove = TEXT.remove;
@@ -178,12 +180,14 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
 
   /**
    * Emitted whenever the the item's label, description, value or metadata properties are modified.
+   *
    * @internal
    */
   @Event() calciteInternalListItemPropsChange: EventEmitter<void>;
 
   /**
    * Emitted whenever the the item's value property is modified.
+   *
    * @internal
    */
   @Event() calciteInternalListItemValueChange: EventEmitter<{
@@ -200,6 +204,8 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   /**
    * Used to toggle the selection state. By default this won't trigger an event.
    * The first argument allows the value to be coerced, rather than swapping values.
+   *
+   * @param coerce
    */
   @Method()
   async toggleSelected(coerce?: boolean): Promise<void> {

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -216,7 +216,11 @@ export class PickList<
     return this.selectedValues;
   }
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param focusId
+   */
   @Method()
   async setFocus(focusId?: ListFocusId): Promise<void> {
     return setFocus.call(this, focusId);

--- a/src/components/popover-manager/popover-manager.tsx
+++ b/src/components/popover-manager/popover-manager.tsx
@@ -29,6 +29,7 @@ export class PopoverManager {
 
   /**
    * CSS Selector to match reference elements for popovers. Reference elements will be identified by this selector in order to open their associated popover.
+   *
    * @default `[data-calcite-popover-reference]`
    */
   @Prop() selector = "[data-calcite-popover-reference]";

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -61,6 +61,7 @@ export class Popover {
 
   /**
    * Display a close button within the Popover.
+   *
    * @deprecated use dismissible instead.
    */
   @Prop({ reflect: true }) closeButton = false;
@@ -105,6 +106,7 @@ export class Popover {
 
   /**
    * Offset the position of the popover away from the reference element.
+   *
    * @default 6
    */
   @Prop({ reflect: true }) offsetDistance = defaultOffsetDistance;
@@ -140,6 +142,7 @@ export class Popover {
 
   /**
    * Determines where the component will be positioned relative to the referenceElement.
+   *
    * @see [PopperPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/popper.ts#L25)
    */
   @Prop({ reflect: true }) placement: PopperPlacement = defaultPopoverPlacement;
@@ -159,7 +162,9 @@ export class Popover {
     this.setUpReferenceElement();
   }
 
-  /** Text for close button.
+  /**
+   * Text for close button.
+   *
    * @default "Close"
    */
   @Prop() intlClose = TEXT.close;
@@ -242,7 +247,11 @@ export class Popover {
       : this.createPopper();
   }
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param focusId
+   */
   @Method()
   async setFocus(focusId?: "close-button"): Promise<void> {
     const { closeButtonEl } = this;
@@ -257,7 +266,11 @@ export class Popover {
     this.el?.focus();
   }
 
-  /** Toggles the popover's open property. */
+  /**
+   * Toggles the popover's open property.
+   *
+   * @param value
+   */
   @Method()
   async toggle(value = !this.open): Promise<void> {
     this.open = value;

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -64,6 +64,7 @@ export class RadioButton
 
   /**
    * The focused state of the radio button.
+   *
    * @internal
    */
   @Prop({ mutable: true, reflect: true }) focused = false;
@@ -76,12 +77,14 @@ export class RadioButton
 
   /**
    * The hovered state of the radio button.
+   *
    * @internal
    */
   @Prop({ reflect: true, mutable: true }) hovered = false;
 
   /**
    * The label of the radio input
+   *
    * @internal
    */
   @Prop() label?: string;
@@ -251,6 +254,7 @@ export class RadioButton
 
   /**
    * Fires when the radio button is blurred.
+   *
    * @internal
    */
   @Event() calciteInternalRadioButtonBlur: EventEmitter;
@@ -266,12 +270,14 @@ export class RadioButton
   /**
    * Fires when the checked property changes.  This is an internal event used for styling purposes only.
    * Use calciteRadioButtonChange or calciteRadioButtonGroupChange for responding to changes in the checked value for forms.
+   *
    * @internal
    */
   @Event() calciteInternalRadioButtonCheckedChange: EventEmitter;
 
   /**
    * Fires when the radio button is focused.
+   *
    * @internal
    */
   @Event() calciteInternalRadioButtonFocus: EventEmitter;

--- a/src/components/radio-group-item/radio-group-item.tsx
+++ b/src/components/radio-group-item/radio-group-item.tsx
@@ -101,6 +101,7 @@ export class RadioGroupItem {
 
   /**
    * Fires when the item has been selected.
+   *
    * @internal
    */
   @Event()

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -62,12 +62,16 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
   /** The name of the rating */
   @Prop({ reflect: true }) name: string;
 
-  /** Localized string for "Rating" (used for aria label)
+  /**
+   * Localized string for "Rating" (used for aria label)
+   *
    * @default "Rating"
    */
   @Prop() intlRating?: string = TEXT.rating;
 
-  /** Localized string for labelling each star, `${num}` in the string will be replaced by the number
+  /**
+   * Localized string for labelling each star, `${num}` in the string will be replaced by the number
+   *
    * @default "Stars: ${num}"
    */
   @Prop() intlStars?: string = TEXT.stars;

--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -17,7 +17,9 @@ export class Scrim {
   //
   // --------------------------------------------------------------------------
 
-  /** string to override English loading text
+  /**
+   * string to override English loading text
+   *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -69,6 +69,7 @@ export class ShellPanel implements ConditionalSlotComponent {
 
   /**
    * Accessible label for resize separator.
+   *
    * @default "Resize"
    */
   @Prop() intlResize = TEXT.resize;
@@ -131,6 +132,7 @@ export class ShellPanel implements ConditionalSlotComponent {
 
   /**
    * Emitted when collapse has been toggled.
+   *
    * @deprecated use a resizeObserver on the shell-panel to listen for changes to its size.
    */
   @Event() calciteShellPanelToggle: EventEmitter;

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -61,6 +61,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * List of x,y coordinates within the slider's min and max, displays above the slider track.
+   *
    * @see [DataSeries](https://github.com/Esri/calcite-components/blob/master/src/components/graph/interfaces.ts#L5)
    */
   @Prop() histogram?: DataSeries;
@@ -855,6 +856,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
    * :warning: Will be fired frequently during drag. If you are performing any
    * expensive operations consider using a debounce or throttle to avoid
    * locking up the main thread.
+   *
    * @deprecated use calciteSliderInput instead
    */
   @Event() calciteSliderUpdate: EventEmitter;
@@ -1040,6 +1042,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Set the prop value if changed at the component level
+   *
    * @param valueProp
    * @param value
    */
@@ -1060,6 +1063,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Set the reference of the track Element
+   *
    * @internal
    * @param node
    */
@@ -1069,6 +1073,9 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * If number is outside range, constrain to min or max
+   *
+   * @param value
+   * @param prop
    * @internal
    */
   private clamp(value: number, prop?: ActiveSliderProperty): number {
@@ -1086,6 +1093,8 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Translate a pixel position to value along the range
+   *
+   * @param x
    * @internal
    */
   private translate(x: number): number {
@@ -1103,6 +1112,8 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Get closest allowed value along stepped values
+   *
+   * @param num
    * @internal
    */
   private getClosestStep(num: number): number {
@@ -1130,6 +1141,8 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Get position of value along range as fractional value
+   *
+   * @param num
    * @return {number} number in the unit interval [0,1]
    * @internal
    */
@@ -1324,6 +1337,9 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Returns an integer representing the number of pixels to offset on the left or right side based on desired position behavior.
+   *
+   * @param leftBounds
+   * @param rightBounds
    * @internal
    */
   private getHostOffset(leftBounds: number, rightBounds: number): number {
@@ -1344,6 +1360,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   /**
    * Returns an integer representing the number of pixels that the two given span elements are overlapping, taking into account
    * a space in between the two spans equal to the font-size set on them to account for the space needed to render a hyphen.
+   *
    * @param leftLabel
    * @param rightLabel
    */
@@ -1358,6 +1375,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Returns a boolean value representing if the minLabel span element is obscured (being overlapped) by the given handle div element.
+   *
    * @param minLabel
    * @param handle
    */
@@ -1369,6 +1387,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
 
   /**
    * Returns a boolean value representing if the maxLabel span element is obscured (being overlapped) by the given handle div element.
+   *
    * @param maxLabel
    * @param handle
    */

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -34,6 +34,7 @@ export class SplitButton implements InteractiveComponent {
 
   /**
    * Is the dropdown currently active or not
+   *
    * @internal
    */
   @Prop({ mutable: true, reflect: true }) active = false;
@@ -51,8 +52,10 @@ export class SplitButton implements InteractiveComponent {
   /** aria label for overflow button */
   @Prop({ reflect: true }) dropdownLabel?: string;
 
-  /** optionally add a calcite-loader component to the control,
-   disabling interaction. with the primary button */
+  /**
+    optionally add a calcite-loader component to the control,
+   disabling interaction. with the primary button
+   */
   @Prop({ reflect: true }) loading = false;
 
   /** Describes the type of positioning to use for the dropdown. If your element is in a fixed container, use the 'fixed' value. */

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -75,6 +75,7 @@ export class Stepper {
 
   /**
    * This event fires when the active stepper item has changed.
+   *
    * @internal
    */
   @Event() calciteInternalStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
@@ -199,7 +200,11 @@ export class Stepper {
     this.emitChangedItem(enabledStepIndex);
   }
 
-  /** set the requested step as active */
+  /**
+   * set the requested step as active
+   *
+   * @param step
+   */
   @Method()
   async goToStep(step: number): Promise<void> {
     const position = step - 1;

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -53,7 +53,9 @@ export class Switch implements LabelableComponent, CheckableFormCompoment, Inter
   /** The scale of the switch */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** True if the switch is initially on
+  /**
+   * True if the switch is initially on
+   *
    * @deprecated use 'checked' instead.
    */
   @Prop({ mutable: true }) switched = false;

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -51,16 +51,24 @@ export class TabNav {
    */
   @Prop() syncId: string;
 
-  /** @internal Parent tabs component scale value */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) scale: Scale = "m";
 
-  /** @internal Parent tabs component layout value */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) layout: TabLayout = "inline";
 
-  /** @internal Parent tabs component position value */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) position: TabPosition = "below";
 
-  /** @internal Parent tabs component bordered value when layout is "inline" */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) bordered = false;
 
   /**
@@ -235,6 +243,8 @@ export class TabNav {
 
   /**
    * Check for active tabs on register and update selected
+   *
+   * @param e
    */
   @Listen("calciteInternalTabTitleRegister")
   updateTabTitles(e: CustomEvent<TabID>): void {
@@ -265,6 +275,7 @@ export class TabNav {
 
   /**
    * Emitted when the active tab changes
+   *
    * @see [TabChangeEventDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tab/interfaces.ts#L1)
    */
   @Event() calciteTabChange: EventEmitter<TabChangeEventDetail>;

--- a/src/components/tab-title/tab-title.tsx
+++ b/src/components/tab-title/tab-title.tsx
@@ -59,16 +59,24 @@ export class TabTitle implements InteractiveComponent {
   /** optionally pass an icon to display at the start of a tab title - accepts calcite ui icon names  */
   @Prop({ reflect: true }) iconStart?: string;
 
-  /** @internal Parent tabs component layout value */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) layout: TabLayout;
 
-  /** @internal Parent tabs component or parent tab-nav component's position */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) position: TabPosition;
 
-  /** @internal Parent tabs component or parent tab-nav component's scale */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) scale: Scale;
 
-  /** @internal Parent tabs component bordered value */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) bordered = false;
 
   /**
@@ -246,12 +254,14 @@ export class TabTitle implements InteractiveComponent {
 
   /**
    * Fires when a specific tab is activated. Emits the "tab" property or the index position.
+   *
    * @see [TabChangeEventDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tab/interfaces.ts#L1)
    */
   @Event() calciteTabsActivate: EventEmitter<TabChangeEventDetail>;
 
   /**
    * Fires when a specific tab is activated (`event.details`)
+   *
    * @see [TabChangeEventDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tab/interfaces.ts#L1)
    * @internal
    */
@@ -298,6 +308,8 @@ export class TabTitle implements InteractiveComponent {
   }
 
   /**
+   * @param tabIds
+   * @param titleIds
    * @internal
    */
   @Method()
@@ -311,7 +323,7 @@ export class TabTitle implements InteractiveComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** watches for changing text content **/
+  /** watches for changing text content */
   mutationObserver: MutationObserver = createObserver("mutation", () => this.updateHasText());
 
   @State() controls: string;

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -50,7 +50,9 @@ export class Tab {
    */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  /** @internal Parent tabs component scale value */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) scale: Scale = "m";
 
   //--------------------------------------------------------------------------
@@ -173,6 +175,8 @@ export class Tab {
   //--------------------------------------------------------------------------
 
   /**
+   * @param tabIds
+   * @param titleIds
    * @internal
    */
   @Method()

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -77,6 +77,7 @@ export class Tabs {
   //--------------------------------------------------------------------------
 
   /**
+   * @param e
    * @internal
    */
   @Listen("calciteInternalTabTitleRegister")
@@ -87,6 +88,7 @@ export class Tabs {
   }
 
   /**
+   * @param e
    * @internal
    */
   @Listen("calciteTabTitleUnregister", { target: "body" })
@@ -97,6 +99,7 @@ export class Tabs {
   }
 
   /**
+   * @param e
    * @internal
    */
   @Listen("calciteInternalTabRegister")
@@ -107,6 +110,7 @@ export class Tabs {
   }
 
   /**
+   * @param e
    * @internal
    */
   @Listen("calciteTabUnregister", { target: "body" })

--- a/src/components/tile/tile.tsx
+++ b/src/components/tile/tile.tsx
@@ -48,6 +48,7 @@ export class Tile implements ConditionalSlotComponent, InteractiveComponent {
 
   /**
    * The focused state of the tile.
+   *
    * @internal
    */
   @Prop({ reflect: true }) focused = false;

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -56,68 +56,93 @@ export class TimePicker {
   //
   //--------------------------------------------------------------------------
 
-  /** aria-label for the hour input
+  /**
+   * aria-label for the hour input
+   *
    * @default "Hour"
    */
   @Prop() intlHour = TEXT.hour;
 
-  /** aria-label for the hour down button
+  /**
+   * aria-label for the hour down button
+   *
    * @default "Decrease hour"
    */
   @Prop() intlHourDown = TEXT.hourDown;
 
-  /** aria-label for the hour up button
+  /**
+   * aria-label for the hour up button
+   *
    * @default "Increase hour"
    */
   @Prop() intlHourUp = TEXT.hourUp;
 
-  /** aria-label for the meridiem (am/pm) input
+  /**
+   * aria-label for the meridiem (am/pm) input
+   *
    * @default "AM/PM"
    */
   @Prop() intlMeridiem = TEXT.meridiem;
 
-  /** aria-label for the meridiem (am/pm) down button
+  /**
+   * aria-label for the meridiem (am/pm) down button
+   *
    * @default "Decrease AM/PM"
    */
   @Prop() intlMeridiemDown = TEXT.meridiemDown;
 
-  /** aria-label for the meridiem (am/pm) up button
+  /**
+   * aria-label for the meridiem (am/pm) up button
+   *
    * @default "Increase AM/PM"
    */
   @Prop() intlMeridiemUp = TEXT.meridiemUp;
 
-  /** aria-label for the minute input
+  /**
+   * aria-label for the minute input
+   *
    * @default "Minute"
    */
   @Prop() intlMinute = TEXT.minute;
 
-  /** aria-label for the minute down button
+  /**
+   * aria-label for the minute down button
+   *
    * @default "Decrease minute"
    */
   @Prop() intlMinuteDown = TEXT.minuteDown;
 
-  /** aria-label for the minute up button
+  /**
+   * aria-label for the minute up button
+   *
    * @default "Increase minute"
    */
   @Prop() intlMinuteUp = TEXT.minuteUp;
 
-  /** aria-label for the second input
+  /**
+   * aria-label for the second input
+   *
    * @default "Second"
    */
   @Prop() intlSecond = TEXT.second;
 
-  /** aria-label for the second down button
+  /**
+   * aria-label for the second down button
+   *
    * @default "Decrease second"
    */
   @Prop() intlSecondDown = TEXT.secondDown;
 
-  /** aria-label for the second up button
+  /**
+   * aria-label for the second up button
+   *
    * @default "Increase second"
    */
   @Prop() intlSecondUp = TEXT.secondUp;
 
   /**
    * BCP 47 language tag for desired language and country format
+   *
    * @internal
    */
   @Prop({ attribute: "lang", mutable: true }) locale: string =
@@ -285,7 +310,11 @@ export class TimePicker {
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param target
+   */
   @Method()
   async setFocus(target: TimePart): Promise<void> {
     this[`${target || "hour"}El`]?.focus();

--- a/src/components/tip-manager/tip-manager.tsx
+++ b/src/components/tip-manager/tip-manager.tsx
@@ -143,6 +143,7 @@ export class TipManager {
 
   /**
    * Emitted when the `calcite-tip-manager` has been toggled open or closed.
+   *
    * @deprecated use calciteTipManagerClose instead.
    */
   @Event() calciteTipManagerToggle: EventEmitter;

--- a/src/components/tooltip-manager/tooltip-manager.tsx
+++ b/src/components/tooltip-manager/tooltip-manager.tsx
@@ -17,6 +17,7 @@ export class TooltipManager {
 
   /**
    * CSS Selector to match reference elements for tooltips. Reference elements will be identified by this selector in order to open their associated tooltip.
+   *
    * @default `[data-calcite-tooltip-reference]`
    */
   @Prop() selector = "[data-calcite-tooltip-reference]";

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -36,6 +36,7 @@ export class Tooltip {
 
   /**
    * Offset the position of the tooltip away from the reference element.
+   *
    * @default 6
    */
   @Prop({ reflect: true }) offsetDistance = defaultOffsetDistance;
@@ -70,6 +71,7 @@ export class Tooltip {
 
   /**
    * Determines where the component will be positioned relative to the referenceElement.
+   *
    * @see [PopperPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/popper.ts#L25)
    */
   @Prop({ reflect: true }) placement: PopperPlacement = "auto";

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -64,35 +64,49 @@ export class TreeItem implements ConditionalSlotComponent {
     this.updateParentIsExpanded(this.el, newValue);
   }
 
-  /** @internal Expanded state of the parent. */
+  /**
+   * @internal
+   */
   @Prop() parentExpanded = false;
 
-  /** @internal Level of depth of the item. */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) depth = -1;
 
-  /** @internal Does this tree item have a tree inside it? */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) hasChildren: boolean = null;
 
-  /** @internal Draws lines (set on parent). */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) lines: boolean;
 
-  /** Displays checkboxes (set on parent).
+  /**
+   * Displays checkboxes (set on parent).
+   *
    * @internal
    * @deprecated Use "ancestors" selection-mode on parent for checkbox input.
    */
   @Prop() inputEnabled: boolean;
 
-  /** @internal Scale of the parent tree. */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) scale: Scale;
 
   /**
+   * In ancestor selection mode, show as indeterminate when only some children are selected.
+   *
    * @internal
-   * In ancestor selection mode,
-   * show as indeterminate when only some children are selected.
-   **/
+   */
   @Prop({ reflect: true }) indeterminate: boolean;
 
-  /** @internal Tree selection-mode (set on parent). */
+  /**
+   * @internal
+   */
   @Prop({ mutable: true }) selectionMode: TreeSelectionMode;
 
   @Watch("selectionMode")

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -40,18 +40,24 @@ export class Tree {
   /** Display indentation guide lines. */
   @Prop({ mutable: true, reflect: true }) lines = false;
 
-  /** Display input
+  /**
+   * Display input
+   *
    * @deprecated Use "ancestors" selection-mode for checkbox input.
    */
   @Prop() inputEnabled = false;
 
-  /** @internal If this tree is nested within another tree, set to false. */
+  /**
+   * @internal
+   */
   @Prop({ reflect: true, mutable: true }) child: boolean;
 
   /** Specify the scale of the tree. */
   @Prop({ mutable: true, reflect: true }) scale: Scale = "m";
 
-  /** Customize how tree selection works.
+  /**
+   * Customize how tree selection works.
+   *
    * @default "single"
    * @see [TreeSelectionMode](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L5)
    */
@@ -341,6 +347,7 @@ export class Tree {
 
   /**
    * Emits when the user selects/deselects tree items. An object including an array of selected items will be passed in the event's "detail" property.
+   *
    * @see [TreeSelectDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L1)
    */
   @Event() calciteTreeSelect: EventEmitter<TreeSelectDetail>;

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -50,7 +50,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * @internal When false, the list item cannot be deselected by user interaction.
+   * @internal
    */
   @Prop() disableDeselect = false;
 
@@ -60,12 +60,13 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   @Prop({ reflect: true }) nonInteractive = false;
 
   /**
-   * @internal - Stores the activated state of the drag handle.
+   * @internal
    */
   @Prop({ mutable: true }) handleActivated? = false;
 
   /**
    * Determines the icon SVG symbol that will be shown. Options are circle, square, grip or null.
+   *
    * @see [ICON_TYPES](https://github.com/Esri/calcite-components/blob/master/src/components/pick-list/resources.ts#L5)
    */
   @Prop({ reflect: true }) icon?: ICON_TYPES | null = null;
@@ -134,6 +135,8 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   /**
    * Toggle the selection state. By default this won't trigger an event.
    * The first argument allows the value to be coerced, rather than swapping values.
+   *
+   * @param coerce
    */
   @Method()
   async toggleSelected(coerce?: boolean): Promise<void> {

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -311,7 +311,11 @@ export class ValueList<
     return this.selectedValues;
   }
 
-  /** Sets focus on the component. */
+  /**
+   * Sets focus on the component.
+   *
+   * @param focusId
+   */
   @Method()
   async setFocus(focusId?: ListFocusId): Promise<void> {
     return setFocus.call(this, focusId);

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -71,9 +71,11 @@ export async function accessible(componentTagOrHTML: TagOrHTML, page?: E2EPage):
  * Helper for asserting that a component renders and is hydrated
  *
  * @param {string} componentTagOrHTML - the component tag or HTML markup to test against
- * @param {Object} options - additional options to assert
+ * @param {object} options - additional options to assert
  * @param {string} employee.visible - is the component visible
  * @param {string} employee.display - is the component's display "inline"
+ * @param options.visible
+ * @param options.display
  */
 export async function renders(
   componentTagOrHTML: TagOrHTML,
@@ -94,7 +96,7 @@ export async function renders(
  * Helper for asserting that a component reflects
  *
  * @param {string} componentTagOrHTML - the component tag or HTML markup to test against
- * @param {Object[]} propsToTest - the properties to test
+ * @param {object[]} propsToTest - the properties to test
  * @param {string} propsToTest.propertyName - the property name
  * @param {any} propsToTest.value - the property value
  */
@@ -144,7 +146,7 @@ function propToAttr(name: string): string {
  * Helper for asserting that a property's value is its default
  *
  * @param {string} componentTagOrHTML - the component tag or HTML markup to test against
- * @param {Object[]} propsToTest - the properties to test
+ * @param {object[]} propsToTest - the properties to test
  * @param {string} propsToTest.propertyName - the property name
  * @param {any} propsToTest.value - the property value
  */
@@ -181,7 +183,7 @@ export async function hidden(componentTagOrHTML: TagOrHTML): Promise<void> {
 }
 
 interface FocusableOptions {
-  /** use this to pass an ID to setFocus() **/
+  /** use this to pass an ID to setFocus() */
   focusId?: string;
 
   /**
@@ -829,6 +831,7 @@ export async function disabled(
  * @param componentTagOrHTML - the component tag or HTML markup to test against
  * @param togglePropName - the component property that toggles the popper
  * @param options - the popper owner test configuration
+ * @param options.shadowPopperSelector
  */
 export async function popperOwner(
   componentTagOrHTML: TagOrHTML,

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -117,6 +117,7 @@ export function selectText(input: E2EElement): Promise<void> {
 
 /**
  * Helper to get an E2EElement's x,y coordinates
+ *
  * @param page
  * @param elementSelector
  * @param shadowSelector
@@ -144,6 +145,8 @@ export async function getElementXY(
  * Note that this util should only be used for test debugging purposes and not be included in a test.
  *
  * Based on https://github.com/puppeteer/puppeteer/issues/4378#issuecomment-499726973
+ *
+ * @param page
  */
 export async function visualizeMouseCursor(page: E2EPage): Promise<void> {
   await page.evaluate(() => {

--- a/src/utils/conditionalSlot.ts
+++ b/src/utils/conditionalSlot.ts
@@ -18,6 +18,8 @@ const observerOptions: Pick<Parameters<MutationObserver["observe"]>[1], "childLi
 
 /**
  * Helper to set up a conditional slot component on connectedCallback.
+ *
+ * @param component
  */
 export function connectConditionalSlotComponent(component: ConditionalSlotComponent): void {
   if (!mutationObserver) {
@@ -29,6 +31,8 @@ export function connectConditionalSlotComponent(component: ConditionalSlotCompon
 
 /**
  * Helper to tear down a conditional slot component on disconnectedCallback.
+ *
+ * @param component
  */
 export function disconnectConditionalSlotComponent(component: ConditionalSlotComponent): void {
   observed.delete(component.el);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -8,6 +8,10 @@ export interface HoverRange {
 
 /**
  * Check if date is within a min and max
+ *
+ * @param date
+ * @param min
+ * @param max
  */
 export function inRange(date: Date, min?: Date | string, max?: Date | string): boolean {
   const time = date.getTime();
@@ -19,6 +23,10 @@ export function inRange(date: Date, min?: Date | string, max?: Date | string): b
 /**
  * Ensures date is within range,
  * returns min or max if out of bounds
+ *
+ * @param date
+ * @param min
+ * @param max
  */
 export function dateFromRange(date?: any, min?: Date | string, max?: Date | string): Date | null {
   if (!(date instanceof Date)) {
@@ -39,6 +47,8 @@ export function dateFromRange(date?: any, min?: Date | string, max?: Date | stri
 /**
  * Parse an iso8601 string (YYYY-mm-dd) into a valid date.
  * TODO: handle time when time of day UI is added
+ *
+ * @param iso8601
  */
 export function dateFromISO(iso8601: string | Date): Date | null {
   if (iso8601 instanceof Date) {
@@ -58,6 +68,8 @@ export function dateFromISO(iso8601: string | Date): Date | null {
 
 /**
  * Return first portion of ISO string (YYYY-mm-dd)
+ *
+ * @param date
  */
 export function dateToISO(date?: Date | string): string {
   if (typeof date === "string") {
@@ -71,6 +83,9 @@ export function dateToISO(date?: Date | string): string {
 
 /**
  * Check if two dates are the same day, month, year
+ *
+ * @param d1
+ * @param d2
  */
 export function sameDate(d1: Date, d2: Date): boolean {
   return (
@@ -84,6 +99,8 @@ export function sameDate(d1: Date, d2: Date): boolean {
 
 /**
  * Get a date one month in the past
+ *
+ * @param date
  */
 export function prevMonth(date: Date): Date {
   const month = date.getMonth();
@@ -98,6 +115,8 @@ export function prevMonth(date: Date): Date {
 
 /**
  * Get a date one month in the future
+ *
+ * @param date
  */
 export function nextMonth(date: Date): Date {
   const month = date.getMonth();
@@ -112,6 +131,9 @@ export function nextMonth(date: Date): Date {
 
 /**
  * Translate a number into a given locals numeral system
+ *
+ * @param num
+ * @param localeData
  */
 export function localizeNumber(num: number, localeData: DateLocaleData): string {
   return String(num)
@@ -122,6 +144,9 @@ export function localizeNumber(num: number, localeData: DateLocaleData): string 
 
 /**
  * Calculate actual number from localized string
+ *
+ * @param str
+ * @param localeData
  */
 export function parseNumber(str: string, localeData: DateLocaleData): number {
   const numerals = "0123456789";
@@ -137,6 +162,9 @@ export function parseNumber(str: string, localeData: DateLocaleData): number {
 /**
  * Parse numeric units for day, month, and year from a localized string
  * month starts at 0 (can pass to date constructor)
+ *
+ * @param str
+ * @param localeData
  */
 export function parseDateString(str: string, localeData: DateLocaleData): { day: number; month: number; year: number } {
   const { separator, unitOrder } = localeData;
@@ -151,6 +179,8 @@ export function parseDateString(str: string, localeData: DateLocaleData): { day:
 
 /**
  * Convert eastern arbic numerals
+ *
+ * @param str
  */
 export function replaceArabicNumerals(str = ""): string {
   return str
@@ -162,6 +192,8 @@ type unitOrderSignifier = "m" | "d" | "y";
 
 /**
  * Based on the unitOrder string, find order of month, day, and year for locale
+ *
+ * @param unitOrder
  */
 export function getOrder(unitOrder: string): unitOrderSignifier[] {
   const signifiers: unitOrderSignifier[] = ["d", "m", "y"];
@@ -171,6 +203,9 @@ export function getOrder(unitOrder: string): unitOrderSignifier[] {
 
 /**
  * Get number of days between two dates
+ *
+ * @param date1
+ * @param date2
  */
 export function getDaysDiff(date1: Date, date2: Date): number {
   const ts1 = date1.getTime();

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -6,6 +6,7 @@ import { guid } from "./guid";
  *
  * If it already has an ID, it will be preserved, otherwise a unique one will be generated and assigned.
  *
+ * @param el
  * @returns {string} The element's ID.
  */
 export function ensureId(el: Element): string {
@@ -54,6 +55,8 @@ export function getHost(root: Document | ShadowRoot): Element | null {
 /**
  * This helper queries an element's rootNodes and any ancestor rootNodes.
  *
+ * @param element
+ * @param selector
  * @returns {Element[]} The elements.
  */
 export function queryElementsRoots<T extends Element = Element>(element: Element, selector: string): T[] {
@@ -89,6 +92,10 @@ export function queryElementsRoots<T extends Element = Element>(element: Element
  *
  * If both an 'id' and 'selector' are supplied, 'id' will take precedence over 'selector'.
  *
+ * @param element
+ * @param root0
+ * @param root0.selector
+ * @param root0.id
  * @returns {Element} The element.
  */
 export function queryElementRoots<T extends Element = Element>(
@@ -280,6 +287,7 @@ export function intersects(rect1: DOMRect, rect2: DOMRect): boolean {
  *
  * It should only be used for aria attributes that require a string value of "true" or "false".
  *
+ * @param value
  * @returns {string} The string conversion of a boolean value ("true" | "false").
  */
 export function toAriaBoolean(value: boolean): string {

--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -135,6 +135,8 @@ function hasRegisteredFormComponentParent(
 
 /**
  * Helper to submit a form.
+ *
+ * @param component
  */
 export function submitForm(component: FormOwner): void {
   component.formEl?.requestSubmit();
@@ -142,6 +144,8 @@ export function submitForm(component: FormOwner): void {
 
 /**
  * Helper to reset a form.
+ *
+ * @param component
  */
 export function resetForm(component: FormOwner): void {
   component.formEl?.reset();
@@ -149,6 +153,8 @@ export function resetForm(component: FormOwner): void {
 
 /**
  * Helper to set up form interactions on connectedCallback.
+ *
+ * @param component
  */
 export function connectForm<T>(component: FormComponent<T>): void {
   const { el, value } = component;
@@ -183,6 +189,8 @@ function onFormReset<T>(this: FormComponent<T>): void {
 
 /**
  * Helper to tear down form interactions on disconnectedCallback.
+ *
+ * @param component
  */
 export function disconnectForm<T>(component: FormComponent<T>): void {
   const { el, formEl } = component;
@@ -202,6 +210,9 @@ export function disconnectForm<T>(component: FormComponent<T>): void {
  * Helper for setting the default value on initialization after connectedCallback.
  *
  * Note that this is only needed if the default value cannot be determined on connectedCallback.
+ *
+ * @param component
+ * @param value
  */
 export function afterConnectDefaultValueSet<T>(component: FormComponent<T>, value: any): void {
   component.defaultValue = value;
@@ -211,6 +222,8 @@ export function afterConnectDefaultValueSet<T>(component: FormComponent<T>, valu
  * Helper for maintaining a form-associated's hidden input in sync with the component.
  *
  * Based on Ionic's approach: https://github.com/ionic-team/ionic-framework/blob/e4bf052794af9aac07f887013b9250d2a045eba3/core/src/utils/helpers.ts#L198
+ *
+ * @param component
  */
 function syncHiddenFormInput(component: FormComponent): void {
   const { el, formEl, name, value } = component;
@@ -321,6 +334,9 @@ interface HiddenFormInputSlotProps {
  * }
  *
  * Note that the hidden-form-input Sass mixin must be added to the component's style to apply specific styles.
+ *
+ * @param root0
+ * @param root0.component
  */
 export const HiddenFormInputSlot: FunctionalComponent<HiddenFormInputSlotProps> = ({
   component

--- a/src/utils/globalAttributes.ts
+++ b/src/utils/globalAttributes.ts
@@ -61,6 +61,9 @@ export interface GlobalAttrComponent {
  *   const lang = this.inheritedAttributes['lang'] ?? 'en';
  *   return <div>My lang is {lang}</div>;
  * }
+ *
+ * @param component
+ * @param attributeFilter
  */
 export function watchGlobalAttributes(component: GlobalAttrComponent, attributeFilter: AllowedGlobalAttribute[]): void {
   const { el } = component;
@@ -79,6 +82,8 @@ export function watchGlobalAttributes(component: GlobalAttrComponent, attributeF
 
 /**
  * Helper remove listening for changes to inherited attributes.
+ *
+ * @param component
  */
 export function unwatchGlobalAttributes(component: GlobalAttrComponent): void {
   elementToComponentAndObserverOptionsMap.delete(component.el);

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -9,8 +9,8 @@ export interface InteractiveComponent {
    *
    * Notes:
    *
-   * * This prop should use the @Prop decorator and reflect.
-   * * The `disabled` Sass mixin must be added to the component's stylesheet.
+   * This prop should use the @Prop decorator and reflect.
+   * The `disabled` Sass mixin must be added to the component's stylesheet.
    */
   disabled: boolean;
 }
@@ -18,7 +18,7 @@ export interface InteractiveComponent {
 type HostIsTabbablePredicate = () => boolean;
 
 function noopClick(): void {
-  /** noop **/
+  /** noop */
 }
 
 /**
@@ -28,8 +28,11 @@ function noopClick(): void {
  *
  * **Notes**
  *
- * * this util is not needed for simple components whose root element or elements are an interactive component (custom element or native control). For those cases, set the `disabled` props on the root components instead.
- * * technically, users can override `tabindex` and restore keyboard navigation, but this will be considered user error
+ * this util is not needed for simple components whose root element or elements are an interactive component (custom element or native control). For those cases, set the `disabled` props on the root components instead.
+ * technically, users can override `tabindex` and restore keyboard navigation, but this will be considered user error
+ *
+ * @param component
+ * @param hostIsTabbable
  */
 export function updateHostInteraction(
   component: InteractiveComponent,

--- a/src/utils/label.spec.ts
+++ b/src/utils/label.spec.ts
@@ -17,6 +17,8 @@ describe("label", () => {
     describe("wires up the associated label", () => {
       /**
        * This util helps simulate calcite-label's behavior since we cannot use the component here
+       *
+       * @param label
        */
       function wireUpFakeLabel(label: HTMLElement): void {
         label.addEventListener("click", (event: MouseEvent) => {

--- a/src/utils/label.ts
+++ b/src/utils/label.ts
@@ -29,6 +29,7 @@ export interface LabelableComponent {
 
 /**
  * Exported for testing purposes only
+ *
  * @internal
  */
 export const labelClickEvent = "calciteInternalLabelClick";
@@ -88,6 +89,8 @@ function hasAncestorCustomElements(label: HTMLCalciteLabelElement, componentEl: 
 
 /**
  * Helper to set up label interactions on connectedCallback.
+ *
+ * @param component
  */
 export function connectLabel(component: LabelableComponent): void {
   const labelEl = findLabelForComponent(component.el);
@@ -114,6 +117,8 @@ export function connectLabel(component: LabelableComponent): void {
 }
 /**
  * Helper to tear down label interactions on disconnectedCallback on labelable components.
+ *
+ * @param component
  */
 export function disconnectLabel(component: LabelableComponent): void {
   unlabeledComponents.delete(component);
@@ -133,6 +138,8 @@ export function disconnectLabel(component: LabelableComponent): void {
 
 /**
  * Helper to get the label text from a component.
+ *
+ * @param component
  */
 export function getLabelText(component: LabelableComponent): string {
   return component.label || component.labelEl?.textContent?.trim() || "";

--- a/support/formatting.ts
+++ b/support/formatting.ts
@@ -2,8 +2,8 @@ import dedent from "dedent";
 
 /**
  * Use this tagged template to help Prettier format any HTML template literals.
- * @param strings the
  *
+ * @param strings the
  * @example
  *
  * ```ts


### PR DESCRIPTION
**Related Issue:** #4550

## Summary
Linted code after adding the jsdoc plugin in the PR above. The PR above needs to be merged first.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
