### PR TITLE
fix(input, input-number, input-text): fix input icons not displaying properly in Firefox

### DIFF
--- a/src/components/input-number/input-number.scss
+++ b/src/components/input-number/input-number.scss
@@ -163,13 +163,10 @@
   @apply transition-default
     pointer-events-none
     absolute
-    block;
-}
+    block
 
-.icon,
-.resize-icon-wrapper {
-  // needed for firefox to display the icon properly
-  @apply z-default;
+    // needed for firefox to display the icon properly
+    z-default;
 }
 
 .clear-button {

--- a/src/components/input-number/input-number.scss
+++ b/src/components/input-number/input-number.scss
@@ -166,6 +166,12 @@
     block;
 }
 
+.icon,
+.resize-icon-wrapper {
+  // needed for firefox to display the icon properly
+  @apply z-default;
+}
+
 .clear-button {
   pointer-events: initial;
   @apply focus-base

--- a/src/components/input-number/input-number.scss
+++ b/src/components/input-number/input-number.scss
@@ -165,8 +165,7 @@
     absolute
     block
 
-    // needed for firefox to display the icon properly
-    z-default;
+    z-default; // needed for firefox to display the icon properly
 }
 
 .clear-button {

--- a/src/components/input-text/input-text.scss
+++ b/src/components/input-text/input-text.scss
@@ -162,8 +162,7 @@ input:focus {
     absolute
     block
 
-    // needed for firefox to display the icon properly
-    z-default;
+    z-default; // needed for firefox to display the icon properly
 }
 
 // hide browser default clear

--- a/src/components/input-text/input-text.scss
+++ b/src/components/input-text/input-text.scss
@@ -160,13 +160,10 @@ input:focus {
   @apply transition-default
     pointer-events-none
     absolute
-    block;
-}
+    block
 
-.icon,
-.resize-icon-wrapper {
-  // needed for firefox to display the icon properly
-  @apply z-default;
+    // needed for firefox to display the icon properly
+    z-default;
 }
 
 // hide browser default clear

--- a/src/components/input-text/input-text.scss
+++ b/src/components/input-text/input-text.scss
@@ -163,6 +163,12 @@ input:focus {
     block;
 }
 
+.icon,
+.resize-icon-wrapper {
+  // needed for firefox to display the icon properly
+  @apply z-default;
+}
+
 // hide browser default clear
 
 input[type="text"]::-ms-clear,

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -221,8 +221,7 @@
 
 .icon,
 .resize-icon-wrapper {
-  // needed for firefox to display the icon properly
-  @apply z-default;
+  @apply z-default; // needed for firefox to display the icon properly
 }
 
 // hide browser default clear

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -216,8 +216,13 @@
   @apply transition-default
     pointer-events-none
     absolute
-    block
-    z-default;
+    block;
+}
+
+.icon,
+.resize-icon-wrapper {
+  // needed for firefox to display the icon properly
+  @apply z-default;
 }
 
 // hide browser default clear

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -216,7 +216,8 @@
   @apply transition-default
     pointer-events-none
     absolute
-    block;
+    block
+    z-default;
 }
 
 // hide browser default clear


### PR DESCRIPTION
**Related Issue:** #5417

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

https://github.com/Esri/calcite-components/pull/5058 introduced a regression when it removed the z-indices for input icons as Chrome rendered fine during testing. This fixes it and adds a note regarding its use.