### PR TITLE
ci(pr-bot): don't label dependabot PRs

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -28,6 +28,7 @@ jobs:
               assignees: updatedAssignees,
             });
   label-type:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,5 +1,6 @@
 import {
   locales,
+  numberingSystems,
   numberStringFormatter,
   defaultLocale,
   defaultNumberingSystem,
@@ -35,7 +36,7 @@ describe("NumberStringFormat", () => {
   });
 
   locales.forEach((locale) => {
-    it(`integers localize and delocalize in "${locale}"`, () => {
+    it(`locale: integers localize and delocalize in "${locale}"`, () => {
       const numberString = "555";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -47,7 +48,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`negative numbers localize and delocalize in "${locale}"`, () => {
+    it(`locale: negative numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "-123";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -59,7 +60,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`floating point numbers localize and delocalize in "${locale}"`, () => {
+    it(`locale: floating point numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "4.321";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -71,7 +72,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`exponential numbers localize and delocalize in "${locale}"`, () => {
+    it(`locale: exponential numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "2.5e-3";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -83,7 +84,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`numbers with group separators localize and delocalize in "${locale}"`, () => {
+    it(`locale: numbers with group separators localize and delocalize in "${locale}"`, () => {
       const numberString = "1234567890";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -96,12 +97,26 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`floating point numbers with group separators localize and delocalize in "${locale}"`, () => {
-      const numberString = "12345678.9";
+    it(`locale: floating point numbers with group separators localize and delocalize in "${locale}"`, () => {
+      const numberString = "12345678.0123456789";
       numberStringFormatter.numberFormatOptions = {
         locale,
         // the group separator is different in arabic depending on the numberingSystem
         numberingSystem: locale === "ar" ? "arab" : "latn",
+        useGrouping: true
+      };
+      const localizedNumberString = numberStringFormatter.localize(numberString);
+      const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
+      expect(delocalizedNumberString).toBe(numberString);
+    });
+  });
+
+  numberingSystems.forEach((numberingSystem) => {
+    const numberString = "0.0123456789";
+    it(`numberingSystem: floating point numbers with group separators localize and delocalize in "${numberingSystem}"`, () => {
+      numberStringFormatter.numberFormatOptions = {
+        locale: numberingSystem === "arab" ? "ar" : "en",
+        numberingSystem,
         useGrouping: true
       };
       const localizedNumberString = numberStringFormatter.localize(numberString);

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,6 +1,5 @@
 import {
   locales,
-  numberingSystems,
   numberStringFormatter,
   defaultLocale,
   defaultNumberingSystem,
@@ -36,7 +35,7 @@ describe("NumberStringFormat", () => {
   });
 
   locales.forEach((locale) => {
-    it(`locale: integers localize and delocalize in "${locale}"`, () => {
+    it(`integers localize and delocalize in "${locale}"`, () => {
       const numberString = "555";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -48,7 +47,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`locale: negative numbers localize and delocalize in "${locale}"`, () => {
+    it(`negative numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "-123";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -60,7 +59,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`locale: floating point numbers localize and delocalize in "${locale}"`, () => {
+    it(`floating point numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "4.321";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -72,7 +71,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`locale: exponential numbers localize and delocalize in "${locale}"`, () => {
+    it(`exponential numbers localize and delocalize in "${locale}"`, () => {
       const numberString = "2.5e-3";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -84,7 +83,7 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`locale: numbers with group separators localize and delocalize in "${locale}"`, () => {
+    it(`numbers with group separators localize and delocalize in "${locale}"`, () => {
       const numberString = "1234567890";
       numberStringFormatter.numberFormatOptions = {
         locale,
@@ -97,26 +96,12 @@ describe("NumberStringFormat", () => {
       expect(delocalizedNumberString).toBe(numberString);
     });
 
-    it(`locale: floating point numbers with group separators localize and delocalize in "${locale}"`, () => {
-      const numberString = "12345678.0123456789";
+    it(`floating point numbers with group separators localize and delocalize in "${locale}"`, () => {
+      const numberString = "12345678.9";
       numberStringFormatter.numberFormatOptions = {
         locale,
         // the group separator is different in arabic depending on the numberingSystem
         numberingSystem: locale === "ar" ? "arab" : "latn",
-        useGrouping: true
-      };
-      const localizedNumberString = numberStringFormatter.localize(numberString);
-      const delocalizedNumberString = numberStringFormatter.delocalize(localizedNumberString);
-      expect(delocalizedNumberString).toBe(numberString);
-    });
-  });
-
-  numberingSystems.forEach((numberingSystem) => {
-    const numberString = "0.0123456789";
-    it(`numberingSystem: floating point numbers with group separators localize and delocalize in "${numberingSystem}"`, () => {
-      numberStringFormatter.numberFormatOptions = {
-        locale: numberingSystem === "arab" ? "ar" : "en",
-        numberingSystem,
         useGrouping: true
       };
       const localizedNumberString = numberStringFormatter.localize(numberString);


### PR DESCRIPTION
**Related Issue:** #5756

## Summary
Dependabot labels itself and behaves differently than normal PRs, so we can just skip labelling it.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
