### PR TITLE
fix: initialize calciteThemeChange when DOM content is loaded before globalScript executes

### DIFF
--- a/src/demos/shell/demo-app-advanced-2-shell-header.html
+++ b/src/demos/shell/demo-app-advanced-2-shell-header.html
@@ -249,5 +249,8 @@
         </div>
       </main>
     </demo-dom-swapper>
+    <script>
+      document.addEventListener("calciteThemeChange", (e) => console.log(e.detail.theme));
+    </script>
   </body>
 </html>

--- a/src/utils/globalScript.ts
+++ b/src/utils/globalScript.ts
@@ -7,7 +7,7 @@ import { initThemeChangeEvent } from "./theme";
  */
 export default function (): void {
   if (isBrowser()) {
-    initThemeChangeEvent();
+    document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent());
   }
 }
 

--- a/src/utils/globalScript.ts
+++ b/src/utils/globalScript.ts
@@ -7,7 +7,11 @@ import { initThemeChangeEvent } from "./theme";
  */
 export default function (): void {
   if (isBrowser()) {
-    document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent());
+    if (document.readyState === "complete") {
+      initThemeChangeEvent();
+    } else {
+      document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent());
+    }
   }
 }
 

--- a/src/utils/globalScript.ts
+++ b/src/utils/globalScript.ts
@@ -7,7 +7,7 @@ import { initThemeChangeEvent } from "./theme";
  */
 export default function (): void {
   if (isBrowser()) {
-    if (document.readyState === "complete") {
+    if (document.readyState === "interactive") {
       initThemeChangeEvent();
     } else {
       document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent());

--- a/src/utils/globalScript.ts
+++ b/src/utils/globalScript.ts
@@ -10,7 +10,7 @@ export default function (): void {
     if (document.readyState === "interactive") {
       initThemeChangeEvent();
     } else {
-      document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent());
+      document.addEventListener("DOMContentLoaded", () => initThemeChangeEvent(), { once: true });
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #5180

## Summary
The fix in the PR linked above could cause `calciteThemeChange` to not fire if the DOM content is loaded before globalScript invokes.

Edit:
Switched to `readystate==="interactive"` because `readystate==="complete"` comes after `DOMContentLoaded` so there would still be a small window of time where the theme event initialization won't happen. See:
https://codepen.io/benesri/pen/xxWmMBM?editors=0012
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
