### PR TITLE
fix: patch esm resolution issue causing webpack build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:copy-icons && stencil build && npm run util:patch-es5-helpers",
+    "build": "npm run util:copy-icons && stencil build && npm run util:patch-es5-helpers && npm run util:patch-esm-resolution",
     "build:watch": "npm run util:copy-icons && stencil build --watch",
     "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch",
     "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs",
@@ -52,6 +52,7 @@
     "util:is-next-deployable": "ts-node --esm support/isNextDeployable.ts",
     "util:hydration-styles": "ts-node --esm support/hydrationStyles.ts",
     "util:patch-es5-helpers": "ts-node --esm support/patchES5Helpers.ts",
+    "util:patch-esm-resolution": "ts-node --esm support/patchESMResolution.ts",
     "util:prep-next": "ts-node --esm support/prepReleaseCommit.ts --next && npm run build",
     "util:publish-next": "npm publish --tag next",
     "util:check-squash-mergeable-branch": "ts-node --esm support/checkSquashMergeableBranch.ts",

--- a/support/patchESMResolution.ts
+++ b/support/patchESMResolution.ts
@@ -1,0 +1,22 @@
+(async function () {
+  const {
+    promises: { readFile, writeFile }
+  } = await import("fs");
+  const { dirname, normalize } = await import("path");
+  const { fileURLToPath } = await import("url");
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  // patch needed due to switching package.json's type to "module"
+  // https://github.com/Esri/calcite-components/issues/5141
+  try {
+    const filePath = normalize(`${__dirname}/../dist/components/index.js`);
+    const importedModule = "@stencil/core/internal/client";
+    const contents = await readFile(filePath, { encoding: "utf8" });
+    await writeFile(filePath, contents.replace(importedModule, importedModule + ".js"));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/support/patchESMResolution.ts
+++ b/support/patchESMResolution.ts
@@ -1,20 +1,24 @@
 (async function () {
   const {
-    promises: { readFile, writeFile }
+    promises: { readFile, readdir, writeFile }
   } = await import("fs");
   const { dirname, normalize } = await import("path");
+  const { quote } = await import("shell-quote");
   const { fileURLToPath } = await import("url");
-
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
 
   // patch needed due to switching package.json's type to "module"
   // https://github.com/Esri/calcite-components/issues/5141
   try {
-    const filePath = normalize(`${__dirname}/../dist/components/index.js`);
     const importedModule = "@stencil/core/internal/client";
-    const contents = await readFile(filePath, { encoding: "utf8" });
-    await writeFile(filePath, contents.replace(importedModule, importedModule + ".js"));
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const componentsOutput = quote([normalize(`${__dirname}/../dist/components/`)]);
+    const files = await readdir(componentsOutput);
+    for (const file of files) {
+      const filePath = quote([normalize(`${componentsOutput}/${file}`)]);
+      const contents = await readFile(filePath, { encoding: "utf8" });
+      await writeFile(filePath, contents.replace(importedModule, importedModule + "/index.js"));
+    }
   } catch (err) {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
**Related Issue:** #5141

## Summary
Patches an ES module resolution error caused by adding `type="module"` in our `package.json`. I confirmed it works using `npm link` w/ our webpack example.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
