### PR TITLE
refactor: introduce test util to skip animations

### DIFF
--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -3,7 +3,7 @@ import { JSX } from "../components";
 import { toHaveNoViolations } from "jest-axe";
 import axe from "axe-core";
 import { config } from "../../stencil.config";
-import { GlobalTestProps } from "./utils";
+import { GlobalTestProps, skipAnimations } from "./utils";
 import { hiddenFormInputSlotName } from "../utils/form";
 import { html } from "../../support/formatting";
 
@@ -714,11 +714,7 @@ export async function disabled(
 
   const component = await page.find(tag);
   const enabledComponentClickSpy = await component.spyOnEvent("click");
-  await page.addStyleTag({
-    // skip animations/transitions
-    content: `:root { --calcite-duration-factor: 0; }`
-  });
-
+  await skipAnimations(page);
   await page.$eval(tag, (el) => {
     el.addEventListener(
       "click",

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -260,3 +260,14 @@ export async function newProgrammaticE2EPage(): Promise<E2EPage> {
 
   return page;
 }
+
+/**
+ * Sets CSS vars to skip animations/transitions
+ *
+ * @param page
+ */
+export async function skipAnimations(page: E2EPage): Promise<void> {
+  await page.addStyleTag({
+    content: `:root { --calcite-duration-factor: 0; }`
+  });
+}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

✨🧰✨