### PR TITLE
ci(screener): fix yaml syntax

### DIFF
--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: skip for markdown only prs
-        id: one
+        id: markdown-check
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           echo "branch: $current_branch"
@@ -32,16 +32,16 @@ jobs:
           # skip if there are only md changes
           if [ -z "$screenable_changes" ]; then
             echo "skip screener"
-           echo "skip=true" >> $GITHUB.ENV
+            echo "SKIP=true" >> $GITHUB_OUTPUT
           else
             echo "run screener"
-            echo "skip=false" >> $GITHUB.ENV
+            echo "SKIP=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
       - run: npm ci --legacy-peer-deps
-      - if: env.skip == 'false'
+      - if: steps.markdown-check.outputs.SKIP == 'false'
         name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
@@ -50,7 +50,7 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
         run: npm run test:storybook || true
-      - if: env.skip == 'true'
+      - if: steps.markdown-check.outputs.SKIP == 'true'
         name: skip screener for markdown PRs
         uses: Sibz/github-status-action@v1
         with:

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: skip for markdown only prs
-        id: markdown-check
+        id: one
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           echo "branch: $current_branch"
@@ -32,16 +32,16 @@ jobs:
           # skip if there are only md changes
           if [ -z "$screenable_changes" ]; then
             echo "skip screener"
-            echo "SKIP=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> $GITHUB.ENV
           else
             echo "run screener"
-            echo "SKIP=false" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB.ENV
           fi
       - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
       - run: npm ci --legacy-peer-deps
-      - if: steps.markdown-check.outputs.SKIP == 'false'
+      - if: env.skip == 'false'
         name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
@@ -50,7 +50,7 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
         run: npm run test:storybook || true
-      - if: steps.markdown-check.outputs.SKIP == 'true'
+      - if: env.skip == 'true'
         name: skip screener for markdown PRs
         uses: Sibz/github-status-action@v1
         with:

--- a/.github/workflows/pr-screener.yml
+++ b/.github/workflows/pr-screener.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: skip for markdown only prs
-        id: one
+        id: markdown-check
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           echo "branch: $current_branch"
@@ -32,16 +32,16 @@ jobs:
           # skip if there are only md changes
           if [ -z "$screenable_changes" ]; then
             echo "skip screener"
-            echo "skip=true" >> $GITHUB.ENV
+            echo "SKIP=true" >> $GITHUB_OUTPUT
           else
             echo "run screener"
-            echo "skip=false" >> $GITHUB.ENV
+            echo "SKIP=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
       - run: npm ci --legacy-peer-deps
-      - if: env.skip == 'false'
+      - if: steps.markdown-check.outputs.SKIP  == 'false'
         name: run screener check
         env:
           SCREENER_API_KEY: ${{ secrets.SCREENER_API_KEY }}
@@ -50,7 +50,7 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
         run: npm run test:storybook || true
-      - if: env.skip == 'true'
+      - if: steps.markdown-check.outputs.SKIP == 'true'
         name: skip screener for markdown PRs
         uses: Sibz/github-status-action@v1
         with:


### PR DESCRIPTION
**Related Issue:** #

## Summary
Fix indent and use GITHUB_OUTPUT instead of GITHUB_ENV
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
