### PR TITLE
chore(flow): rename storybook knob tabs to Flow Items

### DIFF
--- a/src/components/flow/flow.stories.ts
+++ b/src/components/flow/flow.stories.ts
@@ -155,8 +155,8 @@ export const simple = (): string =>
   create(
     "calcite-flow",
     createAttributes(),
-    `${create("calcite-flow-item", createFlowItemAttributes("Panel 1"), createItemHTML(item1HTML))}
-    ${create("calcite-flow-item", createFlowItemAttributes("Panel 2"), createItemHTML(item2HTML))}`
+    `${create("calcite-flow-item", createFlowItemAttributes("Flow Item 1"), createItemHTML(item1HTML))}
+    ${create("calcite-flow-item", createFlowItemAttributes("Flow Item 2"), createItemHTML(item2HTML))}`
   );
 
 export const darkThemeRTL_TestOnly = (): string =>
@@ -169,6 +169,6 @@ export const darkThemeRTL_TestOnly = (): string =>
       },
       { name: "dir", value: "rtl" }
     ),
-    `${create("calcite-flow-item", createFlowItemAttributes("Panel 1"), createItemHTML(item1HTML))}
-    ${create("calcite-flow-item", createFlowItemAttributes("Panel 2"), createItemHTML(item2HTML))}`
+    `${create("calcite-flow-item", createFlowItemAttributes("Flow Item 1"), createItemHTML(item1HTML))}
+    ${create("calcite-flow-item", createFlowItemAttributes("Flow Item 2"), createItemHTML(item2HTML))}`
   );


### PR DESCRIPTION
**Related Issue:** #5256

## Summary
Cleanup mentioned in https://github.com/Esri/calcite-components/pull/5256#issuecomment-1246263939
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
