### PR TITLE
fix(popover): height is no longer inconsistent when dismissable enabled

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -456,9 +456,10 @@ export class Popover {
           class={CSS.closeButton}
           onClick={this.hide}
           ref={(closeButtonEl) => (this.closeButtonEl = closeButtonEl)}
+          scale="s"
           text={intlClose}
         >
-          <calcite-icon icon="x" scale="m" />
+          <calcite-icon icon="x" scale="s" />
         </calcite-action>
       </div>
     ) : null;

--- a/src/demos/popover.html
+++ b/src/demos/popover.html
@@ -210,5 +210,17 @@
         </calcite-tabs>
       </div>
     </div>
+
+    <div class="parent">
+      With Heading
+      <div class="child">
+        <calcite-popover label="Example label" reference-element="popover-button" heading="heading" dismissible>
+          <p style="padding: 0 10px; display: flex; flex-direction: row">
+            <calcite-icon icon="3d-glasses"></calcite-icon> Popover content here
+          </p>
+        </calcite-popover>
+        <calcite-button id="popover-button">Activate Popover</calcite-button>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #4537

## Summary

Popover requests adding a medium button which is inconsistent with the constant height of the component. Setting action to scale=s doesn’t change the nested icon without specified scale to scale=s, but brings in default m. Setting both to scale s, otherwise, both default scaling to m. Will be opening a separate issue to add scale on popover and will be addressing scale cascading from parent to nested children.