### PR TITLE
ci(release): fix Windows errors

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -43,8 +43,6 @@ import yargs from "yargs";
     standardVersionOptions = await getStandardVersionOptions(next, semverTags);
   } catch (error) {
     console.log(baseErrorMessage);
-    await exec(`echo ${baseErrorMessage}`);
-
     process.exitCode = 1;
     return;
   }
@@ -56,8 +54,6 @@ import yargs from "yargs";
       await runStandardVersion(next, standardVersionOptions);
     } catch (error) {
       console.log(changelogGenerationErrorMessage);
-      await exec(`echo ${changelogGenerationErrorMessage}`);
-
       process.exitCode = 1;
     }
     return;
@@ -73,7 +69,6 @@ import yargs from "yargs";
     await runStandardVersion(next, standardVersionOptions);
   } catch (error) {
     console.log(changelogGenerationErrorMessage);
-    await exec(`echo ${changelogGenerationErrorMessage}`);
     process.exitCode = 1;
   } finally {
     // restore deleted prerelease tags
@@ -84,14 +79,14 @@ import yargs from "yargs";
     const target = next ? "next" : "beta";
     const targetVersionPattern = new RegExp(`-${target}\\.\\d+$`);
 
-    await exec(`echo ${semverTags}`);
+    console.log(semverTags);
 
     // we keep track of `beta` and `next` releases since `standard-version` resets the version number when going in between
     // this should not be needed after v1.0.0 since there would no longer be a beta version to keep track of
     const targetDescendingOrderTags = semverTags.filter((tag) => targetVersionPattern.test(tag)).sort(semver.rcompare);
     const targetReleaseVersion = semver.inc(targetDescendingOrderTags[0], "prerelease", target);
 
-    await exec(`echo ${targetDescendingOrderTags}`);
+    console.log(targetDescendingOrderTags);
 
     if (!targetVersionPattern.test(targetReleaseVersion)) {
       throw new Error(`target release version does not have prerelease identifier (${target})`);


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Windows doesn't like `echo`
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
