### PR TITLE
ci(output targets): move patches to postbuild to include them in CCR

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:prep-build-reqs && stencil build --no-docs && npm run util:patch",
+    "build": "npm run util:prep-build-reqs && stencil build --no-docs",
+    "postbuild": "npm run util:patch",
     "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
     "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
     "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs",


### PR DESCRIPTION
**Related Issue:** https://github.com/ArcGIS/calcite-components-output-targets/pull/10

## Summary

When releasing CCR, `stencil build` must be the last command  in CC's `build` script because [CCR appends the `--config` flag](https://github.com/ArcGIS/calcite-components-output-targets/blob/ae776a58efc3212802cd7a79192dcf09964f92b8/packages/calcite-components-output-target-generator/package.json#L15) to use a different config that generates the react output target.

I had been removing the patch because I thought something it changed in the CC build was breaking the CCR build. Moving the patch to `postbuild` will allow the patches to be applied to CCR as well.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
