### PR TITLE
fix(action-bar, action-pad): Allow users to define custom max-width with CSS

### DIFF
--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-bar-expanded-max-width: optionally specify the expanded max width of the action bar.
+ * @prop --calcite-action-bar-expanded-max-width: optionally specify the expanded max width of the action bar when in "vertical" layout.
  */
 
 :host {

--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -1,10 +1,18 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-action-bar-expanded-max-width: optionally specify the expanded max width of the action bar.
+ */
+
 :host {
   @extend %component-host;
   @apply pointer-events-auto
     inline-flex
     flex-col
     self-stretch;
-  max-inline-size: 15vw;
+  --calcite-action-bar-expanded-max-width: auto;
   background: transparent;
 }
 
@@ -13,7 +21,7 @@
 }
 
 :host([expanded]) {
-  max-inline-size: 20vw;
+  max-inline-size: var(--calcite-action-bar-expanded-max-width);
 }
 
 ::slotted(calcite-action-group) {

--- a/src/components/action-bar/action-bar.stories.ts
+++ b/src/components/action-bar/action-bar.stories.ts
@@ -123,11 +123,10 @@ export const withDefinedWidths = (): string =>
   html`
     <style>
       calcite-action-bar {
-        --calcite-action-bar-max-width: auto;
         --calcite-action-bar-expanded-max-width: 150px;
       }
     </style>
-    <calcite-action-bar>
+    <calcite-action-bar expanded>
       <calcite-action-group>
         <calcite-action text="Add to my custom action bar application" icon="plus"></calcite-action>
         <calcite-action text="Save to my custom action bar application" icon="save"></calcite-action>

--- a/src/components/action-bar/action-bar.stories.ts
+++ b/src/components/action-bar/action-bar.stories.ts
@@ -118,3 +118,22 @@ export const withTooltip = (): string =>
       <calcite-action text="Add" icon="plus"></calcite-action>
     `
   );
+
+export const withDefinedWidths = (): string =>
+  html`
+    <style>
+      calcite-action-bar {
+        --calcite-action-bar-max-width: auto;
+        --calcite-action-bar-expanded-max-width: 150px;
+      }
+    </style>
+    <calcite-action-bar>
+      <calcite-action-group>
+        <calcite-action text="Add to my custom action bar application" icon="plus"></calcite-action>
+        <calcite-action text="Save to my custom action bar application" icon="save"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Layers in my custom action bar application" icon="layers"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-bar>
+  `;

--- a/src/components/action-pad/action-pad.scss
+++ b/src/components/action-pad/action-pad.scss
@@ -1,10 +1,19 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-action-pad-expanded-max-width: optionally specify the expanded max width of the action pad.
+ */
+
 :host {
   @extend %component-host;
   @apply animate-in block rounded-sm;
+  --calcite-action-pad-expanded-max-width: auto;
 }
 
 :host([expanded]) {
-  max-inline-size: 20vw;
+  max-inline-size: var(--calcite-action-pad-expanded-max-width);
   background: transparent;
 }
 

--- a/src/components/action-pad/action-pad.scss
+++ b/src/components/action-pad/action-pad.scss
@@ -3,18 +3,18 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-pad-expanded-max-width: optionally specify the expanded max width of the action pad.
+ * @prop --calcite-action-pad-expanded-max-width: optionally specify the expanded max width of the action pad when in "vertical" layout.
  */
 
 :host {
   @extend %component-host;
   @apply animate-in block rounded-sm;
   --calcite-action-pad-expanded-max-width: auto;
+  background: transparent;
 }
 
-:host([expanded]) {
+:host([expanded]) .container {
   max-inline-size: var(--calcite-action-pad-expanded-max-width);
-  background: transparent;
 }
 
 ::slotted(calcite-action-group) {
@@ -32,7 +32,6 @@
   flex-col
   overflow-y-auto
   rounded;
-  max-inline-size: 15vw;
 }
 
 .action-group--bottom {
@@ -42,7 +41,6 @@
 :host([layout="horizontal"]) {
   .container {
     @apply flex-row;
-    max-inline-size: unset;
     .action-group--bottom {
       @apply p-0;
     }

--- a/src/components/action-pad/action-pad.scss
+++ b/src/components/action-pad/action-pad.scss
@@ -13,7 +13,7 @@
   background: transparent;
 }
 
-:host([expanded]) .container {
+:host([expanded][layout="vertical"]) .container {
   max-inline-size: var(--calcite-action-pad-expanded-max-width);
 }
 

--- a/src/components/action-pad/action-pad.stories.ts
+++ b/src/components/action-pad/action-pad.stories.ts
@@ -118,3 +118,20 @@ export const withTooltip = (): string =>
       <calcite-action text="Add" icon="plus"></calcite-action>
     `
   );
+
+export const withDefinedWidths = (): string =>
+  html`
+    <style>
+      --calcite-action-pad-max-width: auto;
+      --calcite-action-pad-expanded-max-width: 100px;
+    </style>
+    <calcite-action-pad>
+      <calcite-action-group>
+        <calcite-action text="Add to my custom action pad application" icon="plus"></calcite-action>
+        <calcite-action text="Save to my custom action pad application" icon="save"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Layers in my custom action pad application" icon="layers"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-pad>
+  `;

--- a/src/components/action-pad/action-pad.stories.ts
+++ b/src/components/action-pad/action-pad.stories.ts
@@ -122,10 +122,11 @@ export const withTooltip = (): string =>
 export const withDefinedWidths = (): string =>
   html`
     <style>
-      --calcite-action-pad-max-width: auto;
-      --calcite-action-pad-expanded-max-width: 100px;
+      calcite-action-pad {
+        --calcite-action-pad-expanded-max-width: 150px;
+      }
     </style>
-    <calcite-action-pad>
+    <calcite-action-pad expanded>
       <calcite-action-group>
         <calcite-action text="Add to my custom action pad application" icon="plus"></calcite-action>
         <calcite-action text="Save to my custom action pad application" icon="save"></calcite-action>


### PR DESCRIPTION
**Related Issue:** #2380

## Summary

fix(action-bar, action-pad): Allow users to define custom max-width with CSS

Users can use the new custom CSS properties to define max widths for action-bar and action-pad