### PR TITLE
refactor(combobox, dropdown): Use pointerdown in favor of onclick for events.

### DIFF
--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -220,7 +220,7 @@ export class Combobox
   //
   //--------------------------------------------------------------------------
 
-  @Listen("click", { target: "document" })
+  @Listen("pointerdown", { target: "document" })
   documentClickHandler(event: Event): void {
     this.setInactiveIfNotContained(event);
   }

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -275,7 +275,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   /** Fires when the component is open and animation is complete. */
   @Event() calciteDropdownOpen: EventEmitter<void>;
 
-  @Listen("click", { target: "window" })
+  @Listen("pointerdown", { target: "window" })
   closeCalciteDropdownOnClick(event: Event): void {
     if (!this.open || event.composedPath().includes(this.el)) {
       return;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

refactor(combobox, dropdown): Use pointerdown in favor of onclick for events.