### PR TITLE
fix: wait for body to load before initializing theme change event

### DIFF
--- a/src/utils/globalScript.ts
+++ b/src/utils/globalScript.ts
@@ -7,7 +7,7 @@ import { initThemeChangeEvent } from "./theme";
  */
 export default function (): void {
   if (isBrowser()) {
-    initThemeChangeEvent();
+    document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent());
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #5104

## Summary
@jcfranco noticed an error in the `demo-app-advanced-2-shell-header.html` and `demo-app-advanced.html` caused by trying to access `body`'s `classList` before it was available.

![image](https://user-images.githubusercontent.com/10986395/185266630-e949e6ef-7655-48b0-a63f-9d5d0ed0de88.png)

<!--
Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
