### PR TITLE
fix(list-item): Use margin instead of padding when slotting icons.

### DIFF
--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -108,7 +108,7 @@
 .content-start,
 .content-end {
   ::slotted(calcite-icon) {
-    @apply self-center px-3;
+    @apply self-center mx-3;
   }
 }
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

fix(list-item): Use margin instead of padding when slotting icons.