### PR TITLE
feat(accordion-item,stepper-item,block,panel): add heading & description prop 

### DIFF
--- a/src/components/accordion-item/accordion-item.scss
+++ b/src/components/accordion-item/accordion-item.scss
@@ -119,12 +119,12 @@
   margin-inline-end: theme("margin.auto");
 }
 
-:host .accordion-item-title,
+:host .accordion-item-heading,
 :host .accordion-item-subtitle {
   @apply flex w-full;
 }
 
-:host .accordion-item-title {
+:host .accordion-item-heading {
   @apply text-color-2 font-medium;
 }
 :host .accordion-item-subtitle {
@@ -133,7 +133,7 @@
 
 :host(:focus),
 :host(:hover) {
-  & .accordion-item-title {
+  & .accordion-item-heading {
     @apply text-color-1;
   }
   & .accordion-item-icon {
@@ -151,7 +151,7 @@
 :host(:focus),
 :host(:active),
 :host([active]) {
-  & .accordion-item-title {
+  & .accordion-item-heading {
     @apply text-color-1;
   }
   & .accordion-item-icon {

--- a/src/components/accordion-item/accordion-item.scss
+++ b/src/components/accordion-item/accordion-item.scss
@@ -120,14 +120,14 @@
 }
 
 :host .accordion-item-heading,
-:host .accordion-item-subtitle {
+:host .accordion-item-description {
   @apply flex w-full;
 }
 
 :host .accordion-item-heading {
   @apply text-color-2 font-medium;
 }
-:host .accordion-item-subtitle {
+:host .accordion-item-description {
   @apply text-color-3 mt-1;
 }
 
@@ -143,7 +143,7 @@
   & .accordion-item-expand-icon {
     @apply text-color-1;
   }
-  & .accordion-item-subtitle {
+  & .accordion-item-description {
     @apply text-color-2;
   }
 }
@@ -160,7 +160,7 @@
   & .accordion-item-expand-icon {
     @apply text-color-1;
   }
-  & .accordion-item-subtitle {
+  & .accordion-item-description {
     @apply text-color-2;
   }
 }

--- a/src/components/accordion-item/accordion-item.tsx
+++ b/src/components/accordion-item/accordion-item.tsx
@@ -51,8 +51,17 @@ export class AccordionItem {
   /** accordion item heading */
   @Prop() heading?: string;
 
-  /** pass a title for the accordion item */
+  /**
+   * pass a title for the accordion item
+   *
+   * deprecated use description instead
+   */
   @Prop() itemSubtitle?: string;
+
+  /**
+   * accordion item description
+   */
+  @Prop() description: string;
 
   /** optionally pass an icon to display - accepts Calcite UI icon names  */
   @Prop({ reflect: true }) icon?: string;
@@ -132,7 +141,9 @@ export class AccordionItem {
             <div class="accordion-item-header-text">
               <span class="accordion-item-heading">{this.heading || this.itemTitle}</span>
               {this.itemSubtitle ? (
-                <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
+                <span class="accordion-item-description">
+                  {this.description || this.itemSubtitle}
+                </span>
               ) : null}
             </div>
             <calcite-icon

--- a/src/components/accordion-item/accordion-item.tsx
+++ b/src/components/accordion-item/accordion-item.tsx
@@ -54,7 +54,7 @@ export class AccordionItem {
   /**
    * pass a title for the accordion item
    *
-   * deprecated use description instead
+   * @deprecated use description instead
    */
   @Prop() itemSubtitle?: string;
 

--- a/src/components/accordion-item/accordion-item.tsx
+++ b/src/components/accordion-item/accordion-item.tsx
@@ -41,8 +41,15 @@ export class AccordionItem {
   /** Indicates whether the item is active. */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  /** pass a title for the accordion item */
+  /**
+   * pass a title for the accordion item
+   *
+   * @deprecated use heading instead
+   */
   @Prop() itemTitle?: string;
+
+  /** accordion item heading */
+  @Prop() heading?: string;
 
   /** pass a title for the accordion item */
   @Prop() itemSubtitle?: string;
@@ -123,7 +130,7 @@ export class AccordionItem {
           >
             {this.icon ? iconEl : null}
             <div class="accordion-item-header-text">
-              <span class="accordion-item-title">{this.itemTitle}</span>
+              <span class="accordion-item-title">{this.heading || this.itemTitle}</span>
               {this.itemSubtitle ? (
                 <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
               ) : null}

--- a/src/components/accordion-item/accordion-item.tsx
+++ b/src/components/accordion-item/accordion-item.tsx
@@ -130,7 +130,7 @@ export class AccordionItem {
           >
             {this.icon ? iconEl : null}
             <div class="accordion-item-header-text">
-              <span class="accordion-item-title">{this.heading || this.itemTitle}</span>
+              <span class="accordion-item-heading">{this.heading || this.itemTitle}</span>
               {this.itemSubtitle ? (
                 <span class="accordion-item-subtitle">{this.itemSubtitle}</span>
               ) : null}

--- a/src/components/block/block.e2e.ts
+++ b/src/components/block/block.e2e.ts
@@ -137,11 +137,11 @@ describe("calcite-block", () => {
       expect(heading).toBeTruthy();
       expect(heading.innerText).toBe("test-heading");
 
-      const summary = await page.find(`calcite-block >>> .${CSS.summary}`);
-      expect(summary).toBeNull();
+      const description = await page.find(`calcite-block >>> .${CSS.description}`);
+      expect(description).toBeNull();
     });
 
-    it("renders a heading with optional summary", async () => {
+    it("renders a heading with optional summary (deprecated)", async () => {
       const page = await newE2EPage();
 
       await page.setContent(`<calcite-block heading="test-heading" summary="test-summary"></calcite-block>`);
@@ -151,6 +151,18 @@ describe("calcite-block", () => {
 
       const summary = await page.find(`calcite-block >>> .${CSS.summary}`);
       expect(summary.innerText).toBe("test-summary");
+    });
+
+    it("renders a heading with optional description", async () => {
+      const page = await newE2EPage();
+
+      await page.setContent(`<calcite-block heading="test-heading" description="test-summary"></calcite-block>`);
+
+      const heading = await page.find(`calcite-block >>> .${CSS.heading}`);
+      expect(heading).toBeTruthy();
+
+      const description = await page.find(`calcite-block >>> .${CSS.description}`);
+      expect(description.innerText).toBe("test-summary");
     });
 
     it("allows users to add a control in a collapsible block", async () => {

--- a/src/components/block/block.e2e.ts
+++ b/src/components/block/block.e2e.ts
@@ -149,7 +149,7 @@ describe("calcite-block", () => {
       const heading = await page.find(`calcite-block >>> .${CSS.heading}`);
       expect(heading).toBeTruthy();
 
-      const summary = await page.find(`calcite-block >>> .${CSS.summary}`);
+      const summary = await page.find(`calcite-block >>> .${CSS.description}`);
       expect(summary.innerText).toBe("test-summary");
     });
 

--- a/src/components/block/block.scss
+++ b/src/components/block/block.scss
@@ -86,7 +86,7 @@ calcite-handle {
     ease-in-out;
 }
 
-.summary {
+.description {
   @apply text-n2
     text-color-3
     word-break

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -99,8 +99,13 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
 
   /**
    * Block summary.
+   *
+   * @deprecated use description instead
    */
   @Prop() summary: string;
+
+  /**Block description */
+  @Prop() description: string;
 
   //--------------------------------------------------------------------------
   //
@@ -199,13 +204,15 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   }
 
   renderTitle(): VNode {
-    const { heading, headingLevel, summary } = this;
-    return heading || summary ? (
+    const { heading, headingLevel, summary, description } = this;
+    return heading || summary || description ? (
       <div class={CSS.title}>
         <Heading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
           {heading}
         </Heading>
-        {summary ? <div class={CSS.summary}>{summary}</div> : null}
+        {summary || description ? (
+          <div class={CSS.description}>{summary || description}</div>
+        ) : null}
       </div>
     ) : null;
   }

--- a/src/components/block/resources.ts
+++ b/src/components/block/resources.ts
@@ -11,6 +11,7 @@ export const CSS = {
   header: "header",
   button: "button",
   summary: "summary",
+  description: "description",
   controlContainer: "control-container",
   valid: "valid",
   invalid: "invalid",

--- a/src/components/panel/panel.e2e.ts
+++ b/src/components/panel/panel.e2e.ts
@@ -248,7 +248,7 @@ describe("calcite-panel", () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      `<calcite-panel heading="test heading" description="test description>
+      `<calcite-panel heading="test heading" description="test description">
         <div slot=${SLOTS.headerContent}>custom header content</div>
       </calcite-panel>`
     );

--- a/src/components/panel/panel.e2e.ts
+++ b/src/components/panel/panel.e2e.ts
@@ -139,14 +139,24 @@ describe("calcite-panel", () => {
     expect(element).toEqualText("test heading");
   });
 
-  it("should have default summary", async () => {
+  it("should have default summary (deprecated)", async () => {
     const page = await newE2EPage();
 
     await page.setContent('<calcite-panel summary="test summary"></calcite-panel>');
 
-    const element = await page.find(`calcite-panel >>> .${CSS.summary}`);
+    const element = await page.find(`calcite-panel >>> .${CSS.description}`);
 
     expect(element).toEqualText("test summary");
+  });
+
+  it("should have default description", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<calcite-panel description="test description"></calcite-panel>');
+
+    const element = await page.find(`calcite-panel >>> .${CSS.description}`);
+
+    expect(element).toEqualText("test description");
   });
 
   it("should not render a header if there are no actions or content", async () => {
@@ -216,7 +226,7 @@ describe("calcite-panel", () => {
     expect(actionsContainerEnd).toBeNull();
   });
 
-  it("header-content should override heading and summary properties", async () => {
+  it("header-content should override heading and summary properties (deprecated)", async () => {
     const page = await newE2EPage();
 
     await page.setContent(
@@ -226,11 +236,29 @@ describe("calcite-panel", () => {
     );
 
     const heading = await page.find(`calcite-panel >>> ${CSS.heading}`);
-    const summary = await page.find(`calcite-panel >>> ${CSS.summary}`);
+    const summary = await page.find(`calcite-panel >>> ${CSS.description}`);
     const header = await page.find(`calcite-panel >>> ${CSS.header}`);
 
     expect(heading).toBeNull();
     expect(summary).toBeNull();
+    expect(header).not.toBeNull();
+  });
+
+  it("header-content should override heading and description properties", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<calcite-panel heading="test heading" description="test description>
+        <div slot=${SLOTS.headerContent}>custom header content</div>
+      </calcite-panel>`
+    );
+
+    const heading = await page.find(`calcite-panel >>> ${CSS.heading}`);
+    const description = await page.find(`calcite-panel >>> ${CSS.description}`);
+    const header = await page.find(`calcite-panel >>> ${CSS.header}`);
+
+    expect(heading).toBeNull();
+    expect(description).toBeNull();
     expect(header).not.toBeNull();
   });
 

--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -94,7 +94,7 @@
     py-3.5;
   margin-inline-end: auto;
   .heading,
-  .summary {
+  .description {
     @apply block
       break-words
       p-0;
@@ -105,7 +105,7 @@
       @apply mb-0;
     }
   }
-  .summary {
+  .description {
     @apply text-color-2 text-n1h;
   }
 }

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -117,8 +117,13 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
 
   /**
    * Summary text. A description displayed underneath the heading.
+   *
+   * @deprecated use description instead
    */
   @Prop() summary?: string;
+
+  /** Panel description */
+  @Prop() description: string;
 
   /**
    * Opens the action menu.
@@ -321,19 +326,20 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
   }
 
   renderHeaderContent(): VNode {
-    const { heading, headingLevel, summary } = this;
+    const { heading, headingLevel, summary, description } = this;
     const headingNode = heading ? (
       <Heading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
         {heading}
       </Heading>
     ) : null;
 
-    const summaryNode = summary ? <span class={CSS.summary}>{summary}</span> : null;
+    const descriptionNode =
+      description || summary ? <span class={CSS.description}>{description || summary}</span> : null;
 
-    return headingNode || summaryNode ? (
+    return headingNode || descriptionNode ? (
       <div class={CSS.headerContent} key="header-content">
         {headingNode}
-        {summaryNode}
+        {descriptionNode}
       </div>
     ) : null;
   }

--- a/src/components/panel/resources.ts
+++ b/src/components/panel/resources.ts
@@ -4,6 +4,7 @@ export const CSS = {
   header: "header",
   heading: "heading",
   summary: "summary",
+  description: "description",
   headerContent: "header-content",
   headerActions: "header-actions",
   headerActionsEnd: "header-actions--end",

--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -113,11 +113,11 @@
   margin-inline-end: auto;
 }
 
-:host .stepper-item-title,
+:host .stepper-item-heading,
 :host .stepper-item-subtitle {
   @apply flex w-full;
 }
-:host .stepper-item-title {
+:host .stepper-item-heading {
   @apply text-color-2 mb-1 font-medium;
 }
 :host .stepper-item-subtitle {
@@ -157,7 +157,7 @@
 :host(:focus:not([disabled]):not([active])) .container {
   @apply border-t-color-brand;
 
-  & .stepper-item-title {
+  & .stepper-item-heading {
     @apply text-color-1;
   }
   & .stepper-item-subtitle {
@@ -172,7 +172,7 @@
 
 :host([active]) .container {
   border-top-color: theme("backgroundColor.brand");
-  & .stepper-item-title {
+  & .stepper-item-heading {
     @apply text-color-1;
   }
   & .stepper-item-subtitle {

--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -4,7 +4,7 @@
   --calcite-stepper-item-spacing-unit-l: theme("spacing.4");
   @apply text-n1h;
   margin-inline-end: theme("margin.1");
-  .stepper-item-subtitle {
+  .stepper-item-description {
     @apply text-n2h;
   }
 }
@@ -15,7 +15,7 @@
   --calcite-stepper-item-spacing-unit-l: theme("spacing.5");
   @apply text-0h;
   margin-inline-end: theme("margin.2");
-  .stepper-item-subtitle {
+  .stepper-item-description {
     @apply text-n1h;
   }
 }
@@ -26,7 +26,7 @@
   --calcite-stepper-item-spacing-unit-l: theme("spacing.6");
   @apply text-1h;
   margin-inline-end: theme("margin.3");
-  .stepper-item-subtitle {
+  .stepper-item-description {
     @apply text-0h;
   }
 }
@@ -114,13 +114,13 @@
 }
 
 :host .stepper-item-heading,
-:host .stepper-item-subtitle {
+:host .stepper-item-description {
   @apply flex w-full;
 }
 :host .stepper-item-heading {
   @apply text-color-2 mb-1 font-medium;
 }
-:host .stepper-item-subtitle {
+:host .stepper-item-description {
   @apply text-color-3;
 }
 
@@ -160,7 +160,7 @@
   & .stepper-item-heading {
     @apply text-color-1;
   }
-  & .stepper-item-subtitle {
+  & .stepper-item-description {
     @apply text-color-2;
   }
 }
@@ -175,7 +175,7 @@
   & .stepper-item-heading {
     @apply text-color-1;
   }
-  & .stepper-item-subtitle {
+  & .stepper-item-description {
     @apply text-color-2;
   }
   & .stepper-item-number {

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -145,7 +145,7 @@ export class StepperItem implements InteractiveComponent {
               <div class="stepper-item-number">{this.getItemPosition() + 1}.</div>
             ) : null}
             <div class="stepper-item-header-text">
-              <span class="stepper-item-title">{this.heading || this.itemTitle}</span>
+              <span class="stepper-item-heading">{this.heading || this.itemTitle}</span>
               <span class="stepper-item-subtitle">{this.itemSubtitle}</span>
             </div>
           </div>

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -60,13 +60,18 @@ export class StepperItem implements InteractiveComponent {
    */
   @Prop() itemTitle?: string;
 
-  /**
-   * stepper item heading
-   */
+  /** stepper item heading */
   @Prop() heading?: string;
 
-  /** pass a title for the stepper item */
+  /**
+   * pass a title for the stepper item
+   *
+   * @deprecated use description instead
+   */
   @Prop() itemSubtitle?: string;
+
+  /** stepper item description */
+  @Prop() description: string;
 
   // internal props inherited from wrapping calcite-stepper
   /** pass a title for the stepper item */
@@ -146,7 +151,7 @@ export class StepperItem implements InteractiveComponent {
             ) : null}
             <div class="stepper-item-header-text">
               <span class="stepper-item-heading">{this.heading || this.itemTitle}</span>
-              <span class="stepper-item-subtitle">{this.itemSubtitle}</span>
+              <span class="stepper-item-description">{this.description || this.itemSubtitle}</span>
             </div>
           </div>
           <div class="stepper-item-content">

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -53,8 +53,17 @@ export class StepperItem implements InteractiveComponent {
   /** is the step disabled and not navigable to by a user */
   @Prop({ reflect: true }) disabled = false;
 
-  /** pass a title for the stepper item */
+  /**
+   * pass a title for the stepper item
+   *
+   * @deprecated use heading instead
+   */
   @Prop() itemTitle?: string;
+
+  /**
+   * stepper item heading
+   */
+  @Prop() heading?: string;
 
   /** pass a title for the stepper item */
   @Prop() itemSubtitle?: string;
@@ -136,7 +145,7 @@ export class StepperItem implements InteractiveComponent {
               <div class="stepper-item-number">{this.getItemPosition() + 1}.</div>
             ) : null}
             <div class="stepper-item-header-text">
-              <span class="stepper-item-title">{this.itemTitle}</span>
+              <span class="stepper-item-title">{this.heading || this.itemTitle}</span>
               <span class="stepper-item-subtitle">{this.itemSubtitle}</span>
             </div>
           </div>


### PR DESCRIPTION
**Related Issue:** #4688 

## Summary

- Deprecated `itemTitle` props in favor of `heading` in  `accordion-item` and `stepper-item` components
- Deprecated `itemSubtitle` , `summary` in favor of `description` in `accordion-item` , `stepper-item`,`block` & `panel` components