### PR TITLE
feat(combobox): add support for placeholder icon & no longer display leading space for placeholder text

### DIFF
--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -284,3 +284,17 @@ export const disabled = (): string => html`<calcite-combobox disabled>
     <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
   </calcite-combobox-item>
 </calcite-combobox>`;
+
+export const WithPlaceHolderIcon = (): string => html` <calcite-combobox
+  id="labelFour"
+  label="test"
+  placeholder="${text("placeholder", "select folder")}"
+  placeholder-icon="${text("placeholder-icon", "select")}"
+  max-items="6"
+  selection-mode="single"
+  scale="s"
+>
+  <calcite-combobox-item value="root" text-label="username" icon="home"></calcite-combobox-item>
+  <calcite-combobox-item value="1" text-label="Folder 1" icon="folder"></calcite-combobox-item>
+  <calcite-combobox-item value="2" text-label="Folder 2" icon="folder"></calcite-combobox-item>
+</calcite-combobox>`;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -108,6 +108,9 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   /** Placeholder text for input */
   @Prop() placeholder?: string;
 
+  /** Placeholder icon for input  */
+  @Prop() placeholderIcon?: string;
+
   /** Specify the maximum number of combobox items (including nested children) to display before showing the scroller */
   @Prop() maxItems = 0;
 
@@ -1123,15 +1126,18 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   }
 
   renderIconStart(): VNode {
-    const { selectionMode, needsIcon, selectedItems } = this;
+    const { selectionMode, needsIcon, selectedItems, placeholderIcon } = this;
     const selectedItem = selectedItems[0];
     return (
       selectionMode === "single" &&
-      needsIcon && (
+      needsIcon &&
+      (selectedItem?.icon || placeholderIcon) && (
         <span class="icon-start">
-          {selectedItem?.icon && (
-            <calcite-icon class="selected-icon" icon={selectedItem.icon} scale="s" />
-          )}
+          <calcite-icon
+            class="selected-icon"
+            icon={selectedItem?.icon ? selectedItem.icon : placeholderIcon}
+            scale="s"
+          />
         </span>
       )
     );

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -1135,7 +1135,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
         <span class="icon-start">
           <calcite-icon
             class="selected-icon"
-            icon={selectedItem?.icon ? selectedItem.icon : placeholderIcon}
+            icon={selectedItem?.icon ?? placeholderIcon}
             scale="s"
           />
         </span>


### PR DESCRIPTION
**Related Issue:** #4629 

## Summary

- Adds support for `@Prop() placeholder-icon` which leads `placeholder` text in  `calcite-combobox `.

![41D43904-F2C5-4D53-B373-5B1FA772FF5E_4_5005_c](https://user-images.githubusercontent.com/88453586/174877330-9553ed5f-8b3d-4512-ba34-97338a9a3c8d.jpeg)

- This will fix the leading space added to the `placeholder` text in combobox when the `combobox-item` contains icon at start.
### Before:
![188DD29D-6F03-4F95-A778-BE936B02838C_4_5005_c](https://user-images.githubusercontent.com/88453586/174876577-8ba38a8b-e39d-4a74-baa6-7be119cf37e7.jpeg)

### After the fix
![0C14FD5E-329B-4598-A9AE-A36697EDC8BE_4_5005_c](https://user-images.githubusercontent.com/88453586/174877151-74f0105e-6731-484a-b9c9-d3e0f488f975.jpeg)

