### PR TITLE
fix(stepper): allow overriding stepper width

### DIFF
--- a/src/components/stepper/stepper.scss
+++ b/src/components/stepper/stepper.scss
@@ -2,7 +2,7 @@
   @apply relative
     flex
     w-full
-    min-w-full
+    min-w-fit
     flex-row
     flex-wrap
     items-stretch

--- a/src/components/stepper/stepper.stories.ts
+++ b/src/components/stepper/stepper.stories.ts
@@ -191,3 +191,10 @@ export const MinHeight = stepStory(
   </calcite-stepper>`,
   createSteps("calcite-stepper").click("#one").snapshot("stepper with min-height")
 );
+
+export const OverriddenWidth = (): string => html` <calcite-stepper style="width: 50vw">
+  <calcite-stepper-item item-title="item1" complete>1</calcite-stepper-item>
+  <calcite-stepper-item item-title="item2">2</calcite-stepper-item>
+  <calcite-stepper-item item-title="item3" active>3</calcite-stepper-item>
+  <calcite-stepper-item item-title="item4" disabled>4</calcite-stepper-item>
+</calcite-stepper>`;

--- a/src/components/stepper/stepper.stories.ts
+++ b/src/components/stepper/stepper.stories.ts
@@ -192,9 +192,25 @@ export const MinHeight = stepStory(
   createSteps("calcite-stepper").click("#one").snapshot("stepper with min-height")
 );
 
-export const OverriddenWidth = (): string => html` <calcite-stepper style="width: 50vw">
-  <calcite-stepper-item item-title="item1" complete>1</calcite-stepper-item>
-  <calcite-stepper-item item-title="item2">2</calcite-stepper-item>
-  <calcite-stepper-item item-title="item3" active>3</calcite-stepper-item>
-  <calcite-stepper-item item-title="item4" disabled>4</calcite-stepper-item>
+export const OverriddenWidth = (): string => html` <calcite-stepper numbered style="width: 50vw">
+  <calcite-stepper-item item-title="Choose method" item-subtitle="Add members without sending invitations" complete>
+    <calcite-notice active width="full">
+      <div slot="message">Step 1 Content Goes Here</div>
+    </calcite-notice>
+  </calcite-stepper-item>
+  <calcite-stepper-item item-title="Compile member list" complete error>
+    <calcite-notice active width="full">
+      <div slot="message">Step 2 Content Goes Here</div>
+    </calcite-notice>
+  </calcite-stepper-item>
+  <calcite-stepper-item item-title="Set member properties" item-subtitle="" active="">
+    <calcite-notice active width="full">
+      <div slot="message">Step 3 Content Goes Here</div>
+    </calcite-notice>
+  </calcite-stepper-item>
+  <calcite-stepper-item item-title="Confirm and complete" item-subtitle="Disabled example" disabled="">
+    <calcite-notice active width="full">
+      <div slot="message">Step 4 Content Goes Here</div>
+    </calcite-notice>
+  </calcite-stepper-item>
 </calcite-stepper>`;


### PR DESCRIPTION
**Related Issue:** #4883 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

🦶🦶🦶🦶↔🤏