### PR TITLE
ci(screener): reenable screener on pushes to master to update baseline

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -1,14 +1,14 @@
 name: Screener
 on:
-  # To conserve snapshots, we are temporarily running Screener on master manually when there are visual changes.
-  # We will eventually go back to visual snapshotting on pushes to master to automatically update the baseline.
+  push:
+    branches: [master]
   workflow_dispatch:
   pull_request:
     branches: [master]
     types: [labeled, synchronize, ready_for_review]
 jobs:
   screenshot_tests:
-    if: "(github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.event.action == 'labeled' && github.event.label.name == 'pr ready for visual snapshots' && github.event.pull_request.draft == false)"
+    if: "(github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.event.action == 'labeled' && github.event.label.name == 'pr ready for visual snapshots' && github.event.pull_request.draft == false) || (github.event_name == 'push')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -8,7 +8,7 @@ on:
     types: [labeled, synchronize, ready_for_review]
 jobs:
   screenshot_tests:
-    if: "(github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.event.action == 'labeled' && github.event.label.name == 'pr ready for visual snapshots' && github.event.pull_request.draft == false) || (github.event_name == 'push')"
+    if: "(github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.event.action == 'labeled' && github.event.label.name == 'pr ready for visual snapshots' && github.event.pull_request.draft == false) || (github.event_name == 'push' && github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
           state: success
           sha: ${{github.event.pull_request.head.sha || github.sha}}
   skip_screenshot_tests:
-    if: "(github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.actor == 'dependabot-preview[bot]' && github.event.action != 'labeled')"
+    if: "github.event_name == 'pull_request' && (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'pr ready for visual snapshots')) || (github.actor == 'dependabot[bot]' && github.event.action != 'labeled')"
     runs-on: ubuntu-latest
     steps:
       - name: skip screener for dependabot PRs or no visual changes


### PR DESCRIPTION
**Related Issue:** #

## Summary

When we scaled back our screener snapshot usage we decided to not run Screener on every push to `master`, which meant it would need to be ran manually whenever a screener change happened. Otherwise baseline gets out of sync and it causes problems. 

People haven't been remembering to tell me to run screener manually, so I'm re-enabling automatic screener runs on `master`. I tweaked it a bit so `dependabot` and `next` deployment pushes to `master` do not run screener. We have the screenshot bandwidth to re-enable this; I think trimming down some of the stories and not running screener on every single push to a PR branch made the biggest difference. 

![image](https://user-images.githubusercontent.com/10986395/196838311-7250f26f-7e98-42f4-9f00-e1b7f4d5e62b.png)

Based on our snapshot count, we can also start adding the `pr ready for visual snapshots` label to all PRs before merging. Which means we won't need admin people to push thru PRs. I'll keep an eye on the snapshot count as we make these changes, but we are more than halfway through the month and still have 2/3rds of our snapshots left.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
