### PR TITLE
fix(flow-item): Position back tooltip above

### DIFF
--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -307,7 +307,12 @@ export class FlowItem implements InteractiveComponent {
           <slot />
         </calcite-panel>
         {backButtonEl ? (
-          <calcite-tooltip label={label} placement="auto" referenceElement={backButtonEl}>
+          <calcite-tooltip
+            label={label}
+            overlayPositioning="fixed"
+            placement="top"
+            referenceElement={backButtonEl}
+          >
             {label}
           </calcite-tooltip>
         ) : null}


### PR DESCRIPTION
**Related Issue:** #

## Summary

fix(flow-item): Position back tooltip above by default.