### PR TITLE
ci: automatically create new milestones

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/github-script@v4
         with:
           script: |
+            const DAYS_PER_SPRINT = 14;
+            const DAYS_BETWEEN_SPRINTS = 3;
             const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 
             const { data: milestones } = await github.issues.listMilestones({
@@ -29,10 +31,10 @@ jobs:
 
             const lastDueDate = new Date(milestones[0].due_on);
             const newMilestoneStartDate = new Date(
-              lastDueDate.getTime() + MILLISECONDS_PER_DAY * 3
+              lastDueDate.getTime() + MILLISECONDS_PER_DAY * DAYS_BETWEEN_SPRINTS
             );
             const newMilestoneDueDate = new Date(
-              lastDueDate.getTime() + MILLISECONDS_PER_DAY * 14
+              lastDueDate.getTime() + MILLISECONDS_PER_DAY * DAYS_PER_SPRINT
             );
 
             const title =

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -1,0 +1,49 @@
+name: Create New Milestone
+on:
+  schedule:
+    - cron: "0 9 1,15 * *"
+  issues:
+    types: [labeled, unlabeled]
+jobs:
+  create-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
+
+            const { data: milestones } = await github.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              sort: "due_on",
+              per_page: 1,
+              direction: "desc",
+            });
+
+            if (!milestones.length || !milestones[0].due_on) {
+              console.log("There are no open milestones with a due date in this repo, ending run.");
+              return;
+            }
+
+            const lastDueDate = new Date(milestones[0].due_on);
+            const newMilestoneStartDate = new Date(
+              lastDueDate.getTime() + MILLISECONDS_PER_DAY * 3
+            );
+            const newMilestoneDueDate = new Date(
+              lastDueDate.getTime() + MILLISECONDS_PER_DAY * 14
+            );
+
+            const title =
+              "Sprint " +
+              newMilestoneStartDate.toISOString().split("T")[0].replace(/-/g, "/") +
+              " - " +
+              newMilestoneDueDate.toISOString().split("T")[0].replace(/-/g, "/");
+
+            await github.issues.createMilestone({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              due_on: newMilestoneDueDate.toISOString(),
+              title
+            });


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Adding an action that creates a new milestone twice a month (1st and 15th). I am also changing the sprint title to include the year to make sure they are all unique. Using ISO format to make sorting easier when we need to look back.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
