### PR TITLE
ci(add-milestone): use milestone until the day after its due date

### DIFF
--- a/.github/workflows/pr-milestone.yml
+++ b/.github/workflows/pr-milestone.yml
@@ -8,4 +8,4 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: benelan/milestone-action@v1.3.0
+      - uses: benelan/milestone-action@v1.3.1


### PR DESCRIPTION
**Related Issue:** #4881

## Summary
Today is the last day of the sprint and it should still be considered the current milestone. However PRs are adding the next milestone. This PR fixes that issue so the sprint ending today will be used.

[relevant code](https://github.com/benelan/milestone-action/commit/c68adeb50cd9b0da6549310a7d8287aa70e2ac5f#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR44)


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
