### PR TITLE
fix(radio-button-group): fix incorrect event payload type

### DIFF
--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -125,7 +125,7 @@ export class RadioButtonGroup {
   /**
    * Fires when the component has changed.
    */
-  @Event({ cancelable: false }) calciteRadioButtonGroupChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteRadioButtonGroupChange: EventEmitter<any>;
 
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a type regression introduced by https://github.com/Esri/calcite-components/pull/5001/files#diff-1db34e36763c50cd41364b15a24af2d25c23a0d61dc2a53e31f570b061a9c17eR128 where `calciteRadioButtonGroupChange`'s payload was typed as `void` instead of `any`.

cc @AdelheidF @paulcpederson 