### PR TITLE
fix: patch __spreadArray helper to work around tslib bug (#4481)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "util:copy-icons": "cpy \"./node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/icon/\" --flat",
     "util:deploy-next": "npm run util:prep-next && npm run util:push-tags && npm run util:publish-next",
     "util:deploy-next-from-ci": "ts-node --project ./tsconfig-node-scripts.json support/deployNextFromCI.ts",
+    "util:patch-es5-helpers": "ts-node support/patchES5Helpers.ts",
     "util:prep-next": "ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts --next && npm run build",
     "util:publish-next": "npm publish --tag next",
     "util:check-squash-mergeable-branch": "ts-node --project ./tsconfig-node-scripts.json support/checkSquashMergeableBranch.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:copy-icons && stencil build",
+    "build": "npm run util:copy-icons && stencil build && npm run util:patch-es5-helpers",
     "build:watch": "npm run util:copy-icons && stencil build --watch",
     "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch",
     "build-storybook": "npm run util:copy-icons && stencil build --config stencil.config.ts && build-storybook --static-dir ./www --output-dir ./docs",

--- a/support/patchES5Helpers.ts
+++ b/support/patchES5Helpers.ts
@@ -1,0 +1,27 @@
+const {
+  promises: { readFile, readdir, writeFile }
+} = require("fs");
+const { normalize } = require("path");
+const { quote } = require("shell-quote");
+
+(async function () {
+  const esmEs5Output = quote([normalize(`${__dirname}/../dist/esm-es5/`)]);
+
+  // we patch __spreadArray to work around https://github.com/microsoft/tslib/issues/175
+  // see https://github.com/Esri/calcite-components/issues/4481#issuecomment-1128336510 for more info
+  const spreadArrayHelperToken =
+    /(var __spreadArray\=this\&\&this\.__spreadArray\|\|function\(\w\,)(\w)(\,\w\)\{)(if\((?:\w)\|\|arguments\.length\=\=\=2\))/;
+  const patchedSpreadArrayReplacement = '$1$2$3if(typeof $2 === "string"){$2=Array.prototype.slice.call($2)}$4';
+  const files = await readdir(esmEs5Output);
+
+  try {
+    for (const file of files) {
+      const filePath = quote([normalize(`${esmEs5Output}/${file}`)]);
+      const contents = await readFile(filePath, { encoding: "utf8" });
+      await writeFile(filePath, contents.replace(spreadArrayHelperToken, patchedSpreadArrayReplacement));
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
**Related Issue:** #4481 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This patches the `__spreadArray` tslib helper emitted from `buildEs5` to handle spreading of strings within arrays.