### PR TITLE
docs: consistent api styling + define card thumbnailPosition

### DIFF
--- a/src/components/block-section/block-section.tsx
+++ b/src/components/block-section/block-section.tsx
@@ -8,7 +8,7 @@ import { guid } from "../../utils/guid";
 import { isActivationKey } from "../../utils/key";
 
 /**
- * @slot - A slot for adding content to the block section.
+ * @slot - A slot for adding content to the component.
  */
 @Component({
   tag: "calcite-block-section",
@@ -23,34 +23,36 @@ export class BlockSection {
   // --------------------------------------------------------------------------
 
   /**
-   * Tooltip used for the toggle when expanded.
+   * Accessible name for the component's collapse button.
    */
   @Prop() intlCollapse?: string;
 
   /**
-   * Tooltip used for the toggle when collapsed.
+   * Accessible name for the component's expand button.
    */
   @Prop() intlExpand?: string;
 
   /**
-   * When true, the block's section content will be displayed.
+   * When `true`, expands the component and its contents.
    */
   @Prop({ reflect: true, mutable: true }) open = false;
 
   /**
-   * BlockSection status. Adds indicator to show valid or invalid status.
+   * Displays a status-related indicator icon.
    */
   @Prop({ reflect: true }) status?: Status;
 
   /**
-   * Text displayed in the button.
+   * The component header text.
    */
   @Prop() text: string;
 
   /**
-   * This property determines the look of the section toggle.
-   * If the value is "switch", a toggle-switch will be displayed.
-   * If the value is "button", a clickable header is displayed.
+   * Specifies the component's toggle display -
+   *
+   * `"button"` (selectable header), or
+   *
+   * `"switch"` (switch).
    */
   @Prop({ reflect: true }) toggleDisplay: BlockSectionToggleDisplay = "button";
 
@@ -71,7 +73,7 @@ export class BlockSection {
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when the header has been clicked.
+   * Emits when the header has been clicked.
    */
   @Event({ cancelable: false }) calciteBlockSectionToggle: EventEmitter<void>;
 

--- a/src/components/block-section/block-section.tsx
+++ b/src/components/block-section/block-section.tsx
@@ -52,7 +52,7 @@ export class BlockSection {
    *
    * `"button"` (selectable header), or
    *
-   * `"switch"` (switch).
+   * `"switch"` (toggle switch).
    */
   @Prop({ reflect: true }) toggleDisplay: BlockSectionToggleDisplay = "button";
 

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -12,10 +12,10 @@ import { InteractiveComponent, updateHostInteraction } from "../../utils/interac
 import { guid } from "../../utils/guid";
 
 /**
- * @slot - A slot for adding content to the block.
- * @slot icon - A slot for adding a leading header icon.
+ * @slot - A slot for adding content to the component.
+ * @slot icon - A slot for adding a leading header icon with `calcite-icon`.
  * @slot control - A slot for adding a single HTML input element in a header.
- * @slot header-menu-actions - a slot for adding an overflow menu with actions inside a dropdown.
+ * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a dropdown.
  */
 @Component({
   tag: "calcite-block",
@@ -30,85 +30,87 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * When true, this block will be collapsible.
+   * When `true`, the component is collapsible.
    */
   @Prop({ reflect: true }) collapsible = false;
 
   /**
-   * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
+   * When `true`, interaction is prevented and the component is displayed with lower opacity.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * When true, displays a drag handle in the header.
+   * When `true`, displays a drag handle in the header.
    */
   @Prop({ reflect: true }) dragHandle = false;
 
   /**
-   * Block heading.
+   * The component header text.
    */
   @Prop() heading!: string;
 
   /**
-   * Number at which section headings should start for this component.
+   * Specifies the number at which section headings should start.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 
   /**
-   * Aria-label for collapsing the toggle and tooltip used for the toggle when expanded.
+   * Accessible name for the component's collapse button.
    *
    * @default "Collapse"
    */
   @Prop() intlCollapse?: string = TEXT.collapse;
 
   /**
-   * Aria-label for expanding the toggle and tooltip used for the toggle when collapsed.
+   * Accessible name for the component's expand button.
    *
    * @default "Expand"
    */
   @Prop() intlExpand?: string = TEXT.expand;
 
   /**
-   * string to override English loading text
+   * Accessible name when the component is loading.
    *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
   /**
-   * Text string used for the actions menu
+   * Accessible name for the component's options button.
    *
    * @default "Options"
    */
   @Prop() intlOptions?: string = TEXT.options;
 
   /**
-   * When true, content is waiting to be loaded. This state shows a busy indicator.
+   * When `true`, a busy indicator is displayed.
    */
   @Prop({ reflect: true }) loading = false;
 
   /**
-   * When true, the block's content will be displayed.
+   * When `true`, expands the component and its contents.
    */
   @Prop({ reflect: true, mutable: true }) open = false;
 
   /**
-   * Block status. Updates or adds icon to show related icon and color.
+   * Displays a status-related indicator icon.
    */
   @Prop({ reflect: true }) status?: Status;
 
   /**
-   * Block summary.
+   * A description for the component, which displays below the heading.
    *
-   * @deprecated use description instead
+   * @deprecated use `description` instead
    */
   @Prop() summary: string;
 
-  /**Block description */
+  /**
+   * A description for the component, which displays below the heading.
+   */
   @Prop() description: string;
 
   /**
-   * When true, removes padding for the slotted content
+   * When `true`, removes padding for the slotted content.
    *
    * @deprecated Use `--calcite-block-padding` CSS variable instead.
    */
@@ -155,7 +157,7 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when the header has been clicked.
+   * Emits when the component's header is clicked.
    */
   @Event({ cancelable: false }) calciteBlockToggle: EventEmitter<void>;
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -87,7 +87,7 @@ export class Button implements LabelableComponent, InteractiveComponent, FormOwn
   /**
    * The form ID to associate with the component.
    *
-   * @deprecated – This property is no longer needed if the component is placed inside a form.
+   * @deprecated – The property is no longer needed if the component is placed inside a form.
    */
   @Prop() form?: string;
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -33,72 +33,88 @@ export class Button implements LabelableComponent, InteractiveComponent, FormOwn
   //
   //--------------------------------------------------------------------------
 
-  /** optionally specify alignment of button elements. */
+  /** Specifies the alignment of the component's elements. */
   @Prop({ reflect: true }) alignment?: ButtonAlignment = "center";
 
-  /** specify the appearance style of the button, defaults to solid. */
+  /** Specifies the appearance style of the component. */
   @Prop({ reflect: true }) appearance: ButtonAppearance = "solid";
 
-  /** Applies to the aria-label attribute on the button or hyperlink */
+  /** Accessible name for the component. */
   @Prop() label?: string;
 
-  /** specify the color of the button, defaults to blue */
+  /** Specifies the color of the component. */
   @Prop({ reflect: true }) color: ButtonColor = "blue";
 
-  /** is the button disabled  */
+  /**  When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** optionally pass a href - used to determine if the component should render as a button or an anchor */
+  /**
+   * Specifies the URL of the linked resource, which can be set as an absolute or relative path.
+   */
   @Prop({ reflect: true }) href?: string;
 
   /** Specifies an icon to display at the end of the component. */
   @Prop({ reflect: true }) iconEnd?: string;
 
-  /** When true, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl?: FlipContext;
 
   /** Specifies an icon to display at the start of the component. */
   @Prop({ reflect: true }) iconStart?: string;
 
   /**
-   * string to override English loading text
+   * Accessible name when the component is loading.
    *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
-  /** optionally add a calcite-loader component to the button, disabling interaction.  */
+  /**
+   * When `true`, a busy indicator is displayed and disables interaction.
+   */
   @Prop({ reflect: true }) loading = false;
 
-  /** The name attribute to apply to the button */
+  /** Specifies the name of the component on form submission. */
   @Prop({ reflect: true }) name?: string;
 
-  /** The rel attribute to apply to the hyperlink */
+  /**
+   * Defines the relationship between the `href` value and the current document.
+   *
+   * @mdn [rel](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel)
+   */
   @Prop({ reflect: true }) rel?: string;
 
   /**
-   * The form ID to associate with the component
+   * The form ID to associate with the component.
    *
-   * @deprecated – this property is no longer needed if placed inside a form.
+   * @deprecated – This property is no longer needed if the component is placed inside a form.
    */
   @Prop() form?: string;
 
-  /** optionally add a round style to the button  */
+  /** When `true`, adds a round style to the component. */
   @Prop({ reflect: true }) round = false;
 
-  /** specify the scale of the button, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** is the button a child of a calcite-split-button */
+  /** Specifies if the component is a child of a `calcite-split-button`. */
   @Prop({ reflect: true }) splitChild?: "primary" | "secondary" | false = false;
 
-  /** The target attribute to apply to the hyperlink */
+  /**
+   * Specifies where to open the linked document defined in the `href` property.
+   *
+   * @mdn [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target)
+   */
   @Prop({ reflect: true }) target?: string;
 
-  /** The type attribute to apply to the button */
+  /**
+   * Specifies the default behavior of the button.
+   *
+   * @mdn [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)
+   */
   @Prop({ mutable: true, reflect: true }) type = "button";
 
-  /** specify the width of the button, defaults to auto */
+  /** Specifies the width of the component. */
   @Prop({ reflect: true }) width: Width = "auto";
 
   @Watch("loading")

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -70,7 +70,7 @@ export class Button implements LabelableComponent, InteractiveComponent, FormOwn
   @Prop() intlLoading?: string = TEXT.loading;
 
   /**
-   * When `true`, a busy indicator is displayed and disables interaction.
+   * When `true`, a busy indicator is displayed and interaction is disabled.
    */
   @Prop({ reflect: true }) loading = false;
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -66,7 +66,7 @@ export class Card implements ConditionalSlotComponent {
   @Prop({ reflect: false }) intlSelect: string = TEXT.select;
 
   /**
-   * When `selectable` is `true`, the accessible name for the component's checkbox for de-selection.
+   * When `selectable` is `true`, the accessible name for the component's checkbox for deselection.
    *
    * @default "Deselect"
    */

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -72,7 +72,7 @@ export class Card implements ConditionalSlotComponent {
    */
   @Prop({ reflect: false }) intlDeselect: string = TEXT.deselect;
 
-  /** Sets the placement of the thumbnail component defined in the `thumbnail` slot. */
+  /** Sets the placement of the thumbnail defined in the `thumbnail` slot. */
   @Prop({ reflect: true }) thumbnailPosition: LogicalFlowPosition = "block-start";
 
   //--------------------------------------------------------------------------

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -15,9 +15,9 @@ import {
 
 /**
  * @slot - A slot for adding subheader/description content.
- * @slot thumbnail - A slot for adding a thumbnail to the card.
- * @slot title - A slot for adding a card title.
- * @slot subtitle - A slot for adding a card subtitle or short summary.
+ * @slot thumbnail - A slot for adding a thumbnail to the component.
+ * @slot title - A slot for adding a title.
+ * @slot subtitle - A slot for adding a subtitle or short summary.
  * @slot footer-leading - A slot for adding a leading footer.
  * @slot footer-trailing - A slot for adding a trailing footer.
  */
@@ -42,36 +42,37 @@ export class Card implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /**  When true, the cards content is waiting to be loaded. This state shows a busy indicator.*/
+  /**  When `true`, a busy indicator is displayed. */
   @Prop({ reflect: true }) loading = false;
 
-  /** Indicates whether the card is selected. */
+  /** When `true`, the component is selected. */
   @Prop({ reflect: true, mutable: true }) selected = false;
 
-  /** Indicates whether the card is selectable. */
+  /** When `true`, the component is selectable. */
   @Prop({ reflect: true }) selectable = false;
 
   /**
-   * string to override English loading text
+   * Accessible name when the component is loading.
    *
    * @default "Loading"
    */
   @Prop() intlLoading?: string = TEXT.loading;
 
   /**
-   * string to override English select text for checkbox when selectable is true
+   * When `selectable` is `true`, the accessible name for the component's checkbox for selection.
    *
    * @default "Select"
    */
   @Prop({ reflect: false }) intlSelect: string = TEXT.select;
 
   /**
-   * string to override English deselect text for checkbox when selectable is true
+   * When `selectable` is `true`, the accessible name for the component's checkbox for de-selection.
    *
    * @default "Deselect"
    */
   @Prop({ reflect: false }) intlDeselect: string = TEXT.deselect;
 
+  /** Sets the placement of the thumbnail component defined in the `thumbnail` slot. */
   @Prop({ reflect: true }) thumbnailPosition: LogicalFlowPosition = "block-start";
 
   //--------------------------------------------------------------------------
@@ -80,7 +81,7 @@ export class Card implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** Fired when a selectable card is selected */
+  /** Fires when `selectable` is `true` and the component is selected. */
   @Event({ cancelable: false }) calciteCardSelect: EventEmitter<void>;
 
   // --------------------------------------------------------------------------

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-checkbox-size: the width and height of the checkbox
+ * @prop --calcite-checkbox-size: Specifies the component's height and width.
  */
 
 :host([scale="s"]) {

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -55,9 +55,7 @@ export class Checkbox implements LabelableComponent, CheckableFormComponent, Int
   @Prop({ reflect: true, mutable: true }) hovered = false;
 
   /**
-   * When `true`, the component is initially indeterminate,
-   *
-   * which is independent from its `checked` value.
+   * When `true`, the component is initially indeterminate, which is independent from its `checked` value.
    *
    * The state is visual only, and can look different across browsers.
    *

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -38,13 +38,13 @@ export class Checkbox implements LabelableComponent, CheckableFormComponent, Int
   //
   //--------------------------------------------------------------------------
 
-  /** The checked state of the checkbox. */
+  /** When `true`, the component is checked. */
   @Prop({ reflect: true, mutable: true }) checked = false;
 
-  /** True if the checkbox is disabled */
+  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** The id attribute of the checkbox.  When omitted, a globally unique identifier is used. */
+  /** The `id` attribute of the component. When omitted, a globally unique identifier is used. */
   @Prop({ reflect: true, mutable: true }) guid: string;
 
   /**
@@ -55,33 +55,37 @@ export class Checkbox implements LabelableComponent, CheckableFormComponent, Int
   @Prop({ reflect: true, mutable: true }) hovered = false;
 
   /**
-   * True if the checkbox is initially indeterminate,
-   * which is independent from its checked state
-   * https://css-tricks.com/indeterminate-checkboxes/
+   * When `true`, the component is initially indeterminate,
+   *
+   * which is independent from its `checked` value.
+   *
+   * The state is visual only, and can look different across browsers.
+   *
+   * @mdn [indeterminate](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes)
    */
   @Prop({ reflect: true, mutable: true }) indeterminate = false;
 
   /**
-   * The label of the checkbox input
+   * Accessible name for the component.
    *
    * @internal
    */
   @Prop() label?: string;
 
-  /** The name of the checkbox input */
+  /** Specifies the name of the component on form submission. */
   @Prop({ reflect: true }) name;
 
   /**
-   * When true, the component must have a value in order for the form to submit.
+   * When `true`, the component must have a value in order for the form to submit.
    *
    * @internal
    */
   @Prop({ reflect: true }) required = false;
 
-  /** specify the scale of the checkbox, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The value of the checkbox input */
+  /** The component's value. */
   @Prop() value: any;
 
   //--------------------------------------------------------------------------
@@ -152,17 +156,17 @@ export class Checkbox implements LabelableComponent, CheckableFormComponent, Int
   //--------------------------------------------------------------------------
 
   /**
-   * Emitted when the checkbox is blurred
+   * Emits when the component is blurred.
    *
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalCheckboxBlur: EventEmitter<boolean>;
 
-  /** Emitted when the checkbox checked status changes */
+  /** Emits when the component's `checked` status changes. */
   @Event({ cancelable: false }) calciteCheckboxChange: EventEmitter<void>;
 
   /**
-   * Emitted when the checkbox is focused
+   * Emits when the component is focused.
    *
    * @internal
    */

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -36,16 +36,16 @@ export class Chip implements ConditionalSlotComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** specify the appearance style of the button, defaults to solid. */
+  /** Specifies the appearance style of the component. */
   @Prop({ reflect: true }) appearance: Extract<"solid" | "clear", Appearance> = "solid";
 
-  /** specify the color of the button, defaults to blue */
+  /** Specifies the color for the component. */
   @Prop({ reflect: true }) color: ChipColor = "grey";
 
   /**
-   * Optionally show a button the user can click to dismiss the chip
+   * When `true`, a close button is added to the component.
    *
-   * @deprecated use closable instead
+   * @deprecated use `closable` instead.
    */
   @Prop({ reflect: true, mutable: true }) dismissible = false;
 
@@ -54,7 +54,7 @@ export class Chip implements ConditionalSlotComponent {
     this.closable = value;
   }
 
-  /** When true, show abutton user can click to dismiss the chip. */
+  /** When `true`, a close button is added to the component. */
   @Prop({ reflect: true, mutable: true }) closable = false;
 
   @Watch("closable")
@@ -63,7 +63,7 @@ export class Chip implements ConditionalSlotComponent {
   }
 
   /**
-   * Aria label for the "x" button
+   * Accessible name for the component's close button.
    *
    * @default "Close"
    */
@@ -72,16 +72,16 @@ export class Chip implements ConditionalSlotComponent {
   /** Specifies an icon to display. */
   @Prop({ reflect: true }) icon?: string;
 
-  /** When true, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
 
-  /** specify the scale of the chip, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The assigned value for the chip */
+  /** The component's value. */
   @Prop() value!: any;
 
-  /** When true, hides the chip  */
+  /** When `true`, hides the component. */
   @Prop({ reflect: true, mutable: true }) closed = false;
 
   // --------------------------------------------------------------------------
@@ -131,9 +131,9 @@ export class Chip implements ConditionalSlotComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when the dismiss button is clicked
+   * Fires when the dismiss button is clicked.
    *
-   * **Note:**: The `el` event payload props is deprecated, please use the event's `target`/`currentTarget` instead
+   * **Note:**: The `el` event payload props is deprecated, please use the event's `target`/`currentTarget` instead.
    */
   @Event({ cancelable: false }) calciteChipDismiss: EventEmitter<DeprecatedEventPayload>;
 

--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -67,33 +67,31 @@ export class ColorPickerHexInput {
   //--------------------------------------------------------------------------
 
   /**
-   * When false, empty color (null) will be allowed as a value. Otherwise, a color value is always enforced by the component.
+   * When `false`, an empty color (`null`) will be allowed as a `value`. Otherwise, a color value is enforced on the component.
    *
-   * When true, clearing the input and blurring will restore the last valid color set. When false, it will set it to empty.
+   * When `true`, clearing the input and blurring will restore the last valid `value`. When `false`, it will set the `value` to empty.
    */
   @Prop() allowEmpty = false;
 
   /**
-   * Label used for the hex input.
+   * Accessible name for the Hex input.
    *
    * @default "Hex"
    */
   @Prop() intlHex = TEXT.hex;
 
   /**
-   * Label used for the hex input when there is no color selected.
+   * Accessible name for the Hex input when there is no color selected.
    *
    * @default "No color"
    */
   @Prop() intlNoColor = TEXT.noColor;
 
-  /**
-   * The component's scale.
-   */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /**
-   * The hex value.
+   * The Hex value.
    */
   @Prop({ mutable: true, reflect: true }) value: string = normalizeHex(DEFAULT_COLOR.hex());
 

--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -69,7 +69,7 @@ export class ColorPickerHexInput {
   /**
    * When `false`, an empty color (`null`) will be allowed as a `value`. Otherwise, a color value is enforced on the component.
    *
-   * When `true`, clearing the input and blurring will restore the last valid `value`. When `false`, it will set the `value` to empty.
+   * When `true`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`. When `false`, an empty color (`null`) will be allowed as a `value`.
    */
   @Prop() allowEmpty = false;
 

--- a/src/components/color-picker-swatch/color-picker-swatch.tsx
+++ b/src/components/color-picker-swatch/color-picker-swatch.tsx
@@ -17,7 +17,7 @@ export class ColorPickerSwatch {
   //--------------------------------------------------------------------------
 
   /**
-   * Used to display whether the swatch is active or not.
+   * When `true`, the component is active.
    */
   @Prop({
     reflect: true
@@ -38,7 +38,7 @@ export class ColorPickerSwatch {
   }
 
   /**
-   * The component scale.
+   * Specifies the size of the component.
    */
   @Prop({
     reflect: true

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -58,13 +58,17 @@ export class ColorPicker implements InteractiveComponent {
   //--------------------------------------------------------------------------
 
   /**
-   * When false, empty color (null) will be allowed as a value. Otherwise, a color value is always enforced by the component.
+   * When `false`, an empty color (`null`) will be allowed as a `value`. Otherwise, a color value is enforced on the component.
    *
-   * When true, clearing the input and blurring will restore the last valid color set. When false, it will set it to empty.
+   * When `true`, clearing the input and blurring will restore the last valid `value`. When `false`, it will set the `value` to empty.
    */
   @Prop({ reflect: true }) allowEmpty = false;
 
-  /** specify the appearance - solid (containing border), or minimal (no containing border) */
+  /**
+   * Specifies the appearance style of the component -
+   *
+   * `"solid"` (containing border) or `"minimal"` (no containing border).
+   */
   @Prop({ reflect: true }) appearance: ColorAppearance = "solid";
 
   /**
@@ -82,14 +86,14 @@ export class ColorPicker implements InteractiveComponent {
   }
 
   /**
-   * When true, disabled prevents user interaction.
+   * When `true`, interaction is prevented and the component is displayed with lower opacity.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The format of the value property.
+   * The format of `value`.
    *
-   * When "auto", the format will be inferred from `value` when set.
+   * When `"auto"`, the format will be inferred from `value` when set.
    *
    * @default "auto"
    */
@@ -101,151 +105,149 @@ export class ColorPicker implements InteractiveComponent {
     this.internalColorSet(this.color, false, "internal");
   }
 
-  /** When true, hides the hex input */
+  /** When `true`, hides the Hex input. */
   @Prop({ reflect: true }) hideHex = false;
 
-  /** When true, hides the RGB/HSV channel inputs */
+  /** When `true`, hides the RGB/HSV channel inputs. */
   @Prop({ reflect: true }) hideChannels = false;
 
-  /** When true, hides the saved colors section */
+  /** When `true`, hides the saved colors section. */
   @Prop({ reflect: true }) hideSaved = false;
 
   /**
-   * Label used for the blue channel
+   * Accessible name for the RGB's blue channel.
    *
    * @default "B"
    */
   @Prop() intlB = TEXT.b;
 
   /**
-   * Label used for the blue channel description
+   * Accessible name for the RGB's blue channel description.
    *
    * @default "Blue"
    */
   @Prop() intlBlue = TEXT.blue;
 
   /**
-   * Label used for the delete color button.
+   * Accessible name for the delete color button.
    *
    * @default "Delete color"
    */
   @Prop() intlDeleteColor = TEXT.deleteColor;
 
   /**
-   * Label used for the green channel
+   * Accessible name for the RGB's green channel.
    *
    * @default "G"
    */
   @Prop() intlG = TEXT.g;
 
   /**
-   * Label used for the green channel description
+   * Accessible name for the RGB's green channel description.
    *
    * @default "Green"
    */
   @Prop() intlGreen = TEXT.green;
 
   /**
-   * Label used for the hue channel
+   * Accessible name for the HSV's hue channel.
    *
    * @default "H"
    */
   @Prop() intlH = TEXT.h;
 
   /**
-   * Label used for the HSV mode
+   * Accessible name for the HSV mode.
    *
    * @default "HSV"
    */
   @Prop() intlHsv = TEXT.hsv;
 
   /**
-   * Label used for the hex input
+   * Accessible name for the Hex input.
    *
    * @default "Hex"
    */
   @Prop() intlHex = TEXT.hex;
 
   /**
-   * Label used for the hue channel description
+   * Accessible name for the HSV's hue channel description.
    *
    * @default "Hue"
    */
   @Prop() intlHue = TEXT.hue;
 
   /**
-   * Label used for the hex input when there is no color selected.
+   * Accessible name for the Hex input when there is no color selected.
    *
    * @default "No color"
    */
   @Prop() intlNoColor = TEXT.noColor;
 
   /**
-   * Label used for the red channel
+   * Accessible name for the RGB's red channel.
    *
    * @default "R"
    */
   @Prop() intlR = TEXT.r;
 
   /**
-   * Label used for the red channel description
+   * Accessible name for the RGB's red channel description.
    *
    * @default "Red"
    */
   @Prop() intlRed = TEXT.red;
 
   /**
-   * Label used for the RGB mode
+   * Accessible name for the RGB mode.
    *
    * @default "RGB"
    */
   @Prop() intlRgb = TEXT.rgb;
 
   /**
-   * Label used for the saturation channel
+   * Accessible name for the HSV's saturation channel.
    *
    * @default "S"
    */
   @Prop() intlS = TEXT.s;
 
   /**
-   * Label used for the saturation channel description
+   * Accessible name for the HSV's saturation channel description.
    *
    * @default "Saturation"
    */
   @Prop() intlSaturation = TEXT.saturation;
 
   /**
-   * Label used for the save color button.
+   * Accessible name for the save color button.
    *
    * @default "Save color"
    */
   @Prop() intlSaveColor = TEXT.saveColor;
 
   /**
-   * Label used for the saved colors section
+   * Accessible name for the saved colors section.
    *
    * @default "Saved"
    */
   @Prop() intlSaved = TEXT.saved;
 
   /**
-   * Label used for the value channel
+   * Accessible name for the HSV's value channel.
    *
    * @default "V"
    */
   @Prop() intlV = TEXT.v;
 
   /**
-   * Label used for the
+   * Accessible name for the HSV's value channel description.
    *
    * @default "Value"
    */
   @Prop() intlValue = TEXT.value;
 
-  /**
-   * The scale of the color picker.
-   */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   @Watch("scale")
@@ -254,19 +256,14 @@ export class ColorPicker implements InteractiveComponent {
     this.updateCanvasSize(this.fieldAndSliderRenderingContext?.canvas);
   }
 
-  /**
-   * Storage ID for colors.
-   */
+  /** Specifies the storage ID for colors. */
   @Prop({ reflect: true }) storageId: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */
   @Prop({ reflect: true }) numberingSystem?: NumberingSystem;
 
   /**
-   * The component's value.
-   *
-   * This value can be either a CSS color string,
-   * a RGB, HSL or HSV object.
+   * The component's value, where the value can be a CSS color string, or a RGB, HSL or HSV object.
    *
    * The type will be preserved as the color is updated.
    *
@@ -383,7 +380,7 @@ export class ColorPicker implements InteractiveComponent {
   /**
    * Fires as the color value changes.
    *
-   * This is similar to the change event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
+   * Similar to the `calciteColorPickerChange` event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
    */
   @Event({ cancelable: false }) calciteColorPickerInput: EventEmitter<void>;
 

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -60,7 +60,7 @@ export class ColorPicker implements InteractiveComponent {
   /**
    * When `false`, an empty color (`null`) will be allowed as a `value`. Otherwise, a color value is enforced on the component.
    *
-   * When `true`, clearing the input and blurring will restore the last valid `value`. When `false`, it will set the `value` to empty.
+   * When `true`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`. When `false`, an empty color (`null`) will be allowed as a `value`.
    */
   @Prop({ reflect: true }) allowEmpty = false;
 
@@ -115,14 +115,14 @@ export class ColorPicker implements InteractiveComponent {
   @Prop({ reflect: true }) hideSaved = false;
 
   /**
-   * Accessible name for the RGB's blue channel.
+   * Accessible name for the RGB section's blue channel.
    *
    * @default "B"
    */
   @Prop() intlB = TEXT.b;
 
   /**
-   * Accessible name for the RGB's blue channel description.
+   * Accessible name for the RGB section's blue channel description.
    *
    * @default "Blue"
    */
@@ -136,21 +136,21 @@ export class ColorPicker implements InteractiveComponent {
   @Prop() intlDeleteColor = TEXT.deleteColor;
 
   /**
-   * Accessible name for the RGB's green channel.
+   * Accessible name for the RGB section's green channel.
    *
    * @default "G"
    */
   @Prop() intlG = TEXT.g;
 
   /**
-   * Accessible name for the RGB's green channel description.
+   * Accessible name for the RGB section's green channel description.
    *
    * @default "Green"
    */
   @Prop() intlGreen = TEXT.green;
 
   /**
-   * Accessible name for the HSV's hue channel.
+   * Accessible name for the HSV section's hue channel.
    *
    * @default "H"
    */
@@ -171,7 +171,7 @@ export class ColorPicker implements InteractiveComponent {
   @Prop() intlHex = TEXT.hex;
 
   /**
-   * Accessible name for the HSV's hue channel description.
+   * Accessible name for the HSV section's hue channel description.
    *
    * @default "Hue"
    */
@@ -185,14 +185,14 @@ export class ColorPicker implements InteractiveComponent {
   @Prop() intlNoColor = TEXT.noColor;
 
   /**
-   * Accessible name for the RGB's red channel.
+   * Accessible name for the RGB section's red channel.
    *
    * @default "R"
    */
   @Prop() intlR = TEXT.r;
 
   /**
-   * Accessible name for the RGB's red channel description.
+   * Accessible name for the RGB section's red channel description.
    *
    * @default "Red"
    */
@@ -206,14 +206,14 @@ export class ColorPicker implements InteractiveComponent {
   @Prop() intlRgb = TEXT.rgb;
 
   /**
-   * Accessible name for the HSV's saturation channel.
+   * Accessible name for the HSV section's saturation channel.
    *
    * @default "S"
    */
   @Prop() intlS = TEXT.s;
 
   /**
-   * Accessible name for the HSV's saturation channel description.
+   * Accessible name for the HSV section's saturation channel description.
    *
    * @default "Saturation"
    */
@@ -234,14 +234,14 @@ export class ColorPicker implements InteractiveComponent {
   @Prop() intlSaved = TEXT.saved;
 
   /**
-   * Accessible name for the HSV's value channel.
+   * Accessible name for the HSV section's value channel.
    *
    * @default "V"
    */
   @Prop() intlV = TEXT.v;
 
   /**
-   * Accessible name for the HSV's value channel description.
+   * Accessible name for the HSV section's value channel description.
    *
    * @default "Value"
    */

--- a/src/components/combobox-item-group/combobox-item-group.tsx
+++ b/src/components/combobox-item-group/combobox-item-group.tsx
@@ -21,7 +21,7 @@ export class ComboboxItemGroup {
   //
   // --------------------------------------------------------------------------
 
-  /** Specifies the parent and grandparent `calcite-combobox-item`s, which is set on `calcite-combobox`. */
+  /** Specifies the parent and grandparent `calcite-combobox-item`s, which are set on `calcite-combobox`. */
   @Prop({ mutable: true }) ancestors: ComboboxChildElement[];
 
   /** Specifies the title of the component. */

--- a/src/components/combobox-item-group/combobox-item-group.tsx
+++ b/src/components/combobox-item-group/combobox-item-group.tsx
@@ -21,10 +21,10 @@ export class ComboboxItemGroup {
   //
   // --------------------------------------------------------------------------
 
-  /** Parent and grandparent combobox items, this is set internally for use from combobox */
+  /** Specifies the parent and grandparent `calcite-combobox-item`s, which is set on `calcite-combobox`. */
   @Prop({ mutable: true }) ancestors: ComboboxChildElement[];
 
-  /** Title of the group */
+  /** Specifies the title of the component. */
   @Prop() label!: string;
 
   // --------------------------------------------------------------------------

--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -38,22 +38,24 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   //
   // --------------------------------------------------------------------------
 
-  /** When true, the item cannot be clicked and is visually muted. */
+  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /** Set this to true to pre-select an item. Toggles when an item is checked/unchecked. */
+  /**
+   * When `true`, the component is selected.
+   */
   @Prop({ reflect: true, mutable: true }) selected = false;
 
-  /** True when item is highlighted either from keyboard or mouse hover */
+  /** When `true`, the component is active. */
   @Prop({ reflect: true }) active = false;
 
-  /** Parent and grandparent combobox items, this is set internally for use from combobox */
+  /** Specifies the parent and grandparent items, which is set on `calcite-combobox`. */
   @Prop({ mutable: true }) ancestors: ComboboxChildElement[];
 
-  /** Unique identifier, used for accessibility */
+  /** The `id` attribute of the component. When omitted, a globally unique identifier is used. */
   @Prop({ reflect: true }) guid = guid();
 
-  /** Custom icon to display both in combobox chips and next to combobox item text */
+  /** Specifies an icon to display. */
   @Prop({ reflect: true }) icon?: string;
 
   @Watch("selected")
@@ -61,21 +63,21 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
     this.calciteComboboxItemChange.emit(this.el);
   }
 
-  /** The main label for this item. */
+  /** The component's text. */
   @Prop({ reflect: true }) textLabel!: string;
 
-  /** The item's associated value */
+  /** The component's value. */
   @Prop() value!: any;
 
   /**
-   * Don't filter this item based on the search text
+   * When `true`, omits the component from the `calcite-combobox` filtered search results.
    *
-   * @deprecated use filterDisabled instead
+   * @deprecated use `filterDisabled` instead.
    */
   @Prop({ reflect: true }) constant: boolean;
 
   /**
-   * Do not filter this item based on the search text
+   * When `true`, omits the component from the `calcite-combobox` filtered search results.
    */
   @Prop({ reflect: true }) filterDisabled: boolean;
 
@@ -118,7 +120,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted whenever the item is selected or unselected.
+   * Emitted whenever the component is selected or unselected.
    *
    * **Note:**: The event's payload is deprecated, please use the event's `target`/`currentTarget` instead
    */

--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -49,7 +49,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   /** When `true`, the component is active. */
   @Prop({ reflect: true }) active = false;
 
-  /** Specifies the parent and grandparent items, which is set on `calcite-combobox`. */
+  /** Specifies the parent and grandparent items, which are set on `calcite-combobox`. */
   @Prop({ mutable: true }) ancestors: ComboboxChildElement[];
 
   /** The `id` attribute of the component. When omitted, a globally unique identifier is used. */
@@ -120,7 +120,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted whenever the component is selected or unselected.
+   * Emits whenever the component is selected or unselected.
    *
    * **Note:**: The event's payload is deprecated, please use the event's `target`/`currentTarget` instead
    */

--- a/src/components/combobox/combobox.scss
+++ b/src/components/combobox/combobox.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-combobox-input-height: the height of the combobox input
+ * @prop --calcite-combobox-input-height: Specifies the height of the component's input.
  */
 
 :host {

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -184,14 +184,14 @@ export class Combobox
    * Specifies the selection mode -
    * `"multi"` (allow any number of selected items),
    * `"single"` (allow only one selection), or
-   * `"ancestors"` (like `"multi"`, but show ancestors of selected items as selected, where only deepest children shown in `calcite-chip`s).
+   * `"ancestors"` (like `"multi"`, but show ancestors of selected items as selected. Only the deepest children are shown in `calcite-chip`s).
    */
   @Prop({ reflect: true }) selectionMode: ComboboxSelectionMode = "multi";
 
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The component's value(s) of the selected `calcite-combobox-item`(s). */
+  /** The component's value(s) from the selected `calcite-combobox-item`(s). */
   @Prop({ mutable: true }) value: string | string[] = null;
 
   @Watch("value")
@@ -210,7 +210,7 @@ export class Combobox
   }
 
   /**
-   * Accessible name for the component's remove tag for when a `calcite-combobox-item` is selected.
+   * Accessible name for the component's remove tag when a `calcite-combobox-item` is selected.
    *
    * @default "Remove tag"
    */
@@ -299,7 +299,7 @@ export class Combobox
     selectedItems: HTMLCalciteComboboxItemElement[];
   }>;
 
-  /** Fires when entering text to filter the options list. */
+  /** Fires when text is added to filter the options list. */
   @Event({ cancelable: false }) calciteComboboxFilterChange: EventEmitter<{
     visibleItems: HTMLCalciteComboboxItemElement[];
     text: string;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -94,9 +94,9 @@ export class Combobox
   //--------------------------------------------------------------------------
 
   /**
-   * When true, opens the combobox
+   * When `true`, displays and positions the component.
    *
-   * @deprecated use open instead
+   * @deprecated use `open` instead.
    */
   @Prop({ reflect: true, mutable: true }) active = false;
 
@@ -110,7 +110,7 @@ export class Combobox
     this.open = value;
   }
 
-  /**When true, opens the combobox */
+  /**When `true`, displays and positions the component. */
   @Prop({ reflect: true, mutable: true }) open = false;
 
   @Watch("open")
@@ -124,7 +124,7 @@ export class Combobox
     this.setMaxScrollerHeight();
   }
 
-  /** Disable combobox input */
+  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   @Watch("disabled")
@@ -135,16 +135,16 @@ export class Combobox
     }
   }
 
-  /** Aria label for combobox (required) */
+  /** Accessible name for the component. */
   @Prop() label!: string;
 
-  /** Placeholder text for input */
+  /** Specifies the placeholder text for the input. */
   @Prop() placeholder?: string;
 
-  /** Placeholder icon for input  */
+  /** Specifies the placeholder icon for the input. */
   @Prop({ reflect: true }) placeholderIcon?: string;
 
-  /** Specify the maximum number of combobox items (including nested children) to display before showing the scroller */
+  /** Specifies the maximum number of `calcite-combobox-item`s (including nested children) to display before displaying a scrollbar. */
   @Prop({ reflect: true }) maxItems = 0;
 
   @Watch("maxItems")
@@ -152,10 +152,10 @@ export class Combobox
     this.setMaxScrollerHeight();
   }
 
-  /** The name of the switch input */
+  /** Specifies the name of the component on form submission. */
   @Prop({ reflect: true }) name: string;
 
-  /** Allow entry of custom values which are not in the original set of items */
+  /** When `true`, allows entry of custom values, which are not in the original set of items. */
   @Prop({ reflect: true }) allowCustomValues: boolean;
 
   /**
@@ -174,24 +174,24 @@ export class Combobox
   }
 
   /**
-   * When true, the component must have a value in order for the form to submit.
+   * When `true`, the component must have a value in order for the form to submit.
    *
    * @internal
    */
   @Prop({ reflect: true }) required = false;
 
   /**
-   * specify the selection mode
-   * - multi: allow any number of selected items (default)
-   * - single: only one selection)
-   * - ancestors: like multi, but show ancestors of selected items as selected, only deepest children shown in chips
+   * Specifies the selection mode -
+   * `"multi"` (allow any number of selected items),
+   * `"single"` (allow only one selection), or
+   * `"ancestors"` (like `"multi"`, but show ancestors of selected items as selected, where only deepest children shown in `calcite-chip`s).
    */
   @Prop({ reflect: true }) selectionMode: ComboboxSelectionMode = "multi";
 
-  /** Specify the scale of the combobox, defaults to m */
+  /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** The value(s) of the selectedItem(s) */
+  /** The component's value(s) of the selected `calcite-combobox-item`(s). */
   @Prop({ mutable: true }) value: string | string[] = null;
 
   @Watch("value")
@@ -210,7 +210,7 @@ export class Combobox
   }
 
   /**
-   * string to override the English "Remove tag" text for when an item is selected.
+   * Accessible name for the component's remove tag for when a `calcite-combobox-item` is selected.
    *
    * @default "Remove tag"
    */
@@ -286,33 +286,33 @@ export class Combobox
   // --------------------------------------------------------------------------
 
   /**
-   * Called when the selected items set changes
+   * Fires when the selected items set changes.
    *
-   * @deprecated use calciteComboboxChange instead
+   * @deprecated use `calciteComboboxChange` instead.
    */
   @Event({ cancelable: false }) calciteLookupChange: EventEmitter<HTMLCalciteComboboxItemElement[]>;
 
   /**
-   * Called when the selected item(s) changes.
+   * Fires when the selected item(s) changes.
    */
   @Event({ cancelable: false }) calciteComboboxChange: EventEmitter<{
     selectedItems: HTMLCalciteComboboxItemElement[];
   }>;
 
-  /** Called when the user has entered text to filter the options list */
+  /** Fires when entering text to filter the options list. */
   @Event({ cancelable: false }) calciteComboboxFilterChange: EventEmitter<{
     visibleItems: HTMLCalciteComboboxItemElement[];
     text: string;
   }>;
 
   /**
-   * Called when a selected item in the combobox is dismissed via its chip
+   * Fires when a selected item in the component is dismissed via its `calcite-chip`.
    *
-   * **Note:**: The event payload is deprecated, please use the `value` property on the component to determine removed value instead
+   * **Note:**: The event payload is deprecated, please use the `value` property on the component to determine the removed value instead.
    */
   @Event({ cancelable: false }) calciteComboboxChipDismiss: EventEmitter<DeprecatedEventPayload>;
 
-  /** Fires when the component is requested to be closed and before the closing transition begins. */
+  /** Fires when the component is requested to be closed, and before the closing transition begins. */
   @Event({ cancelable: false }) calciteComboboxBeforeClose: EventEmitter<void>;
 
   /** Fires when the component is closed and animation is complete. */

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -86,12 +86,12 @@ export class InputDatePicker
   //
   //--------------------------------------------------------------------------
   /**
-   * When true, interaction is prevented and the component is displayed with lower opacity.
+   * When `true`, interaction is prevented and the component is displayed with lower opacity.
    */
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * When true, the component's value can be read, but controls are not accessible and the value cannot be modified.
+   * When `true`, the component's value can be read, but controls are not accessible and the value cannot be modified.
    *
    * @mdn [readOnly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
    */
@@ -185,7 +185,7 @@ export class InputDatePicker
   }
 
   /**
-   * When true, the component is active.
+   * When `true`, the component is active.
    *
    * @deprecated use `open` instead.
    */
@@ -196,7 +196,7 @@ export class InputDatePicker
     this.open = value;
   }
 
-  /** When true, displays the `calcite-date-picker` component. */
+  /** When `true`, displays the `calcite-date-picker` component. */
   @Prop({ mutable: true, reflect: true }) open = false;
 
   @Watch("open")
@@ -255,11 +255,11 @@ export class InputDatePicker
    */
   @Prop({ reflect: true }) placement: MenuPlacement = defaultMenuPlacement;
 
-  /** When true, activates a range for the component. */
+  /** When `true`, activates a range for the component. */
   @Prop({ reflect: true }) range = false;
 
   /**
-   * When true, the component must have a value in order for the form to submit.
+   * When `true`, the component must have a value in order for the form to submit.
    *
    * @internal
    */
@@ -295,7 +295,7 @@ export class InputDatePicker
   }
 
   /**
-   * When true, disables the default behavior on the third click of narrowing or extending the range.
+   * When `true`, disables the default behavior on the third click of narrowing or extending the range.
    * Instead starts a new range.
    */
   @Prop() proximitySelectionDisabled = false;

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -166,7 +166,7 @@ export class InputTimePicker
   @Prop() numberingSystem?: NumberingSystem;
 
   /**
-   * When true, the component must have a value in order for the form to submit.
+   * When `true`, the component must have a value in order for the form to submit.
    *
    * @internal
    */

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -65,7 +65,7 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * When true and clicking outside of the component, automatically closes open `calcite-popover`s.
+   * When `true` and clicking outside of the component, automatically closes open `calcite-popover`s.
    */
   @Prop({ reflect: true }) autoClose = false;
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -65,7 +65,7 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * When `true` and clicking outside of the component, automatically closes open `calcite-popover`s.
+   * When `true`, clicking outside of the component automatically closes open `calcite-popover`s.
    */
   @Prop({ reflect: true }) autoClose = false;
 

--- a/src/components/tip/tip.tsx
+++ b/src/components/tip/tip.tsx
@@ -44,7 +44,7 @@ export class Tip implements ConditionalSlotComponent {
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 
   /**
-   * When `true` and if it has a parent `calcite-tip-manager`, the component is selected.
+   * When `true`, the component is selected if it has a parent `calcite-tip-manager`.
    *
    * Only one tip can be selected within the `calcite-tip-manager` parent.
    */

--- a/src/components/tip/tip.tsx
+++ b/src/components/tip/tip.tsx
@@ -44,7 +44,7 @@ export class Tip implements ConditionalSlotComponent {
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 
   /**
-   * When true and if it has a parent `calcite-tip-manager`, the component is selected.
+   * When `true` and if it has a parent `calcite-tip-manager`, the component is selected.
    *
    * Only one tip can be selected within the `calcite-tip-manager` parent.
    */


### PR DESCRIPTION
**Related Issues:** #4442, https://github.com/Esri/calcite-components/pull/5450#discussion_r998534396 (for `calcite-card`s `thumbnailPosition` prop)

## Summary
1. Adds documentation to `calcite-card`'s `thumbnailPosition` prop
2. Adds consistent doc styling to:
    - block-section
    - block
    - button
    - card
    - checkbox
    - chip
    - color-picker
    - combobox-item-group
    - combobox-item
    - combobox
3. Adds backticks to `true` values for:
    - input-date-picker
    - input-time-picker
    - popover
    - tip 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
