### PR TITLE
ci(next): stop checking if changes pushed before publishing to npm

### DIFF
--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -27,11 +27,6 @@
     console.log(" - pushing tags...");
     await exec(`git push --atomic --follow-tags origin master`);
 
-    const changesPushed = (await exec(`git rev-parse HEAD`)) === (await exec(`git rev-parse origin/master`));
-    if (!changesPushed) {
-      throw new Error("Failed to push changes");
-    }
-
     console.log(" - publishing @next...");
     await exec(`npm run util:publish-next`);
 


### PR DESCRIPTION
**Related Issue:**

## Summary
Next hasn't actually deployed since 582. Looking at the error, it is failing a check to that makes sure the changes were pushed:
https://github.com/Esri/calcite-components/actions/runs/3050425472/jobs/4917508918#step:5:7366

However the following commit is the changes being pushed. According to the commit history we are on `next.590`. It seems like there is some lag happening between pushing and confirming that the push happened which is causing the deployment to fail right before publishing to NPM. So I'm removing that check. 

Hopefully it is an unnecessary check since we are using an atomic push which should provide a non-zero exit code of it doesn't work for any reason.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
