### PR TITLE
fix(modal): calciteModalOpen and calciteModalBeforeOpen now emit on page load

### DIFF
--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -2,7 +2,7 @@ import { newE2EPage } from "@stencil/core/testing";
 import { focusable, renders, slots, hidden } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, SLOTS } from "./resources";
-import { skipAnimations } from "../../tests/utils";
+import { newProgrammaticE2EPage, skipAnimations } from "../../tests/utils";
 
 describe("calcite-modal properties", () => {
   it("renders", () => renders("calcite-modal", { display: "flex", visible: false }));
@@ -63,75 +63,94 @@ describe("calcite-modal properties", () => {
   });
 });
 
-it("opens and closes", async () => {
-  const page = await newE2EPage();
-  await page.setContent(`<calcite-modal></calcite-modal>`);
-  const modal = await page.find("calcite-modal");
-  const beforeOpenSpy = await modal.spyOnEvent("calciteModalBeforeOpen");
-  const openSpy = await modal.spyOnEvent("calciteModalOpen");
-  const beforeCloseSpy = await modal.spyOnEvent("calciteModalBeforeClose");
-  const closeSpy = await modal.spyOnEvent("calciteModalClose");
+describe("opening and closing behavior", () => {
+  it("opens and closes", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-modal></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+    const beforeOpenSpy = await modal.spyOnEvent("calciteModalBeforeOpen");
+    const openSpy = await modal.spyOnEvent("calciteModalOpen");
+    const beforeCloseSpy = await modal.spyOnEvent("calciteModalBeforeClose");
+    const closeSpy = await modal.spyOnEvent("calciteModalClose");
 
-  function getTransitionTransform(
-    modalSelector: string,
-    modalContainerSelector: string,
-    type: "none" | "matrix"
-  ): boolean {
-    const modalContainer = document
-      .querySelector(modalSelector)
-      .shadowRoot.querySelector<HTMLElement>(modalContainerSelector);
-    return getComputedStyle(modalContainer).transform.startsWith(type);
-  }
+    function getTransitionTransform(
+      modalSelector: string,
+      modalContainerSelector: string,
+      type: "none" | "matrix"
+    ): boolean {
+      const modalContainer = document
+        .querySelector(modalSelector)
+        .shadowRoot.querySelector<HTMLElement>(modalContainerSelector);
+      return getComputedStyle(modalContainer).transform.startsWith(type);
+    }
 
-  expect(beforeOpenSpy).toHaveReceivedEventTimes(0);
-  expect(openSpy).toHaveReceivedEventTimes(0);
-  expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
-  expect(closeSpy).toHaveReceivedEventTimes(0);
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "none");
+    expect(beforeOpenSpy).toHaveReceivedEventTimes(0);
+    expect(openSpy).toHaveReceivedEventTimes(0);
+    expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
+    expect(closeSpy).toHaveReceivedEventTimes(0);
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "none");
 
-  await modal.setProperty("active", true);
-  let waitForEvent = page.waitForEvent("calciteModalBeforeOpen");
-  await page.waitForChanges();
-  await waitForEvent;
+    await modal.setProperty("active", true);
+    let waitForEvent = page.waitForEvent("calciteModalBeforeOpen");
+    await page.waitForChanges();
+    await waitForEvent;
 
-  expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
-  expect(openSpy).toHaveReceivedEventTimes(0);
-  expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
-  expect(closeSpy).toHaveReceivedEventTimes(0);
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
+    expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
+    expect(openSpy).toHaveReceivedEventTimes(0);
+    expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
+    expect(closeSpy).toHaveReceivedEventTimes(0);
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
 
-  waitForEvent = page.waitForEvent("calciteModalOpen");
-  await waitForEvent;
+    waitForEvent = page.waitForEvent("calciteModalOpen");
+    await waitForEvent;
 
-  expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
-  expect(openSpy).toHaveReceivedEventTimes(1);
-  expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
-  expect(closeSpy).toHaveReceivedEventTimes(0);
-  expect(await modal.getProperty("open")).toBe(true);
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "none");
+    expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
+    expect(openSpy).toHaveReceivedEventTimes(1);
+    expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
+    expect(closeSpy).toHaveReceivedEventTimes(0);
+    expect(await modal.getProperty("open")).toBe(true);
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "none");
 
-  await modal.setProperty("active", false);
-  waitForEvent = page.waitForEvent("calciteModalBeforeClose");
-  await page.waitForChanges();
-  await waitForEvent;
+    await modal.setProperty("active", false);
+    waitForEvent = page.waitForEvent("calciteModalBeforeClose");
+    await page.waitForChanges();
+    await waitForEvent;
 
-  expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
-  expect(openSpy).toHaveReceivedEventTimes(1);
-  expect(beforeCloseSpy).toHaveReceivedEventTimes(1);
-  expect(closeSpy).toHaveReceivedEventTimes(0);
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
+    expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
+    expect(openSpy).toHaveReceivedEventTimes(1);
+    expect(beforeCloseSpy).toHaveReceivedEventTimes(1);
+    expect(closeSpy).toHaveReceivedEventTimes(0);
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
 
-  waitForEvent = page.waitForEvent("calciteModalClose");
-  await waitForEvent;
+    waitForEvent = page.waitForEvent("calciteModalClose");
+    await waitForEvent;
 
-  expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
-  expect(openSpy).toHaveReceivedEventTimes(1);
-  expect(beforeCloseSpy).toHaveReceivedEventTimes(1);
-  expect(closeSpy).toHaveReceivedEventTimes(1);
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
-  await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "none");
-  expect(await modal.getProperty("open")).toBe(false);
+    expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
+    expect(openSpy).toHaveReceivedEventTimes(1);
+    expect(beforeCloseSpy).toHaveReceivedEventTimes(1);
+    expect(closeSpy).toHaveReceivedEventTimes(1);
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");
+    await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "none");
+    expect(await modal.getProperty("open")).toBe(false);
+  });
+
+  it("emits when set up to open on initial render", async () => {
+    const page = await newProgrammaticE2EPage();
+    const waitForOpen = page.waitForEvent("calciteModalOpen");
+    const beforeOpenSpy = await page.spyOnEvent("calciteModalBeforeOpen");
+    const openSpy = await page.spyOnEvent("calciteModalOpen");
+
+    await page.evaluate(() => {
+      const modal = document.createElement("calcite-modal");
+      modal.open = true;
+      document.body.append(modal);
+    });
+    await waitForOpen;
+
+    expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
+    expect(openSpy).toHaveReceivedEventTimes(1);
+  });
 });
 
 describe("calcite-modal accessibility checks", () => {

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -105,7 +105,7 @@
   }
 }
 
-:host([open]) {
+:host([open][calcite-hydrated]) {
   @apply opacity-100;
   visibility: visible !important;
   transition-delay: 0ms;

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -109,7 +109,7 @@
   @apply opacity-100;
   visibility: visible !important;
   transition-delay: 0ms;
-  .modal {
+  .modal--open {
     @apply pointer-events-auto visible opacity-100;
     transition: transform var(--calcite-internal-animation-timing-slow) $easing-function, visibility 0ms linear,
       opacity var(--calcite-internal-animation-timing-slow) $easing-function,

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -134,7 +134,7 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
   componentWillLoad(): void {
     // when modal initially renders, if active was set we need to open as watcher doesn't fire
     if (this.open) {
-      this.openModal();
+      requestAnimationFrame(() => this.openModal());
     }
   }
 
@@ -168,7 +168,13 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
       >
         <calcite-scrim class={CSS.scrim} onClick={this.handleOutsideClose} />
         {this.renderStyle()}
-        <div class={CSS.modal} ref={this.setTransitionEl}>
+        <div
+          class={{
+            [CSS.modal]: true,
+            [CSS.modalOpen]: this.isOpen
+          }}
+          ref={this.setTransitionEl}
+        >
           <div data-focus-fence onFocus={this.focusLastElement} tabindex="0" />
           <div class={CSS.header}>
             {this.renderCloseButton()}
@@ -266,6 +272,13 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
   closeButtonEl: HTMLButtonElement;
 
   contentId: string;
+
+  /**
+   * We use internal variable to make sure initially open modal can transition from closed state when rendered
+   *
+   * @private
+   */
+  @State() isOpen = false;
 
   modalContent: HTMLDivElement;
 
@@ -425,6 +438,7 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
     this.previousActiveElement = document.activeElement as HTMLElement;
     this.el.addEventListener("calciteModalOpen", this.openEnd);
     this.open = true;
+    this.isOpen = true;
     const titleEl = getSlotted(this.el, SLOTS.header);
     const contentEl = getSlotted(this.el, SLOTS.content);
 
@@ -446,6 +460,7 @@ export class Modal implements ConditionalSlotComponent, OpenCloseComponent {
   close = (): Promise<void> => {
     return this.beforeClose(this.el).then(() => {
       this.open = false;
+      this.isOpen = false;
       focusElement(this.previousActiveElement);
       this.removeOverflowHiddenClass();
     });

--- a/src/components/modal/resources.ts
+++ b/src/components/modal/resources.ts
@@ -1,5 +1,6 @@
 export const CSS = {
   modal: "modal",
+  modalOpen: "modal--open",
   title: "title",
   header: "header",
   footer: "footer",


### PR DESCRIPTION
**Related Issue:** #4689

## Summary

`calciteModalOpen` and `calciteModalBeforeOpen` would not emit on page load like the rest of the components and only when you close and reopen the modal. 

This change ensures that the open styles for the underlay get applied initially and the modal transition styles are applied once the component is fully hydrated.
