### PR TITLE
fix(modal, alert, combobox, dropdown, input-date-picker, popover): Scope open and close events to component

### DIFF
--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -350,13 +350,13 @@ export class Alert implements OpenCloseComponent {
   }
 
   transitionStartHandler = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.active ? this.onBeforeOpen() : this.onBeforeClose();
     }
   };
 
   transitionEnd = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.active ? this.onOpen() : this.onClose();
     }
   };

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -554,13 +554,13 @@ export class Combobox
   }
 
   transitionEnd = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.listContainerEl) {
       this.open || this.active ? this.onOpen() : this.onClose();
     }
   };
 
   transitionStartHandler = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.listContainerEl) {
       this.open || this.active ? this.onBeforeOpen() : this.onBeforeClose();
     }
   };

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -462,13 +462,13 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent {
   };
 
   transitionEnd = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.scrollerEl) {
       this.open || this.active ? this.onOpen() : this.onClose();
     }
   };
 
   transitionStartHandler = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.scrollerEl) {
       this.open || this.active ? this.onBeforeOpen() : this.onBeforeClose();
     }
   };

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -614,13 +614,13 @@ export class InputDatePicker
   }
 
   transitionStartHandler = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.active ? this.onBeforeOpen() : this.onBeforeClose();
     }
   };
 
   transitionEnd = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.active ? this.onOpen() : this.onClose();
     }
   };

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -266,11 +266,6 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
 
   private containerEl: HTMLDivElement;
 
-  private setContainerEl = (el): void => {
-    this.containerEl = el;
-    this.containerEl.addEventListener("transitionstart", this.transitionStartHandler);
-  };
-
   //--------------------------------------------------------------------------
   //
   //  Event Listeners
@@ -361,6 +356,11 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
   //
   //--------------------------------------------------------------------------
 
+  private setContainerEl = (el): void => {
+    this.containerEl = el;
+    this.containerEl.addEventListener("transitionstart", this.transitionStartHandler);
+  };
+
   onBeforeOpen(): void {
     this.calciteModalBeforeOpen.emit();
   }
@@ -378,13 +378,13 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
   }
 
   transitionStartHandler = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.open || this.active ? this.onBeforeOpen() : this.onBeforeClose();
     }
   };
 
   transitionEnd = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.open || this.active ? this.onOpen() : this.onClose();
     }
   };

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -480,13 +480,13 @@ export class Popover implements OpenCloseComponent {
   }
 
   transitionStartHandler = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.open ? this.onBeforeOpen() : this.onBeforeClose();
     }
   };
 
   transitionEnd = (event: TransitionEvent): void => {
-    if (event.propertyName === this.activeTransitionProp) {
+    if (event.propertyName === this.activeTransitionProp && event.target === this.containerEl) {
       this.open ? this.onOpen() : this.onClose();
     }
   };


### PR DESCRIPTION
**Related Issue:** #4902

## Summary

fix(modal, alert, combobox, dropdown, input-date-picker, popover): Scope open and close events to component. (#4902)

Makes sure that transition events are only fired when they occur on the element they are supposed to.