### PR TITLE
feat(input-number): create separate component for input type number

### DIFF
--- a/src/components/input-number/input-number.e2e.ts
+++ b/src/components/input-number/input-number.e2e.ts
@@ -1,0 +1,1306 @@
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import { defaults, disabled, focusable, formAssociated, labelable, reflects, renders } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
+import { letterKeys, numberKeys } from "../../utils/key";
+import { getDecimalSeparator, locales, localizeNumberString } from "../../utils/locale";
+import { getElementXY } from "../../tests/utils";
+import { KeyInput } from "puppeteer";
+
+describe("calcite-input-number", () => {
+  const delayFor2UpdatesInMs = 200;
+
+  /**
+   * This helper wraps number typing to work around test instability
+   *
+   * @param page
+   * @param numberAsText
+   */
+  async function typeNumberValue(page: E2EPage, numberAsText: string): Promise<void> {
+    await page.keyboard.type(numberAsText, numberAsText.length > 1 ? { delay: 100 } : undefined);
+  }
+
+  it("is labelable", async () => labelable("calcite-input-number"));
+
+  it("renders", () => renders("calcite-input-number", { display: "block" }));
+
+  it("reflects", async () =>
+    reflects("calcite-input-number", [
+      {
+        propertyName: "status",
+        value: "valid"
+      },
+      {
+        propertyName: "alignment",
+        value: "center"
+      },
+      {
+        propertyName: "numberButtonType",
+        value: "horizontal"
+      },
+      {
+        propertyName: "scale",
+        value: "s"
+      }
+    ]));
+
+  it("has defaults", async () =>
+    defaults("calcite-input-number", [
+      {
+        propertyName: "status",
+        defaultValue: "idle"
+      },
+      {
+        propertyName: "alignment",
+        defaultValue: "start"
+      },
+      {
+        propertyName: "numberButtonType",
+        defaultValue: "vertical"
+      },
+      {
+        propertyName: "scale",
+        defaultValue: "m"
+      },
+      {
+        propertyName: "value",
+        defaultValue: ""
+      }
+    ]));
+
+  it("can be disabled", () => disabled("calcite-input-number"));
+
+  it("inherits requested props when from wrapping calcite-label when props are provided", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-label status="invalid" scale="s">
+        Label text
+        <calcite-input-number></calcite-input-number>
+      </calcite-label>
+    `);
+
+    const deprecatedLabelStatusElement = await page.find("calcite-input-number");
+    expect(await deprecatedLabelStatusElement.getProperty("status")).toEqual("invalid");
+    expect(await deprecatedLabelStatusElement.getProperty("scale")).toEqual("s");
+  });
+
+  it("renders an icon when explicit Calcite UI is requested, and is a type without a default icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number icon="key"></calcite-input-number>`);
+
+    const icon = await page.find("calcite-input-number >>> .icon");
+    expect(icon).not.toBeNull();
+  });
+
+  it("does not render an icon when requested without an explicit Calcite UI, and is a type without a default icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number icon></calcite-input-number>`);
+
+    const icon = await page.find("calcite-input-number >>> .icon");
+    expect(icon).toBeNull();
+  });
+
+  it("renders number buttons in default vertical alignment", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+
+    const numberVerticalWrapper = await page.find("calcite-input-number >>> .number-button-wrapper");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='up']"
+    );
+
+    expect(numberVerticalWrapper).not.toBeNull();
+    expect(numberHorizontalItemDown).toBeNull();
+    expect(numberHorizontalItemUp).toBeNull();
+  });
+
+  it("renders number buttons in horizontal vertical alignment and number button type is horizontal", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number number-button-type="horizontal"></calcite-input-number>`);
+
+    const numberVerticalWrapper = await page.find("calcite-input-number >>> .number-button-wrapper");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='up']"
+    );
+
+    expect(numberVerticalWrapper).toBeNull();
+    expect(numberHorizontalItemDown).not.toBeNull();
+    expect(numberHorizontalItemUp).not.toBeNull();
+  });
+
+  it("does not render number buttons in default vertical alignment and read-only", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number read-only></calcite-input-number>`);
+
+    const numberVerticalWrapper = await page.find("calcite-input-number >>> .number-button-wrapper");
+
+    expect(numberVerticalWrapper).toBeNull();
+  });
+
+  it("does not render number buttons in horizontal alignment, number button type is horizontal, and read-only", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-input-number number-button-type="horizontal" read-only></calcite-input-number>`
+    );
+
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='up']"
+    );
+
+    expect(numberHorizontalItemDown).toBeNull();
+    expect(numberHorizontalItemUp).toBeNull();
+  });
+
+  it("renders no buttons in type=number and number button type is none", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number number-button-type="none"></calcite-input-number>`);
+
+    const numberVerticalWrapper = await page.find("calcite-input-number >>> .number-button-wrapper");
+    const numberHorizontalItemDown = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='down']"
+    );
+    const numberHorizontalItemUp = await page.find(
+      "calcite-input-number >>> .number-button-item--horizontal[data-adjustment='up']"
+    );
+
+    expect(numberVerticalWrapper).toBeNull();
+    expect(numberHorizontalItemDown).toBeNull();
+    expect(numberHorizontalItemUp).toBeNull();
+  });
+
+  it("is focusable", async () =>
+    focusable(`calcite-input-number`, {
+      shadowFocusTargetSelector: "input"
+    }));
+
+  describe("input type number increment/decrement functionality", () => {
+    let page: E2EPage;
+    beforeEach(async () => {
+      page = await newE2EPage();
+    });
+
+    it("correctly increments and decrements decimal value when number buttons are clicked and the step precision matches the precision of the initial value", async () => {
+      await page.setContent(html`<calcite-input-number value="3.123" step="0.001"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+      expect(await element.getProperty("value")).toBe("3.123");
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("3.122");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("3.123");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("3.124");
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      expect(await element.getProperty("value")).toBe("3.134");
+    });
+
+    it("correctly increments and decrements initial decimal value by 1 when number buttons are clicked and step is set to default of 1.", async () => {
+      await page.setContent(html`<calcite-input-number value="3.123"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+      expect(await element.getProperty("value")).toBe("3.123");
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("2.123");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("3.123");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("4.123");
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      await numberHorizontalItemUp.click();
+      expect(await element.getProperty("value")).toBe("14.123");
+    });
+
+    it("correctly increments and decrements value when number buttons are clicked and step is set to an integer", async () => {
+      await page.setContent(html`<calcite-input-number step="10" value="15"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("5");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("15");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("25");
+    });
+
+    it("correctly increments and decrements on long hold on mousedown and step is set to a decimal", async () => {
+      await page.setContent(html`<calcite-input-number value="0" step="0.01"></calcite-input-number>`);
+      const input = await page.find("calcite-input-number");
+      const [buttonUpLocationX, buttonUpLocationY] = await getElementXY(
+        page,
+        "calcite-input-number",
+        ".number-button-item[data-adjustment='up']"
+      );
+
+      const inputEventSpy = await input.spyOnEvent("calciteInputNumberInput");
+      await page.mouse.move(buttonUpLocationX, buttonUpLocationY);
+      await page.mouse.down();
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.mouse.up();
+      await page.waitForChanges();
+      const totalNudgesUp = inputEventSpy.length;
+      expect(await input.getProperty("value")).toBe(`0.0${totalNudgesUp}`);
+
+      const [buttonDownLocationX, buttonDownLocationY] = await getElementXY(
+        page,
+        "calcite-input-number",
+        ".number-button-item[data-adjustment='down']"
+      );
+
+      await page.mouse.move(buttonDownLocationX, buttonDownLocationY);
+      await page.mouse.down();
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.mouse.up();
+      await page.waitForChanges();
+      const totalNudgesDown = inputEventSpy.length - totalNudgesUp;
+      const finalNudgedValue = totalNudgesUp - totalNudgesDown;
+      expect(await input.getProperty("value")).toBe(finalNudgedValue === 0 ? "0" : `0.0${finalNudgedValue}`);
+    });
+
+    it("correctly increments and decrements value by one when any is set for step", async () => {
+      await page.setContent(html`<calcite-input-number step="any" value="5.5"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("4.5");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("5.5");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("6.5");
+    });
+
+    it("correctly increments and decrements value by one when step is undefined", async () => {
+      await page.setContent(html`<calcite-input-number value="5"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("4");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("5");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("6");
+    });
+
+    it("correctly stops decrementing value when min is set", async () => {
+      await page.setContent(html`<calcite-input-number min="10" value="11"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("10");
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("10");
+    });
+
+    it("correctly stops incrementing value when max is set", async () => {
+      await page.setContent(html`<calcite-input-number max="10" value="9"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("10");
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("10");
+    });
+
+    it("should emit event when up or down clicked on input", async () => {
+      await page.setContent(html`<calcite-input-number max="0" value="-2"></calcite-input-number>`);
+
+      const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+
+      const numberHorizontalItemUp = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='up']"
+      );
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
+      await numberHorizontalItemUp.click();
+      await page.waitForChanges();
+
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(1);
+
+      const numberHorizontalItemDown = await page.find(
+        "calcite-input-number >>> .number-button-item[data-adjustment='down']"
+      );
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(2);
+
+      await numberHorizontalItemDown.click();
+      await page.waitForChanges();
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(3);
+    });
+
+    it("on input type number, should emit an event on an interval when ArrowUp/ArrowDown keys are down and stop on key up", async () => {
+      await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
+      const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+      const input = await page.find("calcite-input-number");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
+      await input.callMethod("setFocus");
+
+      await page.keyboard.down("ArrowUp");
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.waitForEvent("calciteInputNumberInput");
+      await page.keyboard.up("ArrowUp");
+      await page.waitForChanges();
+
+      const totalNudgesUp = calciteInputNumberInput.length;
+      expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
+
+      await page.keyboard.down("ArrowDown");
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.keyboard.up("ArrowDown");
+      await page.waitForChanges();
+
+      const totalNudgesDown = calciteInputNumberInput.length - totalNudgesUp;
+      const finalNudgedValue = totalNudgesUp - totalNudgesDown;
+      expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
+    });
+
+    it("should emit an event on an interval when up/down buttons are down and stop on mouseup/mouseleave", async () => {
+      await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
+      const input = await page.find("calcite-input-number");
+      const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+      const [buttonUpLocationX, buttonUpLocationY] = await getElementXY(
+        page,
+        "calcite-input-number",
+        ".number-button-item[data-adjustment='up']"
+      );
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
+      await page.mouse.move(buttonUpLocationX, buttonUpLocationY);
+      await page.mouse.down();
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.mouse.up();
+      await page.waitForChanges();
+      let totalNudgesUp = calciteInputNumberInput.length;
+      expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
+
+      await page.mouse.down();
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.mouse.move(buttonUpLocationX - 1, buttonUpLocationY - 1);
+
+      totalNudgesUp = calciteInputNumberInput.length;
+      expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
+
+      // assert changes no longer emitted after moving away from stepper
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
+      await page.mouse.up(); // mouseleave assertion done, we release
+
+      const [buttonDownLocationX, buttonDownLocationY] = await getElementXY(
+        page,
+        "calcite-input-number",
+        ".number-button-item[data-adjustment='down']"
+      );
+
+      await page.mouse.move(buttonDownLocationX, buttonDownLocationY);
+      await page.mouse.down();
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      let totalNudgesDown = calciteInputNumberInput.length - totalNudgesUp;
+      let finalNudgedValue = totalNudgesUp - totalNudgesDown;
+      expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
+
+      await page.mouse.down();
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      await page.mouse.move(buttonDownLocationX - 1, buttonDownLocationY - 1);
+
+      totalNudgesDown = calciteInputNumberInput.length - totalNudgesUp;
+      finalNudgedValue = totalNudgesUp - totalNudgesDown;
+      expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
+
+      // assert changes no longer emitted after moving away from stepper
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
+    });
+
+    it("on input type number, when both 'ArrowUp' and 'ArrowDown' are pressed at the same time most recently pressed key takes over", async () => {
+      await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+
+      const arrowUpDown = page.keyboard.down("ArrowUp");
+      const arrowDownDown = page.keyboard.down("ArrowDown");
+      await Promise.all([arrowUpDown, arrowDownDown]);
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+      expect(await element.getProperty("value")).toBe("-1");
+    });
+
+    it("on input type number, should emit event only twice when toggled fast between up/down arrows", async () => {
+      await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
+      const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+
+      const arrowUpDown = page.keyboard.down("ArrowUp");
+      const arrowUpUp = page.keyboard.up("ArrowUp");
+      const arrowDownDown = page.keyboard.down("ArrowDown");
+      const arrowDownUp = page.keyboard.up("ArrowDown");
+      await Promise.all([arrowUpDown, arrowUpUp, arrowDownDown, arrowDownUp]);
+      await page.waitForChanges();
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(2);
+    });
+
+    it("up/down arrow keys increments and decrements correctly when the step is a decimal", async () => {
+      await page.setContent(html`<calcite-input-number step="0.1"></calcite-input-number> `);
+      const input = await page.find("calcite-input-number");
+      await input.callMethod("setFocus");
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0.1");
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0.2");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0.1");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("0");
+    });
+
+    it("up/down arrow keys increments and decrements correctly when the step is an integer and the value is a decimal", async () => {
+      await page.setContent(html`<calcite-input-number step="5" value="1.008"></calcite-input-number>`);
+      const input = await page.find("calcite-input-number");
+      await input.callMethod("setFocus");
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("6.008");
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("11.008");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("6.008");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("1.008");
+    });
+  });
+
+  describe("direct changes to the value", () => {
+    let page: E2EPage;
+    beforeEach(async () => {
+      page = await newE2EPage();
+    });
+
+    it("incrementing correctly updates the value after focus and blur events", async () => {
+      await page.setContent(html`<calcite-input-number value="1"></calcite-input-number>`);
+      const element = await page.find("calcite-input-number");
+      await element.click();
+      await page.waitForChanges;
+      await element.callMethod("blur");
+      await page.waitForChanges;
+      element.setProperty("value", "2");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("2");
+      const input = await page.find("calcite-input-number >>> input");
+      expect(await input.getProperty("value")).toBe("2");
+    });
+  });
+
+  describe("emits events when value is modified", () => {
+    type CodeBranchingTypes = "number";
+
+    async function assertChangeEvents(type: CodeBranchingTypes): Promise<void> {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number type="${type}"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      const calciteInputNumberInput = await element.spyOnEvent("calciteInputNumberInput");
+      const calciteInputNumberChange = await element.spyOnEvent("calciteInputNumberChange");
+
+      const inputFirstPart = "12345";
+      await element.callMethod("setFocus");
+      await typeNumberValue(page, inputFirstPart);
+      expect(await element.getProperty("value")).toBe(inputFirstPart);
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(5);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(0);
+
+      await element.callMethod("setFocus");
+      await page.keyboard.press("Enter");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(5);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
+
+      await element.callMethod("setFocus");
+      await page.keyboard.press("Enter");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(5);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
+
+      const textSecondPart = "67890";
+      await element.callMethod("setFocus");
+      await typeNumberValue(page, textSecondPart);
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
+
+      await element.callMethod("setFocus");
+      await page.keyboard.press("Tab");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
+      expect(await element.getProperty("value")).toBe(`${inputFirstPart}${textSecondPart}`);
+
+      await element.callMethod("setFocus");
+      await page.keyboard.press("Tab");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
+      expect(await element.getProperty("value")).toBe(`${inputFirstPart}${textSecondPart}`);
+
+      const programmaticSetValue = "1337";
+      element.setProperty("value", programmaticSetValue);
+      await page.waitForChanges();
+
+      expect(await element.getProperty("value")).toBe(programmaticSetValue);
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
+    }
+
+    it("emits when type is number", () => assertChangeEvents("number"));
+  });
+
+  it("number input value stays in sync when value property is controlled with javascript", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+    const calciteInput = await page.find("calcite-input-number");
+    const input = await page.find("calcite-input-number >>> input");
+
+    await page.evaluate(() => {
+      document
+        .querySelector("calcite-input-number")
+        .addEventListener("calciteInputNumberInput", (event: InputEvent): void => {
+          const target = event.target as HTMLInputElement;
+          target.value = "5";
+        });
+    });
+
+    await calciteInput.click();
+    await typeNumberValue(page, "1");
+    await page.waitForChanges();
+
+    expect(await calciteInput.getProperty("value")).toBe("5");
+    expect(await input.getProperty("value")).toBe("5");
+
+    await typeNumberValue(page, "2");
+    await page.waitForChanges();
+
+    expect(await calciteInput.getProperty("value")).toBe("5");
+    expect(await input.getProperty("value")).toBe("5");
+  });
+
+  describe("number type", () => {
+    it("doesn't round numbers larger than double-precision floating-point", async () => {
+      const preciseNumber = "4.9999999999999999";
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number value=${preciseNumber}></calcite-input-number>`);
+      const element = await page.find("calcite-input-number");
+      expect(await element.getProperty("value")).toBe(preciseNumber);
+    });
+
+    it("allows typing negative decimal values", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+      await page.waitForChanges();
+      await typeNumberValue(page, "-");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("");
+      await typeNumberValue(page, "0.001");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("-0.001");
+    });
+
+    it("allows exponential number format", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+      await page.waitForChanges();
+      await typeNumberValue(page, "1.2e5");
+      await page.waitForChanges();
+      expect(Number(await element.getProperty("value"))).toBe(120000);
+
+      await page.keyboard.press("ArrowLeft");
+      await page.waitForChanges();
+      typeNumberValue(page, "-");
+      await page.waitForChanges();
+      expect(Number(await element.getProperty("value"))).toBe(0.000012);
+    });
+
+    it("sanitizes numbers when using exponential format", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+      await page.waitForChanges();
+      await typeNumberValue(page, "------000005eeee00005----eee");
+      await page.waitForChanges();
+      expect(await element.getProperty("value")).toBe("-5e5");
+      expect(Number(await element.getProperty("value"))).toBe(-500000);
+    });
+
+    it("increments correctly with exponential numbers", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+      await page.waitForChanges();
+      await typeNumberValue(page, "2e-2");
+      await page.waitForChanges();
+      expect(Number(await element.getProperty("value"))).toBe(0.02);
+      await page.waitForChanges();
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+      expect(Number(await element.getProperty("value"))).toBe(1.02);
+    });
+
+    it("decrements correctly with exponential numbers", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number step="5"></calcite-input-number>`);
+
+      const element = await page.find("calcite-input-number");
+      await element.callMethod("setFocus");
+      await page.waitForChanges();
+      await typeNumberValue(page, "2e2");
+      await page.waitForChanges();
+      expect(Number(await element.getProperty("value"))).toBe(200);
+      await page.waitForChanges();
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+      expect(Number(await element.getProperty("value"))).toBe(195);
+    });
+
+    it("disallows typing any letter or number with shift modifier key down", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+      const calciteInput = await page.find("calcite-input-number");
+      const input = await page.find("calcite-input-number >>> input");
+      await calciteInput.callMethod("setFocus");
+
+      for (let i = 0; i < numberKeys.length; i++) {
+        await page.keyboard.down("Shift");
+        await page.keyboard.press(numberKeys[i] as KeyInput);
+        await page.keyboard.up("Shift");
+        expect(await calciteInput.getProperty("value")).toBeFalsy();
+        expect(await input.getProperty("value")).toBeFalsy();
+      }
+      const nonELetterKeys = letterKeys.filter((key) => key !== "e");
+      for (let i = 0; i < nonELetterKeys.length; i++) {
+        await page.keyboard.down("Shift");
+        await page.keyboard.press(nonELetterKeys[i] as KeyInput);
+        await page.keyboard.up("Shift");
+        expect(await calciteInput.getProperty("value")).toBeFalsy();
+        expect(await input.getProperty("value")).toBeFalsy();
+      }
+    });
+
+    it("allows shift tabbing", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-input-number id="input1" label="one"></calcite-input-number>
+        <calcite-input-number id="input2" label="two"></calcite-input-number>
+      `);
+      const calciteInput2 = await page.find("#input2");
+      await calciteInput2.callMethod("setFocus");
+      expect(await page.evaluate(() => document.activeElement.getAttribute("label"))).toEqual("two");
+      await page.keyboard.down("Shift");
+      await page.keyboard.press("Tab");
+      expect(await page.evaluate(() => document.activeElement.getAttribute("label"))).toEqual("one");
+    });
+
+    it("typing zero and then a non-zero number sets and emits the non-zero number", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+      const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+      const calciteInput = await page.find("calcite-input-number");
+
+      await calciteInput.callMethod("setFocus");
+
+      await page.keyboard.press("0");
+      await page.waitForChanges();
+
+      expect(await calciteInput.getProperty("value")).toBe("0");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(1);
+
+      await page.keyboard.press("1");
+      await page.waitForChanges();
+
+      expect(await calciteInput.getProperty("value")).toBe("1");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(2);
+    });
+
+    it("allows any valid number", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
+      const input = await page.find("calcite-input-number");
+      await input.callMethod("setFocus");
+      await typeNumberValue(page, "1.005");
+      await page.waitForChanges();
+
+      expect(await input.getProperty("value")).toBe("1.005");
+    });
+
+    it("allows clearing value with an empty string", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-number value="1"></calcite-input-number>`);
+      const input = await page.find("calcite-input-number");
+      input.setProperty("value", "");
+      await page.waitForChanges();
+      expect(await input.getProperty("value")).toBe("");
+    });
+  });
+
+  describe("number locale support", () => {
+    // "nb" and "es-MX" locales skipped per: https://github.com/Esri/calcite-components/issues/2323
+    const localesWithIssues = ["ar", "bs", "mk", "nb", "es-MX"];
+    locales
+      .filter((locale) => !localesWithIssues.includes(locale))
+      .forEach((locale) => {
+        it(`displays decimal separator on initial load for ${locale} locale`, async () => {
+          const value = "1234.56";
+          const page = await newE2EPage();
+          await page.setContent(
+            html`<calcite-input-number locale="${locale}" value="${value}"></calcite-input-number>`
+          );
+          const calciteInput = await page.find("calcite-input-number");
+          const input = await page.find("calcite-input-number >>> input");
+
+          expect(await calciteInput.getProperty("value")).toBe(value);
+          expect(await input.getProperty("value")).toBe(localizeNumberString(value, locale));
+        });
+
+        it(`displays group and decimal separator on initial load for ${locale} locale using opt-in prop`, async () => {
+          const value = "1234.56";
+          const page = await newE2EPage();
+          await page.setContent(
+            html`<calcite-input-number locale="${locale}" value="${value}" group-separator></calcite-input-number>`
+          );
+          const calciteInput = await page.find("calcite-input-number");
+          const input = await page.find("calcite-input-number >>> input");
+
+          expect(await calciteInput.getProperty("value")).toBe(value);
+          expect(await input.getProperty("value")).toBe(localizeNumberString(value, locale, true));
+        });
+
+        it(`allows typing valid decimal characters for ${locale} locale`, async () => {
+          const page = await newE2EPage();
+          await page.setContent(html`<calcite-input-number locale="${locale}"></calcite-input-number>`);
+          const calciteInput = await page.find("calcite-input-number");
+          const input = await page.find("calcite-input-number >>> input");
+          const decimal = getDecimalSeparator(locale);
+          const unformattedValue = "1234.56";
+
+          await page.keyboard.press("Tab");
+          await typeNumberValue(page, "1234");
+          await page.keyboard.sendCharacter(decimal);
+          await input.press("5");
+          await input.press("6");
+
+          expect(await calciteInput.getProperty("value")).toBe(`1234.56`);
+          expect(await input.getProperty("value")).toBe(localizeNumberString(unformattedValue, locale));
+        });
+
+        it(`displays correct formatted value when using exponential numbers for ${locale} locale`, async () => {
+          const page = await newE2EPage();
+          await page.setContent(html`<calcite-input-number locale="${locale}"></calcite-input-number>`);
+
+          const calciteInput = await page.find("calcite-input-number");
+          const input = await page.find("calcite-input-number >>> input");
+          const decimal = getDecimalSeparator(locale);
+
+          await page.keyboard.press("Tab");
+          await page.waitForChanges();
+          await typeNumberValue(page, `1${decimal}5e-6`);
+          await page.waitForChanges();
+          expect(await calciteInput.getProperty("value")).toBe(`1.5e-6`);
+          expect(await input.getProperty("value")).toBe(localizeNumberString("1.5e-6", locale));
+        });
+
+        it(`displays correct formatted value when the value is changed programmatically for ${locale} locale`, async () => {
+          const page = await newE2EPage();
+          await page.setContent(
+            html`<calcite-input-number locale="${locale}"></calcite-input-number><input id="external" />`
+          );
+
+          await page.evaluate(() => {
+            const input = document.getElementById("external");
+            const calciteInput = document.querySelector("calcite-input-number");
+            input.addEventListener("input", (event: InputEvent): void => {
+              const value = (event.target as HTMLInputElement).value;
+              if (value.endsWith(".")) {
+                return;
+              }
+              calciteInput.value = value;
+            });
+          });
+
+          const assertedValue = "1234567.891011";
+          const externalInput = await page.find("#external");
+          const calciteInput = await page.find("calcite-input-number");
+          const internalLocaleInput = await page.find("calcite-input-number >>> input");
+
+          await externalInput.click();
+          await typeNumberValue(page, assertedValue);
+          await page.waitForChanges();
+
+          expect(await calciteInput.getProperty("value")).toBe(assertedValue);
+          expect(await internalLocaleInput.getProperty("value")).toBe(localizeNumberString(assertedValue, locale));
+        });
+      });
+  });
+
+  it(`allows negative, decimal numbers for ar locale`, async () => {
+    const value = "-0001.0001";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number locale="ar"></calcite-input-number>`);
+    const element = await page.find("calcite-input-number");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, value);
+    await page.waitForChanges();
+    await page.keyboard.press("Tab");
+    expect(await element.getProperty("value")).toBe("-1.0001");
+  });
+
+  it(`Using the select method selects all text`, async () => {
+    const value = "-98.76";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number value="123.45"></calcite-input-number>`);
+    const element = await page.find("calcite-input-number");
+    // overwrite initial value by selecting and typing
+    await element.callMethod("selectText");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, value);
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe(value);
+  });
+
+  it(`allows clearing value for type=number`, async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number value="1"></calcite-input-number>`);
+    const input = await page.find("calcite-input-number");
+
+    input.setProperty("value", null);
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("");
+
+    input.setProperty("value", undefined);
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("");
+  });
+
+  it(`disallows setting text value`, async () => {
+    const nonNumberValue = "i am a text value";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number value=${nonNumberValue}></calcite-input-number>`);
+    const calciteInput = await page.find("calcite-input-number");
+    const input = await page.find("calcite-input-number >>> input");
+
+    expect(await calciteInput.getProperty("value")).toBe("");
+    expect(await input.getProperty("value")).toBe("");
+
+    const numberValue = "1234";
+    calciteInput.setProperty("value", numberValue);
+    await page.waitForChanges();
+
+    expect(await calciteInput.getProperty("value")).toBe(numberValue);
+    expect(await input.getProperty("value")).toBe(numberValue);
+
+    calciteInput.setProperty("value", nonNumberValue);
+    await page.waitForChanges();
+
+    expect(await calciteInput.getProperty("value")).toBe(numberValue);
+    expect(await input.getProperty("value")).toBe(numberValue);
+  });
+
+  it(`disallows pasting just text characters with no initial value`, async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-input-number></calcite-input-number><input id="copy" value="invalid number" />`
+    );
+    const calciteInput = await page.find("calcite-input-number");
+    const input = await page.find("calcite-input-number >>> input");
+    const copyInput = await page.find("#copy");
+
+    expect(await calciteInput.getProperty("value")).toBe("");
+    expect(await input.getProperty("value")).toBe("");
+
+    await copyInput.focus();
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("a");
+    await page.keyboard.press("c");
+    await page.keyboard.up("Meta");
+
+    await calciteInput.callMethod("setFocus");
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("v");
+    await page.keyboard.up("Meta");
+
+    expect(await calciteInput.getProperty("value")).toBe("");
+    expect(await input.getProperty("value")).toBe("");
+  });
+
+  it(`disallows pasting just text characters with existing number value`, async () => {
+    const initialValue = "1234.56";
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-input-number value="1234.56"></calcite-input-number><input id="copy" value="invalid number" />`
+    );
+    const calciteInput = await page.find("calcite-input-number");
+    const input = await page.find("calcite-input-number >>> input");
+    const copyInput = await page.find("#copy");
+
+    expect(await calciteInput.getProperty("value")).toBe(initialValue);
+    expect(await input.getProperty("value")).toBe(initialValue);
+
+    await copyInput.focus();
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("a");
+    await page.keyboard.press("c");
+    await page.keyboard.up("Meta");
+
+    await calciteInput.callMethod("setFocus");
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("v");
+    await page.keyboard.up("Meta");
+
+    expect(await calciteInput.getProperty("value")).toBe(initialValue);
+    expect(await input.getProperty("value")).toBe(initialValue);
+  });
+
+  it(`disallows pasting just text characters with no initial value with group separator`, async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-input-number group-separator></calcite-input-number><input id="copy" value="invalid number" />`
+    );
+    const calciteInput = await page.find("calcite-input-number");
+    const input = await page.find("calcite-input-number >>> input");
+    const copyInput = await page.find("#copy");
+
+    expect(await calciteInput.getProperty("value")).toBe("");
+    expect(await input.getProperty("value")).toBe("");
+
+    await copyInput.focus();
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("a");
+    await page.keyboard.press("c");
+    await page.keyboard.up("Meta");
+
+    await calciteInput.callMethod("setFocus");
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("v");
+    await page.keyboard.up("Meta");
+
+    expect(await calciteInput.getProperty("value")).toBe("");
+    expect(await input.getProperty("value")).toBe("");
+  });
+
+  it(`disallows pasting just text characters with existing number value with group separator`, async () => {
+    const initialValue = "1234.56";
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-input-number value="1234.56" group-separator></calcite-input-number
+        ><input id="copy" value="invalid number" />`
+    );
+    const calciteInput = await page.find("calcite-input-number");
+    const input = await page.find("calcite-input-number >>> input");
+    const copyInput = await page.find("#copy");
+
+    expect(await calciteInput.getProperty("value")).toBe(initialValue);
+    expect(await input.getProperty("value")).toBe(localizeNumberString(initialValue, "en-US", true));
+
+    await copyInput.focus();
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("a");
+    await page.keyboard.press("c");
+    await page.keyboard.up("Meta");
+
+    await calciteInput.callMethod("setFocus");
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("v");
+    await page.keyboard.up("Meta");
+
+    expect(await calciteInput.getProperty("value")).toBe(initialValue);
+    expect(await input.getProperty("value")).toBe(localizeNumberString(initialValue, "en-US", true));
+  });
+
+  it("cannot be modified when readOnly is true", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number read-only value="123" clearable></calcite-input-number>`);
+
+    const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+    const element = await page.find("calcite-input-number");
+    expect(await element.getProperty("value")).toBe("123");
+    await element.callMethod("setFocus");
+
+    await page.keyboard.press("4");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("123");
+
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("123");
+    expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
+  });
+
+  it("number cannot be modified when readOnly is true", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number read-only value="5"></calcite-input-number>`);
+
+    const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+    const element = await page.find("calcite-input-number");
+    expect(await element.getProperty("value")).toBe("5");
+    await element.callMethod("setFocus");
+
+    await page.keyboard.press("ArrowUp");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("5");
+
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("5");
+    expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
+  });
+
+  it("sets internals to readOnly or disabled when readOnly is true", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number read-only></calcite-input-number>`);
+
+    const inputs = await page.findAll("calcite-input-number >>> input");
+
+    for (const input of inputs) {
+      expect(await input.getProperty("readOnly")).toBe(true);
+    }
+
+    const buttons = await page.findAll("calcite-input-number button");
+
+    for (const button of buttons) {
+      expect(await button.getProperty("disabled")).toBe(true);
+    }
+  });
+
+  it("input event fires when number ends with a decimal", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input-number value="1.2"></calcite-input-number>
+    `);
+
+    const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+    const element = await page.find("calcite-input-number");
+    expect(await element.getProperty("value")).toBe("1.2");
+    await element.callMethod("setFocus");
+
+    await page.keyboard.press("Backspace");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("1");
+    expect(calciteInputNumberInput).toHaveReceivedEventTimes(1);
+  });
+
+  it("sanitize leading zeros from number input value", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-input-number></calcite-input-number>
+    `);
+
+    const element = await page.find("calcite-input-number");
+    await element.callMethod("setFocus");
+    await typeNumberValue(page, "0000000");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("0");
+
+    await typeNumberValue(page, "1");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("1");
+
+    await typeNumberValue(page, "0000000");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("10000000");
+  });
+
+  it("sanitize extra dashes from number input value", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-input-number></calcite-input-number>`);
+
+    const element = await page.find("calcite-input-number");
+    await element.callMethod("setFocus");
+
+    await typeNumberValue(page, "1--2---3");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("123");
+
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.press("ArrowLeft");
+    await typeNumberValue(page, "----");
+    await page.waitForChanges();
+    expect(await element.getProperty("value")).toBe("-123");
+  });
+
+  describe("ArrowUp/ArrowDown function of moving caret to the beginning/end of text within calcite-input-number", () => {
+    let page: E2EPage;
+
+    const determineCaretIndex = (position?: number): Promise<boolean> => {
+      return page.evaluate((position) => {
+        const element = document.querySelector("calcite-input-number") as HTMLCalciteInputNumberElement;
+        const el = element.shadowRoot.querySelector("input");
+        return el.selectionStart === (position !== undefined ? position : el.value.length);
+      }, position);
+    };
+
+    beforeEach(async () => {
+      page = await newE2EPage();
+    });
+
+    it("should not work for type number, but increment instead", async () => {
+      await page.setContent(`<calcite-input-number></calcite-input-number>`);
+      const element = await page.find("calcite-input-number");
+
+      await element.callMethod("setFocus");
+      await page.keyboard.type("12345");
+      await page.waitForChanges();
+
+      await page.keyboard.press("ArrowUp");
+      await page.waitForChanges();
+
+      expect(await determineCaretIndex()).toBeTruthy();
+      expect(await element.getProperty("value")).toBe("12346");
+
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+
+      expect(await determineCaretIndex()).toBeTruthy();
+      expect(await element.getProperty("value")).toBe("12345");
+    });
+
+    it("does not jump to the beginning of input while incrementing on ArrowUp held down on input type number", async () => {
+      await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
+      let cursorHomeCount = 0;
+
+      await page.keyboard.down("ArrowUp");
+      await page.$eval(
+        "calcite-input-number",
+        (element: HTMLInputElement) => {
+          document.addEventListener("calciteInputNumberInput", async () => {
+            const input = element.shadowRoot.querySelector("input");
+            if (input.selectionStart === 0) {
+              cursorHomeCount++;
+            }
+          });
+        },
+        cursorHomeCount
+      );
+      await page.waitForTimeout(delayFor2UpdatesInMs);
+
+      await page.keyboard.up("ArrowUp");
+      await page.waitForChanges();
+
+      expect(cursorHomeCount).toBe(0);
+    });
+  });
+
+  it("is form-associated", () =>
+    formAssociated("<calcite-input-number></calcite-input-number>", {
+      testValue: 5,
+      submitsOnEnter: true
+    }));
+});

--- a/src/components/input-number/input-number.scss
+++ b/src/components/input-number/input-number.scss
@@ -1,0 +1,448 @@
+:host {
+  @apply block;
+}
+
+// scales
+:host([scale="s"]) {
+  & input,
+  & .prefix,
+  & .suffix {
+    @apply text-n2h h-6 px-2;
+  }
+  & .number-button-wrapper,
+  & .action-wrapper calcite-button,
+  & .action-wrapper calcite-button button {
+    @apply h-6;
+  }
+  & .clear-button {
+    min-height: theme("spacing.6");
+    min-width: theme("spacing.6");
+  }
+}
+
+:host([scale="m"]) {
+  & input,
+  & .prefix,
+  & .suffix {
+    @apply text-n1h h-8 px-3;
+  }
+  & .number-button-wrapper,
+  & .action-wrapper calcite-button,
+  & .action-wrapper calcite-button button {
+    @apply h-8;
+  }
+  & .clear-button {
+    min-height: theme("spacing.8");
+    min-width: theme("spacing.8");
+  }
+}
+
+:host([scale="l"]) {
+  & input,
+  & .prefix,
+  & .suffix {
+    @apply text-0h h-11 px-4;
+  }
+  & .number-button-wrapper,
+  & .action-wrapper calcite-button,
+  & .action-wrapper calcite-button button {
+    @apply h-11;
+  }
+  & .clear-button {
+    min-height: theme("spacing.11");
+    min-width: theme("spacing.11");
+  }
+}
+
+@include disabled();
+
+:host input {
+  transition: var(--calcite-animation-timing), height 0, outline-offset 0s;
+  -webkit-appearance: none;
+  @apply font-inherit
+    text-color-1
+    bg-foreground-1
+    relative
+    m-0
+    box-border
+    flex
+    max-h-full
+    w-full
+    max-w-full
+    flex-1
+    rounded-none
+    font-normal;
+}
+
+// states
+:host {
+  & input {
+    @apply text-color-1
+      border-color-input
+      border
+      border-solid;
+    &::placeholder,
+    &:-ms-input-placeholder,
+    &::-ms-input-placeholder {
+      @apply text-color-3 font-normal;
+    }
+  }
+  & input:focus {
+    @apply border-color-brand text-color-1;
+  }
+  & input[readonly] {
+    @apply bg-background font-medium;
+  }
+  & input[readonly]:focus {
+    @apply text-color-1;
+  }
+  & calcite-icon {
+    @apply text-color-3;
+  }
+}
+
+//focus
+:host input {
+  @apply focus-base;
+}
+
+:host input:focus {
+  @apply focus-inset;
+}
+
+:host([status="invalid"]) {
+  & input {
+    @apply border-color-danger;
+  }
+  & input:focus {
+    @apply focus-inset-danger;
+  }
+}
+
+// ICONS
+
+// position icons
+
+:host([scale="s"]) .icon {
+  inset-inline-start: theme("spacing.2");
+}
+
+:host([scale="m"]) .icon {
+  inset-inline-start: theme("spacing.3");
+}
+
+:host([scale="l"]) .icon {
+  inset-inline-start: theme("spacing.4");
+}
+
+// position placeholder/value text in relation to icons
+
+:host([icon][scale="s"]) input {
+  padding-inline-start: theme("padding.8");
+}
+
+:host([icon][scale="m"]) input {
+  padding-inline-start: theme("padding.10");
+}
+
+:host([icon][scale="l"]) input {
+  padding-inline-start: theme("padding.12");
+}
+
+// positioning wrapper for icon and loader
+
+.element-wrapper {
+  @apply relative
+    order-3
+    inline-flex
+    flex-1
+    items-center;
+}
+
+.icon {
+  @apply transition-default
+    pointer-events-none
+    absolute
+    z-10
+    block;
+}
+
+.clear-button {
+  pointer-events: initial;
+  @apply focus-base
+    border-color-input
+    bg-foreground-1
+    order-4
+    m-0
+    box-border
+    flex
+    min-h-full
+    cursor-pointer
+    items-center
+    justify-center
+    self-stretch
+    border
+    border-solid;
+
+  border-inline-start-width: theme("borderWidth.0");
+
+  &:hover {
+    @apply bg-foreground-2 transition-default;
+    calcite-icon {
+      @apply text-color-1 transition-default;
+    }
+  }
+  &:active {
+    @apply bg-foreground-3;
+    calcite-icon {
+      @apply text-color-1;
+    }
+  }
+  &:focus {
+    @apply focus-inset;
+  }
+  &:disabled {
+    @apply opacity-disabled;
+  }
+}
+
+// loading
+.loader {
+  top: 1px;
+  left: 1px;
+  right: 1px;
+  @apply pointer-events-none
+    absolute
+    block;
+}
+
+// slotted action
+.action-wrapper {
+  @apply order-7 flex;
+}
+
+// prefix and suffix
+.prefix,
+.suffix {
+  @apply border-color-input
+    bg-background
+    text-color-2
+    box-border
+    flex
+    h-auto
+    min-h-full
+    select-none
+    content-center
+    items-center
+    break-words
+    border
+    border-solid
+    font-medium
+    leading-none;
+}
+
+.prefix {
+  @apply order-2;
+  border-inline-end-width: theme("borderWidth.0");
+}
+.suffix {
+  @apply order-5;
+  border-inline-start-width: theme("borderWidth.0");
+}
+
+// alignment type
+:host([alignment="start"]) {
+  & input {
+    text-align: start;
+  }
+}
+
+:host([alignment="end"]) {
+  & input {
+    text-align: end;
+  }
+}
+
+:host input {
+  -moz-appearance: textfield;
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    -moz-appearance: textfield;
+    @apply m-0;
+  }
+}
+
+.number-button-wrapper {
+  @apply transition-default
+    pointer-events-none
+    order-6
+    box-border
+    flex
+    flex-col;
+}
+
+:host([number-button-type="vertical"]) .wrapper {
+  flex-direction: row;
+  display: flex;
+}
+
+:host([number-button-type="vertical"]) {
+  & input {
+    @apply order-2;
+  }
+}
+
+:host([number-button-type="horizontal"]) .calcite--rtl {
+  & .number-button-item[data-adjustment="down"] calcite-icon {
+    transform: rotate(-90deg);
+  }
+  & .number-button-item[data-adjustment="up"] calcite-icon {
+    transform: rotate(-90deg);
+  }
+}
+
+.number-button-item.number-button-item--horizontal {
+  &[data-adjustment="down"],
+  &[data-adjustment="up"] {
+    @apply order-1
+      max-h-full
+      min-h-full
+      self-stretch;
+    & calcite-icon {
+      transform: rotate(90deg);
+    }
+  }
+}
+
+.number-button-item.number-button-item--horizontal[data-adjustment="down"] {
+  @apply border-color-input
+    border
+    border-solid;
+  border-inline-end-width: theme("borderWidth.0");
+  &:hover {
+    @apply bg-foreground-2;
+    calcite-icon {
+      @apply text-color-1;
+    }
+  }
+}
+
+.number-button-item.number-button-item--horizontal[data-adjustment="up"] {
+  @apply order-5;
+  &:hover {
+    @apply bg-foreground-2;
+    calcite-icon {
+      @apply text-color-1;
+    }
+  }
+}
+
+:host([number-button-type="vertical"]) .number-button-item[data-adjustment="down"]:hover {
+  @apply bg-foreground-2;
+  calcite-icon {
+    @apply text-color-1;
+  }
+}
+
+:host([number-button-type="vertical"]) .number-button-item[data-adjustment="up"]:hover {
+  @apply bg-foreground-2;
+  calcite-icon {
+    @apply text-color-1;
+  }
+}
+
+:host([number-button-type="vertical"]) .number-button-item[data-adjustment="down"] {
+  @apply border-t-0;
+}
+
+.number-button-item {
+  max-height: 50%;
+  min-height: 50%;
+  pointer-events: initial;
+  @apply border-color-input
+    bg-foreground-1
+    transition-default
+    m-0
+    box-border
+    flex
+    cursor-pointer
+    items-center
+    self-center
+    border
+    border-solid
+    py-0
+    px-2;
+  border-inline-start-width: theme("borderWidth.0");
+  & calcite-icon {
+    @apply transition-default pointer-events-none;
+  }
+  &:focus {
+    @apply bg-foreground-2;
+    calcite-icon {
+      @apply text-color-1;
+    }
+  }
+  &:active {
+    @apply bg-foreground-3;
+  }
+}
+
+.wrapper {
+  @apply relative
+    flex
+    flex-row
+    items-center;
+}
+
+.resize-icon-wrapper {
+  bottom: 2px;
+  inset-inline-end: 2px;
+
+  @apply bg-foreground-1
+    text-color-3
+    pointer-events-none
+    absolute
+    z-10
+    h-3
+    w-3;
+
+  & calcite-icon {
+    bottom: theme("spacing.1");
+    inset-inline-end: theme("spacing.1");
+    transform: rotate(-45deg);
+  }
+}
+
+.calcite--rtl {
+  .resize-icon-wrapper {
+    & calcite-icon {
+      transform: rotate(45deg);
+    }
+  }
+}
+
+:host(.no-bottom-border) input {
+  @apply border-b-0;
+}
+
+:host(.border-top-color-one) input {
+  @apply border-t-color-1;
+}
+
+:host .inline-child {
+  @apply transition-default bg-transparent;
+  .editing-enabled {
+    background-color: inherit;
+  }
+}
+
+:host .inline-child:not(.editing-enabled) {
+  @apply border-color-transparent
+    flex
+    cursor-pointer;
+  padding-inline-start: 0;
+}
+
+@include hidden-form-input();

--- a/src/components/input-number/input-number.stories.ts
+++ b/src/components/input-number/input-number.stories.ts
@@ -5,7 +5,7 @@ import readme from "./readme.md";
 import { html } from "../../../support/formatting";
 
 export default {
-  title: "Components/Controls/Input",
+  title: "Components/Controls/Input Number",
   parameters: {
     notes: readme
   }

--- a/src/components/input-number/input-number.stories.ts
+++ b/src/components/input-number/input-number.stories.ts
@@ -1,0 +1,223 @@
+import { select, text, number } from "@storybook/addon-knobs";
+import { boolean, iconNames } from "../../../.storybook/helpers";
+import { themesDarkDefault } from "../../../.storybook/utils";
+import readme from "./readme.md";
+import { html } from "../../../support/formatting";
+
+export default {
+  title: "Components/Controls/Input",
+  parameters: {
+    notes: readme
+  }
+};
+
+export const WithLabel = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      for="input-with-label"
+    >
+      ${text("label text", "My great label")}
+      <calcite-input-number
+        id="input-with-label"
+        status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+        alignment="${select("alignment", ["start", "end"], "start")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "")}"
+        suffix-text="${text("suffix-text", "")}"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+      </calcite-input-number>
+      <calcite-input-message
+        ${boolean("input-message-active", false)}
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;
+
+export const WithLabelAndInputMessage = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      alignment="${select("alignment", ["start", "center", "end"], "start", "Label")}"
+      scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+      layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+      for="input-with-label-and-input-message"
+    >
+      ${text("label text", "My great label", "Label")}
+      <calcite-input-number
+        id="input-with-label-and-input-message"
+        status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
+        alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "", "Input")}"
+        suffix-text="${text("suffix-text", "", "Input")}"
+        ${boolean("loading", false)}
+        ${boolean("autofocus", false)}
+        ${boolean("required", false)}
+        value="${text("value", "", "Input")}"
+        placeholder="${text("placeholder", "Placeholder text", "Input")}"
+      >
+      </calcite-input-number>
+      <calcite-input-message
+        ${boolean("active", true)}
+        ${boolean("icon", false)}
+        icon="${select("icon", iconNames, "", "Input Message")}"
+        >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;
+
+WithLabelAndInputMessage.storyName = "With Label and Input Message";
+
+export const WithoutLabel = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-input-number
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+      alignment="${select("alignment", ["start", "end"], "start")}"
+      number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+      min="${number("min", 0)}"
+      max="${number("max", 100)}"
+      step="${number("step", 1)}"
+      prefix-text="${text("prefix-text", "")}"
+      suffix-text="${text("suffix-text", "")}"
+      ${boolean("loading", false)}
+      ${boolean("clearable", false)}
+      ${boolean("disabled", false)}
+      value="${text("value", "")}"
+      placeholder="${text("placeholder", "Placeholder text")}"
+    >
+    </calcite-input-number>
+  </div>
+`;
+
+export const WithSlottedAction = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      scale="${select("scale", ["s", "m", "l"], "m")}"
+      for="input-with-slotted-action"
+    >
+      ${text("label text", "My great label")}
+      <calcite-input-number
+        id="input-with-slotted-action"
+        status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+        alignment="${select("alignment", ["start", "end"], "start")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "")}"
+        suffix-text="${text("suffix-text", "")}"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+        <calcite-button slot="action">${text("action button text", "Go")}</calcite-button>
+      </calcite-input-number>
+      <calcite-input-message
+        ${boolean("input-message-active", false)}
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;
+
+export const SimpleDarkMode = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-label
+      class="calcite-theme-dark"
+      status="${select("status", ["idle", "valid", "invalid"], "idle")}"
+      for="input-dark-theme"
+    >
+      ${text("label text", "My great label")}
+      <calcite-input-number
+        id="input-dark-theme"
+        status="${select("status", ["idle", "invalid", "valid"], "idle")}"
+        alignment="${select("alignment", ["start", "end"], "start")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "")}"
+        suffix-text="${text("suffix-text", "")}"
+        ${boolean("loading", false)}
+        ${boolean("clearable", false)}
+        ${boolean("disabled", false)}
+        value="${text("value", "")}"
+        placeholder="${text("placeholder", "Placeholder text")}"
+      >
+      </calcite-input-number>
+      <calcite-input-message
+        ${boolean("calcite-input-message-active", false)}
+        status="${select("input message status", ["idle", "valid", "invalid"], "idle")}"
+        >${text("input message text", "My great input message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;
+
+SimpleDarkMode.storyName = "Simple - Dark mode";
+SimpleDarkMode.parameters = { themes: themesDarkDefault };
+
+export const WithLabelAndInputMessageRTL = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;" dir="rtl">
+    <calcite-label
+      status="${select("status", ["idle", "valid", "invalid"], "idle", "Label")}"
+      alignment="${select("alignment", ["start", "center", "end"], "start", "Label")}"
+      scale="${select("scale", ["s", "m", "l"], "m", "Label")}"
+      layout="${select("layout", ["default", "inline", "inline-space-between"], "default", "Label")}"
+      for="input-with-label-and-input-message-rtl"
+    >
+      ${text("label text", "My great label", "Label")}
+      <calcite-input-number
+        id="input-with-label-and-input-message-rtl"
+        status="${select("status", ["idle", "invalid", "valid"], "idle", "Input")}"
+        alignment="${select("alignment", ["start", "end"], "start", "Input")}"
+        number-button-type="${select("number-button-type", ["none", "horizontal", "vertical"], "horizontal", "Input")}"
+        min="${number("min", 0)}"
+        max="${number("max", 100)}"
+        step="${number("step", 1)}"
+        prefix-text="${text("prefix-text", "", "Input")}"
+        suffix-text="${text("suffix-text", "", "Input")}"
+        ${boolean("loading", false)}
+        ${boolean("autofocus", false)}
+        ${boolean("required", false)}
+        value="${text("value", "", "Input")}"
+        placeholder="${text("placeholder", "Placeholder text", "Input")}"
+      >
+      </calcite-input-number>
+      <calcite-input-message
+        ${boolean("active", true)}
+        ${boolean("icon", false)}
+        icon="${select("icon", iconNames, "", "Input Message")}"
+        >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
+      >
+    </calcite-label>
+  </div>
+`;
+
+export const HebrewNumberingSystem = (): string =>
+  html` <calcite-input-number locale="ar-EG" numbering-system="hebr" value="123456"></calcite-input-number>`;
+
+export const ArabicLocaleWithLatinNumberingSystem = (): string =>
+  html` <calcite-input-number locale="ar-EG" numbering-system="latn" value="123456"></calcite-input-number>`;

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -1,0 +1,884 @@
+import { Scale, Status } from "../interfaces";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Method,
+  Prop,
+  State,
+  VNode,
+  Watch
+} from "@stencil/core";
+import { getElementDir, getElementProp, getSlotted, setRequestedIcon } from "../../utils/dom";
+
+import { CSS, SLOTS, TEXT } from "./resources";
+import { InputPlacement } from "./interfaces";
+import { Position } from "../interfaces";
+import { LabelableComponent, connectLabel, disconnectLabel, getLabelText } from "../../utils/label";
+import {
+  connectForm,
+  disconnectForm,
+  FormComponent,
+  HiddenFormInputSlot,
+  submitForm
+} from "../../utils/form";
+import {
+  getDecimalSeparator,
+  delocalizeNumberString,
+  localizeNumberString
+} from "../../utils/locale";
+import { numberKeys } from "../../utils/key";
+import { isValidNumber, parseNumberString, sanitizeNumberString } from "../../utils/number";
+import { CSS_UTILITY, TEXT as COMMON_TEXT } from "../../utils/resources";
+import { decimalPlaces } from "../../utils/math";
+import { createObserver } from "../../utils/observers";
+import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
+
+type NumberNudgeDirection = "up" | "down";
+type SetValueOrigin = "initial" | "connected" | "user" | "reset" | "direct";
+
+/**
+ * @slot action - A slot for positioning a button next to the component.
+ */
+@Component({
+  tag: "calcite-input-number",
+  styleUrl: "input-number.scss",
+  shadow: true
+})
+export class InputNumber implements LabelableComponent, FormComponent, InteractiveComponent {
+  //--------------------------------------------------------------------------
+  //
+  //  Element
+  //
+  //--------------------------------------------------------------------------
+
+  @Element() el: HTMLCalciteInputNumberElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Properties
+  //
+  //--------------------------------------------------------------------------
+
+  /** Specifies the text alignment of the component's value. */
+  @Prop({ reflect: true }) alignment: Position = "start";
+
+  /**
+   * When true, the component is focused on page load.
+   *
+   * @mdn [autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
+   */
+  @Prop() autofocus = false;
+
+  /**
+   * When true, a clear button is displayed when the component has a value.
+   */
+  @Prop({ reflect: true }) clearable = false;
+
+  /**
+   * When true, interaction is prevented and the component is displayed with lower opacity.
+   *
+   * @mdn [disabled](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled)
+   */
+  @Prop({ reflect: true }) disabled = false;
+
+  @Watch("disabled")
+  disabledWatcher(): void {
+    this.setDisabledAction();
+  }
+
+  /**
+   * When true, number values are displayed with the locale's group separator.
+   */
+  @Prop() groupSeparator = false;
+
+  /**
+   * When true, the component will not be visible.
+   *
+   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+   */
+  @Prop() hidden = false;
+
+  /**
+   * When true, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
+   */
+  @Prop({ reflect: true }) icon: string | boolean;
+
+  /**
+   * A text label that will appear on the clear button for screen readers.
+   */
+  @Prop() intlClear?: string;
+
+  /**
+   * Accessible name that will appear while loading.
+   *
+   * @default "Loading"
+   */
+  @Prop() intlLoading?: string = COMMON_TEXT.loading;
+
+  /** When true, the icon is flipped in RTL. */
+  @Prop({ reflect: true }) iconFlipRtl = false;
+
+  /** Accessible name for the component's button or hyperlink. */
+  @Prop() label?: string;
+
+  /** When true, the component is in the loading state and `calcite-progress` is displayed. */
+  @Prop({ reflect: true }) loading = false;
+
+  /** Specifies the BCP 47 language tag for the desired language and country format. */
+  @Prop() locale: string = document.documentElement.lang || "en";
+
+  /**
+   * Specifies the Unicode numeral system used by the component for localization.
+   *
+   * @mdn [numberingSystem](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem)
+   */
+  @Prop() numberingSystem?: string;
+
+  /**
+   * Toggles locale formatting for numbers.
+   *
+   * @internal
+   */
+  @Prop() localeFormat = false;
+
+  /**
+   * Specifies the maximum value.
+   *
+   * @mdn [max](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#max)
+   */
+  @Prop({ reflect: true }) max?: number;
+
+  /** watcher to update number-to-string for max */
+  @Watch("max")
+  maxWatcher(): void {
+    this.maxString = this.max?.toString() || null;
+  }
+
+  /**
+   * Specifies the minimum value.
+   *
+   * @mdn [min](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#min)
+   */
+  @Prop({ reflect: true }) min?: number;
+
+  /** watcher to update number-to-string for min */
+  @Watch("min")
+  minWatcher(): void {
+    this.minString = this.min?.toString() || null;
+  }
+
+  /**
+   * Specifies the maximum length of text for the component's value.
+   *
+   * @deprecated use maxLength instead
+   */
+  @Prop({ reflect: true }) maxlength?: number;
+
+  /**
+   * Specifies the maximum length of text for the component's value.
+   *
+   * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
+   */
+  @Prop({ reflect: true }) maxLength?: number;
+
+  /**
+   * Specifies the minimum length of text for the component's value.
+   *
+   * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
+   */
+  @Prop({ reflect: true }) minLength?: number;
+
+  /**
+   * Specifies the name of the component.
+   *
+   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
+   */
+  @Prop({ reflect: true }) name: string;
+
+  /** Specifies the placement of the buttons. */
+  @Prop({ reflect: true }) numberButtonType?: InputPlacement = "vertical";
+
+  /**
+   * Specifies placeholder text for the component.
+   *
+   * @mdn [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#placeholder)
+   */
+  @Prop() placeholder: string;
+
+  /** Adds text to the start of the component. */
+  @Prop() prefixText?: string;
+
+  /**
+   * When true, the value cannot be modified.
+   *
+   * @mdn [readOnly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
+   */
+  @Prop() readOnly = false;
+
+  /** When true, the component must have a value in order for the form to submit. */
+  @Prop() required = false;
+
+  /** Specifies the size of the component. */
+  @Prop({ mutable: true, reflect: true }) scale: Scale = "m";
+
+  /** Specifies the status of the input field, which determines message and icons. */
+  @Prop({ mutable: true, reflect: true }) status: Status = "idle";
+
+  /**
+   * Specifies the granularity that the component's value must adhere to.
+   *
+   * @mdn [step](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step)
+   */
+  @Prop({ reflect: true }) step?: number | "any";
+
+  /** Adds text to the end of the component.  */
+  @Prop() suffixText?: string;
+
+  /**
+   * @internal
+   */
+  @Prop({ mutable: true, reflect: true }) editingEnabled = false;
+
+  /** The component's value. */
+  @Prop({ mutable: true }) value = "";
+
+  @Watch("value")
+  valueWatcher(newValue: string, previousValue: string): void {
+    if (!this.userChangedValue) {
+      this.setValue({
+        origin: "direct",
+        previousValue,
+        value:
+          newValue == null || newValue == ""
+            ? ""
+            : isValidNumber(newValue)
+            ? newValue
+            : this.previousValue || ""
+      });
+      this.warnAboutInvalidNumberValue(newValue);
+    }
+    this.userChangedValue = false;
+  }
+
+  @Watch("icon")
+  updateRequestedIcon(): void {
+    this.requestedIcon = setRequestedIcon({}, this.icon, "number");
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Private Properties
+  //
+  //--------------------------------------------------------------------------
+
+  labelEl: HTMLCalciteLabelElement;
+
+  formEl: HTMLFormElement;
+
+  defaultValue: InputNumber["value"];
+
+  inlineEditableEl: HTMLCalciteInlineEditableElement;
+
+  /** number text input element for locale */
+  private childNumberEl?: HTMLInputElement;
+
+  get isClearable(): boolean {
+    return this.clearable && this.value.length > 0;
+  }
+
+  private minString?: string;
+
+  private maxString?: string;
+
+  private previousEmittedValue: string;
+
+  private previousValue: string;
+
+  private previousValueOrigin: SetValueOrigin = "initial";
+
+  /** the computed icon to render */
+  private requestedIcon?: string;
+
+  private nudgeNumberValueIntervalId;
+
+  mutationObserver = createObserver("mutation", () => this.setDisabledAction());
+
+  private userChangedValue = false;
+
+  //--------------------------------------------------------------------------
+  //
+  //  State
+  //
+  //--------------------------------------------------------------------------
+
+  @State() localizedValue: string;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    this.scale = getElementProp(this.el, "scale", this.scale);
+    this.status = getElementProp(this.el, "status", this.status);
+    this.inlineEditableEl = this.el.closest("calcite-inline-editable");
+    if (this.inlineEditableEl) {
+      this.editingEnabled = this.inlineEditableEl.editingEnabled || false;
+    }
+    this.setPreviousEmittedValue(this.value);
+    this.setPreviousValue(this.value);
+
+    this.warnAboutInvalidNumberValue(this.value);
+    this.setValue({
+      origin: "connected",
+      value: isValidNumber(this.value) ? this.value : ""
+    });
+    connectLabel(this);
+    connectForm(this);
+    this.mutationObserver?.observe(this.el, { childList: true });
+    this.setDisabledAction();
+  }
+
+  disconnectedCallback(): void {
+    disconnectLabel(this);
+    disconnectForm(this);
+    this.mutationObserver?.disconnect();
+  }
+
+  componentWillLoad(): void {
+    this.maxString = this.max?.toString();
+    this.minString = this.min?.toString();
+    this.requestedIcon = setRequestedIcon({}, this.icon, "number");
+  }
+
+  componentShouldUpdate(newValue: string, oldValue: string, property: string): boolean {
+    if (property === "value" && newValue && !isValidNumber(newValue)) {
+      this.setValue({
+        origin: "reset",
+        value: oldValue
+      });
+      return false;
+    }
+    return true;
+  }
+
+  componentDidRender(): void {
+    updateHostInteraction(this);
+  }
+
+  //--------------------------------------------------------------------------
+  //
+  //  Events
+  //
+  //--------------------------------------------------------------------------
+
+  /**
+   * @internal
+   */
+  @Event() calciteInternalInputNumberFocus: EventEmitter;
+
+  /**
+   * @internal
+   */
+  @Event() calciteInternalInputNumberBlur: EventEmitter;
+
+  /**
+   * Fires each time a new value is typed.
+   */
+  @Event({ cancelable: true }) calciteInputNumberInput: EventEmitter;
+
+  /**
+   * Fires each time a new value is typed and committed.
+   */
+  @Event() calciteInputNumberChange: EventEmitter<void>;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Public Methods
+  //
+  //--------------------------------------------------------------------------
+
+  /** Sets focus on the component. */
+  @Method()
+  async setFocus(): Promise<void> {
+    this.childNumberEl?.focus();
+  }
+
+  /** Selects all text of the component's `value`. */
+  @Method()
+  async selectText(): Promise<void> {
+    this.childNumberEl?.select();
+  }
+  //--------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  //--------------------------------------------------------------------------
+
+  keyDownHandler = (event: KeyboardEvent): void => {
+    if (this.readOnly || this.disabled) {
+      return;
+    }
+    if (this.isClearable && event.key === "Escape") {
+      this.clearInputValue(event);
+      event.preventDefault();
+    }
+    if (event.key === "Enter" && !event.defaultPrevented) {
+      submitForm(this);
+    }
+  };
+
+  onLabelClick(): void {
+    this.setFocus();
+  }
+
+  incrementOrDecrementNumberValue(
+    direction: NumberNudgeDirection,
+    inputMax: number | null,
+    inputMin: number | null,
+    nativeEvent: KeyboardEvent | MouseEvent
+  ): void {
+    const { value } = this;
+    const inputStep = this.step === "any" ? 1 : Math.abs(this.step || 1);
+    const inputVal = value && value !== "" ? parseFloat(value) : 0;
+
+    const adjustment = direction === "up" ? 1 : -1;
+    const nudgedValue = inputVal + inputStep * adjustment;
+    const finalValue =
+      (typeof inputMin === "number" && !isNaN(inputMin) && nudgedValue < inputMin) ||
+      (typeof inputMax === "number" && !isNaN(inputMax) && nudgedValue > inputMax)
+        ? inputVal
+        : nudgedValue;
+
+    const inputValPlaces = decimalPlaces(inputVal);
+    const inputStepPlaces = decimalPlaces(inputStep);
+
+    this.setValue({
+      committing: true,
+      nativeEvent,
+      origin: "user",
+      value: finalValue.toFixed(Math.max(inputValPlaces, inputStepPlaces))
+    });
+  }
+
+  private clearInputValue = (nativeEvent: KeyboardEvent | MouseEvent): void => {
+    this.setValue({
+      committing: true,
+      nativeEvent,
+      origin: "user",
+      value: ""
+    });
+  };
+
+  private emitChangeIfUserModified = (): void => {
+    if (this.previousValueOrigin === "user" && this.value !== this.previousEmittedValue) {
+      this.calciteInputNumberChange.emit();
+    }
+    this.previousEmittedValue = this.value;
+  };
+
+  private inputBlurHandler = () => {
+    this.calciteInternalInputNumberBlur.emit({
+      element: this.childNumberEl,
+      value: this.value
+    });
+
+    this.emitChangeIfUserModified();
+  };
+
+  private inputFocusHandler = (event: FocusEvent): void => {
+    const slottedActionEl = getSlotted(this.el, "action");
+    if (event.target !== slottedActionEl) {
+      this.setFocus();
+    }
+    this.calciteInternalInputNumberFocus.emit({
+      element: this.childNumberEl,
+      value: this.value
+    });
+  };
+
+  private inputNumberInputHandler = (nativeEvent: InputEvent): void => {
+    if (this.disabled || this.readOnly) {
+      return;
+    }
+    const value = (nativeEvent.target as HTMLInputElement).value;
+    const delocalizedValue = delocalizeNumberString(value, this.locale);
+    if (nativeEvent.inputType === "insertFromPaste") {
+      if (!isValidNumber(delocalizedValue)) {
+        nativeEvent.preventDefault();
+      }
+      this.setValue({
+        nativeEvent,
+        origin: "user",
+        value: parseNumberString(delocalizedValue)
+      });
+      this.childNumberEl.value = this.localizedValue;
+    } else {
+      this.setValue({
+        nativeEvent,
+        origin: "user",
+        value: delocalizedValue
+      });
+    }
+  };
+
+  private inputNumberKeyDownHandler = (event: KeyboardEvent): void => {
+    if (this.disabled || this.readOnly) {
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      /* prevent default behavior of moving cursor to the beginning of the input when holding down ArrowUp */
+      event.preventDefault();
+      this.nudgeNumberValue("up", event);
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      this.nudgeNumberValue("down", event);
+      return;
+    }
+    const supportedKeys = [
+      ...numberKeys,
+      "ArrowLeft",
+      "ArrowRight",
+      "Backspace",
+      "Delete",
+      "Enter",
+      "Escape",
+      "Tab"
+    ];
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+    const isShiftTabEvent = event.shiftKey && event.key === "Tab";
+    if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
+      if (event.key === "Enter") {
+        this.emitChangeIfUserModified();
+      }
+      return;
+    }
+    const decimalSeparator = getDecimalSeparator(this.locale);
+    if (event.key === decimalSeparator) {
+      if (!this.value && !this.childNumberEl.value) {
+        return;
+      }
+      if (this.value && this.childNumberEl.value.indexOf(decimalSeparator) === -1) {
+        return;
+      }
+    }
+    if (/[eE]/.test(event.key)) {
+      if (!this.value && !this.childNumberEl.value) {
+        return;
+      }
+      if (this.value && !/[eE]/.test(this.childNumberEl.value)) {
+        return;
+      }
+    }
+
+    if (event.key === "-") {
+      if (!this.value && !this.childNumberEl.value) {
+        return;
+      }
+      if (this.value && this.childNumberEl.value.split("-").length <= 2) {
+        return;
+      }
+    }
+    event.preventDefault();
+  };
+
+  private nudgeNumberValue = (
+    direction: NumberNudgeDirection,
+    nativeEvent: KeyboardEvent | MouseEvent
+  ): void => {
+    if (nativeEvent instanceof KeyboardEvent && nativeEvent.repeat) {
+      return;
+    }
+
+    const inputMax = this.maxString ? parseFloat(this.maxString) : null;
+    const inputMin = this.minString ? parseFloat(this.minString) : null;
+    const valueNudgeDelayInMs = 100;
+
+    this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
+
+    if (this.nudgeNumberValueIntervalId) {
+      window.clearInterval(this.nudgeNumberValueIntervalId);
+    }
+    let firstValueNudge = true;
+    this.nudgeNumberValueIntervalId = window.setInterval(() => {
+      if (firstValueNudge) {
+        firstValueNudge = false;
+        return;
+      }
+
+      this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
+    }, valueNudgeDelayInMs);
+  };
+
+  private numberButtonPointerUpAndOutHandler = (): void => {
+    window.clearInterval(this.nudgeNumberValueIntervalId);
+  };
+
+  private numberButtonPointerDownHandler = (event: PointerEvent): void => {
+    event.preventDefault();
+    const direction = (event.target as HTMLDivElement).dataset.adjustment as NumberNudgeDirection;
+    this.nudgeNumberValue(direction, event);
+  };
+
+  onFormReset(): void {
+    this.setValue({
+      origin: "reset",
+      value: this.defaultValue
+    });
+  }
+
+  syncHiddenFormInput(input: HTMLInputElement): void {
+    input.type = "number";
+    input.min = this.min?.toString(10) ?? "";
+    input.max = this.max?.toString(10) ?? "";
+  }
+
+  private setChildNumberElRef = (el) => {
+    this.childNumberEl = el;
+  };
+
+  private setDisabledAction(): void {
+    const slottedActionEl = getSlotted(this.el, "action");
+
+    if (!slottedActionEl) {
+      return;
+    }
+
+    this.disabled
+      ? slottedActionEl.setAttribute("disabled", "")
+      : slottedActionEl.removeAttribute("disabled");
+  }
+
+  private setInputValue = (newInputValue: string): void => {
+    if (!this.childNumberEl) {
+      return;
+    }
+    this.childNumberEl.value = newInputValue;
+  };
+
+  private setPreviousEmittedValue = (newPreviousEmittedValue: string): void => {
+    this.previousEmittedValue = isValidNumber(newPreviousEmittedValue)
+      ? newPreviousEmittedValue
+      : "";
+  };
+
+  private setPreviousValue = (newPreviousValue: string): void => {
+    this.previousValue = isValidNumber(newPreviousValue) ? newPreviousValue : "";
+  };
+
+  private setValue = ({
+    committing = false,
+    nativeEvent,
+    origin,
+    previousValue,
+    value
+  }: {
+    committing?: boolean;
+    nativeEvent?: MouseEvent | KeyboardEvent | InputEvent;
+    origin: SetValueOrigin;
+    previousValue?: string;
+    value: string;
+  }): void => {
+    const previousLocalizedValue = localizeNumberString(
+      this.previousValue,
+      this.locale,
+      this.groupSeparator,
+      this.numberingSystem
+    );
+
+    const sanitizedValue = sanitizeNumberString(value);
+    const newValue =
+      value && !sanitizedValue
+        ? isValidNumber(this.previousValue)
+          ? this.previousValue
+          : ""
+        : sanitizedValue;
+
+    const newLocalizedValue = localizeNumberString(
+      newValue,
+      this.locale,
+      this.groupSeparator,
+      this.numberingSystem
+    );
+
+    this.setPreviousValue(previousValue || this.value);
+    this.previousValueOrigin = origin;
+    this.userChangedValue = origin === "user" && this.value !== newValue;
+    this.value = newValue;
+
+    this.localizedValue = newLocalizedValue;
+
+    if (origin === "direct") {
+      this.setInputValue(newLocalizedValue);
+    }
+
+    if (nativeEvent) {
+      const calciteInputNumberInputEvent = this.calciteInputNumberInput.emit({
+        element: this.childNumberEl,
+        nativeEvent,
+        value: this.value
+      });
+
+      if (calciteInputNumberInputEvent.defaultPrevented) {
+        this.value = this.previousValue;
+        this.localizedValue = previousLocalizedValue;
+      } else if (committing) {
+        this.emitChangeIfUserModified();
+      }
+    }
+  };
+
+  private inputKeyUpHandler = (): void => {
+    window.clearInterval(this.nudgeNumberValueIntervalId);
+  };
+
+  private warnAboutInvalidNumberValue(value: string): void {
+    if (value && !isValidNumber(value)) {
+      console.warn(`The specified value "${value}" cannot be parsed, or is out of range.`);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  //
+  //  Render Methods
+  //
+  // --------------------------------------------------------------------------
+
+  render(): VNode {
+    const dir = getElementDir(this.el);
+    const loader = (
+      <div class={CSS.loader}>
+        <calcite-progress label={this.intlLoading} type="indeterminate" />
+      </div>
+    );
+
+    const inputClearButton = (
+      <button
+        aria-label={this.intlClear || TEXT.clear}
+        class={CSS.clearButton}
+        disabled={this.disabled || this.readOnly}
+        onClick={this.clearInputValue}
+        tabIndex={this.disabled ? -1 : 0}
+        type="button"
+      >
+        <calcite-icon icon="x" scale="s" />
+      </button>
+    );
+    const iconEl = (
+      <calcite-icon
+        class={CSS.inputIcon}
+        flipRtl={this.iconFlipRtl}
+        icon={this.requestedIcon}
+        scale="s"
+      />
+    );
+
+    const isHorizontalNumberButton = this.numberButtonType === "horizontal";
+
+    const numberButtonsHorizontalUp = (
+      <button
+        class={{
+          [CSS.numberButtonItem]: true,
+          [CSS.buttonItemHorizontal]: isHorizontalNumberButton
+        }}
+        data-adjustment="up"
+        disabled={this.disabled || this.readOnly}
+        onPointerDown={this.numberButtonPointerDownHandler}
+        onPointerOut={this.numberButtonPointerUpAndOutHandler}
+        onPointerUp={this.numberButtonPointerUpAndOutHandler}
+        tabIndex={-1}
+        type="button"
+      >
+        <calcite-icon icon="chevron-up" scale="s" />
+      </button>
+    );
+
+    const numberButtonsHorizontalDown = (
+      <button
+        class={{
+          [CSS.numberButtonItem]: true,
+          [CSS.buttonItemHorizontal]: isHorizontalNumberButton
+        }}
+        data-adjustment="down"
+        disabled={this.disabled || this.readOnly}
+        onPointerDown={this.numberButtonPointerDownHandler}
+        onPointerOut={this.numberButtonPointerUpAndOutHandler}
+        onPointerUp={this.numberButtonPointerUpAndOutHandler}
+        tabIndex={-1}
+        type="button"
+      >
+        <calcite-icon icon="chevron-down" scale="s" />
+      </button>
+    );
+
+    const numberButtonsVertical = (
+      <div class={CSS.numberButtonWrapper}>
+        {numberButtonsHorizontalUp}
+        {numberButtonsHorizontalDown}
+      </div>
+    );
+
+    const prefixText = <div class={CSS.prefix}>{this.prefixText}</div>;
+
+    const suffixText = <div class={CSS.suffix}>{this.suffixText}</div>;
+
+    const childEl = (
+      <input
+        aria-label={getLabelText(this)}
+        autofocus={this.autofocus ? true : null}
+        defaultValue={this.defaultValue}
+        disabled={this.disabled ? true : null}
+        enterKeyHint={this.el.enterKeyHint}
+        inputMode={this.el.inputMode}
+        key="localized-input"
+        maxLength={this.maxLength}
+        minLength={this.minLength}
+        name={undefined}
+        onBlur={this.inputBlurHandler}
+        onFocus={this.inputFocusHandler}
+        onInput={this.inputNumberInputHandler}
+        onKeyDown={this.inputNumberKeyDownHandler}
+        onKeyUp={this.inputKeyUpHandler}
+        placeholder={this.placeholder || ""}
+        readOnly={this.readOnly}
+        ref={this.setChildNumberElRef}
+        type="text"
+        value={this.localizedValue}
+      />
+    );
+
+    return (
+      <Host onClick={this.inputFocusHandler} onKeyDown={this.keyDownHandler}>
+        <div class={{ [CSS.inputWrapper]: true, [CSS_UTILITY.rtl]: dir === "rtl" }}>
+          {this.numberButtonType === "horizontal" && !this.readOnly
+            ? numberButtonsHorizontalDown
+            : null}
+          {this.prefixText ? prefixText : null}
+          <div class={CSS.wrapper}>
+            {childEl}
+            {this.isClearable ? inputClearButton : null}
+            {this.requestedIcon ? iconEl : null}
+            {this.loading ? loader : null}
+          </div>
+          <div class={CSS.actionWrapper}>
+            <slot name={SLOTS.action} />
+          </div>
+          {this.numberButtonType === "vertical" && !this.readOnly ? numberButtonsVertical : null}
+          {this.suffixText ? suffixText : null}
+          {this.numberButtonType === "horizontal" && !this.readOnly
+            ? numberButtonsHorizontalUp
+            : null}
+          <HiddenFormInputSlot component={this} />
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/input-number/interfaces.ts
+++ b/src/components/input-number/interfaces.ts
@@ -1,0 +1,1 @@
+export type InputPlacement = "vertical" | "horizontal" | "none";

--- a/src/components/input-number/readme.md
+++ b/src/components/input-number/readme.md
@@ -1,0 +1,89 @@
+# calcite-input
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property           | Attribute            | Description                                                                                                                                    | Type                                   | Default                                   |
+| ------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------- |
+| `alignment`        | `alignment`          | Specifies the text alignment of the component's value.                                                                                         | `"end" \| "start"`                     | `"start"`                                 |
+| `autofocus`        | `autofocus`          | When true, the component is focused on page load.                                                                                              | `boolean`                              | `false`                                   |
+| `clearable`        | `clearable`          | When true, a clear button is displayed when the component has a value.                                                                         | `boolean`                              | `false`                                   |
+| `disabled`         | `disabled`           | When true, interaction is prevented and the component is displayed with lower opacity.                                                         | `boolean`                              | `false`                                   |
+| `groupSeparator`   | `group-separator`    | When true, number values are displayed with the locale's group separator.                                                                      | `boolean`                              | `false`                                   |
+| `hidden`           | `hidden`             | When true, the component will not be visible.                                                                                                  | `boolean`                              | `false`                                   |
+| `icon`             | `icon`               | When true, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.                            | `boolean \| string`                    | `undefined`                               |
+| `iconFlipRtl`      | `icon-flip-rtl`      | When true, the icon is flipped in RTL.                                                                                                         | `boolean`                              | `false`                                   |
+| `intlClear`        | `intl-clear`         | A text label that will appear on the clear button for screen readers.                                                                          | `string`                               | `undefined`                               |
+| `intlLoading`      | `intl-loading`       | Accessible name that will appear while loading.                                                                                                | `string`                               | `COMMON_TEXT.loading`                     |
+| `label`            | `label`              | Accessible name for the component's button or hyperlink.                                                                                       | `string`                               | `undefined`                               |
+| `loading`          | `loading`            | When true, the component is in the loading state and `calcite-progress` is displayed.                                                          | `boolean`                              | `false`                                   |
+| `locale`           | `locale`             | Specifies the BCP 47 language tag for the desired language and country format.                                                                 | `string`                               | `document.documentElement.lang \|\| "en"` |
+| `max`              | `max`                | Specifies the maximum value.                                                                                                                   | `number`                               | `undefined`                               |
+| `maxLength`        | `max-length`         | Specifies the maximum length of text for the component's value.                                                                                | `number`                               | `undefined`                               |
+| `maxlength`        | `maxlength`          | <span style="color:red">**[DEPRECATED]**</span> use maxLength instead<br/><br/>Specifies the maximum length of text for the component's value. | `number`                               | `undefined`                               |
+| `min`              | `min`                | Specifies the minimum value.                                                                                                                   | `number`                               | `undefined`                               |
+| `minLength`        | `min-length`         | Specifies the minimum length of text for the component's value.                                                                                | `number`                               | `undefined`                               |
+| `name`             | `name`               | Specifies the name of the component.                                                                                                           | `string`                               | `undefined`                               |
+| `numberButtonType` | `number-button-type` | Specifies the placement of the buttons.                                                                                                        | `"horizontal" \| "none" \| "vertical"` | `"vertical"`                              |
+| `numberingSystem`  | `numbering-system`   | Specifies the Unicode numeral system used by the component for localization.                                                                   | `string`                               | `undefined`                               |
+| `placeholder`      | `placeholder`        | Specifies placeholder text for the component.                                                                                                  | `string`                               | `undefined`                               |
+| `prefixText`       | `prefix-text`        | Adds text to the start of the component.                                                                                                       | `string`                               | `undefined`                               |
+| `readOnly`         | `read-only`          | When true, the value cannot be modified.                                                                                                       | `boolean`                              | `false`                                   |
+| `required`         | `required`           | When true, the component must have a value in order for the form to submit.                                                                    | `boolean`                              | `false`                                   |
+| `scale`            | `scale`              | Specifies the size of the component.                                                                                                           | `"l" \| "m" \| "s"`                    | `"m"`                                     |
+| `status`           | `status`             | Specifies the status of the input field, which determines message and icons.                                                                   | `"idle" \| "invalid" \| "valid"`       | `"idle"`                                  |
+| `step`             | `step`               | Specifies the granularity that the component's value must adhere to.                                                                           | `"any" \| number`                      | `undefined`                               |
+| `suffixText`       | `suffix-text`        | Adds text to the end of the component.                                                                                                         | `string`                               | `undefined`                               |
+| `value`            | `value`              | The component's value.                                                                                                                         | `string`                               | `""`                                      |
+
+## Events
+
+| Event                      | Description                                         | Type                |
+| -------------------------- | --------------------------------------------------- | ------------------- |
+| `calciteInputNumberChange` | Fires each time a new value is typed and committed. | `CustomEvent<void>` |
+| `calciteInputNumberInput`  | Fires each time a new value is typed.               | `CustomEvent<any>`  |
+
+## Methods
+
+### `selectText() => Promise<void>`
+
+Selects all text of the component's `value`.
+
+#### Returns
+
+Type: `Promise<void>`
+
+### `setFocus() => Promise<void>`
+
+Sets focus on the component.
+
+#### Returns
+
+Type: `Promise<void>`
+
+## Slots
+
+| Slot       | Description                                            |
+| ---------- | ------------------------------------------------------ |
+| `"action"` | A slot for positioning a button next to the component. |
+
+## Dependencies
+
+### Depends on
+
+- [calcite-progress](../progress)
+- [calcite-icon](../icon)
+
+### Graph
+
+```mermaid
+graph TD;
+  calcite-input-number --> calcite-progress
+  calcite-input-number --> calcite-icon
+  style calcite-input-number fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/input-number/resources.ts
+++ b/src/components/input-number/resources.ts
@@ -1,0 +1,24 @@
+export const CSS = {
+  loader: "loader",
+  clearButton: "clear-button",
+  editingEnabled: "editing-enabled",
+  inlineChild: "inline-child",
+  inputIcon: "icon",
+  prefix: "prefix",
+  suffix: "suffix",
+  numberButtonWrapper: "number-button-wrapper",
+  buttonItemHorizontal: "number-button-item--horizontal",
+  wrapper: "element-wrapper",
+  inputWrapper: "wrapper",
+  actionWrapper: "action-wrapper",
+  resizeIconWrapper: "resize-icon-wrapper",
+  numberButtonItem: "number-button-item"
+};
+
+export const SLOTS = {
+  action: "action"
+};
+
+export const TEXT = {
+  clear: "Clear value"
+};

--- a/src/demos/input-number.html
+++ b/src/demos/input-number.html
@@ -1,0 +1,658 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Input Number</title>
+
+    <style>
+      .parent-flex {
+        display: flex;
+        padding: 25px 0;
+        flex-wrap: wrap;
+      }
+
+      .font,
+      .header {
+        color: var(--calcite-ui-text-3);
+        font-family: var(--calcite-sans-family);
+        font-weight: var(--calcite-font-weight-medium);
+      }
+
+      .font {
+        font-size: var(--calcite-font-size-0);
+      }
+
+      .header {
+        font-size: var(--calcite-font-size-2);
+      }
+
+      .child-flex {
+        flex: 0 0 22%;
+        margin: 0 25px;
+      }
+
+      .right-aligned-text {
+        text-align: right;
+        flex: 0 0 12%;
+      }
+
+      hr {
+        margin: 25px 0;
+        border-top: 1px solid var(--calcite-ui-border-2);
+      }
+
+      #locales {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        justify-content: center;
+        padding: 0 152px;
+        margin: 0 auto;
+      }
+
+      .locale {
+        flex: 0 0 20%;
+      }
+    </style>
+
+    <script src="./_assets/head.js"></script>
+    <script type="module" src="./_assets/demo-form.js"></script>
+    <script type="module" src="./_assets/demo-spacer.js"></script>
+    <script>
+      const locales = [
+        "ar",
+        "bg",
+        "bs",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "de-CH",
+        "el",
+        "en",
+        "en-AU",
+        "en-CA",
+        "en-GB",
+        "es",
+        "es-MX",
+        "et",
+        "fi",
+        "fr",
+        "fr-CH",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "it",
+        "it-CH",
+        "ja",
+        "ko",
+        "lt",
+        "lv",
+        "mk",
+        "nb",
+        "nl",
+        "pl",
+        "pt",
+        "pt-PT",
+        "ro",
+        "ru",
+        "sk",
+        "sl",
+        "sr",
+        "sv",
+        "th",
+        "tr",
+        "uk",
+        "vi",
+        "zh-CN",
+        "zh-HK",
+        "zh-TW"
+      ];
+    </script>
+  </head>
+
+  <body>
+    <!--
+      ******************************************************************
+      * STANDARD
+      ******************************************************************
+    -->
+    <!-- Sizes -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text"></div>
+      <div class="child-flex font">Small</div>
+      <div class="child-flex font">Medium</div>
+      <div class="child-flex font">Large</div>
+    </div>
+
+    <!-- Number Vertical -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Number Vertical</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Input Label
+          <calcite-input-number placeholder="Placeholder" scale="s" value="123" step="1"></calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label>
+          Input Label
+          <calcite-input-number placeholder="Placeholder" scale="m" value="123" step="1"></calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Input Label
+          <calcite-input-number placeholder="Placeholder" scale="l" value="123" step="1"></calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+
+    <!-- Number Vertical Prefix/Suffix -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Number Vertical Prefix/Suffix</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="s"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label>
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="m"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="l"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+
+    <!-- Number Horizontal -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Number Horizontal</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="s"
+            value="123"
+            step="1"
+            number-button-type="horizontal"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label>
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="m"
+            value="123"
+            step="1"
+            number-button-type="horizontal"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="l"
+            value="123"
+            step="1"
+            number-button-type="horizontal"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+
+    <!-- Number Horizontal Prefix/Suffix -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Number Horizontal Prefix/Suffix</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="s"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            number-button-type="horizontal"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label>
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="m"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            number-button-type="horizontal"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Input Label
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="l"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            number-button-type="horizontal"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Filled (can edit)</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Filled input
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="s"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+      <div class="child-flex">
+        <calcite-label>
+          Filled input
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="m"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Filled input
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="l"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+
+    <!-- Number -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Status (can edit)</div>
+      <div class="child-flex">
+        <calcite-label scale="s" status="invalid">
+          Invalid input
+          <calcite-input-number placeholder="Placeholder" scale="s" value="123" step="1"></calcite-input-number>
+          <calcite-input-number-message scale="s" active icon> Error message </calcite-input-number-message>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label status="invalid">
+          Invalid input
+          <calcite-input-number placeholder="Placeholder" scale="m" value="123" step="1"></calcite-input-number>
+          <calcite-input-number-message scale="m" active icon> Error message </calcite-input-number-message>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l" status="invalid">
+          Invalid input
+          <calcite-input-number placeholder="Placeholder" scale="l" value="123" step="1"></calcite-input-number>
+          <calcite-input-number-message scale="l" active icon> Error message </calcite-input-number-message>
+        </calcite-label>
+      </div>
+    </div>
+
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Read Only (can't edit)</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Read only input
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="s"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            read-only
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+      <div class="child-flex">
+        <calcite-label>
+          Read only input
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="m"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            read-only
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Read only input
+          <calcite-input-number
+            placeholder="Placeholder"
+            scale="l"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            read-only
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">Disabled (can't edit)</div>
+      <div class="child-flex">
+        <calcite-label scale="s">
+          Disabled input
+          <calcite-input-number
+            progress
+            placeholder="Placeholder"
+            scale="s"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            disabled
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+      <div class="child-flex">
+        <calcite-label>
+          Disabled input
+          <calcite-input-number
+            progress
+            placeholder="Placeholder"
+            scale="m"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            disabled
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+      <div class="child-flex">
+        <calcite-label scale="l">
+          Disabled input
+          <calcite-input-number
+            progress
+            placeholder="Placeholder"
+            scale="l"
+            value="123"
+            step="1"
+            prefix-text="Prefix"
+            suffix-text="Suffix"
+            disabled
+          >
+          </calcite-input-number>
+        </calcite-label>
+      </div>
+    </div>
+
+    <hr />
+
+    <demo-form>
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text"></div>
+        <div class="child-flex font header">Form locales</div>
+      </div>
+
+      <form name="demo-form">
+        <demo-spacer>
+          <div id="locales"></div>
+        </demo-spacer>
+        <div class="parent-flex">
+          <div class="child-flex right-aligned-text"></div>
+          <div class="child-flex font header">
+            <calcite-button type="reset" width="half">Reset</calcite-button>
+          </div>
+        </div>
+      </form>
+    </demo-form>
+
+    <script>
+      const localeDemoContainer = document.getElementById("locales");
+      locales.forEach((locale) => {
+        let localeEl = document.createElement("div");
+        localeEl.setAttribute("class", "locale");
+        let label = document.createElement("calcite-label");
+        label.setAttribute("for", locale);
+        label.appendChild(document.createTextNode(locale));
+        let input = document.createElement("calcite-input-number");
+        (locale === "ar" || locale === "he") && input.setAttribute("dir", "rtl");
+        input.setAttribute("id", locale);
+        input.setAttribute("locale", locale);
+        input.setAttribute("name", locale);
+        input.setAttribute("scale", "s");
+        input.setAttribute("type", "number");
+        input.setAttribute("value", "1234.56");
+        localeEl.appendChild(label);
+        localeEl.appendChild(input);
+        localeDemoContainer.appendChild(localeEl);
+
+        localeEl = document.createElement("div");
+        localeEl.setAttribute("class", "locale");
+        label = document.createElement("calcite-label");
+        label.setAttribute("for", locale);
+        label.appendChild(document.createTextNode(`${locale} (with group separator)`));
+        input = document.createElement("calcite-input-number");
+        (locale === "ar" || locale === "he") && input.setAttribute("dir", "rtl");
+        input.setAttribute("group-separator", true);
+        input.setAttribute("id", `${locale}-group-separator`);
+        input.setAttribute("locale", locale);
+        input.setAttribute("name", `${locale}-group-separator`);
+        input.setAttribute("scale", "s");
+        input.setAttribute("type", "number");
+        input.setAttribute("value", "1234.56");
+        localeEl.appendChild(label);
+        localeEl.appendChild(input);
+        localeDemoContainer.appendChild(localeEl);
+      });
+    </script>
+
+    <hr />
+
+    <div class="parent-flex">
+      <div class="child-flex right-aligned-text"></div>
+      <div class="child-flex font header">Locale variants</div>
+    </div>
+
+    <!-- default locale number input -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">default locale number input</div>
+      <div class="child-flex">
+        <calcite-input-number name="default" placeholder="default locale number input"></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- default locale number input with group -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">default locale number input with group</div>
+      <div class="child-flex">
+        <calcite-input-number
+          name="default-group"
+          placeholder="default locale number input with group"
+          group-separator
+        ></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- french number input -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">french number input</div>
+      <div class="child-flex">
+        <calcite-input-number name="french" locale="fr" placeholder="french number input"></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- french number input with group separator -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">french number input with group separator</div>
+      <div class="child-flex">
+        <calcite-input-number
+          name="french-group"
+          locale="fr"
+          group-separator
+          placeholder="french number input with group separator"
+        ></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- set to undefined -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">set to undefined</div>
+      <div class="child-flex">
+        <calcite-input-number name="set-to-undefined" placeholder="set to undefined"></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- minlength=2 maxlength=3 -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">minlength=2 maxlength=3</div>
+      <div class="child-flex">
+        <calcite-input-number
+          name="minmax"
+          minLength="2"
+          maxLength="3"
+          placeholder="minlength=2 maxlength=3"
+          required
+        ></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- no-locale number -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">no-locale number</div>
+      <div class="child-flex">
+        <calcite-input-number name="no-locale-number" placeholder="no-locale-number" value="4"></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- arabic -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">arabic</div>
+      <div class="child-flex">
+        <calcite-input-number locale="ar" name="arabic"></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- french-whole -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">french-whole</div>
+      <div class="child-flex">
+        <calcite-input-number locale="fr" name="french-whole" value="1234" step="1"></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- french-novalue -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">french-novalue</div>
+      <div class="child-flex">
+        <calcite-input-number
+          locale="fr"
+          name="french-novalue"
+          placeholder="french-novalue"
+          step="1"
+        ></calcite-input-number>
+      </div>
+    </div>
+
+    <!-- step-any -->
+    <div class="parent-flex">
+      <div class="child-flex font right-aligned-text">step-any</div>
+      <div class="child-flex">
+        <calcite-input-number name="step-any" step="any" placeholder='step="any"'></calcite-input-number>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -201,6 +201,13 @@
         </div>
 
         <div>
+          <a href="/demos/input-number.html">
+            <calcite-action scale="s" text="Input Number" alignment="start" text-enabled appearance="solid">
+            </calcite-action>
+          </a>
+        </div>
+
+        <div>
           <a href="/demos/input-date-picker.html">
             <calcite-action scale="s" text="Input Date Picker" alignment="start" text-enabled appearance="solid">
             </calcite-action>

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -37,6 +37,7 @@ export const create: () => Config = () => ({
     { components: ["calcite-icon"] },
     { components: ["calcite-inline-editable"] },
     { components: ["calcite-input"] },
+    { components: ["calcite-input-number"] },
     { components: ["calcite-input-date-picker"] },
     { components: ["calcite-input-message"] },
     { components: ["calcite-input-time-picker", "calcite-time-picker"] },


### PR DESCRIPTION
**Related Issue:** part of the roadmap item to separate `calcite-input` types
 
## Summary
Created a new `calcite-input-number` component by copying over input and removing all non-number functionality.
