### PR TITLE
ci(dependabot): change back to tuesdays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     # Check the npm registry for updates every week (Tuesdays)
     schedule:
       interval: "weekly"
-      day: "thursday"
+      day: "tuesday"
       time: "05:00"
       timezone: "America/Los_Angeles"
     # Conventional commits


### PR DESCRIPTION
**Related Issue:** #4770

## Summary
We were using the bump-deps action on Tuesdays, and I moved dependabot to Thursday as a backup incase the action failed. Now that the action isn't working anymore (linked issue), I'm changing dependabot back to Tuesdays
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
