### PR TITLE
docs(handle, pick-list-item, rating): remove repeat the in comments

### DIFF
--- a/src/components/handle/handle.tsx
+++ b/src/components/handle/handle.tsx
@@ -42,7 +42,7 @@ export class Handle {
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when the the handle is activated and the up or down arrow key is pressed.
+   * Emitted when the handle is activated and the up or down arrow key is pressed.
    *
    * **Note:**: The `handle` event payload prop is deprecated, please use the event's target/currentTarget instead
    */

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -179,14 +179,14 @@ export class PickListItem implements ConditionalSlotComponent, InteractiveCompon
   @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>;
 
   /**
-   * Emits when the the component's label, description, value, or metadata properties are modified.
+   * Emits when the component's label, description, value, or metadata properties are modified.
    *
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalListItemPropsChange: EventEmitter<void>;
 
   /**
-   * Emits when the the component's value property is modified.
+   * Emits when the component's value property is modified.
    *
    * @internal
    */

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -170,7 +170,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
             name={this.guid}
             onChange={() => this.updateValue(i)}
             onClick={(event) =>
-              // click is fired from the the component's label, so we treat this as an internal event
+              // click is fired from the component's label, so we treat this as an internal event
               event.stopPropagation()
             }
             onFocus={() => this.onFocusChange(i)}


### PR DESCRIPTION
**Related Issue:** #5124

## Summary
Caught in the PR linked above when find/replacing. The one for handle actually shows up in the doc so it seemed worth the extra PR
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
