### PR TITLE
fix(accordion, combobox, dropdown, tree): remove excessive borders in high contrast mode

### DIFF
--- a/src/components/accordion-item/accordion-item.scss
+++ b/src/components/accordion-item/accordion-item.scss
@@ -33,8 +33,7 @@
     relative
     flex
     flex-col
-    no-underline
-    outline-none;
+    no-underline;
   background-color: var(--calcite-accordion-item-background, theme("backgroundColor.foreground.1"));
 }
 
@@ -44,7 +43,8 @@
 }
 
 :host(:focus) .accordion-item-header {
-  @apply focus-inset;
+  @apply focus-inset
+  outline-none;
 }
 
 :host([active]),
@@ -166,5 +166,24 @@
   }
   & .accordion-item-description {
     @apply text-color-2;
+  }
+}
+
+@media (forced-colors: active) {
+  :host([expanded]) {
+    & .accordion-item-header {
+      border-bottom: none;
+    }
+    & .accordion-item-heading {
+      /** give visual indicator of expanded state since subtle color changes can't be done **/
+      font-weight: bolder;
+    }
+  }
+  :host(:hover),
+  :host(:focus) {
+    & .accordion-item-heading {
+      /** give visual indicator of expandability/click-ability since subtle color changes can't be done **/
+      text-decoration: underline;
+    }
   }
 }

--- a/src/components/combobox-item-group/combobox-item-group.scss
+++ b/src/components/combobox-item-group/combobox-item-group.scss
@@ -24,7 +24,12 @@
 
 :host,
 .list {
-  @apply m-0 flex flex-col p-0 outline-none;
+  @apply m-0 flex flex-col p-0;
+}
+
+:host(:focus),
+.list:focus {
+  @apply outline-none;
 }
 
 .label {

--- a/src/components/combobox-item/combobox-item.scss
+++ b/src/components/combobox-item/combobox-item.scss
@@ -33,7 +33,12 @@
 
 :host,
 ul {
-  @apply m-0 flex flex-col p-0 outline-none;
+  @apply m-0 flex flex-col p-0;
+}
+
+:host(:focus),
+ul:focus {
+  @apply outline-none;
 }
 
 .label {

--- a/src/components/combobox/combobox.scss
+++ b/src/components/combobox/combobox.scss
@@ -52,12 +52,6 @@
   @apply cursor-pointer flex-nowrap;
 }
 
-@media (forced-colors: active) {
-  .wrapper {
-    border: 1px solid canvasText;
-  }
-}
-
 .grid-input {
   @apply flex
     flex-grow
@@ -155,6 +149,13 @@
 
 .popper-container--active {
   @include popperWrapperActive();
+}
+
+@media (forced-colors: active) {
+  .wrapper,
+  .popper-container--active {
+    border: 1px solid canvasText;
+  }
 }
 
 .screen-readers-only {

--- a/src/components/combobox/combobox.scss
+++ b/src/components/combobox/combobox.scss
@@ -52,6 +52,12 @@
   @apply cursor-pointer flex-nowrap;
 }
 
+@media (forced-colors: active) {
+  .wrapper {
+    border: 1px solid canvasText;
+  }
+}
+
 .grid-input {
   @apply flex
     flex-grow

--- a/src/components/dropdown-item/dropdown-item.scss
+++ b/src/components/dropdown-item/dropdown-item.scss
@@ -46,7 +46,6 @@
     cursor-pointer
     items-center
     no-underline
-    outline-none
     duration-150
     ease-in-out;
 }
@@ -75,7 +74,7 @@
   @apply focus-base;
 }
 :host(:focus) {
-  @apply focus-inset;
+  @apply focus-inset outline-none;
 }
 
 // when used as link move styling anchor

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -32,6 +32,15 @@
 .calcite-dropdown-trigger-container {
   @apply relative flex flex-auto;
 }
+
+@media (forced-colors: active) {
+  /* use real border since box-shadow is removed in high contrast mode */
+  :host([active]) .calcite-dropdown-wrapper,
+  :host([open]) .calcite-dropdown-wrapper {
+    border: 1px solid canvasText;
+  }
+}
+
 // width
 :host([width="s"]) {
   --calcite-dropdown-width: theme("spacing.48");

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -2,8 +2,7 @@
   @apply text-color-3
     block
     max-w-full
-    cursor-pointer
-    outline-none;
+    cursor-pointer;
 }
 
 @include calciteHydratedHidden();
@@ -87,16 +86,19 @@
   @apply focus-base;
 }
 :host(:focus) {
-  @apply focus-inset;
+  @apply focus-inset outline-none;
 }
 
 .checkbox {
-  @apply outline-none;
   line-height: 0;
 }
 
 .checkbox-label {
   @apply pointer-events-none flex items-center;
+}
+
+.checkbox:focus {
+  @apply outline-none;
 }
 
 .children-container {

--- a/src/components/tree/tree.scss
+++ b/src/components/tree/tree.scss
@@ -1,3 +1,7 @@
 :host {
-  @apply block outline-none;
+  @apply block;
+}
+
+:host(:focus) {
+  @apply outline-none;
 }


### PR DESCRIPTION
**Related Issue:** #4912 

## Summary

Updates to the components' high contrast rendering

**Accordion**
<img width="250" alt="high contrast accordion" src="https://user-images.githubusercontent.com/142636/178793987-2af89064-2586-471c-bc6e-608bf37fbc2b.png">

**Combobox**
<img width="250" alt="high contrast comboboxes" src="https://user-images.githubusercontent.com/142636/178795026-344164fd-659f-493b-9883-f63221999e7b.png">


**Dropdown**
<img width="250" alt="high contrast dropdown" src="https://user-images.githubusercontent.com/142636/178795261-82a787f8-40bf-4f18-8383-c123c7176e95.png">


**Tree**
<img width="200" alt="high contrast tree" src="https://user-images.githubusercontent.com/142636/178794303-4b333805-7385-4990-a676-1fb3cf4924df.png">


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
