### PR TITLE
fix(tree): fix keyboard navigation when wrapped in shadow DOM

### DIFF
--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -9,7 +9,7 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { focusElement, nodeListToArray } from "../../utils/dom";
+import { focusElement, getRootNode, nodeListToArray } from "../../utils/dom";
 import { TreeItemSelectDetail } from "../tree-item/interfaces";
 import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
@@ -275,7 +275,7 @@ export class Tree {
           if (!target.hasChildren) {
             break;
           }
-          if (target.expanded && document.activeElement === target) {
+          if (target.expanded && getRootNode(this.el).activeElement === target) {
             // When focus is on an open node, moves focus to the first child node.
             target.querySelector("calcite-tree-item")?.focus();
             event.preventDefault();


### PR DESCRIPTION
**Related Issue:** #4814 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Tree was using the document's `activeElement` instead of its root node for keyboard navigation. 

Automatically testing our components when wrapped in shadow DOM can get complex. I'll look into an approach with demo pages and possibly storybook to see if we can spot these earlier. It'd be a manual check, but at least something easy to test.