### PR TITLE
refactor(input-time-picker, tab-nav): remove duplicate stopPropagations

### DIFF
--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -249,7 +249,6 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
     event.preventDefault();
     event.stopPropagation();
     this.active = false;
-    event.stopPropagation;
   }
 
   private timePickerChangeHandler = (event: CustomEvent): void => {
@@ -257,7 +256,6 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
     const target = event.target as HTMLCalciteTimePickerElement;
     const value = target.value;
     this.setValue({ value, origin: "time-picker" });
-    event.stopPropagation();
   };
 
   @Listen("calciteInternalTimePickerFocus")
@@ -267,7 +265,6 @@ export class InputTimePicker implements LabelableComponent, FormComponent, Inter
     if (!this.readOnly) {
       this.active = true;
     }
-    event.stopPropagation;
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -264,7 +264,6 @@ export class TabNav {
       this.selectedTab !== event.detail.tab
     ) {
       this.selectedTab = event.detail.tab;
-      event.stopPropagation();
     }
     event.stopPropagation();
   }


### PR DESCRIPTION
**Related Issue:** NA

## Summary
🧹 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
