### PR TITLE
chore(i18n): small cleanups

### DIFF
--- a/conventions/Internationalization.md
+++ b/conventions/Internationalization.md
@@ -1,6 +1,6 @@
 # Internationalization (i18n)
 
-Typically, components allow users supply text values via slots and attributes, but there are cases where components need to take additional steps to support internationalization.
+Typically, components allow users to supply text values via slots and attributes, but there are cases where components need to take additional steps to support internationalization.
 
 ### Formatting
 
@@ -31,13 +31,13 @@ This pattern enables components to support built-in translations. In order to su
 
 1. Add the following translation bundles as component assets under a `t9n` folder (please refer to https://github.com/Esri/calcite-components/blob/master/conventions/README.md#assets for additional info on assets)
    1. `messages.json` – main bundle
-   1. `messages_en.json` – locale-specific bundle (kept in sync with main one via scripts)
-1. Implement the `T9nComponent` interface
+   2. `messages_en.json` – locale-specific bundle (kept in sync with main one via scripts)
+2. Implement the `T9nComponent` interface
    1. The `onMessagesChange` method must be empty as it is wired up by the support utils.
-   1. The `onMessagesChange` method must also be configured with watchers for the messages properties as well as Intl props.
-1. Use the `setUpMessages` util in the component's `componentWillLoad` lifecycle methods. This must be awaited on to have an initial set of strings available before rendering.
-1. Use the `connectMessages`/`disconnectMessages` utils in the component's `connectedCallback`/`disconnectedCallback` lifecycle methods. This will set up and tear down supporting methods on the component.
-1. Add an appropriate E2E test by using the `t9n` common test helper.
+   2. The `onMessagesChange` method must also be configured with watchers for the messages properties as well as Intl props.
+3. Use the `setUpMessages` util in the component's `componentWillLoad` lifecycle methods. This must be awaited on to have an initial set of strings available before rendering.
+4. Use the `connectMessages`/`disconnectMessages` utils in the component's `connectedCallback`/`disconnectedCallback` lifecycle methods. This will set up and tear down supporting methods on the component.
+5. Add an appropriate E2E test by using the `t9n` common test helper.
 
 #### Notes
 
@@ -50,7 +50,7 @@ This pattern enables components to support built-in translations. In order to su
 
 ## Translated strings
 
-**Note ⚠️**: this pattern deprecated and should no longer be followed for future components
+**Note ⚠️**: this pattern is deprecated and should no longer be followed for future components!
 
 In the future it will likely become necessary to provide string translations for components. An example would be the `aria-label` for the `<calcite-modal>` close button. Initial research looks promising and we could likely implement one of these approaches and set a `lang` for each component.
 

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -370,7 +370,7 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
     return html.includes("id=") ? html : html.replace(componentTag, `${componentTag} id="${id}" `);
   }
 
-  const wrappedHtml = html` <calcite-label> ${labelTitle} ${componentHtml}</calcite-label>`;
+  const wrappedHtml = html`<calcite-label> ${labelTitle} ${componentHtml}</calcite-label>`;
   const wrappedPage: E2EPage = await newE2EPage({ html: wrappedHtml });
   await wrappedPage.waitForChanges();
 
@@ -508,7 +508,7 @@ export async function formAssociated(componentTagOrHtml: TagOrHTML, options: For
   }
 
   const page = await newE2EPage({
-    html: html` <form>
+    html: html`<form>
       ${componentHtml}
       <!--
           keeping things simple by using submit-type input

--- a/src/utils/t9n.ts
+++ b/src/utils/t9n.ts
@@ -40,14 +40,11 @@ export function overridesFromIntlProps(component: T9nComponent): MessageBundle {
   Object.keys(el.constructor.prototype)
     .filter((prop) => prop.startsWith("intl"))
     .forEach((prop) => {
-      if (prop.startsWith("intl")) {
-        const assignedValue = el[prop];
-
-        if (assignedValue) {
-          let mappedProp = prop.replace("intl", "");
-          mappedProp = `${mappedProp[0].toLowerCase()}${mappedProp.slice(1)}`;
-          overrides[mappedProp] = assignedValue;
-        }
+      const assignedValue = el[prop];
+      if (assignedValue) {
+        let mappedProp = prop.replace("intl", "");
+        mappedProp = `${mappedProp[0].toLowerCase()}${mappedProp.slice(1)}`;
+        overrides[mappedProp] = assignedValue;
       }
     });
 


### PR DESCRIPTION
**Related Issue:** #5425

## Summary
A couple nitpicky cleanups for the i18n PR linked above
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
