### PR TITLE
ci(product-label): fix version syntax and use os agnostic newline char

### DIFF
--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -21,7 +21,7 @@ jobs:
               return;
             }
 
-            const productRegex = new RegExp("(?<=### Esri team)(\r\n?|\n)(\r\n?|\n).+$", "m");
+            const productRegex = new RegExp("(?<=### Esri team[\r\n?|\n][\r\n?|\n]).+$", "m");
             const productRegexMatch = body.match(productRegex);
 
             if (!productRegexMatch || !productRegexMatch[0]) {

--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -17,14 +17,16 @@ jobs:
             } = context;
 
             if (!body) {
-              throw new Error("Could not determine the issue body");
+              console.log("could not determine the issue body");
+              return;
             }
 
-            const productRegex = new RegExp("(?<=### Esri team\r\n\r\n).+", "m");
+            const productRegex = new RegExp("(?<=### Esri team)(\r\n?|\n)(\r\n?|\n).+$", "m");
             const productRegexMatch = body.match(productRegex);
 
             if (!productRegexMatch || !productRegexMatch[0]) {
-              throw new Error("Could not determine the Esri product");
+              console.log("Could not determine the Esri product");
+              return;
             }
 
             const product = productRegexMatch[0].trim();

--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -12,6 +12,7 @@ jobs:
             const {
               repo: { owner, repo },
               payload: {
+                action,
                 issue: { body, labels: currentLabels, number: issue_number },
               },
             } = context;
@@ -21,15 +22,21 @@ jobs:
               return;
             }
 
-            const productRegex = new RegExp("(?<=### Esri team[\r\n?|\n][\r\n?|\n]).+$", "m");
+            const productRegex = new RegExp(
+              action === "edited"
+                ? // the way GitHub parses the issue body into plaintext
+                  // requires this exact format for edits
+                  "(?<=### Esri team\r\n\r\n).+"
+                : // otherwise it depends on the submitter's OS
+                  "(?<=### Esri team[\r\n|\r|\n]{2}).+$",
+              "m"
+            );
+
             const productRegexMatch = body.match(productRegex);
 
-            if (!productRegexMatch || !productRegexMatch[0]) {
-              console.log("Could not determine the Esri product");
-              return;
-            }
-
-            const product = productRegexMatch[0].trim();
+            const product = (
+              productRegexMatch && productRegexMatch[0] ? productRegexMatch[0] : ""
+            ).trim();
 
             if (product && product !== "N/A") {
               /** Creates a label if it does not exist */

--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -6,7 +6,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@6
+      - uses: actions/github-script@v6
         with:
           script: |
             const {


### PR DESCRIPTION
**Related Issue:** #5687

## Summary
Sorry, not sure how I missed this issue being logged. The script I am going to write to add the labels to issues logged before the action was created will do the failed ones too
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
