### PR TITLE
fix(link): fix link underline and icon placement when used with calcite fonts 2.x

### DIFF
--- a/src/components/link/link.scss
+++ b/src/components/link/link.scss
@@ -40,8 +40,8 @@ calcite-icon {
 }
 
 .calcite-link--icon {
-  @apply transition-default align-text-top;
-  margin-block-start: 0.125rem;
+  @apply transition-default align-middle;
+  margin-block-start: -0.25em;
 }
 
 // icon positioning and styles
@@ -67,7 +67,8 @@ calcite-icon {
     white-space: initial;
     background-image: linear-gradient(currentColor, currentColor),
       linear-gradient(var(--calcite-link-blue-underline), var(--calcite-link-blue-underline));
-    background-position: 0% 100%, 100% 100%;
+    background-position-x: 0%, 100%;
+    background-position-y: min(1.5em, 100%);
     background-repeat: no-repeat, no-repeat;
     background-size: 0% 1px, 100% 1px;
 


### PR DESCRIPTION
**Related Issue:** #5262 

## Summary

Link underline and link icon placement was wrong when used with calcite-fonts 2.x. The metrics of the new font files are taller in general, so links were displaying noticeably off vertical center.

I've tweaked the underline placement and icon positioning slightly to account for this change. I've checked this with the old and new versions of calcite fonts and it seems to work with both. 

@macandcheese I know you did a ton of work while creating this component to make sure it rendered in all these scenarios (ie. inline text in a paragraph, etc), so let me know if there is more to check than what's on the demo page. 
