### PR TITLE
ci(prepReleaseCommit): throw error when target release version not determined

### DIFF
--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -112,6 +112,9 @@ import yargs from "yargs";
       await appendUnreleasedNotesToChangelog();
       await exec(`git add ${changelogPath}`);
     } else {
+      if (!standardVersionOptions.releaseAs) {
+        throw new Error("an error occurred determining the target release version ");
+      }
       await updateReadmeCdnUrls(standardVersionOptions.releaseAs);
       await exec(`git add ${readmePath}`);
     }
@@ -162,11 +165,7 @@ import yargs from "yargs";
     ).stdout.trim();
   }
 
-  async function updateReadmeCdnUrls(version: string | undefined): Promise<void> {
-    if (!version) {
-      return;
-    }
-
+  async function updateReadmeCdnUrls(version: string): Promise<void> {
     const scriptTagPattern = /(<script\s+type="module"\s+src=").+("\s*><\/script>)/m;
     const linkTagPattern = /(<link\s+rel="stylesheet"\s+type="text\/css"\s+href=").+("\s*\/>)/m;
     const baseCdnUrl = `https://unpkg.com/@esri/calcite-components@${version}/dist/calcite/calcite.`;

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -84,7 +84,7 @@ import yargs from "yargs";
     const targetReleaseVersion = semver.inc(targetDescendingOrderTags[0], "prerelease", target);
 
     if (!targetReleaseVersion) {
-      throw new Error("an error occurred determining the target release version ");
+      throw new Error("an error occurred determining the target release version");
     }
 
     if (!targetVersionPattern.test(targetReleaseVersion)) {
@@ -113,7 +113,7 @@ import yargs from "yargs";
       await exec(`git add ${changelogPath}`);
     } else {
       if (!standardVersionOptions.releaseAs) {
-        throw new Error("an error occurred determining the target release version ");
+        throw new Error("an error occurred determining the target release version");
       }
       await updateReadmeCdnUrls(standardVersionOptions.releaseAs);
       await exec(`git add ${readmePath}`);

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -81,7 +81,11 @@ import yargs from "yargs";
     // we keep track of `beta` and `next` releases since `standard-version` resets the version number when going in between
     // this should not be needed after v1.0.0 since there would no longer be a beta version to keep track of
     const targetDescendingOrderTags = semverTags.filter((tag) => targetVersionPattern.test(tag)).sort(semver.rcompare);
-    const targetReleaseVersion = semver.inc(targetDescendingOrderTags[0], "prerelease", target) || "";
+    const targetReleaseVersion = semver.inc(targetDescendingOrderTags[0], "prerelease", target);
+
+    if (!targetReleaseVersion) {
+      throw new Error("an error occurred determining the target release version ");
+    }
 
     if (!targetVersionPattern.test(targetReleaseVersion)) {
       throw new Error(`target release version does not have prerelease identifier (${target})`);


### PR DESCRIPTION
**Related Issue:**
## Summary
Cleanup from https://github.com/Esri/calcite-components/pull/5302#discussion_r969838912
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
