### PR TITLE
fix(stepper-item): restore disabled styling on horizontal layout stepper items

### DIFF
--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -43,7 +43,7 @@
 // additional styling can be passed via @content
 @mixin disabled() {
   :host([disabled]) {
-    @apply opacity-disabled pointer-events-none cursor-default select-none;
+    @extend %disabled-host-only;
     @content;
 
     ::slotted([calcite-hydrated][disabled]),
@@ -52,6 +52,11 @@
       @apply opacity-100;
     }
   }
+}
+
+// used for host-specific styling when the `disabled` mixin cannot be applied on the host (e.g., `display: contents`)
+%disabled-host-only {
+  @apply opacity-disabled pointer-events-none cursor-default select-none;
 }
 
 // mixin to provide default invisibility and disabling of pointer events for components.

--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -274,6 +274,12 @@
   }
 }
 
+:host([layout="horizontal"][disabled]) {
+  .stepper-item-header {
+    @extend %disabled-host-only;
+  }
+}
+
 :host([layout="horizontal"][active]) {
   .stepper-item-content {
     grid-area: 2 / 1 / 2 / -1;


### PR DESCRIPTION
**Related Issue:** #4955 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

The disabled style mixin was no longer applied to the host as the stepper item uses `display:contents`, which basically replaces the host container with its children. This extracts the host styles from that mixin to be applied individually in this case.