### PR TITLE
ci: changelog modifications aren't overwritten after next releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,45 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### ⚠ BREAKING CHANGES
 
 - **list, list-item, list-item-group:** To know when `calcite-list-item` content is selected, listen to the event `calciteListItemSelect` instead of `click`.
-
-* `List`
-  - Adds `label` property to specify an accessible name for the component.
-  - Adds `loading` property to show a busy indicator.
-  - Adds `selectionMode` and `selectionAppearance` properties to handle configuration of selection.
-  - Adds `filterEnabled`, `filteredData`, `filteredItems`, `filterText`, and `filterPlaceholder` properties to support filtering.
-  - Adds `calciteListFilter` event to notify when a filter has changed.
-  - Deprecates `headingLevel` property.
-* `ListItemGroup`
-  - Adds `disabled` property to prevent user interaction.
-  - Deprecates `headingLevel` property.
-* `ListItem`
-  - Adds `calciteListItemSelect` event to notify when list item content is selected.
-  - Adds `selected` and `value` properties to handle selection.
-  - Adds `open` property to show child components.
-  - Deprecates `nonInteractive` property.
-
 - **calcite-loader, calcite-input-message:** use hidden native global attribute to toggle visibility on the components instead of the deprecated active prop.
-
-- fix(calcite-loader, calcite-input-message)! : drop active in favor of hidden
-
-- same for loader
-
-- Remove instance of active prop used with loader throughout components
-
-- cleanup
-
-- more cleanup
-
-- test fix for screener failures related to loader visibility changes in other components
-
-- Remove active knob from stories and sub the ones set to false with static hidden for consistency, as we don't provide knobs for native global attributes
-
-- cleanup: remove input-message from slotted stories, remove redundant loader render test, fix a doc typo
-
-- cleanup: restore visibility on some cases of input-message
-
-- clean loader readme file
-- **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Set default internal heading to a div. (#5728)
+- **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Sets internal heading HTML element to be a div by default. If users would like to retain an internal H1-H6 HTML element, they will need to set the headingLevel property on the component. Users already setting the headingLevel property are not affected. ([#5728](https://github.com/Esri/calcite-components/pull/5728)) ([38ca639](https://github.com/Esri/calcite-components/commit/38ca639010b8bd1d1fe32c9cf9b54dfc38cf9877)), closes [5099](https://github.com/Esri/calcite-components/issues/5099)
 
 ### Features
 

--- a/support/prepReleaseCommit.ts
+++ b/support/prepReleaseCommit.ts
@@ -22,6 +22,19 @@ import yargs from "yargs";
   const changelogPath = quote([normalize(`${__dirname}/../CHANGELOG.md`)]);
   const readmePath = quote([normalize(`${__dirname}/../readme.md`)]);
 
+  // git sanity checks to prevent unapproved changes from making it into a release
+  if ((await exec("git rev-parse --abbrev-ref HEAD")).stdout.trim() !== "master") {
+    throw new Error("The master branch must be checked out before releasing.");
+  }
+  if (
+    (await exec("git rev-parse master")).stdout.trim() !== (await exec("git rev-parse origin/master")).stdout.trim()
+  ) {
+    throw new Error("The master branch must be in sync with origin before releasing.");
+  }
+  if ((await exec("git status --porcelain=v1")).stdout.trim()) {
+    throw new Error("There cannot be any uncommitted changes before releasing.");
+  }
+
   const { next } = yargs(process.argv.slice(2))
     .options({ next: { type: "boolean", default: false } })
     .parseSync();


### PR DESCRIPTION
**Related Issue:** #

## Summary
It turns out the default behavior of conventional-changelog is to generate the changelog items since the most recent tag. Whoever wrote the script was deleting all of the next tags and readding them so that the whole changelog would be regenerated. I ended up writing some helpers to combine the existing unreleased changelog items and the new ones. 

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
