### PR TITLE
ci: remove npm dependency cache

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org/
-          cache: npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: e2e test

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: npm
       - name: Deploy storybook
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: npm
-      - run: npm install --legacy-peer-deps
+      - run: npm ci
       - if: steps.testable.outputs.skip == 'false'
         run: npm test

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -38,8 +38,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: npm
-      - run: npm install --legacy-peer-deps
+      - run: npm ci
       - if: steps.one.outputs.skip == 'screen'
         name: run screener check
         env:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: npm
       - uses: fregante/setup-git-user@v1
       - name: run dependency-updating script
         shell: 'script --return --quiet --command "bash {0}"'

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -10,10 +10,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
-          cache: npm
       - name: generate doc
         run: |
-          npm install
+          npm ci
           npx stencil build --docs
           npm run lint:md
 


### PR DESCRIPTION
**Related Issue:** #4703

## Summary
Testing to see if the action's npm dep cache is causing the issue
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
