### PR TITLE
fix(tooltip): Prevent opening when closeOnClick is true and referenceElement is clicked quickly

### DIFF
--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -89,6 +89,7 @@ export default class TooltipManager {
 
     if (clickedTooltip?.closeOnClick) {
       this.toggleTooltip(clickedTooltip, false);
+      this.clearHoverTimeout(clickedTooltip);
     }
   };
 

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -561,6 +561,35 @@ describe("calcite-tooltip", () => {
     expect(await tooltip.getProperty("open")).toBe(false);
   });
 
+  it("should close tooltip when closeOnClick is true and referenceElement is clicked quickly", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      html`
+        <calcite-tooltip reference-element="ref" close-on-click>Content</calcite-tooltip>
+        <button id="ref">Button</button>
+      `
+    );
+
+    await page.waitForChanges();
+
+    const tooltip = await page.find("calcite-tooltip");
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+
+    await referenceElement.hover();
+
+    await referenceElement.click();
+
+    await page.waitForTimeout(TOOLTIP_DELAY_MS);
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(false);
+  });
+
   it("should still function when disconnected and reconnected", async () => {
     const page = await newE2EPage();
 

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -571,8 +571,6 @@ describe("calcite-tooltip", () => {
       `
     );
 
-    await page.waitForChanges();
-
     const tooltip = await page.find("calcite-tooltip");
 
     expect(await tooltip.getProperty("open")).toBe(false);


### PR DESCRIPTION
**Related Issue:** #5538

## Summary

fix(tooltip): Prevent opening when closeOnClick is true and referenceElement is clicked quickly. (#5538)