### PR TITLE
fix(color-picker): resize color field/hue slider canvas on scale change

### DIFF
--- a/src/components/color-picker/color-picker.stories.ts
+++ b/src/components/color-picker/color-picker.stories.ts
@@ -9,6 +9,7 @@ import {
 import colorReadme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { html } from "../../../support/formatting";
+import { createSteps, stepStory } from "../../../.storybook/helpers";
 
 export default {
   title: "Components/Controls/ColorPicker",
@@ -108,3 +109,10 @@ export const thumbsOnEdgeDoNotOverflowContainer = (): string => html`<div style=
 export const thumbsOnEdgeDoNotSnapToFrontOfContainer = (): string => html`<div style="overflow: auto; width: 272px;">
   <calcite-color-picker value="#824142"></calcite-color-picker>
 </div>`;
+
+export const colorFieldAndHueSliderAreResizedAfterScaleChange = stepStory(
+  (): string => html` <calcite-color-picker scale="m"></calcite-color-picker>`,
+  createSteps("calcite-color-picker")
+    .executeScript(`document.querySelector("calcite-color-picker").scale = "s"`)
+    .snapshot("Color field and hue slider are resized after scale change")
+);

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -249,6 +249,7 @@ export class ColorPicker implements InteractiveComponent {
   @Watch("scale")
   handleScaleChange(scale: Scale = "m"): void {
     this.updateDimensions(scale);
+    this.updateCanvasSize(this.fieldAndSliderRenderingContext?.canvas);
   }
 
   /**
@@ -1245,6 +1246,14 @@ export class ColorPicker implements InteractiveComponent {
 
   private initColorFieldAndSlider = (canvas: HTMLCanvasElement): void => {
     this.fieldAndSliderRenderingContext = canvas.getContext("2d");
+    this.updateCanvasSize(canvas);
+  };
+
+  private updateCanvasSize(canvas: HTMLCanvasElement) {
+    if (!canvas) {
+      return;
+    }
+
     this.setCanvasContextSize(canvas, {
       width: this.dimensions.colorField.width,
       height:
@@ -1254,7 +1263,7 @@ export class ColorPicker implements InteractiveComponent {
     });
 
     this.drawColorFieldAndSlider();
-  };
+  }
 
   private containsPoint(
     testPointX: number,


### PR DESCRIPTION
**Related Issue:** #4685 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This addresses an issue where the internal canvas (for color field and hue slider) would stay the same size as its initial scale.