### PR TITLE
build(deps): downgrade stencil to fix types error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
         "@popperjs/core": "2.11.5",
-        "@stencil/core": "2.17.0",
+        "@stencil/core": "2.16.1",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "form-request-submit-polyfill": "2.0.0",
@@ -3094,9 +3094,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.0.tgz",
-      "integrity": "sha512-KJJH097K2TJlJWj2LANWO0yXCidxOpv1L2MmtYqFxE443t75fxOhtKBZq6zebDaZj2DFGlUtV4pcM/uapfd8TQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -33541,9 +33541,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.0.tgz",
-      "integrity": "sha512-KJJH097K2TJlJWj2LANWO0yXCidxOpv1L2MmtYqFxE443t75fxOhtKBZq6zebDaZj2DFGlUtV4pcM/uapfd8TQ=="
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw=="
     },
     "@stencil/eslint-plugin": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@a11y/focus-trap": "1.0.5",
     "@popperjs/core": "2.11.5",
-    "@stencil/core": "2.17.0",
+    "@stencil/core": "2.16.1",
     "@types/color": "3.0.3",
     "color": "4.2.3",
     "form-request-submit-polyfill": "2.0.0",


### PR DESCRIPTION
**Related Issue:** #4786

## Summary
[Type errors appeared in `next.500`](https://unpkg.com/browse/@esri/calcite-components@1.0.0-next.500/dist/components/index.d.ts) after  [bumping `@stencil/core` to `2.17.0`](https://github.com/Esri/calcite-components/commit/4bca90679c19a2c7fed7acb8f126bdd223c0e50f). @dasa finally noticed the errors after the release of `beta.84`. Downgrading to `@stencil/core@2.16.1` resolved the issue locally.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
