### PR TITLE
fix(date-picker): display correct date format order in header for zh-CN locale.

### DIFF
--- a/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -73,6 +73,7 @@
 .text {
   @apply my-auto
     w-full
+    flex
     flex-auto
     items-center
     justify-center
@@ -80,7 +81,7 @@
     leading-none;
 }
 
-.text-nreverse {
+.text--reverse {
   @apply flex-row-reverse;
 }
 


### PR DESCRIPTION


**Related Issue:** #5532 

## Summary

This PR will fix the format order issue in `calcite-date-picker` header for locales of order YYYY.MM.DD