### PR TITLE
fix(input): update number stepper buttons to work with both mouse/touch inputs

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -684,11 +684,11 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
     }, valueNudgeDelayInMs);
   };
 
-  private numberButtonMouseUpAndMouseOutHandler = (): void => {
+  private numberButtonPointerUpAndOutHandler = (): void => {
     window.clearInterval(this.nudgeNumberValueIntervalId);
   };
 
-  private numberButtonMouseDownHandler = (event: MouseEvent): void => {
+  private numberButtonPointerDownHandler = (event: PointerEvent): void => {
     event.preventDefault();
     const direction = (event.target as HTMLDivElement).dataset.adjustment as NumberNudgeDirection;
     this.nudgeNumberValue(direction, event);
@@ -887,9 +887,9 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
         }}
         data-adjustment="up"
         disabled={this.disabled || this.readOnly}
-        onMouseDown={this.numberButtonMouseDownHandler}
-        onMouseOut={this.numberButtonMouseUpAndMouseOutHandler}
-        onMouseUp={this.numberButtonMouseUpAndMouseOutHandler}
+        onPointerDown={this.numberButtonPointerDownHandler}
+        onPointerOut={this.numberButtonPointerUpAndOutHandler}
+        onPointerUp={this.numberButtonPointerUpAndOutHandler}
         tabIndex={-1}
         type="button"
       >
@@ -905,9 +905,9 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
         }}
         data-adjustment="down"
         disabled={this.disabled || this.readOnly}
-        onMouseDown={this.numberButtonMouseDownHandler}
-        onMouseOut={this.numberButtonMouseUpAndMouseOutHandler}
-        onMouseUp={this.numberButtonMouseUpAndMouseOutHandler}
+        onPointerDown={this.numberButtonPointerDownHandler}
+        onPointerOut={this.numberButtonPointerUpAndOutHandler}
+        onPointerUp={this.numberButtonPointerUpAndOutHandler}
         tabIndex={-1}
         type="button"
       >


### PR DESCRIPTION
**Related Issue:** #4172

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Switches mouse events to pointer events to improve interactivity regardless of input type.