### PR TITLE
docs(contributing): add additional info about environment setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,9 +102,11 @@ If your IDE supports the [Language Server Protocol (LSP) specification](https://
 
 ## Starting the demos
 
-First, install the NPM dependencies from within the `calcite-components` directory:
+First, clone the repo and install the NPM dependencies from within the `calcite-components` directory:
 
 ```sh
+git clone git@github.com:Esri/calcite-components.git
+cd calcite-components
 npm install
 ```
 
@@ -118,17 +120,17 @@ npm install
 >
 > Hopefully this will no longer be an issue once [`@stencil/eslint-plugin`](https://github.com/ionic-team/stencil-eslint) supports ESLint v8.
 
-Next, start the local Stencil development server on `localhost`, which will open the demos in the browser.
+Next, start the local Stencil development server on `localhost`:
 
 ```sh
 npm start
 ```
 
-From there, you can view the current demo pages and make changes in [`src/demos`](./src/demos). When adding a new demo page, make sure to add a link in [index.html](./src/index.html) so others can find it.
+The demos will open in the browser after building. Edit the pages in [`src/demos`](./src/demos) modify the component demos, such as changing attributes or adding content to slots. When adding a new demo page, make sure to add a link in [index.html](./src/index.html) so others can find it. You can also edit the component code in [`src/components`](./src/components), and the changes will be reflected in the demos.
 
 ## Linting
 
-This project uses [lint-staged](https://www.npmjs.com/package/lint-staged) to automatically format code on commit, making it easier to contribute. There are also NPM scripts in [`package.json`(./package.json)] to lint a variety of filetypes. To run them all:
+This project uses [lint-staged](https://www.npmjs.com/package/lint-staged) to automatically format code on commit, making it easier to contribute. There are also NPM scripts in [`package.json`](./package.json)] to lint a variety of filetypes. To run them all:
 
 ```sh
 npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,24 +89,39 @@ Our code base is written in TypeScript and must adhere to specific conventions a
 
 ## Getting a development environment set up
 
-An installation of Node is required for development. If you don't have Node installed, we recommend [Volta], which will automatically use the Node versions we pinned in `package.json`. We also recommend installing the following extensions in your editor of choice: TypeScript, TailwindCSS, ESLint, Stylelint, and Prettier. If you use VS Code, you will see a pop up in the bottom right corner prompting you to install or view the workspaces's recommended extensions. Here are instructions for manually installing the extensions in a variety of editors:
+An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions we pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure you are using the major versions of Node/NPM specified in `package.json`.
+
+We also recommend installing the following extensions in your editor of choice: TypeScript, TailwindCSS, ESLint, Stylelint, and Prettier. If you use VS Code, you will see a pop up in the bottom right corner prompting you to install or view the workspaces's recommended extensions. Here are instructions for manually installing the extensions in a variety of editors:
 
 - https://tailwindcss.com/docs/intellisense
 - https://eslint.org/docs/latest/user-guide/integrations
 - https://stylelint.io/user-guide/integrations/editor
 - https://prettier.io/docs/en/editors.html
 
-The first time installing dependencies, you need to use the `--legacy-peer-deps` flag due to an ESLint dependency conflict. The conflict won't affect the components since ESLint is only in `devDependencies`. Hopefully this will no longer be an issue once [`@stencil/eslint-plugin`](https://github.com/ionic-team/stencil-eslint) supports ESLint v8.
+If your IDE supports the [Language Server Protocol (LSP) specification](https://microsoft.github.io/language-server-protocol/) but isn't mentioned in the links above, ask Ben for help getting set up.
+
+## Starting the demos
+
+First, install the NPM dependencies from within the `calcite-components` directory:
 
 ```sh
-npm install --legacy-peer-deps
+npm install
 ```
 
-To start the local development environment, run `npm start`, which will start the local Stencil development server on localhost. You can modify the [index.html](./src/index.html) to add and test your new component. Just add another HTML file to the `demos` folder and link to this new page from `index.html`.
+> **NOTE**
+>
+> The first time installing dependencies, you may need to use the `legacy-peer-deps` flag due to an Stencil/ESLint dependency conflict: `npm install --legacy-peer-deps`.
+> The conflict won't affect the components since ESLint is in `devDependencies`. Hopefully this will no longer be an issue once [`@stencil/eslint-plugin`](https://github.com/ionic-team/stencil-eslint) supports ESLint v8.
+
+Next, run `npm start`, which will start the local Stencil development server on `localhost` and open it in the browser. From there, you can view the current demo pages and make changes in [`src/demos`](./src/demos). When adding a new demo page, make sure to add a link in [index.html](./src/index.html) so others can find it.
 
 ## Linting
 
-This project uses [lint-staged](https://www.npmjs.com/package/lint-staged) to automatically format code on commit, making it easier to contribute.
+This project uses [lint-staged](https://www.npmjs.com/package/lint-staged) to automatically format code on commit, making it easier to contribute. There are also NPM scripts in [`package.json`(./package.json)] to lint a variety of filetypes. To run them all:
+
+```sh
+npm run lint
+```
 
 ## Running the tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Our code base is written in TypeScript and must adhere to specific conventions a
 
 ## Getting a development environment set up
 
-An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions we pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure you are using the major versions of Node/NPM specified in [`package.json`](./package.json).
+An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure to use the major versions of Node/NPM specified in [`package.json`](./package.json).
 
 We also recommend installing the following extensions in your editor of choice: TypeScript, TailwindCSS, ESLint, Stylelint, and Prettier. If you use VS Code, you will see a pop up in the bottom right corner prompting you to install or view the workspaces's recommended extensions. Here are instructions for manually installing the extensions in a variety of editors:
 
@@ -120,17 +120,17 @@ npm install
 >
 > Hopefully this will no longer be an issue once [`@stencil/eslint-plugin`](https://github.com/ionic-team/stencil-eslint) supports ESLint v8.
 
-Next, start the local Stencil development server on `localhost`:
+Next, start the local Stencil development server on localhost:
 
 ```sh
 npm start
 ```
 
-The demos will open in the browser after building. Edit the pages in [`src/demos`](./src/demos) modify the component demos, such as changing attributes or adding content to slots. When adding a new demo page, make sure to add a link in [index.html](./src/index.html) so others can find it. You can also edit the component code in [`src/components`](./src/components), and the changes will be reflected in the demos.
+The demos will open in the browser after building. Edit the pages in [`src/demos`](./src/demos) to modify the component demos, such as changing attributes or adding content to slots. When adding a new demo page, make sure to add a link in [`index.html`](./src/index.html) so others can find it. You can also edit the component code in [`src/components`](./src/components), and the changes will be reflected in the demos.
 
 ## Linting
 
-This project uses [lint-staged](https://www.npmjs.com/package/lint-staged) to automatically format code on commit, making it easier to contribute. There are also NPM scripts in [`package.json`](./package.json)] to lint a variety of filetypes. To run them all:
+This project uses [lint-staged](https://www.npmjs.com/package/lint-staged) to automatically format code on commit, making it easier to contribute. There are also NPM scripts in [`package.json`](./package.json) to lint a variety of filetypes. To run them all:
 
 ```sh
 npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Our code base is written in TypeScript and must adhere to specific conventions a
 
 ## Getting a development environment set up
 
-An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions we pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure you are using the major versions of Node/NPM specified in `package.json`.
+An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions we pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure you are using the major versions of Node/NPM specified in [`package.json`](./package.json).
 
 We also recommend installing the following extensions in your editor of choice: TypeScript, TailwindCSS, ESLint, Stylelint, and Prettier. If you use VS Code, you will see a pop up in the bottom right corner prompting you to install or view the workspaces's recommended extensions. Here are instructions for manually installing the extensions in a variety of editors:
 
@@ -110,10 +110,21 @@ npm install
 
 > **NOTE**
 >
-> The first time installing dependencies, you may need to use the `legacy-peer-deps` flag due to an Stencil/ESLint dependency conflict: `npm install --legacy-peer-deps`.
-> The conflict won't affect the components since ESLint is in `devDependencies`. Hopefully this will no longer be an issue once [`@stencil/eslint-plugin`](https://github.com/ionic-team/stencil-eslint) supports ESLint v8.
+> The first time installing dependencies, you may need to use the `legacy-peer-deps` flag due to an Stencil/ESLint dependency conflict:
+>
+> ```sh
+> npm install --legacy-peer-deps
+> ```
+>
+> Hopefully this will no longer be an issue once [`@stencil/eslint-plugin`](https://github.com/ionic-team/stencil-eslint) supports ESLint v8.
 
-Next, run `npm start`, which will start the local Stencil development server on `localhost` and open it in the browser. From there, you can view the current demo pages and make changes in [`src/demos`](./src/demos). When adding a new demo page, make sure to add a link in [index.html](./src/index.html) so others can find it.
+Next, start the local Stencil development server on `localhost`, which will open the demos in the browser.
+
+```sh
+npm start
+```
+
+From there, you can view the current demo pages and make changes in [`src/demos`](./src/demos). When adding a new demo page, make sure to add a link in [index.html](./src/index.html) so others can find it.
 
 ## Linting
 


### PR DESCRIPTION
**Related Issue:** #

## Summary

Designers are running into issues getting an environment set up to run the demos locally, so I'm clarifying a few things in the contributing guide.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
