### PR TITLE
feat(tree): add none selection mode

### DIFF
--- a/src/components/tree-item/resources.ts
+++ b/src/components/tree-item/resources.ts
@@ -15,5 +15,6 @@ export const SLOTS = {
 export const ICONS = {
   bulletPoint: "bullet-point",
   checkmark: "check",
-  chevronRight: "chevron-right"
+  chevronRight: "chevron-right",
+  blank: "blank"
 };

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -5,6 +5,12 @@
     cursor-pointer;
 }
 
+:host([selection-mode="none"]:not([has-children])) {
+  .node-container {
+    margin-inline: theme("margin.3");
+  }
+}
+
 @include calciteHydratedHidden();
 
 :host([scale="s"]) {
@@ -177,7 +183,7 @@
 }
 
 // dropdown expanded and not selected
-:host([has-children][expanded]:not([selected])) > .node-container {
+:host([has-children][expanded]:not([selected]):not([selection-mode="none"])) > .node-container {
   ::slotted(*) {
     @apply text-color-1 font-medium;
   }

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -107,7 +107,7 @@ export class TreeItem implements ConditionalSlotComponent {
   /**
    * @internal
    */
-  @Prop({ mutable: true }) selectionMode: TreeSelectionMode;
+  @Prop({ mutable: true, reflect: true }) selectionMode: TreeSelectionMode;
 
   @Watch("selectionMode")
   getselectionMode(): void {
@@ -181,7 +181,6 @@ export class TreeItem implements ConditionalSlotComponent {
     const showCheckmark =
       this.selectionMode === TreeSelectionMode.Multi ||
       this.selectionMode === TreeSelectionMode.MultiChildren;
-    const showBlank = this.selectionMode === TreeSelectionMode.None;
     const chevron = this.hasChildren ? (
       <calcite-icon
         class={{
@@ -213,8 +212,6 @@ export class TreeItem implements ConditionalSlotComponent {
       ? ICONS.bulletPoint
       : showCheckmark
       ? ICONS.checkmark
-      : showBlank
-      ? ICONS.blank
       : null;
     const itemIndicator = selectedIcon ? (
       <calcite-icon

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -181,6 +181,7 @@ export class TreeItem implements ConditionalSlotComponent {
     const showCheckmark =
       this.selectionMode === TreeSelectionMode.Multi ||
       this.selectionMode === TreeSelectionMode.MultiChildren;
+    const showBlank = this.selectionMode === TreeSelectionMode.None;
     const chevron = this.hasChildren ? (
       <calcite-icon
         class={{
@@ -212,8 +213,10 @@ export class TreeItem implements ConditionalSlotComponent {
       ? ICONS.bulletPoint
       : showCheckmark
       ? ICONS.checkmark
+      : showBlank
+      ? ICONS.blank
       : null;
-    const bulletOrCheckIcon = selectedIcon ? (
+    const itemIndicator = selectedIcon ? (
       <calcite-icon
         class={{
           [CSS.bulletPointIcon]: selectedIcon === ICONS.bulletPoint,
@@ -245,7 +248,7 @@ export class TreeItem implements ConditionalSlotComponent {
           ref={(el) => (this.defaultSlotWrapper = el as HTMLElement)}
         >
           {chevron}
-          {bulletOrCheckIcon}
+          {itemIndicator}
           {checkbox ? checkbox : defaultSlotNode}
         </div>
         <div

--- a/src/components/tree/interfaces.ts
+++ b/src/components/tree/interfaces.ts
@@ -5,6 +5,7 @@ export interface TreeSelectDetail {
 export enum TreeSelectionMode {
   Single = "single",
   Multi = "multi",
+  None = "none",
   Children = "children",
   MultiChildren = "multi-children",
   Ancestors = "ancestors"

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -49,14 +49,12 @@ export default {
   }
 };
 
+const selectionModes = ["single", "multi", "children", "multi-children", "ancestors", "none"];
+
 export const Simple = (): string => html`
   <calcite-tree
     ${boolean("lines", false)}
-    selection-mode="${select(
-      "selection-mode",
-      ["single", "multi", "children", "multi-children", "ancestors"],
-      "single"
-    )}"
+    selection-mode="${select("selection-mode", selectionModes, "single")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     ${treeItems}
@@ -67,11 +65,7 @@ export const RTL = (): string => html`
   <calcite-tree
     dir="rtl"
     ${boolean("lines", false)}
-    selection-mode="${select(
-      "selection-mode",
-      ["single", "multi", "children", "multi-children", "ancestors"],
-      "single"
-    )}"
+    selection-mode="${select("selection-mode", selectionModes, "single")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     ${treeItems}
@@ -82,11 +76,7 @@ export const DarkMode = (): string => html`
   <calcite-tree
     class="calcite-theme-dark"
     ${boolean("lines", false)}
-    selection-mode="${select(
-      "selection-mode",
-      ["single", "multi", "children", "multi-children", "ancestors"],
-      "single"
-    )}"
+    selection-mode="${select("selection-mode", selectionModes, "single")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     ${treeItems}

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -152,6 +152,8 @@ export class Tree {
       return;
     }
 
+    const isNoneSelectionMode = this.selectionMode === TreeSelectionMode.None;
+
     const shouldSelect =
       this.selectionMode !== null &&
       (!target.hasChildren ||
@@ -160,6 +162,7 @@ export class Tree {
             this.selectionMode === TreeSelectionMode.MultiChildren)));
 
     const shouldModifyToCurrentSelection =
+      !isNoneSelectionMode &&
       event.detail.modifyCurrentSelection &&
       (this.selectionMode === TreeSelectionMode.Multi ||
         this.selectionMode === TreeSelectionMode.MultiChildren);
@@ -220,20 +223,20 @@ export class Tree {
         targetItems.forEach((treeItem) => {
           treeItem.selected = false;
         });
-      } else {
+      } else if (!isNoneSelectionMode) {
         targetItems.forEach((treeItem) => {
           treeItem.selected = true;
         });
       }
     }
 
-    this.calciteTreeSelect.emit({
-      selected: (
-        nodeListToArray(
-          this.el.querySelectorAll("calcite-tree-item")
-        ) as HTMLCalciteTreeItemElement[]
-      ).filter((i) => i.selected)
-    });
+    const selected = isNoneSelectionMode
+      ? [target]
+      : (nodeListToArray(this.el.querySelectorAll("calcite-tree-item")).filter(
+          (i) => i.selected
+        ) as HTMLCalciteTreeItemElement[]);
+
+    this.calciteTreeSelect.emit({ selected });
 
     event.stopPropagation();
   }

--- a/src/demos/tree.html
+++ b/src/demos/tree.html
@@ -353,6 +353,95 @@
         </div>
       </div>
 
+      <!-- none selection mode -->
+      <div class="parent">
+        <div class="child right-aligned-text">none selection mode</div>
+
+        <div class="child">
+          <calcite-tree selection-mode="none" scale="s">
+            <calcite-tree-item>
+              <span>Child 1</span>
+            </calcite-tree-item>
+
+            <calcite-tree-item>
+              <span>Child 2</span>
+
+              <calcite-tree slot="children">
+                <calcite-tree-item>
+                  <span>Grandchild 1</span>
+                  <calcite-tree slot="children">
+                    <calcite-tree-item>
+                      <span>Great Grandchild 1</span>
+                    </calcite-tree-item>
+                    <calcite-tree-item>
+                      <span>Great Grandchild 2</span>
+                    </calcite-tree-item>
+                    <calcite-tree-item>
+                      <span>Great Grandchild 3</span>
+                    </calcite-tree-item>
+                  </calcite-tree>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <span>Grandchild 2</span>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <span>Grandchild 3</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+
+            <calcite-tree-item>
+              <span>Child 3</span>
+            </calcite-tree-item>
+            <calcite-tree-item>
+              <span>Child 4</span>
+            </calcite-tree-item>
+          </calcite-tree>
+        </div>
+
+        <div class="child">
+          <calcite-tree selection-mode="none" scale="m">
+            <calcite-tree-item>
+              <span>Child 1</span>
+            </calcite-tree-item>
+
+            <calcite-tree-item>
+              <span>Child 2</span>
+
+              <calcite-tree slot="children">
+                <calcite-tree-item>
+                  <span>Grandchild 1</span>
+                  <calcite-tree slot="children">
+                    <calcite-tree-item>
+                      <span>Great Grandchild 1</span>
+                    </calcite-tree-item>
+                    <calcite-tree-item>
+                      <span>Great Grandchild 2</span>
+                    </calcite-tree-item>
+                    <calcite-tree-item>
+                      <span>Great Grandchild 3</span>
+                    </calcite-tree-item>
+                  </calcite-tree>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <span>Grandchild 2</span>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <span>Grandchild 3</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+
+            <calcite-tree-item>
+              <span>Child 3</span>
+            </calcite-tree-item>
+            <calcite-tree-item>
+              <span>Child 4</span>
+            </calcite-tree-item>
+          </calcite-tree>
+        </div>
+      </div>
+
       <!-- events to test -->
       <div class="parent">
         <div class="child right-aligned-text">events</div>


### PR DESCRIPTION
**Related Issue:** #3121

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This introduces a new `none` selection mode that will still allow tree navigation, but prevent an item from being selected. The `calciteTreeSelect` event will emit as well after an item is 'selected'.