### PR TITLE
ci: deploy storybook before releasing next

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
             npm run util:is-next-deployable
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
             # deploy storybook, but still release next if it fails
             { npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GH_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true
             npm run util:deploy-next-from-ci

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -31,6 +31,9 @@ jobs:
           GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
         run: |
           if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
+            npm run util:is-next-deployable
+            # deploy storybook, but still release next if it fails
+            { npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GH_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true
             npm run util:deploy-next-from-ci
           else
             echo "Next release is disabled"

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -24,11 +24,16 @@ jobs:
         run: |
           npm ci --legacy-peer-deps
           npm test
-      - name: next deployment
+      - name: storybook/next deployment
         env:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
         run: |
           if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            npm run build-storybook
+            npx storybook-to-ghpages --existing-output-dir=docs --ci
             npm run util:deploy-next-from-ci
           else
             echo "Next release is disabled"
@@ -42,11 +47,3 @@ jobs:
           show-on-start: false
           card-layout-exit: complete
           timezone: America/Los_Angeles
-      - name: storybook deployment
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          npm run build-storybook
-          npx storybook-to-ghpages --existing-output-dir=docs --ci
-        env:
-          GH_TOKEN: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -27,13 +27,10 @@ jobs:
       - name: storybook/next deployment
         env:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
-          GH_TOKEN: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
+          # https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-618560481
+          GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
         run: |
           if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
-            git config --global user.name "github-actions[bot]"
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            npm run build-storybook
-            npx storybook-to-ghpages --existing-output-dir=docs --ci
             npm run util:deploy-next-from-ci
           else
             echo "Next release is disabled"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "util:copy-icons": "cpy \"./node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/icon/\" --flat",
     "util:deploy-next": "npm run util:prep-next && npm run util:push-tags && npm run util:publish-next",
     "util:deploy-next-from-ci": "ts-node --esm support/deployNextFromCI.ts",
+    "util:is-next-deployable": "ts-node --esm support/isNextDeployable.ts",
     "util:hydration-styles": "ts-node --esm support/hydrationStyles.ts",
     "util:patch-es5-helpers": "ts-node --esm support/patchES5Helpers.ts",
     "util:prep-next": "ts-node --esm support/prepReleaseCommit.ts --next && npm run build",

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -2,7 +2,6 @@ import pify from "pify";
 
 /*
  * This script is meant to be run by a CI environment during the deploy phase.
- * It checks if there are release-worthy (deployable) changes and will publish to NPM when applicable.
  *
  * Based on https://github.com/conventional-changelog/standard-version/issues/192#issuecomment-610494804
  */
@@ -11,102 +10,42 @@ import pify from "pify";
   const exec = pify(childProcess.exec);
 
   async function deployNextFromCI(): Promise<void> {
-    console.log("Determining @next deployability 🔍");
+    console.log("Deploying @next 🚧");
 
-    if (!(await deployable(await mostRecentTag("HEAD")))) {
-      console.log("No changes since the previous release, skipping ⛔");
-      return;
+    console.log(" - adding user details...");
+
+    await exec(`git config --global user.email "github-actions[bot]@users.noreply.github.com"`);
+    await exec(`git config --global user.name "github-actions[bot]"`);
+
+    // the setup-node gh action handles the token
+    // https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
+
+    console.log(" - prepping and building package...");
+    await exec(`npm run util:prep-next`);
+
+    const changesCommitted = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
+    if (!changesCommitted) {
+      console.log("an error occurred committing changes");
+      process.exitCode = 1;
     }
 
-    await runGit("checkout", "master", "--quiet");
-    await runGit("fetch", "--tags", "--quiet");
+    await exec(`git log --pretty=format:'%h : %s' --graph`);
 
-    if (
-      (await latestCommit("master")) != (await latestCommit("origin/master")) &&
-      (await deployable("master", "origin/master"))
-    ) {
-      console.log("There is a more recent deployable install, aborting ⛔️");
-    } else {
-      console.log("Deploying @next 🚧");
+    // github token provided by the checkout action
+    // https://github.com/actions/checkout#usage
+    console.log(" - pushing tags...");
+    await exec(`git push --atomic --follow-tags origin master`);
 
-      console.log(" - adding user details...");
-
-      await exec(`git config --global user.email "github-actions[bot]@users.noreply.github.com"`);
-      await exec(`git config --global user.name "github-actions[bot]"`);
-
-      // the setup-node gh action handles the token
-      // https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
-
-      console.log(" - prepping and building package...");
-      await exec(`npm run util:prep-next`);
-
-      const changesCommitted = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
-      if (!changesCommitted) {
-        console.log("an error occurred committing changes");
-        process.exitCode = 1;
-      }
-
-      // deploy storybook, but still release next if it fails
-      await exec(
-        "{ npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GH_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true"
-      );
-
-      await exec(`git log --pretty=format:'%h : %s' --graph`);
-
-      // github token provided by the checkout action
-      // https://github.com/actions/checkout#usage
-      console.log(" - pushing tags...");
-      await exec(`git push --atomic --follow-tags origin master`);
-
-      const changesPushed = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
-      if (!changesPushed) {
-        console.log("an error occurred pushing changes");
-        process.exitCode = 1;
-      }
-
-      console.log(" - publishing @next...");
-      await exec(`npm run util:publish-next`);
-
-      console.log("@next deployed! 🚀");
+    const changesPushed = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
+    if (!changesPushed) {
+      console.log("an error occurred pushing changes");
+      process.exitCode = 1;
     }
-  }
 
-  /**
-   * Determines if the changes between from and to refs are deployable.
-   *
-   * Deployable scenarios:
-   *
-   * 1. there is a feat or fix type commit in the ref range
-   * 2. there is a commit type that introduced a breaking change
-   *
-   * @param fromRef
-   * @param toRef
-   */
-  async function deployable(fromRef = "HEAD", toRef = "HEAD"): Promise<boolean> {
-    const subjectLog = await runGit("log", `${fromRef}..${toRef} --format='%s'`);
-    const bodyLog = await runGit("log", `${fromRef}..${toRef} --format='%b'`);
+    console.log(" - publishing @next...");
+    await exec(`npm run util:publish-next`);
 
-    const deployableCommitTypeHeaderPattern = /^(feat|fix)(\(.*\))?:.+$/im;
-    const breakingChangesCommitTypeHeaderPattern = /^(.+)(\(.*\))?\!:.+$/im;
-    const breakingChangesCommitFooterPattern = /^BREAKING CHANGE:/i;
-
-    return (
-      deployableCommitTypeHeaderPattern.test(subjectLog) ||
-      breakingChangesCommitTypeHeaderPattern.test(subjectLog) ||
-      breakingChangesCommitFooterPattern.test(bodyLog)
-    );
-  }
-
-  async function latestCommit(branch: string): Promise<string> {
-    return runGit("rev-parse", branch);
-  }
-
-  async function mostRecentTag(branch: string): Promise<string> {
-    return runGit("describe", "--tags", `--abbrev=0 ${branch}`);
-  }
-
-  async function runGit(command: string, ...args: string[]): Promise<string> {
-    return (await exec(`git ${command} ${args.join(" ")}`, { encoding: "utf-8" })).trim();
+    console.log("@next deployed! 🚀");
   }
 
   try {

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -46,6 +46,11 @@ import pify from "pify";
         process.exitCode = 1;
       }
 
+      await exec("npm run build-storybook");
+      await exec(
+        "npx storybook-to-ghpages --host-token-env-variable=GITHUB_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci"
+      );
+
       await exec(`git log --pretty=format:'%h : %s' --graph`);
 
       // github token provided by the checkout action

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -48,7 +48,7 @@ import pify from "pify";
 
       // deploy storybook, but still release next if it fails
       await exec(
-        "{ npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GITHUB_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true"
+        "{ npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GH_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true"
       );
 
       await exec(`git log --pretty=format:'%h : %s' --graph`);

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -12,11 +12,6 @@ import pify from "pify";
   async function deployNextFromCI(): Promise<void> {
     console.log("Deploying @next 🚧");
 
-    console.log(" - adding user details...");
-
-    await exec(`git config --global user.email "github-actions[bot]@users.noreply.github.com"`);
-    await exec(`git config --global user.name "github-actions[bot]"`);
-
     // the setup-node gh action handles the token
     // https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
 
@@ -25,11 +20,8 @@ import pify from "pify";
 
     const changesCommitted = (await exec(`git rev-parse HEAD`)) !== (await exec(`git rev-parse origin/master`));
     if (!changesCommitted) {
-      console.log("an error occurred committing changes");
-      process.exitCode = 1;
+      throw new Error("Failed to commit changes");
     }
-
-    await exec(`git log --pretty=format:'%h : %s' --graph`);
 
     // github token provided by the checkout action
     // https://github.com/actions/checkout#usage
@@ -38,8 +30,7 @@ import pify from "pify";
 
     const changesPushed = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
     if (!changesPushed) {
-      console.log("an error occurred pushing changes");
-      process.exitCode = 1;
+      throw new Error("Failed to push changes");
     }
 
     console.log(" - publishing @next...");
@@ -55,5 +46,6 @@ import pify from "pify";
       `An error occurred during deployment ❌:
 ${error}`
     );
+    process.exit(1);
   }
 })();

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -46,9 +46,9 @@ import pify from "pify";
         process.exitCode = 1;
       }
 
-      await exec("npm run build-storybook");
+      // deploy storybook, but still release next if it fails
       await exec(
-        "npx storybook-to-ghpages --host-token-env-variable=GITHUB_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci"
+        "{ npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GITHUB_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true"
       );
 
       await exec(`git log --pretty=format:'%h : %s' --graph`);

--- a/support/isNextDeployable.ts
+++ b/support/isNextDeployable.ts
@@ -1,0 +1,78 @@
+import pify from "pify";
+
+/*
+ * This script is meant to be run by a CI environment during the deploy phase.
+ * It throws an error if there are not release-worthy (deployable) changes.
+ *
+ * Based on https://github.com/conventional-changelog/standard-version/issues/192#issuecomment-610494804
+ */
+(async function runner(): Promise<void> {
+  const childProcess = await import("child_process");
+  const exec = pify(childProcess.exec);
+
+  async function isNextDeployable(): Promise<void> {
+    console.log("Determining @next deployability 🔍");
+
+    if (!(await deployable(await mostRecentTag("HEAD")))) {
+      throw new Error("No deployable changes since the previous release, skipping ⛔");
+    }
+
+    await runGit("checkout", "master", "--quiet");
+    await runGit("fetch", "--tags", "--quiet");
+
+    if (
+      (await latestCommit("master")) != (await latestCommit("origin/master")) &&
+      (await deployable("master", "origin/master"))
+    ) {
+      throw new Error("There is a more recent deployable install, aborting ⛔️");
+    }
+  }
+
+  /**
+   * Determines if the changes between from and to refs are deployable.
+   *
+   * Deployable scenarios:
+   *
+   * 1. there is a feat or fix type commit in the ref range
+   * 2. there is a commit type that introduced a breaking change
+   *
+   * @param fromRef
+   * @param toRef
+   */
+  async function deployable(fromRef = "HEAD", toRef = "HEAD"): Promise<boolean> {
+    const subjectLog = await runGit("log", `${fromRef}..${toRef} --format='%s'`);
+    const bodyLog = await runGit("log", `${fromRef}..${toRef} --format='%b'`);
+
+    const deployableCommitTypeHeaderPattern = /^(feat|fix)(\(.*\))?:.+$/im;
+    const breakingChangesCommitTypeHeaderPattern = /^(.+)(\(.*\))?\!:.+$/im;
+    const breakingChangesCommitFooterPattern = /^BREAKING CHANGE:/i;
+
+    return (
+      deployableCommitTypeHeaderPattern.test(subjectLog) ||
+      breakingChangesCommitTypeHeaderPattern.test(subjectLog) ||
+      breakingChangesCommitFooterPattern.test(bodyLog)
+    );
+  }
+
+  async function latestCommit(branch: string): Promise<string> {
+    return runGit("rev-parse", branch);
+  }
+
+  async function mostRecentTag(branch: string): Promise<string> {
+    return runGit("describe", "--tags", `--abbrev=0 ${branch}`);
+  }
+
+  async function runGit(command: string, ...args: string[]): Promise<string> {
+    return (await exec(`git ${command} ${args.join(" ")}`, { encoding: "utf-8" })).trim();
+  }
+
+  try {
+    await isNextDeployable();
+  } catch (error) {
+    console.log(
+      `An error occurred during deployment ❌:
+${error}`
+    );
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
**Related Issue:** #

## Summary
The storybook deployment isn't happening because we set up concurrency to batch `next` release commits, which cancels the current run when a new push to master happens. Moving the storybook deployment before the `next` release will fix the issue.

Edits:
- Put the storybook deployment inside of the `deployNextFromCI` script so that storybook only deploys when there are deployable commits
- Make sure that `next` releases even if the storybook deployment fails
    
    ![image](https://user-images.githubusercontent.com/10986395/180897244-0c6420db-2cd9-48be-a4ae-749804b7a070.png)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
