### PR TITLE
refactor(combobox): rename functions that emit open/close events

### DIFF
--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -311,7 +311,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
     disconnectForm(this);
 
     if (this.listContainerEl) {
-      this.listContainerEl.removeEventListener("transitionrun", this.onTransitionRun);
+      this.listContainerEl.removeEventListener("transitionrun", this.transitionRunHandler);
     }
   }
 
@@ -520,7 +520,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
 
   transitionEnd = (event: TransitionEvent): void => {
     if (event.propertyName === this.activeTransitionProp) {
-      this.active ? this.openCloseEventEmitter("open") : this.openCloseEventEmitter("close");
+      this.active ? this.emitOpenCloseEvent("open") : this.emitOpenCloseEvent("close");
     }
   };
 
@@ -528,15 +528,13 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   - `transitionrun` fires when the transition is created at the start of any delay and is not cancellable once started.
   - if there is no transition delay, both `transitionrun` and `transitionstart` are fired at the same time.
   */
-  onTransitionRun = (event: TransitionEvent): void => {
+  transitionRunHandler = (event: TransitionEvent): void => {
     if (event.propertyName === this.activeTransitionProp) {
-      this.active
-        ? this.openCloseEventEmitter("beforeOpen")
-        : this.openCloseEventEmitter("beforeClose");
+      this.active ? this.emitOpenCloseEvent("beforeOpen") : this.emitOpenCloseEvent("beforeClose");
     }
   };
 
-  private openCloseEventEmitter(componentVisibilityState: string): void {
+  private emitOpenCloseEvent(componentVisibilityState: string): void {
     const payload = {
       el: this.el
     };
@@ -618,7 +616,7 @@ export class Combobox implements LabelableComponent, FormComponent, InteractiveC
   setListContainerEl = (el: HTMLDivElement): void => {
     this.resizeObserver.observe(el);
     this.listContainerEl = el;
-    this.listContainerEl.addEventListener("transitionrun", this.onTransitionRun);
+    this.listContainerEl.addEventListener("transitionrun", this.transitionRunHandler);
   };
 
   setReferenceEl = (el: HTMLDivElement): void => {


### PR DESCRIPTION
**Related Issue:** #4689 

Small follow-up: rename functions to be more explicit that it is a handler function as opposed to an event.


