### PR TITLE
feat(stepper, stepper-item): add numberingSystem property

### DIFF
--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -8,6 +8,7 @@ import {
   Listen,
   Method,
   Prop,
+  State,
   VNode,
   Watch
 } from "@stencil/core";
@@ -19,6 +20,12 @@ import {
   StepperItemEventDetail,
   StepperItemKeyEventDetail
 } from "../stepper/interfaces";
+import {
+  numberStringFormatter,
+  LocalizedComponent,
+  disconnectLocalized,
+  connectLocalized
+} from "../../utils/locale";
 
 /**
  * @slot - A slot for adding custom content.
@@ -28,7 +35,7 @@ import {
   styleUrl: "stepper-item.scss",
   shadow: true
 })
-export class StepperItem implements InteractiveComponent {
+export class StepperItem implements InteractiveComponent, LocalizedComponent {
   //--------------------------------------------------------------------------
   //
   //  Element
@@ -127,6 +134,8 @@ export class StepperItem implements InteractiveComponent {
   //
   //--------------------------------------------------------------------------
 
+  @State() effectiveLocale = "";
+
   headerEl: HTMLDivElement;
 
   //--------------------------------------------------------------------------
@@ -166,6 +175,7 @@ export class StepperItem implements InteractiveComponent {
   //--------------------------------------------------------------------------
 
   connectedCallback(): void {
+    connectLocalized(this);
     const { selected, active } = this;
 
     if (selected) {
@@ -193,7 +203,17 @@ export class StepperItem implements InteractiveComponent {
     updateHostInteraction(this, true);
   }
 
+  disconnectedCallback(): void {
+    disconnectLocalized(this);
+  }
+
   render(): VNode {
+    numberStringFormatter.setOptions({
+      locale: this.effectiveLocale,
+      numberingSystem: this.parentStepperEl?.numberingSystem,
+      useGrouping: false
+    });
+
     return (
       <Host
         aria-expanded={toAriaBoolean(this.active)}
@@ -210,7 +230,11 @@ export class StepperItem implements InteractiveComponent {
             }
           >
             {this.icon ? this.renderIcon() : null}
-            {this.numbered ? <div class="stepper-item-number">{this.itemPosition + 1}.</div> : null}
+            {this.numbered ? (
+              <div class="stepper-item-number">
+                {numberStringFormatter.numberFormatter.format(this.itemPosition + 1)}.
+              </div>
+            ) : null}
             <div class="stepper-item-header-text">
               <span class="stepper-item-heading">{this.heading || this.itemTitle}</span>
               <span class="stepper-item-description">{this.description || this.itemSubtitle}</span>

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -136,6 +136,15 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent {
 
   @State() effectiveLocale = "";
 
+  @Watch("effectiveLocale")
+  effectiveLocaleWatcher(locale: string): void {
+    numberStringFormatter.numberFormatOptions = {
+      locale,
+      numberingSystem: this.parentStepperEl?.numberingSystem,
+      useGrouping: false
+    };
+  }
+
   headerEl: HTMLDivElement;
 
   //--------------------------------------------------------------------------
@@ -208,12 +217,6 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent {
   }
 
   render(): VNode {
-    numberStringFormatter.numberFormatOptions = {
-      locale: this.effectiveLocale,
-      numberingSystem: this.parentStepperEl?.numberingSystem,
-      useGrouping: false
-    };
-
     return (
       <Host
         aria-expanded={toAriaBoolean(this.active)}

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -208,11 +208,11 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent {
   }
 
   render(): VNode {
-    numberStringFormatter.setOptions({
+    numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.parentStepperEl?.numberingSystem,
       useGrouping: false
-    });
+    };
 
     return (
       <Host

--- a/src/components/stepper/stepper.stories.ts
+++ b/src/components/stepper/stepper.stories.ts
@@ -1,5 +1,5 @@
 import { select, text } from "@storybook/addon-knobs";
-import { boolean, createSteps, stepStory, storyFilters } from "../../../.storybook/helpers";
+import { boolean, storyFilters } from "../../../.storybook/helpers";
 import { themesDarkDefault } from "../../../.storybook/utils";
 import readme1 from "./readme.md";
 import readme2 from "../stepper-item/readme.md";
@@ -133,15 +133,6 @@ export const darkThemeRTL_TestOnly = (): string => html`
 
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
 
-export const minHeight_TestOnly = stepStory(
-  (): string => html`<calcite-stepper style="min-height: 500px;">
-    <calcite-stepper-item item-title="Title one" id="one"> Step one </calcite-stepper-item>
-    <calcite-stepper-item item-title="Title two"> Step two </calcite-stepper-item>
-    <calcite-stepper-item item-title="Title three"> Step three </calcite-stepper-item>
-  </calcite-stepper>`,
-  createSteps("calcite-stepper").click("#one").snapshot("stepper with min-height")
-);
-
 export const overriddenWidth_TestOnly = (): string => html` <calcite-stepper numbered style="width: 50vw">
   <calcite-stepper-item item-title="Choose method" item-subtitle="Add members without sending invitations" complete>
     <calcite-notice active width="full">
@@ -170,4 +161,15 @@ export const disabled_TestOnly = (): string => html`<calcite-stepper>
   <calcite-stepper-item item-title="item2">2</calcite-stepper-item>
   <calcite-stepper-item item-title="item3" active>3</calcite-stepper-item>
   <calcite-stepper-item item-title="item4" disabled>4</calcite-stepper-item>
+</calcite-stepper>`;
+
+export const arabicNumberingSystem_TestOnly = (): string => html`<calcite-stepper
+  numbered
+  numbering-system="arab"
+  lang="ar"
+>
+  <calcite-stepper-item item-title="Maps" complete>Content one</calcite-stepper-item>
+  <calcite-stepper-item item-title="Forms">Content two</calcite-stepper-item>
+  <calcite-stepper-item item-title="Tables" active>Content three</calcite-stepper-item>
+  <calcite-stepper-item item-title="Graphs">Content four</calcite-stepper-item>
 </calcite-stepper>`;

--- a/src/components/stepper/stepper.stories.ts
+++ b/src/components/stepper/stepper.stories.ts
@@ -163,13 +163,31 @@ export const disabled_TestOnly = (): string => html`<calcite-stepper>
   <calcite-stepper-item item-title="item4" disabled>4</calcite-stepper-item>
 </calcite-stepper>`;
 
-export const arabicNumberingSystem_TestOnly = (): string => html`<calcite-stepper
+export const arabicNumberingSystem_TestOnly = (): string => html` <calcite-stepper
   numbered
   numbering-system="arab"
   lang="ar"
+  dir="rtl"
+  scale="s"
 >
-  <calcite-stepper-item item-title="Maps" complete>Content one</calcite-stepper-item>
-  <calcite-stepper-item item-title="Forms">Content two</calcite-stepper-item>
-  <calcite-stepper-item item-title="Tables" active>Content three</calcite-stepper-item>
-  <calcite-stepper-item item-title="Graphs">Content four</calcite-stepper-item>
+  <calcite-stepper-item item-title="الخطوةالاولى" complete>
+    <calcite-notice active width="full">
+      <div slot="message">الخطوة الأولى للمحتوى هنا</div>
+    </calcite-notice>
+  </calcite-stepper-item>
+  <calcite-stepper-item item-title="الخطوة الثانية" complete>
+    <calcite-notice active width="full">
+      <div slot="message">الخطوة الثانية للمحتوى هنا</div>
+    </calcite-notice>
+  </calcite-stepper-item>
+  <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+    <calcite-notice active width="full">
+      <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
+    </calcite-notice>
+  </calcite-stepper-item>
+  <calcite-stepper-item item-title="الخطوة الرابعة">
+    <calcite-notice active width="full">
+      <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
+    </calcite-notice>
+  </calcite-stepper-item>
 </calcite-stepper>`;

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -13,6 +13,7 @@ import {
 import { Layout, Scale } from "../interfaces";
 import { StepperItemChangeEventDetail, StepperItemKeyEventDetail } from "./interfaces";
 import { focusElement } from "../../utils/dom";
+import { NumberingSystem } from "../../utils/locale";
 
 /**
  * @slot - A slot for adding `calcite-stepper-item`s.
@@ -45,6 +46,11 @@ export class Stepper {
 
   /** When true, displays the step number in the `calcite-stepper-item` heading. */
   @Prop({ reflect: true }) numbered = false;
+
+  /**
+   * Specifies the Unicode numeral system used by the component for localization.
+   */
+  @Prop({ reflect: true }) numberingSystem?: NumberingSystem;
 
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";

--- a/src/demos/stepper.html
+++ b/src/demos/stepper.html
@@ -278,26 +278,28 @@
         <div class="child-flex right-aligned-text">Arabic numbering system</div>
 
         <div class="child-flex">
-          <calcite-stepper-item item-title="الخطوةالاولى" complete>
-            <calcite-notice active width="full">
-              <div slot="message">الخطوة الأولى للمحتوى هنا</div>
-            </calcite-notice>
-          </calcite-stepper-item>
-          <calcite-stepper-item item-title="الخطوة الثانية" complete>
-            <calcite-notice active width="full">
-              <div slot="message">الخطوة الثانية للمحتوى هنا</div>
-            </calcite-notice>
-          </calcite-stepper-item>
-          <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
-            <calcite-notice active width="full">
-              <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
-            </calcite-notice>
-          </calcite-stepper-item>
-          <calcite-stepper-item item-title="الخطوة الرابعة">
-            <calcite-notice active width="full">
-              <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
-            </calcite-notice>
-          </calcite-stepper-item>
+          <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="m">
+            <calcite-stepper-item item-title="الخطوةالاولى" complete>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الأولى للمحتوى هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الثانية" complete>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الثانية للمحتوى هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الرابعة">
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
         </div>
       </div>
 
@@ -423,7 +425,7 @@
         <div class="child-flex right-aligned-text">Arabic numbering system</div>
 
         <div class="child-flex">
-          <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="m">
+          <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="l">
             <calcite-stepper-item item-title="الخطوةالاولى" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الأولى للمحتوى هنا</div>

--- a/src/demos/stepper.html
+++ b/src/demos/stepper.html
@@ -126,6 +126,36 @@
         </div>
       </div>
 
+      <!-- Arabic numberingSystem -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">Arabic numbering system</div>
+
+        <div class="child-flex">
+          <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="s">
+            <calcite-stepper-item item-title="الخطوةالاولى" complete>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الأولى للمحتوى هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الثانية" complete>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الثانية للمحتوى هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الرابعة">
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+      </div>
+
       <!-- disabled -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">disabled</div>
@@ -243,6 +273,34 @@
         </div>
       </div>
 
+      <!-- Arabic numberingSystem -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">Arabic numbering system</div>
+
+        <div class="child-flex">
+          <calcite-stepper-item item-title="الخطوةالاولى" complete>
+            <calcite-notice active width="full">
+              <div slot="message">الخطوة الأولى للمحتوى هنا</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="الخطوة الثانية" complete>
+            <calcite-notice active width="full">
+              <div slot="message">الخطوة الثانية للمحتوى هنا</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+            <calcite-notice active width="full">
+              <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+          <calcite-stepper-item item-title="الخطوة الرابعة">
+            <calcite-notice active width="full">
+              <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
+            </calcite-notice>
+          </calcite-stepper-item>
+        </div>
+      </div>
+
       <!-- disabled -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">disabled</div>
@@ -354,6 +412,36 @@
             <calcite-stepper-item item-title="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+          </calcite-stepper>
+        </div>
+      </div>
+
+      <!-- Arabic numberingSystem -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">Arabic numbering system</div>
+
+        <div class="child-flex">
+          <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="m">
+            <calcite-stepper-item item-title="الخطوةالاولى" complete>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الأولى للمحتوى هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الثانية" complete>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الثانية للمحتوى هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
+              </calcite-notice>
+            </calcite-stepper-item>
+            <calcite-stepper-item item-title="الخطوة الرابعة">
+              <calcite-notice active width="full">
+                <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
           </calcite-stepper>


### PR DESCRIPTION
**Related Issue:** #4893

## Summary
Adds `numberingSystem` property to `calcite-stepper`. A couple lines in `calcite-stepper-item` will need to be changed due to a refactor in #5466. The small change can go in which ever PR is merged last.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
