### PR TITLE
refactor: fix typo in form interface

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -11,7 +11,7 @@ import {
 } from "@stencil/core";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
-import { CheckableFormCompoment, HiddenFormInputSlot } from "../../utils/form";
+import { CheckableFormComponent, HiddenFormInputSlot } from "../../utils/form";
 import { LabelableComponent, connectLabel, disconnectLabel, getLabelText } from "../../utils/label";
 import { connectForm, disconnectForm } from "../../utils/form";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
@@ -23,7 +23,7 @@ import { isActivationKey } from "../../utils/key";
   styleUrl: "checkbox.scss",
   shadow: true
 })
-export class Checkbox implements LabelableComponent, CheckableFormCompoment, InteractiveComponent {
+export class Checkbox implements LabelableComponent, CheckableFormComponent, InteractiveComponent {
   //--------------------------------------------------------------------------
   //
   //  Element

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -19,7 +19,7 @@ import {
   HiddenFormInputSlot,
   connectForm,
   disconnectForm,
-  CheckableFormCompoment
+  CheckableFormComponent
 } from "../../utils/form";
 import { CSS } from "./resources";
 import { getRoundRobinIndex } from "../../utils/array";
@@ -31,7 +31,7 @@ import { InteractiveComponent, updateHostInteraction } from "../../utils/interac
   shadow: true
 })
 export class RadioButton
-  implements LabelableComponent, CheckableFormCompoment, InteractiveComponent
+  implements LabelableComponent, CheckableFormComponent, InteractiveComponent
 {
   //--------------------------------------------------------------------------
   //

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -16,7 +16,7 @@ import { LabelableComponent, connectLabel, disconnectLabel, getLabelText } from 
 import {
   connectForm,
   disconnectForm,
-  CheckableFormCompoment,
+  CheckableFormComponent,
   HiddenFormInputSlot
 } from "../../utils/form";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
@@ -27,7 +27,7 @@ import { isActivationKey } from "../../utils/key";
   styleUrl: "switch.scss",
   shadow: true
 })
-export class Switch implements LabelableComponent, CheckableFormCompoment, InteractiveComponent {
+export class Switch implements LabelableComponent, CheckableFormComponent, InteractiveComponent {
   //--------------------------------------------------------------------------
   //
   //  Element

--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -80,7 +80,7 @@ export interface FormComponent<T = any> extends FormOwner {
  *
  * Along with the interface, use the matching form utils to help set up the component behavior.
  */
-export interface CheckableFormCompoment<T = any> extends FormComponent<T> {
+export interface CheckableFormComponent<T = any> extends FormComponent<T> {
   /**
    * For boolean-valued components, this property defines whether the associated value is submitted to the form or not.
    */
@@ -94,7 +94,7 @@ export interface CheckableFormCompoment<T = any> extends FormComponent<T> {
   defaultChecked: boolean;
 }
 
-function isCheckable(component: FormComponent): component is CheckableFormCompoment {
+function isCheckable(component: FormComponent): component is CheckableFormComponent {
   return "checked" in component;
 }
 


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Not sure why it was irrationally bothersome, but I had to fix it
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
