### PR TITLE
build(docs): generate docs-json for afd usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:prep-build-reqs && stencil build --no-docs",
-    "postbuild": "npm run util:patch",
+    "build": "npm run util:prep-build-reqs && stencil build",
+    "postbuild": "npm run util:patch && git restore src/components/*/readme.md",
     "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
     "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
     "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs",


### PR DESCRIPTION
**Related Issue:** #5654

## Summary
Turns out adding `--no-docs` to the build prevents the `docs-json` output target from being created. The reason I added it was the annoying readmes being generated for each component. The `git restore` I added to `postbuild` resolves that, while still generating `docs-json`.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
