### PR TITLE
refactor(tree): drop the optional chaining operator ? from tree within the event handler

### DIFF
--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -283,7 +283,7 @@ export class Tree {
       }
 
       // When focus is on a child node that is also either an end node or a closed node, moves focus to its parent node.
-      const parentItem = target.parentElement?.closest("calcite-tree-item");
+      const parentItem = target.parentElement.closest("calcite-tree-item");
 
       if (parentItem && (!target.hasChildren || target.expanded === false)) {
         parentItem.focus();
@@ -320,10 +320,10 @@ export class Tree {
     }
 
     const ancestors: HTMLCalciteTreeItemElement[] = [];
-    let parent = item.parentElement?.closest<HTMLCalciteTreeItemElement>("calcite-tree-item");
+    let parent = item.parentElement.closest<HTMLCalciteTreeItemElement>("calcite-tree-item");
     while (parent) {
       ancestors.push(parent);
-      parent = parent.parentElement?.closest<HTMLCalciteTreeItemElement>("calcite-tree-item");
+      parent = parent.parentElement.closest<HTMLCalciteTreeItemElement>("calcite-tree-item");
     }
 
     const childItems = Array.from(


### PR DESCRIPTION
**Related Issue:** #5520

## Summary

Some of the optional chaining `?` added to get rid of the typeError in cases when there is no `parentEl` (#5472) was redundant. In the context of events from child items, there is no need for the `?` operator as the event is processed after it bubbles, so we can assume there's an ancestor chain.