### PR TITLE
fix(action-bar, action-pad): Background color should be transparent on host.

### DIFF
--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -5,6 +5,7 @@
     flex-col
     self-stretch;
   max-width: 15vw;
+  background: transparent;
 }
 
 :host([overflow-actions-disabled]) {

--- a/src/components/action-pad/action-pad.scss
+++ b/src/components/action-pad/action-pad.scss
@@ -5,6 +5,7 @@
 
 :host([expanded]) {
   max-width: 20vw;
+  background: transparent;
 }
 
 ::slotted(calcite-action-group) {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

fix(action-bar, action-pad): Background color should be transparent on host.

`@extend %component-host;` sets a background color but these components shouldn't have one since they expand.