### PR TITLE
fix(inline-editable): Add text-ellipsis when not editing

### DIFF
--- a/src/components/inline-editable/inline-editable.stories.ts
+++ b/src/components/inline-editable/inline-editable.stories.ts
@@ -72,3 +72,12 @@ export const darkThemeRTL_TestOnly = (): string => html`
   </div>
 `;
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
+
+export const longValue_TestOnly = (): string => html`<div style="width: 300px;">
+  <calcite-inline-editable>
+    <calcite-input
+      value="A flower, sometimes known as a bloom or blossom, is the reproductive structure found in flowering plants (plants of the division Angiospermae)."
+      placeholder="My placeholder"
+    ></calcite-input>
+  </calcite-inline-editable>
+</div>`;

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -565,7 +565,7 @@ input[type="time"]::-webkit-clear-button {
 :host .inline-child:not(.editing-enabled) {
   @apply border-color-transparent
     flex
-    cursor-pointer;
+    cursor-pointer text-ellipsis;
   padding-inline-start: 0;
 }
 


### PR DESCRIPTION
**Related Issue:** #5489

## Summary

fix(inline-editable): Add text-ellipsis when not editing. (#5489)

## Example

<img width="321" alt="image" src="https://user-images.githubusercontent.com/1231455/199555230-63153a37-94a2-42b1-bc65-1d51336a13d4.png">
