### PR TITLE
feat(pick-list-item): add built-in translations

### DIFF
--- a/src/components/pick-list-item/pick-list-item.e2e.ts
+++ b/src/components/pick-list-item/pick-list-item.e2e.ts
@@ -1,5 +1,5 @@
 import { CSS, SLOTS } from "./resources";
-import { accessible, disabled, renders, slots, hidden } from "../../tests/commonTests";
+import { accessible, disabled, renders, slots, hidden, t9n } from "../../tests/commonTests";
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 
@@ -31,6 +31,8 @@ describe("calcite-pick-list-item", () => {
   it("has slots", () => slots("calcite-pick-list-item", SLOTS));
 
   it("can be disabled", async () => disabled("calcite-pick-list-item"));
+
+  it("supports translations", () => t9n("calcite-pick-list-item"));
 
   it("should toggle selected attribute when clicked", async () => {
     const page = await newE2EPage({ html: `<calcite-pick-list-item label="test"></calcite-pick-list-item>` });

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -147,7 +147,7 @@ export class PickListItem
    *
    * @deprecated – translations are now built-in, if you need to override a string, please use `messageOverrides`
    */
-  @Prop({ reflect: true }) intlRemove;
+  @Prop({ reflect: true }) intlRemove: string;
 
   /**
    * The component's value.

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -21,7 +21,13 @@ import {
 } from "../../utils/conditionalSlot";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { connectMessages, disconnectMessages, T9nComponent, updateMessages } from "../../utils/t9n";
+import {
+  connectMessages,
+  disconnectMessages,
+  setUpMessages,
+  T9nComponent,
+  updateMessages
+} from "../../utils/t9n";
 import { Messages } from "./assets/pick-list-item/t9n";
 
 /**
@@ -184,6 +190,10 @@ export class PickListItem
     connectLocalized(this);
     connectMessages(this);
     connectConditionalSlotComponent(this);
+  }
+
+  async componentWillLoad(): Promise<void> {
+    await setUpMessages(this);
   }
 
   disconnectedCallback(): void {

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -138,6 +138,8 @@ export class PickListItem
 
   /**
    * Accessible name for the component's remove button. Only applicable if removable is "true".
+   *
+   * @deprecated – translations are now built-in, if you need to override a string, please use `messageOverrides`
    */
   @Prop({ reflect: true }) intlRemove;
 
@@ -317,7 +319,7 @@ export class PickListItem
         icon={ICONS.remove}
         onCalciteActionClick={this.removeClickHandler}
         slot={SLOTS.actionsEnd}
-        text={this.intlRemove}
+        text={this.messages.remove}
       />
     ) : null;
   }

--- a/src/components/pick-list-item/resources.ts
+++ b/src/components/pick-list-item/resources.ts
@@ -23,7 +23,3 @@ export const SLOTS = {
   actionsEnd: "actions-end",
   actionsStart: "actions-start"
 };
-
-export const TEXT = {
-  remove: "Remove"
-};

--- a/src/components/pick-list/assets/pick-list/t9n/messages.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Filter results"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_ar.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_ar.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "بيت_Filter results_______________لاحقة"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_bg.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_bg.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "й_Filter results_______________й"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_bs.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_bs.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Č_Filter results_______________ž"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_ca.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_ca.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ó_Filter results_______________à"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_cs.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_cs.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Ř_Filter results_______________ů"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_da.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_da.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ø_Filter results_______________å"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_de.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_de.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ä_Filter results_______________Ü"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_el.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_el.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Đ_Filter results_______________ớ"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_en.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_en.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Filter results"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_es.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_es.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "á_Filter results_______________Ó"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_et.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_et.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Š_Filter results_______________ä"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_fi.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_fi.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Å_Filter results_______________ö"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_fr.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_fr.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "æ_Filter results_______________Â"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_he.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_he.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "כן_Filter results_______________ש"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_hr.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_hr.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Č_Filter results_______________ž"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_hu.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_hu.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "í_Filter results_______________ő"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_id.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_id.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ng_Filter results_______________ny"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_it.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_it.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "é_Filter results_______________È"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_ja.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_ja.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "須_Filter results_______________鷗"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_ko.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_ko.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "한_Filter results_______________빠"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_lt.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_lt.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Į_Filter results_______________š"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_lv.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_lv.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ķ_Filter results_______________ū"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_nl.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_nl.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Ĳ_Filter results_______________ä"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_no.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_no.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "å_Filter results_______________ø"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_pl.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_pl.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ł_Filter results_______________ą"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_pt-BR.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_pt-BR.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ã_Filter results_______________Ç"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_pt-PT.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_pt-PT.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ã_Filter results_______________Ç"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_ro.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_ro.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Ă_Filter results_______________ș"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_ru.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_ru.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Ж_Filter results_______________Я"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_sk.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_sk.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ĺ_Filter results_______________ľ"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_sl.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_sl.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Š_Filter results_______________č"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_sr.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_sr.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Č_Filter results_______________ž"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_sv.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_sv.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Å_Filter results_______________ö"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_th.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_th.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ก้_Filter results_______________ษฺ"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_tr.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_tr.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ı_Filter results_______________İ"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_uk.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_uk.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "ґ_Filter results_______________Ї"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_vi.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_vi.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "Đ_Filter results_______________ớ"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_zh-CN.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_zh-CN.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "试_Filter results_______________验"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_zh-HK.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_zh-HK.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "試_Filter results_______________驗"
-}

--- a/src/components/pick-list/assets/pick-list/t9n/messages_zh-TW.json
+++ b/src/components/pick-list/assets/pick-list/t9n/messages_zh-TW.json
@@ -1,3 +1,0 @@
-{
-  "filterResults": "試_Filter results_______________驗"
-}

--- a/t9nmanifest.txt
+++ b/t9nmanifest.txt
@@ -21,7 +21,6 @@ src\components\notice\assets\notice\t9n
 src\components\pagination\assets\pagination\t9n
 src\components\panel\assets\panel\t9n
 src\components\pick-list-item\assets\pick-list-item\t9n
-src\components\pick-list\assets\pick-list\t9n
 src\components\popover\assets\popover\t9n
 src\components\rating\assets\rating\t9n
 src\components\scrim\assets\scrim\t9n


### PR DESCRIPTION
**Related Issue:** #4961

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Wires up translations to the pick-list-item component.