### PR TITLE
docs: api styling consistency for radio components and rating

### DIFF
--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -36,7 +36,7 @@ export class RadioButtonGroup {
   //
   //--------------------------------------------------------------------------
 
-  /** The disabled state of the radio button group. */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   @Watch("disabled")
@@ -44,7 +44,7 @@ export class RadioButtonGroup {
     this.passPropsToRadioButtons();
   }
 
-  /** The radio button group's hidden status.  When a radio button group is hidden none of its options are focusable or checkable. */
+  /** When true, the component is not displayed and its `calcite-radio-button`s are not focusable or checkable. */
   @Prop({ reflect: true }) hidden = false;
 
   @Watch("hidden")
@@ -52,7 +52,7 @@ export class RadioButtonGroup {
     this.passPropsToRadioButtons();
   }
 
-  /** The layout direction of the radio buttons in a group. */
+  /** Defines the layout of the component. */
   @Prop({ reflect: true }) layout: Layout = "horizontal";
 
   @Watch("layout")
@@ -60,13 +60,13 @@ export class RadioButtonGroup {
     this.passPropsToRadioButtons();
   }
 
-  /** The name of the radio button group. `name` must be unique to other radio button group instances. */
+  /** Specifies the name of the component on form submission. Must be unique to other component instances. */
   @Prop({ reflect: true }) name!: string;
 
-  /** Requires that a value is selected for the radio button group before the parent form will submit. */
+  /** When true, the component must have a value on form submission. */
   @Prop({ reflect: true }) required = false;
 
-  /** The scale (size) of the radio button group. */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   @Watch("scale")
@@ -123,7 +123,7 @@ export class RadioButtonGroup {
   //--------------------------------------------------------------------------
 
   /**
-   * Emitted when the radio button group has changed.
+   * Fires when the component has changed.
    */
   @Event({ cancelable: false }) calciteRadioButtonGroupChange: EventEmitter<void>;
 

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -47,7 +47,7 @@ export class RadioButton
   //
   //--------------------------------------------------------------------------
 
-  /** The checked state of the radio button. */
+  /** When true, the component is checked. */
   @Prop({ mutable: true, reflect: true }) checked = false;
 
   @Watch("checked")
@@ -59,37 +59,37 @@ export class RadioButton
     this.calciteInternalRadioButtonCheckedChange.emit();
   }
 
-  /** The disabled state of the radio button. */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The focused state of the radio button.
+   * The focused state of the component.
    *
    * @internal
    */
   @Prop({ mutable: true, reflect: true }) focused = false;
 
-  /** The id attribute of the radio button.  When omitted, a globally unique identifier is used. */
+  /** The id attribute of the component. When omitted, a globally unique identifier is used. */
   @Prop({ reflect: true, mutable: true }) guid: string;
 
-  /** The radio button's hidden status.  When a radio button is hidden it is not focusable or checkable. */
+  /** When true, the component is not displayed and is not focusable or checkable. */
   @Prop({ reflect: true }) hidden = false;
 
   /**
-   * The hovered state of the radio button.
+   * The hovered state of the component.
    *
    * @internal
    */
   @Prop({ reflect: true, mutable: true }) hovered = false;
 
   /**
-   * The label of the radio input
+   * Accessible name for the component.
    *
    * @internal
    */
   @Prop() label?: string;
 
-  /** The name of the radio button. `name` is passed as a property automatically from `calcite-radio-button-group`. */
+  /** Specifies the name of the component, passed from the `calcite-radio-button-group` on form submission. */
   @Prop({ reflect: true }) name: string;
 
   @Watch("name")
@@ -97,13 +97,13 @@ export class RadioButton
     this.checkLastRadioButton();
   }
 
-  /** Requires that a value is selected for the radio button group before the parent form will submit. */
+  /** When true, the component must have a value selected from the `calcite-radio-button-group` on form submission. */
   @Prop({ reflect: true }) required = false;
 
-  /** The scale (size) of the radio button. `scale` is passed as a property automatically from `calcite-radio-button-group`. */
+  /** Specifies the size of the component inherited from the `calcite-radio-button-group`. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The value of the radio button. */
+  /** The component's value. */
   @Prop({ mutable: true }) value!: any;
 
   //--------------------------------------------------------------------------

--- a/src/components/radio-group-item/radio-group-item.tsx
+++ b/src/components/radio-group-item/radio-group-item.tsx
@@ -35,7 +35,7 @@ export class RadioGroupItem {
   //
   //--------------------------------------------------------------------------
 
-  /** Indicates whether the control is checked. */
+  /** When true, the component is checked. */
   @Prop({ reflect: true, mutable: true }) checked = false;
 
   @Watch("checked")
@@ -43,17 +43,17 @@ export class RadioGroupItem {
     this.calciteInternalRadioGroupItemChange.emit();
   }
 
-  /** optionally pass an icon to display - accepts Calcite UI icon names  */
+  /** Specifies an icon to display - accepts Calcite UI icon names. */
   @Prop({ reflect: true }) icon?: string;
 
-  /** flip the icon in rtl */
+  /** When true, the icon will be flipped when the element direction is right-to-left ("rtl"). */
   @Prop({ reflect: true }) iconFlipRtl = false;
 
-  /** optionally used with icon, select where to position the icon */
+  /** When used with "icon", specifies its position. */
   @Prop({ reflect: true }) iconPosition?: Position = "start";
 
   /**
-   * The control's value.
+   * The component's value.
    */
   @Prop({ mutable: true })
   value: any | null;

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -49,31 +49,31 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
   //
   //--------------------------------------------------------------------------
 
-  /** specify the appearance style of the radio group, defaults to solid. */
+  /** Specifies the appearance style of the component. */
   @Prop({ reflect: true }) appearance: RadioAppearance = "solid";
 
-  /** is the radio group disabled  */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * When true, makes the component required for form-submission.
+   * When true, the component must have a value on form submission.
    *
    * @internal
    */
   @Prop({ reflect: true }) required = false;
 
-  /** specify the layout of the radio group, defaults to horizontal */
+  /** Defines the layout of the component. */
   @Prop({ reflect: true }) layout: Layout = "horizontal";
 
   /**
-   * The group's name. Gets submitted with the form.
+   * Specifies the name of the component on form submission.
    */
   @Prop() name: string;
 
-  /** The scale of the radio group */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The value of the selectedItem */
+  /** The component's "selectedItem" value. */
   @Prop({ mutable: true }) value: string = null;
 
   @Watch("value")
@@ -83,7 +83,7 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
   }
 
   /**
-   * The group's selected item.
+   * The component's selected item `HTMLElement`.
    *
    * @readonly
    */
@@ -110,7 +110,7 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
     }
   }
 
-  /** specify the width of the group, defaults to auto */
+  /** Specifies the width of the component. */
   @Prop({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";
 
   //--------------------------------------------------------------------------
@@ -238,7 +238,7 @@ export class RadioGroup implements LabelableComponent, FormComponent, Interactiv
   //
   //--------------------------------------------------------------------------
 
-  /** Fired when the selected option changes, event detail is the new value */
+  /** Fires when the selected option changes, where the event detail is the new value. */
   @Event({ cancelable: false }) calciteRadioGroupChange: EventEmitter<string>;
 
   // --------------------------------------------------------------------------

--- a/src/components/rating/rating.scss
+++ b/src/components/rating/rating.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-rating-spacing-unit: the amount of left/right margin between each rating star
+ * @prop --calcite-rating-spacing-unit: The amount of left and right margin spacing between each rating star.
  */
 
 :host {

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -39,46 +39,46 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
   //
   // --------------------------------------------------------------------------
 
-  /** specify the scale of the component, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** the value of the rating component */
+  /** The component's value. */
   @Prop({ reflect: true, mutable: true }) value = 0;
 
-  /** is the rating component in a selectable mode */
+  /** When true, the component's value can be read, but cannot be modified. */
   @Prop({ reflect: true }) readOnly = false;
 
-  /** is the rating component in a selectable mode */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** Show average and count data summary chip (if available) */
+  /** When true, and if available, displays the "average" and/or "count" data summary in a `calcite-chip`. */
   @Prop({ reflect: true }) showChip = false;
 
-  /** optionally pass a number of previous ratings to display */
+  /** Specifies the number of previous ratings to display. */
   @Prop({ reflect: true }) count?: number;
 
-  /** optionally pass a cumulative average rating to display */
+  /** Specifies a cumulative average from previous ratings to display. */
   @Prop({ reflect: true }) average?: number;
 
-  /** The name of the rating */
+  /** Specifies the name of the component on form submission. */
   @Prop({ reflect: true }) name: string;
 
   /**
-   * Localized string for "Rating" (used for aria label)
+   * Accessible name for the component.
    *
    * @default "Rating"
    */
   @Prop() intlRating?: string = TEXT.rating;
 
   /**
-   * Localized string for labelling each star, `${num}` in the string will be replaced by the number
+   * Accessible name for each star. The `${num}` in the string will be replaced by the number.
    *
    * @default "Stars: ${num}"
    */
   @Prop() intlStars?: string = TEXT.stars;
 
   /**
-   * When true, makes the component required for form-submission.
+   * When true, the component must have a value on form submission.
    *
    * @internal
    */
@@ -111,7 +111,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
   //--------------------------------------------------------------------------
 
   /**
-   * Fires when the rating value has changed.
+   * Fires when the component's value changes.
    */
   @Event({ cancelable: false }) calciteRatingChange: EventEmitter<{ value: number }>;
 


### PR DESCRIPTION
**Related Issue:** #4442

## Summary

🧹 

Adds consistency to our API styling documentation for the radio components and rating, including:
- radio-button
- radio-button-group
- radio-group
- radio-group-item
- rating

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
