### PR TITLE
fix(tabs): reverts regression that makes tabs ignore layout center

### DIFF
--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -21,6 +21,10 @@
     overflow-auto;
 }
 
+:host([layout="center"]) .tab-nav {
+  @apply justify-center;
+}
+
 // prevent indicator overflow in horizontal scrolling situations
 .tab-nav-active-indicator-container {
   @apply absolute

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -247,3 +247,14 @@ export const disabled = (): string => html`<calcite-tabs>
   <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
   <calcite-tab><p>Tab 2 Content</p></calcite-tab>
 </calcite-tabs>`;
+
+export const LayoutCenter = (): string => html` <calcite-tabs
+  layout="${select("layout", ["inline", "center"], "center")}"
+>
+  <calcite-tab-nav slot="tab-nav">
+    <calcite-tab-title>Tab 1 Title</calcite-tab-title>
+    <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+    <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+    <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+  </calcite-tab-nav>
+</calcite-tabs>`;


### PR DESCRIPTION
**Related Issue:** #4971

## Summary


Reverts regression that makes `tabs` ignore `layout="center"`. When `calcite-tabs` is passed a `layout="center"` attribute, the `calcite-tab-nav` component now centers again.