### PR TITLE
fix: Make sure component setFocus methods do not throw error

### DIFF
--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -193,7 +193,7 @@ export class Accordion {
 
   private focusElement(item) {
     const target = item as HTMLCalciteAccordionItemElement;
-    target.focus();
+    target?.focus();
   }
 
   private sortItems = (items: any[]): any[] =>

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -185,7 +185,7 @@ export class ActionBar implements ConditionalSlotComponent {
       return;
     }
 
-    this.el.focus();
+    this.el?.focus();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -135,7 +135,7 @@ export class ActionPad implements ConditionalSlotComponent {
       return;
     }
 
-    this.el.focus();
+    this.el?.focus();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -151,7 +151,7 @@ export class Action implements InteractiveComponent {
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.buttonEl.focus();
+    this.buttonEl?.focus();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -219,7 +219,7 @@ export class Button implements LabelableComponent, InteractiveComponent, FormOwn
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.childEl.focus();
+    this.childEl?.focus();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -556,7 +556,7 @@ export class ColorPicker implements InteractiveComponent {
     } else if (region === "slider") {
       this.sliderThumbState = "drag";
       this.captureHueSliderColor(offsetX);
-      this.hueScopeNode.focus();
+      this.hueScopeNode?.focus();
     }
 
     // prevent text selection outside of color field & slider area

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -552,7 +552,7 @@ export class ColorPicker implements InteractiveComponent {
     if (region === "color-field") {
       this.hueThumbState = "drag";
       this.captureColorFieldColor(offsetX, offsetY);
-      this.colorFieldScopeNode.focus();
+      this.colorFieldScopeNode?.focus();
     } else if (region === "slider") {
       this.sliderThumbState = "drag";
       this.captureHueSliderColor(offsetX);

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -89,7 +89,7 @@ export class DropdownItem {
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.el.focus();
+    this.el?.focus();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/handle/handle.tsx
+++ b/src/components/handle/handle.tsx
@@ -54,7 +54,7 @@ export class Handle {
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.handleButton.focus();
+    this.handleButton?.focus();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -274,7 +274,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.calciteInputEl.setFocus();
+    this.calciteInputEl?.setFocus();
   }
 
   /** Updates the position of the component. */

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -236,7 +236,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.inputFocusRef.focus();
+    this.inputFocusRef?.focus();
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -871,7 +871,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   @Method()
   async setFocus(): Promise<void> {
     const handle = this.minHandle ? this.minHandle : this.maxHandle;
-    handle.focus();
+    handle?.focus();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -331,7 +331,7 @@ export class Stepper {
   }
 
   private focusElement(item: HTMLCalciteStepperItemElement) {
-    item.focus();
+    item?.focus();
   }
 
   private sortItems(): HTMLCalciteStepperItemElement[] {

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -202,7 +202,7 @@ export class TabNav {
       this.enabledTabTitles[currentIndex - 1] ||
       this.enabledTabTitles[this.enabledTabTitles.length - 1];
 
-    previousTab.focus();
+    previousTab?.focus();
 
     e.stopPropagation();
     e.preventDefault();
@@ -217,7 +217,7 @@ export class TabNav {
 
     const nextTab = this.enabledTabTitles[currentIndex + 1] || this.enabledTabTitles[0];
 
-    nextTab.focus();
+    nextTab?.focus();
 
     e.stopPropagation();
     e.preventDefault();

--- a/src/components/tile-select/tile-select.tsx
+++ b/src/components/tile-select/tile-select.tsx
@@ -125,7 +125,7 @@ export class TileSelect implements InteractiveComponent {
   /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
-    this.input.setFocus();
+    this.input?.setFocus();
   }
 
   //--------------------------------------------------------------------------

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -328,7 +328,7 @@ export class TreeItem implements ConditionalSlotComponent {
 
         const firstNode = root.querySelector("calcite-tree-item");
 
-        firstNode.focus();
+        firstNode?.focus();
 
         break;
       case "End":
@@ -344,7 +344,7 @@ export class TreeItem implements ConditionalSlotComponent {
             e.matches("calcite-tree")
           );
         }
-        currentNode.focus();
+        currentNode?.focus();
         break;
     }
   }

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -295,7 +295,7 @@ export class ValueList<
     this.items = this.getItems();
     this.calciteListOrderChange.emit(this.items.map(({ value }) => value));
 
-    requestAnimationFrame(() => handleElement.focus());
+    requestAnimationFrame(() => handleElement?.focus());
     item.handleActivated = true;
   };
 


### PR DESCRIPTION
**Related Issue:** #4731

## Summary

fix: Make sure component setFocus methods do not throw error. (#4731)

When calling setFocus before the first render, an error may be thrown. This prevents that.