### PR TITLE
fix(flow-item, panel): fix layout issue that would cause double scrollbars

### DIFF
--- a/src/components/flow-item/flow-item.stories.ts
+++ b/src/components/flow-item/flow-item.stories.ts
@@ -13,7 +13,7 @@ import { html } from "../../../support/formatting";
 import { storyFilters } from "../../../.storybook/helpers";
 
 export default {
-  title: "Components/Panel",
+  title: "Components/Flow Item",
   parameters: {
     notes: readme
   },
@@ -110,7 +110,7 @@ const footerHTML = html`
   <calcite-button slot="${SLOTS.footer}" width="half">Yeah!</calcite-button>
 `;
 
-const panelContent = `${headerHTML}
+const flowItemContent = `${headerHTML}
   <calcite-action text="Action" label="Action" slot="${SLOTS.headerActionsStart}" icon="bluetooth"></calcite-action>
   <calcite-action text="Action" label="Action" slot="${SLOTS.headerActionsEnd}" icon="attachment"></calcite-action>
   ${contentHTML}
@@ -118,7 +118,7 @@ const panelContent = `${headerHTML}
 
 export const simple = (): string =>
   create(
-    "calcite-panel",
+    "calcite-flow-item",
     createAttributes(),
     html`
       ${headerHTML}
@@ -132,7 +132,7 @@ export const simple = (): string =>
 
 export const onlyProps = (): string => html`
   <div style="width: 300px;">
-    <calcite-panel
+    <calcite-flow-item
       height-scale="s"
       heading-level="${text("heading-level", "2")}"
       summary="${text(
@@ -141,21 +141,21 @@ export const onlyProps = (): string => html`
       )}"
       heading="${text(
         "heading",
-        "Panel title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
+        "flowItem title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
       )}"
     />
   </div>
 `;
 
 export const disabledWithStyledSlot_TestOnly = (): string => html`
-  <calcite-panel style="height: 100%;" heading="Heading" disabled>
+  <calcite-flow-item style="height: 100%;" heading="Heading" disabled>
     <div id="content" style="height: 100%;">${contentHTML}</div>
-  </calcite-panel>
+  </calcite-flow-item>
 `;
 
 export const darkThemeRTL_TestOnly = (): string =>
   create(
-    "calcite-panel",
+    "calcite-flow-item",
     createAttributes({ exceptions: ["dir", "class"] }).concat([
       {
         name: "dir",
@@ -166,7 +166,7 @@ export const darkThemeRTL_TestOnly = (): string =>
         value: "calcite-theme-dark"
       }
     ]),
-    panelContent
+    flowItemContent
   );
 
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
@@ -188,7 +188,7 @@ export const noDoubleScrollbars_TestOnly = (): string => html`
   </style>
   <div id="container">
     <calcite-flow>
-      <calcite-panel heading="Example">
+      <calcite-flow-item heading="Example">
         <div>### Stickied Content e.g. toolbar</div>
         <div class="content">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sapien lectus, ultricies a molestie nec,
@@ -213,7 +213,7 @@ export const noDoubleScrollbars_TestOnly = (): string => html`
           sodales viverra lectus efficitur vitae. Nam molestie, neque consequat mollis pulvinar, sapien sem semper nunc,
           et euismod enim sem vitae ligula.
         </div>
-      </calcite-panel>
+      </calcite-flow-item>
     </calcite-flow>
   </div>
 `;

--- a/src/components/flow-item/flow-item.stories.ts
+++ b/src/components/flow-item/flow-item.stories.ts
@@ -9,6 +9,7 @@ import {
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import readme from "./readme.md";
 import { SLOTS, TEXT } from "./resources";
+import { TEXT as PANEL_TEXT } from "../panel/resources";
 import { html } from "../../../support/formatting";
 import { storyFilters } from "../../../.storybook/helpers";
 
@@ -68,7 +69,11 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
       {
         name: "intl-close",
         commit(): Attribute {
-          this.value = text("intlClose", TEXT.close);
+          this.value = text(
+            "intlClose",
+            /* reusing `calcite-panel`'s value due to the current implementation */
+            PANEL_TEXT.close
+          );
           delete this.build;
           return this;
         }

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -597,7 +597,7 @@ export class Panel implements InteractiveComponent {
     const showFooter = hasFooterContent || hasFooterActions;
 
     return (
-      <footer class={CSS.footer} hidden={!showFooter} key="footer">
+      <footer class={CSS.footer} hidden={!showFooter}>
         <slot key="footer-slot" name={SLOTS.footer} onSlotchange={this.handleFooterSlotChange} />
         <slot
           key="footer-actions-slot"
@@ -622,8 +622,6 @@ export class Panel implements InteractiveComponent {
     const { hasFab } = this;
 
     const defaultSlotNode: VNode = <slot key="default-slot" />;
-    const contentWrapperKey = "content-wrapper";
-
     const containerNode = hasFab ? (
       <section class={CSS.contentContainer}>{defaultSlotNode}</section>
     ) : (
@@ -632,8 +630,11 @@ export class Panel implements InteractiveComponent {
 
     return (
       <div
-        class={{ [CSS.contentWrapper]: true, [CSS.contentHeight]: true }}
-        key={contentWrapperKey}
+        class={{
+          [CSS.contentWrapper]: true,
+          [CSS.contentContainer]: !hasFab,
+          [CSS.contentHeight]: hasFab
+        }}
         onScroll={this.panelScrollHandler}
         ref={this.setPanelScrollEl}
       >


### PR DESCRIPTION
**Related Issue:** #5428

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

https://github.com/Esri/calcite-components/pull/5129 refactored panel's content rendering function and it missed toggling some CSS classes on the parent node based on whether there was a fab or not (before: https://github.com/Esri/calcite-components/blob/6f6316c8532e1876aadc63f71c3e4095db2af3b6~/src/components/panel/panel.tsx#L533 + https://github.com/Esri/calcite-components/blob/6f6316c8532e1876aadc63f71c3e4095db2af3b6~/src/components/panel/panel.tsx#L523; after: https://github.com/Esri/calcite-components/blob/6f6316c8532e1876aadc63f71c3e4095db2af3b6/src/components/panel/panel.tsx#L629 ).

**Notable changes:**

- adds missing flow-item stories (to include in screenshot testing)
- removes unnecessary keys for nodes that are no longer conditionally rendered

cc @driskull 