### PR TITLE
ci: user impact field for bug issue prioritization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -67,6 +67,13 @@ body:
       placeholder: beta.1
     validations:
       required: false
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: How does the issue effect your team, or your work? Can range from minor to blocking or prohibiting workflows. Helps Calcite Design System team members with prioritization.
+    validations:
+      required: false
   - type: dropdown
     id: esri-team
     validations:


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Allows users to input prioritization as it relates to the work to help us prioritize while triaging bugs 🐛 . 

The user input is optional and located at the bottom of the bug issue template, prior to selecting their team.

cc @brittneyzwolfer 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
