### PR TITLE
ci: close past due milestone when its last issue is moved

### DIFF
--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
     types: [closed]
   issues:
-    types: [closed]
+    types: [closed, demilestoned]
 jobs:
   close-milestone:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Related Issue:** #

## Summary
We have a GitHub Action that closes a milestone when all of the issues are completed. Currently it is only triggered when an issue is closed. Sometimes an issue does not pass the QA verification and the issue needs to be moved to the current sprint or backburner. With this PR the milestone will properly close.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
