### PR TITLE
ci: assign designers to installed issues when figma changes are required

### DIFF
--- a/.github/workflows/assign-for-verification.yml
+++ b/.github/workflows/assign-for-verification.yml
@@ -9,18 +9,32 @@ jobs:
       - uses: actions/github-script@v4
         env:
           ISSUE_VERIFIERS: ${{secrets.ISSUE_VERIFIERS}}
+          CALCITE_DESIGNERS: ${{secrets.CALCITE_DESIGNERS}}
         with:
           script: |
-            const { ISSUE_VERIFIERS } = process.env;
+            const { ISSUE_VERIFIERS, CALCITE_DESIGNERS } = process.env;
             const { label } = context.payload;
             if (label && label.name === "3 - installed") {
-              const assignees = ISSUE_VERIFIERS.split(",").map(v => v.trim());
+              const assignees = ISSUE_VERIFIERS.split(",").map((v) => v.trim());
+
+              const { data: issue } = await github.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+
+              // assign designers if figma updates are required
+              if (issue.labels.map((label) => label.name).includes("figma changes")) {
+                assignees.push(...CALCITE_DESIGNERS.split(",").map((v) => v.trim()));
+              }
+
               await github.issues.update({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 assignees,
               });
+
               await github.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,


### PR DESCRIPTION
**Related Issue:** NA

## Summary
The verification action now also assigns designers to installed issues when the issue contains the `figma changes` label. The label should be added during triage when the issue involves:

- new components
- new properties
- changed property names/types/values
- new or changed css variables
- anything that registers as a change in screener


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
