### PR TITLE
build(output-target): drop undocumented and deprecated dist-custom-elements-bundle output target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ hydrate/
 node_modules/
 
 # Compiled files
-support/output-targets/custom-elements/bundles/
 src/**/components.d.ts
 src/**/*.js
 __docs-temp__/*

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -77,7 +77,6 @@ export const create: () => Config = () => ({
   ],
   outputTargets: [
     { type: "dist-hydrate-script" },
-    { type: "dist-custom-elements-bundle" },
     { type: "dist-custom-elements", autoDefineCustomElements: true },
     { type: "dist" },
     { type: "docs-readme" },


### PR DESCRIPTION
# Request for comments 🗣️

**Related Issue:** https://github.com/Esri/calcite-components/issues/3957

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Removes an output target that we were [using](https://github.com/Esri/calcite-components/pull/781) [initially](https://github.com/Esri/calcite-components/pull/1499) to do what the `dist-custom-elements` output target does ([and better](https://github.com/Esri/calcite-components/pull/3224)). Our doc and examples use the supported output target, so this should not introduce breaking changes from that perspective.
