### PR TITLE
build: fix dynamic ESM imports

### DIFF
--- a/support/cleanOnProcessExit.ts
+++ b/support/cleanOnProcessExit.ts
@@ -1,7 +1,7 @@
 import yargs from "yargs";
 
 (async function () {
-  const rimraf = await import("rimraf");
+  const { default: rimraf } = await import("rimraf");
   const { resolve } = await import("path");
 
   // 👇 based on https://stackoverflow.com/a/14032965

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -9,7 +9,7 @@ import yargs from "yargs";
   const { default: gitSemverTags } = await import("git-semver-tags");
   const { dirname, normalize } = await import("path");
   const prettier = await import("prettier");
-  const semver = await import("semver");
+  const { default: semver } = await import("semver");
   const { quote } = await import("shell-quote");
   const { default: standardVersion } = await import("standard-version");
   const { fileURLToPath } = await import("url");

--- a/support/releaseToGitHub.ts
+++ b/support/releaseToGitHub.ts
@@ -2,8 +2,8 @@ import pify from "pify";
 
 (async function () {
   const childProcess = await import("child_process");
-  const githubRelease = await import("gh-release");
-  const rimraf = await import("rimraf");
+  const { default: githubRelease } = await import("gh-release");
+  const { default: rimraf } = await import("rimraf");
 
   const packageFileName = childProcess.execSync("npm pack", { encoding: "utf-8" }).trim();
   const packageScope = "esri-";


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes additional imports from #4890. 
