### PR TITLE
test(dropdown): skip unstable test: scrolling > control max items dis…

### DIFF
--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -537,7 +537,7 @@ describe("calcite-dropdown", () => {
       expect(await item.isIntersectingViewport()).toBe(true);
     });
 
-    it("control max items displayed", async () => {
+    it.skip("control max items displayed", async () => {
       const maxItems = 7;
       const page = await newE2EPage({
         html: html`<calcite-dropdown max-items="${maxItems}">


### PR DESCRIPTION

This might be a timing issue.
<img width="557" alt="Screen Shot 2022-06-23 at 2 19 20 PM" src="https://user-images.githubusercontent.com/19231036/175424062-c685835f-75ec-4216-9437-3b864cc7b040.png">


I noticed when there is a max item limit and more items, it’ll fail with this message (regardless if there are more items in just one group or spanning 2 groups).