### PR TITLE
fix(date-picker): add short day names for pt-PT date picker

### DIFF
--- a/src/components/date-picker/assets/date-picker/nls/pt-PT.json
+++ b/src/components/date-picker/assets/date-picker/nls/pt-PT.json
@@ -7,6 +7,7 @@
   "days": {
     "abbreviated": ["domingo", "segunda", "terça", "quarta", "quinta", "sexta", "sábado"],
     "narrow": ["D", "S", "T", "Q", "Q", "S", "S"],
+    "short": ["dom.", "seg.", "ter.", "qua.", "qui.", "sex.", "sáb."],
     "wide": ["domingo", "segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado"]
   },
   "numerals": "0123456789",

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -211,6 +211,14 @@ export const Default = stepStory(
     .executeScript(
       setKnobs({
         story: "components-controls-datepicker--default",
+        knobs: [{ name: "locale", value: "pt-PT" }]
+      })
+    )
+    .snapshot("pt-PT locale")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--default",
         knobs: [{ name: "locale", value: "ru" }]
       })
     )


### PR DESCRIPTION
**Related Issue:** #4776 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Adds short day entry from CLDR.

cc @annierm18 