### PR TITLE
docs(notice): consistent api refs

### DIFF
--- a/src/components/notice/notice.scss
+++ b/src/components/notice/notice.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-notice-width: the width of the notice
+ * @prop --calcite-notice-width: The width of `calcite-notice`.
  */
 
 // scale variables

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -28,10 +28,10 @@ import {
  */
 
 /**
- * @slot title - Title of the notice (optional)
- * @slot message - Main text of the notice
- * @slot link - Optional action to take from the notice (undo, try again, link to page, etc.)
- * @slot actions-end - Allows adding a `calcite-action` at the end of the notice. It is recommended to use 2 or less actions.
+ * @slot title - A slot for adding the title (optional).
+ * @slot message - A slot for adding the message.
+ * @slot link - A slot for adding actions to take, such as: undo, try again, link to page, etc. (optional).
+ * @slot actions-end - A slot for adding actions to the end of the `calcite-notice` (optional). It is recommended to use two or less actions.
  */
 
 @Component({
@@ -54,32 +54,32 @@ export class Notice implements ConditionalSlotComponent {
   //
   //---------------------------------------------------------------------------
 
-  /** Is the notice currently active or not */
+  /** When true, the `calcite-notice` is active. */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  /** Color for the notice (will apply to top border and icon) */
+  /** The color for the `calcite-notice` (will apply to top border and icon). */
   @Prop({ reflect: true }) color: StatusColor = "blue";
 
-  /** Optionally show a button the user can click to dismiss the notice */
-  @Prop({ reflect: true }) dismissible = false;
+  /** Shows a button the user can click to dismiss the `calcite-notice`. */
+  @Prop({ reflect: true }) dismissible? = false;
 
   /**
-   * when used as a boolean set to true, show a default recommended icon. You can
-   * also pass a calcite-ui-icon name to this prop to display a requested icon
+   * When present, shows a default recommended icon. You can
+   * also pass a calcite-ui-icon name to display a requested icon.
    */
   @Prop({ reflect: true }) icon: string | boolean;
 
   /**
-   * String for the close button.
+   * Aria label for the close button.
    *
    * @default "Close"
    */
   @Prop({ reflect: false }) intlClose: string = TEXT.close;
 
-  /** specify the scale of the notice, defaults to m */
+  /** Specify the scale of `calcite-notice`. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** specify the width of the notice, defaults to auto */
+  /** Specify the width of the `calcite-notice`. */
   @Prop({ reflect: true }) width: Width = "auto";
 
   @Watch("icon")
@@ -149,10 +149,10 @@ export class Notice implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** Fired when an notice is closed */
+  /** Fired when `calcite-notice` is closed. */
   @Event() calciteNoticeClose: EventEmitter;
 
-  /** Fired when an Notice is opened */
+  /** Fired when `calcite-notice` is opened. */
   @Event() calciteNoticeOpen: EventEmitter;
 
   //--------------------------------------------------------------------------
@@ -161,7 +161,7 @@ export class Notice implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /** Sets focus on the `calcite-notice`. */
   @Method()
   async setFocus(): Promise<void> {
     const noticeLinkEl = this.el.querySelector("calcite-link");
@@ -192,9 +192,9 @@ export class Notice implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** the close button element */
+  /** The close button element. */
   private closeButton?: HTMLButtonElement;
 
-  /** the computed icon to render */
+  /** The computed icon to render. */
   private requestedIcon?: string;
 }

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -57,7 +57,7 @@ export class Notice implements ConditionalSlotComponent {
   /** When true, the `calcite-notice` is active. */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  /** The color for the `calcite-notice` (will apply to top border and icon). */
+  /** The color for the `calcite-notice`. Color will apply to top border and icon. */
   @Prop({ reflect: true }) color: StatusColor = "blue";
 
   /** Shows a button the user can click to dismiss the `calcite-notice`. */


### PR DESCRIPTION
**Related Issue:** #4442

## Summary
- Consistent API style guide references for `calcite-notice`.
- Note: Added a JSDoc optional tag for the `dismissible` property instead of using the "Optionally" supporting text.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
