### PR TITLE
fix(dropdown): Remove scrolling when max-items >= number of dropdown items

### DIFF
--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -429,6 +429,17 @@ export const ScrollingWithoutMaxItems = (): string => html`
   </calcite-dropdown>
 `;
 
+export const NoScrollingMaxItemsEqualsItems = (): string => html` <calcite-dropdown max-items="3" open>
+  <calcite-button slot="dropdown-trigger">Activate Dropdown</calcite-button>
+  <calcite-dropdown-group selection-mode="single" group-title="Selection Mode: Single">
+    <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+    <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+    <calcite-dropdown-item>Title</calcite-dropdown-item>
+  </calcite-dropdown-group>
+</calcite-dropdown>`;
+
+NoScrollingMaxItemsEqualsItems.storyName = "No Scrolling when maxItems equals items";
+
 export const FlipPositioning = stepStory(
   (): string => html`
     <div style="margin:10px;">

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -567,7 +567,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   }
 
   private getMaxScrollerHeight(): number {
-    const { maxItems } = this;
+    const { maxItems, items } = this;
     let itemsToProcess = 0;
     let maxScrollerHeight = 0;
     let groupHeaderHeight: number;
@@ -591,7 +591,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
       }
     });
 
-    return maxScrollerHeight;
+    return items.length > maxItems ? maxScrollerHeight : 0;
   }
 
   private closeCalciteDropdown(focusTrigger = true) {


### PR DESCRIPTION
**Related Issue:** #4880

## Summary

fix(dropdown): Remove scrolling when max-items >= number of dropdown items. (#4880)