### PR TITLE
test(modal): remove test for firstFocus property

### DIFF
--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -38,24 +38,6 @@ describe("calcite-modal properties", () => {
     expect(style).toEqual("400px");
   });
 
-  it("focuses the firstFocus element on load", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-modal active>
-        <h3 slot="header">Title</h3>
-        <p slot="content">This is the content <button class="test">test</button></p>
-      </calcite-modal>
-    `);
-    const modal = await page.find("calcite-modal");
-    let $button;
-    await page.$eval(".test", (elm: any) => {
-      $button = elm.querySelector(".test");
-    });
-    modal.setProperty("firstFocus", $button);
-    await page.waitForChanges();
-    expect(document.activeElement).toEqual($button);
-  });
-
   it("calls the beforeClose method prior to closing", async () => {
     const page = await newE2EPage();
     const mockCallBack = jest.fn();


### PR DESCRIPTION
**Related Issue:** #4613

## Summary
Removing the e2e test for the firstFocus property that was removed in #4671
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
