### PR TITLE
refactor(combobox-item): enable filter-disabled prop support 

### DIFF
--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -67,8 +67,17 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   /** The item's associated value */
   @Prop() value!: any;
 
-  /** Don't filter this item based on the search text */
+  /**
+   * Don't filter this item based on the search text
+   *
+   * @deprecated use filterDisabled instead
+   */
   @Prop({ reflect: true }) constant: boolean;
+
+  /**
+   * Do not filter this item based on the search text
+   */
+  @Prop() filterDisabled: boolean;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -1133,6 +1133,29 @@ describe("calcite-combobox", () => {
     expect(three).toBeFalsy();
   });
 
+  it("respects the filterDisabled item property", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-combobox selection-mode="single">
+        <calcite-combobox-item id="one" value="one" text-label="One"></calcite-combobox-item>
+        <calcite-combobox-item id="two" value="two" text-label="Two" ></calcite-combobox-item>
+        <calcite-combobox-item id="three" value="three" text-label="Three" filter-disabled></calcite-combobox-item>
+      </calcite-combobox>
+    `);
+
+    await page.waitForChanges();
+    const input = await page.find("calcite-combobox >>> .wrapper");
+    await input.click();
+    await page.keyboard.type("two");
+    await page.waitForChanges();
+    const one = await (await page.find("#one")).isVisible();
+    const two = await (await page.find("#two")).isVisible();
+    const three = await (await page.find("#three")).isVisible();
+    expect(one).toBeFalsy();
+    expect(two).toBeTruthy();
+    expect(three).toBeTruthy();
+  });
+
   it("works correctly inside a shadowRoot", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -825,7 +825,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   getData(): ItemData[] {
     return this.items.map((item) => ({
       constant: item.constant,
-      disableFilter: item.filterDisabled,
+      filterDisabled: item.filterDisabled,
       value: item.value,
       label: item.textLabel
     }));

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -825,6 +825,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   getData(): ItemData[] {
     return this.items.map((item) => ({
       constant: item.constant,
+      disableFilter: item.filterDisabled,
       value: item.value,
       label: item.textLabel
     }));

--- a/src/demos/combobox.html
+++ b/src/demos/combobox.html
@@ -221,7 +221,12 @@
           selection-mode="single"
           scale="s"
         >
-          <calcite-combobox-item value="New Item" constant text-label="Add new plant"></calcite-combobox-item>
+          <calcite-combobox-item
+            value="New Item"
+            constant
+            text-label="Add new plant"
+            filter-disabled
+          ></calcite-combobox-item>
           <calcite-combobox-item value="Trees" text-label="Trees">
             <calcite-combobox-item value="Pine" text-label="Pine">
               <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
@@ -255,7 +260,12 @@
           selection-mode="single"
           scale="m"
         >
-          <calcite-combobox-item value="New Item" constant text-label="Add new plant"></calcite-combobox-item>
+          <calcite-combobox-item
+            value="New Item"
+            constant
+            text-label="Add new plant"
+            filter-disabled
+          ></calcite-combobox-item>
           <calcite-combobox-item value="Trees" text-label="Trees">
             <calcite-combobox-item value="Pine" text-label="Pine">
               <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
@@ -289,7 +299,12 @@
           selection-mode="single"
           scale="l"
         >
-          <calcite-combobox-item value="New Item" constant text-label="Add new plant"></calcite-combobox-item>
+          <calcite-combobox-item
+            value="New Item"
+            constant
+            text-label="Add new plant"
+            filter-disabled
+          ></calcite-combobox-item>
           <calcite-combobox-item value="Trees" text-label="Trees">
             <calcite-combobox-item value="Pine" text-label="Pine">
               <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -10,7 +10,7 @@ export const filter = (data: Array<object>, value: string): Array<any> => {
   }
 
   const find = (input: object, RE: RegExp) => {
-    if ((input as any)?.constant) {
+    if ((input as any)?.constant || (input as any)?.filterDisabled) {
       return true;
     }
     let found = false;


### PR DESCRIPTION
**Related Issue:** #2115

## Summary

 enable` filter-disabled` prop support for `combobox-item` which is equivalent of `constant` prop.  deprecation of `constant` prop will follow.
