### PR TITLE
fix(tabs): update style for centered and bordered tab titles

### DIFF
--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -21,10 +21,6 @@
     overflow-auto;
 }
 
-:host([layout="center"]) .tab-nav {
-  @apply justify-center;
-}
-
 // prevent indicator overflow in horizontal scrolling situations
 .tab-nav-active-indicator-container {
   @apply absolute

--- a/src/components/tab-title/tab-title.scss
+++ b/src/components/tab-title/tab-title.scss
@@ -143,12 +143,13 @@ span {
 :host([bordered]:hover) {
   a {
     background-color: var(--calcite-button-transparent-hover);
-    @apply transition-default;
   }
 }
 
 :host([bordered]) a {
   border-bottom-style: unset;
+  border-inline-start: 1px solid transparent;
+  border-inline-end: 1px solid transparent;
 }
 
 :host([bordered][position="below"]) a {
@@ -156,8 +157,8 @@ span {
 }
 
 :host([active][bordered]) a {
-  border-left: 1px solid var(--calcite-ui-border-1);
-  border-right: 1px solid var(--calcite-ui-border-1);
+  border-inline-start-color: var(--calcite-ui-border-1);
+  border-inline-end-color: var(--calcite-ui-border-1);
 }
 
 :host([bordered]) {

--- a/src/components/tab-title/tab-title.tsx
+++ b/src/components/tab-title/tab-title.tsx
@@ -139,7 +139,6 @@ export class TabTitle implements InteractiveComponent {
 
   render(): VNode {
     const id = this.el.id || this.guid;
-    const showSideBorders = this.bordered && !this.disabled && this.layout !== "center";
 
     const iconStartEl = (
       <calcite-icon
@@ -171,7 +170,6 @@ export class TabTitle implements InteractiveComponent {
             container: true,
             "container--has-text": this.hasText
           }}
-          style={showSideBorders && { width: `${this.parentTabNavEl.indicatorWidth}px` }}
         >
           {this.iconStart ? iconStartEl : null}
           <slot />


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/3682


## Summary
Adjusts styling for long titles in bordered mode, and fix for cut off content in center alignment. 

- Long titles should now display properly in "bordered" mode.
![Screen Shot 2022-06-10 at 10 35 19 AM](https://user-images.githubusercontent.com/4733155/173123734-8d9cd011-2ca9-4d0f-87cb-56405b4e0a78.png)
![Screen Shot 2022-06-10 at 10 34 22 AM](https://user-images.githubusercontent.com/4733155/173123735-00c4dd47-6fd5-4e99-adc1-491d4a10804f.png)

- Center alignment should no longer cut off names 
  - if the container is wide enough to display all items, it will appear center-aligned.
  - if the container is not wide enough, the first tab will remain visible.
![Screen Shot 2022-06-10 at 10 36 45 AM](https://user-images.githubusercontent.com/4733155/173123726-d392dea6-337a-4879-91c8-181fc35cc55b.png)
![Screen Shot 2022-06-10 at 10 36 33 AM](https://user-images.githubusercontent.com/4733155/173123731-ede7a243-d66c-4c7a-8baf-c8d72da673b1.png)


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
