### PR TITLE
refactor(action)!: Removed deprecated properties and values

### DIFF
--- a/.storybook/resources.ts
+++ b/.storybook/resources.ts
@@ -17,7 +17,7 @@ const logicalFlowPositionOptions: LogicalFlowPosition[] = ["inline-start", "inli
 const positionOptions: Position[] = ["start", "end"];
 const scaleOptions: Scale[] = ["s", "m", "l"];
 const alignmentOptions: Alignment[] = ["start", "center", "end"];
-const appearanceOptions: Appearance[] = ["solid", "clear", "outline"];
+const appearanceOptions: Appearance[] = ["solid", "transparent", "outline"];
 
 export const ATTRIBUTES: CommonAttributes = {
   alignment: {

--- a/src/components/action/action.scss
+++ b/src/components/action/action.scss
@@ -145,8 +145,6 @@
   @apply bg-foreground-1;
 }
 
-//clear is deprecated. use transparent
-:host([appearance="clear"]) .button,
 :host([appearance="transparent"]) .button {
   @apply bg-transparent
     transition-shadow
@@ -154,25 +152,18 @@
     ease-in-out;
 }
 
-:host([appearance="clear"]) .button:hover,
-:host([appearance="clear"]) .button:focus,
 :host([appearance="transparent"]) .button:hover,
 :host([appearance="transparent"]) .button:focus {
   @apply bg-transparent;
   box-shadow: 0 0 0 2px theme("borderColor.color.1") inset;
 }
 
-:host([active][appearance="clear"]) .button,
-:host([active][appearance="clear"]) .button:hover,
-:host([active][appearance="clear"]) .button:focus,
 :host([active][appearance="transparent"]) .button,
 :host([active][appearance="transparent"]) .button:hover,
 :host([active][appearance="transparent"]) .button:focus {
   @apply text-color-1 fill-color-1 bg-foreground-3;
 }
 
-:host([appearance="clear"][loading]) .button,
-:host([appearance="clear"][disabled]) .button,
 :host([appearance="transparent"][loading]) .button,
 :host([appearance="transparent"][disabled]) .button {
   @apply bg-transparent;

--- a/src/components/action/action.stories.ts
+++ b/src/components/action/action.stories.ts
@@ -42,7 +42,7 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
       {
         name: "appearance",
         commit(): Attribute {
-          this.value = select("appearance", ["solid", "clear"], "solid");
+          this.value = select("appearance", ["solid", "transparent"], "solid");
           delete this.build;
           return this;
         }
@@ -160,14 +160,14 @@ export const disabledAndCompactAndTextOnly_TestOnly = (): string =>
     )}
   </div>`;
 
-export const activeAndAppearanceClear_TestOnly = (): string =>
+export const activeAndAppearanceTransparent_TestOnly = (): string =>
   html`<div>
     ${create(
       "calcite-action",
       createAttributes({ exceptions: ["icon", "appearance", "active"] }).concat([
         { name: "active", value: true },
         { name: "icon", value: "banana" },
-        { name: "appearance", value: "clear" }
+        { name: "appearance", value: "transparent" }
       ])
     )}
   </div>`;

--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -1,15 +1,4 @@
-import {
-  Component,
-  Element,
-  Event,
-  EventEmitter,
-  Host,
-  Method,
-  Prop,
-  h,
-  forceUpdate,
-  VNode
-} from "@stencil/core";
+import { Component, Element, Host, Method, Prop, h, forceUpdate, VNode } from "@stencil/core";
 
 import { Alignment, Appearance, Scale } from "../interfaces";
 
@@ -102,19 +91,6 @@ export class Action implements InteractiveComponent, LoadableComponent {
    * Indicates whether the text is displayed.
    */
   @Prop({ reflect: true }) textEnabled = false;
-
-  // --------------------------------------------------------------------------
-  //
-  //  Events
-  //
-  // --------------------------------------------------------------------------
-
-  /**
-   * Emits when the component has been clicked.
-   *
-   * @deprecated use `onClick` instead.
-   */
-  @Event({ cancelable: false }) calciteActionClick: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //
@@ -231,7 +207,7 @@ export class Action implements InteractiveComponent, LoadableComponent {
     };
 
     return (
-      <Host onClick={this.calciteActionClickHandler}>
+      <Host>
         <button
           aria-busy={toAriaBoolean(loading)}
           aria-disabled={toAriaBoolean(disabled)}
@@ -265,12 +241,6 @@ export class Action implements InteractiveComponent, LoadableComponent {
 
     if (tooltip) {
       tooltip.referenceElement = this.buttonEl;
-    }
-  };
-
-  calciteActionClickHandler = (): void => {
-    if (!this.disabled) {
-      this.calciteActionClick.emit();
     }
   };
 }

--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -40,7 +40,7 @@ export class Action implements InteractiveComponent, LoadableComponent {
   @Prop({ reflect: true }) alignment?: Alignment;
 
   /** Specifies the appearance of the component. */
-  @Prop({ reflect: true }) appearance: Extract<"solid" | "clear", Appearance> = "solid";
+  @Prop({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> = "solid";
 
   /**
    * When `true`, the side padding of the component is reduced. Compact mode is used internally by components, e.g. `calcite-block-section`.

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -1,5 +1,6 @@
 /* Note: using `.d.ts` file extension will exclude it from the output build */
 export type Alignment = "start" | "center" | "end";
+/* Note: "clear" has been deprecated and should be removed before 1.0 */
 export type Appearance = "solid" | "clear" | "outline" | "transparent" | "minimal";
 export type Columns = 1 | 2 | 3 | 4 | 5 | 6;
 export type FlipContext = "both" | "start" | "end";

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -296,7 +296,7 @@ export class PickListItem
       <calcite-action
         class={CSS.remove}
         icon={ICONS.remove}
-        onCalciteActionClick={this.removeClickHandler}
+        onClick={this.removeClickHandler}
         slot={SLOTS.actionsEnd}
         text={this.intlRemove}
       />


### PR DESCRIPTION
BREAKING CHANGE: Removed the `calciteActionClick` event and the `clear` value for the `appearance` property.

- Listen to the `click` event instead of `calciteActionClick.
- Use the value `transparent` instead of `clear` for the property `appearance`.