### PR TITLE
fix(input): Align type="time" correctly in Firefox

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -7,7 +7,7 @@
   & input,
   & .prefix,
   & .suffix {
-    @apply text-n2h h-6 p-2;
+    @apply text-n2h h-6;
   }
   & textarea {
     @apply h-6;
@@ -37,7 +37,7 @@
   & input,
   & .prefix,
   & .suffix {
-    @apply text-n1h h-8 p-3;
+    @apply text-n1h h-8;
   }
   & textarea {
     min-height: theme("spacing.8");
@@ -66,7 +66,7 @@
   & input,
   & .prefix,
   & .suffix {
-    @apply text-0h h-11 p-4;
+    @apply text-0h h-11;
   }
   & textarea {
     min-height: theme("spacing.11");

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -7,7 +7,7 @@
   & input,
   & .prefix,
   & .suffix {
-    @apply text-n2h h-6;
+    @apply text-n2h h-6 px-2;
   }
   & textarea {
     @apply h-6;
@@ -37,7 +37,7 @@
   & input,
   & .prefix,
   & .suffix {
-    @apply text-n1h h-8;
+    @apply text-n1h h-8 px-3;
   }
   & textarea {
     min-height: theme("spacing.8");
@@ -66,7 +66,7 @@
   & input,
   & .prefix,
   & .suffix {
-    @apply text-0h h-11;
+    @apply text-0h h-11 px-4;
   }
   & textarea {
     min-height: theme("spacing.11");


### PR DESCRIPTION
**Related Issue:** #4591

## Summary

fix(input): Align type="time" correctly in Firefox. (#4591)