### PR TITLE
ci: add action to close completed milestones

### DIFF
--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -1,0 +1,49 @@
+name: Close Completed Milestone
+on:
+  pull_request:
+    branches: [master]
+    types: [closed]
+  issues:
+    types: [closed]
+jobs:
+  close-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const {
+              repo: { repo, owner },
+              payload: { issue, pull_request },
+            } = context;
+
+            // no optional chaining support
+            // https://github.com/actions/github-script/pull/182
+            const milestone_number =
+              (issue && issue.milestone.number) ||
+              (pull_request && pull_request.milestone.number);
+
+            if (!milestone_number) {
+              console.log("No milestone found, ending run.");
+              return;
+            }
+
+            const { data: milestone } = await github.issues.getMilestone({
+              owner,
+              repo,
+              milestone_number,
+            });
+
+            const currentDate = new Date(Date.now());
+            currentDate.setUTCHours(0, 0, 0, 0);
+
+            // close milestone if it is past due and there are no open issues/PRs
+            !milestone.open_issues &&
+              milestone.due_on &&
+              new Date(milestone.due_on) < currentDate &&
+              (await github.issues.updateMilestone({
+                owner,
+                repo,
+                milestone_number,
+                state: "closed",
+              }));


### PR DESCRIPTION
**Related Issue:** 

## Summary
Close milestones once 100% of its issues/PRs are completed and the milestone is past due
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
