### PR TITLE
docs: rectify cancelable event metadata

### DIFF
--- a/src/components/accordion-item/accordion-item.tsx
+++ b/src/components/accordion-item/accordion-item.tsx
@@ -98,22 +98,22 @@ export class AccordionItem implements ConditionalSlotComponent {
   /**
    * @internal
    */
-  @Event() calciteInternalAccordionItemKeyEvent: EventEmitter<ItemKeyEvent>;
+  @Event({ cancelable: false }) calciteInternalAccordionItemKeyEvent: EventEmitter<ItemKeyEvent>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalAccordionItemSelect: EventEmitter<RequestedItem>;
+  @Event({ cancelable: false }) calciteInternalAccordionItemSelect: EventEmitter<RequestedItem>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalAccordionItemClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalAccordionItemClose: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalAccordionItemRegister: EventEmitter<RegistryEntry>;
+  @Event({ cancelable: false }) calciteInternalAccordionItemRegister: EventEmitter<RegistryEntry>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -52,7 +52,7 @@ export class Accordion {
   /**
    * @internal
    */
-  @Event() calciteInternalAccordionChange: EventEmitter<RequestedItem>;
+  @Event({ cancelable: false }) calciteInternalAccordionChange: EventEmitter<RequestedItem>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -113,7 +113,7 @@ export class ActionBar implements ConditionalSlotComponent {
   /**
    * Emits when the `expanded` property is toggled.
    */
-  @Event() calciteActionBarToggle: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteActionBarToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -125,7 +125,7 @@ export class ActionMenu implements ConditionalSlotComponent {
    *
    * **Note:**: The event payload is deprecated, please use the `open` property on the component instead
    */
-  @Event() calciteActionMenuOpenChange: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteActionMenuOpenChange: EventEmitter<DeprecatedEventPayload>;
 
   @Listen("pointerdown", { target: "window" })
   closeCalciteActionMenuOnClick(event: Event): void {

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -85,7 +85,7 @@ export class ActionPad implements ConditionalSlotComponent {
   /**
    * Emits when the `expanded` property is toggled.
    */
-  @Event() calciteActionPadToggle: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteActionPadToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -108,7 +108,7 @@ export class Action implements InteractiveComponent {
    *
    * @deprecated use onClick instead.
    */
-  @Event() calciteActionClick: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteActionClick: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -214,30 +214,30 @@ export class Alert implements OpenCloseComponent {
   //--------------------------------------------------------------------------
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
-  @Event() calciteAlertBeforeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteAlertBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */
-  @Event() calciteAlertClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteAlertClose: EventEmitter<void>;
 
   /** Fires when the component is added to the DOM but not rendered, and before the opening transition begins. */
-  @Event() calciteAlertBeforeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteAlertBeforeOpen: EventEmitter<void>;
 
   /** Fires when the component is open and animation is complete. */
-  @Event() calciteAlertOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteAlertOpen: EventEmitter<void>;
 
   /**
    * Fires to sync queue when opened or closed.
    *
    * @internal
    */
-  @Event() calciteInternalAlertSync: EventEmitter<Sync>;
+  @Event({ cancelable: false }) calciteInternalAlertSync: EventEmitter<Sync>;
 
   /**
    * Fires when the component is added to DOM - used to receive initial queue.
    *
    * @internal
    */
-  @Event() calciteInternalAlertRegister: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalAlertRegister: EventEmitter<void>;
 
   // when an alert is opened or closed, update queue and determine active alert
   @Listen("calciteInternalAlertSync", { target: "window" })

--- a/src/components/block-section/block-section.tsx
+++ b/src/components/block-section/block-section.tsx
@@ -72,7 +72,7 @@ export class BlockSection {
   /**
    * Emitted when the header has been clicked.
    */
-  @Event() calciteBlockSectionToggle: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteBlockSectionToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -157,7 +157,7 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   /**
    * Emitted when the header has been clicked.
    */
-  @Event() calciteBlockToggle: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteBlockToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -81,7 +81,7 @@ export class Card implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
 
   /** Fired when a selectable card is selected */
-  @Event() calciteCardSelect: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteCardSelect: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -155,17 +155,17 @@ export class Checkbox implements LabelableComponent, CheckableFormCompoment, Int
    *
    * @internal
    */
-  @Event() calciteInternalCheckboxBlur: EventEmitter<boolean>;
+  @Event({ cancelable: false }) calciteInternalCheckboxBlur: EventEmitter<boolean>;
 
   /** Emitted when the checkbox checked status changes */
-  @Event() calciteCheckboxChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteCheckboxChange: EventEmitter<void>;
 
   /**
    * Emitted when the checkbox is focused
    *
    * @internal
    */
-  @Event() calciteInternalCheckboxFocus: EventEmitter<boolean>;
+  @Event({ cancelable: false }) calciteInternalCheckboxFocus: EventEmitter<boolean>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -109,7 +109,7 @@ export class Chip implements ConditionalSlotComponent {
    *
    * **Note:**: The `el` event payload props is deprecated, please use the event's target/currentTarget instead
    */
-  @Event() calciteChipDismiss: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteChipDismiss: EventEmitter<DeprecatedEventPayload>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -113,7 +113,7 @@ export class ColorPickerHexInput {
   /**
    * Emitted when the hex value changes.
    */
-  @Event() calciteColorPickerHexInputChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteColorPickerHexInputChange: EventEmitter<void>;
 
   private onCalciteInternalInputBlur = (): void => {
     const node = this.inputNode;

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -375,14 +375,14 @@ export class ColorPicker implements InteractiveComponent {
   /**
    * Fires when the color value has changed.
    */
-  @Event() calciteColorPickerChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteColorPickerChange: EventEmitter<void>;
 
   /**
    * Fires as the color value changes.
    *
    * This is similar to the change event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
    */
-  @Event() calciteColorPickerInput: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteColorPickerInput: EventEmitter<void>;
 
   private handleTabActivate = (event: Event): void => {
     this.channelMode = (event.currentTarget as HTMLElement).getAttribute(

--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -122,7 +122,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
    *
    * **Note:**: The event's payload is deprecated, please use the event's target/currentTarget instead
    */
-  @Event() calciteComboboxItemChange: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteComboboxItemChange: EventEmitter<DeprecatedEventPayload>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -276,15 +276,17 @@ export class Combobox
    *
    * @deprecated use calciteComboboxChange instead
    */
-  @Event() calciteLookupChange: EventEmitter<HTMLCalciteComboboxItemElement[]>;
+  @Event({ cancelable: false }) calciteLookupChange: EventEmitter<HTMLCalciteComboboxItemElement[]>;
 
   /**
    * Called when the selected item(s) changes.
    */
-  @Event() calciteComboboxChange: EventEmitter<{ selectedItems: HTMLCalciteComboboxItemElement[] }>;
+  @Event({ cancelable: false }) calciteComboboxChange: EventEmitter<{
+    selectedItems: HTMLCalciteComboboxItemElement[];
+  }>;
 
   /** Called when the user has entered text to filter the options list */
-  @Event() calciteComboboxFilterChange: EventEmitter<{
+  @Event({ cancelable: false }) calciteComboboxFilterChange: EventEmitter<{
     visibleItems: HTMLCalciteComboboxItemElement[];
     text: string;
   }>;
@@ -294,19 +296,19 @@ export class Combobox
    *
    * **Note:**: The event payload is deprecated, please use the `value` property on the component to determine removed value instead
    */
-  @Event() calciteComboboxChipDismiss: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteComboboxChipDismiss: EventEmitter<DeprecatedEventPayload>;
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
-  @Event() calciteComboboxBeforeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteComboboxBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */
-  @Event() calciteComboboxClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteComboboxClose: EventEmitter<void>;
 
   /** Fires when the component is added to the DOM but not rendered, and before the opening transition begins. */
-  @Event() calciteComboboxBeforeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteComboboxBeforeOpen: EventEmitter<void>;
 
   /** Fires when the component is open and animation is complete. */
-  @Event() calciteComboboxOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteComboboxOpen: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/date-picker-day/date-picker-day.tsx
+++ b/src/components/date-picker-day/date-picker-day.tsx
@@ -107,14 +107,14 @@ export class DatePickerDay implements InteractiveComponent {
   /**
    * Emitted when user selects day
    */
-  @Event() calciteDaySelect: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteDaySelect: EventEmitter<void>;
 
   /**
    * Emitted when user hovers over a day
    *
    * @internal
    */
-  @Event() calciteInternalDayHover: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalDayHover: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -87,7 +87,7 @@ export class DatePickerMonthHeader {
   /**
    *  Changes to active date
    */
-  @Event() calciteDatePickerSelect: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteDatePickerSelect: EventEmitter<Date>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -73,24 +73,24 @@ export class DatePickerMonth {
   /**
    * Event emitted when user selects the date.
    */
-  @Event() calciteDatePickerSelect: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteDatePickerSelect: EventEmitter<Date>;
 
   /**
    * Event emitted when user hovers the date.
    *
    * @internal
    */
-  @Event() calciteInternalDatePickerHover: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteInternalDatePickerHover: EventEmitter<Date>;
 
   /**
    * Active date for the user keyboard access.
    */
-  @Event() calciteDatePickerActiveDateChange: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteDatePickerActiveDateChange: EventEmitter<Date>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalDatePickerMouseOut: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalDatePickerMouseOut: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -162,14 +162,14 @@ export class DatePicker {
   /**
    * Trigger calcite date change when a user changes the date.
    */
-  @Event() calciteDatePickerChange: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteDatePickerChange: EventEmitter<Date>;
 
   /**
    * Trigger calcite date change when a user changes the date range.
    *
    * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/date-picker/interfaces.ts#L1)
    */
-  @Event() calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
+  @Event({ cancelable: false }) calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
 
   /**
    * Active date.

--- a/src/components/dropdown-group/dropdown-group.tsx
+++ b/src/components/dropdown-group/dropdown-group.tsx
@@ -59,7 +59,7 @@ export class DropdownGroup {
   /**
    * @internal
    */
-  @Event() calciteInternalDropdownItemChange: EventEmitter<RequestedItem>;
+  @Event({ cancelable: false }) calciteInternalDropdownItemChange: EventEmitter<RequestedItem>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -73,13 +73,14 @@ export class DropdownItem {
   /**
    * @internal
    */
-  @Event() calciteInternalDropdownItemSelect: EventEmitter<RequestedItem>;
+  @Event({ cancelable: false }) calciteInternalDropdownItemSelect: EventEmitter<RequestedItem>;
 
   /** @internal */
-  @Event() calciteInternalDropdownItemKeyEvent: EventEmitter<ItemKeyboardEvent>;
+  @Event({ cancelable: false })
+  calciteInternalDropdownItemKeyEvent: EventEmitter<ItemKeyboardEvent>;
 
   /** @internal */
-  @Event() calciteInternalDropdownCloseRequest: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalDropdownCloseRequest: EventEmitter<void>;
   //--------------------------------------------------------------------------
   //
   //  Public Methods

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -262,19 +262,19 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   //--------------------------------------------------------------------------
 
   /** fires when a dropdown item has been selected or deselected */
-  @Event() calciteDropdownSelect: EventEmitter<Selection>;
+  @Event({ cancelable: false }) calciteDropdownSelect: EventEmitter<Selection>;
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
-  @Event() calciteDropdownBeforeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteDropdownBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */
-  @Event() calciteDropdownClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteDropdownClose: EventEmitter<void>;
 
   /** Fires when the component is added to the DOM but not rendered, and before the opening transition begins. */
-  @Event() calciteDropdownBeforeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteDropdownBeforeOpen: EventEmitter<void>;
 
   /** Fires when the component is open and animation is complete. */
-  @Event() calciteDropdownOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteDropdownOpen: EventEmitter<void>;
 
   @Listen("pointerdown", { target: "window" })
   closeCalciteDropdownOnClick(event: Event): void {

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -111,7 +111,7 @@ export class Filter implements InteractiveComponent {
   /**
    * This event fires when the filter text changes.
    */
-  @Event() calciteFilterChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteFilterChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/handle/handle.tsx
+++ b/src/components/handle/handle.tsx
@@ -46,7 +46,7 @@ export class Handle {
    *
    * **Note:**: The `handle` event payload prop is deprecated, please use the event's target/currentTarget instead
    */
-  @Event() calciteHandleNudge: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteHandleNudge: EventEmitter<DeprecatedEventPayload>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/inline-editable/inline-editable.tsx
+++ b/src/components/inline-editable/inline-editable.tsx
@@ -187,17 +187,18 @@ export class InlineEditable implements InteractiveComponent, LabelableComponent 
   /**
    * Emitted when the cancel button gets clicked.
    */
-  @Event() calciteInlineEditableEditCancel: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInlineEditableEditCancel: EventEmitter<void>;
 
   /**
    * Emitted when the check button gets clicked.
    */
-  @Event() calciteInlineEditableEditConfirm: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInlineEditableEditConfirm: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalInlineEditableEnableEditingChange: EventEmitter<void>;
+  @Event({ cancelable: false })
+  calciteInternalInlineEditableEnableEditingChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -309,7 +309,7 @@ export class InputDatePicker
    *
    * @deprecated use `calciteInputDatePickerChange` instead.
    */
-  @Event() calciteDatePickerChange: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteDatePickerChange: EventEmitter<Date>;
 
   /**
    * Trigger calcite date change when a user changes the date range.
@@ -317,24 +317,24 @@ export class InputDatePicker
    * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/calcite-date-picker/interfaces.ts#L1)
    * @deprecated use `calciteInputDatePickerChange` instead.
    */
-  @Event() calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
+  @Event({ cancelable: false }) calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
 
   /**
    * This event fires when the input date picker value changes.
    */
-  @Event() calciteInputDatePickerChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputDatePickerChange: EventEmitter<void>;
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
-  @Event() calciteInputDatePickerBeforeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputDatePickerBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */
-  @Event() calciteInputDatePickerClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputDatePickerClose: EventEmitter<void>;
 
   /** Fires when the component is added to the DOM but not rendered, and before the opening transition begins. */
-  @Event() calciteInputDatePickerBeforeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputDatePickerBeforeOpen: EventEmitter<void>;
 
   /** Fires when the component is open and animation is complete. */
-  @Event() calciteInputDatePickerOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputDatePickerOpen: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -373,12 +373,12 @@ export class InputNumber implements LabelableComponent, FormComponent, Interacti
   /**
    * @internal
    */
-  @Event() calciteInternalInputNumberFocus: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalInputNumberFocus: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalInputNumberBlur: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalInputNumberBlur: EventEmitter<void>;
 
   /**
    * Fires each time a new value is typed.
@@ -390,7 +390,7 @@ export class InputNumber implements LabelableComponent, FormComponent, Interacti
   /**
    * Fires each time a new value is typed and committed.
    */
-  @Event() calciteInputNumberChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputNumberChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -202,7 +202,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
   /**
    * Fires when the time value is changed as a result of user input.
    */
-  @Event({ cancelable: false }) calciteInputTimePickerChange: EventEmitter<string>;
+  @Event({ cancelable: true }) calciteInputTimePickerChange: EventEmitter<string>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -202,7 +202,7 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
   /**
    * Fires when the time value is changed as a result of user input.
    */
-  @Event() calciteInputTimePickerChange: EventEmitter<string>;
+  @Event({ cancelable: false }) calciteInputTimePickerChange: EventEmitter<string>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -418,12 +418,12 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   /**
    * @internal
    */
-  @Event() calciteInternalInputFocus: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalInputFocus: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalInputBlur: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalInputBlur: EventEmitter<void>;
 
   /**
    * Fires each time a new value is typed.
@@ -435,7 +435,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
   /**
    * Fires each time a new value is typed and committed.
    */
-  @Event() calciteInputChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInputChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/label/label.tsx
+++ b/src/components/label/label.tsx
@@ -68,7 +68,7 @@ export class Label {
   /**
    * @internal
    */
-  @Event({ bubbles: false }) calciteInternalLabelClick: EventEmitter<{
+  @Event({ bubbles: false, cancelable: false }) calciteInternalLabelClick: EventEmitter<{
     sourceEvent: MouseEvent;
   }>;
 

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -294,16 +294,16 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
   //
   //--------------------------------------------------------------------------
   /** Fires when the component is requested to be closed and before the closing transition begins. */
-  @Event() calciteModalBeforeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteModalBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */
-  @Event() calciteModalClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteModalClose: EventEmitter<void>;
 
   /** Fires when the component is added to the DOM but not rendered, and before the opening transition begins. */
-  @Event() calciteModalBeforeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteModalBeforeOpen: EventEmitter<void>;
 
   /** Fires when the component is open and animation is complete. */
-  @Event() calciteModalOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteModalOpen: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -180,10 +180,10 @@ export class Notice implements ConditionalSlotComponent {
   //--------------------------------------------------------------------------
 
   /** Fired when the component is closed. */
-  @Event() calciteNoticeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteNoticeClose: EventEmitter<void>;
 
   /** Fired when the component is opened. */
-  @Event() calciteNoticeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteNoticeOpen: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/option-group/option-group.tsx
+++ b/src/components/option-group/option-group.tsx
@@ -44,7 +44,7 @@ export class OptionGroup {
   /**
    * @internal
    */
-  @Event()
+  @Event({ cancelable: false })
   private calciteInternalOptionGroupChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------

--- a/src/components/option/option.tsx
+++ b/src/components/option/option.tsx
@@ -80,7 +80,7 @@ export class Option {
   /**
    * @internal
    */
-  @Event()
+  @Event({ cancelable: false })
   private calciteInternalOptionChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -88,14 +88,14 @@ export class Pagination implements GlobalAttrComponent {
    *
    * @deprecated use calcitePaginationChange instead
    */
-  @Event() calcitePaginationUpdate: EventEmitter<PaginationDetail>;
+  @Event({ cancelable: false }) calcitePaginationUpdate: EventEmitter<PaginationDetail>;
 
   /**
    * Emits when the selected page changes.
    *
    * @see [PaginationDetail](https://github.com/Esri/calcite-components/blob/master/src/components/pagination/pagination.tsx#L23)
    */
-  @Event() calcitePaginationChange: EventEmitter<PaginationDetail>;
+  @Event({ cancelable: false }) calcitePaginationChange: EventEmitter<PaginationDetail>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -220,24 +220,24 @@ export class Panel implements ConditionalSlotComponent, InteractiveComponent {
   /**
    * Fires when the close button is clicked.
    */
-  @Event() calcitePanelDismiss: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePanelDismiss: EventEmitter<void>;
 
   /**
    * Fires when there is a change to the `dismissed` property value .
    *
    * @deprecated use calcitePanelDismiss instead.
    */
-  @Event() calcitePanelDismissedChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePanelDismissedChange: EventEmitter<void>;
 
   /**
    * Fires when the content is scrolled.
    */
-  @Event() calcitePanelScroll: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePanelScroll: EventEmitter<void>;
 
   /**
    * Fires when the back button is clicked.
    */
-  @Event() calcitePanelBackClick: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePanelBackClick: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -166,7 +166,7 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   /**
    * Fires when the component is selected or unselected.
    */
-  @Event() calciteListItemChange: EventEmitter<{
+  @Event({ cancelable: false }) calciteListItemChange: EventEmitter<{
     item: HTMLCalcitePickListItemElement;
     value: any;
     selected: boolean;
@@ -176,21 +176,21 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   /**
    * Fires when the remove button is pressed.
    */
-  @Event() calciteListItemRemove: EventEmitter<void>;
+  @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>;
 
   /**
    * Emits when the the component's label, description, value, or metadata properties are modified.
    *
    * @internal
    */
-  @Event() calciteInternalListItemPropsChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalListItemPropsChange: EventEmitter<void>;
 
   /**
    * Emits when the the component's value property is modified.
    *
    * @internal
    */
-  @Event() calciteInternalListItemValueChange: EventEmitter<{
+  @Event({ cancelable: false }) calciteInternalListItemValueChange: EventEmitter<{
     oldValue: any;
     newValue: any;
   }>;

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -143,7 +143,9 @@ export class PickList<
   /**
    * Emits when any of the `calcite-pick-list-item` selections have changed.
    */
-  @Event() calciteListChange: EventEmitter<Map<string, HTMLCalcitePickListItemElement>>;
+  @Event({ cancelable: false }) calciteListChange: EventEmitter<
+    Map<string, HTMLCalcitePickListItemElement>
+  >;
 
   @Listen("calciteListItemRemove")
   calciteListItemRemoveHandler(event: CustomEvent<void>): void {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -248,16 +248,16 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   //--------------------------------------------------------------------------
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
-  @Event() calcitePopoverBeforeClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePopoverBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */
-  @Event() calcitePopoverClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePopoverClose: EventEmitter<void>;
 
   /** Fires when the component is added to the DOM but not rendered, and before the opening transition begins. */
-  @Event() calcitePopoverBeforeOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePopoverBeforeOpen: EventEmitter<void>;
 
   /** Fires when the component is open and animation is complete. */
-  @Event() calcitePopoverOpen: EventEmitter<void>;
+  @Event({ cancelable: false }) calcitePopoverOpen: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -125,7 +125,7 @@ export class RadioButtonGroup {
   /**
    * Emitted when the radio button group has changed.
    */
-  @Event() calciteRadioButtonGroupChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteRadioButtonGroupChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -260,7 +260,7 @@ export class RadioButton
    *
    * @internal
    */
-  @Event() calciteInternalRadioButtonBlur: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalRadioButtonBlur: EventEmitter<void>;
 
   /**
    * Fires only when the radio button is checked.  This behavior is identical to the native HTML input element.
@@ -268,7 +268,7 @@ export class RadioButton
    * directly on the element, but instead either attach it to a node that contains all of the radio buttons in the group
    * or use the calciteRadioButtonGroupChange event if using this with calcite-radio-button-group.
    */
-  @Event() calciteRadioButtonChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteRadioButtonChange: EventEmitter<void>;
 
   /**
    * Fires when the checked property changes.  This is an internal event used for styling purposes only.
@@ -276,14 +276,14 @@ export class RadioButton
    *
    * @internal
    */
-  @Event() calciteInternalRadioButtonCheckedChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalRadioButtonCheckedChange: EventEmitter<void>;
 
   /**
    * Fires when the radio button is focused.
    *
    * @internal
    */
-  @Event() calciteInternalRadioButtonFocus: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalRadioButtonFocus: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/radio-group-item/radio-group-item.tsx
+++ b/src/components/radio-group-item/radio-group-item.tsx
@@ -104,6 +104,6 @@ export class RadioGroupItem {
    *
    * @internal
    */
-  @Event()
+  @Event({ cancelable: false })
   calciteInternalRadioGroupItemChange: EventEmitter<void>;
 }

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -239,7 +239,7 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
   //--------------------------------------------------------------------------
 
   /** Fired when the selected option changes, event detail is the new value */
-  @Event() calciteRadioGroupChange: EventEmitter<string>;
+  @Event({ cancelable: false }) calciteRadioGroupChange: EventEmitter<string>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -113,7 +113,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
   /**
    * Fires when the rating value has changed.
    */
-  @Event() calciteRatingChange: EventEmitter<{ value: number }>;
+  @Event({ cancelable: false }) calciteRatingChange: EventEmitter<{ value: number }>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -180,7 +180,7 @@ export class Select implements LabelableComponent, FormComponent, InteractiveCom
   /**
    * This event will fire whenever the selected option changes.
    */
-  @Event() calciteSelectChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteSelectChange: EventEmitter<void>;
 
   private handleInternalSelectChange = (): void => {
     const selected = this.selectEl.selectedOptions[0];

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -135,7 +135,7 @@ export class ShellPanel implements ConditionalSlotComponent {
    *
    * @deprecated use a resizeObserver on the shell-panel to listen for changes to its size.
    */
-  @Event() calciteShellPanelToggle: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteShellPanelToggle: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -838,14 +838,14 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
    * expensive operations consider using a debounce or throttle to avoid
    * locking up the main thread.
    */
-  @Event() calciteSliderInput: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteSliderInput: EventEmitter<void>;
 
   /**
    * Fires on when the thumb is released on slider
    * If you need to constantly listen to the drag event,
    * please use calciteSliderInput instead
    */
-  @Event() calciteSliderChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteSliderChange: EventEmitter<void>;
 
   /**
    * Fires on all updates to the slider.
@@ -855,7 +855,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
    *
    * @deprecated use calciteSliderInput instead
    */
-  @Event() calciteSliderUpdate: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteSliderUpdate: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/sortable-list/sortable-list.tsx
+++ b/src/components/sortable-list/sortable-list.tsx
@@ -112,7 +112,7 @@ export class SortableList implements InteractiveComponent {
   /**
    * Emitted when the order of the list has changed.
    */
-  @Event() calciteListOrderChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteListOrderChange: EventEmitter<void>;
 
   @Listen("calciteHandleNudge")
   calciteHandleNudgeHandler(event: CustomEvent): void {

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -87,14 +87,16 @@ export class SplitButton implements InteractiveComponent {
    *
    * **Note:** The event payload is deprecated, please use separate mouse event listeners to get info about click.
    */
-  @Event() calciteSplitButtonPrimaryClick: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false })
+  calciteSplitButtonPrimaryClick: EventEmitter<DeprecatedEventPayload>;
 
   /**
    * fired when the secondary button is clicked
    *
    * **Note:** The event payload is deprecated, please use separate mouse event listeners to get info about click.
    */
-  @Event() calciteSplitButtonSecondaryClick: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false })
+  calciteSplitButtonSecondaryClick: EventEmitter<DeprecatedEventPayload>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -122,23 +122,26 @@ export class StepperItem implements InteractiveComponent {
   /**
    * @internal
    */
-  @Event() calciteInternalStepperItemKeyEvent: EventEmitter<StepperItemKeyEventDetail>;
+  @Event({ cancelable: false })
+  calciteInternalStepperItemKeyEvent: EventEmitter<StepperItemKeyEventDetail>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalStepperItemSelect: EventEmitter<StepperItemEventDetail>;
+  @Event({ cancelable: false })
+  calciteInternalStepperItemSelect: EventEmitter<StepperItemEventDetail>;
 
   /**
    * @internal
    */
-  @Event()
+  @Event({ cancelable: false })
   calciteInternalUserRequestedStepperItemSelect: EventEmitter<StepperItemChangeEventDetail>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalStepperItemRegister: EventEmitter<StepperItemEventDetail>;
+  @Event({ cancelable: false })
+  calciteInternalStepperItemRegister: EventEmitter<StepperItemEventDetail>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -59,14 +59,16 @@ export class Stepper {
    * This event fires when the active stepper item has changed.
    *
    */
-  @Event() calciteStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
+  @Event({ cancelable: false })
+  calciteStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
 
   /**
    * This event fires when the active stepper item has changed.
    *
    * @internal
    */
-  @Event() calciteInternalStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
+  @Event({ cancelable: false })
+  calciteInternalStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -146,7 +146,7 @@ export class Switch implements LabelableComponent, CheckableFormCompoment, Inter
    *
    * **Note:** The event payload is deprecated, please use the `checked` property on the component instead
    */
-  @Event() calciteSwitchChange: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteSwitchChange: EventEmitter<DeprecatedEventPayload>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -280,12 +280,12 @@ export class TabNav {
    *
    * @see [TabChangeEventDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tab/interfaces.ts#L1)
    */
-  @Event() calciteTabChange: EventEmitter<TabChangeEventDetail>;
+  @Event({ cancelable: false }) calciteTabChange: EventEmitter<TabChangeEventDetail>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalTabChange: EventEmitter<TabChangeEventDetail>;
+  @Event({ cancelable: false }) calciteInternalTabChange: EventEmitter<TabChangeEventDetail>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tab-title/tab-title.tsx
+++ b/src/components/tab-title/tab-title.tsx
@@ -260,7 +260,7 @@ export class TabTitle implements InteractiveComponent {
    *
    * @see [TabChangeEventDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tab/interfaces.ts#L1)
    */
-  @Event() calciteTabsActivate: EventEmitter<TabChangeEventDetail>;
+  @Event({ cancelable: false }) calciteTabsActivate: EventEmitter<TabChangeEventDetail>;
 
   /**
    * Fires when a specific tab is activated (`event.details`)
@@ -268,22 +268,22 @@ export class TabTitle implements InteractiveComponent {
    * @see [TabChangeEventDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tab/interfaces.ts#L1)
    * @internal
    */
-  @Event() calciteInternalTabsActivate: EventEmitter<TabChangeEventDetail>;
+  @Event({ cancelable: false }) calciteInternalTabsActivate: EventEmitter<TabChangeEventDetail>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalTabsFocusNext: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalTabsFocusNext: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalTabsFocusPrevious: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalTabsFocusPrevious: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalTabTitleRegister: EventEmitter<TabID>;
+  @Event({ cancelable: false }) calciteInternalTabTitleRegister: EventEmitter<TabID>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -108,7 +108,7 @@ export class Tab {
   /**
    * @internal
    */
-  @Event() calciteInternalTabRegister: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalTabRegister: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tile-select/tile-select.tsx
+++ b/src/components/tile-select/tile-select.tsx
@@ -114,7 +114,7 @@ export class TileSelect implements InteractiveComponent {
   /**
    * Emits a custom change event.  For checkboxes, it emits when the checkbox is checked or unchecked.  For radios it only emits when it is checked.
    */
-  @Event() calciteTileSelectChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteTileSelectChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -227,17 +227,17 @@ export class TimePicker {
   /**
    * @internal
    */
-  @Event() calciteInternalTimePickerBlur: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalTimePickerBlur: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalTimePickerChange: EventEmitter<string>;
+  @Event({ cancelable: false }) calciteInternalTimePickerChange: EventEmitter<string>;
 
   /**
    * @internal
    */
-  @Event() calciteInternalTimePickerFocus: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteInternalTimePickerFocus: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tip-manager/tip-manager.tsx
+++ b/src/components/tip-manager/tip-manager.tsx
@@ -146,12 +146,12 @@ export class TipManager {
    *
    * @deprecated use calciteTipManagerClose instead.
    */
-  @Event() calciteTipManagerToggle: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteTipManagerToggle: EventEmitter<void>;
 
   /**
    * Emitted when the `calcite-tip-manager` has been closed.
    */
-  @Event() calciteTipManagerClose: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteTipManagerClose: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/tip/tip.tsx
+++ b/src/components/tip/tip.tsx
@@ -84,7 +84,7 @@ export class Tip implements ConditionalSlotComponent {
   /**
    * Emitted when the component has been dismissed.
    */
-  @Event() calciteTipDismiss: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteTipDismiss: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -358,7 +358,7 @@ export class TreeItem implements ConditionalSlotComponent {
   /**
    * @internal
    */
-  @Event() calciteInternalTreeItemSelect: EventEmitter<TreeItemSelectDetail>;
+  @Event({ cancelable: false }) calciteInternalTreeItemSelect: EventEmitter<TreeItemSelectDetail>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -350,7 +350,7 @@ export class Tree {
    *
    * @see [TreeSelectDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L1)
    */
-  @Event() calciteTreeSelect: EventEmitter<TreeSelectDetail>;
+  @Event({ cancelable: false }) calciteTreeSelect: EventEmitter<TreeSelectDetail>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -12,9 +12,8 @@ import {
 } from "@stencil/core";
 import { ICON_TYPES } from "../pick-list/resources";
 import { guid } from "../../utils/guid";
-import { CSS } from "../pick-list-item/resources";
+import { CSS, SLOTS as PICK_LIST_SLOTS } from "../pick-list-item/resources";
 import { ICONS, SLOTS } from "./resources";
-import { SLOTS as PICK_LIST_SLOTS } from "../pick-list-item/resources";
 import { getSlotted } from "../../utils/dom";
 import {
   ConditionalSlotComponent,
@@ -158,7 +157,7 @@ export class ValueListItem implements ConditionalSlotComponent, InteractiveCompo
   /**
    * Fires when the remove button is pressed.
    */
-  @Event() calciteListItemRemove: EventEmitter<void>; // wrapped pick-list-item emits this
+  @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>; // wrapped pick-list-item emits this
 
   @Listen("calciteListItemChange")
   calciteListItemChangeHandler(event: CustomEvent): void {

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -189,12 +189,14 @@ export class ValueList<
   /**
    * Emits when any of the list item selections have changed.
    */
-  @Event() calciteListChange: EventEmitter<Map<string, HTMLCalciteValueListItemElement>>;
+  @Event({ cancelable: false }) calciteListChange: EventEmitter<
+    Map<string, HTMLCalciteValueListItemElement>
+  >;
 
   /**
    * Emits when the order of the list has changed.
    */
-  @Event() calciteListOrderChange: EventEmitter<any[]>;
+  @Event({ cancelable: false }) calciteListOrderChange: EventEmitter<any[]>;
 
   @Listen("focusout")
   calciteListFocusOutHandler(event: FocusEvent): void {


### PR DESCRIPTION
**Related Issue:** #3967

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Stencil's `@Event` decorator marks events as cancelable by default. This PR updates the event metadata accordingly.

### Known cancelable events

* `calciteInputNumberInput`
* `calciteInputTextInput`
* `calciteInputInput`
* `calciteListItemRemove` (for both pick/value list items)
* `calciteInputTimePickerChange`