### PR TITLE
fix(time-picker, input-time-picker): initialize meridiem at the start of the time for rtl locales

### DIFF
--- a/src/components/time-picker/time-picker.e2e.ts
+++ b/src/components/time-picker/time-picker.e2e.ts
@@ -1043,5 +1043,14 @@ describe("calcite-time-picker", () => {
       const timePickerDir = await timePicker.getAttribute("dir");
       expect(timePickerDir).toBe("ltr");
     });
+
+    it("meridiem is at the start of the time for arabic locale", async () => {
+      const page = await newE2EPage({
+        html: `<calcite-time-picker lang="ar" dir="rtl"></calcite-time-picker>`
+      });
+
+      const meridiemStart = await page.find(`calcite-time-picker >>> .${CSS.meridiemStart}`);
+      expect(meridiemStart).toBeTruthy();
+    });
   });
 });

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -722,6 +722,7 @@ export class TimePicker {
   connectedCallback() {
     this.setValue(this.value, false);
     this.hourCycle = getLocaleHourCycle(this.locale);
+    this.meridiemOrder = this.getMeridiemOrder(getTimeParts("0:00:00", this.locale));
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #4957 

## Summary
Makes sure the meridiem location is determined on load.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
