### PR TITLE
fix(tabs): apply forced colors styles where needed

### DIFF
--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -63,3 +63,9 @@
   bottom: 0; // display active blue line below instead of above
   top: unset;
 }
+
+@media (forced-colors: active) {
+  .tab-nav-active-indicator {
+    background-color: highlight;
+  }
+}

--- a/src/components/tab-title/tab-title.scss
+++ b/src/components/tab-title/tab-title.scss
@@ -180,3 +180,14 @@ span {
     @apply pl-4 pr-4;
   }
 }
+
+@media (forced-colors: active) {
+  :host {
+    outline-width: 0;
+    outline-offset: 0;
+  }
+
+  :host(:focus) a {
+    outline-color: highlight;
+  }
+}


### PR DESCRIPTION
* Removes excessive outlining
* Adds obvious selection indicator
* Adds specific outline color for focus

**Related Issue:** #4558 

## Summary
Add forced color (high contrast) styles to tabs
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
