### PR TITLE
revert: Fix navigating without a dropdown-group 

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -53,3 +53,7 @@
 :host([width="l"]) {
   --calcite-dropdown-width: theme("spacing.64");
 }
+
+::slotted(calcite-dropdown-item) {
+  display: none;
+}

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -17,10 +17,6 @@
   @include floatingUIWrapper();
 }
 
-::slotted(calcite-dropdown-item) {
-  display: none;
-}
-
 @include floatingUIElemAnim(".calcite-dropdown-wrapper");
 :host([active]) .calcite-dropdown-wrapper,
 :host([open]) .calcite-dropdown-wrapper {

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -17,6 +17,10 @@
   @include floatingUIWrapper();
 }
 
+::slotted(calcite-dropdown-item) {
+  display: none;
+}
+
 @include floatingUIElemAnim(".calcite-dropdown-wrapper");
 :host([active]) .calcite-dropdown-wrapper,
 :host([open]) .calcite-dropdown-wrapper {
@@ -52,8 +56,4 @@
 }
 :host([width="l"]) {
   --calcite-dropdown-width: theme("spacing.64");
-}
-
-::slotted(calcite-dropdown-item) {
-  display: none;
 }

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -406,11 +406,13 @@ export const FlipPositioning = stepStory(
     <div style="margin:10px;">
       <calcite-dropdown width="m" placement="${select("placement", menuPlacements, "top")}">
         <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-        <calcite-dropdown-item>1</calcite-dropdown-item>
-        <calcite-dropdown-item>2</calcite-dropdown-item>
-        <calcite-dropdown-item>3</calcite-dropdown-item>
-        <calcite-dropdown-item>4</calcite-dropdown-item>
-        <calcite-dropdown-item>5</calcite-dropdown-item>
+        <calcite-dropdown-group>
+          <calcite-dropdown-item>1</calcite-dropdown-item>
+          <calcite-dropdown-item>2</calcite-dropdown-item>
+          <calcite-dropdown-item>3</calcite-dropdown-item>
+          <calcite-dropdown-item>4</calcite-dropdown-item>
+          <calcite-dropdown-item>5</calcite-dropdown-item>
+        </calcite-dropdown-group>
       </calcite-dropdown>
     </div>
   `,
@@ -485,3 +487,12 @@ export const AlignedCenterRTL = (): string => html`
     </calcite-dropdown>
   </div>
 `;
+
+export const InvalidWithoutDropdownGroup = (): string => html` <calcite-dropdown open>
+  <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+  <calcite-dropdown-item>1</calcite-dropdown-item>
+  <calcite-dropdown-item>2</calcite-dropdown-item>
+  <calcite-dropdown-item>3</calcite-dropdown-item>
+  <calcite-dropdown-item>4</calcite-dropdown-item>
+  <calcite-dropdown-item>5</calcite-dropdown-item>
+</calcite-dropdown>`;

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -487,12 +487,3 @@ export const AlignedCenterRTL = (): string => html`
     </calcite-dropdown>
   </div>
 `;
-
-export const InvalidWithoutDropdownGroup = (): string => html` <calcite-dropdown open>
-  <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-  <calcite-dropdown-item>1</calcite-dropdown-item>
-  <calcite-dropdown-item>2</calcite-dropdown-item>
-  <calcite-dropdown-item>3</calcite-dropdown-item>
-  <calcite-dropdown-item>4</calcite-dropdown-item>
-  <calcite-dropdown-item>5</calcite-dropdown-item>
-</calcite-dropdown>`;

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -217,7 +217,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
             role="menu"
           >
             <div hidden={!(open || active)}>
-              <slot onSlotchange={this.slotChangeHandler} />
+              <slot onSlotchange={this.updateGroups} />
             </div>
           </div>
         </div>
@@ -367,6 +367,8 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
 
   private items: HTMLCalciteDropdownItemElement[] = [];
 
+  private groups: HTMLCalciteDropdownGroupElement[] = [];
+
   /** trigger elements */
   private triggers: HTMLElement[];
 
@@ -417,25 +419,23 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   };
 
   updateItems = (): void => {
-    const { defaultAssignedElements } = this;
-
-    this.items = (
-      defaultAssignedElements.filter((el) =>
-        el?.matches("calcite-dropdown-group, calcite-dropdown-item")
-      ) as (HTMLCalciteDropdownItemElement | HTMLCalciteDropdownGroupElement)[]
-    )
-      .map((el) =>
-        el.matches("calcite-dropdown-group")
-          ? Array.from(
-              (el as HTMLCalciteDropdownGroupElement).querySelectorAll("calcite-dropdown-item")
-            )
-          : [el as HTMLCalciteDropdownItemElement]
-      )
+    this.items = this.groups
+      .map((group) => Array.from(group?.querySelectorAll("calcite-dropdown-item")))
       .reduce((previousValue, currentValue) => [...previousValue, ...currentValue], []);
 
     this.updateSelectedItems();
 
     this.reposition();
+  };
+
+  updateGroups = (event: Event): void => {
+    const groups = (event.target as HTMLSlotElement)
+      .assignedElements({ flatten: true })
+      .filter((el) => el?.matches("calcite-dropdown-group")) as HTMLCalciteDropdownGroupElement[];
+
+    this.groups = groups;
+
+    this.updateItems();
   };
 
   resizeObserverCallback = (entries: ResizeObserverEntry[]): void => {
@@ -553,22 +553,24 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
     let maxScrollerHeight = 0;
     let groupHeaderHeight: number;
 
-    if (maxItems > 0 && itemsToProcess < maxItems) {
-      this.items.forEach((item: HTMLCalciteDropdownItemElement) => {
-        if (item.matches("calcite-dropdown-group calcite-dropdown-item:first-child")) {
-          if (isNaN(groupHeaderHeight)) {
-            groupHeaderHeight = item.offsetTop;
+    this.groups.forEach((group) => {
+      if (maxItems > 0 && itemsToProcess < maxItems) {
+        Array.from(group.children).forEach((item: HTMLCalciteDropdownItemElement, index) => {
+          if (index === 0) {
+            if (isNaN(groupHeaderHeight)) {
+              groupHeaderHeight = item.offsetTop;
+            }
+
+            maxScrollerHeight += groupHeaderHeight;
           }
 
-          maxScrollerHeight += groupHeaderHeight;
-        }
-
-        if (itemsToProcess < maxItems) {
-          maxScrollerHeight += item.offsetHeight;
-          itemsToProcess += 1;
-        }
-      });
-    }
+          if (itemsToProcess < maxItems) {
+            maxScrollerHeight += item.offsetHeight;
+            itemsToProcess += 1;
+          }
+        });
+      }
+    });
 
     return maxScrollerHeight;
   }


### PR DESCRIPTION
This reverts commit 4392fb20658b5a0f0e25f16da20aaa14826697c9.

**Related Issue:** #4949 #5020

## Summary

Revert "fix(dropdown): Fix navigating without a dropdown-group (#4949)"
Keep menu/group roles.