### PR TITLE
ci(stale): exempt epics from auto-closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
           stale-pr-message: "This PR has been automatically marked as stale because it has not had recent activity. Please close your PR if it is no longer relevant. Thank you for your contributions."
           close-issue-message: "This issue has been automatically closed due to inactivity."
-          exempt-issue-labels: "0 - new,1 - assigned,2 - in development"
+          exempt-issue-labels: "0 - new,1 - assigned,2 - in development,epic"
           days-before-issue-stale: 30
           days-before-issue-close: 7
           days-before-pr-stale: 7


### PR DESCRIPTION
**Related Issue:** #4598 #4599

## Summary
Exempt stale epics from auto-closing
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
