### PR TITLE
chore: add calcite dev/design to issue template dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -90,6 +90,8 @@ body:
       description: If you work at Esri, please select your product team. Otherwise choose "N/A".
       options:
         - N/A
+        - Calcite (dev)
+        - Calcite (design)
         - ArcGIS API for JavaScript
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -77,6 +77,8 @@ body:
       description: If you work at Esri, please select your product team. Otherwise choose "N/A".
       options:
         - N/A
+        - Calcite (dev)
+        - Calcite (design)
         - ArcGIS API for JavaScript
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -51,6 +51,8 @@ body:
       description: If you work at Esri, please select your product team. Otherwise choose "N/A".
       options:
         - N/A
+        - Calcite (dev)
+        - Calcite (design)
         - ArcGIS API for JavaScript
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst


### PR DESCRIPTION
**Related Issue:** #

## Summary
Adds dev and design Calcite team options to the issue template dropdown
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
