### PR TITLE
build: patch rollup tree shaking stencil issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
         "@floating-ui/dom": "1.0.1",
-        "@stencil/core": "2.16.1",
+        "@stencil/core": "2.17.4",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "form-request-submit-polyfill": "2.0.0",
@@ -3110,9 +3110,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
-      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.4.tgz",
+      "integrity": "sha512-SGRlHpjV1RyFvzw6jFMVKpLNox9Eds3VvpbpD2SW9CuxdLonHDSFtQks5zmT4zs1Rse9I6kFc2mFK/dHNTalkg==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -33652,9 +33652,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.1.tgz",
-      "integrity": "sha512-s/UJp9qxExL3DyQPT70kiuWeb3AdjbUZM+5lEIXn30I2DLcLYPOPXfsoWJODieQywq+3vPiLZeIdkoqjf6jcSw=="
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.4.tgz",
+      "integrity": "sha512-SGRlHpjV1RyFvzw6jFMVKpLNox9Eds3VvpbpD2SW9CuxdLonHDSFtQks5zmT4zs1Rse9I6kFc2mFK/dHNTalkg=="
     },
     "@stencil/eslint-plugin": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:copy-icons && stencil build && npm run util:patch-es5-helpers && npm run util:patch-esm-resolution",
+    "build": "npm run util:copy-icons && stencil build && npm run util:patch",
     "build:watch": "npm run util:copy-icons && stencil build --watch",
     "build:watch-dev": "npm run util:copy-icons && stencil build --dev --watch",
     "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs",
@@ -51,8 +51,10 @@
     "util:deploy-next-from-ci": "ts-node --esm support/deployNextFromCI.ts",
     "util:is-next-deployable": "ts-node --esm support/isNextDeployable.ts",
     "util:hydration-styles": "ts-node --esm support/hydrationStyles.ts",
+    "util:patch": "npm run util:patch-es5-helpers && npm run util:patch-esm-resolution && npm run util:patch-tree-shaking",
     "util:patch-es5-helpers": "ts-node --esm support/patchES5Helpers.ts",
     "util:patch-esm-resolution": "ts-node --esm support/patchESMResolution.ts",
+    "util:patch-tree-shaking": "ts-node --esm support/patchTreeShaking.ts",
     "util:prep-next": "ts-node --esm support/prepReleaseCommit.ts --next && npm run build",
     "util:publish-next": "npm publish --tag next",
     "util:check-squash-mergeable-branch": "ts-node --esm support/checkSquashMergeableBranch.ts",
@@ -66,7 +68,7 @@
   "dependencies": {
     "@a11y/focus-trap": "1.0.5",
     "@floating-ui/dom": "1.0.1",
-    "@stencil/core": "2.16.1",
+    "@stencil/core": "2.17.4",
     "@types/color": "3.0.3",
     "color": "4.2.3",
     "form-request-submit-polyfill": "2.0.0",

--- a/support/patchESMResolution.ts
+++ b/support/patchESMResolution.ts
@@ -1,3 +1,5 @@
+// patch needed due to switching package.json's type to "module"
+// https://github.com/Esri/calcite-components/issues/5141
 (async function () {
   const {
     promises: { readFile, readdir, writeFile }
@@ -6,8 +8,6 @@
   const { quote } = await import("shell-quote");
   const { fileURLToPath } = await import("url");
 
-  // patch needed due to switching package.json's type to "module"
-  // https://github.com/Esri/calcite-components/issues/5141
   try {
     const importedModule = "@stencil/core/internal/client";
     const __filename = fileURLToPath(import.meta.url);

--- a/support/patchTreeShaking.ts
+++ b/support/patchTreeShaking.ts
@@ -1,0 +1,22 @@
+(async function () {
+  const {
+    promises: { readFile, writeFile }
+  } = await import("fs");
+  const { dirname, normalize } = await import("path");
+  const { quote } = await import("shell-quote");
+  const { fileURLToPath } = await import("url");
+
+  // patch needed due to Stencil tree-shaking bug
+  // https://github.com/ionic-team/stencil/issues/3470
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const calciteComponentExports = new RegExp("^.*export { Calcite.*$(\r\n|\r|\n)", "gm");
+    const filePath = quote([normalize(`${__dirname}/../dist/components/index.js`)]);
+    const contents = await readFile(filePath, { encoding: "utf8" });
+    await writeFile(filePath, contents.replace(calciteComponentExports, ""));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/support/patchTreeShaking.ts
+++ b/support/patchTreeShaking.ts
@@ -1,3 +1,5 @@
+// patch needed due to Stencil tree-shaking bug
+// https://github.com/ionic-team/stencil/issues/3470
 (async function () {
   const {
     promises: { readFile, writeFile }
@@ -6,8 +8,6 @@
   const { quote } = await import("shell-quote");
   const { fileURLToPath } = await import("url");
 
-  // patch needed due to Stencil tree-shaking bug
-  // https://github.com/ionic-team/stencil/issues/3470
   try {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);


### PR DESCRIPTION
**Related Issue:** https://github.com/ionic-team/stencil/issues/3470

## Summary

It looks like Stencil wont fix the rollup tree shaking bug until v3 ([source](https://github.com/ionic-team/stencil/pull/3556)), so I'm adding another post-build patch until then. 

I looked through the [breaking PR](https://github.com/ionic-team/stencil/commit/ff0e8cc54e5e68631cd83302d59b19f2626d43cb#diff-474e24df74c0221a170d7c067c32acfa2501ed400f4694df986bd84ddd43b7ee), and it didn't look like any changes occured that would cause problems due to removing the component exports in `dist/components/index.js`. To be safe I tested with the [CC rollup example](https://github.com/Esri/calcite-components-examples/tree/master/rollup), `npm link`, and my [`build-sizes`](https://github.com/benelan/build-sizes) package. 

Using the latest version of Stencil (which contains the tree-shaking issue) these are the build sizes:

```
-----------------------------
|> Application Build Sizes <|
-----------------------------
Build
 --> file count: 2548
 --> size: 2.19 MB
 --> size on disk: 2.31 MB
-----------------------------
Main JS bundle
 --> name: main.js
 --> size: 1.07 MB
 --> gzip size: 181.39 KB
 --> brotli size: 130.63 KB
-----------------------------
```
And these were the build sizes after applying the patch:

```
-----------------------------
|> Application Build Sizes <|
-----------------------------
Build
 --> file count: 2548
 --> size: 1.25 MB
 --> size on disk: 1.38 MB
-----------------------------
Main JS bundle
 --> name: main.js
 --> size: 138.4 KB
 --> gzip size: 25.45 KB
 --> brotli size: 21.35 KB
-----------------------------
```

There were no build or runtime errors when using the patched build and the components rendered correctly. So the patch seems safe and effective.

cc @dasa