### PR TITLE
fix: Enter key should submit forms in Safari

### DIFF
--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -139,7 +139,13 @@ function hasRegisteredFormComponentParent(
  * @param component
  */
 export function submitForm(component: FormOwner): void {
-  component.formEl?.requestSubmit();
+  const { formEl } = component;
+
+  if (!formEl) {
+    return;
+  }
+
+  "requestSubmit" in formEl ? formEl.requestSubmit() : formEl.submit();
 }
 
 /**


### PR DESCRIPTION
**Related Issue:** #4793

## Summary

fix: Enter key should submit forms in Safari (#4793)