### PR TITLE
feat(input-time-picker): add readOnly prop support

### DIFF
--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -44,6 +44,34 @@ describe("calcite-input-time-picker", () => {
 
   it("can be disabled", () => disabled("calcite-input-time-picker"));
 
+  it("when set to readOnly, element still focusable but won't display the controls or allow for changing the value", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-time-picker read-only triggerDisabled={true} id="canReadOnly"></calcite-input-time-picker>`
+    );
+
+    const component = await page.find("#canReadOnly");
+    const input = await page.find("#canReadOnly >>> calcite-input");
+    const popover = await page.find("#canReadOnly >>> calcite-popover");
+
+    expect(await input.getProperty("value")).toBe("");
+
+    await component.callMethod("setFocus");
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("canReadOnly");
+    expect(await popover.getProperty("open")).toBe(false);
+
+    await component.click();
+    await page.waitForChanges();
+    expect(await popover.getProperty("open")).toBe(false);
+
+    await component.type("atención atención");
+    await page.waitForChanges();
+
+    expect(await input.getProperty("value")).toBe("");
+  });
+
   it("opens the time picker on input keyboard focus", async () => {
     const page = await newE2EPage({
       html: `<calcite-input-time-picker></calcite-input-time-picker>`

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -51,7 +51,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
 
   @Watch("active")
   activeHandler(): void {
-    if (this.disabled) {
+    if (this.disabled || this.readOnly) {
       this.active = false;
       return;
     }
@@ -62,8 +62,16 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
   /** The disabled state of the time input */
   @Prop({ reflect: true }) disabled = false;
 
+  /**
+   * When true, still focusable but controls are gone and the value cannot be modified.
+   *
+   * @mdn [readOnly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
+   */
+  @Prop() readOnly = false;
+
   @Watch("disabled")
-  handleDisabledChange(value: boolean): void {
+  @Watch("readOnly")
+  handleDisabledAndReadOnlyChange(value: boolean): void {
     if (!value) {
       this.active = false;
     }
@@ -217,8 +225,10 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
   };
 
   private calciteInternalInputFocusHandler = (event: CustomEvent): void => {
-    this.active = true;
-    event.stopPropagation();
+    if (!this.readOnly) {
+      this.active = true;
+      event.stopPropagation();
+    }
   };
 
   private calciteInputInputHandler = (event: CustomEvent): void => {
@@ -261,7 +271,9 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
   timePickerFocusHandler(event: CustomEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    this.active = true;
+    if (!this.readOnly) {
+      this.active = true;
+    }
     event.stopPropagation;
   }
 
@@ -428,6 +440,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
             onCalciteInputInput={this.calciteInputInputHandler}
             onCalciteInternalInputBlur={this.calciteInternalInputBlurHandler}
             onCalciteInternalInputFocus={this.calciteInternalInputFocusHandler}
+            readOnly={this.readOnly}
             ref={this.setCalciteInputEl}
             scale={this.scale}
             step={this.step}

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -453,6 +453,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
           placement={this.placement}
           ref={this.setCalcitePopoverEl}
           referenceElement={this.referenceElementId}
+          triggerDisabled={true}
         >
           <calcite-time-picker
             intlHour={this.intlHour}

--- a/src/demos/input-time-picker.html
+++ b/src/demos/input-time-picker.html
@@ -67,18 +67,18 @@
           <calcite-input-time-picker scale="l" value="23:59"></calcite-input-time-picker>
         </calcite-label>
 
-        <calcite-label scale="l">seconds</calcite-label>
+        <calcite-label scale="l">seconds LOOK HERE!</calcite-label>
         <calcite-label scale="s">
           Small Label
-          <calcite-input-time-picker scale="s" step="1" value="23:59"></calcite-input-time-picker>
+          <calcite-input-time-picker read-only scale="s" step="1" value="23:59"></calcite-input-time-picker>
         </calcite-label>
         <calcite-label scale="m">
           Medium Label
-          <calcite-input-time-picker scale="m" step="1" value="23:59"></calcite-input-time-picker>
+          <calcite-input-time-picker read-only scale="m" step="1" value="23:59"></calcite-input-time-picker>
         </calcite-label>
         <calcite-label scale="l"
           >Large Label
-          <calcite-input-time-picker scale="l" step="1" value="23:59"></calcite-input-time-picker>
+          <calcite-input-time-picker read-only scale="l" step="1" value="23:59"></calcite-input-time-picker>
         </calcite-label>
 
         <calcite-label scale="l">time-picker basic</calcite-label>

--- a/src/demos/input-time-picker.html
+++ b/src/demos/input-time-picker.html
@@ -67,18 +67,18 @@
           <calcite-input-time-picker scale="l" value="23:59"></calcite-input-time-picker>
         </calcite-label>
 
-        <calcite-label scale="l">seconds LOOK HERE!</calcite-label>
+        <calcite-label scale="l">seconds</calcite-label>
         <calcite-label scale="s">
           Small Label
-          <calcite-input-time-picker read-only scale="s" step="1" value="23:59"></calcite-input-time-picker>
+          <calcite-input-time-picker scale="s" step="1" value="23:59"></calcite-input-time-picker>
         </calcite-label>
         <calcite-label scale="m">
           Medium Label
-          <calcite-input-time-picker read-only scale="m" step="1" value="23:59"></calcite-input-time-picker>
+          <calcite-input-time-picker scale="m" step="1" value="23:59"></calcite-input-time-picker>
         </calcite-label>
         <calcite-label scale="l"
           >Large Label
-          <calcite-input-time-picker read-only scale="l" step="1" value="23:59"></calcite-input-time-picker>
+          <calcite-input-time-picker scale="l" step="1" value="23:59"></calcite-input-time-picker>
         </calcite-label>
 
         <calcite-label scale="l">time-picker basic</calcite-label>


### PR DESCRIPTION
**Related Issue:** #1947

## Summary

- added `readOnly prop` support

- modified the documentation to reflect the difference between `disabled` and `readOnly`:

> `readOnly` input is still focusable but won’t display the controls or allow for changing the value, whereas `disabled` controls can not receive focus and generally do not function as controls until they are enabled, refer to [MDN here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly#:~:text=The%20difference%20between%20disabled%20and%20readonly%20is%20that%20read%2Donly%20controls%20can%20still%20function%20and%20are%20still%20focusable%2C%20whereas%20disabled%20controls%20can%20not%20receive%20focus%20and%20are%20not%20submitted%20with%20the%20form%20and%20generally%20do%20not%20function%20as%20controls%20until%20they%20are%20enabled.)

- add a test to ensure when set to readOnly, the element is still focusable but won’t display the controls or allow for changing the value