### PR TITLE
fix(card): Prevent content from overflowing when corners are rounded

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -13,7 +13,8 @@
     border-solid
     shadow-none
     duration-150
-    ease-in-out;
+    ease-in-out
+    overflow-hidden;
     border-radius: var(--calcite-border-radius-base);
     &:hover {
       @apply shadow-1-lg;

--- a/src/components/card/card.stories.ts
+++ b/src/components/card/card.stories.ts
@@ -263,3 +263,35 @@ export const Thumbnail = stepStory(
     .ltr()
     .snapshot("Thumbnail Inline End Dark")
 );
+
+export const ThumbnailRounded = (): string => html`
+  <div id="card-container" style="width:260px;">
+    <style>
+      calcite-card {
+        --calcite-border-radius-base: 12px;
+      }
+    </style>
+    <calcite-card>
+      ${thumbnailHtml}
+      <h3 slot="title">Portland Businesses</h3>
+      <span slot="subtitle"
+        >by
+        <calcite-link href="">example_user</calcite-link>
+      </span>
+      <div>
+        Created: Apr 22, 2019
+        <br />
+        Updated: Dec 9, 2019
+        <br />
+        View Count: 0
+      </div>
+      <calcite-button
+        slot="footer-leading"
+        color="neutral"
+        scale="s"
+        id="card-icon-test-1"
+        icon-start="circle"
+      ></calcite-button>
+    </calcite-card>
+  </div>
+`;


### PR DESCRIPTION
**Related Issue:** #4895

## Summary

fix(card): Prevent content from overflowing when corners are rounded. ([#4895](https://github.com/Esri/calcite-components/issues/4895))