### PR TITLE
ci: automatically create product label when added after submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -87,11 +87,9 @@ body:
     attributes:
       label: Esri team
       multiple: false
-      description: If you work at Esri, please select your product team. Otherwise choose "N/A".
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A". If your team is not listed, choose "N/A", and then edit the line after submitting the issue.
       options:
         - N/A
-        - Calcite (dev)
-        - Calcite (design)
         - ArcGIS API for JavaScript
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
@@ -119,3 +117,5 @@ body:
         - ArcGIS Survey123
         - ArcGIS Urban
         - Marketing UI
+        - Calcite (dev)
+        - Calcite (design)

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -74,11 +74,9 @@ body:
     attributes:
       label: Esri team
       multiple: false
-      description: If you work at Esri, please select your product team. Otherwise choose "N/A".
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A". If your team is not listed, choose "N/A", and then edit the line after submitting the issue.
       options:
         - N/A
-        - Calcite (dev)
-        - Calcite (design)
         - ArcGIS API for JavaScript
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
@@ -106,3 +104,5 @@ body:
         - ArcGIS Survey123
         - ArcGIS Urban
         - Marketing UI
+        - Calcite (dev)
+        - Calcite (design)

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -48,11 +48,9 @@ body:
     attributes:
       label: Esri team
       multiple: false
-      description: If you work at Esri, please select your product team. Otherwise choose "N/A".
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A". If your team is not listed, choose "N/A", and then edit the line after submitting the issue.
       options:
         - N/A
-        - Calcite (dev)
-        - Calcite (design)
         - ArcGIS API for JavaScript
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
@@ -80,3 +78,5 @@ body:
         - ArcGIS Survey123
         - ArcGIS Urban
         - Marketing UI
+        - Calcite (dev)
+        - Calcite (design)

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -42,3 +42,42 @@ body:
       description: Code snippet, link to a similar product, suggestions, etc.
     validations:
       required: false
+  - type: dropdown
+    id: esri-team
+    validations:
+      required: true
+    attributes:
+      label: Esri team
+      multiple: false
+      description: If you work at Esri, please select your product team. Otherwise choose "N/A". If your team is not listed, choose "N/A", and then edit the line after submitting the issue.
+      options:
+        - N/A
+        - ArcGIS API for JavaScript
+        - ArcGIS AppStudio
+        - ArcGIS Business/Community Analyst
+        - ArcGIS Dashboard
+        - ArcGIS Developer Experience
+        - ArcGIS Enterprise
+        - ArcGIS Excalibur
+        - ArcGIS Experience Builder
+        - ArcGIS Field Apps
+        - ArcGIS GeoBIM
+        - ArcGIS GeoPlanner
+        - ArcGIS Hub
+        - ArcGIS Indoors
+        - ArcGIS Insights
+        - ArcGIS Instant Apps
+        - ArcGIS Living Atlas
+        - ArcGIS Map Viewer
+        - ArcGIS Marketplace
+        - ArcGIS Mission
+        - ArcGIS Network Analyst
+        - ArcGIS Online
+        - ArcGIS Scene Viewer
+        - ArcGIS Site Scan
+        - ArcGIS StoryMaps
+        - ArcGIS Survey123
+        - ArcGIS Urban
+        - Marketing UI
+        - Calcite (dev)
+        - Calcite (design)

--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -3,33 +3,61 @@ on:
   issues:
     types: [opened, edited]
 jobs:
-  assign:
+  label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v4
-        env:
-          ISSUE_BODY: ${{ github.event.issue.body }}
         with:
           script: |
-            const { ISSUE_BODY } = process.env;
-            if (!ISSUE_BODY) {
-              throw new Error("Could not determine the issue body")
+            const {
+              repo: { owner, repo },
+              payload: {
+                issue: { body, labels: currentLabels, number: issue_number },
+              },
+            } = context;
+
+            if (!body) {
+              throw new Error("Could not determine the issue body");
             }
 
-            const productRegex = new RegExp("(?<=### Esri team).*", "s");
-            const productRegexMatch = ISSUE_BODY.match(productRegex);
+            const productRegex = new RegExp("(?<=### Esri team\r\n\r\n).+", "m");
+            const productRegexMatch = body.match(productRegex);
 
             if (!productRegexMatch || !productRegexMatch[0]) {
-              throw new Error("Could not determine the Esri product")
+              throw new Error("Could not determine the Esri product");
             }
 
             const product = productRegexMatch[0].trim();
 
             if (product && product !== "N/A") {
-              await github.issues.addLabels({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: [product],
+              /** Creates a label if it does not exist */
+              try {
+                await github.issues.getLabel({
+                  owner,
+                  repo,
+                  name: product,
+                });
+              } catch (e) {
+                await github.issues.createLabel({
+                  owner,
+                  repo,
+                  name: product,
+                  color: "006B75",
+                  description: `Issues logged by ${product} team members.`,
+                });
+              }
+
+              /** remove any existing product label(s) */
+              const labels = currentLabels
+                .filter((l) => !/Issues logged by/.test(l.description))
+                .map((l) => l.name);
+
+              labels.push(product);
+
+              await github.issues.setLabels({
+                issue_number,
+                owner,
+                repo,
+                labels,
               });
             }


### PR DESCRIPTION
**Related Issue:** #

## Summary
If a team label does not exist, the user can edit it in after submitting the issue and the label will be automatically created. This also moves the `Calcite (dev)` and `Calcite (design)` options to the bottom of the list, since some people were selecting them w/o reading the prompt.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
