### PR TITLE
docs: Include code documentation notes

### DIFF
--- a/conventions/Documentation.md
+++ b/conventions/Documentation.md
@@ -17,4 +17,4 @@ For additional documentation, create a [usage folder](https://github.com/Esri/ca
 There are two documentation sources for displaying deprecations, depending on the API reference. In both cases a deprecated chip will be displayed within the component's API reference section.
 
 1. The JSDoc `@deprecated` tag is used for JavaScript properties, events, and methods in the `<component-name>.tsx` file. Notes can accompany the JSDoc tag, such as "use `<property>` instead".
-2. The `[Deprecated]` text is used for slots (`@Slots`) in the `<component-name>.tsx` file and CSS custom properties in the `<component-name>.scss` file.
+2. The `[Deprecated]` text is used for slots (`@slots`) in the `<component-name>.tsx` file and CSS custom properties in the `<component-name>.scss` file.

--- a/conventions/Documentation.md
+++ b/conventions/Documentation.md
@@ -1,9 +1,20 @@
 # Documentation
 
-This project uses [Storybook](https://storybook.js.org/) to provide an interactive showcase of components with accompanying documentation.
+Calcite Components uses [Storybook](https://storybook.js.org/) to provide an interactive showcase of components with accompanying documentation.
 
-For each main component (i.e., one that can be used by itself), there should be a `<component-name>.stories.ts` file in its component folder.
+For each main component (e.g., one that can be used by itself), there should be a `<component-name>.stories.ts` file in its component folder.
 
 Each story should provide access to relevant [knobs](https://github.com/storybookjs/storybook/tree/next/addons/knobs) so users can test out different properties.
 
 For additional documentation, create a [usage folder](https://github.com/Esri/calcite-components/tree/master/src/components/action/usage) in the component directory with a basic.md and optionally an advanced.md file (if additional documentation or examples are required) with snippets showing different supported use cases for the component.
+
+## Code Documentation
+
+[JSDoc](https://jsdoc.app) is used to document each component. After a release, the documentation builds on the respective component page on the [SDK site](https://developers.arcgis.com/calcite-design-system/components) specifying property/attribute names, descriptions, types, values, and description notes (e.g., required, optional, deprecated, etc.).
+
+### Deprecated
+
+There are two documentation sources for displaying deprecations, depending on the API reference. In both cases a deprecated chip will be displayed within the component's API reference section.
+
+1. The JSDoc `@deprecated` tag is used for JavaScript properties, events, and methods in the `<component-name>.tsx` file. Notes can accompany the JSDoc tag, such as "use `<property>` instead".
+2. The `[Deprecated]` text is used for slots (`@Slots`) in the `<component-name>.tsx` file and CSS custom properties in the `<component-name>.scss` file.

--- a/conventions/Documentation.md
+++ b/conventions/Documentation.md
@@ -2,7 +2,7 @@
 
 Calcite Components uses [Storybook](https://storybook.js.org/) to provide an interactive showcase of components with accompanying documentation.
 
-For each main component (e.g., one that can be used by itself), there should be a `<component-name>.stories.ts` file in its component folder.
+For each main component (i.e., one that can be used by itself), there should be a `<component-name>.stories.ts` file in its component folder.
 
 Each story should provide access to relevant [knobs](https://github.com/storybookjs/storybook/tree/next/addons/knobs) so users can test out different properties.
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Adds documentation to the documentation ❗ convention file. 📝 

- Includes new section on documenting deprecation for our docs with a deprecated chip. 🐿️ 
- Provides usage guidance to display a deprecated chip on our SDK site for:
  - JSDoc `@deprecated` tag 🏷️ for props, events, and methods 
  - `[Deprecated]` text 📔  for slots and CSS props

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
