### PR TITLE
feat(flow-item): Add `calciteFlowItemBack` event and deprecate `calciteFlowItemBackClick` event

### DIFF
--- a/src/components/flow-item/flow-item.e2e.ts
+++ b/src/components/flow-item/flow-item.e2e.ts
@@ -85,13 +85,15 @@ describe("calcite-flow-item", () => {
 
     expect(await backButtonNew.isVisible()).toBe(true);
 
-    const eventSpy = await page.spyOnEvent("calciteFlowItemBackClick", "window");
+    const calciteFlowItemBackClick = await page.spyOnEvent("calciteFlowItemBackClick", "window");
+    const calciteFlowItemBack = await page.spyOnEvent("calciteFlowItemBack", "window");
 
     await page.$eval("calcite-flow-item", (elm: HTMLElement) => {
       const nativeBackButton = elm.shadowRoot.querySelector(`calcite-action`);
       nativeBackButton.click();
     });
 
-    expect(eventSpy).toHaveReceivedEvent();
+    expect(calciteFlowItemBackClick).toHaveReceivedEvent();
+    expect(calciteFlowItemBack).toHaveReceivedEvent();
   });
 });

--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -127,6 +127,13 @@ export class FlowItem implements InteractiveComponent {
   /**
    * Fires when the back button is clicked.
    */
+  @Event({ cancelable: false }) calciteFlowItemBack: EventEmitter<void>;
+
+  /**
+   * Fires when the back button is clicked.
+   *
+   * @deprecated use calciteFlowItemBack instead.
+   */
   @Event({ cancelable: false }) calciteFlowItemBackClick: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
@@ -189,6 +196,7 @@ export class FlowItem implements InteractiveComponent {
 
   backButtonClick = (): void => {
     this.calciteFlowItemBackClick.emit();
+    this.calciteFlowItemBack.emit();
   };
 
   setBackRef = (node: HTMLCalciteActionElement): void => {


### PR DESCRIPTION
**Related Issue:** #

## Summary

feat(flow-item): Add `calciteFlowItemBack` event and deprecate `calciteFlowItemBackClick` event