### PR TITLE
ci(release): add checks to keep out uncommited code

### DIFF
--- a/src/components/tile-select/tile-select.stories.ts
+++ b/src/components/tile-select/tile-select.stories.ts
@@ -158,12 +158,3 @@ export const radioWidthFull_TestOnly = (): string =>
     type="radio"
     width="full"
   ></calcite-tile-select>`;
-
-export const checked_TestOnly = (): string =>
-  html`<calcite-tile-select-group>
-    <calcite-tile-select
-      heading="Tile heading"
-      description="Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor"
-      checked
-    ></calcite-tile-select>
-  </calcite-tile-select-group>`;

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -28,7 +28,7 @@ import yargs from "yargs";
     (await exec("git status --porcelain=v1 2>/dev/null | wc -l")).stdout !== "0"
   ) {
     throw new Error(
-      "Make sure master is checked out and in line with origin/master, and that there are no uncommitted changes."
+      "Make sure the master branch is checked out, in sync with origin, and that there are no uncommitted changes."
     );
   }
 

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -23,9 +23,9 @@ import yargs from "yargs";
   const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 
   if (
-    (await exec("git rev-parse --abbrev-ref HEAD")).stdout !== "master" ||
-    (await exec("git rev-parse master")).stdout !== (await exec("git rev-parse origin/master")).stdout ||
-    (await exec("git status --porcelain=v1 2>/dev/null | wc -l")).stdout !== "0"
+    (await exec("git rev-parse --abbrev-ref HEAD")).stdout.trim() !== "master" ||
+    (await exec("git rev-parse master")).stdout.trim() !== (await exec("git rev-parse origin/master")).stdout.trim() ||
+    (await exec("git status --porcelain=v1 2>/dev/null | wc -l")).stdout.trim() !== "0"
   ) {
     throw new Error(
       "Make sure the master branch is checked out, in sync with origin, and that there are no uncommitted changes."

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -22,6 +22,16 @@ import yargs from "yargs";
   const changelogPath = quote([normalize(`${__dirname}/../CHANGELOG.md`)]);
   const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 
+  if (
+    (await exec("git rev-parse --abbrev-ref HEAD")).stdout !== "master" ||
+    (await exec("git rev-parse master")).stdout !== (await exec("git rev-parse origin/master")).stdout ||
+    (await exec("git status --porcelain=v1 2>/dev/null | wc -l")).stdout !== "0"
+  ) {
+    throw new Error(
+      "Make sure master is checked out and in line with origin/master, and that there are no uncommitted changes."
+    );
+  }
+
   const { next } = yargs(process.argv.slice(2))
     .options({ next: { type: "boolean", default: false } })
     .parseSync();


### PR DESCRIPTION
## Summary
Shockingly we don't have any sanity checks in `prepReleaseCommit` to make sure `master` is checked out and up to date, and that no uncommited changes make it into a release. I figured that out the hardway when a new story got commited with `beta.95` 😅 

I have a bash alias on my new work computer that checks out `master` and makes sure everything is up to date and clean, which is probably why this hasn't happened before. But as other people start to release we definitely want it as part of that script

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
