### PR TITLE
feat: use pointer events instead of mouse events to improve device compatibility

### DIFF
--- a/conventions/README.md
+++ b/conventions/README.md
@@ -112,6 +112,10 @@ class CompositeOrParentComponent {
 }
 ```
 
+### Interaction events
+
+Pointer events should be used in favor of mouse events to maximize device compatibility.
+
 ## Properties
 
 Private/internal properties should be annotated accordingly to avoid exposing them in the doc and/or API. You can do this by using the `@private`/`@internal` [JSDoc](https://jsdoc.app/) tags.

--- a/src/components/date-picker-day/date-picker-day.tsx
+++ b/src/components/date-picker-day/date-picker-day.tsx
@@ -94,7 +94,7 @@ export class DatePickerDay implements InteractiveComponent {
     }
   };
 
-  @Listen("mouseover")
+  @Listen("pointerover")
   mouseoverHandler(): void {
     this.calciteInternalDayHover.emit();
   }

--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -159,7 +159,7 @@ export class DatePickerMonth {
     this.activeFocus = false;
   };
 
-  @Listen("mouseout")
+  @Listen("pointerout")
   mouseoutHandler(): void {
     this.calciteInternalDatePickerMouseOut.emit();
   }

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -312,14 +312,14 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
     this.open = false;
   }
 
-  @Listen("mouseenter")
+  @Listen("pointerenter")
   mouseEnterHandler(): void {
     if (this.type === "hover") {
       this.openCalciteDropdown();
     }
   }
 
-  @Listen("mouseleave")
+  @Listen("pointerleave")
   mouseLeaveHandler(): void {
     if (this.type === "hover") {
       this.closeCalciteDropdown();

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -291,12 +291,12 @@ export class RadioButton
   //
   //--------------------------------------------------------------------------
 
-  @Listen("mouseenter")
+  @Listen("pointerenter")
   mouseenter(): void {
     this.hovered = true;
   }
 
-  @Listen("mouseleave")
+  @Listen("pointerleave")
   mouseleave(): void {
     this.hovered = false;
   }

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -145,7 +145,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
           <label
             class={{ star: true, focused, selected, average, hovered, partial }}
             htmlFor={`${this.guid}-${i}`}
-            onMouseOver={() => {
+            onPointerOver={() => {
               this.hoverValue = i;
             }}
           >
@@ -195,7 +195,7 @@ export class Rating implements LabelableComponent, FormComponent, InteractiveCom
           class="fieldset"
           disabled={disabled}
           onBlur={() => (this.hoverValue = null)}
-          onMouseLeave={() => (this.hoverValue = null)}
+          onPointerLeave={() => (this.hoverValue = null)}
           onTouchEnd={() => (this.hoverValue = null)}
         >
           <legend class="visually-hidden">{intlRating}</legend>

--- a/src/components/tile-select/tile-select.tsx
+++ b/src/components/tile-select/tile-select.tsx
@@ -200,7 +200,7 @@ export class TileSelect implements InteractiveComponent {
     }
   }
 
-  @Listen("mouseenter")
+  @Listen("pointerenter")
   mouseenter(): void {
     if (this.input.localName === "calcite-radio-button") {
       (this.input as HTMLCalciteRadioButtonElement).hovered = true;
@@ -210,7 +210,7 @@ export class TileSelect implements InteractiveComponent {
     }
   }
 
-  @Listen("mouseleave")
+  @Listen("pointerleave")
   mouseleave(): void {
     if (this.input.localName === "calcite-radio-button") {
       (this.input as HTMLCalciteRadioButtonElement).hovered = false;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Stems from https://github.com/Esri/calcite-components/pull/5320. This moves components to use pointer events for better device compatibility.