### PR TITLE
build(deps): bump calcite-ui-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.0.1",
-        "@esri/calcite-ui-icons": "3.19.9",
+        "@esri/calcite-ui-icons": "3.20.2",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil/eslint-plugin": "0.4.0",
         "@stencil/postcss": "2.1.0",
@@ -2245,9 +2245,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.19.9",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.19.9.tgz",
-      "integrity": "sha512-e2E0PiAi9tiZM3shymgzNlUVmkB7m8EviN+H6ZJaQh53nDd2y6YCL33E12K3diSwT+pyp8KDd6FPgza9AJ23UQ==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.2.tgz",
+      "integrity": "sha512-8usv/xhrq3dPJmfIrsaEIdq/l36LAOBgzale6KYaKRcwC5ieYtX5Olntm/BnukpuQAGoccQuDJ1Cwn2fdb3PuQ==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -33107,9 +33107,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.19.9",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.19.9.tgz",
-      "integrity": "sha512-e2E0PiAi9tiZM3shymgzNlUVmkB7m8EviN+H6ZJaQh53nDd2y6YCL33E12K3diSwT+pyp8KDd6FPgza9AJ23UQ==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.2.tgz",
+      "integrity": "sha512-8usv/xhrq3dPJmfIrsaEIdq/l36LAOBgzale6KYaKRcwC5ieYtX5Olntm/BnukpuQAGoccQuDJ1Cwn2fdb3PuQ==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.1",
-    "@esri/calcite-ui-icons": "3.19.9",
+    "@esri/calcite-ui-icons": "3.20.2",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** NA

## Summary
Bumps the icons
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
