### PR TITLE
fix(color-picker): update color-field and hue slider to work with both mouse/touch inputs

### DIFF
--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -453,9 +453,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("allows selecting colors via color field/slider", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker value='#000' scale='m'></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker value='#000' scale='m'></calcite-color-picker>");
     const picker = await page.find(`calcite-color-picker`);
     const spy = await picker.spyOnEvent("calciteColorPickerChange");
     let changes = 0;
@@ -498,13 +497,13 @@ describe("calcite-color-picker", () => {
 
     const expectedColorSamples = [
       "#ff0000",
-      "#ffdd00",
+      "#ffd900",
       "#48ff00",
       "#00ff91",
       "#0095ff",
       "#4800ff",
       "#ff00dd",
-      "#ff0000"
+      "#ff0004"
     ];
 
     for (let i = 0; i < expectedColorSamples.length; i++) {

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -124,6 +124,7 @@ $gap--large: 12px;
 
 .color-field-and-slider {
   margin-bottom: -16px;
+  touch-action: none;
 
   &--interactive {
     cursor: pointer;

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -537,7 +537,7 @@ export class ColorPicker implements InteractiveComponent {
     }
   };
 
-  private handleColorFieldAndSliderMouseLeave = (): void => {
+  private handleColorFieldAndSliderPointerLeave = (): void => {
     this.colorFieldAndSliderInteractive = false;
     this.colorFieldAndSliderHovered = false;
 
@@ -548,7 +548,7 @@ export class ColorPicker implements InteractiveComponent {
     }
   };
 
-  private handleColorFieldAndSliderMouseDown = (event: MouseEvent): void => {
+  private handleColorFieldAndSliderPointerDown = (event: PointerEvent): void => {
     const { offsetX, offsetY } = event;
     const region = this.getCanvasRegion(offsetY);
 
@@ -565,14 +565,14 @@ export class ColorPicker implements InteractiveComponent {
     // prevent text selection outside of color field & slider area
     event.preventDefault();
 
-    document.addEventListener("mousemove", this.globalMouseMoveHandler);
-    document.addEventListener("mouseup", this.globalMouseUpHandler, { once: true });
+    document.addEventListener("pointermove", this.globalPointerMoveHandler);
+    document.addEventListener("pointerup", this.globalPointerUpHandler, { once: true });
 
     this.activeColorFieldAndSliderRect =
       this.fieldAndSliderRenderingContext.canvas.getBoundingClientRect();
   };
 
-  private globalMouseUpHandler = (): void => {
+  private globalPointerUpHandler = (): void => {
     const previouslyDragging = this.sliderThumbState === "drag" || this.hueThumbState === "drag";
 
     this.hueThumbState = "idle";
@@ -585,7 +585,7 @@ export class ColorPicker implements InteractiveComponent {
     }
   };
 
-  private globalMouseMoveHandler = (event: MouseEvent): void => {
+  private globalPointerMoveHandler = (event: PointerEvent): void => {
     const { el, dimensions } = this;
     const sliderThumbDragging = this.sliderThumbState === "drag";
     const hueThumbDragging = this.hueThumbState === "drag";
@@ -638,7 +638,10 @@ export class ColorPicker implements InteractiveComponent {
     }
   };
 
-  private handleColorFieldAndSliderMouseEnterOrMove = ({ offsetX, offsetY }: MouseEvent): void => {
+  private handleColorFieldAndSliderPointerEnterOrMove = ({
+    offsetX,
+    offsetY
+  }: PointerEvent): void => {
     const {
       dimensions: { colorField, slider, thumb }
     } = this;
@@ -754,8 +757,8 @@ export class ColorPicker implements InteractiveComponent {
   }
 
   disconnectedCallback(): void {
-    document.removeEventListener("mousemove", this.globalMouseMoveHandler);
-    document.removeEventListener("mouseup", this.globalMouseUpHandler);
+    document.removeEventListener("pointermove", this.globalPointerMoveHandler);
+    document.removeEventListener("pointerup", this.globalPointerUpHandler);
   }
 
   componentDidRender(): void {
@@ -808,10 +811,10 @@ export class ColorPicker implements InteractiveComponent {
               [CSS.colorFieldAndSlider]: true,
               [CSS.colorFieldAndSliderInteractive]: colorFieldAndSliderInteractive
             }}
-            onMouseDown={this.handleColorFieldAndSliderMouseDown}
-            onMouseEnter={this.handleColorFieldAndSliderMouseEnterOrMove}
-            onMouseLeave={this.handleColorFieldAndSliderMouseLeave}
-            onMouseMove={this.handleColorFieldAndSliderMouseEnterOrMove}
+            onPointerDown={this.handleColorFieldAndSliderPointerDown}
+            onPointerEnter={this.handleColorFieldAndSliderPointerEnterOrMove}
+            onPointerLeave={this.handleColorFieldAndSliderPointerLeave}
+            onPointerMove={this.handleColorFieldAndSliderPointerEnterOrMove}
             ref={this.initColorFieldAndSlider}
           />
           <div


### PR DESCRIPTION
**Related Issue:** #4171 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Switches mouse events to pointer events to improve interactivity regardless of input type.