### PR TITLE
fix(date-picker): no longer misalign dates with day in `en-gb`,`en-au`,`nb`,`es`,`de` locales

### DIFF
--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -272,7 +272,8 @@ export class DatePickerMonth {
     if (day - 6 === startOfWeek) {
       return days;
     }
-    for (let i = Math.abs(lastDate.getDay() - startOfWeek); i >= 0; i--) {
+    console.log(lastDate, lastDate.getDay(), startOfWeek);
+    for (let i = lastDate.getDay() - startOfWeek; i >= 0; i--) {
       days.push(date - i);
     }
     return days;

--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -272,7 +272,6 @@ export class DatePickerMonth {
     if (day - 6 === startOfWeek) {
       return days;
     }
-    console.log(lastDate, lastDate.getDay(), startOfWeek);
     for (let i = lastDate.getDay() - startOfWeek; i >= 0; i--) {
       days.push(date - i);
     }

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -264,4 +264,15 @@ export const Default = stepStory(
       })
     )
     .snapshot("norwegian locale")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--default",
+        knobs: [
+          { name: "locale", value: "en-gb" },
+          { name: "value", value: "2023-04-11" }
+        ]
+      })
+    )
+    .snapshot("birtish english locale")
 );

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -231,4 +231,37 @@ export const Default = stepStory(
       })
     )
     .snapshot("th locale (Buddhist calendar)")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--default",
+        knobs: [
+          { name: "locale", value: "de" },
+          { name: "value", value: "2022-08-11" }
+        ]
+      })
+    )
+    .snapshot("german locale")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--default",
+        knobs: [
+          { name: "locale", value: "es" },
+          { name: "value", value: "2023-05-11" }
+        ]
+      })
+    )
+    .snapshot("spanish locale")
+
+    .executeScript(
+      setKnobs({
+        story: "components-controls-datepicker--default",
+        knobs: [
+          { name: "locale", value: "nb" },
+          { name: "value", value: "2023-05-11" }
+        ]
+      })
+    )
+    .snapshot("norwegian locale")
 );

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -270,7 +270,7 @@ export const Default = stepStory(
         story: "components-controls-datepicker--default",
         knobs: [
           { name: "locale", value: "en-gb" },
-          { name: "value", value: "2023-04-11" }
+          { name: "value", value: "2024-01-11" }
         ]
       })
     )


### PR DESCRIPTION
**Related Issue:** #5136 


Fixes misalignemnt of days with dates in `en-gb`,`en-au`,`nb`,`es`,`de` locales



Side bar:

`Math.abs` is not required to make sure if the indexed value of startofWeek is  greater than lastDay of the previous month we don't need to display any dates from previous in current month

Example : startOfWeek = 1 (Monday) and lastDay of previous month is 0 ( sunday) 