### PR TITLE
refactor(tooltip): Use pointer events in favor of mouse events

### DIFF
--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -97,8 +97,8 @@ export default class TooltipManager {
 
   private addListeners(): void {
     document.addEventListener("keydown", this.keyDownHandler);
-    document.addEventListener("mouseover", this.mouseEnterShow, { capture: true });
-    document.addEventListener("mouseout", this.mouseLeaveHide, { capture: true });
+    document.addEventListener("pointerover", this.mouseEnterShow, { capture: true });
+    document.addEventListener("pointerout", this.mouseLeaveHide, { capture: true });
     document.addEventListener("pointerdown", this.clickHandler, { capture: true });
     document.addEventListener("focusin", this.focusShow, { capture: true });
     document.addEventListener("focusout", this.blurHide, { capture: true });
@@ -106,8 +106,8 @@ export default class TooltipManager {
 
   private removeListeners(): void {
     document.removeEventListener("keydown", this.keyDownHandler);
-    document.removeEventListener("mouseover", this.mouseEnterShow, { capture: true });
-    document.removeEventListener("mouseout", this.mouseLeaveHide, { capture: true });
+    document.removeEventListener("pointerover", this.mouseEnterShow, { capture: true });
+    document.removeEventListener("pointerout", this.mouseLeaveHide, { capture: true });
     document.removeEventListener("pointerdown", this.clickHandler, { capture: true });
     document.removeEventListener("focusin", this.focusShow, { capture: true });
     document.removeEventListener("focusout", this.blurHide, { capture: true });
@@ -178,9 +178,9 @@ export default class TooltipManager {
       return;
     }
 
-    if (type === "mouseover" && event.composedPath().includes(activeTooltipEl)) {
+    if (type === "pointerover" && event.composedPath().includes(activeTooltipEl)) {
       this.clearHoverTimeout(activeTooltipEl);
-    } else if (type === "mouseout" && !hoverTimeouts.has(activeTooltipEl)) {
+    } else if (type === "pointerout" && !hoverTimeouts.has(activeTooltipEl)) {
       this.hoverTooltip(activeTooltipEl, false);
     }
   }

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -229,7 +229,7 @@ describe("calcite-tooltip", () => {
     expect(content.textContent).toBe("hi");
   });
 
-  it("should honor tooltips on mouseover/mouseout", async () => {
+  it("should honor tooltips on pointerover/pointerout", async () => {
     const page = await newE2EPage();
 
     await page.setContent(
@@ -450,7 +450,7 @@ describe("calcite-tooltip", () => {
     expect(await hoverTip.getProperty("open")).toBe(false);
 
     await page.$eval("#hoverRef", (elm: HTMLElement) => {
-      elm.dispatchEvent(new Event("mouseover"));
+      elm.dispatchEvent(new Event("pointerover"));
     });
 
     await page.waitForTimeout(TOOLTIP_DELAY_MS);
@@ -507,7 +507,7 @@ describe("calcite-tooltip", () => {
     expect(await hoverTip.getProperty("open")).toBe(false);
 
     await page.$eval("#hoverRef", (elm: HTMLElement) => {
-      elm.dispatchEvent(new Event("mouseover"));
+      elm.dispatchEvent(new Event("pointerover"));
     });
 
     await page.waitForTimeout(TOOLTIP_DELAY_MS);

--- a/src/demos/tooltip.html
+++ b/src/demos/tooltip.html
@@ -156,6 +156,38 @@
         </div>
       </div>
 
+      <!-- disabled -->
+      <div class="parent">
+        <div class="child right-aligned-text">disabled</div>
+
+        <div class="child">
+          <calcite-button disabled appearance="outline" id="tooltip-auto-disabled-ref">auto</calcite-button>
+        </div>
+
+        <div class="child">
+          <calcite-button disabled appearance="outline" id="tooltip-auto-start-disabled-ref">auto-start</calcite-button>
+        </div>
+        <div class="child">
+          <calcite-button disabled appearance="outline" id="tooltip-auto-end-disabled-ref">auto-end</calcite-button>
+        </div>
+      </div>
+
+      <!-- disabled native -->
+      <div class="parent">
+        <div class="child right-aligned-text">disabled</div>
+
+        <div class="child">
+          <button disabled id="tooltip-auto-disabled-native-ref">auto</button>
+        </div>
+
+        <div class="child">
+          <button disabled id="tooltip-auto-start-disabled-native-ref">auto</button>
+        </div>
+        <div class="child">
+          <button disabled id="tooltip-auto-end-disabled-native-ref">auto</button>
+        </div>
+      </div>
+
       <!-- containers to hold the tooltip -->
       <div>
         <calcite-tooltip label="tooltip - auto" placement="auto" reference-element="tooltip-auto-ref">
@@ -284,6 +316,54 @@
           reference-element="tooltip-trailing-start-ref"
         >
           <p>placement: trailing-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </calcite-tooltip>
+
+        <calcite-tooltip label="tooltip - auto" placement="auto" reference-element="tooltip-auto-disabled-ref">
+          <p>placement: auto</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip
+          label="tooltip - auto-start"
+          placement="auto-start"
+          reference-element="tooltip-auto-start-disabled-ref"
+        >
+          <p>placement: auto-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip
+          label="tooltip - auto-end"
+          placement="auto-end"
+          reference-element="tooltip-auto-end-disabled-ref"
+        >
+          <p>placement: auto-end</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </calcite-tooltip>
+
+        <calcite-tooltip label="tooltip - auto" placement="auto" reference-element="tooltip-auto-disabled-native-ref">
+          <p>placement: auto</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip
+          label="tooltip - auto-start"
+          placement="auto-start"
+          reference-element="tooltip-auto-start-disabled-native-ref"
+        >
+          <p>placement: auto-start</p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </calcite-tooltip>
+        <calcite-tooltip
+          label="tooltip - auto-end"
+          placement="auto-end"
+          reference-element="tooltip-auto-end-disabled-native-ref"
+        >
+          <p>placement: auto-end</p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
           magna aliqua.
         </calcite-tooltip>


### PR DESCRIPTION
**Related Issue:** #5318

## Summary

refactor(tooltip): Use pointer events in favor of mouse events. (#5318)

pointer events will fire on disabled elements.