### PR TITLE
fix(tooltip): Remove internal flex display. (#4631)

### DIFF
--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -6,9 +6,6 @@
     text-color-1
     text-n2-wrap
     relative
-    flex
-    flex-col
-    justify-start
     overflow-hidden
     rounded
     py-3
@@ -16,6 +13,7 @@
     font-medium;
   max-width: 20rem;
   max-height: 20rem;
+  text-align: start;
 }
 
 .calcite-popper-anim {


### PR DESCRIPTION
**Related Issue:** #4631

## Summary

fix(tooltip): Remove internal flex display. (#4631)

The flex display is making `<span />` placed inside the tooltip act like a block element.

Demo can be seen here: https://codepen.io/afreitag/pen/KKQZmXP