### PR TITLE
refactor(changelog): remove redundant information from changelog and add a follow-up note to contributing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,26 +10,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### ⚠ BREAKING CHANGES
 
 - **calcite-loader, calcite-input-message:** use hidden native global attribute to toggle visibility on the components instead of the deprecated active prop.
-
-- fix(calcite-loader, calcite-input-message)! : drop active in favor of hidden
-
-- same for loader
-
-- Remove instance of active prop used with loader throughout components
-
-- cleanup
-
-- more cleanup
-
-- test fix for screener failures related to loader visibility changes in other components
-
-- Remove active knob from stories and sub the ones set to false with static hidden for consistency, as we don't provide knobs for native global attributes
-
-- cleanup: remove input-message from slotted stories, remove redundant loader render test, fix a doc typo
-
-- cleanup: restore visibility on some cases of input-message
-
-- clean loader readme file
 - **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Sets internal heading HTML element to be a div by default. If users would like to retain an internal H1-H6 HTML element, they will need to set the headingLevel property on the component. Users already setting the headingLevel property are not affected. (#5728)
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,8 @@ Commit messages for breaking changes should use both the header (`!`) and body (
 BREAKING CHANGE: <details about the change and migration options (this can span multiple lines)>
 ```
 
+When adding a `BREAKING CHANGE:` note to the summary block right before confirming a squash merge, remove all the info except the `BREAKING CHANGE:` note itself, or else everything ends up being added to the changelog.
+
 See the [conventional commits doc](https://www.conventionalcommits.org/en/v1.0.0/) for more helpful information.
 
 ## Pull requests


### PR DESCRIPTION
I didn't realize that when adding a `BREAKING CHANGE` note to the summary block right before confirming a squash merge, we need to remove all the info except the `BREAKING CHANGE` note itself, or else everything ends up being added to the `changelog`. 

- Refactors `changelog` to remove the redundancy. 
- Adds a follow-up note regarding this to the contributing docs: https://github.com/Esri/calcite-components/blob/master/CONTRIBUTING.md#breaking-changes