### PR TITLE
fix(input): set the default numbering system for arab languages to latin

### DIFF
--- a/src/components/input/input.stories.ts
+++ b/src/components/input/input.stories.ts
@@ -275,6 +275,6 @@ export const HebrewNumberingSystem = (): string =>
   html` <calcite-input type="number" locale="ar-EG" numbering-system="hebr" value="123456"></calcite-input>`;
 
 export const ArabicLocaleWithLatinNumberingSystem = (): string =>
-  html` <calcite-input type="number" locale="ar-EG" numbering-system="latn" value="123456"></calcite-input>`;
+  html` <calcite-input type="number" locale="ar-EG" value="123456"></calcite-input>`;
 
 export const disabled = (): string => html`<calcite-input disabled value="disabled"></calcite-input>`;

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -55,7 +55,9 @@ export const locales = [
 const allDecimalsExceptLast = new RegExp(`[.](?=.*[.])`, "g");
 const everythingExceptNumbersDecimalsAndMinusSigns = new RegExp("[^0-9-.]", "g");
 const defaultGroupSeparator = new RegExp(",", "g");
-const defaultNumberingSystem = new Intl.NumberFormat().resolvedOptions().numberingSystem;
+
+const browserNumberingSystem = new Intl.NumberFormat().resolvedOptions().numberingSystem;
+const defaultNumberingSystem = browserNumberingSystem === "arab" ? "latn" : browserNumberingSystem;
 
 export function createLocaleNumberFormatter(
   locale: string,


### PR DESCRIPTION
**Related Issue:** #3079

## Summary
Sets the default numbering system for arab languages to latin. This is for browser consistency so that Firefox behaves like Chrome and Safari. According to the locale team, this is what our arab users want and it is the way other esri products do it, including the JSAPI team.

Users can still use the arab numbering system like:
```html
<calcite-input numbering-system="arab" type="number" value="5"></calcite-input>
```
<!--
Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
