### PR TITLE
fix(pick-list-item): Make label property required. (#3373)

### DIFF
--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -71,7 +71,7 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   /**
    * Label and accessible name for the component. Appears next to the icon.
    */
-  @Prop({ reflect: true }) label: string;
+  @Prop({ reflect: true }) label!: string;
 
   @Watch("label")
   labelWatchHandler(): void {


### PR DESCRIPTION
**Related Issue:** #3373

## Summary

fix(pick-list-item): Make label property required. (https://github.com/Esri/calcite-components/issues/3373)