### PR TITLE
test(dropdown, icon, modal, tab-title): skip unstable tests

### DIFF
--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -1065,7 +1065,7 @@ describe("calcite-dropdown", () => {
     await expect(finalSelectedItem).toBe("item-3");
   });
 
-  it("dropdown should not overflow when wrapped inside a tab #3007", async () => {
+  it.skip("dropdown should not overflow when wrapped inside a tab #3007", async () => {
     const page = await newE2EPage({
       html: html`<calcite-tabs>
         <calcite-tab-nav slot="tab-nav">

--- a/src/components/icon/icon.e2e.ts
+++ b/src/components/icon/icon.e2e.ts
@@ -61,7 +61,7 @@ describe("calcite-icon", () => {
       expect(path.getAttribute("d")).toBe(iconPathData);
     });
 
-    it("loads icon when it's close to viewport", async () => {
+    it.skip("loads icon when it's close to viewport", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-icon icon="a-z" style="margin-top: 1000px"></calcite-icon>`);
       await page.waitForChanges();

--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -64,7 +64,7 @@ describe("calcite-modal properties", () => {
 });
 
 describe("opening and closing behavior", () => {
-  it("opens and closes", async () => {
+  it.skip("opens and closes", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-modal></calcite-modal>`);
     const modal = await page.find("calcite-modal");

--- a/src/components/tab-title/tab-title.e2e.ts
+++ b/src/components/tab-title/tab-title.e2e.ts
@@ -43,7 +43,7 @@ describe("calcite-tab-title", () => {
     expect(iconEnd).not.toBeNull();
   });
 
-  it("emits active event on user interaction only", async () => {
+  it.skip("emits active event on user interaction only", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-tab-title>Title</calcite-tab-title>`);
     const activeEventSpy = await page.spyOnEvent("calciteTabsActivate");


### PR DESCRIPTION
**Related Issue:** # N/A

## Summary

### ✂️🙅 🪤🔬 

Skips unstable tests:

- src/components/dropdown/dropdown.e2e.ts `dropdown should not overflow when wrapped inside a tab`
- src/components/icon/icon.e2e.ts `loads icon when it's close to viewport`
-  src/components/modal/modal.e2e.ts`opens and closes`
- src/components/tab-title/tab-title.e2e.ts `emits active event on user interaction only`