### PR TITLE
feat(pagination): format page numbers with localized group seperators

### DIFF
--- a/src/components/pagination/pagination.stories.ts
+++ b/src/components/pagination/pagination.stories.ts
@@ -1,5 +1,5 @@
 import { number, select } from "@storybook/addon-knobs";
-
+import { locales } from "../../utils/locale";
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { html } from "../../../support/formatting";
@@ -16,8 +16,20 @@ export const Simple = (): string => html`
   <calcite-pagination
     scale="${select("scale", ["s", "m", "l"], "m")}"
     start="${number("start", 1)}"
-    total="${number("total", 128)}"
-    num="${number("num", 20)}"
+    total="${number("total", 123456789)}"
+    num="${number("num", 10)}"
+    dir="${select("dir", ["ltr", "rtl"], "ltr")}"
+  >
+  </calcite-pagination>
+`;
+
+export const Locales = (): string => html`
+  <calcite-pagination
+    lang="${select("lang", locales, "fr")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    start="${number("start", 1)}"
+    total="${number("total", 123456789)}"
+    num="${number("num", 10)}"
     dir="${select("dir", ["ltr", "rtl"], "ltr")}"
   >
   </calcite-pagination>
@@ -28,8 +40,8 @@ export const DarkMode = (): string => html`
     class="calcite-theme-dark"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     start="${number("start", 1)}"
-    total="${number("total", 128)}"
-    num="${number("num", 20)}"
+    total="${number("total", 123456789)}"
+    num="${number("num", 10)}"
     dir="${select("dir", ["ltr", "rtl"], "ltr")}"
     class="calcite-theme-dark"
   >
@@ -43,8 +55,8 @@ export const RTL = (): string => html`
     dir="rtl"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     start="${number("start", 1)}"
-    total="${number("total", 128)}"
-    num="${number("num", 20)}"
+    total="${number("total", 123456789)}"
+    num="${number("num", 10)}"
     dir="${select("dir", ["ltr", "rtl"], "ltr")}"
   >
   </calcite-pagination>

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -63,13 +63,6 @@ export class Pagination implements GlobalAttrComponent {
   /** The scale of the pagination */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /**
-   * for number values, displays the locale's group separator
-   *
-   * @internal
-   */
-  @Prop() globalAttributes = {};
-
   // --------------------------------------------------------------------------
   //
   //  Private Properties
@@ -83,8 +76,8 @@ export class Pagination implements GlobalAttrComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** Inherited from global attributes */
-  @State() inheritedAttributes = {};
+  /** Inherited global attributes */
+  @State() globalAttributes = {};
 
   //--------------------------------------------------------------------------
   //
@@ -219,7 +212,7 @@ export class Pagination implements GlobalAttrComponent {
   }
 
   renderPage(start: number): VNode {
-    const lang = this.inheritedAttributes["lang"] || document.documentElement.lang || "en";
+    const lang = this.globalAttributes["lang"] || document.documentElement.lang || "en";
     const page = Math.floor(start / this.num) + (this.num === 1 ? 0 : 1);
     return (
       <button

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -7,10 +7,16 @@ import {
   Prop,
   Method,
   VNode,
-  Fragment
+  Fragment,
+  State
 } from "@stencil/core";
 import { Scale } from "../interfaces";
-
+import {
+  GlobalAttrComponent,
+  unwatchGlobalAttributes,
+  watchGlobalAttributes
+} from "../../utils/globalAttributes";
+import { localizeNumberString } from "../../utils/locale";
 import { CSS, TEXT } from "./resources";
 
 const maxPagesDisplayed = 5;
@@ -25,7 +31,7 @@ export interface PaginationDetail {
   styleUrl: "pagination.scss",
   shadow: true
 })
-export class Pagination {
+export class Pagination implements GlobalAttrComponent {
   //--------------------------------------------------------------------------
   //
   //  Public Properties
@@ -57,12 +63,28 @@ export class Pagination {
   /** The scale of the pagination */
   @Prop({ reflect: true }) scale: Scale = "m";
 
+  /**
+   * for number values, displays the locale's group separator
+   *
+   * @internal
+   */
+  @Prop() globalAttributes = {};
+
   // --------------------------------------------------------------------------
   //
   //  Private Properties
   //
   // --------------------------------------------------------------------------
   @Element() el: HTMLCalcitePaginationElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  State
+  //
+  //--------------------------------------------------------------------------
+
+  /** Inherited from global attributes */
+  @State() inheritedAttributes = {};
 
   //--------------------------------------------------------------------------
   //
@@ -83,6 +105,20 @@ export class Pagination {
    * @see [PaginationDetail](https://github.com/Esri/calcite-components/blob/master/src/components/pagination/calcite-pagination.tsx#L18)
    */
   @Event() calcitePaginationChange: EventEmitter<PaginationDetail>;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    watchGlobalAttributes(this, ["lang"]);
+  }
+
+  disconnectedCallback(): void {
+    unwatchGlobalAttributes(this);
+  }
 
   // --------------------------------------------------------------------------
   //
@@ -149,8 +185,8 @@ export class Pagination {
 
   renderPages(): VNode[] {
     const lastStart = this.getLastStart();
-    let end;
-    let nextStart;
+    let end: number;
+    let nextStart: number;
 
     // if we don't need ellipses render the whole set
     if (this.total / this.num <= maxPagesDisplayed) {
@@ -183,6 +219,7 @@ export class Pagination {
   }
 
   renderPage(start: number): VNode {
+    const lang = this.inheritedAttributes["lang"] || document.documentElement.lang || "en";
     const page = Math.floor(start / this.num) + (this.num === 1 ? 0 : 1);
     return (
       <button
@@ -195,7 +232,7 @@ export class Pagination {
           this.emitUpdate();
         }}
       >
-        {page}
+        {localizeNumberString(page.toString(), lang, true)}
       </button>
     );
   }

--- a/src/demos/pagination.html
+++ b/src/demos/pagination.html
@@ -82,5 +82,53 @@
         </div>
       </div>
     </div>
+    <div class="flex">
+      <div class="parent">
+        <div class="child">small french</div>
+
+        <div class="child">
+          <calcite-pagination lang="fr" total="300" num="100" start="1" scale="s"></calcite-pagination>
+        </div>
+        <div class="child">
+          <calcite-pagination lang="fr" total="1200" num="100" start="1" scale="s">Hello</calcite-pagination>
+        </div>
+
+        <div class="child">
+          <calcite-pagination lang="fr" total="150000" num="100" start="5400" scale="s"></calcite-pagination>
+        </div>
+      </div>
+
+      <!-- Medium -->
+      <div class="parent">
+        <div class="child">medium french</div>
+
+        <div class="child">
+          <calcite-pagination lang="fr" total="300" num="100" start="1" scale="m"></calcite-pagination>
+        </div>
+        <div class="child">
+          <calcite-pagination lang="fr" total="1200" num="100" start="1" scale="m">Hello</calcite-pagination>
+        </div>
+
+        <div class="child">
+          <calcite-pagination lang="fr" total="150000" num="100" start="5400" scale="m"></calcite-pagination>
+        </div>
+      </div>
+
+      <!-- Large -->
+      <div class="parent">
+        <div class="child">large french</div>
+
+        <div class="child">
+          <calcite-pagination lang="fr" total="300" num="100" start="1" scale="l"></calcite-pagination>
+        </div>
+        <div class="child">
+          <calcite-pagination lang="fr" total="1200" num="100" start="1" scale="l">Hello</calcite-pagination>
+        </div>
+
+        <div class="child">
+          <calcite-pagination lang="fr" total="150000" num="100" start="5400" scale="l"></calcite-pagination>
+        </div>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #2664

## Summary
- Used the `globalAttributes` util to format page numbers based on `lang` (Thanks for the help Franco)
- Added a "Locales" pagination story which defaults to "fr" (which uses a space for group separators)
- Updated the existing stories to have larger page numbers to display commas for the default "en".

The visual regressions related to page numbers that will be in screener are expected.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
