### PR TITLE
test(radio-button): update to help test click behavior via HTMLElement.click()

### DIFF
--- a/src/components/radio-button/radio-button.e2e.ts
+++ b/src/components/radio-button/radio-button.e2e.ts
@@ -195,7 +195,9 @@ describe("calcite-radio-button", () => {
     expect(await first.getProperty("checked")).toBe(true);
     expect(await second.getProperty("checked")).toBe(false);
 
-    //in addition to .click() check with .callMethod("click") as well
+    /* call a 'click' @method on a component with stencil utility function .callMethod("click") as an additional check to
+    the HTMLElement.click() method that simulates a mouse click on an element */
+
     await second.callMethod("click");
     await page.waitForChanges();
 
@@ -285,17 +287,6 @@ describe("calcite-radio-button", () => {
 
     expect(focusEvent).toHaveReceivedEventTimes(1);
     expect(blurEvent).toHaveReceivedEventTimes(1);
-
-    //in addition to .click() check with .callMethod("click") as well
-    await radio.callMethod("click");
-
-    expect(focusEvent).toHaveReceivedEventTimes(2);
-    expect(blurEvent).toHaveReceivedEventTimes(1);
-
-    await radio2.callMethod("click");
-
-    expect(focusEvent).toHaveReceivedEventTimes(2);
-    expect(blurEvent).toHaveReceivedEventTimes(2);
   });
 
   it("appropriately triggers the custom internal focus and blur events with keyboard", async () => {

--- a/src/components/radio-button/radio-button.e2e.ts
+++ b/src/components/radio-button/radio-button.e2e.ts
@@ -194,6 +194,19 @@ describe("calcite-radio-button", () => {
 
     expect(await first.getProperty("checked")).toBe(true);
     expect(await second.getProperty("checked")).toBe(false);
+
+    //in addition to .click() check with .callMethod("click") as well
+    await second.callMethod("click");
+    await page.waitForChanges();
+
+    expect(await first.getProperty("checked")).toBe(false);
+    expect(await second.getProperty("checked")).toBe(true);
+
+    await first.callMethod("click");
+    await page.waitForChanges();
+
+    expect(await first.getProperty("checked")).toBe(true);
+    expect(await second.getProperty("checked")).toBe(false);
   });
 
   it("programmatically checking a radio button updates the group's state correctly", async () => {
@@ -272,6 +285,17 @@ describe("calcite-radio-button", () => {
 
     expect(focusEvent).toHaveReceivedEventTimes(1);
     expect(blurEvent).toHaveReceivedEventTimes(1);
+
+    //in addition to .click() check with .callMethod("click") as well
+    await radio.callMethod("click");
+
+    expect(focusEvent).toHaveReceivedEventTimes(2);
+    expect(blurEvent).toHaveReceivedEventTimes(1);
+
+    await radio2.callMethod("click");
+
+    expect(focusEvent).toHaveReceivedEventTimes(2);
+    expect(blurEvent).toHaveReceivedEventTimes(2);
   });
 
   it("appropriately triggers the custom internal focus and blur events with keyboard", async () => {

--- a/src/components/radio-button/radio-button.e2e.ts
+++ b/src/components/radio-button/radio-button.e2e.ts
@@ -195,9 +195,7 @@ describe("calcite-radio-button", () => {
     expect(await first.getProperty("checked")).toBe(true);
     expect(await second.getProperty("checked")).toBe(false);
 
-    /* call a 'click' @method on a component with stencil utility function .callMethod("click") as an additional check to
-    the HTMLElement.click() method that simulates a mouse click on an element */
-
+    // helps test click behavior via HTMLElement.click()
     await second.callMethod("click");
     await page.waitForChanges();
 


### PR DESCRIPTION
**Related Issue:** #4212

## Summary


Update tests that cover behavior on element click to use the .callMethod("click") in addition to .click(). In the case of the `radio-button`, click triggers a boolean toggle on the checked prop.
