### PR TITLE
feat(dropdown): include selection-triggering item in select event payload

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -11,7 +11,7 @@ import {
   VNode,
   Watch
 } from "@stencil/core";
-import { ItemKeyboardEvent } from "./interfaces";
+import { ItemKeyboardEvent, Selection } from "./interfaces";
 
 import { focusElement, toAriaBoolean } from "../../utils/dom";
 import {
@@ -32,6 +32,7 @@ import { createObserver } from "../../utils/observers";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 import { OpenCloseComponent } from "../../utils/openCloseComponent";
 import { guid } from "../../utils/guid";
+import { RequestedItem } from "../dropdown-group/interfaces";
 
 /**
  * @slot - A slot for adding `calcite-dropdown-group`s or `calcite-dropdown-item`s.
@@ -260,8 +261,12 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   //
   //--------------------------------------------------------------------------
 
-  /** fires when a dropdown item has been selected or deselected */
-  @Event() calciteDropdownSelect: EventEmitter<void>;
+  /**
+   * fires when a dropdown item has been selected or deselected
+   *
+   *
+   */
+  @Event() calciteDropdownSelect: EventEmitter<Selection>;
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   @Event() calciteDropdownBeforeClose: EventEmitter<void>;
@@ -351,10 +356,12 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   }
 
   @Listen("calciteInternalDropdownItemSelect")
-  handleItemSelect(event: CustomEvent): void {
+  handleItemSelect(event: CustomEvent<RequestedItem>): void {
     this.updateSelectedItems();
     event.stopPropagation();
-    this.calciteDropdownSelect.emit();
+    this.calciteDropdownSelect.emit({
+      item: event.detail.requestedDropdownItem
+    });
     if (
       !this.disableCloseOnSelect ||
       event.detail.requestedDropdownGroup.selectionMode === "none"

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -261,11 +261,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   //
   //--------------------------------------------------------------------------
 
-  /**
-   * fires when a dropdown item has been selected or deselected
-   *
-   *
-   */
+  /** fires when a dropdown item has been selected or deselected */
   @Event() calciteDropdownSelect: EventEmitter<Selection>;
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -1,3 +1,10 @@
 export interface ItemKeyboardEvent {
   keyboardEvent: KeyboardEvent;
 }
+
+export interface Selection {
+  /**
+   * The item that caused a selection event to emit.
+   */
+  item: HTMLCalciteDropdownItemElement;
+}


### PR DESCRIPTION
**Related Issue:** #1967 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Adds the most recently selected item to `calciteDropdownSelect`'s payload. This will benefit users in knowing the item that triggered the event, especially when the item group's selection mode is `none`.