### PR TITLE
fix(input, input-number): hide non-interactive number up/down buttons from assistive technologies

### DIFF
--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -789,6 +789,7 @@ export class InputNumber implements LabelableComponent, FormComponent, Interacti
 
     const numberButtonsHorizontalUp = (
       <button
+        aria-hidden="true"
         class={{
           [CSS.numberButtonItem]: true,
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton
@@ -807,6 +808,7 @@ export class InputNumber implements LabelableComponent, FormComponent, Interacti
 
     const numberButtonsHorizontalDown = (
       <button
+        aria-hidden="true"
         class={{
           [CSS.numberButtonItem]: true,
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -900,6 +900,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
 
     const numberButtonsHorizontalUp = (
       <button
+        aria-hidden="true"
         class={{
           [CSS.numberButtonItem]: true,
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton
@@ -918,6 +919,7 @@ export class Input implements LabelableComponent, FormComponent, InteractiveComp
 
     const numberButtonsHorizontalDown = (
       <button
+        aria-hidden="true"
         class={{
           [CSS.numberButtonItem]: true,
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton


### PR DESCRIPTION
**Related Issue:** #5287

## Summary
Adds an `aria-hidden` prop to `input` when `type="number"` and `input-number` to hide the non-interactive up/down buttons.

Both buttons are not accessible via keyboard, and keyboard users can increment numbers using the arrow keys. This fix hides the buttons from the accessibility API to improve the experience for assistive technology users.


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
