### PR TITLE
ci: fix npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release:next": "npm ci && npm test && npm run util:deploy-next",
     "release:prepare": "npm ci && npm test && ts-node --project ./tsconfig-node-scripts.json support/prepReleaseCommit.ts && npm run build",
     "release:publish": "npm run util:push-tags && npm publish && ts-node ./support/releaseToGitHub.ts",
-    "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm:build -- --dev --watch --serve\" \"ts-node ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
+    "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\" \"ts-node ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
     "test": "npm run util:run-tests",
     "test:prerender": "stencil build --no-docs --prerender",
     "test:storybook": "concurrently --raw \"npm:util:build-docs && screener-storybook --conf screener.config.js\"",


### PR DESCRIPTION
**Related Issue:** NA

## Summary
`npm run start` was exiting with `1` because it appends flags to the build script, which was now appending it to the patch instead. I switched it to the prexisting `build:watch-dev` script, which is not getting patched. We don't need the es5 patch locally, it's just needed for releases.

Confirmed that the release is not failing with the patch: https://github.com/Esri/calcite-components/commit/120899649fb991a937c5c524304eff87f50ec084

@jcfranco can you confirm that the code is actually patched here:
https://unpkg.com/browse/@esri/calcite-components@1.0.0-next.473/dist/esm-es5/
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
