### PR TITLE
feat(block): support noPadding property

### DIFF
--- a/src/components/block/block.scss
+++ b/src/components/block/block.scss
@@ -142,9 +142,11 @@ calcite-handle {
 
 .content {
   @apply animate-in
-    relative
-    px-3
-    py-2;
+    relative;
+}
+
+.content--spaced {
+  @apply px-3 py-2;
 }
 
 .control-container {

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -176,7 +176,7 @@ export const disabled = (): string => html`<calcite-block heading="heading" summ
 </calcite-block>`;
 
 export const noPadding = (): string => html` <calcite-panel heading="Properties">
-  <calcite-block heading="Example block heading" summary="example summary heading" collapsible open>
+  <calcite-block heading="Example block heading" summary="example summary heading" collapsible open no-padding>
     <div>calcite components ninja</div>
   </calcite-block>
 </calcite-panel>`;

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -174,3 +174,9 @@ export const disabled = (): string => html`<calcite-block heading="heading" summ
     <img alt="demo" src="${placeholderImage({ width: 320, height: 240 })}" />
   </calcite-block-section>
 </calcite-block>`;
+
+export const noPadding = (): string => html` <calcite-panel heading="Properties">
+  <calcite-block heading="Example block heading" summary="example summary heading" collapsible>
+    <div>calcite components ninja</div>
+  </calcite-block>
+</calcite-panel>`;

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -176,7 +176,7 @@ export const disabled = (): string => html`<calcite-block heading="heading" summ
 </calcite-block>`;
 
 export const noPadding = (): string => html` <calcite-panel heading="Properties">
-  <calcite-block heading="Example block heading" summary="example summary heading" collapsible>
+  <calcite-block heading="Example block heading" summary="example summary heading" collapsible open>
     <div>calcite components ninja</div>
   </calcite-block>
 </calcite-panel>`;

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -107,6 +107,9 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   /**Block description */
   @Prop() description: string;
 
+  /** When true, removes padding for the slotted content */
+  @Prop() noPadding: string;
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -290,7 +293,10 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
           <section
             aria-expanded={toAriaBoolean(open)}
             aria-labelledby={buttonId}
-            class={CSS.content}
+            class={{
+              content: true,
+              "content--spaced": !this.noPadding
+            }}
             hidden={!open}
             id={regionId}
           >

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -108,7 +108,7 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   @Prop() description: string;
 
   /** When true, removes padding for the slotted content */
-  @Prop() noPadding: string;
+  @Prop() noPadding = false;
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #4116 

## Summary

This will add a new prop `noPadding` which is defaulted to `false`. When `true`, it removes padding of the content slotted in `calcite-block`