### PR TITLE
ci(chromatic): use diffThreshold value saved in secrets

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -52,7 +52,7 @@ jobs:
           exitOnceUploaded: true
         env:
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
-          CHROMATIC_DIFF_THRESHOLD: $${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
       - if: steps.markdown-check.outputs.SKIP == 'true'
         name: skip chromatic for markdown PRs
         uses: Sibz/github-status-action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -52,6 +52,7 @@ jobs:
           exitOnceUploaded: true
         env:
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
+          CHROMATIC_DIFF_THRESHOLD: $${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
       - if: steps.markdown-check.outputs.SKIP == 'true'
         name: skip chromatic for markdown PRs
         uses: Sibz/github-status-action@v1


### PR DESCRIPTION
**Related Issue:** #

## Summary

I forgot to pass the diff threshold GH secret to the chromatic workflow's environment variables 😅
That explains why bumping up the value wasn't doing anything

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
