### PR TITLE
refactor(dropdown): added 'before' events for events that fire after transition

### DIFF
--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -540,9 +540,8 @@ describe("calcite-dropdown", () => {
 
     it("control max items displayed", async () => {
       const maxItems = 7;
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-dropdown max-items="${maxItems}">
+      const page = await newE2EPage({
+        html: html`<calcite-dropdown max-items="${maxItems}">
           <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
           <calcite-dropdown-group group-title="First group">
             <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -558,8 +557,8 @@ describe("calcite-dropdown", () => {
             <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
             <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
           </calcite-dropdown-group>
-        </calcite-dropdown>
-      `);
+        </calcite-dropdown>`
+      });
 
       const element = await page.find("calcite-dropdown");
       const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -1024,4 +1024,56 @@ describe("calcite-dropdown", () => {
         shadowPopperSelector: ".calcite-dropdown-wrapper"
       }
     ));
+
+  it("should emit component status for transition-chained events: 'calciteDropdownBeforeOpen', 'calciteDropdownOpen', 'calciteDropdownBeforeClose', 'calciteDropdownClose'", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-dropdown>
+        <calcite-button slot="dropdown-trigger">Open dropdown</calcite-button>
+        <calcite-dropdown-group id="group-1">
+          <calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>
+          <calcite-dropdown-item id="item-2" active> Dropdown Item Content </calcite-dropdown-item>
+          <calcite-dropdown-item id="item-3"> Dropdown Item Content </calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
+    `);
+    const element = await page.find("calcite-dropdown");
+    const group = await page.find(`calcite-dropdown-group`);
+
+    expect(await group.isVisible()).toBe(false);
+
+    const calciteDropdownBeforeOpenEvent = page.waitForEvent("calciteDropdownBeforeOpen");
+    const calciteDropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");
+
+    const calciteDropdownBeforeOpenSpy = await element.spyOnEvent("calciteDropdownBeforeOpen");
+    const calciteDropdownOpenSpy = await element.spyOnEvent("calciteDropdownxOpen");
+
+    await element.setProperty("active", true);
+    await page.waitForChanges();
+
+    await calciteDropdownBeforeOpenEvent;
+    await calciteDropdownOpenEvent;
+
+    expect(calciteDropdownBeforeOpenSpy).toHaveReceivedEventTimes(1);
+    expect(calciteDropdownOpenSpy).toHaveReceivedEventTimes(1);
+
+    expect(await group.isVisible()).toBe(true);
+
+    const calciteDropdownBeforeCloseEvent = page.waitForEvent("calciteDropdownBeforeClose");
+    const calciteDropdownCloseEvent = page.waitForEvent("calciteDropdownClose");
+
+    const calciteDropdownBeforeCloseSpy = await element.spyOnEvent("calciteDropdownBeforeClose");
+    const calciteDropdownCloseSpy = await element.spyOnEvent("calciteDropdownClose");
+
+    await element.setProperty("active", false);
+    await page.waitForChanges();
+
+    await calciteDropdownBeforeCloseEvent;
+    await calciteDropdownCloseEvent;
+
+    expect(calciteDropdownBeforeCloseSpy).toHaveReceivedEventTimes(1);
+    expect(calciteDropdownCloseSpy).toHaveReceivedEventTimes(1);
+
+    expect(await group.isVisible()).toBe(false);
+  });
 });

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -2,6 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, popperOwner, renders } from "../../tests/commonTests";
 import dedent from "dedent";
 import { html } from "../../../support/formatting";
+import { CSS } from "./resources";
 
 describe("calcite-dropdown", () => {
   it("renders", () =>
@@ -1037,8 +1038,8 @@ describe("calcite-dropdown", () => {
         </calcite-dropdown-group>
       </calcite-dropdown>
     `);
-    const element = await page.find("calcite-dropdown");
-    const group = await page.find(`calcite-dropdown-group`);
+    const element = await page.find(`calcite-dropdown`);
+    const group = await page.find(`calcite-dropdown >>> .${CSS.calciteDropdownContent}`);
 
     expect(await group.isVisible()).toBe(false);
 
@@ -1046,7 +1047,7 @@ describe("calcite-dropdown", () => {
     const calciteDropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");
 
     const calciteDropdownBeforeOpenSpy = await element.spyOnEvent("calciteDropdownBeforeOpen");
-    const calciteDropdownOpenSpy = await element.spyOnEvent("calciteDropdownxOpen");
+    const calciteDropdownOpenSpy = await element.spyOnEvent("calciteDropdownOpen");
 
     await element.setProperty("active", true);
     await page.waitForChanges();

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -540,8 +540,9 @@ describe("calcite-dropdown", () => {
 
     it("control max items displayed", async () => {
       const maxItems = 7;
-      const page = await newE2EPage({
-        html: html`<calcite-dropdown max-items="${maxItems}">
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-dropdown max-items="${maxItems}">
           <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
           <calcite-dropdown-group group-title="First group">
             <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
@@ -557,8 +558,8 @@ describe("calcite-dropdown", () => {
             <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
             <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
           </calcite-dropdown-group>
-        </calcite-dropdown>`
-      });
+        </calcite-dropdown>
+      `);
 
       const element = await page.find("calcite-dropdown");
       const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -235,11 +235,17 @@ export class Dropdown implements InteractiveComponent {
   /** fires when a dropdown item has been selected or deselected */
   @Event() calciteDropdownSelect: EventEmitter<void>;
 
-  /** fires when a dropdown has been opened */
-  @Event() calciteDropdownOpen: EventEmitter<void>;
+  /* Fired while a dropdown is still invisible but was added to the DOM, and before the opening transition begins. */
+  @Event() calciteDropdownBeforeOpen: EventEmitter<{ el: HTMLCalciteDropdownElement }>;
 
-  /** fires when a dropdown has been closed */
-  @Event() calciteDropdownClose: EventEmitter<void>;
+  /* Fired when a dropdown has been opened and animation is complete */
+  @Event() calciteDropdownOpen: EventEmitter<{ el: HTMLCalciteDropdownElement }>;
+
+  /* Fired when a dropdown is requested to be closed and before the closing transition begins. */
+  @Event() calciteDropdownBeforeClose: EventEmitter<{ el: HTMLCalciteDropdownElement }>;
+
+  /* Fired when a dropdown has been closed and animation is complete */
+  @Event() calciteDropdownClose: EventEmitter<{ el: HTMLCalciteDropdownElement }>;
 
   @Listen("click", { target: "window" })
   closeCalciteDropdownOnClick(e: Event): void {

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -161,7 +161,7 @@ export class Dropdown implements InteractiveComponent {
     this.resizeObserver?.disconnect();
     this.destroyPopper();
     if (this.scrollerEl) {
-      this.scrollerEl.removeEventListener("transitionrun", this.onTransitionRun);
+      this.scrollerEl.removeEventListener("transitionrun", this.transitionRunHandler);
     }
   }
 
@@ -448,24 +448,22 @@ export class Dropdown implements InteractiveComponent {
   setScrollerEl = (scrollerEl: HTMLDivElement): void => {
     this.resizeObserver.observe(scrollerEl);
     this.scrollerEl = scrollerEl;
-    this.scrollerEl.addEventListener("transitionrun", this.onTransitionRun);
+    this.scrollerEl.addEventListener("transitionrun", this.transitionRunHandler);
   };
 
   transitionEnd = (event: TransitionEvent): void => {
     if (event.propertyName === this.activeTransitionProp) {
-      this.active ? this.openCloseEventEmitter("open") : this.openCloseEventEmitter("close");
+      this.active ? this.emitOpenCloseEvent("open") : this.emitOpenCloseEvent("close");
     }
   };
 
-  onTransitionRun = (event: TransitionEvent): void => {
+  transitionRunHandler = (event: TransitionEvent): void => {
     if (event.propertyName === this.activeTransitionProp) {
-      this.active
-        ? this.openCloseEventEmitter("beforeOpen")
-        : this.openCloseEventEmitter("beforeClose");
+      this.active ? this.emitOpenCloseEvent("beforeOpen") : this.emitOpenCloseEvent("beforeClose");
     }
   };
 
-  private openCloseEventEmitter(componentVisibilityState: string): void {
+  private emitOpenCloseEvent(componentVisibilityState: string): void {
     const payload = {
       el: this.el
     };

--- a/src/components/dropdown/resources.ts
+++ b/src/components/dropdown/resources.ts
@@ -1,3 +1,7 @@
 export const SLOTS = {
   dropdownTrigger: "dropdown-trigger"
 };
+
+export const CSS = {
+  calciteDropdownContent: "calcite-dropdown-content"
+};


### PR DESCRIPTION
**Related Issue:** #4689

## Summary

Provide devs with more control of the components through additional hooks. For public events that are emitted after a transition finishes (in this case, opening/closing of the dropdown), we are now adding events that fire before the transition kicks off as well.