### PR TITLE
fix(alert, input-message, popover, tooltip, tree-item): Make component invisible by default.

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -2,7 +2,7 @@ import { addons } from "@storybook/addons";
 import cheerio from "cheerio";
 import theme from "./theme";
 
-const globalInternalAttributes = ["calcite-hydrated", "calcite-hydrated-hidden"];
+const globalInternalAttributes = ["calcite-hydrated"];
 
 addons.register("@whitespace/storybook-addon-html", (api) => {
   // intercept HTML-preview event and remove global internal-attrs

--- a/src/assets/styles/_popper.scss
+++ b/src/assets/styles/_popper.scss
@@ -17,6 +17,7 @@ $popper-default-z-index: 900;
     transition-property: transform, visibility, opacity;
     opacity: 0;
     box-shadow: $shadow-2;
+    pointer-events: none;
     @apply rounded;
   }
 }
@@ -25,6 +26,7 @@ $popper-default-z-index: 900;
   opacity: 1;
   visibility: visible;
   transform: translate(0);
+  pointer-events: initial;
 }
 
 @mixin popperElemAnim($selector) {

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -70,8 +70,3 @@
 .overflow-hidden {
   overflow: hidden;
 }
-
-[calcite-hydrated-hidden] {
-  visibility: hidden;
-  pointer-events: none;
-}

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -76,7 +76,7 @@
 
 :host {
   --calcite-alert-edge-distance: theme("spacing.8");
-  @apply block;
+  @apply block opacity-0;
   .container {
     @apply shadow-2
       bg-foreground-1
@@ -129,7 +129,8 @@
   @apply flex
     w-full
     items-center
-    justify-center;
+    justify-center
+    invisible;
 }
 
 // focus styles
@@ -141,6 +142,10 @@
 }
 
 :host([active]) {
+  @apply opacity-100;
+  .container {
+    @apply visible;
+  }
   .container:not(.queued) {
     @apply max-h-full border-t-2 opacity-100;
     pointer-events: initial;

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -155,12 +155,7 @@ export class Alert {
     const role = autoDismiss ? "alert" : "alertdialog";
     const hidden = !active;
     return (
-      <Host
-        aria-hidden={toAriaBoolean(hidden)}
-        aria-label={label}
-        calcite-hydrated-hidden={hidden}
-        role={role}
-      >
+      <Host aria-hidden={toAriaBoolean(hidden)} aria-label={label} role={role}>
         <div
           class={{
             container: true,

--- a/src/components/input-message/input-message.scss
+++ b/src/components/input-message/input-message.scss
@@ -13,10 +13,12 @@
 
 :host {
   @apply text-color-1 transition-default invisible box-border flex h-0 w-full items-center font-medium opacity-0;
+  pointer-events: none;
 }
 
 :host([active]) {
   @apply transition-default visible h-auto opacity-100;
+  pointer-events: initial;
 }
 
 :host([active][scale="m"]),

--- a/src/components/input-message/input-message.tsx
+++ b/src/components/input-message/input-message.tsx
@@ -67,9 +67,8 @@ export class InputMessage {
   }
 
   render(): VNode {
-    const hidden = !this.active;
     return (
-      <Host calcite-hydrated-hidden={hidden}>
+      <Host>
         {this.renderIcon(this.requestedIcon)}
         <slot />
       </Host>

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -2,11 +2,12 @@
 @include popperArrow();
 
 :host {
-  @apply pointer-events-none;
+  @apply opacity-0;
 }
 
 :host([open]) {
   pointer-events: initial;
+  @apply opacity-100;
 }
 
 .calcite-popper-anim {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -489,13 +489,7 @@ export class Popover {
     ) : null;
 
     return (
-      <Host
-        aria-hidden={toAriaBoolean(hidden)}
-        aria-label={label}
-        calcite-hydrated-hidden={hidden}
-        id={this.getId()}
-        role="dialog"
-      >
+      <Host aria-hidden={toAriaBoolean(hidden)} aria-label={label} id={this.getId()} role="dialog">
         <div
           class={{
             [PopperCSS.animation]: true,

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -1,6 +1,13 @@
 @include popperHost(999);
 @include popperArrow();
 
+:host {
+  @apply opacity-0;
+}
+
+:host([open]) {
+  @apply opacity-100;
+}
 .container {
   @apply bg-foreground-1
     text-color-1

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -271,13 +271,7 @@ export class Tooltip {
     const hidden = !displayed;
 
     return (
-      <Host
-        aria-hidden={toAriaBoolean(hidden)}
-        aria-label={label}
-        calcite-hydrated-hidden={hidden}
-        id={this.getId()}
-        role="tooltip"
-      >
+      <Host aria-hidden={toAriaBoolean(hidden)} aria-label={label} id={this.getId()} role="tooltip">
         <div
           class={{
             [PopperCSS.animation]: true,

--- a/src/components/tree-item/tree-item.e2e.ts
+++ b/src/components/tree-item/tree-item.e2e.ts
@@ -216,7 +216,6 @@ describe("calcite-tree-item", () => {
 
       const item = await page.find("#newbie");
       expect(item).toEqualAttribute("aria-hidden", "false");
-      expect(item).not.toHaveAttribute("calcite-hydrated-hidden");
       expect(item.tabIndex).toBe(0);
     });
   });

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -209,3 +209,7 @@
     color: var(--calcite-ui-brand);
   }
 }
+
+:host([aria-hidden="true"]) {
+  @apply opacity-0 pointer-events-none;
+}

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -174,6 +174,7 @@ export class TreeItem implements ConditionalSlotComponent {
   private isSelectionMultiLike: boolean;
 
   render(): VNode {
+    const hidden = !(this.parentExpanded || this.depth === 1);
     const rtl = getElementDir(this.el) === "rtl";
     const showBulletPoint =
       this.selectionMode === TreeSelectionMode.Single ||
@@ -193,7 +194,7 @@ export class TreeItem implements ConditionalSlotComponent {
         scale="s"
       />
     ) : null;
-    const defaultSlotNode: VNode = <slot key="default-slot" />;
+    const defaultSlotNode: VNode = !hidden ? <slot key="default-slot" /> : null;
     const checkbox =
       this.selectionMode === TreeSelectionMode.Ancestors ? (
         <label class={CSS.checkboxLabel} key="checkbox-label">
@@ -225,16 +226,13 @@ export class TreeItem implements ConditionalSlotComponent {
       />
     ) : null;
 
-    const hidden = !(this.parentExpanded || this.depth === 1);
-
     return (
       <Host
         aria-expanded={this.hasChildren ? toAriaBoolean(this.expanded) : undefined}
         aria-hidden={toAriaBoolean(hidden)}
         aria-selected={this.selected ? "true" : showCheckmark ? "false" : undefined}
-        calcite-hydrated-hidden={hidden}
         role="treeitem"
-        tabindex={this.parentExpanded || this.depth === 1 ? "0" : "-1"}
+        tabindex={hidden ? null : this.parentExpanded || this.depth === 1 ? "0" : "-1"}
       >
         <div
           class={{


### PR DESCRIPTION
**Related Issue:** #4577

## Summary

fix(alert, input-message, popover, tooltip, tree-item): Make component invisible by default.