### PR TITLE
ci(next): fix error due to updating action runner

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,14 +1,14 @@
 #!/bin/bash
 # from https://riptutorial.com/git/example/16164/pre-push
 
-protected_branch='master'
+protected_branch="master"
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
-if [ $protected_branch = $current_branch ] && [ exec < /dev/tty ]
+if [ "$protected_branch" = "$current_branch" ] && bash -c ': >/dev/tty'
 then
     read -p "You're about to push master, is that what you intended? [y|n] " -n 1 -r < /dev/tty
     echo
-    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
+    if echo "$REPLY" | grep -E "^[Yy]$" > /dev/null
     then
         exit 0
     fi

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "util:patch-tree-shaking": "ts-node --esm support/patchTreeShaking.ts",
     "util:prep-build-reqs": "npm run util:copy-icons && npm run util:generate-t9n-types",
     "util:prep-next": "ts-node --esm support/prepReleaseCommit.ts --next && npm run build",
-    "util:publish-next": "npm run util:test-types && npm run util:push-tags && npm publish --tag next",
+    "util:publish-next": "npm run util:test-types && npm publish --tag next && npm run util:push-tags",
     "util:check-squash-mergeable-branch": "ts-node --esm support/checkSquashMergeableBranch.ts",
     "util:push-tags": "git push --atomic --follow-tags origin master",
     "util:sync-t9n-en-bundles": "ts-node --esm support/syncEnT9nBundles.ts",


### PR DESCRIPTION
**Related Issue:** #

## Summary

I just updated the GH Action runners from node12 to node16 and I've been slowly chipping away at some problems as they pop up. For this round, we got an error during a next deployment:
https://github.com/Esri/calcite-components/actions/runs/3422971878/jobs/5701302669#step:5:8861

The husky prepush that caused the error is checking to see if the shell is interactive. I ran into this error with GH Actions a while ago in #3782

Not sure why the error didn't show up here until now. I changed the hook's tty check to run in a subshell so it won't throw errors in the main script. We only care about the exit code for the conditional. I Also cleaned up the hook to use quotes so we don't run into any parameter expansion issues down the road.

Additionally, I moved the `npm publish` to go before the `push`. The deploy action gets cancelled if another commit comes in, so that deployable commits are batched instead of having a bunch of releases back to back. So having the push before the publish could potentially cancel deployment.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
