### PR TITLE
fix: add custom logic for floating-ui positioning across shadow DOM in non-Chromium browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "SEE LICENSE IN copyright.txt",
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
-        "@floating-ui/dom": "1.0.2",
         "@stencil/core": "2.18.1",
         "@types/color": "3.0.3",
         "color": "4.2.3",
@@ -24,6 +23,7 @@
         "@esri/calcite-colors": "6.0.1",
         "@esri/calcite-ui-icons": "3.20.5",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
+        "@floating-ui/dom": "1.0.3",
         "@stencil/eslint-plugin": "0.4.0",
         "@stencil/postcss": "2.1.0",
         "@stencil/sass": "2.0.0",
@@ -2283,12 +2283,14 @@
     "node_modules/@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==",
+      "dev": true
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
-      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
+      "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
+      "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.0.1"
       }
@@ -35225,12 +35227,14 @@
     "@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==",
+      "dev": true
     },
     "@floating-ui/dom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
-      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
+      "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
+      "dev": true,
       "requires": {
         "@floating-ui/core": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "@a11y/focus-trap": "1.0.5",
-    "@floating-ui/dom": "1.0.2",
     "@stencil/core": "2.18.1",
     "@types/color": "3.0.3",
     "color": "4.2.3",
@@ -84,6 +83,7 @@
     "@esri/calcite-colors": "6.0.1",
     "@esri/calcite-ui-icons": "3.20.5",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
+    "@floating-ui/dom": "1.0.3",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",
     "@stencil/sass": "2.0.0",

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,21 @@
+/**
+ * This module helps users provide custom configuration for component internals.
+ *
+ * @internal
+ */
+
+const configOverrides = globalThis["calciteComponentsConfig"];
+
+const config = {
+  /**
+   * We apply a custom fix to improve positioning for non-Chromium browsers.
+   * The fix comes at a performance cost, so provides users a way to opt-out if necessary.
+   *
+   * @internal
+   */
+  floatingUINonChromiumPositioningFix: true,
+
+  ...configOverrides
+};
+
+export { config };

--- a/src/utils/floating-ui.ts
+++ b/src/utils/floating-ui.ts
@@ -15,6 +15,7 @@ import {
 } from "@floating-ui/dom";
 import { getElementDir } from "./dom";
 import { Build } from "@stencil/core";
+import { config } from "./config";
 
 const floatingUIBrowserCheck = patchFloatingUiForNonChromiumBrowsers();
 
@@ -37,6 +38,7 @@ async function patchFloatingUiForNonChromiumBrowsers(): Promise<void> {
 
   if (
     Build.isBrowser &&
+    config.floatingUINonChromiumPositioningFix &&
     // ⚠️ browser-sniffing is not a best practice and should be avoided ⚠️
     /firefox|safari/i.test(getUAString())
   ) {

--- a/src/utils/floating-ui.ts
+++ b/src/utils/floating-ui.ts
@@ -36,7 +36,7 @@ async function patchFloatingUiForNonChromiumBrowsers(): Promise<void> {
   }
 
   if (
-    !Build.isBrowser ||
+    Build.isBrowser &&
     // ⚠️ browser-sniffing is not a best practice and should be avoided ⚠️
     /firefox|safari/i.test(getUAString())
   ) {

--- a/src/utils/floating-ui.ts
+++ b/src/utils/floating-ui.ts
@@ -14,7 +14,6 @@ import {
   VirtualElement
 } from "@floating-ui/dom";
 import { getElementDir } from "./dom";
-import { debounce } from "lodash-es";
 import { Build } from "@stencil/core";
 
 const floatingUIBrowserCheck = patchFloatingUiForNonChromiumBrowsers();

--- a/src/utils/floating-ui/nonChromiumPlatformUtils.ts
+++ b/src/utils/floating-ui/nonChromiumPlatformUtils.ts
@@ -1,0 +1,599 @@
+import { rectToClientRect, Strategy } from "@floating-ui/core";
+import type { ElementRects } from "@floating-ui/dom";
+import { FloatingElement, ReferenceElement } from "@floating-ui/dom/src/types";
+
+/**
+ * This module provides utils to fix positioning across shadow DOM in non-Chromium browsers
+ *
+ * It is based on floating-ui's distributable
+ */
+
+/**
+ * 👇 the following are needed to fix shadow DOM positioning 👇️
+ *
+ * @param element
+ */
+function getTrueOffsetParent(element) {
+  if (!isHTMLElement(element) || getComputedStyle(element).position === "fixed") {
+    return null;
+  }
+
+  return composedOffsetParent(element);
+}
+
+/**
+ * Polyfills the old offsetParent behavior from before the spec was changed:
+ * https://github.com/w3c/csswg-drafts/issues/159
+ *
+ * @param element
+ */
+function composedOffsetParent(element) {
+  let { offsetParent } = element;
+  let ancestor = element;
+  let foundInsideSlot = false;
+
+  while (ancestor && ancestor !== offsetParent) {
+    const { assignedSlot } = ancestor;
+
+    if (assignedSlot) {
+      let newOffsetParent = assignedSlot.offsetParent;
+
+      if (getComputedStyle(assignedSlot).display === "contents") {
+        const hadStyleAttribute = assignedSlot.hasAttribute("style");
+        const oldDisplay = assignedSlot.style.display;
+        assignedSlot.style.display = getComputedStyle(ancestor).display;
+        newOffsetParent = assignedSlot.offsetParent;
+        assignedSlot.style.display = oldDisplay;
+
+        if (!hadStyleAttribute) {
+          assignedSlot.removeAttribute("style");
+        }
+      }
+
+      ancestor = assignedSlot;
+
+      if (offsetParent !== newOffsetParent) {
+        offsetParent = newOffsetParent;
+        foundInsideSlot = true;
+      }
+    } else if (isShadowRoot(ancestor) && ancestor.host && foundInsideSlot) {
+      break;
+    }
+
+    ancestor = (isShadowRoot(ancestor) && ancestor.host) || ancestor.parentNode;
+  }
+
+  return offsetParent;
+}
+
+function getElementRects(_ref: {
+  reference: ReferenceElement;
+  floating: FloatingElement;
+  strategy: Strategy;
+}): ElementRects {
+  const { reference, floating, strategy } = _ref;
+  return {
+    reference: getRectRelativeToOffsetParent(reference, getOffsetParent(floating), strategy),
+    floating: { ...getDimensions(floating), x: 0, y: 0 }
+  };
+}
+
+export { getClippingRect, getElementRects, getOffsetParent };
+
+/**
+ * ☝️ the following are needed to fix shadow DOM positioning ☝️
+ */
+
+/**
+ * 👇 the following are taken directly from floating-ui's ESM distributable to support the exports above 👇️
+ *
+ * **Notes**:
+ * unused functions are removed
+ * ESLint is disabled
+ * TS-warnings are suppressed
+ */
+/* eslint-disable */
+
+function isWindow(value) {
+  return value && value.document && value.location && value.alert && value.setInterval;
+}
+function getWindow(node) {
+  if (node == null) {
+    return window;
+  }
+
+  if (!isWindow(node)) {
+    const ownerDocument = node.ownerDocument;
+    return ownerDocument ? ownerDocument.defaultView || window : window;
+  }
+
+  return node;
+}
+
+function getComputedStyle(element) {
+  return getWindow(element).getComputedStyle(element);
+}
+
+function getNodeName(node) {
+  return isWindow(node) ? "" : node ? (node.nodeName || "").toLowerCase() : "";
+}
+
+function getUAString() {
+  // @ts-ignore
+  const uaData = navigator.userAgentData;
+
+  if (uaData != null && uaData.brands) {
+    return uaData.brands.map((item) => item.brand + "/" + item.version).join(" ");
+  }
+
+  return navigator.userAgent;
+}
+
+function isHTMLElement(value) {
+  return value instanceof getWindow(value).HTMLElement;
+}
+function isElement(value) {
+  return value instanceof getWindow(value).Element;
+}
+function isNode(value) {
+  return value instanceof getWindow(value).Node;
+}
+function isShadowRoot(node) {
+  // Browsers without `ShadowRoot` support
+  if (typeof ShadowRoot === "undefined") {
+    return false;
+  }
+
+  const OwnElement = getWindow(node).ShadowRoot;
+  return node instanceof OwnElement || node instanceof ShadowRoot;
+}
+function isOverflowElement(element) {
+  // Firefox wants us to check `-x` and `-y` variations as well
+  const { overflow, overflowX, overflowY, display } = getComputedStyle(element);
+  return (
+    /auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX) && !["inline", "contents"].includes(display)
+  );
+}
+function isTableElement(element) {
+  return ["table", "td", "th"].includes(getNodeName(element));
+}
+function isContainingBlock(element) {
+  // TODO: Try and use feature detection here instead
+  const isFirefox = /firefox/i.test(getUAString());
+  const css = getComputedStyle(element); // This is non-exhaustive but covers the most common CSS properties that
+  // create a containing block.
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
+
+  return (
+    css.transform !== "none" ||
+    css.perspective !== "none" ||
+    (isFirefox && css.willChange === "filter") ||
+    (isFirefox && (css.filter ? css.filter !== "none" : false)) ||
+    ["transform", "perspective"].some((value) => css.willChange.includes(value)) ||
+    ["paint", "layout", "strict", "content"].some(
+      // TS 4.1 compat
+      (value) => {
+        const contain = css.contain;
+        return contain != null ? contain.includes(value) : false;
+      }
+    )
+  );
+}
+function isLayoutViewport() {
+  // Not Safari
+  return !/^((?!chrome|android).)*safari/i.test(getUAString()); // Feature detection for this fails in various ways
+  // • Always-visible scrollbar or not
+  // • Width of <html>, etc.
+  // const vV = win.visualViewport;
+  // return vV ? Math.abs(win.innerWidth / vV.scale - vV.width) < 0.5 : true;
+}
+function isLastTraversableNode(node) {
+  return ["html", "body", "#document"].includes(getNodeName(node));
+}
+
+const min = Math.min;
+const max = Math.max;
+const round = Math.round;
+
+function getBoundingClientRect(element, includeScale, isFixedStrategy) {
+  var _win$visualViewport$o, _win$visualViewport, _win$visualViewport$o2, _win$visualViewport2;
+
+  if (includeScale === void 0) {
+    includeScale = false;
+  }
+
+  if (isFixedStrategy === void 0) {
+    isFixedStrategy = false;
+  }
+
+  const clientRect = element.getBoundingClientRect();
+  let scaleX = 1;
+  let scaleY = 1;
+
+  if (includeScale && isHTMLElement(element)) {
+    scaleX = element.offsetWidth > 0 ? round(clientRect.width) / element.offsetWidth || 1 : 1;
+    scaleY = element.offsetHeight > 0 ? round(clientRect.height) / element.offsetHeight || 1 : 1;
+  }
+
+  const win = isElement(element) ? getWindow(element) : window;
+  const addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
+  const x =
+    (clientRect.left +
+      (addVisualOffsets
+        ? (_win$visualViewport$o =
+            (_win$visualViewport = win.visualViewport) == null ? void 0 : _win$visualViewport.offsetLeft) != null
+          ? _win$visualViewport$o
+          : 0
+        : 0)) /
+    scaleX;
+  const y =
+    (clientRect.top +
+      (addVisualOffsets
+        ? (_win$visualViewport$o2 =
+            (_win$visualViewport2 = win.visualViewport) == null ? void 0 : _win$visualViewport2.offsetTop) != null
+          ? _win$visualViewport$o2
+          : 0
+        : 0)) /
+    scaleY;
+  const width = clientRect.width / scaleX;
+  const height = clientRect.height / scaleY;
+  return {
+    width,
+    height,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+    left: x,
+    x,
+    y
+  };
+}
+
+function getDocumentElement(node) {
+  return ((isNode(node) ? node.ownerDocument : node.document) || window.document).documentElement;
+}
+
+function getNodeScroll(element) {
+  if (isElement(element)) {
+    return {
+      scrollLeft: element.scrollLeft,
+      scrollTop: element.scrollTop
+    };
+  }
+
+  return {
+    scrollLeft: element.pageXOffset,
+    scrollTop: element.pageYOffset
+  };
+}
+
+function getWindowScrollBarX(element) {
+  // If <html> has a CSS width greater than the viewport, then this will be
+  // incorrect for RTL.
+  // @ts-ignore
+  return getBoundingClientRect(getDocumentElement(element)).left + getNodeScroll(element).scrollLeft;
+}
+
+function isScaled(element) {
+  // @ts-ignore
+  const rect = getBoundingClientRect(element);
+  return round(rect.width) !== element.offsetWidth || round(rect.height) !== element.offsetHeight;
+}
+
+function getRectRelativeToOffsetParent(element, offsetParent, strategy) {
+  const isOffsetParentAnElement = isHTMLElement(offsetParent);
+  const documentElement = getDocumentElement(offsetParent);
+  const rect = getBoundingClientRect(
+    element, // @ts-ignore - checked above (TS 4.1 compat)
+    isOffsetParentAnElement && isScaled(offsetParent),
+    strategy === "fixed"
+  );
+  let scroll = {
+    scrollLeft: 0,
+    scrollTop: 0
+  };
+  const offsets = {
+    x: 0,
+    y: 0
+  };
+
+  if (isOffsetParentAnElement || (!isOffsetParentAnElement && strategy !== "fixed")) {
+    if (getNodeName(offsetParent) !== "body" || isOverflowElement(documentElement)) {
+      scroll = getNodeScroll(offsetParent);
+    }
+
+    if (isHTMLElement(offsetParent)) {
+      // @ts-ignore
+      const offsetRect = getBoundingClientRect(offsetParent, true);
+      offsets.x = offsetRect.x + offsetParent.clientLeft;
+      offsets.y = offsetRect.y + offsetParent.clientTop;
+    } else if (documentElement) {
+      offsets.x = getWindowScrollBarX(documentElement);
+    }
+  }
+
+  return {
+    x: rect.left + scroll.scrollLeft - offsets.x,
+    y: rect.top + scroll.scrollTop - offsets.y,
+    width: rect.width,
+    height: rect.height
+  };
+}
+
+function getParentNode(node) {
+  if (getNodeName(node) === "html") {
+    return node;
+  }
+
+  return (
+    // this is a quicker (but less type safe) way to save quite some bytes from the bundle
+    // @ts-ignore
+    node.assignedSlot || // step into the shadow DOM of the parent of a slotted node
+    node.parentNode || // DOM Element detected
+    (isShadowRoot(node) ? node.host : null) || // ShadowRoot detected
+    getDocumentElement(node) // fallback
+  );
+}
+
+function getContainingBlock(element) {
+  let currentNode = getParentNode(element);
+
+  if (isShadowRoot(currentNode)) {
+    currentNode = currentNode.host;
+  }
+
+  while (isHTMLElement(currentNode) && !isLastTraversableNode(currentNode)) {
+    if (isContainingBlock(currentNode)) {
+      return currentNode;
+    } else {
+      const parent = currentNode.parentNode;
+      currentNode = isShadowRoot(parent) ? parent.host : parent;
+    }
+  }
+
+  return null;
+} // Gets the closest ancestor positioned element. Handles some edge cases,
+// such as table ancestors and cross browser bugs.
+
+function getOffsetParent(element) {
+  const window = getWindow(element);
+  let offsetParent = getTrueOffsetParent(element);
+
+  while (offsetParent && isTableElement(offsetParent) && getComputedStyle(offsetParent).position === "static") {
+    offsetParent = getTrueOffsetParent(offsetParent);
+  }
+
+  if (
+    offsetParent &&
+    (getNodeName(offsetParent) === "html" ||
+      (getNodeName(offsetParent) === "body" &&
+        getComputedStyle(offsetParent).position === "static" &&
+        !isContainingBlock(offsetParent)))
+  ) {
+    return window;
+  }
+
+  return offsetParent || getContainingBlock(element) || window;
+}
+
+function getDimensions(element) {
+  if (isHTMLElement(element)) {
+    return {
+      width: element.offsetWidth,
+      height: element.offsetHeight
+    };
+  }
+
+  // @ts-ignore
+  const rect = getBoundingClientRect(element);
+  return {
+    width: rect.width,
+    height: rect.height
+  };
+}
+
+function getViewportRect(element, strategy) {
+  const win = getWindow(element);
+  const html = getDocumentElement(element);
+  const visualViewport = win.visualViewport;
+  let width = html.clientWidth;
+  let height = html.clientHeight;
+  let x = 0;
+  let y = 0;
+
+  if (visualViewport) {
+    width = visualViewport.width;
+    height = visualViewport.height;
+    const layoutViewport = isLayoutViewport();
+
+    if (layoutViewport || (!layoutViewport && strategy === "fixed")) {
+      x = visualViewport.offsetLeft;
+      y = visualViewport.offsetTop;
+    }
+  }
+
+  return {
+    width,
+    height,
+    x,
+    y
+  };
+}
+
+// of the `<html>` and `<body>` rect bounds if horizontally scrollable
+
+function getDocumentRect(element) {
+  var _element$ownerDocumen;
+
+  const html = getDocumentElement(element);
+  const scroll = getNodeScroll(element);
+  const body = (_element$ownerDocumen = element.ownerDocument) == null ? void 0 : _element$ownerDocumen.body;
+  const width = max(html.scrollWidth, html.clientWidth, body ? body.scrollWidth : 0, body ? body.clientWidth : 0);
+  const height = max(html.scrollHeight, html.clientHeight, body ? body.scrollHeight : 0, body ? body.clientHeight : 0);
+  let x = -scroll.scrollLeft + getWindowScrollBarX(element);
+  const y = -scroll.scrollTop;
+
+  if (getComputedStyle(body || html).direction === "rtl") {
+    x += max(html.clientWidth, body ? body.clientWidth : 0) - width;
+  }
+
+  return {
+    width,
+    height,
+    x,
+    y
+  };
+}
+
+function getNearestOverflowAncestor(node) {
+  const parentNode = getParentNode(node);
+
+  if (isLastTraversableNode(parentNode)) {
+    // @ts-ignore assume body is always available
+    return node.ownerDocument.body;
+  }
+
+  if (isHTMLElement(parentNode) && isOverflowElement(parentNode)) {
+    return parentNode;
+  }
+
+  return getNearestOverflowAncestor(parentNode);
+}
+
+function getOverflowAncestors(node, list) {
+  var _node$ownerDocument;
+
+  if (list === void 0) {
+    list = [];
+  }
+
+  const scrollableAncestor = getNearestOverflowAncestor(node);
+  const isBody =
+    scrollableAncestor === ((_node$ownerDocument = node.ownerDocument) == null ? void 0 : _node$ownerDocument.body);
+  const win = getWindow(scrollableAncestor);
+  const target = isBody
+    ? [win].concat(win.visualViewport || [], isOverflowElement(scrollableAncestor) ? scrollableAncestor : [])
+    : scrollableAncestor;
+  const updatedList = list.concat(target);
+  return isBody
+    ? updatedList // @ts-ignore: isBody tells us target will be an HTMLElement here
+    : updatedList.concat(getOverflowAncestors(target));
+}
+
+function contains(parent, child) {
+  const rootNode = child.getRootNode == null ? void 0 : child.getRootNode(); // First, attempt with faster native method
+
+  if (parent.contains(child)) {
+    return true;
+  } // then fallback to custom implementation with Shadow DOM support
+  else if (rootNode && isShadowRoot(rootNode)) {
+    let next = child;
+
+    do {
+      // use `===` replace node.isSameNode()
+      if (next && parent === next) {
+        return true;
+      } // @ts-ignore: need a better way to handle this...
+
+      next = next.parentNode || next.host;
+    } while (next);
+  }
+
+  return false;
+}
+
+function getNearestParentCapableOfEscapingClipping(element, clippingAncestors) {
+  let currentNode = element;
+
+  while (currentNode && !isLastTraversableNode(currentNode) && !clippingAncestors.includes(currentNode)) {
+    if (isElement(currentNode) && ["absolute", "fixed"].includes(getComputedStyle(currentNode).position)) {
+      break;
+    }
+
+    const parentNode = getParentNode(currentNode);
+    currentNode = isShadowRoot(parentNode) ? parentNode.host : parentNode;
+  }
+
+  return currentNode;
+}
+
+function getInnerBoundingClientRect(element, strategy) {
+  const clientRect = getBoundingClientRect(element, false, strategy === "fixed");
+  const top = clientRect.top + element.clientTop;
+  const left = clientRect.left + element.clientLeft;
+  return {
+    top,
+    left,
+    x: left,
+    y: top,
+    right: left + element.clientWidth,
+    bottom: top + element.clientHeight,
+    width: element.clientWidth,
+    height: element.clientHeight
+  };
+}
+
+function getClientRectFromClippingAncestor(element, clippingParent, strategy) {
+  if (clippingParent === "viewport") {
+    return rectToClientRect(getViewportRect(element, strategy));
+  }
+
+  if (isElement(clippingParent)) {
+    return getInnerBoundingClientRect(clippingParent, strategy);
+  }
+
+  return rectToClientRect(getDocumentRect(getDocumentElement(element)));
+} // A "clipping ancestor" is an overflowable container with the characteristic of
+// clipping (or hiding) overflowing elements with a position different from
+// `initial`
+
+function getClippingAncestors(element) {
+  // @ts-ignore
+  const clippingAncestors = getOverflowAncestors(element);
+  const nearestEscapableParent = getNearestParentCapableOfEscapingClipping(element, clippingAncestors);
+  let clipperElement = null;
+
+  if (nearestEscapableParent && isHTMLElement(nearestEscapableParent)) {
+    const offsetParent = getOffsetParent(nearestEscapableParent);
+
+    if (isOverflowElement(nearestEscapableParent)) {
+      clipperElement = nearestEscapableParent;
+    } else if (isHTMLElement(offsetParent)) {
+      clipperElement = offsetParent;
+    }
+  }
+
+  if (!isElement(clipperElement)) {
+    return [];
+  } // @ts-ignore isElement check ensures we return Array<Element>
+
+  return clippingAncestors.filter(
+    (clippingAncestors) =>
+      clipperElement &&
+      isElement(clippingAncestors) &&
+      contains(clippingAncestors, clipperElement) &&
+      getNodeName(clippingAncestors) !== "body"
+  );
+} // Gets the maximum area that the element is visible in due to any number of
+// clipping ancestors
+
+function getClippingRect(_ref) {
+  let { element, boundary, rootBoundary, strategy } = _ref;
+  const mainClippingAncestors = boundary === "clippingAncestors" ? getClippingAncestors(element) : [].concat(boundary);
+  const clippingAncestors = [...mainClippingAncestors, rootBoundary];
+  const firstClippingAncestor = clippingAncestors[0];
+  const clippingRect = clippingAncestors.reduce((accRect, clippingAncestor) => {
+    const rect = getClientRectFromClippingAncestor(element, clippingAncestor, strategy);
+    accRect.top = max(rect.top, accRect.top);
+    accRect.right = min(rect.right, accRect.right);
+    accRect.bottom = min(rect.bottom, accRect.bottom);
+    accRect.left = max(rect.left, accRect.left);
+    return accRect;
+  }, getClientRectFromClippingAncestor(element, firstClippingAncestor, strategy));
+  return {
+    width: clippingRect.right - clippingRect.left,
+    height: clippingRect.bottom - clippingRect.top,
+    x: clippingRect.left,
+    y: clippingRect.top
+  };
+}


### PR DESCRIPTION
**Related Issue:** #5429

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This restores positioning logic that was reverted from [`@floating-ui/dom@1.0.2`](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fdom%401.0.2) due to the performance impact. The fix will only be applied to non-Chromium browsers (targeting Firefox and Safari specifically) by default and can be disabled by providing the following config flag:

```html
<script>
  var calciteComponentsConfig = {
    floatingUINonChromiumPositioningFix: false
  }
</script>
```

### Notes

* introduces a global config for components to allow users to opt-out of the fix in favor of performance
* bumps `@floating-ui/dom` to [1.0.3](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fdom%401.0.3)
* dynamically loads custom code for non-Chromium browsers for proper positioning
* the nature of this fix requires using some perf-degrading code for non-Chromium browsers, but with #5399/#5484  (less frequent positioning updates), this should be less severe though
* the config should not be documented until we solidify a few items first (naming, scope, feedback on defaults), but should be fine to share as a workaround
* the module for the fix depends on copying over some `floating-ui` code (doc has move info) and we'll have to keep this in sync until we submit a PR to only require passing  our custom `getOffsetParent` implementation.

