### PR TITLE
ci(dependabot): prevent bumping cheerio and chalk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       prefix: "build(deps): "
     # Ignore updates to packages below
     ignore:
+      - dependency-name: "chalk"
+      - dependency-name: "cheerio"
       - dependency-name: "typescript"
       - dependency-name: "@types/jest"
       - dependency-name: "jest"


### PR DESCRIPTION
**Related Issue:** #4763

## Summary

chalk/cheerio were already excluded from the `update-deps` npm script but not dependabot
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
