### PR TITLE
ci(next): fix next releases take 3

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -38,9 +38,9 @@ jobs:
               # deploy storybook, but still release next if it fails
               { npm run build-storybook && npx storybook-to-ghpages --host-token-env-variable=GH_TOKEN_FOR_STORYBOOK --existing-output-dir=docs --ci; } || true
 
-              # remove the build to ./docs after storybook deploys to gh-pages
+              # remove the build to docs after storybook deploys to gh-pages
               # if there are changes the git sanity checks will prevent deployment
-              cd ./docs && git clean -fd
+              git clean -fd
               npm run util:deploy-next-from-ci
             fi
           else

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -41,6 +41,7 @@ jobs:
               # remove the build to docs after storybook deploys to gh-pages
               # if there are changes the git sanity checks will prevent deployment
               git clean -fd
+              git checkout master
               npm run util:deploy-next-from-ci
             fi
           else


### PR DESCRIPTION
**Related Issue:** #

## Summary

Forgot how weird GH Action's runner is. I don't think the cwd is the repo's root, but then somehow git/npm commands still work. Fun stuff.

https://github.com/Esri/calcite-components/actions/runs/3267954519/jobs/5373794675#step:5:7464

Also checking out `master` to be safe because I'm tired of submitting PRs for this. _I don't think_ `npx storybook-to-ghpages` changes the branch to gh-pages, but maybe it does?
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
