### PR TITLE
ci: use npm ci to install deps

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -22,7 +22,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: e2e test
         run: |
-          npm install --legacy-peer-deps
+          npm ci --legacy-peer-deps
           npm test
       - name: next deployment
         env:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          npm install --legacy-peer-deps
+          npm ci --legacy-peer-deps
           npm run build-storybook
           npx storybook-to-ghpages --existing-output-dir=docs --ci
         env:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           node-version: lts/*
           cache: npm
-      - run: npm install --legacy-peer-deps
+      - run: npm ci --legacy-peer-deps
       - if: steps.testable.outputs.skip == 'false'
         run: npm test

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: lts/*
           cache: npm
-      - run: npm install --legacy-peer-deps
+      - run: npm ci --legacy-peer-deps
       - if: steps.one.outputs.skip == 'screen'
         name: run screener check
         env:

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -13,10 +13,9 @@ jobs:
           cache: npm
       - name: generate doc
         run: |
-          npm install
+          npm ci --legacy-peer-deps
           npx stencil build --docs
           npm run lint:md
-
       - name: commit readme files/create pull request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
**Related Issue:** #4704 #4703

## Summary
In the PRs above I had to change the GH Actions to use the `legacy-peer-deps` flag. For some reason I didn't think you could use that flag with `npm ci` but I was mistaken. Changing back to using `npm ci` since it is faster. Also adding the flag to the doc update which I missed last time.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
