### PR TITLE
ci: stop generating readmes on every build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:prep-build-reqs && stencil build && npm run util:patch",
-    "build:watch": "npm run util:prep-build-reqs && stencil build --watch",
-    "build:watch-dev": "npm run util:prep-build-reqs && stencil build --dev --watch",
+    "build": "npm run util:prep-build-reqs && stencil build --no-docs && npm run util:patch",
+    "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
+    "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
     "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs",
     "deps:update": "updtr --exclude chalk cheerio typescript @types/jest jest jest-cli ts-jest puppeteer && npm audit fix",
     "docs": "concurrently --kill-others --raw \"npm run build-storybook\" \"ts-node --esm ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",
@@ -45,7 +45,7 @@
     "test:prerender": "stencil build --no-docs --prerender",
     "test:storybook": "concurrently --raw \"npm:util:build-docs && screener-storybook --conf .storybook/screener.config.js\"",
     "test:watch": "npm run test -- -- --watchAll",
-    "util:build-docs": "npm run util:copy-icons && stencil build --config stencil.storybook.config.ts",
+    "util:build-docs": "npm run util:copy-icons && stencil build --docs --config stencil.storybook.config.ts",
     "util:clean-tested-build": "npm ci && npm test && npm run build",
     "util:copy-icons": "cpy \"./node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/icon/\" --flat",
     "util:deploy-next": "npm run util:prep-next && npm run util:publish-next",


### PR DESCRIPTION
**Related Issue:** #

## Summary

All those readmes that are generated on every build have been slowly driving me to madness. I've had it - NO MORE, I SAY!

The only time we actually need the readmes built is in the GH Action, which doesn't even use `npm run build`. 
It runs `npx stencil build --docs`, which will still generate the docs after this change. 
We also have a util script specifically for building docs, which will still do so: `npm run util:build-docs`.

We can free ourselves from the opressive reign of these markdown clad menaces! They may be many, but we are strong. Who will ~~ride with me~~ approve this PR?

![FCm6URe](https://user-images.githubusercontent.com/10986395/198176087-40a80d60-83f5-4f9c-97ee-daf2ebd5486f.gif)

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
