### PR TITLE
fix(tree-item): preserve the alignment of tree-items with selection-mode: none regardless of whether they have children

### DIFF
--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -7,7 +7,7 @@
 
 :host([selection-mode="none"]:not([has-children])) {
   .node-container {
-    margin-inline: theme("margin.3");
+    margin-inline: theme("margin.2");
   }
 }
 

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -149,7 +149,6 @@
   }
 }
 
-// selection-mode none, dropdown without children
 :host([selection-mode="none"]:not([has-children])) {
   &:host([scale="s"]) > .node-container {
     padding-inline-start: theme("padding.2");

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -5,12 +5,6 @@
     cursor-pointer;
 }
 
-:host([selection-mode="none"]:not([has-children])) {
-  .node-container {
-    margin-inline: theme("margin.2");
-  }
-}
-
 @include calciteHydratedHidden();
 
 :host([scale="s"]) {
@@ -152,6 +146,19 @@
   .checkmark {
     @apply opacity-100;
     color: theme("colors.brand");
+  }
+}
+
+// selection-mode none, dropdown without children
+:host([selection-mode="none"]:not([has-children])) {
+  &:host([scale="s"]) > .node-container {
+    padding-inline-start: theme("padding.2");
+  }
+  &:host([scale="m"]) > .node-container {
+    padding-inline-start: theme("padding.4");
+  }
+  &:host([scale="l"]) > .node-container {
+    padding-inline-start: theme("padding.6");
   }
 }
 

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -181,6 +181,7 @@ export class TreeItem implements ConditionalSlotComponent {
     const showCheckmark =
       this.selectionMode === TreeSelectionMode.Multi ||
       this.selectionMode === TreeSelectionMode.MultiChildren;
+    const showBlank = this.selectionMode === TreeSelectionMode.None && !this.hasChildren;
     const chevron = this.hasChildren ? (
       <calcite-icon
         class={{
@@ -212,6 +213,8 @@ export class TreeItem implements ConditionalSlotComponent {
       ? ICONS.bulletPoint
       : showCheckmark
       ? ICONS.checkmark
+      : showBlank
+      ? ICONS.blank
       : null;
     const itemIndicator = selectedIcon ? (
       <calcite-icon

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -1,5 +1,5 @@
 import { select } from "@storybook/addon-knobs";
-import { boolean, storyFilters } from "../../../.storybook/helpers";
+import { boolean, createSteps, stepStory, storyFilters } from "../../../.storybook/helpers";
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import treeItemReadme from "../tree-item/readme.md";
@@ -60,6 +60,22 @@ export const simple = (): string => html`
     ${treeItems}
   </calcite-tree>
 `;
+
+export const selectionModeNoneScales = stepStory(
+  (): string => html` <calcite-tree
+    ${boolean("lines", false)}
+    selection-mode="${select("selection-mode", selectionModes, "none")}"
+  >
+    ${treeItems}
+  </calcite-tree>`,
+  createSteps("calcite-tree")
+    .executeScript(`document.querySelector("calcite-tree").scale = "s"`)
+    .snapshot("selection-mode:none small")
+    .executeScript(`document.querySelector("calcite-tree").scale = "m"`)
+    .snapshot("selection-mode:none medium")
+    .executeScript(`document.querySelector("calcite-tree").scale = "l"`)
+    .snapshot("selection-mode:none large")
+);
 
 export const darkThemeRTL_TestOnly = (): string => html`
   <calcite-tree

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -1,5 +1,5 @@
 import { select } from "@storybook/addon-knobs";
-import { boolean, createSteps, stepStory, storyFilters } from "../../../.storybook/helpers";
+import { boolean, storyFilters } from "../../../.storybook/helpers";
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme from "./readme.md";
 import treeItemReadme from "../tree-item/readme.md";
@@ -61,21 +61,12 @@ export const simple = (): string => html`
   </calcite-tree>
 `;
 
-export const selectionModeNoneScales = stepStory(
-  (): string => html` <calcite-tree
-    ${boolean("lines", false)}
-    selection-mode="${select("selection-mode", selectionModes, "none")}"
-  >
-    ${treeItems}
-  </calcite-tree>`,
-  createSteps("calcite-tree")
-    .executeScript(`document.querySelector("calcite-tree").scale = "s"`)
-    .snapshot("selection-mode:none small")
-    .executeScript(`document.querySelector("calcite-tree").scale = "m"`)
-    .snapshot("selection-mode:none medium")
-    .executeScript(`document.querySelector("calcite-tree").scale = "l"`)
-    .snapshot("selection-mode:none large")
-);
+export const selectionModeNone = (): string => html`<calcite-tree
+  ${boolean("lines", false)}
+  selection-mode="${select("selection-mode", selectionModes, "none")}"
+>
+  ${treeItems}
+</calcite-tree>`;
 
 export const darkThemeRTL_TestOnly = (): string => html`
   <calcite-tree

--- a/src/demos/tree.html
+++ b/src/demos/tree.html
@@ -440,48 +440,6 @@
             </calcite-tree-item>
           </calcite-tree>
         </div>
-
-        <div class="child">
-          <calcite-tree selection-mode="none" scale="l">
-            <calcite-tree-item>
-              <span>Child 1</span>
-            </calcite-tree-item>
-
-            <calcite-tree-item>
-              <span>Child 2</span>
-
-              <calcite-tree slot="children">
-                <calcite-tree-item>
-                  <span>Grandchild 1</span>
-                  <calcite-tree slot="children">
-                    <calcite-tree-item>
-                      <span>Great Grandchild 1</span>
-                    </calcite-tree-item>
-                    <calcite-tree-item>
-                      <span>Great Grandchild 2</span>
-                    </calcite-tree-item>
-                    <calcite-tree-item>
-                      <span>Great Grandchild 3</span>
-                    </calcite-tree-item>
-                  </calcite-tree>
-                </calcite-tree-item>
-                <calcite-tree-item>
-                  <span>Grandchild 2</span>
-                </calcite-tree-item>
-                <calcite-tree-item>
-                  <span>Grandchild 3</span>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-
-            <calcite-tree-item>
-              <span>Child 3</span>
-            </calcite-tree-item>
-            <calcite-tree-item>
-              <span>Child 4</span>
-            </calcite-tree-item>
-          </calcite-tree>
-        </div>
       </div>
 
       <!-- events to test -->

--- a/src/demos/tree.html
+++ b/src/demos/tree.html
@@ -440,6 +440,48 @@
             </calcite-tree-item>
           </calcite-tree>
         </div>
+
+        <div class="child">
+          <calcite-tree selection-mode="none" scale="l">
+            <calcite-tree-item>
+              <span>Child 1</span>
+            </calcite-tree-item>
+
+            <calcite-tree-item>
+              <span>Child 2</span>
+
+              <calcite-tree slot="children">
+                <calcite-tree-item>
+                  <span>Grandchild 1</span>
+                  <calcite-tree slot="children">
+                    <calcite-tree-item>
+                      <span>Great Grandchild 1</span>
+                    </calcite-tree-item>
+                    <calcite-tree-item>
+                      <span>Great Grandchild 2</span>
+                    </calcite-tree-item>
+                    <calcite-tree-item>
+                      <span>Great Grandchild 3</span>
+                    </calcite-tree-item>
+                  </calcite-tree>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <span>Grandchild 2</span>
+                </calcite-tree-item>
+                <calcite-tree-item>
+                  <span>Grandchild 3</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+
+            <calcite-tree-item>
+              <span>Child 3</span>
+            </calcite-tree-item>
+            <calcite-tree-item>
+              <span>Child 4</span>
+            </calcite-tree-item>
+          </calcite-tree>
+        </div>
       </div>
 
       <!-- events to test -->


### PR DESCRIPTION
**Related Issue:** #5186

## Summary

Preserve the alignment of the `tree-items` regardless of whether they have children: outdent the disclosure arrows.