### PR TITLE
fix(stepper): remove invalid layout value (#4766)

### DIFF
--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -11,7 +11,7 @@ import {
   Watch
 } from "@stencil/core";
 import { getElementProp, toAriaBoolean } from "../../utils/dom";
-import { Scale } from "../interfaces";
+import { Layout, Scale } from "../interfaces";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 import {
   StepperItemChangeEventDetail,
@@ -77,7 +77,8 @@ export class StepperItem implements InteractiveComponent {
   /** pass a title for the stepper item */
   /** @internal */
 
-  @Prop({ reflect: true, mutable: true }) layout?: string;
+  @Prop({ reflect: true, mutable: true }) layout?: Extract<"horizontal" | "vertical", Layout> =
+    "horizontal";
 
   /** should the items display an icon based on status */
   /** @internal */

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -45,7 +45,7 @@ export class Stepper {
   @Prop({ reflect: true }) icon = false;
 
   /** specify the layout of stepper, defaults to horizontal */
-  @Prop({ reflect: true }) layout: Layout = "horizontal";
+  @Prop({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "horizontal";
 
   /** optionally display the number next to the step title */
   @Prop({ reflect: true }) numbered = false;


### PR DESCRIPTION
Updates typing of layout prop in stepper and stepper-item

**Related Issue:** #4766 

## Summary
This extracts just the values that are relevant to Stepper from the shared Layout interface.

Note - we should probably move away from styling based on reflected props in a future update.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
