### PR TITLE
fix(tooltip): Fix syntax typo in `TooltipManager`

### DIFF
--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -100,7 +100,7 @@ export default class TooltipManager {
     document.addEventListener("mouseover", this.mouseEnterShow, { capture: true });
     document.addEventListener("mouseout", this.mouseLeaveHide, { capture: true });
     document.addEventListener("pointerdown", this.clickHandler, { capture: true });
-    document.addEventListener("focusin", this.focusShow), { capture: true };
+    document.addEventListener("focusin", this.focusShow, { capture: true });
     document.addEventListener("focusout", this.blurHide, { capture: true });
   }
 


### PR DESCRIPTION
**Related Issue:** #

## Summary
It was preventing the `focusin` handler from being removed in `removeListeners()` because the `capture` flag was obscured when first adding the handler.

Looking to get this fix in quickly to unblock a Calcite upgrade to Field Maps ahead of the EA release next week. Is it worth a follow-on issue to add test coverage for this scenario?

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
