### PR TITLE
chore: specify esri product team when logging issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -91,6 +91,29 @@ body:
       options:
         - N/A
         - ArcGIS API for JavaScript
-        - ArcGIS Map Viewer
+        - ArcGIS AppStudio
+        - ArcGIS Business/Community Analyst
         - ArcGIS Dashboard
+        - ArcGIS Developer Experience
+        - ArcGIS Enterprise
+        - ArcGIS Excalibur
+        - ArcGIS Experience Builder
+        - ArcGIS Field Apps
+        - ArcGIS GeoBIM
+        - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Indoors
+        - ArcGIS Insights
+        - ArcGIS Instant Apps
+        - ArcGIS Living Atlas
+        - ArcGIS Map Viewer
+        - ArcGIS Marketplace
+        - ArcGIS Mission
+        - ArcGIS Network Analyst
+        - ArcGIS Online
+        - ArcGIS Scene Viewer
+        - ArcGIS Site Scan
+        - ArcGIS StoryMaps
+        - ArcGIS Survey123
+        - ArcGIS Urban
+        - Marketing UI

--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -80,3 +80,17 @@ body:
       placeholder: beta.1
     validations:
       required: false
+  - type: dropdown
+    id: esri-team
+    validations:
+      required: true
+    attributes:
+      label: Esri team
+      multiple: false
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A".
+      options:
+        - N/A
+        - ArcGIS API for JavaScript
+        - ArcGIS Map Viewer
+        - ArcGIS Dashboard
+        - ArcGIS Hub

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -78,6 +78,29 @@ body:
       options:
         - N/A
         - ArcGIS API for JavaScript
-        - ArcGIS Map Viewer
+        - ArcGIS AppStudio
+        - ArcGIS Business/Community Analyst
         - ArcGIS Dashboard
+        - ArcGIS Developer Experience
+        - ArcGIS Enterprise
+        - ArcGIS Excalibur
+        - ArcGIS Experience Builder
+        - ArcGIS Field Apps
+        - ArcGIS GeoBIM
+        - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Indoors
+        - ArcGIS Insights
+        - ArcGIS Instant Apps
+        - ArcGIS Living Atlas
+        - ArcGIS Map Viewer
+        - ArcGIS Marketplace
+        - ArcGIS Mission
+        - ArcGIS Network Analyst
+        - ArcGIS Online
+        - ArcGIS Scene Viewer
+        - ArcGIS Site Scan
+        - ArcGIS StoryMaps
+        - ArcGIS Survey123
+        - ArcGIS Urban
+        - Marketing UI

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -67,3 +67,17 @@ body:
       placeholder: beta.1
     validations:
       required: false
+  - type: dropdown
+    id: esri-team
+    validations:
+      required: true
+    attributes:
+      label: Esri team
+      multiple: false
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A".
+      options:
+        - N/A
+        - ArcGIS API for JavaScript
+        - ArcGIS Map Viewer
+        - ArcGIS Dashboard
+        - ArcGIS Hub

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -41,3 +41,17 @@ body:
       description: Code snippet, link to a similar product, etc.
     validations:
       required: false
+  - type: dropdown
+    id: esri-team
+    validations:
+      required: true
+    attributes:
+      label: Esri team
+      multiple: false
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A".
+      options:
+        - N/A
+        - ArcGIS API for JavaScript
+        - ArcGIS Map Viewer
+        - ArcGIS Dashboard
+        - ArcGIS Hub

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -52,6 +52,29 @@ body:
       options:
         - N/A
         - ArcGIS API for JavaScript
-        - ArcGIS Map Viewer
+        - ArcGIS AppStudio
+        - ArcGIS Business/Community Analyst
         - ArcGIS Dashboard
+        - ArcGIS Developer Experience
+        - ArcGIS Enterprise
+        - ArcGIS Excalibur
+        - ArcGIS Experience Builder
+        - ArcGIS Field Apps
+        - ArcGIS GeoBIM
+        - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Indoors
+        - ArcGIS Insights
+        - ArcGIS Instant Apps
+        - ArcGIS Living Atlas
+        - ArcGIS Map Viewer
+        - ArcGIS Marketplace
+        - ArcGIS Mission
+        - ArcGIS Network Analyst
+        - ArcGIS Online
+        - ArcGIS Scene Viewer
+        - ArcGIS Site Scan
+        - ArcGIS StoryMaps
+        - ArcGIS Survey123
+        - ArcGIS Urban
+        - Marketing UI

--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -1,0 +1,50 @@
+name: Add Esri Product Label
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        with:
+          script: |
+            const { ISSUE_BODY } = process.env;
+            if (!ISSUE_BODY) {
+              throw new Error("Could not determine the issue body")
+            }
+
+            const productRegex = new RegExp("(?<=### Esri team).*", "s");
+            const productRegexMatch = ISSUE_BODY.match(productRegex);
+
+            if (!productRegexMatch || !productRegexMatch[0]) {
+              throw new Error("Could not determine the Esri product")
+            }
+
+            const getLabel = (product) => {
+              switch (product) {
+                case "ArcGIS Map Viewer":
+                  return "MV";
+                case "ArcGIS API for JavaScript":
+                  return "JSAPI";
+                case "ArcGIS Hub":
+                  return "Hub";
+                case "ArcGIS Dashboard":
+                  return "Dashboard";
+                default:
+                  return "";
+              }
+            };
+
+            const label = getLabel(productRegexMatch[0].trim());
+
+            if (label) {
+              await github.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -23,28 +23,13 @@ jobs:
               throw new Error("Could not determine the Esri product")
             }
 
-            const getLabel = (product) => {
-              switch (product) {
-                case "ArcGIS Map Viewer":
-                  return "MV";
-                case "ArcGIS API for JavaScript":
-                  return "JSAPI";
-                case "ArcGIS Hub":
-                  return "Hub";
-                case "ArcGIS Dashboard":
-                  return "Dashboard";
-                default:
-                  return "";
-              }
-            };
+            const product = productRegexMatch[0].trim();
 
-            const label = getLabel(productRegexMatch[0].trim());
-
-            if (label) {
+            if (product && product !== "N/A") {
               await github.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: [label],
+                labels: [product],
               });
             }


### PR DESCRIPTION
**Related Issue:** #

## Summary
Adds a required dropdown field for specifying an esri product team to the bug/a11y/enhancement issue templates. A github action will parse the field and add a label for filtering.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
