### PR TITLE
fix(flow-item): fix scrollContentTo

### DIFF
--- a/src/components/flow-item/flow-item.e2e.ts
+++ b/src/components/flow-item/flow-item.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, focusable, hidden, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-flow-item", () => {
   it("renders", async () => renders("calcite-flow-item", { display: "flex" }));
@@ -95,5 +96,49 @@ describe("calcite-flow-item", () => {
 
     expect(calciteFlowItemBackClick).toHaveReceivedEvent();
     expect(calciteFlowItemBack).toHaveReceivedEvent();
+  });
+
+  it("allows scrolling content", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-flow style="height: 300px">
+        <calcite-flow-item heading="Flow heading" id="flowOrPanel">
+          <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+            <calcite-notice active>
+              <div slot="message">An excellent assortment of content.</div>
+            </calcite-notice>
+          </calcite-block>
+          <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+            <calcite-notice active>
+              <div slot="message">An excellent assortment of content.</div>
+            </calcite-notice>
+          </calcite-block>
+          <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+            <calcite-notice active>
+              <div slot="message">An excellent assortment of content.</div>
+            </calcite-notice>
+          </calcite-block>
+          <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+            <calcite-notice active>
+              <div slot="message">An excellent assortment of content.</div>
+            </calcite-notice>
+          </calcite-block>
+        </calcite-flow-item>
+      </calcite-flow>
+    `);
+    const [top, _middle, bottom] = await page.findAll("calcite-block");
+
+    await bottom.callMethod("scrollIntoView");
+
+    expect(await top.isIntersectingViewport()).toBe(false);
+
+    await page.$eval("calcite-flow-item", (panel: HTMLCalcitePanelElement) =>
+      panel.scrollContentTo({
+        top: 0,
+        behavior: "auto"
+      })
+    );
+
+    expect(await top.isIntersectingViewport()).toBe(true);
   });
 });

--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -188,7 +188,7 @@ export class FlowItem implements InteractiveComponent {
    */
   @Method()
   async scrollContentTo(options?: ScrollToOptions): Promise<void> {
-    this.containerEl?.scrollContentTo(options);
+    await this.containerEl?.scrollContentTo(options);
   }
 
   // --------------------------------------------------------------------------
@@ -209,6 +209,10 @@ export class FlowItem implements InteractiveComponent {
 
   setBackRef = (node: HTMLCalciteActionElement): void => {
     this.backButtonEl = node;
+  };
+
+  setContainerRef = (node: HTMLCalcitePanelElement): void => {
+    this.containerEl = node;
   };
 
   getBackLabel = (): string => {
@@ -278,6 +282,7 @@ export class FlowItem implements InteractiveComponent {
           loading={loading}
           menuOpen={menuOpen}
           onCalcitePanelClose={this.handlePanelClose}
+          ref={this.setContainerRef}
           widthScale={widthScale}
         >
           <slot name={SLOTS.headerActionsStart} slot={PANEL_SLOTS.headerActionsStart} />


### PR DESCRIPTION
**Related Issue:** #5414 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

Fixes `flow-item#scrollContentTo` by storing missing reference.

cc @driskull 