### PR TITLE
docs: re-add backticks

### DIFF
--- a/src/components/list-item-group/list-item-group.tsx
+++ b/src/components/list-item-group/list-item-group.tsx
@@ -4,7 +4,7 @@ import { HEADING_LEVEL } from "./resources";
 import { HeadingLevel, Heading, constrainHeadingLevel } from "../functional/Heading";
 
 /**
- * @slot - A slot for adding calcite-list-item and calcite-list-item-group elements.
+ * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
  */
 @Component({
   tag: "calcite-list-item-group",
@@ -19,7 +19,7 @@ export class ListItemGroup {
   // --------------------------------------------------------------------------
 
   /**
-   * The title for all nested calcite-list-item rows.
+   * The title for all nested `calcite-list-item` rows.
    *
    */
   @Prop({ reflect: true }) heading: string;

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -9,11 +9,11 @@ import {
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot for adding calcite-list-item and calcite-list-item-group elements.
- * @slot actions-start - A slot for adding actionable calcite-action elements before the content of the list item.
+ * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
+ * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the list item.
  * @slot content-start - A slot for adding non-actionable elements before the label and description of the list item.
  * @slot content-end - A slot for adding non-actionable elements after the label and description of the list item.
- * @slot actions-end - A slot for adding actionable calcite-action elements after the content of the list item.
+ * @slot actions-end - A slot for adding actionable `calcite-action` elements after the content of the list item.
  */
 @Component({
   tag: "calcite-list-item",

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -5,7 +5,7 @@ import { InteractiveComponent, updateHostInteraction } from "../../utils/interac
 
 /**
  * A general purpose list that enables users to construct list items that conform to Calcite styling.
- * @slot - A slot for adding calcite-list-item elements.
+ * @slot - A slot for adding `calcite-list-item` elements.
  */
 @Component({
   tag: "calcite-list",

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -31,7 +31,7 @@ import {
 
 /**
  * @slot - A slot for adding content to the item.
- * @slot children - A slot for adding nested calcite-tree elements.
+ * @slot children - A slot for adding nested `calcite-tree` elements.
  */
 @Component({
   tag: "calcite-tree-item",

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -15,7 +15,7 @@ import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
 
 /**
- * @slot - A slot for calcite-tree-item elements.
+ * @slot - A slot for `calcite-tree-item` elements.
  */
 @Component({
   tag: "calcite-tree",

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -38,7 +38,7 @@ import { createObserver } from "../../utils/observers";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot for adding calcite-value-list-item elements. List items are displayed as a vertical list.
+ * @slot - A slot for adding `calcite-value-list-item` elements. List items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
 @Component({


### PR DESCRIPTION
**Related Issue:** #4442

## Summary
Re-add backticks previously removed from:
* list
* list-item
* list-item-group
* tree
* tree-item
* value-list

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
