### PR TITLE
fix(action): Assistive technology support and announcement for "active" prop

### DIFF
--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -220,6 +220,7 @@ export class Action implements InteractiveComponent {
           aria-busy={toAriaBoolean(loading)}
           aria-disabled={toAriaBoolean(disabled)}
           aria-label={ariaLabel}
+          aria-pressed={this.active ? "true" : "false"}
           class={buttonClasses}
           disabled={disabled}
           ref={(buttonEl): HTMLButtonElement => (this.buttonEl = buttonEl)}
@@ -240,6 +241,7 @@ export class Action implements InteractiveComponent {
   calciteActionClickHandler = (): void => {
     if (!this.disabled) {
       this.calciteActionClick.emit();
+      this.active = !this.active;
     }
   };
 }


### PR DESCRIPTION
**Related Issue:** #4813 

## Summary
Adds an `aria-pressed` attribute that provides context to screen reader users (tested with JAWS, NVDA, and VoiceOver) when the `action` component is pressed via click, or the Enter or spacebar keys.

Additionally, toggles the `active` prop when the button is clicked, or pressed via the Enter or spacebar keys, via `calciteActionClickHandler`.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
