### PR TITLE
build: fix dynamic import in prepReleaseCommit

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -6,7 +6,7 @@ import yargs from "yargs";
 (async function prepReleaseCommit(): Promise<void> {
   const childProcess = await import("child_process");
   const { promises: fs } = await import("fs");
-  const gitSemverTags = await import("git-semver-tags");
+  const { default: gitSemverTags } = await import("git-semver-tags");
   const { dirname, normalize } = await import("path");
   const prettier = await import("prettier");
   const semver = await import("semver");


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This got overlooked in https://github.com/Esri/calcite-components/pull/4890. 