### PR TITLE
Revert "fix(block, date-picker, list-item-group, panel, pick-list-gro…

### DIFF
--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Host, Prop, VNode } from "@stencil/core";
-import { CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, HEADING_LEVEL, ICONS, SLOTS, TEXT } from "./resources";
 import { getSlotted, toAriaBoolean } from "../../utils/dom";
 import { Heading, HeadingLevel } from "../functional/Heading";
 import { Status } from "../interfaces";
@@ -216,7 +216,7 @@ export class Block implements ConditionalSlotComponent, InteractiveComponent {
     const { heading, headingLevel, summary, description } = this;
     return heading || summary || description ? (
       <div class={CSS.title}>
-        <Heading class={CSS.heading} level={headingLevel}>
+        <Heading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
           {heading}
         </Heading>
         {summary || description ? (

--- a/src/components/block/resources.ts
+++ b/src/components/block/resources.ts
@@ -39,3 +39,5 @@ export const ICONS = {
   invalid: "exclamation-mark-triangle",
   refresh: "refresh"
 };
+
+export const HEADING_LEVEL = 4;

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -23,7 +23,7 @@ import {
 import { HeadingLevel } from "../functional/Heading";
 
 import { DateRangeChange } from "./interfaces";
-import { TEXT } from "./resources";
+import { HEADING_LEVEL, TEXT } from "./resources";
 import {
   connectLocalized,
   disconnectLocalized,
@@ -482,7 +482,7 @@ export class DatePicker implements LocalizedComponent {
       this.localeData && [
         <calcite-date-picker-month-header
           activeDate={activeDate}
-          headingLevel={this.headingLevel}
+          headingLevel={this.headingLevel || HEADING_LEVEL}
           intlNextMonth={this.intlNextMonth}
           intlPrevMonth={this.intlPrevMonth}
           intlYear={this.intlYear}

--- a/src/components/date-picker/resources.ts
+++ b/src/components/date-picker/resources.ts
@@ -1,3 +1,5 @@
+export const HEADING_LEVEL = 2;
+
 export const TEXT = {
   nextMonth: "Next month",
   prevMonth: "Previous month",

--- a/src/components/functional/Heading.spec.tsx
+++ b/src/components/functional/Heading.spec.tsx
@@ -29,13 +29,4 @@ describe("Heading", () => {
 
     expect(page.root).toEqualHtml(`<h1 class="test">My Heading</h1>`);
   });
-
-  it("should render a div", async () => {
-    const page = await newSpecPage({
-      components: [Dummy], // Required so we are feeding it a Dummy component
-      template: () => <Heading class="test">My Heading</Heading>
-    });
-
-    expect(page.root).toEqualHtml(`<div class="test">My Heading</div>`);
-  });
 });

--- a/src/components/functional/Heading.tsx
+++ b/src/components/functional/Heading.tsx
@@ -4,7 +4,7 @@ import { JSXBase } from "@stencil/core/internal";
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 interface HeadingProps extends JSXBase.HTMLAttributes {
-  level?: HeadingLevel;
+  level: HeadingLevel;
 }
 
 export function constrainHeadingLevel(level: number): HeadingLevel {
@@ -12,7 +12,7 @@ export function constrainHeadingLevel(level: number): HeadingLevel {
 }
 
 export const Heading: FunctionalComponent<HeadingProps> = (props, children) => {
-  const HeadingTag = props.level ? `h${props.level}` : "div";
+  const HeadingTag = `h${props.level}`;
 
   delete props.level;
 

--- a/src/components/list-item-group/list-item-group.tsx
+++ b/src/components/list-item-group/list-item-group.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Prop, h, VNode, Host } from "@stencil/core";
 import { CSS } from "./resources";
+import { HEADING_LEVEL } from "./resources";
 import { HeadingLevel, Heading, constrainHeadingLevel } from "../functional/Heading";
 
 /**
@@ -49,7 +50,7 @@ export class ListItemGroup {
       "calcite-list, calcite-list-item-group"
     )?.headingLevel;
     const relativeLevel = parentLevel ? constrainHeadingLevel(parentLevel + 1) : null;
-    const level = headingLevel || relativeLevel;
+    const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return (
       <Host>

--- a/src/components/list-item-group/resources.ts
+++ b/src/components/list-item-group/resources.ts
@@ -2,3 +2,5 @@ export const CSS = {
   heading: "heading",
   container: "container"
 };
+
+export const HEADING_LEVEL = 3;

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -11,7 +11,7 @@ import {
   Fragment,
   State
 } from "@stencil/core";
-import { CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, HEADING_LEVEL, ICONS, SLOTS, TEXT } from "./resources";
 import { getElementDir, toAriaBoolean } from "../../utils/dom";
 import { Scale } from "../interfaces";
 import { HeadingLevel, Heading } from "../functional/Heading";
@@ -457,7 +457,7 @@ export class Panel implements InteractiveComponent {
   renderHeaderContent(): VNode {
     const { heading, headingLevel, summary, description, hasHeaderContent } = this;
     const headingNode = heading ? (
-      <Heading class={CSS.heading} level={headingLevel}>
+      <Heading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
         {heading}
       </Heading>
     ) : null;

--- a/src/components/panel/resources.ts
+++ b/src/components/panel/resources.ts
@@ -39,3 +39,5 @@ export const TEXT = {
   open: "Open",
   options: "Options"
 };
+
+export const HEADING_LEVEL = 3;

--- a/src/components/pick-list-group/pick-list-group.tsx
+++ b/src/components/pick-list-group/pick-list-group.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Prop, h, VNode, Fragment } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
+import { HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
 import { HeadingLevel, Heading, constrainHeadingLevel } from "../functional/Heading";
 import {
@@ -73,7 +74,7 @@ export class PickListGroup implements ConditionalSlotComponent {
     const title = groupTitle;
     const parentLevel = el.closest("calcite-pick-list")?.headingLevel;
     const relativeLevel = parentLevel ? constrainHeadingLevel(parentLevel + 1) : null;
-    const level = headingLevel || relativeLevel;
+    const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return (
       <Fragment>

--- a/src/components/pick-list-group/resources.ts
+++ b/src/components/pick-list-group/resources.ts
@@ -7,3 +7,5 @@ export const CSS = {
 export const SLOTS = {
   parentItem: "parent-item"
 };
+
+export const HEADING_LEVEL = 3;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -12,7 +12,14 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CSS, ARIA_CONTROLS, ARIA_EXPANDED, TEXT, defaultPopoverPlacement } from "./resources";
+import {
+  CSS,
+  ARIA_CONTROLS,
+  ARIA_EXPANDED,
+  HEADING_LEVEL,
+  TEXT,
+  defaultPopoverPlacement
+} from "./resources";
 import {
   FloatingCSS,
   OverlayPositioning,
@@ -507,7 +514,7 @@ export class Popover implements FloatingUIComponent, OpenCloseComponent {
   renderHeader(): VNode {
     const { heading, headingLevel } = this;
     const headingNode = heading ? (
-      <Heading class={CSS.heading} level={headingLevel}>
+      <Heading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
         {heading}
       </Heading>
     ) : null;

--- a/src/components/popover/resources.ts
+++ b/src/components/popover/resources.ts
@@ -18,3 +18,5 @@ export const TEXT = {
 export const defaultPopoverPlacement = "auto";
 export const ARIA_CONTROLS = "aria-controls";
 export const ARIA_EXPANDED = "aria-expanded";
+
+export const HEADING_LEVEL = 2;

--- a/src/components/tip-manager/resources.ts
+++ b/src/components/tip-manager/resources.ts
@@ -25,3 +25,5 @@ export const TEXT = {
   previous: "Previous",
   next: "Next"
 };
+
+export const HEADING_LEVEL = 2;

--- a/src/components/tip-manager/tip-manager.tsx
+++ b/src/components/tip-manager/tip-manager.tsx
@@ -10,7 +10,7 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CSS, ICONS, TEXT } from "./resources";
+import { CSS, ICONS, TEXT, HEADING_LEVEL } from "./resources";
 import { getElementDir, toAriaBoolean } from "../../utils/dom";
 import { HeadingLevel, Heading } from "../functional/Heading";
 import { createObserver } from "../../utils/observers";
@@ -288,7 +288,7 @@ export class TipManager {
         tabIndex={0}
       >
         <header class={CSS.header}>
-          <Heading class={CSS.heading} level={headingLevel}>
+          <Heading class={CSS.heading} level={headingLevel || HEADING_LEVEL}>
             {groupTitle}
           </Heading>
           <calcite-action

--- a/src/components/tip/resources.ts
+++ b/src/components/tip/resources.ts
@@ -1,3 +1,6 @@
+import { HEADING_LEVEL as PARENT_HEADING_LEVEL } from "../tip-manager/resources";
+import { HeadingLevel } from "../functional/Heading";
+
 export const CSS = {
   container: "container",
   header: "header",
@@ -19,3 +22,5 @@ export const SLOTS = {
 export const TEXT = {
   close: "Close"
 };
+
+export const HEADING_LEVEL = (PARENT_HEADING_LEVEL + 1) as HeadingLevel;

--- a/src/components/tip/tip.tsx
+++ b/src/components/tip/tip.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Prop, h, VNode, Fragment } from "@stencil/core";
-import { CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, ICONS, SLOTS, TEXT, HEADING_LEVEL } from "./resources";
 import { getSlotted } from "../../utils/dom";
 import { HeadingLevel, Heading, constrainHeadingLevel } from "../functional/Heading";
 import {
@@ -110,7 +110,7 @@ export class Tip implements ConditionalSlotComponent {
     const { heading, headingLevel, el } = this;
     const parentLevel = el.closest("calcite-tip-manager")?.headingLevel;
     const relativeLevel = parentLevel ? constrainHeadingLevel(parentLevel + 1) : null;
-    const level = headingLevel || relativeLevel;
+    const level = headingLevel || relativeLevel || HEADING_LEVEL;
 
     return heading ? (
       <header class={CSS.header}>


### PR DESCRIPTION
…up, popover, tip, tip-manager)!: Set default internal heading to a div. (#5728)"

This reverts commit 38ca639010b8bd1d1fe32c9cf9b54dfc38cf9877.

**Related Issue:** #

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
