### PR TITLE
ci(e2e): use step output in github action

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: skip for markdown only prs
-        id: testable
+        id: markdown-check
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           # diff of branch excluding md
@@ -19,14 +19,14 @@ jobs:
           # skip if there are only md changes
           if [ -z "$testable_changes" ]; then
             echo "skip e2e"
-            echo "skip=true" >> $GITHUB.ENV
+            echo "skip=true" >> $GITHUB.OUTPUT
           else
             echo "run e2e"
-            echo "skip=false" >> $GITHUB.ENV
+            echo "skip=false" >> $GITHUB.OUTPUT
           fi
       - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
       - run: npm ci --legacy-peer-deps
-      - if: env.skip == 'false'
+      - if: steps.markdown-check.outputs.SKIP == 'false'
         run: npm test

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -19,10 +19,10 @@ jobs:
           # skip if there are only md changes
           if [ -z "$testable_changes" ]; then
             echo "skip e2e"
-            echo "SKIP=true" >> $GITHUB.OUTPUT
+            echo "SKIP=true" >> $GITHUB_OUTPUT
           else
             echo "run e2e"
-            echo "SKIP=false" >> $GITHUB.OUTPUT
+            echo "SKIP=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -19,10 +19,10 @@ jobs:
           # skip if there are only md changes
           if [ -z "$testable_changes" ]; then
             echo "skip e2e"
-            echo "skip=true" >> $GITHUB.OUTPUT
+            echo "SKIP=true" >> $GITHUB.OUTPUT
           else
             echo "run e2e"
-            echo "skip=false" >> $GITHUB.OUTPUT
+            echo "SKIP=false" >> $GITHUB.OUTPUT
           fi
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
**Related Issue:** #5711

## Summary
Forgot to change the e2e action as well
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
