### PR TITLE
build: fix CLI option handling in ESM scripts

### DIFF
--- a/support/cleanOnProcessExit.ts
+++ b/support/cleanOnProcessExit.ts
@@ -16,7 +16,9 @@ import yargs from "yargs";
     exit: boolean;
   }
 
-  const { path } = yargs(process.argv) as any;
+  const { path } = yargs(process.argv.slice(2))
+    .options({ path: { type: "string" } })
+    .parseSync();
 
   const exitHandler = (options: CleanupOptions | ExitOptions): void => {
     if ("cleanup" in options) {

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -23,7 +23,9 @@ import yargs from "yargs";
   const changelogPath = quote([normalize(`${__dirname}/../CHANGELOG.md`)]);
   const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 
-  const { next } = yargs(process.argv) as any;
+  const { next } = yargs(process.argv.slice(2))
+    .options({ next: { type: "boolean", default: false } })
+    .parseSync();
 
   // deepen the history when fetching tags due to shallow clone
   await exec("git fetch --deepen=250 --tags");


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes an issue in ESMified™ scripts where options were not parsed properly.