### PR TITLE
ci(next): clean docs build before deployment

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -37,6 +37,10 @@ jobs:
               git config --global user.name "github-actions[bot]"
               # deploy storybook, but still release next if it fails
               { npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GH_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true
+
+              # remove the build to ./docs after storybook deploys to gh-pages
+              # if there are changes the git sanity checks will prevent deployment
+              cd ./docs && git clean -fd
               npm run util:deploy-next-from-ci
             fi
           else

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -22,21 +22,19 @@ import yargs from "yargs";
   const changelogPath = quote([normalize(`${__dirname}/../CHANGELOG.md`)]);
   const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 
-  const { next } = yargs(process.argv.slice(2))
-    .options({ next: { type: "boolean", default: false } })
-    .parseSync();
-
   if (
-    !next && // next releases already have sanity checks in `isNextDeployable.ts`
-    ((await exec("git rev-parse --abbrev-ref HEAD")).stdout.trim() !== "master" ||
-      (await exec("git rev-parse master")).stdout.trim() !==
-        (await exec("git rev-parse origin/master")).stdout.trim() ||
-      (await exec("git status --porcelain=v1 2>/dev/null | wc -l")).stdout.trim() !== "0")
+    (await exec("git rev-parse --abbrev-ref HEAD")).stdout.trim() !== "master" ||
+    (await exec("git rev-parse master")).stdout.trim() !== (await exec("git rev-parse origin/master")).stdout.trim() ||
+    (await exec("git status --porcelain=v1 2>/dev/null | wc -l")).stdout.trim() !== "0"
   ) {
     throw new Error(
       "Make sure the master branch is checked out, in sync with origin, and that there are no uncommitted changes."
     );
   }
+
+  const { next } = yargs(process.argv.slice(2))
+    .options({ next: { type: "boolean", default: false } })
+    .parseSync();
 
   // deepen the history when fetching tags due to shallow clone
   await exec("git fetch --deepen=250 --tags");


### PR DESCRIPTION
**Related Issue:** #5460

## Summary
PR linked above didn't fix next deployments 😞. It looks like it is failing because `npm run build-storybook` is running before the deployment, which builds to `./docs`. The check fails if there are uncomitted changes so removing the changes to ./docs should fix the issue.