### PR TITLE
fix(action-bar, combobox, dropdown, filter, input-date-picker, popover, tooltip): make methods using debounce/throttle private to prevent lodash type errors

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -221,7 +221,7 @@ export class ActionBar implements ConditionalSlotComponent {
     this.resize({ width, height });
   };
 
-  resize = debounce(({ width, height }: { width: number; height: number }): void => {
+  private resize = debounce(({ width, height }: { width: number; height: number }): void => {
     const { el, expanded, expandDisabled, layout } = this;
 
     if ((layout === "vertical" && !height) || (layout === "horizontal" && !width)) {

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -452,7 +452,7 @@ export class Combobox
   //
   // --------------------------------------------------------------------------
 
-  debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
+  private debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
 
   setFilteredPlacements = (): void => {
     const { el, flipPlacements } = this;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -736,7 +736,7 @@ export class Combobox
     return [...this.groupItems, ...this.items];
   }
 
-  filterItems = (() => {
+  private filterItems = (() => {
     const find = (item: ComboboxChildElement, filteredData: ItemData[]) =>
       item &&
       filteredData.some(({ label, value }) => {

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -776,14 +776,14 @@ export class Combobox
     this.calciteLookupChange.emit(this.selectedItems);
   };
 
-  emitCalciteLookupChange = debounce(this.internalCalciteLookupChangeEvent, 0);
+  private emitCalciteLookupChange = debounce(this.internalCalciteLookupChangeEvent, 0);
 
   internalComboboxChangeEvent = (): void => {
     const { selectedItems } = this;
     this.calciteComboboxChange.emit({ selectedItems });
   };
 
-  emitComboboxChange = debounce(this.internalComboboxChangeEvent, 0);
+  private emitComboboxChange = debounce(this.internalComboboxChangeEvent, 0);
 
   toggleSelection(item: HTMLCalciteComboboxItemElement, value = !item.selected): void {
     if (!item) {

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -418,7 +418,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   //
   //--------------------------------------------------------------------------
 
-  debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
+  private debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
 
   slotChangeHandler = (event: Event): void => {
     this.defaultAssignedElements = (event.target as HTMLSlotElement).assignedElements({

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -141,7 +141,7 @@ export class Filter implements InteractiveComponent {
   //
   // --------------------------------------------------------------------------
 
-  filter = debounce(
+  private filter = debounce(
     (value: string, emit = false): void => this.updateFiltered(filter(this.items, value), emit),
     DEBOUNCE_TIMEOUT
   );

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -612,7 +612,7 @@ export class InputDatePicker
   //
   //--------------------------------------------------------------------------
 
-  debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
+  private debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
 
   setFilteredPlacements = (): void => {
     const { el, flipPlacements } = this;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -356,7 +356,7 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   //
   // --------------------------------------------------------------------------
 
-  debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
+  private debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
 
   private setTransitionEl = (el): void => {
     this.transitionEl = el;

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -184,7 +184,7 @@ export class Tooltip implements FloatingUIComponent {
   //
   // --------------------------------------------------------------------------
 
-  debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
+  private debouncedReposition = debounce(() => this.reposition(), repositionDebounceTimeout);
 
   setUpReferenceElement = (warn = true): void => {
     this.removeReferences();


### PR DESCRIPTION
**Related Issue:** NA

## Summary
@dasa reported a `lodash` type error from `calcite-tooltip` when bumping the JSAPI to `beta.94`. You can see lodash being imported in the types on line 59 of [`tooltip.d.ts`](https://unpkg.com/browse/@esri/calcite-components@1.0.0-beta.94/dist/types/components/tooltip/tooltip.d.ts).

Making the method private prevents the generated interface member from having a type defined. 

Edit:
Looks like there were additional components besides `tooltip`:
![image](https://user-images.githubusercontent.com/10986395/190826308-d322ae4c-05b2-4c81-9800-9523945ac277.png)

I added a bash command to Franco's type testing PR #5062 so this won't happen again 
```bash
! grep -rnw 'dist/types' -e '<reference types='
```

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
