### PR TITLE
feat(stepper): Add calciteStepperItemChange event

### DIFF
--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -102,6 +102,12 @@ export class StepperItem implements InteractiveComponent {
   /**
    * @internal
    */
+  @Event()
+  calciteInternalUserRequestedStepperItemSelect: EventEmitter<StepperItemChangeEventDetail>;
+
+  /**
+   * @internal
+   */
   @Event() calciteInternalStepperItemRegister: EventEmitter<StepperItemEventDetail>;
 
   //--------------------------------------------------------------------------
@@ -126,7 +132,7 @@ export class StepperItem implements InteractiveComponent {
     return (
       <Host
         aria-expanded={toAriaBoolean(this.active)}
-        onClick={this.emitRequestedItem}
+        onClick={this.emitUserRequestedItem}
         onKeyDown={this.keyDownHandler}
       >
         <div class="container">
@@ -194,7 +200,7 @@ export class StepperItem implements InteractiveComponent {
       switch (e.key) {
         case " ":
         case "Enter":
-          this.emitRequestedItem();
+          this.emitUserRequestedItem();
           e.preventDefault();
           break;
         case "ArrowUp":
@@ -232,6 +238,15 @@ export class StepperItem implements InteractiveComponent {
       content: this.itemContent
     });
   }
+
+  private emitUserRequestedItem = (): void => {
+    this.emitRequestedItem();
+    if (!this.disabled) {
+      this.calciteInternalUserRequestedStepperItemSelect.emit({
+        position: this.itemPosition
+      });
+    }
+  };
 
   private emitRequestedItem = (): void => {
     if (!this.disabled) {

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -242,17 +242,22 @@ export class StepperItem implements InteractiveComponent {
   private emitUserRequestedItem = (): void => {
     this.emitRequestedItem();
     if (!this.disabled) {
+      const position = this.itemPosition;
+
       this.calciteInternalUserRequestedStepperItemSelect.emit({
-        position: this.itemPosition
+        position
       });
     }
   };
 
   private emitRequestedItem = (): void => {
     if (!this.disabled) {
+      const position = this.itemPosition;
+      const content = this.itemContent;
+
       this.calciteInternalStepperItemSelect.emit({
-        position: this.itemPosition,
-        content: this.itemContent
+        position,
+        content
       });
     }
   };

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -436,5 +436,15 @@ describe("calcite-stepper", () => {
     expect(await items[3].getProperty("active")).toBe(true);
     expect(eventSpy).toHaveReceivedEventTimes(2);
     expect(eventSpy.lastEvent.detail.position).toBe(3);
+
+    await element.callMethod("prevStep");
+    await page.waitForChanges();
+    expect(await items[1].getProperty("active")).toBe(true);
+    expect(eventSpy).toHaveReceivedEventTimes(2);
+
+    await element.callMethod("nextStep");
+    await page.waitForChanges();
+    expect(await items[3].getProperty("active")).toBe(true);
+    expect(eventSpy).toHaveReceivedEventTimes(2);
   });
 });

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -391,4 +391,44 @@ describe("calcite-stepper", () => {
 
     expect(finalSelectedItem).toBe("item-3");
   });
+
+  it("should emit calciteStepperItemChange on user interaction", async () => {
+    const page = await newE2EPage({
+      html: html`<calcite-stepper>
+        <calcite-stepper-item item-title="Step 1" id="step-1">
+          <div>Step 1 content</div>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Step 2" id="step-2">
+          <div>Step 2 content</div>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Step 3" id="step-3">
+          <div>Step 3 content</div>
+        </calcite-stepper-item>
+        <calcite-stepper-item item-title="Step 4" id="step-4">
+          <div>Step 4 content</div>
+        </calcite-stepper-item>
+      </calcite-stepper>`
+    });
+
+    await page.waitForChanges();
+
+    const element = await page.find("calcite-stepper");
+    const eventSpy = await element.spyOnEvent("calciteStepperItemChange");
+    const items = await page.findAll("calcite-stepper-item");
+
+    items[0].setProperty("active", true);
+    items[0].innerHTML = "<div>New content</div>";
+    await page.waitForChanges();
+    expect(eventSpy).toHaveReceivedEventTimes(0);
+
+    await items[1].click();
+    expect(await items[1].getProperty("active")).toBe(true);
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+    expect(eventSpy.lastEvent.detail.position).toBe(1);
+
+    await items[3].click();
+    expect(await items[3].getProperty("active")).toBe(true);
+    expect(eventSpy).toHaveReceivedEventTimes(2);
+    expect(eventSpy.lastEvent.detail.position).toBe(3);
+  });
 });

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -401,7 +401,7 @@ describe("calcite-stepper", () => {
         <calcite-stepper-item item-title="Step 2" id="step-2">
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item item-title="Step 3" id="step-3" disabled>
           <div>Step 3 content</div>
         </calcite-stepper-item>
         <calcite-stepper-item item-title="Step 4" id="step-4">
@@ -416,6 +416,7 @@ describe("calcite-stepper", () => {
     const eventSpy = await element.spyOnEvent("calciteStepperItemChange");
     const items = await page.findAll("calcite-stepper-item");
 
+    // non user interaction
     items[0].setProperty("active", true);
     items[0].innerHTML = "<div>New content</div>";
     await page.waitForChanges();
@@ -425,6 +426,11 @@ describe("calcite-stepper", () => {
     expect(await items[1].getProperty("active")).toBe(true);
     expect(eventSpy).toHaveReceivedEventTimes(1);
     expect(eventSpy.lastEvent.detail.position).toBe(1);
+
+    // disabled item
+    await items[2].click();
+    expect(await items[3].getProperty("active")).toBe(false);
+    expect(eventSpy).toHaveReceivedEventTimes(1);
 
     await items[3].click();
     expect(await items[3].getProperty("active")).toBe(true);

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -76,6 +76,12 @@ export class Stepper {
   /**
    * This event fires when the active stepper item has changed.
    *
+   */
+  @Event() calciteStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
+
+  /**
+   * This event fires when the active stepper item has changed.
+   *
    * @internal
    */
   @Event() calciteInternalStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
@@ -160,13 +166,33 @@ export class Stepper {
 
   @Listen("calciteInternalStepperItemSelect")
   updateItem(event: CustomEvent<StepperItemEventDetail>): void {
-    if (event.detail.content) {
-      this.requestedContent = event.detail.content;
+    const { content, position } = event.detail;
+
+    if (content) {
+      this.requestedContent = content;
     }
-    this.currentPosition = event.detail.position;
+
+    if (typeof position === "number") {
+      this.currentPosition = position;
+    }
+
     this.calciteInternalStepperItemChange.emit({
-      position: this.currentPosition
+      position
     });
+
+    event.stopPropagation();
+  }
+
+  @Listen("calciteInternalUserRequestedStepperItemSelect")
+  handlecalciteInternalUserRequestedStepperItemSelect(
+    event: CustomEvent<StepperItemChangeEventDetail>
+  ): void {
+    const { position } = event.detail;
+
+    this.calciteStepperItemChange.emit({
+      position
+    });
+
     event.stopPropagation();
   }
 

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -184,9 +184,7 @@ export class Stepper {
   }
 
   @Listen("calciteInternalUserRequestedStepperItemSelect")
-  handlecalciteInternalUserRequestedStepperItemSelect(
-    event: CustomEvent<StepperItemChangeEventDetail>
-  ): void {
+  handleUserRequestedStepperItemSelect(event: CustomEvent<StepperItemChangeEventDetail>): void {
     const { position } = event.detail;
 
     this.calciteStepperItemChange.emit({


### PR DESCRIPTION
**Related Issue:** #4595

## Summary

feat(stepper): Add calciteStepperItemChange event. (#4595)

- Adds new public event `calciteStepperItemChange`
- Added new internal event for handling only user interaction.
- Keeps other internal events needed for updating DOM. These could be removed during a refactor.