### PR TITLE
fix(modal): drop unnecessary calcite-hydrated selector for open/close eventing

### DIFF
--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -105,7 +105,7 @@
   }
 }
 
-:host([open][calcite-hydrated]) {
+:host([open]) {
   @apply opacity-100;
   visibility: visible !important;
   transition-delay: 0ms;


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/5396

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression from https://github.com/Esri/calcite-components/pull/5187 where we forgot to remove the use of the `calcite-hydrated` selector (see https://github.com/Esri/calcite-components/pull/5187/commits/fb5e58e62f2d8882b4af986efdd35b3545c27fc9). 

**Note**: I'm not sure how we can test within this repo since it depends on building Stencil components separately

cc @Elijbet 