### PR TITLE
docs(radio-group): mark selectedItem as read-only

### DIFF
--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -78,6 +78,8 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
 
   /**
    * The group's selected item.
+   *
+   * @readonly
    */
   @Prop({ mutable: true }) selectedItem: HTMLCalciteRadioGroupItemElement;
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This doc update makes the `selectedItem` consistent with similar props (e.g., `HTMLCalciteSelectElement#selectedOption`).