### PR TITLE
fix(value-list): no longer display screen reader only text when drag-enabled

### DIFF
--- a/src/components/pick-list/shared-list-render.scss
+++ b/src/components/pick-list/shared-list-render.scss
@@ -1,3 +1,0 @@
-.assistive-text {
-  @apply sr-only;
-}

--- a/src/components/value-list/value-list.e2e.ts
+++ b/src/components/value-list/value-list.e2e.ts
@@ -25,6 +25,25 @@ describe("calcite-value-list", () => {
       </calcite-value-list>
     `));
 
+  it("should not display screen reader only text when drag-enabled", async () => {
+    const page = await newE2EPage({});
+    await page.setContent(`<calcite-value-list drag-enabled>
+      <calcite-value-list-item label="Lakes" description="Summary lorem ipsum" value="lakes">
+      </calcite-value-list-item>
+    </calcite-value-list>`);
+
+    const srOnlyElement = await page.find("calcite-value-list >>> span");
+    await page.keyboard.press("Tab");
+    await page.waitForChanges();
+    await page.keyboard.press("Space");
+    await page.waitForChanges();
+    expect(srOnlyElement.getAttribute("aria-live")).toBe("assertive");
+
+    const srElementStyle = await srOnlyElement.getComputedStyle();
+    expect(srElementStyle.height).toBe("1px");
+    expect(srElementStyle.width).toBe("1px");
+  });
+
   describe("disabling", () => {
     disabling("value");
   });

--- a/src/components/value-list/value-list.scss
+++ b/src/components/value-list/value-list.scss
@@ -35,3 +35,7 @@ calcite-value-list-item:last-of-type {
 calcite-filter {
   @apply mb-px;
 }
+
+.assistive-text {
+  @apply sr-only;
+}


### PR DESCRIPTION
**Related Issue:** #5690 

## Summary

This PR will hide the screen reader only text when drag-enabled in `value-list` component. 