### PR TITLE
fix(input-message): remove the scaling transition effect when displaying an input message

### DIFF
--- a/src/components/input-message/input-message.scss
+++ b/src/components/input-message/input-message.scss
@@ -50,19 +50,17 @@
 
 // Validation Text
 :host([status][active]) {
-  @apply text-color-1
-    font-medium;
+  @apply text-color-1;
 }
 
-:host([status][active][scale="s"]) {
+:host([status][scale="s"]) {
   @apply text-n3h;
 }
 
-:host([status][active][scale="m"]) {
-  @apply text-n2h
-    mt-1;
+:host([status][scale="m"]) {
+  @apply text-n2h mt-1;
 }
 
-:host([status][active][scale="l"]) {
+:host([status][scale="l"]) {
   @apply text-n1h mt-1;
 }


### PR DESCRIPTION
**Related Issue:** #4291

## Summary

The discrepancy between status active=false and status active=true font size was causing an odd scaling effect when transitioning all. There shouldn’t be any font size transitioning for message display, so the nonactive state shouldn’t have a size that is different from the active one. 


https://user-images.githubusercontent.com/19231036/168929796-b2e37cab-e249-4b8c-b38c-e3053767abd9.mov


