### PR TITLE
fix(combobox): set min width of combobox items to match its input

### DIFF
--- a/src/components/combobox/combobox.scss
+++ b/src/components/combobox/combobox.scss
@@ -142,7 +142,6 @@
 }
 
 .floating-ui-container {
-  @apply w-full;
   @include floatingUIContainer();
   @include floatingUIWrapper();
 }

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -339,3 +339,48 @@ export const ScrollingWithoutMaxItems = (): string => html`
     </calcite-combobox>
   </div>
 `;
+
+export const OptionListMinWidthMatchesInputWhenOverlayPositioningIsFixed = (): string => html`
+  <style>
+    .wrapper {
+      display: flex;
+      width: 100%;
+    }
+
+    calcite-combobox {
+      width: 400px;
+      margin: 0 auto;
+    }
+  </style>
+  <div class="wrapper">
+    <calcite-combobox placeholder="placeholder" overlay-positioning="fixed" placement="bottom" open>
+      <calcite-combobox-item value="Trees" text-label="Trees" aria-hidden="true">
+        <calcite-combobox-item value="Pine" text-label="Pine" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item
+          value="Sequoia"
+          disabled=""
+          text-label="Sequoia"
+          aria-hidden="true"
+        ></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" aria-hidden="true"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" text-label="Flowers" aria-hidden="true">
+        <calcite-combobox-item value="Daffodil" text-label="Daffodil" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item
+          value="Black Eyed Susan"
+          text-label="Black Eyed Susan"
+          aria-hidden="true"
+        ></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium" aria-hidden="true"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Animals" text-label="Animals" aria-hidden="true">
+        <calcite-combobox-item value="Birds" text-label="Birds" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" text-label="Reptiles" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" text-label="Amphibians" aria-hidden="true"></calcite-combobox-item>
+      </calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" text-label="Rocks" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" text-label="Insects" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" text-label="Rivers" aria-hidden="true"></calcite-combobox-item>
+    </calcite-combobox>
+  </div>
+`;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -590,7 +590,7 @@ export class Combobox
   };
 
   setMaxScrollerHeight = async (): Promise<void> => {
-    const { listContainerEl, open } = this;
+    const { listContainerEl, open, referenceEl } = this;
 
     if (!listContainerEl || !open) {
       return;
@@ -599,6 +599,7 @@ export class Combobox
     await this.reposition();
     const maxScrollerHeight = this.getMaxScrollerHeight();
     listContainerEl.style.maxHeight = maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "";
+    listContainerEl.style.minWidth = `${referenceEl.clientWidth}px`;
     await this.reposition();
   };
 


### PR DESCRIPTION
**Related Issue:** #3099 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This updates the combobox to avoid a situation where the option list will stretch to the combobox's parent width (see https://codepen.io/jcfranco/pen/BarmpJV?editors=1000).

This is part 1 of 2 fixes needed for #3099. 

@driskull I tried following the same approach as the dropdown. LMK if I need to make any adjustments. 🙇‍♂️