### PR TITLE
fix(block): improve content layout

### DIFF
--- a/src/components/block/block.scss
+++ b/src/components/block/block.scss
@@ -129,9 +129,12 @@ calcite-handle {
   @apply text-color-1;
 }
 
+.container {
+  @apply flex flex-col h-full;
+}
+
 .content {
-  @apply animate-in
-    relative;
+  @apply animate-in flex-1 relative;
 }
 
 .content--spaced {

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -203,7 +203,7 @@ export const darkThemeRTL_TestOnly = (): string =>
     `
   );
 
-export const canSetFullHeight_TestOnly = (): string =>
+export const contentCanTakeFullHeight_TestOnly = (): string =>
   html`<calcite-block open heading="Heading" summary="summary" style="height: 250px">
     <div style="background: red; height: 100%;">should take full width of the content area</div>
   </calcite-block>`;

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -202,3 +202,8 @@ export const darkThemeRTL_TestOnly = (): string =>
       </calcite-block-section>
     `
   );
+
+export const canSetFullHeight_TestOnly = (): string =>
+  html`<calcite-block open heading="Heading" summary="summary" style="height: 250px">
+    <div style="background: red; height: 100%;">should take full width of the content area</div>
+  </calcite-block>`;

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -290,7 +290,7 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
         <article
           aria-busy={toAriaBoolean(loading)}
           class={{
-            [CSS.article]: true
+            [CSS.container]: true
           }}
         >
           {headerNode}

--- a/src/components/block/resources.ts
+++ b/src/components/block/resources.ts
@@ -1,5 +1,5 @@
 export const CSS = {
-  article: "article",
+  container: "container",
   content: "content",
   headerContainer: "header-container",
   icon: "icon",


### PR DESCRIPTION
**Related Issue:** #5422 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This improves layout of block's content area.