### PR TITLE
fix(popover): autoClose should work when clicking on another popover reference element

### DIFF
--- a/src/components/popover/PopoverManager.ts
+++ b/src/components/popover/PopoverManager.ts
@@ -54,15 +54,16 @@ export default class PopoverManager {
 
   private togglePopovers = (event: KeyboardEvent | MouseEvent): void => {
     const composedPath = event.composedPath();
-    const popover = this.queryPopover(composedPath);
+    const togglePopover = this.queryPopover(composedPath);
 
-    if (popover && !popover.triggerDisabled) {
-      popover.toggle();
-      return;
+    if (togglePopover && !togglePopover.triggerDisabled) {
+      togglePopover.toggle();
     }
 
     Array.from(this.registeredElements.values())
-      .filter((popover) => popover.autoClose && popover.open && !composedPath.includes(popover))
+      .filter(
+        (popover) => popover !== togglePopover && popover.autoClose && popover.open && !composedPath.includes(popover)
+      )
       .forEach((popover) => popover.toggle(false));
   };
 

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -526,6 +526,47 @@ describe("calcite-popover", () => {
     expect(await popover.getProperty("open")).toBe(false);
   });
 
+  it("should autoClose popovers when clicked on another referenceElement", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      html`
+        <p>
+          Some text
+          <button id="ref1">Button</button>
+        </p>
+        <p>
+          Some more text
+          <button id="ref2">Button</button>
+        </p>
+        <calcite-popover id="popover1" auto-close reference-element="ref1" open>Content 1</calcite-popover>
+        <calcite-popover id="popover2" auto-close reference-element="ref2">Content 2</calcite-popover>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const popover1 = await page.find("#popover1");
+    const popover2 = await page.find("#popover2");
+    const ref1 = await page.find("#ref1");
+    const ref2 = await page.find("#ref2");
+
+    expect(await popover1.getProperty("open")).toBe(true);
+    expect(await popover2.getProperty("open")).toBe(false);
+
+    await ref2.click();
+    await page.waitForChanges();
+
+    expect(await popover1.getProperty("open")).toBe(false);
+    expect(await popover2.getProperty("open")).toBe(true);
+
+    await ref1.click();
+    await page.waitForChanges();
+
+    expect(await popover1.getProperty("open")).toBe(true);
+    expect(await popover2.getProperty("open")).toBe(false);
+  });
+
   it("should not be visible if ui has escaped", async () => {
     const page = await newE2EPage();
 


### PR DESCRIPTION
**Related Issue:** #5142

## Summary

fix(popover): autoClose should work when clicking on another popover. (#5142)