### PR TITLE
test(switch): update to help test click behavior via HTMLElement.click()

### DIFF
--- a/src/components/switch/switch.e2e.ts
+++ b/src/components/switch/switch.e2e.ts
@@ -52,7 +52,7 @@ describe("calcite-switch", () => {
 
     expect(await calciteSwitch.getProperty("checked")).toBe(true);
 
-    //in addition to .click() check with .callMethod("click") as well
+    // helps test click behavior via HTMLElement.click()
     await calciteSwitch.callMethod("click");
     await page.waitForChanges();
 

--- a/src/components/switch/switch.e2e.ts
+++ b/src/components/switch/switch.e2e.ts
@@ -51,6 +51,12 @@ describe("calcite-switch", () => {
     });
 
     expect(await calciteSwitch.getProperty("checked")).toBe(true);
+
+    //in addition to .click() check with .callMethod("click") as well
+    await calciteSwitch.callMethod("click");
+    await page.waitForChanges();
+
+    expect(await calciteSwitch.getProperty("checked")).toBe(false);
   });
 
   it("can be checked via the switched property (deprecated)", async () => {


### PR DESCRIPTION
**Related Issue:** #4212

## Summary

Update tests that cover behavior on element click to use the `.callMethod("click")` in addition to `.click()`. In the case of the `switch`, click triggers a boolean toggle on the `checked` prop.