### PR TITLE
fix(dropdown): Fix placement typings

### DIFF
--- a/src/utils/floating-ui.ts
+++ b/src/utils/floating-ui.ts
@@ -37,7 +37,7 @@ type AutoPlacement = "auto" | "auto-start" | "auto-end";
  *
  * There is no need for our "*-leading" and "*-trailing" values anymore since "*-start" and "*-end" are already flipped in RTL.
  *
- * @deprecated use expanded instead
+ * @deprecated
  */
 type DeprecatedPlacement =
   | "leading-leading"
@@ -121,10 +121,21 @@ export const flipPlacements: EffectivePlacement[] = [
   "left-end"
 ];
 
-export type MenuPlacement = Extract<
-  LogicalPlacement,
-  "top-start" | "top" | "top-end" | "bottom-start" | "bottom" | "bottom-end"
+/**
+ * Use "*-start" and "*-end" instead.
+ *
+ * There is no need for our "*-leading" and "*-trailing" values anymore since "*-start" and "*-end" are already flipped in RTL.
+ *
+ * @deprecated
+ */
+type DeprecatedMenuPlacement = Extract<
+  DeprecatedPlacement,
+  "top-leading" | "top-trailing" | "bottom-leading" | "bottom-trailing"
 >;
+
+export type MenuPlacement =
+  | DeprecatedMenuPlacement
+  | Extract<LogicalPlacement, "top-start" | "top" | "top-end" | "bottom-start" | "bottom" | "bottom-end">;
 
 export const defaultMenuPlacement: MenuPlacement = "bottom-start";
 


### PR DESCRIPTION
**Related Issue:** #5163

## Summary

fix(dropdown): Fix placement typings. (#5163)

Allows deprecated placement values for menu dropdown components.
