### PR TITLE
build(deps): downgrade stencil due to unresolved tree shaking bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
         "@floating-ui/dom": "1.0.1",
-        "@stencil/core": "2.17.3",
+        "@stencil/core": "2.16.1",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "form-request-submit-polyfill": "2.0.0",
@@ -3110,9 +3110,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.3.tgz",
-      "integrity": "sha512-qw2DZzOpyaltLLEfYRTj3n+XbvRtkmv4QQimYDJubC6jMY0NXK9r6H2+VyszdbbVmvK1D9GqZtyvY0NmOrztsg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -33696,9 +33696,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.3.tgz",
-      "integrity": "sha512-qw2DZzOpyaltLLEfYRTj3n+XbvRtkmv4QQimYDJubC6jMY0NXK9r6H2+VyszdbbVmvK1D9GqZtyvY0NmOrztsg=="
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
+      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw=="
     },
     "@stencil/eslint-plugin": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@a11y/focus-trap": "1.0.5",
     "@floating-ui/dom": "1.0.1",
-    "@stencil/core": "2.17.3",
+    "@stencil/core": "2.16.1",
     "@types/color": "3.0.3",
     "color": "4.2.3",
     "form-request-submit-polyfill": "2.0.0",


### PR DESCRIPTION
**Related Issue:** #5098 

## Summary

PR to déBump stencil back to 2.16.1 since https://github.com/ionic-team/stencil/issues/3470 still hasn't been resolved. If we need to bump Stencil I can close this PR and write something up to inform our users before releasing. I assume many of them will not be able to use `beta.91` if that's the case though.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
