### PR TITLE
ci(actions): remove deprecated set-output workflow commands

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -19,14 +19,15 @@ jobs:
           # skip if there are only md changes
           if [ -z "$testable_changes" ]; then
             echo "skip e2e"
+            echo "skip=true" >> $GITHUB.ENV
           else
             echo "run e2e"
-            echo "::set-output name=skip::false"
+            echo "skip=false" >> $GITHUB.ENV
           fi
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
           cache: npm
       - run: npm ci --legacy-peer-deps
-      - if: steps.testable.outputs.skip == 'false'
+      - if: env.skip == 'false'
         run: npm test

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -32,17 +32,17 @@ jobs:
           # skip if there are only md changes
           if [ -z "$screenable_changes" ]; then
             echo "skip screener"
-            echo "::set-output name=skip::skip"
+           echo "skip=true" >> $GITHUB.ENV
           else
             echo "run screener"
-            echo "::set-output name=skip::screen"
+            echo "skip=false" >> $GITHUB.ENV
           fi
       - uses: actions/setup-node@v2
         with:
           node-version: lts/*
           cache: npm
       - run: npm ci --legacy-peer-deps
-      - if: steps.one.outputs.skip == 'screen'
+      - if: env.skip == 'false'
         name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}


### PR DESCRIPTION
**Related Issue:** #

## Summary

Gets rid of `set-output` deprecation notices

![image](https://user-images.githubusercontent.com/10986395/200472660-14ec1727-ee94-45c8-a25c-605492fb1071.png)

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
