### PR TITLE
feat(action): Add css variable to override indicator color

### DIFF
--- a/src/components/action/action.scss
+++ b/src/components/action/action.scss
@@ -1,6 +1,15 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-action-indicator-color: optionally specify the color of the action indicator
+ */
+
 :host {
   @extend %component-host;
   @apply flex bg-transparent;
+  --calcite-action-indicator-color: theme("colors.brand");
 }
 
 @include disabled();
@@ -189,13 +198,14 @@
 :host([indicator]) {
   .button::after {
     content: "";
-    @apply bg-brand
-      absolute
+    @apply absolute
       z-10
       h-2
       w-2
       rounded-full
       border-2;
+
+    background-color: var(--calcite-action-indicator-color);
     border-color: theme("colors.background.foreground.1");
     inset-block-end: theme("spacing.3");
     inset-inline-end: theme("spacing.3");


### PR DESCRIPTION
**Related Issue:** #4702 

## Summary
Adds a css variable to optionally set the indicator color on the action.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
