### PR TITLE
fix(panel): Add back z-index usage for internal component styles

### DIFF
--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -70,6 +70,7 @@
 :host([loading]) .container,
 :host([disabled]) .container {
   @apply relative;
+  z-index: 1;
 }
 
 .header {
@@ -82,6 +83,7 @@
     items-stretch
     justify-start;
   flex: 0 0 auto;
+  z-index: 2;
 }
 
 .header-content {
@@ -153,6 +155,7 @@
   flex-col
   flex-nowrap
   items-stretch;
+  z-index: 1;
 }
 
 .footer {
@@ -180,4 +183,5 @@
   block
   p-2;
   width: fit-content;
+  z-index: 1;
 }


### PR DESCRIPTION
**Related Issue:** #4682

## Summary

fix(panel): Add back z-index usage for internal component styles. (#4682)

This PR reverts the style changes in this one: https://github.com/Esri/calcite-components/pull/4182

The reasoning is here: https://github.com/Esri/calcite-components/issues/3724#issuecomment-1146461507