### PR TITLE
feat(color-picker): allow pasting hex values with # character

### DIFF
--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -179,6 +179,15 @@ export class ColorPickerHexInput {
     }
   }
 
+  private onPaste(event: ClipboardEvent): void {
+    const hex = event.clipboardData.getData("text");
+
+    if (isValidHex(hex)) {
+      event.preventDefault();
+      this.inputNode.value = hex.slice(1);
+    }
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Private State/Props
@@ -214,6 +223,7 @@ export class ColorPickerHexInput {
           onCalciteInputChange={this.onInputChange}
           onCalciteInternalInputBlur={this.onCalciteInternalInputBlur}
           onKeyDown={this.handleKeyDown}
+          onPaste={this.onPaste}
           prefixText="#"
           ref={this.storeInputRef}
           scale={this.scale}


### PR DESCRIPTION
**Related Issue:** #4072

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This allows users to paste a formatted hex value (e.g., `#aaa` or `#aaaaaa`), which is a common use case.

I attempted to set up a test for this, but it seems this isn't possible due to [puppeteer having issues with this](https://github.com/puppeteer/puppeteer/issues/2147) and security mechanisms when I tried setting something up via synthetic events. I'll include the test here in case it's supported in the future:

```tsx
  it("handles pasted hex values with #", async () => {
    const page = await newE2EPage();
    await page.setContent(html` <calcite-color-picker></calcite-color-picker>
      <input id="source-hex" value="#abcdef" />
      `);
    const colorPicker = await page.find("calcite-color-picker");

    const context = page.browserContext();
    const origin = await page.evaluate(() => location.origin);
    await context.overridePermissions(origin, ["clipboard-write", "clipboard-read"]);

    // approach 1: copying from existing content on page
    await selectText(await page.find(`#source-hex`));
    await page.keyboard.down("Meta");
    await page.keyboard.down("C");
    await page.keyboard.up("Meta");
    await page.keyboard.up("C");

    // approach 2: using clipboard API
    // await page.evaluate(async () => await navigator.clipboard.writeText("#abcdef"));

    // approach 3: using `clipboardy`
    // clipboard.write("#abcdef");

    const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
    await selectText(hexInput);
    await page.keyboard.down("Meta");
    await page.keyboard.down("V");
    await page.keyboard.up("Meta");
    await page.keyboard.up("V");
    await page.keyboard.press("Enter");
    await page.waitForChanges();

    expect(await colorPicker.getProperty("value")).toBe("#abcdef");
  });
```