### PR TITLE
docs: update color-picker JSDoc link

### DIFF
--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -264,12 +264,13 @@ export class ColorPicker implements InteractiveComponent {
   /**
    * The color value.
    *
-   * This value can be either a {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color|CSS string}
+   * This value can be either a CSS color string,
    * a RGB, HSL or HSV object.
    *
    * The type will be preserved as the color is updated.
    *
    * @default "#007ac2"
+   * @see [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
    * @see [ColorValue](https://github.com/Esri/calcite-components/blob/master/src/components/color-picker/interfaces.ts#L10)
    */
   @Prop({ mutable: true }) value: ColorValue | null = defaultValue;

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -262,7 +262,7 @@ export class ColorPicker implements InteractiveComponent {
   @Prop({ reflect: true }) numberingSystem?: string;
 
   /**
-   * The color value.
+   * The component's value.
    *
    * This value can be either a CSS color string,
    * a RGB, HSL or HSV object.


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Tidy up for color-picker's `value` doc.

This also works as a side-effect fix for a build error in Stencil v2.18. 🎉 cc @driskull 