### PR TITLE
ci(next): add back default npm registry url

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: e2e test


### PR DESCRIPTION
**Related Issue:** #5719

## Summary

I just remembered that gitignored files aren't considered untracked, which means `git clean` won't remove them. So my last PR (linked above) probably won't fix the issue. I'm starting to run out of ideas, but maybe it is due to removing the default NPM registry url? Not sure why we would be required to specify the default registry, but serves me right for trying to tidy up, I guess.

If this isn't it, I'll revert back to the node12 runner until I have more time to troubleshoot.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
