### PR TITLE
fix(color-picker): fixed hue bar click and drag interaction

### DIFF
--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -613,7 +613,7 @@ export class ColorPicker implements InteractiveComponent {
       } else if (clientX < colorFieldAndSliderRect.x) {
         samplingX = 0;
       } else {
-        samplingX = colorFieldWidth;
+        samplingX = colorFieldWidth - 1;
       }
 
       if (


### PR DESCRIPTION
**Related Issue:** #

Prevent the selector from snapping, while using a mouse to click and drag past the component boundary. 

Because of the radial nature of HSV representation, the end value of colorFieldWidth is basically the same as 0. Subtracting one from the value prevents going it full circle. 