### PR TITLE
fix(stepper-item): remove bottom margin on content from horizontal layout

### DIFF
--- a/src/components/stepper-item/stepper-item.scss
+++ b/src/components/stepper-item/stepper-item.scss
@@ -191,9 +191,6 @@
 :host([active]) .container {
   & .stepper-item-content {
     @apply flex;
-    & ::slotted(:last-child) {
-      margin-block-end: var(--calcite-stepper-item-spacing-unit-l);
-    }
   }
 }
 
@@ -233,6 +230,12 @@
 }
 :host([layout="vertical"][active]) .container {
   @apply border-color-brand;
+
+  & .stepper-item-content {
+    & ::slotted(:last-child) {
+      margin-block-end: var(--calcite-stepper-item-spacing-unit-l);
+    }
+  }
 }
 :host([layout="vertical"]:hover:not([disabled]):not([active])) .container,
 :host([layout="vertical"]:focus:not([disabled]):not([active])) .container {


### PR DESCRIPTION
**Related Issue:** #4956 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
The vertical layout applies margin to item content. This is not needed when the stepper's layout is horizontal.