### PR TITLE
fix(dropdown): fix calculation of max-items for non-Chromium browsers.

### DIFF
--- a/src/components/dropdown-group/dropdown-group.scss
+++ b/src/components/dropdown-group/dropdown-group.scss
@@ -1,5 +1,6 @@
 :host {
-  @apply block;
+  // we make the host relative, so items can consistently compute their offsetTop based on the group
+  @apply block relative;
 }
 
 .container {


### PR DESCRIPTION
**Related Issue:** #5663 

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression caused by #5399 where the floating-ui element is placed offscreen and its styles change the offsetParent in non-Chromium browsers.