### PR TITLE
test(action, card, tooltip): cleanup screener snapshots

### DIFF
--- a/src/components/action/action.stories.ts
+++ b/src/components/action/action.stories.ts
@@ -3,11 +3,12 @@ import {
   Attribute,
   filterComponentAttributes,
   Attributes,
-  createComponentHTML as create
+  createComponentHTML as create,
+  themesDarkDefault
 } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import { html } from "../../../support/formatting";
-import { createSteps, iconNames, stepStory, setTheme, setKnobs, storyFilters } from "../../../.storybook/helpers";
+import { iconNames, storyFilters } from "../../../.storybook/helpers";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 const { alignment, scale } = ATTRIBUTES;
 
@@ -65,7 +66,7 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
       {
         name: "icon",
         commit(): Attribute {
-          this.value = select("icon", ["", ...iconNames], "");
+          this.value = select("icon", ["", ...iconNames], "banana");
           delete this.build;
           return this;
         }
@@ -131,424 +132,80 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
   );
 };
 
-const selector = "calcite-action";
+export const simple = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["icon"] }).concat([
+        {
+          name: "icon",
+          value: "banana"
+        }
+      ])
+    )}
+  </div>`;
 
-export const simple = stepStory(
-  (): string => html`<div style="width: 150px">${create("calcite-action", createAttributes())}</div>`,
+export const disabledAndCompact_TestOnly = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["compact", "disabled", "icon"] }).concat([
+        { name: "compact", value: true },
+        { name: "disabled", value: true }
+      ])
+    )}
+  </div>`;
 
-  createSteps("calcite-action")
-    // No Icon
-    .snapshot("No Icon")
+export const activeAndAppearanceClear_TestOnly = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["icon", "appearance", "active"] }).concat([
+        { name: "appearance", value: "clear" },
+        { name: "active", value: true }
+      ])
+    )}
+  </div>`;
 
-    // Default
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [{ name: "icon", value: "beaker" }]
-      })
-    )
-    .snapshot("Default")
-    .hover(selector)
-    .snapshot("Default Hover")
-    .mouseDown(selector)
-    .snapshot("Default Mouse Down")
-    .mouseUp(selector)
-    .snapshot("Default Mouse Up")
+export const indicatorAndText_TestOnly = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text"] }).concat([
+        { name: "textEnabled", value: true },
+        { name: "text", value: "Blah" },
+        { name: "indicator", value: true }
+      ])
+    )}
+  </div>`;
 
-    // Active
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "active", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Active")
-    .hover(selector)
-    .snapshot("Active Hover")
-    .mouseDown(selector)
-    .snapshot("Active Mouse Down")
-    .mouseUp(selector)
-    .snapshot("Active Mouse Up")
+export const alignmentStartSmallScale_TestOnly = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text", "alignment", "scale"] }).concat([
+        { name: "textEnabled", value: true },
+        { name: "text", value: "Blah" },
+        { name: "indicator", value: true },
+        { name: "alignment", value: "start" },
+        { name: "scale", value: "s" }
+      ])
+    )}
+  </div>`;
 
-    // Alignment Center
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "center" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Alignment Center")
-
-    // Alignment End
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "end" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Alignment End")
-
-    // Appearance Clear
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "appearance", value: "clear" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Appearance Clear")
-    .hover(selector)
-    .snapshot("Appearance Clear Hover")
-    .mouseDown(selector)
-    .snapshot("Appearance Clear Mouse Down")
-    .mouseUp(selector)
-    .snapshot("Appearance Clear Mouse Up")
-
-    // Compact
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "compact", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Compact Alignment Start")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "end" },
-          { name: "compact", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Compact Alignment End")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "compact", value: "true" },
-          { name: "textEnabled", value: "false" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Compact Text Disabled")
-
-    // Dark
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .executeScript(setTheme("dark"))
-    .snapshot("Dark")
-    .hover(selector)
-    .snapshot("Dark Hover")
-    .mouseDown(selector)
-    .snapshot("Dark Mouse Down")
-    .mouseUp(selector)
-    .snapshot("Dark Mouse Up")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "active", value: "true" },
-          { name: "icon", value: "beaker" },
-          { name: "indicator", value: "true" }
-        ]
-      })
-    )
-    .executeScript(setTheme("dark"))
-    .snapshot("Dark Active")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "active", value: "true" },
-          { name: "disabled", value: "true" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .executeScript(setTheme("dark"))
-    .snapshot("Dark Active Disabled")
-
-    // Disabled
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "active", value: "true" },
-          { name: "disabled", value: "true" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .executeScript(setTheme("light"))
-    .snapshot("Disabled Active")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "appearance", value: "solid" },
-          { name: "disabled", value: "true" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Disabled Appearance Solid")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "appearance", value: "clear" },
-          { name: "disabled", value: "true" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Disabled Appearance Clear")
-
-    // Indicator
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Indicator")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "textEnabled", value: "false" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Indicator Text Disabled")
-
-    // Loading
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "loading", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Loading")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "loading", value: "true" },
-          { name: "textEnabled", value: "false" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Loading Text Disabled")
-
-    // RTL
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "start" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Alignment Start")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "center" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Alignment Center")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "end" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Alignment End")
-
-    // RTL Indicator
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "start" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Indicator Alignment Start")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "center" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Indicator Alignment Center")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "end" },
-          { name: "indicator", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Indicator Alignment End")
-
-    // RTL Loading
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "start" },
-          { name: "loading", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Loading Alignment Start")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "center" },
-          { name: "loading", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Loading Alignment Center")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "alignment", value: "end" },
-          { name: "loading", value: "true" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .rtl()
-    .snapshot("RTL Loading Alignment End")
-
-    // Scale
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "scale", value: "s" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Scale Small")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "scale", value: "s" },
-          { name: "textEnabled", value: "false" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Scale Small Text Disabled")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "scale", value: "l" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Scale Large")
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "indicator", value: "true" },
-          { name: "scale", value: "l" },
-          { name: "textEnabled", value: "false" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Scale Large Text Disabled")
-
-    // Text
-    .executeScript(
-      setKnobs({
-        story: "components-buttons-action--simple",
-        knobs: [
-          { name: "text", value: "A long amount of text" },
-          { name: "icon", value: "beaker" }
-        ]
-      })
-    )
-    .snapshot("Text Overflow")
-);
+export const alignmentEndLargeScaleTextOverflow_TestOnly = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text", "alignment", "scale"] }).concat([
+        { name: "textEnabled", value: true },
+        { name: "text", value: "Blah blah blah blah blah blah blah blah blah blah" },
+        { name: "indicator", value: true },
+        { name: "alignment", value: "end" },
+        { name: "scale", value: "l" }
+      ])
+    )}
+  </div>`;
 
 export const arabicLocale_TestOnly = (): string => html`
   <calcite-action
@@ -560,3 +217,19 @@ export const arabicLocale_TestOnly = (): string => html`
     text-enabled
   ></calcite-action>
 `;
+
+export const darkThemeRTL_TestOnly = (): string =>
+  html`<div style="width: 150px">
+    ${create(
+      "calcite-action",
+      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text", "class", "dir"] }).concat([
+        { name: "textEnabled", value: true },
+        { name: "text", value: "Blah" },
+        { name: "indicator", value: true },
+        { name: "class", value: "calcite-theme-dark" },
+        { name: "dir", value: "rtl" }
+      ])
+    )}
+  </div>`;
+
+darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };

--- a/src/components/action/action.stories.ts
+++ b/src/components/action/action.stories.ts
@@ -133,23 +133,27 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
 };
 
 export const simple = (): string =>
-  html`<div style="width: 150px">
+  html`<div>
     ${create(
       "calcite-action",
-      createAttributes({ exceptions: ["icon"] }).concat([
+      createAttributes({ exceptions: ["icon", "text"] }).concat([
         {
           name: "icon",
           value: "banana"
+        },
+        {
+          name: "text",
+          value: ""
         }
       ])
     )}
   </div>`;
 
-export const disabledAndCompact_TestOnly = (): string =>
-  html`<div style="width: 150px">
+export const disabledAndCompactAndTextOnly_TestOnly = (): string =>
+  html`<div>
     ${create(
       "calcite-action",
-      createAttributes({ exceptions: ["compact", "disabled", "icon"] }).concat([
+      createAttributes({ exceptions: ["compact", "disabled"] }).concat([
         { name: "compact", value: true },
         { name: "disabled", value: true }
       ])
@@ -157,51 +161,38 @@ export const disabledAndCompact_TestOnly = (): string =>
   </div>`;
 
 export const activeAndAppearanceClear_TestOnly = (): string =>
-  html`<div style="width: 150px">
+  html`<div>
     ${create(
       "calcite-action",
       createAttributes({ exceptions: ["icon", "appearance", "active"] }).concat([
-        { name: "appearance", value: "clear" },
-        { name: "active", value: true }
+        { name: "active", value: true },
+        { name: "icon", value: "banana" },
+        { name: "appearance", value: "clear" }
       ])
     )}
   </div>`;
 
-export const indicatorAndText_TestOnly = (): string =>
-  html`<div style="width: 150px">
+export const alignmentEndAndSmallScaleAndIndicator_TestOnly = (): string =>
+  html`<div style="width: 300px">
     ${create(
       "calcite-action",
-      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text"] }).concat([
-        { name: "textEnabled", value: true },
-        { name: "text", value: "Blah" },
-        { name: "indicator", value: true }
-      ])
-    )}
-  </div>`;
-
-export const alignmentStartSmallScale_TestOnly = (): string =>
-  html`<div style="width: 150px">
-    ${create(
-      "calcite-action",
-      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text", "alignment", "scale"] }).concat([
-        { name: "textEnabled", value: true },
-        { name: "text", value: "Blah" },
+      createAttributes({ exceptions: ["icon", "indicator", "alignment", "scale"] }).concat([
+        { name: "icon", value: "banana" },
+        { name: "alignment", value: "end" },
         { name: "indicator", value: true },
-        { name: "alignment", value: "start" },
         { name: "scale", value: "s" }
       ])
     )}
   </div>`;
 
-export const alignmentEndLargeScaleTextOverflow_TestOnly = (): string =>
+export const alignmentStartAndLargeScaleAndTextOverflow_TestOnly = (): string =>
   html`<div style="width: 150px">
     ${create(
       "calcite-action",
-      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text", "alignment", "scale"] }).concat([
-        { name: "textEnabled", value: true },
+      createAttributes({ exceptions: ["icon", "text", "alignment", "scale"] }).concat([
+        { name: "icon", value: "banana" },
         { name: "text", value: "Blah blah blah blah blah blah blah blah blah blah" },
-        { name: "indicator", value: true },
-        { name: "alignment", value: "end" },
+        { name: "alignment", value: "start" },
         { name: "scale", value: "l" }
       ])
     )}
@@ -219,13 +210,11 @@ export const arabicLocale_TestOnly = (): string => html`
 `;
 
 export const darkThemeRTL_TestOnly = (): string =>
-  html`<div style="width: 150px">
+  html`<div>
     ${create(
       "calcite-action",
-      createAttributes({ exceptions: ["icon", "indicator", "textEnabled", "text", "class", "dir"] }).concat([
-        { name: "textEnabled", value: true },
-        { name: "text", value: "Blah" },
-        { name: "indicator", value: true },
+      createAttributes({ exceptions: ["icon", "class", "dir"] }).concat([
+        { name: "icon", value: "banana" },
         { name: "class", value: "calcite-theme-dark" },
         { name: "dir", value: "rtl" }
       ])

--- a/src/components/card/card.stories.ts
+++ b/src/components/card/card.stories.ts
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import { placeholderImage } from "../../../.storybook/utils";
+import { placeholderImage, themesDarkDefault } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
 import readme from "./readme.md";
 import {
@@ -8,7 +8,7 @@ import {
   Attributes,
   createComponentHTML as create
 } from "../../../.storybook/utils";
-import { createSteps, stepStory, setTheme, setKnobs, storyFilters } from "../../../.storybook/helpers";
+import { storyFilters } from "../../../.storybook/helpers";
 import { TEXT } from "./resources";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 
@@ -148,109 +148,60 @@ export const simpleWithFooterTextButtonTooltip_NoTest = (): string => html`
   ${tooltipHtml}
 `;
 
-export const thumbnail = stepStory(
-  (): string => html`
-    <div style="width:260px">
-      ${create(
-        "calcite-card",
-        createAttributes(),
-        html`
-          ${thumbnailHtml}
-          <h3 slot="title">Portland Businesses</h3>
-          <span slot="subtitle"
-            >by
-            <calcite-link href="">example_user</calcite-link>
-          </span>
-          <div>
-            Created: Apr 22, 2019
-            <br />
-            Updated: Dec 9, 2019
-            <br />
-            View Count: 0
-          </div>
-          <calcite-button
-            slot="footer-leading"
-            color="neutral"
-            scale="s"
-            id="card-icon-test-1"
-            icon-start="circle"
-          ></calcite-button>
-          <div slot="footer-trailing">
-            <calcite-button scale="s" color="neutral" id="card-icon-test-2" icon-start="circle"></calcite-button>
-            <calcite-button scale="s" color="neutral" id="card-icon-test-3" icon-start="circle"></calcite-button>
-            <calcite-dropdown type="hover">
-              <calcite-button
-                id="card-icon-test-5"
-                slot="dropdown-trigger"
-                scale="s"
-                color="neutral"
-                icon-start="circle"
-              ></calcite-button>
-              <calcite-dropdown-group selection-mode="none">
-                <calcite-dropdown-item>View details</calcite-dropdown-item>
-                <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
-                <calcite-dropdown-item>Delete</calcite-dropdown-item>
-              </calcite-dropdown-group>
-            </calcite-dropdown>
-          </div>
-        `
-      )}
-      <calcite-tooltip placement="bottom-start" reference-element="card-icon-test-1"
-        >My great tooltip example
-      </calcite-tooltip>
-      <calcite-tooltip placement="bottom-start" reference-element="card-icon-test-2">Sharing level: 2 </calcite-tooltip>
-      <calcite-tooltip placement="top-end" reference-element="card-icon-test-3">More... </calcite-tooltip>
-      <calcite-tooltip placement="top-start" reference-element="card-icon-test-5">More options </calcite-tooltip>
-    </div>
-  `,
-  createSteps("calcite-card")
-    .snapshot("Thumbnail Block Start")
-    .rtl()
-    .snapshot("Thumbnail Block Start RTL")
-    .executeScript(setTheme("dark"))
-    .snapshot("Thumbnail Block Start RTL Dark")
-    .ltr()
-    .snapshot("Thumbnail Block Start Dark")
-    .executeScript(
-      setKnobs({
-        story: "components-card--thumbnail",
-        knobs: [{ name: "thumbnail-position", value: "block-end" }]
-      })
-    )
-    .snapshot("Thumbnail Block End")
-    .rtl()
-    .snapshot("Thumbnail Block End RTL")
-    .executeScript(setTheme("dark"))
-    .snapshot("Thumbnail Block End RTL Dark")
-    .ltr()
-    .snapshot("Thumbnail Block End Dark")
-    .executeScript(
-      setKnobs({
-        story: "components-card--thumbnail",
-        knobs: [{ name: "thumbnail-position", value: "inline-start" }]
-      })
-    )
-    .snapshot("Thumbnail Inline Start")
-    .rtl()
-    .snapshot("Thumbnail Inline Start RTL")
-    .executeScript(setTheme("dark"))
-    .snapshot("Thumbnail Inline Start RTL Dark")
-    .ltr()
-    .snapshot("Thumbnail Inline Start Dark")
-    .executeScript(
-      setKnobs({
-        story: "components-card--thumbnail",
-        knobs: [{ name: "thumbnail-position", value: "inline-end" }]
-      })
-    )
-    .snapshot("Thumbnail Inline End")
-    .rtl()
-    .snapshot("Thumbnail Inline End RTL")
-    .executeScript(setTheme("dark"))
-    .snapshot("Thumbnail Inline End RTL Dark")
-    .ltr()
-    .snapshot("Thumbnail Inline End Dark")
-);
+export const thumbnail = (): string => html`
+  <div style="width:260px">
+    ${create(
+      "calcite-card",
+      createAttributes(),
+      html`
+        ${thumbnailHtml}
+        <h3 slot="title">Portland Businesses</h3>
+        <span slot="subtitle"
+          >by
+          <calcite-link href="">example_user</calcite-link>
+        </span>
+        <div>
+          Created: Apr 22, 2019
+          <br />
+          Updated: Dec 9, 2019
+          <br />
+          View Count: 0
+        </div>
+        <calcite-button
+          slot="footer-leading"
+          color="neutral"
+          scale="s"
+          id="card-icon-test-1"
+          icon-start="circle"
+        ></calcite-button>
+        <div slot="footer-trailing">
+          <calcite-button scale="s" color="neutral" id="card-icon-test-2" icon-start="circle"></calcite-button>
+          <calcite-button scale="s" color="neutral" id="card-icon-test-3" icon-start="circle"></calcite-button>
+          <calcite-dropdown type="hover">
+            <calcite-button
+              id="card-icon-test-5"
+              slot="dropdown-trigger"
+              scale="s"
+              color="neutral"
+              icon-start="circle"
+            ></calcite-button>
+            <calcite-dropdown-group selection-mode="none">
+              <calcite-dropdown-item>View details</calcite-dropdown-item>
+              <calcite-dropdown-item>Duplicate</calcite-dropdown-item>
+              <calcite-dropdown-item>Delete</calcite-dropdown-item>
+            </calcite-dropdown-group>
+          </calcite-dropdown>
+        </div>
+      `
+    )}
+    <calcite-tooltip placement="bottom-start" reference-element="card-icon-test-1"
+      >My great tooltip example
+    </calcite-tooltip>
+    <calcite-tooltip placement="bottom-start" reference-element="card-icon-test-2">Sharing level: 2 </calcite-tooltip>
+    <calcite-tooltip placement="top-end" reference-element="card-icon-test-3">More... </calcite-tooltip>
+    <calcite-tooltip placement="top-start" reference-element="card-icon-test-5">More options </calcite-tooltip>
+  </div>
+`;
 
 export const thumbnailRounded = (): string => html`
   <div id="card-container" style="width:260px;">
@@ -289,3 +240,5 @@ export const darkThemeRTL_TestOnly = (): string => html`
     <calcite-card>${thumbnailHtml}${titleHtml}${footerLeadingTextHtml}${footerTrailingButtonsHtml}</calcite-card>
   </div>
 `;
+
+darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };

--- a/src/components/tooltip/tooltip.stories.ts
+++ b/src/components/tooltip/tooltip.stories.ts
@@ -1,8 +1,9 @@
 import { select, number } from "@storybook/addon-knobs";
 import readme from "./readme.md";
 import { html } from "../../../support/formatting";
-import { boolean, createSteps, stepStory, setTheme, storyFilters } from "../../../.storybook/helpers";
+import { boolean, storyFilters } from "../../../.storybook/helpers";
 import { placements } from "../../utils/floating-ui";
+import { themesDarkDefault } from "../../../.storybook/utils";
 
 const contentHTML = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua`;
 
@@ -16,28 +17,51 @@ export default {
   ...storyFilters()
 };
 
-export const simple = stepStory(
-  (): string => html`
-    <div style="width: 400px;">
-      ${referenceElementHTML}
-      <calcite-tooltip
-        reference-element="reference-element"
-        placement="${select("placement", placements, "auto")}"
-        offset-distance="${number("offset-distance", 6)}"
-        offset-skidding="${number("offset-skidding", 0)}"
-        ${boolean("open", false)}
-      >
-        ${contentHTML}
-      </calcite-tooltip>
-    </div>
-  `,
-  createSteps("calcite-tooltip")
-    .snapshot("Default")
-    .hover("#reference-element")
-    .snapshot("Open")
-    .rtl()
-    .snapshot("Rtl")
-    .ltr()
-    .executeScript(setTheme("dark"))
-    .snapshot("Dark theme")
-);
+export const simple = (): string => html`
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-tooltip
+      reference-element="reference-element"
+      placement="${select("placement", placements, "auto")}"
+      offset-distance="${number("offset-distance", 6)}"
+      offset-skidding="${number("offset-skidding", 0)}"
+      ${boolean("open", false)}
+    >
+      ${contentHTML}
+    </calcite-tooltip>
+  </div>
+`;
+
+export const open_TestOnly = (): string => html`
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-tooltip
+      reference-element="reference-element"
+      placement="${select("placement", placements, "auto")}"
+      offset-distance="${number("offset-distance", 6)}"
+      offset-skidding="${number("offset-skidding", 0)}"
+      ${boolean("open", true)}
+    >
+      ${contentHTML}
+    </calcite-tooltip>
+  </div>
+`;
+
+export const darkThemeRTL_TestOnly = (): string => html`
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-tooltip
+      class="calcite-theme-dark"
+      dir="rtl"
+      reference-element="reference-element"
+      placement="${select("placement", placements, "auto")}"
+      offset-distance="${number("offset-distance", 6)}"
+      offset-skidding="${number("offset-skidding", 0)}"
+      ${boolean("open", false)}
+    >
+      ${contentHTML}
+    </calcite-tooltip>
+  </div>
+`;
+
+darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };


### PR DESCRIPTION
**Related Issue:** #5257

## Summary
Some additional cleanup. I nuked a lot of the combinations but we can add some back once we are out of crisis mode
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
