### PR TITLE
fix(block): slow down loading icon spin

### DIFF
--- a/src/components/block/block.scss
+++ b/src/components/block/block.scss
@@ -98,7 +98,7 @@ calcite-handle {
 }
 
 .status-icon.loading {
-  animation: spin var(--calcite-internal-animation-timing-medium) linear infinite;
+  animation: spin calc(var(--calcite-internal-animation-timing-slow) * 2) linear infinite;
 }
 
 @keyframes spin {


### PR DESCRIPTION
**Related Issue:** #5776

## Summary

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->

This fixes a regression from https://github.com/Esri/calcite-components/pull/5314/ where the block loading icon would spin way too fast.

It uses the same speed as [`calcite-loader`](https://github.com/Esri/calcite-components/blob/master/src/components/loader/loader.scss#L23) for consistency.

Tested manually with the block demo page as animations are not supported by automated testing.