### PR TITLE
fix(stepper): Add high contrast specific styles to stepper

### DIFF
--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -244,3 +244,29 @@
 :host([layout="vertical"][error]:focus:not([disabled]):not([active])) .container {
   @apply border-color-danger-hover;
 }
+
+@media (forced-colors: active) {
+  :host .container {
+    outline-width: 0;
+    outline-offset: 0;
+  }
+
+  :host(:focus),
+  :host(:focus-visible) {
+    outline-color: canvasText;
+  }
+
+  :host([active]) .container {
+    border-top-color: highlight;
+    & .stepper-item-number {
+      color: highlight;
+    }
+    & .stepper-item-icon {
+      color: highlight;
+    }
+  }
+
+  :host([layout="vertical"][active]) .container {
+    border-color: highlight;
+  }
+}


### PR DESCRIPTION
**Related Issue:** #4564 

## Summary
* Removes the excessive outlines
* Adds an obvious selection indicator
* Make focus state obvious and work on different layouts

Changes produce this layout:
<img width="1015" alt="Screen Shot 2022-05-17 at 7 54 06 AM" src="https://user-images.githubusercontent.com/142636/168819938-2311454d-36c1-49fd-88a9-b94757cc021a.png">

Colored states for non-active steps is not something that can be done in the high contrast mode. Additional text or visual clues will need to be used if a design is to work well in both normal and high contrast mode.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
