### PR TITLE
fix(input): re-align overflowed text to start on blur

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -481,8 +481,10 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
       value: this.value
     });
 
-    this.childEl.setSelectionRange(0, 0);
     this.emitChangeIfUserModified();
+    this.type === "number"
+      ? this.childNumberEl.setSelectionRange(0, 0)
+      : this.childEl.setSelectionRange(0, 0);
   };
 
   private inputFocusHandler = (event: FocusEvent): void => {

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -481,6 +481,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
       value: this.value
     });
 
+    this.childEl.setSelectionRange(0, 0);
     this.emitChangeIfUserModified();
   };
 


### PR DESCRIPTION
**Related Issue:** #4726

## Summary
There was different behavior between browsers (Firefox specifically). Now all browsers re-align overflowed text to the start of the input on blur.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
