### PR TITLE
fix(shell): fix z-index for content-behind mode

### DIFF
--- a/src/components/shell/shell.scss
+++ b/src/components/shell/shell.scss
@@ -52,8 +52,8 @@
 .content--behind {
   @apply absolute
     inset-0
-    z-default
     border-0;
+  z-index: calc(theme("zIndex.default") - 1);
   display: initial;
 }
 

--- a/src/components/shell/shell.stories.ts
+++ b/src/components/shell/shell.stories.ts
@@ -539,3 +539,12 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
     </calcite-shell-panel>
     <footer slot="footer">My Shell Footer</footer>
   </calcite-shell>`;
+
+export const contentBehind = (): string => html`<calcite-shell content-behind>
+  ${headerHTML}
+  <calcite-shell-panel slot="panel-start">${leadingPanelHTML}</calcite-shell-panel>
+  ${contentHTML}
+  <calcite-shell-center-row slot="center-row">${centerRowHTML}</calcite-shell-center-row>
+  <calcite-shell-panel slot="panel-end">${trailingPanelHTML}</calcite-shell-panel>
+  ${footerHTML}
+</calcite-shell>`;


### PR DESCRIPTION
**Related Issue:** #5177 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression from https://github.com/Esri/calcite-components/pull/5058 where the content-behind z-index was set to the same value as surrounding shell-panels and shell-center-rows.