### PR TITLE
chore(linting): suggest alternative CSS approach for high specificity selectors

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,6 +13,12 @@
       }
     ],
     "property-case": "lower",
+    "selector-max-specificity": [
+      "0,5,5",
+      {
+        "message": "selector is too complex, consider applying multiple classes dynamically during rendering"
+      }
+    ],
     "selector-type-no-unknown": [
       true,
       {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This enables the [`selector-max-specificity`](https://stylelint.io/user-guide/rules/list/selector-max-specificity) rule to suggest using dynamic classes in rendering to decrease selector complexity.

Stems from https://github.com/Esri/calcite-components/pull/4367#discussion_r921534454

cc @driskull 

### Pending

-  ~define sensible value for max specificity~ -> starting w/ current one
-  ~update selectors wherever applicable (can be tackled separately)~ -> will tackle as we encounter them