### PR TITLE
fix: (radio group) - apply forced-colors styles

### DIFF
--- a/src/components/radio-group-item/radio-group-item.scss
+++ b/src/components/radio-group-item/radio-group-item.scss
@@ -72,6 +72,18 @@
   @apply hidden;
 }
 
+@media (forced-colors: active) {
+  :host([checked]) label {
+    background-color: highlight;
+  }
+  :host([checked]) .label--outline {
+    @apply outline-none;
+  }
+  :host([checked]) label:not([class~="label--outline"]) .radio-group-item-icon {
+    color: highlightText;
+  }
+}
+
 // icon
 .radio-group-item-icon {
   @apply relative


### PR DESCRIPTION
* Adds highlight color to solid selected item
* Adds bold outline to outline selected item
* Modifies icon color on solid selected item for better contrast

**Related Issue:** #4873 

## Summary

Modifies the radio group selections to look like this on High Contrast mode:

<img width="800" alt="Screen Shot of high contrast radio group selection states" src="https://user-images.githubusercontent.com/142636/177892587-4246c525-2c68-4674-8731-6d3b7ac50446.png">

Unfortunately, the text *ALWAYS* has its own un-style-able background so it doesn't have the same background as the radio group "button".

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
