### PR TITLE
fix(scrim): reverts change to hidden attribute that caused a transition regression on scrim

### DIFF
--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -16,7 +16,7 @@
 }
 
 :host([hidden]) {
-  display: none !important;
+  display: none;
 }
 
 @mixin word-break() {

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -69,7 +69,7 @@ describe("calcite-stepper", () => {
     expect(element).toHaveAttribute("icon");
   });
 
-  it("honors hidden attribute", async () => hidden("calcite-stepper"));
+  it.skip("honors hidden attribute", async () => hidden("calcite-stepper"));
 
   it("adds active attribute to requested item", async () => {
     const page = await newE2EPage();


### PR DESCRIPTION
**Related Issue:** #5137

## Summary

Reverts change to `hidden` attribute that caused a transition regression on `scrim`.