### PR TITLE
fix(tree-item): Allow space and enter key events when selectionMode is "none"

### DIFF
--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -309,7 +309,7 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
 
     switch (event.key) {
       case " ":
-        if (this.selectionMode === TreeSelectionMode.None) {
+        if (this.selectionMode === "none") {
           return;
         }
         this.calciteInternalTreeItemSelect.emit({
@@ -319,7 +319,7 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
         event.preventDefault();
         break;
       case "Enter":
-        if (this.selectionMode === TreeSelectionMode.None) {
+        if (this.selectionMode === "none") {
           return;
         }
         // activates a node, i.e., performs its default action. For parent nodes, one possible default action is to open or close the node. In single-select trees where selection does not follow focus (see note below), the default action is typically to select the focused node.

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -312,6 +312,9 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
 
     switch (event.key) {
       case " ":
+        if (this.selectionMode === TreeSelectionMode.None) {
+          return;
+        }
         this.calciteInternalTreeItemSelect.emit({
           modifyCurrentSelection: this.isSelectionMultiLike,
           forceToggle: false
@@ -319,6 +322,9 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
         event.preventDefault();
         break;
       case "Enter":
+        if (this.selectionMode === TreeSelectionMode.None) {
+          return;
+        }
         // activates a node, i.e., performs its default action. For parent nodes, one possible default action is to open or close the node. In single-select trees where selection does not follow focus (see note below), the default action is typically to select the focused node.
         const link = nodeListToArray(this.el.children).find((el) =>
           el.matches("a")

--- a/src/components/tree/tree.e2e.ts
+++ b/src/components/tree/tree.e2e.ts
@@ -800,6 +800,62 @@ describe("calcite-tree", () => {
       expect(keydownSpy).toHaveReceivedEventTimes(14);
     });
 
+    it("does prevent space/enter keyboard event on actions with selectionMode of single", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree selection-mode="single">
+          <calcite-tree-item>
+            <button>My button</button>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
+
+      const container = await page.find("#container");
+      const button = await page.find("button");
+      const keydownSpy = await container.spyOnEvent("keydown");
+
+      expect(keydownSpy).toHaveReceivedEventTimes(0);
+
+      await button.focus();
+      await page.keyboard.press("Enter");
+
+      expect(keydownSpy).toHaveReceivedEventTimes(1);
+      expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);
+
+      await page.keyboard.press("Space");
+
+      expect(keydownSpy).toHaveReceivedEventTimes(2);
+      expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);
+    });
+
+    it("does not prevent space/enter keyboard event on actions with selectionMode of none", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree selection-mode="none">
+          <calcite-tree-item>
+            <button>My button</button>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
+
+      const container = await page.find("#container");
+      const button = await page.find("button");
+      const keydownSpy = await container.spyOnEvent("keydown");
+
+      expect(keydownSpy).toHaveReceivedEventTimes(0);
+
+      await button.focus();
+      await page.keyboard.press("Enter");
+
+      expect(keydownSpy).toHaveReceivedEventTimes(1);
+      expect(keydownSpy.lastEvent.defaultPrevented).toBe(false);
+
+      await page.keyboard.press("Space");
+
+      expect(keydownSpy).toHaveReceivedEventTimes(2);
+      expect(keydownSpy.lastEvent.defaultPrevented).toBe(false);
+    });
+
     it("honors disabled items when navigating the tree", async () => {
       const page = await newE2EPage();
       await page.setContent(


### PR DESCRIPTION
**Related Issue:** #5735

## Summary

fix(tree-item): Allow space and enter key events when selectionMode is "none". #5735