### PR TITLE
ci(next): fix deployments by specifying master branch

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN }}
+          ref: master
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*


### PR DESCRIPTION
**Related Issue:** #5398

## Summary
The sanity checks I added in the PR linked above have been preventing `next` from deploying in our CI. Here is the error:
https://github.com/Esri/calcite-components/actions/runs/3230896841/jobs/5289848000#step:5:7451

My guess is it's failing because it's not on `master`. The other options would be uncomitted files or the local `master` branch not being in sync with `origin/master`, which don't seem as likely.

I thought it would be okay because we do checkout `master` in the action here:
https://github.com/Esri/calcite-components/blob/77e041e5b3d69dbad62c3c9b7f2d7acc446c0582/support/isNextDeployable.ts#L19

But maybe it is scoped and `master` is not staying checked out? I'm not sure. Hopefully this fixes it 🤞 


<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
