### PR TITLE
fix(calcite-loader, calcite-input-message): drop active in favor of hidden

### DIFF
--- a/src/components/input-message/input-message.e2e.ts
+++ b/src/components/input-message/input-message.e2e.ts
@@ -3,7 +3,10 @@ import { accessible, renders, hidden } from "../../tests/commonTests";
 import { StatusIconDefaults } from "./interfaces";
 
 describe("calcite-input-message", () => {
-  it("renders", async () => renders("calcite-input-message", { visible: false, display: "flex" }));
+  it("renders", async () => {
+    await renders(`<calcite-input-message hidden></calcite-input-message>`, { display: "none", visible: false });
+    await renders(`<calcite-input-message></calcite-input-message>`, { display: "flex", visible: true });
+  });
 
   it("honors hidden attribute", async () => hidden(`<calcite-input-message active>Text</calcite-input-message>`));
 

--- a/src/components/input-message/input-message.scss
+++ b/src/components/input-message/input-message.scss
@@ -6,8 +6,8 @@
  * @prop --calcite-input-message-spacing-value: The top margin spacing above the component.
  */
 
-:host([active][scale="m"]),
-:host([active][scale="l"]) {
+:host([scale="m"]),
+:host([scale="l"]) {
   --calcite-input-message-spacing-value: theme("spacing.1");
 }
 
@@ -15,16 +15,14 @@
   @apply text-color-1 transition-default invisible box-border flex h-0 w-full items-center font-medium opacity-0;
 }
 
-:host([active]) {
+:host {
   @apply transition-default visible h-auto opacity-100;
 }
 
-:host([active][scale="m"]),
-:host([active][scale="l"]) {
+:host([scale="m"]),
+:host([scale="l"]) {
   margin-block-start: var(--calcite-input-message-spacing-value);
 }
-
-@include calciteHydratedHidden();
 
 .calcite-input-message-icon {
   @apply transition-default
@@ -51,7 +49,7 @@
 }
 
 // Validation Text
-:host([status][active]) {
+:host([status]) {
   @apply text-color-1;
 }
 

--- a/src/components/input-message/input-message.tsx
+++ b/src/components/input-message/input-message.tsx
@@ -33,13 +33,6 @@ export class InputMessage {
    */
   @Prop({ reflect: true }) active = false;
 
-  /**
-   * When `true`, the component will not be visible.
-   *
-   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-   */
-  @Prop({ reflect: true }) hidden = false;
-
   /** Specifies an icon to display. */
   @Prop({ reflect: true }) icon: boolean | string;
 

--- a/src/components/input-message/input-message.tsx
+++ b/src/components/input-message/input-message.tsx
@@ -30,6 +30,7 @@ export class InputMessage {
    * When `true`, the component is active.
    *
    * @deprecated use global `hidden` attribute instead.
+   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
    */
   @Prop({ reflect: true }) active = false;
 

--- a/src/components/input-message/input-message.tsx
+++ b/src/components/input-message/input-message.tsx
@@ -26,8 +26,19 @@ export class InputMessage {
   //
   //--------------------------------------------------------------------------
 
-  /** When `true`, the component is active. */
+  /**
+   * When `true`, the component is active.
+   *
+   * @deprecated use global `hidden` attribute instead.
+   */
   @Prop({ reflect: true }) active = false;
+
+  /**
+   * When `true`, the component will not be visible.
+   *
+   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+   */
+  @Prop({ reflect: true }) hidden = false;
 
   /** Specifies an icon to display. */
   @Prop({ reflect: true }) icon: boolean | string;

--- a/src/components/loader/loader.e2e.ts
+++ b/src/components/loader/loader.e2e.ts
@@ -3,8 +3,8 @@ import { renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-loader", () => {
   it("renders", async () => {
-    await renders("calcite-loader", { display: "none", visible: false });
-    await renders(`<calcite-loader active></calcite-loader>`, { display: "flex", visible: true });
+    await renders(`<calcite-loader hidden></calcite-loader>`, { display: "none", visible: false });
+    await renders(`<calcite-loader></calcite-loader>`, { display: "flex", visible: true });
   });
 
   it("honors hidden attribute", async () => hidden("calcite-loader"));

--- a/src/components/loader/loader.scss
+++ b/src/components/loader/loader.scss
@@ -48,10 +48,6 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
 }
 
 :host {
-  @apply hidden;
-}
-
-:host([active]) {
   @apply flex;
 }
 
@@ -126,7 +122,7 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   vertical-align: calc(var(--calcite-loader-size-inline) * -1 * 0.2);
 }
 
-:host([active][inline]) {
+:host([inline]) {
   @apply inline-block;
 }
 

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -20,8 +20,20 @@ export class Loader {
   //  Properties
   //
   //--------------------------------------------------------------------------
-  /** When `true`, the component is active. */
+
+  /**
+   * When `true`, the component is active.
+   *
+   * @deprecated use global `hidden` attribute instead.
+   */
   @Prop({ reflect: true }) active = false;
+
+  /**
+   * When `true`, the component will not be visible.
+   *
+   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+   */
+  @Prop({ reflect: true }) hidden = false;
 
   /** When `true`, displays smaller and appears to the left of the text. */
   @Prop({ reflect: true }) inline = false;

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -25,6 +25,7 @@ export class Loader {
    * When `true`, the component is active.
    *
    * @deprecated use global `hidden` attribute instead.
+   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
    */
   @Prop({ reflect: true }) active = false;
 

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -28,13 +28,6 @@ export class Loader {
    */
   @Prop({ reflect: true }) active = false;
 
-  /**
-   * When `true`, the component will not be visible.
-   *
-   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-   */
-  @Prop({ reflect: true }) hidden = false;
-
   /** When `true`, displays smaller and appears to the left of the text. */
   @Prop({ reflect: true }) inline = false;
 


### PR DESCRIPTION
**Related Issue:** #3821

## Summary

Loader and Input-Message are small building blocks that an owning component should be able to display or hide.

This deprecates/removes the role of `active` prop in toggling visibility in favor of the global attribute `hidden`. Styles for hidden take precedence over active. 

The benefit is one less custom prop to manage, and it aligns with existing HTML conventions.