### PR TITLE
refactor(block): move hardcoded classes to CSS object

### DIFF
--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -298,8 +298,8 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
             aria-expanded={toAriaBoolean(open)}
             aria-labelledby={buttonId}
             class={{
-              content: true,
-              "content--spaced": !this.disablePadding
+              [CSS.content]: true,
+              [CSS.contentSpaced]: !this.disablePadding
             }}
             hidden={!open}
             id={regionId}

--- a/src/components/block/resources.ts
+++ b/src/components/block/resources.ts
@@ -1,6 +1,7 @@
 export const CSS = {
   article: "article",
   content: "content",
+  contentSpaced: "content--spaced",
   headerContainer: "header-container",
   icon: "icon",
   statusIcon: "status-icon",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

✨🧹✨