### PR TITLE
docs: consistent api ref s-named components

### DIFF
--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -18,15 +18,14 @@ export class Scrim {
   // --------------------------------------------------------------------------
 
   /**
-   * string to override English loading text
+   * Accessible name when the component is loading.
    *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
   /**
-   * Determines if the component will have the loader overlay.
-   * Otherwise, will render opaque disabled state.
+   * When true, a busy indicator is displayed.
    */
   @Prop({ reflect: true }) loading = false;
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -3,8 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-select-font-size: the font-size of items in the select
- * @prop --calcite-select-spacing: the padding around the selected option text
+ * @prop --calcite-select-font-size: The font size of items in the component.
+ * @prop --calcite-select-spacing: The padding around the selected option text.
  */
 
 :host {

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -54,34 +54,34 @@ export class Select implements LabelableComponent, FormComponent, InteractiveCom
   //--------------------------------------------------------------------------
 
   /**
-   * When true, it prevents the option from being selected.
+   * When true, interaction is prevented and the component is displayed with lower opacity.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The component's label. This is required for accessibility purposes.
+   * Accessible name for the component.
    *
    */
   @Prop() label!: string;
 
   /**
-   * The select's name. Gets submitted with the form.
+   * Specifies the name of the component on form submission.
    */
   @Prop() name: string;
 
   /**
-   * When true, makes the component required for form-submission.
+   * When true, the component must have a value on form submission.
    *
    * @internal
    */
   @Prop({ reflect: true }) required = false;
 
   /**
-   * The component scale.
+   * Specifies the size of the component.
    */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The value of the selectedOption */
+  /** The component's "selectedOption" value. */
   @Prop({ mutable: true }) value: string = null;
 
   @Watch("value")
@@ -91,7 +91,7 @@ export class Select implements LabelableComponent, FormComponent, InteractiveCom
   }
 
   /**
-   * The currently selected option.
+   * The component's selected item `HTMLElement`.
    *
    * @readonly
    */
@@ -103,7 +103,7 @@ export class Select implements LabelableComponent, FormComponent, InteractiveCom
   }
 
   /**
-   * The component width.
+   * Specifies the width of the component.
    */
   @Prop({ reflect: true }) width: Width = "auto";
 
@@ -178,7 +178,7 @@ export class Select implements LabelableComponent, FormComponent, InteractiveCom
   //--------------------------------------------------------------------------
 
   /**
-   * This event will fire whenever the selected option changes.
+   * Fires when the selected option changes.
    */
   @Event({ cancelable: false }) calciteSelectChange: EventEmitter<void>;
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -91,7 +91,7 @@ export class Select implements LabelableComponent, FormComponent, InteractiveCom
   }
 
   /**
-   * The component's selected item `HTMLElement`.
+   * The component's selected option `HTMLElement`.
    *
    * @readonly
    */

--- a/src/components/shell-center-row/shell-center-row.tsx
+++ b/src/components/shell-center-row/shell-center-row.tsx
@@ -9,8 +9,8 @@ import {
 } from "../../utils/conditionalSlot";
 
 /**
- * @slot - A slot for adding content to the shell panel.
- * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
+ * @slot - A slot for adding content to the `calcite-shell-panel`.
+ * @slot action-bar - A slot for adding a `calcite-action-bar` to the `calcite-shell-panel`.
  */
 @Component({
   tag: "calcite-shell-center-row",
@@ -25,17 +25,17 @@ export class ShellCenterRow implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * This property makes the content area appear like a "floating" panel.
+   * When true, the content area displays like a floating panel.
    */
   @Prop({ reflect: true }) detached = false;
 
   /**
-   * Specifies the maximum height of the row.
+   * Specifies the maximum height of the component.
    */
   @Prop({ reflect: true }) heightScale: Scale = "s";
 
   /**
-   * Arranges the component depending on the elements 'dir' property.
+   * Specifies the component's position. Will be flipped when the element direction is right-to-left ("rtl").
    */
   @Prop({ reflect: true }) position: Position = "end";
 

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -21,8 +21,8 @@ import {
 } from "../../utils/conditionalSlot";
 
 /**
- * @slot - A slot for adding content to the shell panel.
- * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
+ * @slot - A slot for adding content to the component.
+ * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  */
 @Component({
   tag: "calcite-shell-panel",
@@ -37,7 +37,7 @@ export class ShellPanel implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * Hide the content panel.
+   * When true, hides the component's content area.
    */
   @Prop({ reflect: true }) collapsed = false;
 
@@ -47,35 +47,35 @@ export class ShellPanel implements ConditionalSlotComponent {
   }
 
   /**
-   * This property makes the content area appear like a "floating" panel.
+   * When true, the content area displays like a floating panel.
    */
   @Prop({ reflect: true }) detached = false;
 
   /**
-   * Specifies the maximum height of the contents when detached.
+   * When "detached", specifies the maximum height of the component.
    */
   @Prop({ reflect: true }) detachedHeightScale: Scale = "l";
 
   /**
-   * This sets width of the content area.
+   * Specifies the width of the component's content area.
    */
 
   @Prop({ reflect: true }) widthScale: Scale = "m";
 
   /**
-   * Arranges the component depending on the elements 'dir' property.
+   * Specifies the component's position. Will be flipped when the element direction is right-to-left ("rtl").
    */
   @Prop({ reflect: true }) position: Position;
 
   /**
-   * Accessible label for resize separator.
+   * Accessible name for the resize separator.
    *
    * @default "Resize"
    */
   @Prop() intlResize = TEXT.resize;
 
   /**
-   * This property makes the content area resizable if the calcite-shell-panel is not 'detached'.
+   * When true and not "detached", the component's content area is resizable.
    */
   @Prop({ reflect: true }) resizable = false;
 
@@ -133,7 +133,7 @@ export class ShellPanel implements ConditionalSlotComponent {
   /**
    * Emitted when collapse has been toggled.
    *
-   * @deprecated use a resizeObserver on the shell-panel to listen for changes to its size.
+   * @deprecated use a resizeObserver on the component to listen for changes to its size.
    */
   @Event({ cancelable: false }) calciteShellPanelToggle: EventEmitter<void>;
 

--- a/src/components/shell/shell.scss
+++ b/src/components/shell/shell.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-shell-tip-spacing: the left/right positioning of the tip-manager when slotted within a shell
+ * @prop --calcite-shell-tip-spacing: The left and right spacing of the `calcite-tip-manager` when slotted in the component.
  */
 
 :host {

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -8,14 +8,14 @@ import {
 } from "../../utils/conditionalSlot";
 
 /**
- * @slot - A slot for adding content to the shell. This content will appear between any leading and trailing panels added to the shell. (eg. a map)
- * @slot header - A slot for adding header content. This content will be positioned at the top of the shell.
- * @slot footer - A slot for adding footer content. This content will be positioned at the bottom of the shell.
+ * @slot - A slot for adding content to the component. This content will appear between any leading and trailing panels added to the component, such as a map.
+ * @slot header - A slot for adding header content. This content will be positioned at the top of the component.
+ * @slot footer - A slot for adding footer content. This content will be positioned at the bottom of the component.
  * @slot panel-start - A slot for adding the starting `calcite-shell-panel`.
  * @slot panel-end - A slot for adding the ending `calcite-shell-panel`.
  * @slot primary-panel - [DEPRECATED] A slot for adding the leading `calcite-shell-panel`.
  * @slot contextual-panel - [DEPRECATED] A slot for adding the trailing `calcite-shell-panel`.
- * @slot center-row - A slot for adding custom content in the center row.
+ * @slot center-row - A slot for adding content to the center row.
  */
 @Component({
   tag: "calcite-shell",
@@ -30,7 +30,7 @@ export class Shell implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * Positions the center content behind any calcite-shell-panels.
+   * Positions the center content behind any `calcite-shell-panel`s.
    */
   @Prop({ reflect: true }) contentBehind = false;
 

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -54,14 +54,14 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   //
   //--------------------------------------------------------------------------
 
-  /** Disable and gray out the slider */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** Indicates if a histogram is present */
+  /** When true, indicates if a histogram is present. */
   @Prop({ reflect: true, mutable: true }) hasHistogram = false;
 
   /**
-   * List of x,y coordinates within the slider's min and max, displays above the slider track.
+   * A list of the histogram's x,y coordinates within the component's "min" and "max". Displays above the component's track.
    *
    * @see [DataSeries](https://github.com/Esri/calcite-components/blob/master/src/components/graph/interfaces.ts#L5)
    */
@@ -73,32 +73,32 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   }
 
   /**
-   * Array of values describing a single color stop, sorted by offset ascending.
+   * A set of single color stops for a histogram, sorted by offset ascending.
    */
   @Prop() histogramStops: ColorStop[];
 
-  /** Label handles with their numeric value */
+  /** When true, displays label handles with their numeric value. */
   @Prop({ reflect: true }) labelHandles = false;
 
-  /** Label tick marks with their numeric value. */
+  /** When true and "ticks" is specified, displays label tick marks with their numeric value. */
   @Prop({ reflect: true }) labelTicks = false;
 
-  /** Maximum selectable value */
+  /** The component's maximum selectable value. */
   @Prop({ reflect: true }) max = 100;
 
-  /** Used as an accessible label (aria-label) for second handle if needed (ex. "Temperature, upper bound") */
+  /** Accessible name for second handle for multiple selections, such as "Temperature, upper bound". */
   @Prop() maxLabel?: string;
 
-  /** Currently selected upper number (if multi-select) */
+  /** For multiple selections, the component's upper value. */
   @Prop({ mutable: true }) maxValue?: number;
 
-  /** Minimum selectable value */
+  /** The component's minimum selectable value. */
   @Prop({ reflect: true }) min = 0;
 
-  /** Used as an accessible label (aria-label) for first (or only) handle (ex. "Temperature, lower bound") */
+  /** Accessible name for first (or only) handle, such as "Temperature, lower bound". */
   @Prop() minLabel: string;
 
-  /** Currently selected lower number (if multi-select) */
+  /** For multiple selections, the component's lower value. */
   @Prop({ mutable: true }) minValue?: number;
 
   /**
@@ -108,30 +108,30 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
    */
   @Prop({ reflect: true }) mirrored = false;
 
-  /** The name of the slider */
+  /** Specifies the name of the component on form submission. */
   @Prop({ reflect: true }) name: string;
 
-  /** Interval to move on page up/page down keys */
+  /** Specifies the interval to move with the page up, or page down keys. */
   @Prop() pageStep?: number;
 
-  /** Use finer point for handles */
+  /** When true, sets a finer point for handles. */
   @Prop() precise = false;
 
   /**
-   * When true, makes the component required for form-submission.
+   * When true, the component must have a value on form submission.
    */
   @Prop({ reflect: true }) required = false;
 
-  /** When true, enables snap selection along the step interval */
+  /** When true, enables snap selection in coordination with "step" via a mouse. */
   @Prop() snap = false;
 
-  /** Interval to move on up/down keys */
+  /** Specifies the interval to move with the up, or down keys. */
   @Prop() step?: number = 1;
 
-  /** Show tick marks on the number line at provided interval */
+  /** Display tick marks on the number line at a specified interval. */
   @Prop() ticks?: number;
 
-  /** Currently selected number (if single select) */
+  /** The component's value. */
   @Prop({ reflect: true, mutable: true }) value: null | number | number[] = 0;
 
   @Watch("value")
@@ -146,7 +146,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   }
 
   /**
-   * Specify the scale of the slider, defaults to m
+   *  Specifies the size of the component.
    */
   @Prop() scale: Scale = "m";
 
@@ -834,27 +834,30 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   //
   //--------------------------------------------------------------------------
   /**
-   * Fires on all updates to the slider.
-   * :warning: Will be fired frequently during drag. If you are performing any
+   * Fires on all updates to the component.
+   *
+   * **Note:** Will be fired frequently during drag. If you are performing any
    * expensive operations consider using a debounce or throttle to avoid
    * locking up the main thread.
    */
   @Event({ cancelable: false }) calciteSliderInput: EventEmitter<void>;
 
   /**
-   * Fires on when the thumb is released on slider
-   * If you need to constantly listen to the drag event,
-   * please use calciteSliderInput instead
+   * Fires when the thumb is released on the component.
+   *
+   * **Note:** If you need to constantly listen to the drag event,
+   * use "calciteSliderInput" instead.
    */
   @Event({ cancelable: false }) calciteSliderChange: EventEmitter<void>;
 
   /**
-   * Fires on all updates to the slider.
-   * :warning: Will be fired frequently during drag. If you are performing any
+   * Fires on all updates to the component.
+   *
+   * **Note:** Will be fired frequently during drag. If you are performing any
    * expensive operations consider using a debounce or throttle to avoid
    * locking up the main thread.
    *
-   * @deprecated use calciteSliderInput instead
+   * @deprecated use "calciteSliderInput" instead.
    */
   @Event({ cancelable: false }) calciteSliderUpdate: EventEmitter<void>;
 

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -57,7 +57,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** When true, indicates if a histogram is present. */
+  /** When true, indicates a histogram is present. */
   @Prop({ reflect: true, mutable: true }) hasHistogram = false;
 
   /**
@@ -86,7 +86,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   /** The component's maximum selectable value. */
   @Prop({ reflect: true }) max = 100;
 
-  /** Accessible name for second handle for multiple selections, such as "Temperature, upper bound". */
+  /** For multiple selections, the accessible name for the second handle, such as "Temperature, upper bound". */
   @Prop() maxLabel?: string;
 
   /** For multiple selections, the component's upper value. */
@@ -128,7 +128,7 @@ export class Slider implements LabelableComponent, FormComponent, InteractiveCom
   /** Specifies the interval to move with the up, or down keys. */
   @Prop() step?: number = 1;
 
-  /** Display tick marks on the number line at a specified interval. */
+  /** Displays tick marks on the number line at a specified interval. */
   @Prop() ticks?: number;
 
   /** The component's value. */

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -95,7 +95,7 @@ export class SplitButton implements InteractiveComponent {
   calciteSplitButtonPrimaryClick: EventEmitter<DeprecatedEventPayload>;
 
   /**
-   * Fires when the secondary button is clicked.
+   * Fires when the dropdown menu is clicked.
    *
    * **Note:** The event payload is deprecated, use separate mouse event listeners to get info about click.
    */

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -16,13 +16,13 @@ import { InteractiveComponent, updateHostInteraction } from "../../utils/interac
 export class SplitButton implements InteractiveComponent {
   @Element() el: HTMLCalciteSplitButtonElement;
 
-  /** specify the appearance style of the button, defaults to solid. */
+  /** Specifies the appearance style of the component. */
   @Prop({ reflect: true }) appearance: ButtonAppearance = "solid";
 
-  /** specify the color of the control, defaults to blue */
+  /** Specifies the color of the component. */
   @Prop({ reflect: true }) color: ButtonColor = "blue";
 
-  /** is the control disabled  */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   @Watch("disabled")
@@ -33,7 +33,7 @@ export class SplitButton implements InteractiveComponent {
   }
 
   /**
-   * Is the dropdown currently active or not
+   * When true, the component is active.
    *
    * @internal
    */
@@ -46,15 +46,14 @@ export class SplitButton implements InteractiveComponent {
     }
   }
 
-  /** specify the icon used for the dropdown menu, defaults to chevron */
+  /** Specifies the icon used for the dropdown menu. */
   @Prop({ reflect: true }) dropdownIconType: DropdownIconType = "chevron";
 
-  /** aria label for overflow button */
+  /** Accessible name for the dropdown menu. */
   @Prop({ reflect: true }) dropdownLabel?: string;
 
   /**
-    optionally add a calcite-loader component to the control,
-   disabling interaction. with the primary button
+    When true, a busy indicator is displayed on the primary button.
    */
   @Prop({ reflect: true }) loading = false;
 
@@ -66,39 +65,39 @@ export class SplitButton implements InteractiveComponent {
    */
   @Prop() overlayPositioning: OverlayPositioning = "absolute";
 
-  /** optionally pass an icon to display at the end of the primary button - accepts Calcite UI icon names  */
+  /** Specifies an icon to display at the end of the primary button - accepts Calcite UI icon names. */
   @Prop({ reflect: true }) primaryIconEnd?: string;
 
-  /** flip the primary icon(s) in rtl */
+  /**  When true, the primary button icon will be flipped when the element direction is right-to-left ("rtl"). */
   @Prop({ reflect: true }) primaryIconFlipRtl?: FlipContext;
 
-  /** optionally pass an icon to display at the start of the primary button - accepts Calcite UI icon names  */
+  /** Specifies an icon to display at the start of the primary button - accepts Calcite UI icon names.  */
   @Prop({ reflect: true }) primaryIconStart?: string;
 
-  /** optionally pass an aria-label for the primary button */
+  /** Accessible name for the primary button. */
   @Prop({ reflect: true }) primaryLabel?: string;
 
-  /** text for primary action button  */
+  /** Text displayed in the primary button. */
   @Prop({ reflect: true }) primaryText: string;
 
-  /** specify the scale of the control, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** specify the width of the button, defaults to auto */
+  /** Specifies the width of the component. */
   @Prop({ reflect: true }) width: Width = "auto";
 
   /**
-   * fired when the primary button is clicked
+   * Fires when the primary button is clicked.
    *
-   * **Note:** The event payload is deprecated, please use separate mouse event listeners to get info about click.
+   * **Note:** The event payload is deprecated, use separate mouse event listeners to get info about click.
    */
   @Event({ cancelable: false })
   calciteSplitButtonPrimaryClick: EventEmitter<DeprecatedEventPayload>;
 
   /**
-   * fired when the secondary button is clicked
+   * Fires when the secondary button is clicked.
    *
-   * **Note:** The event payload is deprecated, please use separate mouse event listeners to get info about click.
+   * **Note:** The event payload is deprecated, use separate mouse event listeners to get info about click.
    */
   @Event({ cancelable: false })
   calciteSplitButtonSecondaryClick: EventEmitter<DeprecatedEventPayload>;

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -42,53 +42,53 @@ export class StepperItem implements InteractiveComponent {
   //  Public Properties
   //
   //--------------------------------------------------------------------------
-  /** is the step active */
+  /** When true, the component is active. */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  /** has the step been completed */
+  /** When true, the component's workflow has been completed. */
   @Prop({ reflect: true }) complete = false;
 
-  /** does the step contain an error that needs to be resolved by the user */
+  /** When true, the component contains an error that requires resolution from the user. */
   @Prop() error = false;
 
-  /** is the step disabled and not navigable to by a user */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * pass a title for the stepper item
+   * The component header text.
    *
-   * @deprecated use heading instead
+   * @deprecated use "heading" instead.
    */
   @Prop() itemTitle?: string;
 
-  /** stepper item heading */
+  /** The component header text. */
   @Prop() heading?: string;
 
   /**
-   * pass a title for the stepper item
+   * A description for the component. Displays below the header text.
    *
-   * @deprecated use description instead
+   * @deprecated use "description" instead.
    */
   @Prop() itemSubtitle?: string;
 
-  /** stepper item description */
+  /** A description for the component. Displays below the header text. */
   @Prop() description: string;
 
   // internal props inherited from wrapping calcite-stepper
-  /** pass a title for the stepper item */
+  /** Defines the layout of the component. */
   /** @internal */
   @Prop({ reflect: true, mutable: true }) layout?: Extract<"horizontal" | "vertical", Layout> =
     "horizontal";
 
-  /** should the items display an icon based on status */
+  /** When true, displays a status icon in the `calcite-stepper-item` heading. */
   /** @internal */
   @Prop({ mutable: true }) icon = false;
 
-  /** optionally display the step number next to the title and subtitle */
+  /** When true, displays the step number in the `calcite-stepper-item` heading. */
   /** @internal */
   @Prop({ mutable: true }) numbered = false;
 
-  /** the scale of the item */
+  /** Specifies the size of the component. */
   /** @internal */
   @Prop({ reflect: true, mutable: true }) scale: Scale = "m";
 
@@ -234,7 +234,7 @@ export class StepperItem implements InteractiveComponent {
   /** position within parent */
   private itemPosition: number;
 
-  /** the latest requested item position*/
+  /** the latest requested item position */
   private activePosition: number;
 
   /** the parent stepper component */

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -37,16 +37,16 @@ export class Stepper {
   //
   //--------------------------------------------------------------------------
 
-  /** optionally display a status icon next to the step title */
+  /** When true, displays a status icon in the `calcite-stepper-item` heading. */
   @Prop({ reflect: true }) icon = false;
 
-  /** specify the layout of stepper, defaults to horizontal */
+  /** Defines the layout of the component. */
   @Prop({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "horizontal";
 
-  /** optionally display the number next to the step title */
+  /** When true, displays the step number in the `calcite-stepper-item` heading. */
   @Prop({ reflect: true }) numbered = false;
 
-  /** specify the scale of stepper, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   //--------------------------------------------------------------------------
@@ -56,14 +56,14 @@ export class Stepper {
   //--------------------------------------------------------------------------
 
   /**
-   * This event fires when the active stepper item has changed.
+   * Fires when the active `calcite-stepper-item` changes.
    *
    */
   @Event({ cancelable: false })
   calciteStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
 
   /**
-   * This event fires when the active stepper item has changed.
+   * Fires when the active `calcite-stepper-item` changes.
    *
    * @internal
    */
@@ -176,7 +176,7 @@ export class Stepper {
   //
   //--------------------------------------------------------------------------
 
-  /** set the next step as active */
+  /** Set the next `calcite-stepper-item` as active. */
   @Method()
   async nextStep(): Promise<void> {
     const enabledStepIndex = this.getEnabledStepIndex(this.currentPosition + 1, "next");
@@ -188,7 +188,7 @@ export class Stepper {
     this.updateStep(enabledStepIndex);
   }
 
-  /** set the previous step as active */
+  /** Set the previous `calcite-stepper-item` as active. */
   @Method()
   async prevStep(): Promise<void> {
     const enabledStepIndex = this.getEnabledStepIndex(this.currentPosition - 1, "previous");
@@ -201,7 +201,7 @@ export class Stepper {
   }
 
   /**
-   * set the requested step as active
+   * Set a specified `calcite-stepper-item` as active.
    *
    * @param step
    */
@@ -214,7 +214,7 @@ export class Stepper {
     }
   }
 
-  /** set the first step as active */
+  /** Set the first `calcite-stepper-item` as active. */
   @Method()
   async startStep(): Promise<void> {
     const enabledStepIndex = this.getEnabledStepIndex(0, "next");
@@ -226,7 +226,7 @@ export class Stepper {
     this.updateStep(enabledStepIndex);
   }
 
-  /** set the last step as active */
+  /** Set the last `calcite-stepper-item` as active. */
   @Method()
   async endStep(): Promise<void> {
     const enabledStepIndex = this.getEnabledStepIndex(this.items.length - 1, "previous");

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -42,22 +42,22 @@ export class Switch implements LabelableComponent, CheckableFormComponent, Inter
   //
   //--------------------------------------------------------------------------
 
-  /** True if the switch is disabled */
+  /** When true, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** Applies to the aria-label attribute on the switch */
+  /** Accessible name for the component. */
   @Prop() label?: string;
 
-  /** The name of the switch input */
+  /** Specifies the name of the component on form submission. */
   @Prop({ reflect: true }) name: string;
 
-  /** The scale of the switch */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /**
-   * True if the switch is initially on
+   * When true, the component is checked.
    *
-   * @deprecated use 'checked' instead.
+   * @deprecated use "checked" instead.
    */
   @Prop({ mutable: true }) switched = false;
 
@@ -66,10 +66,10 @@ export class Switch implements LabelableComponent, CheckableFormComponent, Inter
     this.checked = switched;
   }
 
-  /** True if the switch is initially on */
+  /** When true, the component is checked. */
   @Prop({ reflect: true, mutable: true }) checked = false;
 
-  /** The value of the switch input */
+  /** The component's value. */
   @Prop() value: any;
 
   //--------------------------------------------------------------------------
@@ -145,7 +145,7 @@ export class Switch implements LabelableComponent, CheckableFormComponent, Inter
   /**
    * Fires when the checked value has changed.
    *
-   * **Note:** The event payload is deprecated, please use the `checked` property on the component instead
+   * **Note:** The event payload is deprecated, use the component's "checked" property instead.
    */
   @Event({ cancelable: false }) calciteSwitchChange: EventEmitter<DeprecatedEventPayload>;
 


### PR DESCRIPTION
**Related Issue:** #4442 

## Summary
📖 Adds consistency to our API styling documentation for the s-named components, including:

- scrim
- select
- shell
- shell-center-row
- shell-panel
- slider
- split-button
- stepper
- stepper-item
- switch

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
