### PR TITLE
fix(combobox): Announce selection to assistive technologies in focus and on demand

### DIFF
--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -56,7 +56,6 @@ const isGroup = (el: ComboboxChildElement): el is HTMLCalciteComboboxItemGroupEl
 const itemUidPrefix = "combobox-item-";
 const chipUidPrefix = "combobox-chip-";
 const labelUidPrefix = "combobox-label-";
-//const announceUiDPrefix = "combobox-announce-";
 const listboxUidPrefix = "combobox-listbox-";
 const inputUidPrefix = "combobox-input-";
 

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -56,6 +56,7 @@ const isGroup = (el: ComboboxChildElement): el is HTMLCalciteComboboxItemGroupEl
 const itemUidPrefix = "combobox-item-";
 const chipUidPrefix = "combobox-chip-";
 const labelUidPrefix = "combobox-label-";
+//const announceUiDPrefix = "combobox-announce-";
 const listboxUidPrefix = "combobox-listbox-";
 const inputUidPrefix = "combobox-input-";
 
@@ -281,6 +282,7 @@ export class Combobox
   }>;
 
   /** Called when a selected item in the combobox is dismissed via its chip */
+  // eslint-disable-next-line @esri/calcite-components/require-event-emitter-type
   @Event() calciteComboboxChipDismiss: EventEmitter;
 
   /* Fires when the component is requested to be closed and before the closing transition begins. */
@@ -1015,6 +1017,7 @@ export class Combobox
           icon={item.icon}
           id={item.guid ? `${chipUidPrefix}${item.guid}` : null}
           key={item.textLabel}
+          // eslint-disable-next-line react/jsx-no-bind
           onCalciteChipDismiss={(event) => this.calciteChipDismissHandler(event, item)}
           scale={scale}
           title={label}
@@ -1147,12 +1150,14 @@ export class Combobox
     const single = this.selectionMode === "single";
 
     return (
-      <Host onKeyDown={this.keydownHandler}>
+      <Host>
         <div
           aria-autocomplete="list"
+          aria-controls={`${listboxUidPrefix}${guid}`}
           aria-expanded={toAriaBoolean(open || active)}
           aria-haspopup="listbox"
           aria-labelledby={`${labelUidPrefix}${guid}`}
+          aria-live="polite"
           aria-owns={`${listboxUidPrefix}${guid}`}
           class={{
             wrapper: true,
@@ -1160,8 +1165,10 @@ export class Combobox
             "wrapper--active": open || active
           }}
           onClick={this.clickHandler}
+          onKeyDown={this.keydownHandler}
           ref={this.setReferenceEl}
           role="combobox"
+          tabindex="0"
         >
           <div class="grid-input">
             {this.renderIconStart()}

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -1016,7 +1016,6 @@ export class Combobox
           icon={item.icon}
           id={item.guid ? `${chipUidPrefix}${item.guid}` : null}
           key={item.textLabel}
-          // eslint-disable-next-line react/jsx-no-bind
           onCalciteChipDismiss={(event) => this.calciteChipDismissHandler(event, item)}
           scale={scale}
           title={label}


### PR DESCRIPTION
**Related Issue:** #4918, #4917 

## Summary
Adds support to `combobox` selection(s) and provides context to users of assistive technologies.

Includes:

1. When the `combobox` is in focus and has a value, or values selected, announces the selections via JAWS, NVDA, and VoiceOver
3. Adds an announcement to a `combobox-item` selection on-demand via JAWS, NVDA, and VoiceOver


_Of Note_: There were two eslint rules preventing commits from occurring in the component, including:  
- `require event emitter type` (line [285](https://github.com/Esri/calcite-components/compare/geospatialem/4918-fix-combobox-selection-a11y?expand=1#diff-8eb51d8ec5c3891740279618f20aa76593ead68fae27b701743289a341689bcfR285)), and  
- `react jsx no bind` (line [1020](https://github.com/Esri/calcite-components/compare/geospatialem/4918-fix-combobox-selection-a11y?expand=1#diff-8eb51d8ec5c3891740279618f20aa76593ead68fae27b701743289a341689bcfR1020))  

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
