### PR TITLE
fix(Input): type number spinner buttons will no longer interact when disabled

### DIFF
--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -78,6 +78,18 @@ describe("calcite-input", () => {
 
   it("can be disabled", () => disabled("calcite-input"));
 
+  it("spinner buttons on disabled number input should not be interactive/should not nudge the number", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input type="number" disabled></calcite-input>`);
+
+    const numberButtonItem = await page.find("calcite-input >>> .number-button-item");
+    const calciteInputInput = await page.spyOnEvent("calciteInputInput");
+
+    await numberButtonItem.click();
+    await page.waitForChanges();
+    expect(calciteInputInput).not.toHaveReceivedEvent();
+  });
+
   it("inherits requested props when from wrapping calcite-label when props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(html`

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -461,6 +461,9 @@ input[type="time"]::-webkit-clear-button {
   &:active {
     @apply bg-foreground-3;
   }
+  &:disabled {
+    @apply pointer-events-none;
+  }
 }
 
 .wrapper {

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -691,7 +691,9 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   private numberButtonPointerDownHandler = (event: PointerEvent): void => {
     event.preventDefault();
     const direction = (event.target as HTMLDivElement).dataset.adjustment as NumberNudgeDirection;
-    this.nudgeNumberValue(direction, event);
+    if (!this.disabled) {
+      this.nudgeNumberValue(direction, event);
+    }
   };
 
   onFormReset(): void {


### PR DESCRIPTION
**Related Issue:** #4879, PR #4870

## Summary

Added:
- `:disabled` pseudo-class to `.number-button-item`, set to `pointer-events-none` 
- a backup check for the `disabled` prop before the number value can be nudged
- test to make sure `disabled` stepper buttons should not be interactive/nudge the number