### PR TITLE
docs(changelog): cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **calcite-loader, calcite-input-message:** use hidden native global attribute to toggle visibility on the components instead of the deprecated active prop.
 
-- fix(calcite-loader, calcite-input-message)! : drop active in favor of hidden
-
-- same for loader
-
-- Remove instance of active prop used with loader throughout components
-
-- cleanup
-
-- more cleanup
-
-- test fix for screener failures related to loader visibility changes in other components
-
-- Remove active knob from stories and sub the ones set to false with static hidden for consistency, as we don't provide knobs for native global attributes
-
-- cleanup: remove input-message from slotted stories, remove redundant loader render test, fix a doc typo
-
-- cleanup: restore visibility on some cases of input-message
-
-- clean loader readme file
 - **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Set default internal heading to a div. (#5728)
 
 ### Features


### PR DESCRIPTION
**Related Issue:** #

## Summary
Removing this manually after every next release until I fix the script. The I noted the rest of the changes that I need to make after the next beta release once it will stick, but this part needs to go now
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
