### PR TITLE
ci(close-milestone): fix issue due to no optional chaining

### DIFF
--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -20,8 +20,8 @@ jobs:
             // no optional chaining support
             // https://github.com/actions/github-script/pull/182
             const milestone_number =
-              (issue && issue.milestone.number) ||
-              (pull_request && pull_request.milestone.number);
+              (issue && issue.milestone && issue.milestone.number) ||
+              (pull_request && pull_request.milestone && pull_request.milestone.number);
 
             if (!milestone_number) {
               console.log("No milestone found, ending run.");


### PR DESCRIPTION
**Related Issue:** #

## Summary
How did we ever live w/o optional chaining :'(

Error: https://github.com/Esri/calcite-components/runs/8052344919?check_suite_focus=true#step:2:44
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
