### PR TITLE
ci(next): fix potential type error due to the components.d.ts stencil bug

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -39,7 +39,7 @@ jobs:
 
               # remove the build to docs after storybook deploys to gh-pages
               # if there are changes the git sanity checks will prevent deployment
-              git clean -fd && git reset --hard && git checkout master && git pull
+              git reset --hard && git checkout master && git pull
               npm run util:deploy-next-from-ci
             fi
           else

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 www/
 hydrate/
 node_modules/
+docs/
 
 # Compiled files
 src/**/components.d.ts


### PR DESCRIPTION
**Related Issue:** #5714

## Summary
The error from the PR linked above is fixed, but it failed again:
https://github.com/Esri/calcite-components/actions/runs/3424220966/jobs/5703841849#step:5:8860

My guess is the [`git clean`](https://github.com/Esri/calcite-components/blob/114d47bc53a821b17e3da393ae60c41dbe798287/.github/workflows/deploy-next.yml#L42) removed the `components.d.ts` file which caused the [type check in `publish:next`](https://github.com/Esri/calcite-components/blob/f28b82f9a2ee23b864b73fccbc9d6fe0dcee7b1e/package.json#L61) to fail due to that stencil bug.

Not sure why this wasn't an issue before updating the GitHub Actions to the new node version. I gitignored `./docs` so I don't have to do a `git clean`, and that will prevent the type bug from occuring, if that's what is causing issues. We don't want to accidently push the autogenerated docs directory anyway, so it should have already been in `.gitignore`.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
