### PR TITLE
feat(input): add selectText method

### DIFF
--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1142,6 +1142,19 @@ describe("calcite-input", () => {
     expect(await element.getProperty("value")).toBe("-1.0001");
   });
 
+  it(`Using the select method selects all text`, async () => {
+    const value = "-98.76";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input type="number" value="123.45"></calcite-input>`);
+    const element = await page.find("calcite-input");
+    // overwrite initial value by selecting and typing
+    await element.callMethod("selectText");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, value);
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe(value);
+  });
+
   it(`allows clearing value for type=number`, async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number" value="1"></calcite-input>`);

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -407,6 +407,15 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
     }
   }
 
+  /** Selects all text of the component's `value`. */
+  @Method()
+  async selectText(): Promise<void> {
+    if (this.type === "number") {
+      this.childNumberEl?.select();
+    } else {
+      this.childEl?.select();
+    }
+  }
   //--------------------------------------------------------------------------
   //
   //  Private Methods


### PR DESCRIPTION
**Related Issue:** #3976

## Summary
Add `selectText` method which calls the native input's `select` method.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
