### PR TITLE
docs(readme): use the same stencil version as calcite components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,14 @@ const loader = document.querySelector(".my-loader-element") as HTMLCalciteLoader
 loader.active = true;
 ```
 
+## `@stencil/core` Version
+
+When using Stencil, make sure the `@stencil/core` version in your project matches the one used by Calcite Components. You may run into type errors if the `@stencil/core` versions are different. You can install the same Stencil version used by `@esri/calcite-components`:
+
+```bash
+npm install @stencil/core@$(npm view @esri/calcite-components dependencies["@stencil/core"])
+```
+
 ## Browser Support
 
 <table>


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Added section about matching stencil versions w/ CC (brought up in Teams). Easy way to install the same version used by CC:
```bash
npm install @stencil/core@$(npm view @esri/calcite-components dependencies["@stencil/core"])
```
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
