### PR TITLE
fix(slider): fix slider (single-value) error when clicking range

### DIFF
--- a/src/components/slider/slider.e2e.ts
+++ b/src/components/slider/slider.e2e.ts
@@ -270,6 +270,60 @@ describe("calcite-slider", () => {
     expect(changeEvent).toHaveReceivedEventTimes(1);
   });
 
+  describe("thumb focus for single value", () => {
+    const sliderForThumbFocusTests = html`<calcite-slider
+      style="width:${sliderWidthFor1To1PixelValueTrack}"
+      min="0"
+      max="100"
+      snap
+      ticks="10"
+      value="50"
+    ></calcite-slider>`;
+
+    it("should focus thumb when clicked near", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`${sliderForThumbFocusTests}`);
+      const slider = await page.find("calcite-slider");
+      const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
+
+      await page.mouse.move(trackX + 50, trackY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      let isThumbFocused = await page.$eval("calcite-slider", (slider) =>
+        slider.shadowRoot.activeElement?.classList.contains("thumb--value")
+      );
+
+      expect(isThumbFocused).toBe(true);
+      expect(await slider.getProperty("value")).toBe(50);
+
+      await page.mouse.move(trackX + 40, trackY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      isThumbFocused = await page.$eval("calcite-slider", (slider) =>
+        slider.shadowRoot.activeElement?.classList.contains("thumb--value")
+      );
+
+      expect(isThumbFocused).toBe(true);
+      expect(await slider.getProperty("value")).toBe(40);
+
+      await page.mouse.move(trackX + 60, trackY);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.waitForChanges();
+
+      isThumbFocused = await page.$eval("calcite-slider", (slider) =>
+        slider.shadowRoot.activeElement?.classList.contains("thumb--value")
+      );
+
+      expect(isThumbFocused).toBe(true);
+      expect(await slider.getProperty("value")).toBe(60);
+    });
+  });
+
   describe("thumb focus in range", () => {
     const sliderForThumbFocusTests = html`<calcite-slider
       style="width:${sliderWidthFor1To1PixelValueTrack}"

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -830,7 +830,6 @@ export class Slider
   @Listen("pointerdown")
   pointerDownHandler(event: PointerEvent): void {
     const x = event.clientX || event.pageX;
-    this.focusActiveHandle(x);
     const position = this.translate(x);
     let prop: ActiveSliderProperty = "value";
     if (isRange(this.value)) {
@@ -848,6 +847,7 @@ export class Slider
     if (!isThumbActive) {
       this.setValue(prop, this.clamp(position, prop));
     }
+    this.focusActiveHandle(x);
   }
 
   handleTouchStart(event: TouchEvent): void {
@@ -913,6 +913,8 @@ export class Slider
 
   defaultValue: Slider["value"];
 
+  private activeProp: ActiveSliderProperty = "value";
+
   private guid = `calcite-slider-${guid()}`;
 
   private dragProp: ActiveSliderProperty;
@@ -928,8 +930,6 @@ export class Slider
   private trackEl: HTMLDivElement;
 
   @State() effectiveLocale = "";
-
-  @State() private activeProp: ActiveSliderProperty = "value";
 
   @State() private minMaxValueRange: number = null;
 
@@ -1004,6 +1004,7 @@ export class Slider
         this.minHandle.focus();
         break;
       case "maxValue":
+      case "value":
         this.maxHandle.focus();
         break;
       case "minMaxValue":


### PR DESCRIPTION
**Related Issue:** #5321 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression from https://github.com/Esri/calcite-components/commit/24a6b9548e8eaa2ab8b8c9faa05869c0c29d6136 where the thumb was being focused before the drag prop was set, causing an error to be thrown when clicking on the track, on opposite sides of the thumb.

### Notes

* `activeProp` is no longer a state prop as it does not affect rendering (takes care of Stencil dev-time rendering warning)
* makes slider UX more consistent by focusing the single-thumb immediately on `pointerdown` (currently, this only happens with range slider)