### PR TITLE
fix(tab): Screen reader support to access tab content

### DIFF
--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -65,15 +65,12 @@ export class Tab {
     const id = this.el.id || this.guid;
 
     return (
-      <Host
-        aria-labelledby={this.labeledBy}
-        id={id}
-        role="tabpanel"
-        tabIndex={this.active ? 0 : -1}
-      >
-        <section>
-          <slot />
-        </section>
+      <Host aria-labelledby={this.labeledBy} id={id}>
+        <div role="tabpanel" tabIndex={this.active ? 0 : -1}>
+          <section>
+            <slot />
+          </section>
+        </div>
       </Host>
     );
   }


### PR DESCRIPTION
**Related Issue:** #2124 

## Summary
Adds screen reader support to access the `calcite-tab` content by moving the `role` and `tabindex` to a child element.

Prior to the fix when accessing the tab content, screen reader users were provided with the `tab-title`, but not the `tab` content in particular with JAWS and VoiceOver.

Additional reference: [4979 comment](https://github.com/Esri/calcite-components/pull/4979#discussion_r926069374)

Verified on:
- [x] JAWS and Chrome
- [x] JAWS and Firefox
- [x] NVDA and Chrome
- [x] NVDA and Firefox
- [x] VoiceOver and Safari


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
