### PR TITLE
refactor: require defaultChecked prop for CheckableFormComponents

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -97,6 +97,8 @@ export class Checkbox implements LabelableComponent, CheckableFormCompoment, Int
 
   formEl: HTMLFormElement;
 
+  defaultChecked: boolean;
+
   defaultValue: Checkbox["checked"];
 
   toggleEl: HTMLDivElement;

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -116,6 +116,8 @@ export class RadioButton
 
   formEl: HTMLFormElement;
 
+  defaultChecked: boolean;
+
   defaultValue: RadioButton["value"];
 
   rootNode: HTMLElement;

--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -90,10 +90,8 @@ export interface CheckableFormCompoment<T = any> extends FormComponent<T> {
    * The initial checked value for this form component.
    *
    * When the form is reset, the checked property will be set to this value.
-   *
-   * @todo remove optional in follow-up PR
    */
-  defaultChecked?: boolean;
+  defaultChecked: boolean;
 }
 
 function isCheckable(component: FormComponent): component is CheckableFormCompoment {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Enforces a prop required by all checkable form components.