### PR TITLE
ci(next): try to get logs displayed in github action

### DIFF
--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -1,5 +1,5 @@
 import pify from "pify";
-
+import { prepReleaseCommit } from "./prepReleaseCommit";
 /*
  * This script is meant to be run by a CI environment during the deploy phase.
  * It checks if there are release-worthy (deployable) changes and will publish to NPM when applicable.
@@ -38,7 +38,7 @@ import pify from "pify";
       // https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
 
       console.log(" - prepping and building package...");
-      await exec(`npm run util:prep-next`);
+      await prepReleaseCommit();
 
       const changesCommitted = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
       if (!changesCommitted) {


### PR DESCRIPTION
**Related Issue:** #

## Summary
- Fixes a type error in the release prep script
- exports the release prep script as a function to use in the next release. Hopefully that gets us better logging in the GH Action. Currently logs from `deployNextFromCI` show up, and that scripts uses the pify to call the npm script for the prep release script. Now it stays in JS which _might_ make the logs show up? shot in the dark 🤞 
- Removes `echo` calls from the script which was a previous attempt to get logging to work
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
