### PR TITLE
ci: add another type check to our releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "util:check-squash-mergeable-branch": "ts-node --esm support/checkSquashMergeableBranch.ts",
     "util:push-tags": "git push --atomic --follow-tags origin master",
     "util:sync-t9n-en-bundles": "ts-node --esm support/syncEnT9nBundles.ts",
-    "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw 'dist/types' -e '<reference types='"
+    "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw '<reference types=' dist/types && ! grep -rnwiP 'import(\\s?type)?\\s{.+}\\sfrom\\s\"(?!\\.|preact|@esri).+\"\\;' dist/types"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Related Issue:** #5649

## Summary
Floating UI types snuck into our `next` release 😓 
https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-next.612/dist/types/utils/floating-ui/nonChromiumPlatformUtils.d.ts


This adds another test for types, which checks for non-relative ESM imports. We should probably find a better long term solution so we don't have to keep adding a bunch of greps, but this will work in the short term. I'll probably look into @dasa's suggestion to create a typescript test app to run `tsc` in, since that should cover the bases. We just need to figure out a clean way to run that in our CI.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
