### PR TITLE
ci(screener): fix lock file error when running manually

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -76,11 +76,11 @@ jobs:
     if: "github.event_name == 'workflow_dispatch'"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
           cache: npm
-          cache-dependency-path: ./package-lock.json
       - run: npm ci --legacy-peer-deps
       - name: run screener check
         env:

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           node-version: lts/*
           cache: npm
+          cache-dependency-path: ./package-lock.json
       - run: npm ci --legacy-peer-deps
       - name: run screener check
         env:


### PR DESCRIPTION
**Related Issue:** #5285

## Summary
Fixes error that happens when running the screener action manually. Not sure why this is happening since its the same step code I use for all the other actions, but providing the path to the lock file should fix it.

Error:
https://github.com/Esri/calcite-components/runs/8257764671?check_suite_focus=true#step:2:13

> Dependencies lock file is not found in /home/runner/work/calcite-components/calcite-components. Supported file patterns: package-lock.json,yarn.lock
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
