### PR TITLE
ci(screener): create job for manual screener runs

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -1,15 +1,14 @@
 name: Screener
 on:
+  # To conserve snapshots, we are temporarily running Screener on master manually when there are visual changes.
+  # We will eventually go back to visual snapshotting on pushes to master to automatically update the baseline.
   workflow_dispatch:
   pull_request:
     branches: [master]
     types: [labeled, synchronize, ready_for_review]
-  # need to run on the base branch when merging to keep the baseline state up to date
-  push:
-    branches: [master]
 jobs:
   screenshot_tests:
-    if: "(github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.event.action == 'labeled' && github.event.label.name == 'pr ready for visual snapshots' && github.event.pull_request.draft == false) || github.event.action == 'push'"
+    if: "(github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.event.action == 'labeled' && github.event.label.name == 'pr ready for visual snapshots' && github.event.pull_request.draft == false)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -62,7 +61,7 @@ jobs:
           state: success
           sha: ${{github.event.pull_request.head.sha || github.sha}}
   skip_screenshot_tests:
-    if: "(github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || github.event.pull_request.draft == true || (github.actor == 'dependabot-preview[bot]' && github.event.action != 'labeled')"
+    if: "(github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.actor == 'dependabot-preview[bot]' && github.event.action != 'labeled')"
     runs-on: ubuntu-latest
     steps:
       - name: skip screener for dependabot PRs or no visual changes
@@ -73,3 +72,20 @@ jobs:
           description: Screener run skipped (not ready for snapshots or dependabot PR)
           state: success
           sha: ${{github.event.pull_request.head.sha || github.sha}}
+  manual_screenshot_tests:
+    if: "github.event_name == 'workflow_dispatch'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - name: run screener check
+        env:
+          SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
+          COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}
+          SAUCE_ACCESS_NAME: ${{ secrets.SAUCE_ACCESS_NAME}}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          STORYBOOK_SCREENSHOT_TEST_BUILD: true
+        run: npm run test:storybook || true


### PR DESCRIPTION
**Related Issue:** 

## Summary
Allow screener to run manually w/o skipping due to strict conditionals
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
