### PR TITLE
feat(scrim): add built-in translations

### DIFF
--- a/src/components/scrim/resources.ts
+++ b/src/components/scrim/resources.ts
@@ -2,7 +2,3 @@ export const CSS = {
   scrim: "scrim",
   content: "content"
 };
-
-export const TEXT = {
-  loading: "Loading"
-};

--- a/src/components/scrim/scrim.e2e.ts
+++ b/src/components/scrim/scrim.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-scrim", () => {
@@ -18,6 +18,8 @@ describe("calcite-scrim", () => {
         defaultValue: false
       }
     ]));
+
+  it("supports translations", () => t9n("calcite-scrim"));
 
   it("shows loading component", async () => {
     const page = await newE2EPage();

--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -1,8 +1,8 @@
 import { Component, Element, Prop, h, VNode, Watch, State } from "@stencil/core";
 
 import { CSS } from "./resources";
-import { disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { disconnectMessages, setUpMessages, T9nComponent } from "../../utils/t9n";
+import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
+import { connectMessages, disconnectMessages, setUpMessages, T9nComponent } from "../../utils/t9n";
 import { Messages } from "./assets/scrim/t9n";
 
 /**
@@ -77,8 +77,8 @@ export class Scrim implements LocalizedComponent, T9nComponent {
   //--------------------------------------------------------------------------
 
   connectedCallback(): void {
-    disconnectLocalized(this);
-    disconnectMessages(this);
+    connectLocalized(this);
+    connectMessages(this);
   }
 
   async componentWillLoad(): Promise<void> {

--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -2,7 +2,13 @@ import { Component, Element, Prop, h, VNode, Watch, State } from "@stencil/core"
 
 import { CSS } from "./resources";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { connectMessages, disconnectMessages, setUpMessages, T9nComponent } from "../../utils/t9n";
+import {
+  connectMessages,
+  disconnectMessages,
+  setUpMessages,
+  T9nComponent,
+  updateMessages
+} from "../../utils/t9n";
 import { Messages } from "./assets/scrim/t9n";
 
 /**
@@ -69,6 +75,11 @@ export class Scrim implements LocalizedComponent, T9nComponent {
   @State() defaultMessages: Messages;
 
   @State() effectiveLocale = "";
+
+  @Watch("effectiveLocale")
+  effectiveLocaleChange(): void {
+    updateMessages(this, this.effectiveLocale);
+  }
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -1,6 +1,9 @@
-import { Component, Element, Prop, h, VNode } from "@stencil/core";
+import { Component, Element, Prop, h, VNode, Watch, State } from "@stencil/core";
 
-import { CSS, TEXT } from "./resources";
+import { CSS } from "./resources";
+import { LocalizedComponent } from "../../utils/locale";
+import { T9nComponent } from "../../utils/t9n";
+import { Messages } from "./assets/scrim/t9n";
 
 /**
  * @slot - A slot for adding custom content, primarily loading information.
@@ -10,7 +13,7 @@ import { CSS, TEXT } from "./resources";
   styleUrl: "scrim.scss",
   shadow: true
 })
-export class Scrim {
+export class Scrim implements LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -20,14 +23,33 @@ export class Scrim {
   /**
    * Accessible name when the component is loading.
    *
-   * @default "Loading"
+   * @deprecated – translations are now built-in, if you need to override a string, please use `messageOverrides`
    */
-  @Prop() intlLoading?: string = TEXT.loading;
+  @Prop() intlLoading?: string;
 
   /**
    * When true, a busy indicator is displayed.
    */
   @Prop({ reflect: true }) loading = false;
+
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @internal
+   */
+  @Prop({ mutable: true }) messages: Messages;
+
+  /**
+   * Use this property to override individual strings used by the component.
+   */
+  @Prop({ mutable: true }) messageOverrides: Partial<Messages>;
+
+  @Watch("intlLoading")
+  @Watch("defaultMessages")
+  @Watch("messageOverrides")
+  onMessagesChange(): void {
+    /* wired up by t9n util */
+  }
 
   // --------------------------------------------------------------------------
   //
@@ -39,14 +61,24 @@ export class Scrim {
 
   // --------------------------------------------------------------------------
   //
+  //  Private State / Properties
+  //
+  // --------------------------------------------------------------------------
+
+  @State() defaultMessages: Messages;
+
+  @State() effectiveLocale = "";
+
+  // --------------------------------------------------------------------------
+  //
   //  Render Method
   //
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const { el, loading, intlLoading } = this;
+    const { el, loading, messages } = this;
     const hasContent = el.innerHTML.trim().length > 0;
-    const loaderNode = loading ? <calcite-loader active label={intlLoading} /> : null;
+    const loaderNode = loading ? <calcite-loader active label={messages.loading} /> : null;
     const contentNode = hasContent ? (
       <div class={CSS.content}>
         <slot />

--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -11,7 +11,8 @@ import { Messages } from "./assets/scrim/t9n";
 @Component({
   tag: "calcite-scrim",
   styleUrl: "scrim.scss",
-  shadow: true
+  shadow: true,
+  assetsDirs: ["assets"]
 })
 export class Scrim implements LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
@@ -25,7 +26,7 @@ export class Scrim implements LocalizedComponent, T9nComponent {
    *
    * @deprecated – translations are now built-in, if you need to override a string, please use `messageOverrides`
    */
-  @Prop() intlLoading?: string;
+  @Prop() intlLoading: string;
 
   /**
    * When true, a busy indicator is displayed.

--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -1,8 +1,8 @@
 import { Component, Element, Prop, h, VNode, Watch, State } from "@stencil/core";
 
 import { CSS } from "./resources";
-import { LocalizedComponent } from "../../utils/locale";
-import { T9nComponent } from "../../utils/t9n";
+import { disconnectLocalized, LocalizedComponent } from "../../utils/locale";
+import { disconnectMessages, setUpMessages, T9nComponent } from "../../utils/t9n";
 import { Messages } from "./assets/scrim/t9n";
 
 /**
@@ -69,6 +69,26 @@ export class Scrim implements LocalizedComponent, T9nComponent {
   @State() defaultMessages: Messages;
 
   @State() effectiveLocale = "";
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  connectedCallback(): void {
+    disconnectLocalized(this);
+    disconnectMessages(this);
+  }
+
+  async componentWillLoad(): Promise<void> {
+    await setUpMessages(this);
+  }
+
+  disconnectedCallback(): void {
+    disconnectLocalized(this);
+    disconnectMessages(this);
+  }
 
   // --------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #4961 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Wires up translations to the scrim component.