### PR TITLE
fix(dropdown): Correct placement when opening

### DIFF
--- a/src/assets/styles/_floating-ui.scss
+++ b/src/assets/styles/_floating-ui.scss
@@ -86,11 +86,17 @@ $floating-ui-default-z-index: 900;
 @mixin floatingUIWrapper {
   visibility: hidden;
   pointer-events: none;
+  inline-size: 0;
+  block-size: 0;
+  overflow: hidden;
 }
 
 @mixin floatingUIWrapperActive {
   pointer-events: initial;
   visibility: visible;
+  inline-size: unset;
+  block-size: unset;
+  overflow: unset;
 }
 
 @mixin floatingUIHost($zIndex: $floating-ui-default-z-index) {

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -236,9 +236,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
             ref={this.setScrollerAndTransitionEl}
             role="menu"
           >
-            <div hidden={!open}>
-              <slot onSlotchange={this.updateGroups} />
-            </div>
+            <slot onSlotchange={this.updateGroups} />
           </div>
         </div>
       </Host>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -481,8 +481,8 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   };
 
   setMaxScrollerHeight = (): void => {
-    const { scrollerEl, open } = this;
-    if (!scrollerEl || !open) {
+    const { scrollerEl } = this;
+    if (!scrollerEl) {
       return;
     }
 


### PR DESCRIPTION
**Related Issue:** #5102

## Summary

fix(dropdown): Correct placement when opening. (#5102)

The dropdown group needs to remain visible so floating UI can calculate its height. Instead, we set the width/height on its container to be 0 when not opened. This prevents the dropdown group from taking up space when not opened.

cc @benelan 