### PR TITLE
ci: adds w3c url for a11y issue filing

### DIFF
--- a/.github/need-info.yml
+++ b/.github/need-info.yml
@@ -15,5 +15,6 @@ requiredItems:
       - "ember-twiddle.com/"
       - "jsfiddle.net/"
       - "github.com/"
+      - "w3.org/WAI/"
 commentFooter: "Issues without reproduction samples may not be prioritized. If you were unable to create a sample, please try to answer any questions that arise once development begins. Thanks for your understanding."
 excludeComments: true


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Adds in W3C URLs as a resource for issues to avoid the `needs info` label. 

W3C resources provide context for a11y audits, bugs, or enhancements, and are acceptable resources when filing a11y-related issues.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
