### PR TITLE
ci(next releases): check types before pushing tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "util:build-docs": "npm run util:copy-icons && stencil build --config stencil.storybook.config.ts",
     "util:clean-tested-build": "npm ci && npm test && npm run build",
     "util:copy-icons": "cpy \"./node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/icon/\" --flat",
-    "util:deploy-next": "npm run util:prep-next && npm run util:push-tags && npm run util:publish-next",
+    "util:deploy-next": "npm run util:prep-next && npm run util:publish-next",
     "util:deploy-next-from-ci": "ts-node --esm support/deployNextFromCI.ts",
     "util:is-next-deployable": "ts-node --esm support/isNextDeployable.ts",
     "util:hydration-styles": "ts-node --esm support/hydrationStyles.ts",
@@ -57,7 +57,7 @@
     "util:patch-esm-resolution": "ts-node --esm support/patchESMResolution.ts",
     "util:patch-tree-shaking": "ts-node --esm support/patchTreeShaking.ts",
     "util:prep-next": "ts-node --esm support/prepReleaseCommit.ts --next && npm run build",
-    "util:publish-next": "npm run util:test-types && npm publish --tag next",
+    "util:publish-next": "npm run util:test-types && npm run util:push-tags && npm publish --tag next",
     "util:check-squash-mergeable-branch": "ts-node --esm support/checkSquashMergeableBranch.ts",
     "util:push-tags": "git push --atomic --follow-tags origin master",
     "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw 'dist/types' -e '<reference types='"

--- a/support/deployNextFromCI.ts
+++ b/support/deployNextFromCI.ts
@@ -24,10 +24,7 @@
 
     // github token provided by the checkout action
     // https://github.com/actions/checkout#usage
-    console.log(" - pushing tags...");
-    await exec(`git push --atomic --follow-tags origin master`);
-
-    console.log(" - publishing @next...");
+    console.log(" - pushes tags and publishing @next...");
     await exec(`npm run util:publish-next`);
 
     console.log("@next deployed! 🚀");


### PR DESCRIPTION
**Related Issue:** #5062

## Summary
Reorganize the `next` release NPM scripts so that they are in line with the normal release ones. The push should happen in the `util:publish-next` script so that we don't run into an issue where a version pushes but doesn't get published to NPM.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
