### PR TITLE
refactor: use getters and setters in NumberStringFormat

### DIFF
--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -181,11 +181,11 @@ export class Alert implements OpenCloseComponent, LocalizedComponent {
       </button>
     );
 
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       signDisplay: "always"
-    });
+    };
 
     const queueNumber = this.queueLength > 2 ? this.queueLength - 1 : 1;
     const queueText = numberStringFormatter.numberFormatter.format(queueNumber);

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -22,11 +22,11 @@ import {
   disconnectOpenCloseComponent
 } from "../../utils/openCloseComponent";
 import {
-  getSupportedNumberingSystem,
   LocalizedComponent,
   connectLocalized,
   disconnectLocalized,
-  NumberingSystem
+  NumberingSystem,
+  numberStringFormatter
 } from "../../utils/locale";
 
 /**
@@ -180,15 +180,15 @@ export class Alert implements OpenCloseComponent, LocalizedComponent {
         <calcite-icon icon="x" scale={this.scale === "l" ? "m" : "s"} />
       </button>
     );
-    const formatter = new Intl.NumberFormat(this.effectiveLocale, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 20,
-      numberingSystem: getSupportedNumberingSystem(this.numberingSystem),
+
+    numberStringFormatter.setOptions({
+      locale: this.effectiveLocale,
+      numberingSystem: this.numberingSystem,
       signDisplay: "always"
-    } as Intl.NumberFormatOptions);
+    });
 
     const queueNumber = this.queueLength > 2 ? this.queueLength - 1 : 1;
-    const queueText = formatter.format(queueNumber);
+    const queueText = numberStringFormatter.numberFormatter.format(queueNumber);
 
     const queueCount = (
       <div class={`${this.queueLength > 1 ? "active " : ""}alert-queue-count`}>

--- a/src/components/input-number/input-number.e2e.ts
+++ b/src/components/input-number/input-number.e2e.ts
@@ -881,11 +881,11 @@ describe("calcite-input-number", () => {
           const calciteInput = await page.find("calcite-input-number");
           const input = await page.find("calcite-input-number >>> input");
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
           expect(await calciteInput.getProperty("value")).toBe(value);
           expect(await input.getProperty("value")).toBe(numberStringFormatter.localize(value));
         });
@@ -899,21 +899,21 @@ describe("calcite-input-number", () => {
           const calciteInput = await page.find("calcite-input-number");
           const input = await page.find("calcite-input-number >>> input");
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: true
-          });
+          };
           expect(await calciteInput.getProperty("value")).toBe(value);
           expect(await input.getProperty("value")).toBe(numberStringFormatter.localize(value));
         });
 
         it(`allows typing valid decimal characters for ${locale} locale`, async () => {
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const page = await newE2EPage();
           await page.setContent(html`<calcite-input-number lang="${locale}"></calcite-input-number>`);
@@ -932,11 +932,11 @@ describe("calcite-input-number", () => {
         });
 
         it(`displays correct formatted value when using exponential numbers for ${locale} locale`, async () => {
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const page = await newE2EPage();
           await page.setContent(html`<calcite-input-number lang="${locale}"></calcite-input-number>`);
@@ -979,11 +979,11 @@ describe("calcite-input-number", () => {
           await typeNumberValue(page, assertedValue);
           await page.waitForChanges();
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
           expect(await calciteInput.getProperty("value")).toBe(assertedValue);
           expect(await internalLocaleInput.getProperty("value")).toBe(numberStringFormatter.localize(assertedValue));
         });
@@ -1148,11 +1148,11 @@ describe("calcite-input-number", () => {
     const input = await page.find("calcite-input-number >>> input");
     const copyInput = await page.find("#copy");
 
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: "en-US",
       numberingSystem: "latn",
       useGrouping: true
-    });
+    };
     expect(await calciteInput.getProperty("value")).toBe(initialValue);
     expect(await input.getProperty("value")).toBe(numberStringFormatter.localize(initialValue));
 

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -519,11 +519,11 @@ export class InputNumber
       return;
     }
     const value = (nativeEvent.target as HTMLInputElement).value;
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
     const delocalizedValue = numberStringFormatter.delocalize(value);
     if (nativeEvent.inputType === "insertFromPaste") {
       if (!isValidNumber(delocalizedValue)) {
@@ -579,11 +579,11 @@ export class InputNumber
       return;
     }
 
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
 
     if (event.key === numberStringFormatter.decimal) {
       if (!this.value && !this.childNumberEl.value) {
@@ -722,11 +722,11 @@ export class InputNumber
     previousValue?: string;
     value: string;
   }): void => {
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
 
     const sanitizedValue = sanitizeNumberString(
       (this.numberingSystem && this.numberingSystem !== "latn") || defaultNumberingSystem !== "latn"

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1067,11 +1067,11 @@ describe("calcite-input", () => {
           const calciteInput = await page.find("calcite-input");
           const input = await page.find("calcite-input >>> input");
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const localizedValue = numberStringFormatter.localize(value);
 
@@ -1088,11 +1088,11 @@ describe("calcite-input", () => {
           const calciteInput = await page.find("calcite-input");
           const input = await page.find("calcite-input >>> input");
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: true
-          });
+          };
 
           const localizedValue = numberStringFormatter.localize(value);
 
@@ -1101,11 +1101,11 @@ describe("calcite-input", () => {
         });
 
         it(`allows typing valid decimal characters for ${locale} locale`, async () => {
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const page = await newE2EPage();
           await page.setContent(html`<calcite-input lang="${locale}" type="number"></calcite-input>`);
@@ -1119,11 +1119,11 @@ describe("calcite-input", () => {
           await input.press("5");
           await input.press("6");
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const localizedValue = numberStringFormatter.localize(unformattedValue);
 
@@ -1132,11 +1132,11 @@ describe("calcite-input", () => {
         });
 
         it(`displays correct formatted value when using exponential numbers for ${locale} locale`, async () => {
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const page = await newE2EPage();
           await page.setContent(html`<calcite-input lang="${locale}" type="number"></calcite-input>`);
@@ -1182,11 +1182,11 @@ describe("calcite-input", () => {
           await typeNumberValue(page, assertedValue);
           await page.waitForChanges();
 
-          numberStringFormatter.setOptions({
+          numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",
             useGrouping: false
-          });
+          };
 
           const localizedValue = numberStringFormatter.localize(assertedValue);
 
@@ -1354,11 +1354,11 @@ describe("calcite-input", () => {
     const input = await page.find("calcite-input >>> input");
     const copyInput = await page.find("#copy");
 
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: "en-US",
       numberingSystem: "latn",
       useGrouping: true
-    });
+    };
 
     expect(await calciteInput.getProperty("value")).toBe(initialValue);
     expect(await input.getProperty("value")).toBe(numberStringFormatter.localize(initialValue));

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -595,11 +595,11 @@ export class Input
       return;
     }
     const value = (nativeEvent.target as HTMLInputElement).value;
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
     const delocalizedValue = numberStringFormatter.delocalize(value);
     if (nativeEvent.inputType === "insertFromPaste") {
       if (!isValidNumber(delocalizedValue)) {
@@ -654,11 +654,11 @@ export class Input
       }
       return;
     }
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
     if (event.key === numberStringFormatter.decimal) {
       if (!this.value && !this.childNumberEl.value) {
         return;
@@ -833,11 +833,11 @@ export class Input
     previousValue?: string;
     value: string;
   }): void => {
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
 
     if (this.type === "number") {
       const delocalizedValue =

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -187,11 +187,11 @@ export class Pagination implements LocalizedComponent {
    * @param value
    */
   private determineGroupSeparator = (value: number): string => {
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
       useGrouping: this.groupSeparator
-    });
+    };
 
     return this.groupSeparator
       ? numberStringFormatter.localize(value.toString())

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1433,11 +1433,11 @@ export class Slider
    */
   private determineGroupSeparator = (value: number): string => {
     if (typeof value === "number") {
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale: this.effectiveLocale,
         numberingSystem: this.numberingSystem,
         useGrouping: this.groupSeparator
-      });
+      };
 
       return numberStringFormatter.localize(value.toString());
     }

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -4,11 +4,11 @@ describe("NumberStringFormat", () => {
   locales.forEach((locale) => {
     it(`integers localize and delocalize in "${locale}"`, () => {
       const numberString = "555";
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         numberingSystem: "latn",
         useGrouping: false
-      });
+      };
       const localizedNumberString = numberStringFormatter.localize(numberString);
       const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
       expect(delocalizedNumberString).toBe(numberString);
@@ -16,11 +16,11 @@ describe("NumberStringFormat", () => {
 
     it(`negative numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "-123";
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         numberingSystem: "latn",
         useGrouping: false
-      });
+      };
       const localizedNumberString = numberStringFormatter.localize(numberString);
       const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
       expect(delocalizedNumberString).toBe(numberString);
@@ -28,11 +28,11 @@ describe("NumberStringFormat", () => {
 
     it(`floating point numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "4.321";
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         numberingSystem: "latn",
         useGrouping: false
-      });
+      };
       const localizedNumberString = numberStringFormatter.localize(numberString);
       const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
       expect(delocalizedNumberString).toBe(numberString);
@@ -40,11 +40,11 @@ describe("NumberStringFormat", () => {
 
     it(`exponential numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "2.5e-3";
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         numberingSystem: "latn",
         useGrouping: false
-      });
+      };
       const localizedNumberString = numberStringFormatter.localize(numberString);
       const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
       expect(delocalizedNumberString).toBe(numberString);
@@ -52,12 +52,12 @@ describe("NumberStringFormat", () => {
 
     it(`numbers with group separators localize and delocalize in "${locale}"`, () => {
       const numberString = "1234567890";
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         // the group separator is different in arabic depending on the numberingSystem
         numberingSystem: locale === "ar" ? "arab" : "latn",
         useGrouping: true
-      });
+      };
       const localizedNumberString = numberStringFormatter.localize(numberString);
       const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
       expect(delocalizedNumberString).toBe(numberString);
@@ -65,12 +65,12 @@ describe("NumberStringFormat", () => {
 
     it(`floating point numbers with group separators localize and delocalize in "${locale}"`, () => {
       const numberString = "12345678.9";
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         // the group separator is different in arabic depending on the numberingSystem
         numberingSystem: locale === "ar" ? "arab" : "latn",
         useGrouping: true
-      });
+      };
       const localizedNumberString = numberStringFormatter.localize(numberString);
       const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
       expect(delocalizedNumberString).toBe(numberString);

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -264,25 +264,25 @@ class NumberStringFormat {
   /** the corrected group separator */
   private _group: string;
 
-  public get group(): string {
+  get group(): string {
     return this._group;
   }
 
   private _decimal: string;
 
-  public get decimal(): string {
+  get decimal(): string {
     return this._decimal;
   }
 
   private _minusSign: string;
 
-  public get minusSign(): string {
+  get minusSign(): string {
     return this._minusSign;
   }
 
   private _digits: Array<string>;
 
-  public get digits(): Array<string> {
+  get digits(): Array<string> {
     return this._digits;
   }
 
@@ -290,20 +290,20 @@ class NumberStringFormat {
 
   private _numberFormatter: Intl.NumberFormat;
 
-  public get numberFormatter(): Intl.NumberFormat {
+  get numberFormatter(): Intl.NumberFormat {
     return this._numberFormatter;
   }
 
   private _numberFormatOptions: NumberStringFormatOptions;
 
-  public get numberFormatOptions(): NumberStringFormatOptions {
+  get numberFormatOptions(): NumberStringFormatOptions {
     return this._numberFormatOptions;
   }
 
   /**
    * numberFormatOptions needs to be set before localize/delocalize is called to ensure the options are up to date
    */
-  public set numberFormatOptions(options: NumberStringFormatOptions) {
+  set numberFormatOptions(options: NumberStringFormatOptions) {
     options.locale = getSupportedLocale(options.locale);
     options.numberingSystem = getSupportedNumberingSystem(options.numberingSystem);
 

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -245,105 +245,114 @@ function getLocale(component: LocalizedComponent): string {
   );
 }
 
-interface NumberStringFormatOptions {
+interface NumberStringFormatOptions extends Intl.NumberFormatOptions {
   numberingSystem: NumberingSystem;
   locale: string;
-  useGrouping: boolean;
 }
 
 /**
  * This util formats and parses numbers for localization
  */
 class NumberStringFormat {
-  numberingSystem: string;
-
-  locale: string;
-
-  useGrouping: boolean;
-
   /**
-   * The actual group separator for the specified locale
-   * some white space group separators don't render correctly in the browser
-   * so we replace them with a normal <SPACE>
+   * The actual group separator for the specified locale.
+   * Some white space group separators don't render correctly in the browser,
+   * so we replace them with a normal <SPACE>.
    */
-  actualGroup: string;
+  private _actualGroup: string;
 
   /** the corrected group separator */
-  group: string;
+  private _group: string;
 
-  decimal: string;
+  public get group(): string {
+    return this._group;
+  }
 
-  minusSign: string;
+  private _decimal: string;
 
-  digits: Array<string>;
+  public get decimal(): string {
+    return this._decimal;
+  }
 
-  getDigitIndex;
+  private _minusSign: string;
 
-  numberFormatter: Intl.NumberFormat;
+  public get minusSign(): string {
+    return this._minusSign;
+  }
+
+  private _digits: Array<string>;
+
+  public get digits(): Array<string> {
+    return this._digits;
+  }
+
+  private _getDigitIndex;
+
+  private _numberFormatter: Intl.NumberFormat;
+
+  public get numberFormatter(): Intl.NumberFormat {
+    return this._numberFormatter;
+  }
+
+  private _numberFormatOptions: NumberStringFormatOptions;
+
+  public get numberFormatOptions(): NumberStringFormatOptions {
+    return this._numberFormatOptions;
+  }
 
   /**
-   * This method needs to be called before localize/delocalize to ensure the options are up to date
-   *
-   * @param options
+   * numberFormatOptions needs to be set before localize/delocalize is called to ensure the options are up to date
    */
-  setOptions = (options: NumberStringFormatOptions) => {
-    const locale = getSupportedLocale(options.locale);
-    const numberingSystem = getSupportedNumberingSystem(options.numberingSystem);
+  public set numberFormatOptions(options: NumberStringFormatOptions) {
+    options.locale = getSupportedLocale(options.locale);
+    options.numberingSystem = getSupportedNumberingSystem(options.numberingSystem);
 
     // cache formatter by only recreating when options change
-    if (
-      numberingSystem === this.numberingSystem &&
-      locale === this.locale &&
-      options?.useGrouping === this.useGrouping
-    ) {
+    if (JSON.stringify(this._numberFormatOptions) === JSON.stringify(options)) {
       return;
     }
 
-    this.locale = locale;
-    this.numberingSystem = numberingSystem;
-    this.useGrouping = options.useGrouping;
+    this._numberFormatOptions = options;
 
-    this.numberFormatter = new Intl.NumberFormat(this.locale, {
-      useGrouping: this.useGrouping,
-      numberingSystem: this.numberingSystem,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 20
-    } as Intl.NumberFormatOptions);
+    this._numberFormatter = new Intl.NumberFormat(
+      this._numberFormatOptions.locale,
+      this._numberFormatOptions as Intl.NumberFormatOptions
+    );
 
-    this.digits = [
-      ...new Intl.NumberFormat(this.locale, {
+    this._digits = [
+      ...new Intl.NumberFormat(this._numberFormatOptions.locale, {
         useGrouping: false,
-        numberingSystem: this.numberingSystem
+        numberingSystem: this._numberFormatOptions.numberingSystem
       } as Intl.NumberFormatOptions).format(9876543210)
     ].reverse();
 
-    const index = new Map(this.digits.map((d, i) => [d, i]));
-    const parts = new Intl.NumberFormat(this.locale).formatToParts(-12345678.9);
+    const index = new Map(this._digits.map((d, i) => [d, i]));
+    const parts = new Intl.NumberFormat(this._numberFormatOptions.locale).formatToParts(-12345678.9);
 
-    this.actualGroup = parts.find((d) => d.type === "group").value;
+    this._actualGroup = parts.find((d) => d.type === "group").value;
     // change whitespace group characters that don't render correctly
-    this.group = this.actualGroup.trim().length === 0 ? " " : this.actualGroup;
-    this.decimal = parts.find((d) => d.type === "decimal").value;
-    this.minusSign = parts.find((d) => d.type === "minusSign").value;
-    this.getDigitIndex = (d) => index.get(d);
-  };
+    this._group = this._actualGroup.trim().length === 0 ? " " : this._actualGroup;
+    this._decimal = parts.find((d) => d.type === "decimal").value;
+    this._minusSign = parts.find((d) => d.type === "minusSign").value;
+    this._getDigitIndex = (d: string) => index.get(d);
+  }
 
   delocalize = (numberString: string) =>
     sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string =>
       nonExpoNumString
         .trim()
-        .replace(new RegExp(`[${this.minusSign}]`, "g"), "-")
-        .replace(new RegExp(`[${this.group}]`, "g"), "")
-        .replace(new RegExp(`[${this.decimal}]`, "g"), ".")
-        .replace(new RegExp(`[${this.digits.join("")}]`, "g"), this.getDigitIndex)
+        .replace(new RegExp(`[${this._minusSign}]`, "g"), "-")
+        .replace(new RegExp(`[${this._group}]`, "g"), "")
+        .replace(new RegExp(`[${this._decimal}]`, "g"), ".")
+        .replace(new RegExp(`[${this._digits.join("")}]`, "g"), this._getDigitIndex)
     );
 
   localize = (numberString: string) =>
     sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string =>
       isValidNumber(nonExpoNumString)
         ? new BigDecimal(nonExpoNumString.trim())
-            .format(this.numberFormatter)
-            .replace(new RegExp(`[${this.actualGroup}]`, "g"), this.group)
+            .format(this._numberFormatter)
+            .replace(new RegExp(`[${this._actualGroup}]`, "g"), this._group)
         : nonExpoNumString
     );
 }

--- a/src/utils/number.spec.ts
+++ b/src/utils/number.spec.ts
@@ -113,12 +113,12 @@ describe("BigDecimal", () => {
 
   locales.forEach((locale) => {
     it(`correctly localizes number parts - ${locale}`, () => {
-      numberStringFormatter.setOptions({
+      numberStringFormatter.numberFormatOptions = {
         locale,
         // the group separator is different in arabic depending on the numberingSystem
         numberingSystem: locale === "ar" ? "arab" : "latn",
         useGrouping: true
-      });
+      };
 
       const parts = new BigDecimal("-12345678.9").formatToParts(numberStringFormatter.numberFormatter);
       const groupPart = parts.find((part) => part.type === "group").value;


### PR DESCRIPTION
**Related Issue:** #5301

## Summary
Uses getter and setter methods in `NumberStringFormat` for safesies. Also caches the number formatter in `calcite-alert` by serializing and comparing the options object, and using the whole object for the `Intl.NumberFormat` options when there are changes.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
