### PR TITLE
ci(screener): disable screener PR checks

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -1,22 +1,74 @@
 name: Screener
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [master]
+    types: [ready_for_review]
+  # need to run on the base branch when merging to keep the baseline state up to date
+  push:
+    branches: [master]
 jobs:
   screenshot_tests:
+    if: "!contains(github.event.pull_request.labels.*.name, 'pr has no visual changes') && github.actor!='dependabot-preview[bot]'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: skip for markdown only prs
+        id: one
+        run: |
+          current_branch=$(git rev-parse --abbrev-ref HEAD)
+          echo "branch: $current_branch"
+          if [ "$current_branch" == "master" ]; then
+            # diff of last commit excluding md (assumes squash merge)
+            screenable_changes=$(git diff --name-only @~..@ -- . ':(exclude)*.md*')
+            echo "push run"
+          else
+            # diff of branch excluding md
+            screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md*')
+            echo "pr run"
+          fi
+          echo "changed files: $screenable_changes"
+          # skip if there are only md changes
+          if [ -z "$screenable_changes" ]; then
+            echo "skip screener"
+            echo "::set-output name=skip::skip"
+          else
+            echo "run screener"
+            echo "::set-output name=skip::screen"
+          fi
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
           cache: npm
       - run: npm ci --legacy-peer-deps
-      - name: run screener check
+      - if: steps.one.outputs.skip == 'screen'
+        name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
           SAUCE_ACCESS_NAME: ${{ secrets.SAUCE_ACCESS_NAME}}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: npm run test:storybook || true
+      - if: steps.one.outputs.skip == 'skip'
+        name: skip screener for markdown PRs
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: screener
+          description: Screener run skipped (markdown PRs)
+          state: success
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+  skip_screenshot_tests:
+    if: "contains(github.event.pull_request.labels.*.name, 'pr has no visual changes') || github.actor=='dependabot-preview[bot]'"
+    runs-on: ubuntu-latest
+    steps:
+      - name: skip screener for dependabot PRs or no visual changes
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: screener
+          description: Screener run skipped (no visual changes or dependabot PR)
+          state: success
+          sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -1,10 +1,6 @@
 name: Screener
 on:
-  pull_request:
-    branches: [master]
-  # need to run on the base branch when merging to keep the baseline state up to date
-  push:
-    branches: [master]
+  workflow_dispatch:
 jobs:
   screenshot_tests:
     runs-on: ubuntu-latest
@@ -12,48 +8,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: skip for markdown only prs
-        id: one
-        run: |
-          current_branch=$(git rev-parse --abbrev-ref HEAD)
-          echo "branch: $current_branch"
-          if [ "$current_branch" == "master" ]; then
-            # diff of last commit excluding md (assumes squash merge)
-            screenable_changes=$(git diff --name-only @~..@ -- . ':(exclude)*.md*')
-            echo "push run"
-          else
-            # diff of branch excluding md
-            screenable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- . ':(exclude)*.md*')
-            echo "pr run"
-          fi
-          echo "changed files: $screenable_changes"
-          # skip if there are only md changes
-          if [ -z "$screenable_changes" ]; then
-            echo "skip screener"
-            echo "::set-output name=skip::skip"
-          else
-            echo "run screener"
-            echo "::set-output name=skip::screen"
-          fi
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
           cache: npm
       - run: npm ci --legacy-peer-deps
-      - if: steps.one.outputs.skip == 'screen'
-        name: run screener check
+      - name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
           COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
           SAUCE_ACCESS_NAME: ${{ secrets.SAUCE_ACCESS_NAME}}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: npm run test:storybook || true
-      - if: steps.one.outputs.skip == 'skip'
-        name: skip screener
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{ secrets.GITHUB_TOKEN }}
-          context: screener
-          description: Screener run skipped (markdown PRs)
-          state: success
-          sha: ${{github.event.pull_request.head.sha || github.sha}}


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Unfortunately we need to temporarily disable screener to prevent insane overage fees. We are working on a short term solution to turn screener back on, and a mid-term solution to switch to Chromatic. Screener can still be run on a branch manually following these steps: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

For now, please try not to manually run screener unless absolutely necessary. We only have around 35 runs per month at our current snapshot count. We will be working to reduce the number of stories so we can reenable screener PR checks in the short term.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
