### PR TITLE
fix(stepper-item): avoid cursor-pointer on item content for horizontal layouts

### DIFF
--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -46,6 +46,7 @@
     relative
     flex
     flex-grow
+    cursor-pointer
     flex-col
     border-0
     border-t-2
@@ -266,7 +267,7 @@
   }
 
   .stepper-item-content {
-    @apply duration-150 ease-in-out;
+    @apply cursor-auto duration-150 ease-in-out;
     padding-block: 0;
     padding-inline-end: var(--calcite-stepper-item-spacing-unit-m);
     text-align: start;

--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -46,7 +46,6 @@
     relative
     flex
     flex-grow
-    cursor-pointer
     flex-col
     border-0
     border-t-2


### PR DESCRIPTION
**Related Issue:** #4954 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a mouse-cursor regression introduced by #4367.

Note: this has no accompanying screenshot test as Screener does not capture the mouse cursor