### PR TITLE
fix(radio-group-item): Add aria-label providing context to users

### DIFF
--- a/src/components/radio-group-item/radio-group-item.tsx
+++ b/src/components/radio-group-item/radio-group-item.tsx
@@ -74,7 +74,7 @@ export class RadioGroupItem {
     );
 
     return (
-      <Host aria-checked={toAriaBoolean(checked)} role="radio">
+      <Host aria-checked={toAriaBoolean(checked)} aria-label={value} role="radio">
         <label
           class={{
             "label--scale-s": scale === "s",


### PR DESCRIPTION
**Related Issue:** #3431

## Summary
Identified as part of the a11y audit in 2021.

When interacting with `radio-group-item` users must have an accompanying `aria-label` depicting the value. 

Added an `aria-label={value}` to the `<Host>` to ensure users are provided context when interacting with the `radio-group` and `radio-group-item`s.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
