### PR TITLE
ci: add action to move issues to current milestone

### DIFF
--- a/.github/workflows/change-milestone.yml
+++ b/.github/workflows/change-milestone.yml
@@ -1,7 +1,7 @@
-# Action that moves open, non-installed issues from the previous, past-due milestone to the current one
+# Moves open, non-installed issues from the previous, past-due milestone to the current one.
 # This action only retrieves up to 100 issues per issue lifecycle label because of the per_page max.
-# The max page count is not a problem for our 2 week sprints, but if we change to monthly
-# we need to iterate through issue list pages using the `page` .
+# The max per_page is not a problem for our 2 week sprints, but if we change to monthly
+# we need to iterate through the issue list's pages using the `page` parameter.
 # https://octokit.github.io/rest.js/v18#issues-list-for-repo
 name: Move Issues To Current Milestone
 on:

--- a/.github/workflows/change-milestone.yml
+++ b/.github/workflows/change-milestone.yml
@@ -1,0 +1,105 @@
+# Action that moves open, non-installed issues from the previous, past-due milestone to the current one
+# This action only retrieves up to 100 issues per issue lifecycle label because of the per_page max.
+# The max page count is not a problem for our 2 week sprints, but if we change to monthly
+# we need to iterate through issue list pages using the `page` .
+# https://octokit.github.io/rest.js/v18#issues-list-for-repo
+name: Move Issues To Current Milestone
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+jobs:
+  move:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const { data: milestones } = await github.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              sort: "due_on",
+              per_page: 100,
+              direction: "asc",
+            });
+
+            if (!milestones.length) {
+              console.log("There are no open milestones in this repo, ending run.");
+              return;
+            }
+
+            const currentDate = new Date(Date.now());
+            for (const [index, milestone] of milestones.entries()) {
+              if (!milestone.due_on || new Date(milestone.due_on) < currentDate) {
+                continue;
+              }
+
+              if (index < 1) {
+                console.log(
+                  "There is no open, past due milestone to move issues from, ending run."
+                );
+                return;
+              }
+
+              const { data: previousMilestoneIssuesNew } = await github.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                milestone: milestones[index - 1].number,
+                per_page: 100,
+                labels: "0 - new",
+              });
+
+              const { data: previousMilestoneIssuesAssigned } = await github.issues.listForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                  milestone: milestones[index - 1].number,
+                  per_page: 100,
+                  labels: "1 - assigned",
+                });
+
+              const { data: previousMilestoneIssuesInDev } = await github.issues.listForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                  milestone: milestones[index - 1].number,
+                  per_page: 100,
+                  labels: "2 - in development",
+                });
+
+              const moveableIssues = [
+                ...previousMilestoneIssuesNew,
+                ...previousMilestoneIssuesAssigned,
+                ...previousMilestoneIssuesInDev,
+              ];
+
+              if (!moveableIssues.length) {
+                console.log("There are no movable issues, ending run.");
+                return;
+              }
+
+              for (const issue of moveableIssues) {
+                const labels = [
+                  ...issue.labels
+                    .map((label) => label.name)
+                    .filter((name) => name !== "milestone adjusted"),
+                  "milestone adjusted",
+                ];
+
+                await github.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  milestone: milestone.number,
+                  labels,
+                });
+              }
+
+              console.log(
+                "Moved",
+                moveableIssues.length,
+                "issues to the current milestone, ending run."
+              );
+              return;
+            }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Created an action that moves issues from the previous, past due milestone to the current one. Only moves issues with one of these three labels:
- `0 - new`
- `1 - assigned`
- `2 - in development`

The action runs on Mondays. It won't do anything for the week between sprints since all of the movable issues were already moved. It automatically adds the `milestone adjusted` label to the issues it moves.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
