### PR TITLE
fix: remove unsafe-eval to support CSP script-src

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,6 +73,9 @@
     "lines-between-class-members": ["error", "always"],
     "no-multiple-empty-lines": ["error", { "max": 1 }],
     "no-unneeded-ternary": "error",
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "no-new-func": "error",
     "react/forbid-component-props": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,9 +73,6 @@
     "lines-between-class-members": ["error", "always"],
     "no-multiple-empty-lines": ["error", { "max": 1 }],
     "no-unneeded-ternary": "error",
-    "no-eval": "error",
-    "no-implied-eval": "error",
-    "no-new-func": "error",
     "react/forbid-component-props": [
       "warn",
       {

--- a/src/utils/globalScript.ts
+++ b/src/utils/globalScript.ts
@@ -6,7 +6,14 @@ import { initThemeChangeEvent } from "./theme";
  * @see {@link https://stenciljs.com/docs/config#globalscript}
  */
 export default function (): void {
-  if (isBrowser()) {
+  const isBrowser =
+    typeof window !== "undefined" &&
+    typeof location !== "undefined" &&
+    typeof document !== "undefined" &&
+    window.location === location &&
+    window.document === document;
+
+  if (isBrowser) {
     if (document.readyState === "interactive") {
       initThemeChangeEvent();
     } else {
@@ -14,5 +21,3 @@ export default function (): void {
     }
   }
 }
-
-const isBrowser = new Function("try {return this===window;}catch(e){ return false;}");


### PR DESCRIPTION
**Related Issue:** #5104

## Summary
@dasa noticed this while we were looking into an unrelated JSAPI issue. He suggested I use the [`isBrowser` check the JSAPI copied from dojo](https://devtopia.esri.com/WebGIS/arcgis-js-api/blob/4master/esri/core/has.ts#L229-L235) and that I add the `no-eval`, `no-implied-eval`, and `no-new-func` ESLint rules, which the JSAPI uses, so we don't run into this problem in the future. 

[More info from MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions)

Edit:
I ran `npm run test:prerender` and there were no errors. 
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
