### PR TITLE
fix(date-picker): update Thai locale to use Buddhist calendar

### DIFF
--- a/src/components/date-picker-month-header/resources.ts
+++ b/src/components/date-picker-month-header/resources.ts
@@ -1,0 +1,1 @@
+export const BUDDHIST_CALENDAR_YEAR_OFFSET = 543;

--- a/src/components/date-picker/assets/date-picker/nls/th.json
+++ b/src/components/date-picker/assets/date-picker/nls/th.json
@@ -1,5 +1,5 @@
 {
-  "default-calendar": "gregorian",
+  "default-calendar": "buddhist",
   "separator": "/",
   "unitOrder": "DD/MM/YYYY",
   "weekStart": 7,

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -215,4 +215,12 @@ export const Default = stepStory(
       })
     )
     .snapshot("ru locale")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--default",
+        knobs: [{ name: "locale", value: "th" }]
+      })
+    )
+    .snapshot("th locale (Buddhist calendar)")
 );

--- a/src/components/date-picker/utils.ts
+++ b/src/components/date-picker/utils.ts
@@ -7,7 +7,7 @@ import { locales } from "../../utils/locale";
  * @private
  */
 export interface DateLocaleData {
-  "default-calendar": "gregorian";
+  "default-calendar": "gregorian" | "buddhist";
   separator: string;
   unitOrder: string;
   weekStart: number;


### PR DESCRIPTION
**Related Issue:** #4571 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This PR updates the date picker to use the Buddhist calendar for the Thai locale. 

Additional locales may opt in simply by changing the default calendar in the locale metadata.