### PR TITLE
feat(panel): Add `calcitePanelClose` event and deprecate `calcitePanelDismiss` event

### DIFF
--- a/src/components/panel/panel.e2e.ts
+++ b/src/components/panel/panel.e2e.ts
@@ -73,9 +73,10 @@ describe("calcite-panel", () => {
     expect(await container.isVisible()).toBe(false);
   });
 
-  it("dismiss event should fire when closed", async () => {
+  it("close event should fire when closed", async () => {
     const page = await newE2EPage({ html: "<calcite-panel closable>test</calcite-panel>" });
 
+    const calcitePanelClose = await page.spyOnEvent("calcitePanelClose", "window");
     const calcitePanelDismiss = await page.spyOnEvent("calcitePanelDismiss", "window");
     const calcitePanelDismissedChange = await page.spyOnEvent("calcitePanelDismissedChange", "window");
 
@@ -83,6 +84,7 @@ describe("calcite-panel", () => {
 
     await closeButton.click();
 
+    expect(calcitePanelClose).toHaveReceivedEvent();
     expect(calcitePanelDismiss).toHaveReceivedEvent();
     expect(calcitePanelDismissedChange).toHaveReceivedEvent();
   });

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -234,12 +234,19 @@ export class Panel implements InteractiveComponent {
   /**
    * Fires when the close button is clicked.
    */
+  @Event({ cancelable: false }) calcitePanelClose: EventEmitter<void>;
+
+  /**
+   * Fires when the close button is clicked.
+   *
+   * @deprecated use calcitePanelClose instead.
+   */
   @Event({ cancelable: false }) calcitePanelDismiss: EventEmitter<void>;
 
   /**
    * Fires when there is a change to the `dismissed` property value .
    *
-   * @deprecated use calcitePanelDismiss instead.
+   * @deprecated use calcitePanelClose instead.
    */
   @Event({ cancelable: false }) calcitePanelDismissedChange: EventEmitter<void>;
 

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -304,6 +304,7 @@ export class Panel implements InteractiveComponent {
   close = (): void => {
     this.closed = true;
     this.calcitePanelDismiss.emit();
+    this.calcitePanelClose.emit();
   };
 
   panelScrollHandler = (): void => {


### PR DESCRIPTION
**Related Issue:** #

## Summary

feat(panel): Add `calcitePanelClose` event and deprecate `calcitePanelDismiss` event