### PR TITLE
fix(radio-group): fix form reset for radio groups with initial selected item

### DIFF
--- a/src/components/radio-group/radio-group.e2e.ts
+++ b/src/components/radio-group/radio-group.e2e.ts
@@ -25,6 +25,22 @@ describe("calcite-radio-group", () => {
       { focusTarget: "child" }
     ));
 
+  it("sets value from selected item", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-radio-group>
+        <calcite-radio-group-item id="child-1" value="1" checked>one</calcite-radio-group-item>
+        <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+        <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+      </calcite-radio-group>
+    `);
+
+    const element = await page.find("calcite-radio-group");
+    const value = await element.getProperty("value");
+
+    expect(value).toBe("1");
+  });
+
   it("does not require an item to be checked", async () => {
     const page = await newE2EPage();
     await page.setContent(
@@ -310,15 +326,31 @@ describe("calcite-radio-group", () => {
       ));
   });
 
-  it("is form-associated", () =>
-    formAssociated(
-      html`
-        <calcite-radio-group>
-          <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
-          <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
-          <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
-        </calcite-radio-group>
-      `,
-      { testValue: "2" }
-    ));
+  describe("is form-associated", () => {
+    const formAssociatedOptions = { testValue: "2" };
+
+    it("unselected value", () =>
+      formAssociated(
+        html`
+          <calcite-radio-group>
+            <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-2" value="2">two</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+          </calcite-radio-group>
+        `,
+        formAssociatedOptions
+      ));
+
+    it("selected-value", () =>
+      formAssociated(
+        html`
+          <calcite-radio-group>
+            <calcite-radio-group-item id="child-1" value="1">one</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-2" value="2" checked>two</calcite-radio-group-item>
+            <calcite-radio-group-item id="child-3" value="3">three</calcite-radio-group-item>
+          </calcite-radio-group>
+        `,
+        formAssociatedOptions
+      ));
+  });
 });

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -1,22 +1,28 @@
 import {
-  Component,
-  Event,
-  h,
-  EventEmitter,
-  Listen,
-  Element,
-  Prop,
-  Watch,
-  Host,
   Build,
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
   Method,
-  VNode
+  Prop,
+  VNode,
+  Watch
 } from "@stencil/core";
 
 import { getElementDir } from "../../utils/dom";
 import { Layout, Scale, Width } from "../interfaces";
-import { LabelableComponent, connectLabel, disconnectLabel } from "../../utils/label";
-import { connectForm, disconnectForm, FormComponent, HiddenFormInputSlot } from "../../utils/form";
+import { connectLabel, disconnectLabel, LabelableComponent } from "../../utils/label";
+import {
+  afterConnectDefaultValueSet,
+  connectForm,
+  disconnectForm,
+  FormComponent,
+  HiddenFormInputSlot
+} from "../../utils/form";
 import { RadioAppearance } from "./interfaces";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
@@ -122,6 +128,10 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
     } else if (items[0]) {
       items[0].tabIndex = 0;
     }
+  }
+
+  componentDidLoad(): void {
+    afterConnectDefaultValueSet(this, this.value);
   }
 
   connectedCallback(): void {


### PR DESCRIPTION
**Related Issue:** #4662 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue where the radio group would not assign its default value properly.