### PR TITLE
build(deps): bump calcite icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.0.1",
-        "@esri/calcite-ui-icons": "3.20.3",
+        "@esri/calcite-ui-icons": "3.20.5",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil/eslint-plugin": "0.4.0",
         "@stencil/postcss": "2.1.0",
@@ -2255,9 +2255,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.3.tgz",
-      "integrity": "sha512-7IFIbsCx5bVNFqn/6R7veVug6jJEFeEzBwpya432rQY9sOyDzA7IQJPTWmOCNFiBSRCjoI//ovR3pyZgkmTaDA==",
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.5.tgz",
+      "integrity": "sha512-HoHt6I3gzVg557dPY+g+ilUt1EQSbqtkn+hI5qjhrcxQu3kur+VuEDLkaiS9MYpWyNNh2CE2hffPtOYl5m8wvA==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -35207,9 +35207,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.3.tgz",
-      "integrity": "sha512-7IFIbsCx5bVNFqn/6R7veVug6jJEFeEzBwpya432rQY9sOyDzA7IQJPTWmOCNFiBSRCjoI//ovR3pyZgkmTaDA==",
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.5.tgz",
+      "integrity": "sha512-HoHt6I3gzVg557dPY+g+ilUt1EQSbqtkn+hI5qjhrcxQu3kur+VuEDLkaiS9MYpWyNNh2CE2hffPtOYl5m8wvA==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.1",
-    "@esri/calcite-ui-icons": "3.20.3",
+    "@esri/calcite-ui-icons": "3.20.5",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** #5481

## Summary
Bumps `@esri/calcite-ui-icons`
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
