### PR TITLE
fix(label): apply matching flex display to host

### DIFF
--- a/src/components/label/label.e2e.ts
+++ b/src/components/label/label.e2e.ts
@@ -2,7 +2,11 @@ import { newE2EPage } from "@stencil/core/testing";
 import { renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-label", () => {
-  it("renders", () => renders("calcite-label", { display: "inline" }));
+  describe("renders", () => {
+    it("renders (default)", () => renders("calcite-label", { display: "flex" }));
+    it("renders (inline)", () =>
+      renders("<calcite-label layout='inline'></calcite-label>", { display: "inline-flex" }));
+  });
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();

--- a/src/components/label/label.scss
+++ b/src/components/label/label.scss
@@ -7,7 +7,7 @@
  */
 
 :host {
-  @apply inline;
+  @apply flex;
 }
 
 :host([alignment="start"]) {
@@ -69,6 +69,7 @@
 
 :host([layout="inline"]),
 :host([layout="inline-space-between"]) {
+  @apply inline-flex;
   .container {
     @apply flex flex-row items-center gap-2;
   }


### PR DESCRIPTION
**Related Issue:** #2921 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Updates host display value to match layout.