### PR TITLE
ci: notify leads of new component label

### DIFF
--- a/.github/workflows/new-component-notify.yml
+++ b/.github/workflows/new-component-notify.yml
@@ -1,30 +1,30 @@
-# If the "new component" label is added to an issue, generates a notification to the CC team lead(s)
-# The secret is formatted like so: lead1, lead2, lead3
-# Note the script automatically adds the "@" character in to notify the leads
-name: "Notify CC Leads of New Component Issue"
+# If the "new component" label is added to an issue, generates a notification to the Calcite designer lead(s)
+# The secret is formatted like so: designer1, designer2, designer3
+# Note the script automatically adds the "@" character in to notify the designer lead(s)
+name: "Notify CC Designer Leads of New Component Issue"
 
 on:
   issues:
     types: [labeled]
 
 jobs:
-  notify-lead-new-component:
+  notify-designer-new-component:
     if: github.event.label.name == 'new component'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v4
         env:
-          leads: ${{secrets.cc_leads}}
+          designers: ${{secrets.CALCITE_DESIGNERS}}
         with:
           script: |
-            const { leads } = process.env;
+            const { designers } = process.env;
             // Add a "@" character to notify the user
-            const cc_leads = leads.split(",").map(v => " @" + v.trim());
+            const calcite_designers = designers.split(",").map(v => " @" + v.trim());
 
-            // Add a comment to issues with the 'new component' label to notify the lead(s)
+            // Add a comment to issues with the 'new component' label to notify the designer(s)
             await github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `cc ${cc_leads}`,
+              body: `cc ${calcite_designers}`,
             });

--- a/.github/workflows/new-component-notify.yml
+++ b/.github/workflows/new-component-notify.yml
@@ -1,0 +1,30 @@
+# If the "new component" label is added to an issue, generates a notification to the CC team lead(s)
+# The secret is formatted like so: lead1, lead2, lead3
+# Note the script automatically adds the "@" character in to notify the leads
+name: "Notify CC Leads of New Component Issue"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify-lead-new-component:
+    if: github.event.label.name == 'new component'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        env:
+          leads: ${{secrets.cc_leads}}
+        with:
+          script: |
+            const { leads } = process.env;
+            // Add a "@" character to notify the user
+            const cc_leads = leads.split(",").map(v => " @" + v.trim());
+
+            // Add a comment to issues with the 'new component' label to notify the lead(s)
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `cc ${cc_leads}`,
+            });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Adds automation  to notify CC design lead(s) when the `new component` label is added to an issue. 🤖

### Features
* The automation adds text to the issue's body `cc @<design-username>`  
* The design lead(s) are stored in a GH secret `CALCITE_DESIGNERS` 🔒 
    * The entries in the secret will be entered as `<design-username>` or `<design-username1>, <design-username2>, ....` 
    * The automation automatically adds in the `@` before the `<design-username>` text.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
