### PR TITLE
build: add __dirname vars that are missing in ESM

### DIFF
--- a/support/patchES5Helpers.ts
+++ b/support/patchES5Helpers.ts
@@ -2,9 +2,12 @@
   const {
     promises: { readFile, readdir, writeFile }
   } = await import("fs");
-  const { normalize } = await import("path");
+  const { dirname, normalize } = await import("path");
   const { quote } = await import("shell-quote");
+  const { fileURLToPath } = await import("url");
 
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
   const esmEs5Output = quote([normalize(`${__dirname}/../dist/esm-es5/`)]);
 
   // we patch __spreadArray to work around https://github.com/microsoft/tslib/issues/175

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -7,16 +7,19 @@ import yargs from "yargs";
   const childProcess = await import("child_process");
   const { promises: fs } = await import("fs");
   const gitSemverTags = await import("git-semver-tags");
-  const { normalize } = await import("path");
+  const { dirname, normalize } = await import("path");
   const prettier = await import("prettier");
   const semver = await import("semver");
   const { quote } = await import("shell-quote");
   const { default: standardVersion } = await import("standard-version");
+  const { fileURLToPath } = await import("url");
 
   const exec = pify(childProcess.exec);
   const header = `# Changelog\n\nThis document maintains a list of released versions and changes introduced by them.\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)\n`;
   const unreleasedSectionTokenStart = "<!--@unreleased-section-start-->";
   const unreleasedSectionTokenEnd = "<!--@unreleased-section-end-->";
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
   const changelogPath = quote([normalize(`${__dirname}/../CHANGELOG.md`)]);
   const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

These got left out from https://github.com/Esri/calcite-components/pull/4890/.