### PR TITLE
docs:  improve overlayPositioning property description

### DIFF
--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -89,7 +89,7 @@ export class ActionMenu {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -86,7 +86,12 @@ export class ActionMenu {
     this.setTooltipReferenceElement();
   }
 
-  /** Determines the type of positioning to use for the overlaid content. If your element is in a fixed container, use the "fixed" value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /**

--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -89,7 +89,7 @@ export class ActionMenu {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -160,7 +160,7 @@ export class Combobox
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -157,7 +157,12 @@ export class Combobox
   /** Allow entry of custom values which are not in the original set of items */
   @Prop() allowCustomValues: boolean;
 
-  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   @Watch("overlayPositioning")

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -160,7 +160,7 @@ export class Combobox
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -128,7 +128,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -125,7 +125,12 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
     this.setMaxScrollerHeight();
   }
 
-  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   @Watch("overlayPositioning")

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -128,7 +128,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -268,7 +268,12 @@ export class InputDatePicker
    */
   @Prop({ mutable: true }) end?: string;
 
-  /** Describes the type of positioning to use for the overlaid content. If your element is in a fixed container, use the 'fixed' value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   @Watch("overlayPositioning")

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -271,7 +271,7 @@ export class InputDatePicker
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -271,7 +271,7 @@ export class InputDatePicker
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -179,7 +179,7 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>;
 
   /**
-   * Emits when the component's label, description, value, or metadata properties are modified.
+   * Emits when the the component's label, description, value, or metadata properties are modified.
    *
    * @internal
    */

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -179,14 +179,14 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>;
 
   /**
-   * Emits when the the component's label, description, value, or metadata properties are modified.
+   * Emits when the component's label, description, value, or metadata properties are modified.
    *
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalListItemPropsChange: EventEmitter<void>;
 
   /**
-   * Emits when the the component's value property is modified.
+   * Emits when the component's value property is modified.
    *
    * @internal
    */

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -163,7 +163,7 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -160,7 +160,12 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
     this.setExpandedAttr();
   }
 
-  /** Describes the positioning type to use for the overlaid content. If the element is in a fixed container, use the "fixed" value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   @Watch("overlayPositioning")

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -163,7 +163,7 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -170,7 +170,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
             name={this.guid}
             onChange={() => this.updateValue(i)}
             onClick={(event) =>
-              // click is fired from the the component's label, so we treat this as an internal event
+              // click is fired from the component's label, so we treat this as an internal event
               event.stopPropagation()
             }
             onFocus={() => this.onFocusChange(i)}

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -170,7 +170,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
             name={this.guid}
             onChange={() => this.updateValue(i)}
             onClick={(event) =>
-              // click is fired from the component's label, so we treat this as an internal event
+              // click is fired from the the component's label, so we treat this as an internal event
               event.stopPropagation()
             }
             onFocus={() => this.onFocusChange(i)}

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -58,7 +58,12 @@ export class SplitButton implements InteractiveComponent {
    */
   @Prop({ reflect: true }) loading = false;
 
-  /** Describes the type of positioning to use for the dropdown. If your element is in a fixed container, use the 'fixed' value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   /** optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names  */

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -61,7 +61,7 @@ export class SplitButton implements InteractiveComponent {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -61,7 +61,7 @@ export class SplitButton implements InteractiveComponent {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -74,7 +74,7 @@ export class Tooltip implements FloatingUIComponent {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * Using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -71,7 +71,12 @@ export class Tooltip implements FloatingUIComponent {
     this.reposition();
   }
 
-  /** Describes the positioning type to use for the overlaid content. If the `referenceElement` is in a fixed container, use the "fixed" value. */
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   *
+   */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
   @Watch("overlayPositioning")

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -74,7 +74,7 @@ export class Tooltip implements FloatingUIComponent {
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
-   * Using the `absolute` value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
+   * using the "absolute" value will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the the container's layout. The "fixed" value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is "fixed".
    *
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";


### PR DESCRIPTION
**Related Issue:** #3815 #4355

## Summary
Improves `overlayPositioning` description
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
