### PR TITLE
fix: apply layered z-indices across components

### DIFF
--- a/src/assets/styles/_floating-ui.scss
+++ b/src/assets/styles/_floating-ui.scss
@@ -11,13 +11,12 @@ $floating-ui-default-z-index: 900;
 @mixin floatingUIAnim {
   .calcite-floating-ui-anim {
     position: relative;
-    z-index: 1;
     transition: var(--calcite-floating-ui-transition);
     visibility: hidden;
     transition-property: transform, visibility, opacity;
     opacity: 0;
     box-shadow: $shadow-2;
-    @apply rounded;
+    @apply rounded z-default;
   }
 }
 
@@ -113,7 +112,7 @@ $pointer_offset: -$pointer_size * 0.5;
     position: absolute;
     inline-size: $pointer_size;
     block-size: $pointer_size;
-    z-index: -1;
+    @apply -z-default;
   }
 
   .arrow::before {

--- a/src/components/action/action.scss
+++ b/src/components/action/action.scss
@@ -199,7 +199,6 @@
   .button::after {
     content: "";
     @apply absolute
-      z-10
       h-2
       w-2
       rounded-full

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -87,7 +87,8 @@
       flex
       items-center
       justify-center
-      opacity-0;
+      opacity-0
+      z-toast;
     border-radius: var(--calcite-border-radius);
     border-block-start: 0px solid transparent;
     border-inline: 1px solid var(--calcite-ui-border-3);
@@ -96,7 +97,6 @@
     inline-size: var(--calcite-alert-width);
     max-inline-size: calc(100% - (var(--calcite-alert-edge-distance) * 2 + 2px));
     max-block-size: 0;
-    z-index: 101;
     transition: var(--calcite-internal-animation-timing-slow) $easing-function,
       opacity var(--calcite-internal-animation-timing-slow) $easing-function,
       all var(--calcite-animation-timing) ease-in-out;
@@ -264,7 +264,6 @@
     overflow-hidden;
   inset-block-start: -2px;
   block-size: 2px;
-  z-index: 103;
   border-radius: var(--calcite-border-radius) var(--calcite-border-radius) 0 0;
   &:after {
     @apply absolute
@@ -273,7 +272,6 @@
     block-size: 2px;
     content: "";
     background-color: var(--calcite-alert-dismiss-progress-background);
-    z-index: 104;
     inset-inline-end: 0;
   }
 }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -17,12 +17,10 @@
     overflow-hidden;
     border-radius: var(--calcite-border-radius-base);
     &:hover {
-      @apply shadow-1-lg;
-      z-index: 1;
+      @apply shadow-1-lg z-default;
     }
     &:active {
-      @apply shadow-1-sm duration-75;
-      z-index: 1;
+      @apply shadow-1-sm duration-75 z-default;
     }
   }
 }

--- a/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -15,7 +15,6 @@
     mx-1
     flex
     items-center;
-  z-index: 1;
 }
 
 .preview,

--- a/src/components/date-picker-day/date-picker-day.scss
+++ b/src/components/date-picker-day/date-picker-day.scss
@@ -96,7 +96,6 @@
 :host(:focus),
 :host([active]) {
   @apply outline-none;
-  z-index: 1;
 }
 
 :host(:focus:not([disabled])) .day {
@@ -108,7 +107,6 @@
   @apply font-medium;
   background-color: var(--calcite-ui-brand) !important;
   color: var(--calcite-ui-foreground-1) !important;
-  z-index: 1;
 }
 
 :host([range][selected]) {
@@ -398,7 +396,6 @@
 
   :host([selected]) {
     outline: 2px solid canvasText;
-    z-index: 1;
     .day {
       @apply rounded-none;
       background-color: highlight;

--- a/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -105,7 +105,6 @@
     border-none
     bg-transparent
     text-center;
-  z-index: 2;
   &:hover {
     @apply duration-100 ease-in-out;
     transition-property: outline-color;

--- a/src/components/input-date-picker/input-date-picker.scss
+++ b/src/components/input-date-picker/input-date-picker.scss
@@ -64,7 +64,7 @@
     @apply bg-foreground-1
       absolute
       left-0
-      z-10
+      z-default
       mx-px
       px-2.5;
   }

--- a/src/components/input-number/input-number.scss
+++ b/src/components/input-number/input-number.scss
@@ -163,7 +163,6 @@
   @apply transition-default
     pointer-events-none
     absolute
-    z-10
     block;
 }
 
@@ -395,7 +394,6 @@
     text-color-3
     pointer-events-none
     absolute
-    z-10
     h-3
     w-3;
 

--- a/src/components/input-text/input-text.scss
+++ b/src/components/input-text/input-text.scss
@@ -160,7 +160,6 @@ input:focus {
   @apply transition-default
     pointer-events-none
     absolute
-    z-10
     block;
 }
 
@@ -283,7 +282,6 @@ input[type="text"]::-ms-reveal {
     text-color-3
     pointer-events-none
     absolute
-    z-10
     h-3
     w-3;
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -216,7 +216,6 @@
   @apply transition-default
     pointer-events-none
     absolute
-    z-10
     block;
 }
 
@@ -499,7 +498,6 @@ input[type="time"]::-webkit-clear-button {
     text-color-3
     pointer-events-none
     absolute
-    z-10
     h-3
     w-3;
 

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -18,11 +18,11 @@
     items-center
     justify-center
     overflow-y-hidden
-    opacity-0;
+    opacity-0
+    z-overlay;
   visibility: hidden !important;
   transition: visibility 0ms linear var(--calcite-internal-animation-timing-slow),
     opacity var(--calcite-internal-animation-timing-slow) $easing-function;
-  z-index: 101;
 }
 
 :host([scale="s"]) {
@@ -75,8 +75,8 @@
     flex-col
     overflow-hidden
     rounded
-    opacity-0;
-  z-index: 102;
+    opacity-0
+    z-modal;
   -webkit-overflow-scrolling: touch;
   visibility: hidden;
   transition: transform var(--calcite-internal-animation-timing-slow) $easing-function,
@@ -131,9 +131,9 @@
     rounded-t
     border-0
     border-b
-    border-solid;
+    border-solid
+    z-header;
   flex: 0 0 auto;
-  z-index: 2;
 }
 
 .close {
@@ -181,7 +181,6 @@
 .content {
   @apply bg-foreground-1 relative box-border block h-full overflow-auto p-0;
   max-block-size: calc(100vh - 12rem);
-  z-index: 1;
 }
 
 .content--spaced {
@@ -216,11 +215,11 @@
     rounded-b
     border-0
     border-t
-    border-solid;
+    border-solid
+    z-header;
   flex: 0 0 auto;
   padding-block: var(--calcite-modal-padding, var(--calcite-modal-padding-internal));
   padding-inline: var(--calcite-modal-padding-large, var(--calcite-modal-padding-large-internal));
-  z-index: 2;
 }
 
 .footer--hide-back .back,

--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -67,12 +67,6 @@
   @apply hidden;
 }
 
-:host([loading]) .container,
-:host([disabled]) .container {
-  @apply relative;
-  z-index: 1;
-}
-
 .header {
   border-block-end: 1px solid;
   @apply bg-foreground-1
@@ -81,9 +75,9 @@
     top-0
     w-full
     items-stretch
-    justify-start;
+    justify-start
+    z-header;
   flex: 0 0 auto;
-  z-index: 2;
 }
 
 .header-content {
@@ -155,7 +149,6 @@
   flex-col
   flex-nowrap
   items-stretch;
-  z-index: 1;
 }
 
 .footer {
@@ -181,7 +174,7 @@
   my-0
   mx-auto
   block
-  p-2;
+  p-2
+  z-sticky;
   inline-size: fit-content;
-  z-index: 1;
 }

--- a/src/components/pick-list/pick-list.scss
+++ b/src/components/pick-list/pick-list.scss
@@ -24,8 +24,7 @@
     items-stretch
     justify-end;
   &.sticky-pos {
-    @apply sticky top-0;
-    z-index: 1;
+    @apply sticky top-0 z-default;
   }
   @apply shadow-border-bottom;
 }

--- a/src/components/progress/progress.scss
+++ b/src/components/progress/progress.scss
@@ -9,12 +9,12 @@
 }
 
 .track {
-  @apply z-0 w-full overflow-hidden;
+  @apply z-default w-full overflow-hidden;
   background: theme("borderColor.color.3");
 }
 
 .bar {
-  @apply bg-brand z-0;
+  @apply bg-brand z-default;
 }
 
 @media (forced-colors: active) {

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -25,9 +25,4 @@
   @apply justify-start;
 }
 
-::slotted(calcite-radio-group-item[checked]),
-::slotted(calcite-radio-group-item:focus) {
-  @apply z-0;
-}
-
 @include hidden-form-input();

--- a/src/components/scrim/scrim.scss
+++ b/src/components/scrim/scrim.scss
@@ -1,7 +1,7 @@
 :host {
   @apply absolute
   inset-0
-  z-50
+  z-overlay
   flex
   h-full
   w-full

--- a/src/components/shell-panel/shell-panel.scss
+++ b/src/components/shell-panel/shell-panel.scss
@@ -35,7 +35,6 @@
   absolute
   bottom-0
   top-0
-  z-10
   flex
   h-full
   w-0.5

--- a/src/components/shell/shell.scss
+++ b/src/components/shell/shell.scss
@@ -52,7 +52,7 @@
 .content--behind {
   @apply absolute
     inset-0
-    z-0
+    z-default
     border-0;
   display: initial;
 }
@@ -71,8 +71,7 @@ slot[name="panel-end"]::slotted(calcite-shell-panel) {
 
 ::slotted(calcite-shell-panel),
 ::slotted(calcite-shell-center-row) {
-  @apply relative;
-  z-index: 1;
+  @apply relative z-default;
 }
 
 ::slotted(calcite-panel),
@@ -93,8 +92,8 @@ slot[name="center-row"]::slotted(calcite-shell-center-row:not([detached])) {
   animate-in-up
   absolute
   box-border
-  rounded;
+  rounded
+  z-toast;
   inset-block-end: theme("spacing.2");
   inset-inline: var(--calcite-shell-tip-spacing);
-  z-index: 2;
 }

--- a/src/components/tile-select/tile-select.scss
+++ b/src/components/tile-select/tile-select.scss
@@ -14,10 +14,9 @@ $spacing: $baseline * 0.5;
     padding: $spacing;
     position: relative;
     vertical-align: top;
-    @apply transition-default z-10;
+    @apply transition-default;
 
     &.checked {
-      @apply z-30;
       box-shadow: 0 0 0 1px var(--calcite-ui-brand);
     }
 
@@ -35,7 +34,6 @@ $spacing: $baseline * 0.5;
     &.focused {
       @apply focus-base;
       &:not(.disabled) {
-        @apply z-30;
         &:not(.input-enabled) {
           @apply focus-inset;
           outline-offset: -4px;
@@ -123,7 +121,6 @@ $spacing: $baseline * 0.5;
 
 :host(:hover) {
   .container {
-    @apply z-20;
     &:not(.input-enabled) {
       box-shadow: 0 0 0 1px var(--calcite-ui-brand);
     }

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -55,12 +55,12 @@
         absolute
         top-0
         w-px
-        transition-colors;
+        transition-colors
+        z-default;
     // ensure lines don't overlap focus outline
     block-size: 96%;
     content: "";
     background-color: var(--calcite-ui-border-2);
-    z-index: -1;
   }
 }
 

--- a/src/components/value-list/value-list.scss
+++ b/src/components/value-list/value-list.scss
@@ -27,7 +27,7 @@ calcite-value-list-item:last-of-type {
     items-center
     justify-end;
   &.sticky-pos {
-    @apply sticky top-0 z-10;
+    @apply sticky top-0 z-sticky;
   }
   @apply shadow-border-bottom;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -208,6 +208,17 @@ export default {
       },
       maxHeight: {
         menu: "45vh"
+      },
+      zIndex: {
+        deep: "-999999",
+        default: "1",
+        sticky: "300",
+        header: "400",
+        toast: "500",
+        dropdown: "600",
+        overlay: "700",
+        modal: "800",
+        popup: "900"
       }
     }
   },


### PR DESCRIPTION
**Related Issue:** #4372 #3099 #4682 #3724 #4781 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a couple of layering issues we had in our components by doing the following:

1. updated tailwind config to introduce contextual z-index layers
2. updated component styles to reference these
3. removed unnecessary z-indices (see 3 below)

### Notes

1. I can break any of these items to separate PRs if deemed appropriate
2. Layers are based on https://www.duetds.com/tokens/#z-index and can be tweaked accordingly
3. Any removed `z-index` can be restored if we spot a regression. Removal was determined by:
    * evaluating the need for a stacking context
    * local testing
4. Repro cases from the referenced issues were tested and work as expected
5. Updated all z-indices to be applied as tailwind utils
6. Skipped adding CSS props for now until the z-index tokens are decided