### PR TITLE
fix(types): fix type issue caused by unintentionally moving @floating-ui/dom as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "SEE LICENSE IN copyright.txt",
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
+        "@floating-ui/dom": "1.0.3",
         "@stencil/core": "2.18.1",
         "@types/color": "3.0.3",
         "color": "4.2.3",
@@ -23,7 +24,6 @@
         "@esri/calcite-colors": "6.0.1",
         "@esri/calcite-ui-icons": "3.20.5",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
-        "@floating-ui/dom": "1.0.3",
         "@stencil/eslint-plugin": "0.4.0",
         "@stencil/postcss": "2.1.0",
         "@stencil/sass": "2.0.0",
@@ -2283,14 +2283,12 @@
     "node_modules/@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==",
-      "dev": true
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
       "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.0.1"
       }
@@ -35227,14 +35225,12 @@
     "@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==",
-      "dev": true
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
     },
     "@floating-ui/dom": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.3.tgz",
       "integrity": "sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==",
-      "dev": true,
       "requires": {
         "@floating-ui/core": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@a11y/focus-trap": "1.0.5",
+    "@floating-ui/dom": "1.0.3",
     "@stencil/core": "2.18.1",
     "@types/color": "3.0.3",
     "color": "4.2.3",
@@ -83,7 +84,6 @@
     "@esri/calcite-colors": "6.0.1",
     "@esri/calcite-ui-icons": "3.20.5",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
-    "@floating-ui/dom": "1.0.3",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",
     "@stencil/sass": "2.0.0",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression caused by https://github.com/Esri/calcite-components/pull/5542 (bumped as a devdep vs dep 😅 #derp). cc @AdelheidF 