### PR TITLE
refactor(tip-manager)!: Remove deprecated `calciteTipManagerToggle` event.

### DIFF
--- a/src/components/tip-manager/tip-manager.e2e.ts
+++ b/src/components/tip-manager/tip-manager.e2e.ts
@@ -76,7 +76,6 @@ describe("calcite-tip-manager", () => {
       isVisible = await container.isVisible();
       expect(isVisible).toBe(false);
 
-      expect(toggleEventSpy).toHaveReceivedEvent();
       expect(closeEventSpy).toHaveReceivedEvent();
 
       const isClosed = await tipManager.getProperty("closed");

--- a/src/components/tip-manager/tip-manager.e2e.ts
+++ b/src/components/tip-manager/tip-manager.e2e.ts
@@ -65,7 +65,6 @@ describe("calcite-tip-manager", () => {
       let isVisible = await container.isVisible();
       expect(isVisible).toBe(true);
 
-      const toggleEventSpy = await page.spyOnEvent("calciteTipManagerToggle", "window");
       const closeEventSpy = await page.spyOnEvent("calciteTipManagerClose", "window");
 
       const closeButton = await page.find(`calcite-tip-manager >>> .${CSS.close}`);

--- a/src/components/tip-manager/tip-manager.tsx
+++ b/src/components/tip-manager/tip-manager.tsx
@@ -37,7 +37,6 @@ export class TipManager {
   @Watch("closed")
   closedChangeHandler(): void {
     this.direction = null;
-    this.calciteTipManagerToggle.emit();
   }
 
   /**
@@ -142,13 +141,6 @@ export class TipManager {
   // --------------------------------------------------------------------------
 
   /**
-   * Emits when the component has been open or closed.
-   *
-   * @deprecated use `calciteTipManagerClose` instead.
-   */
-  @Event({ cancelable: false }) calciteTipManagerToggle: EventEmitter<void>;
-
-  /**
    * Emits when the component has been closed.
    */
   @Event({ cancelable: false }) calciteTipManagerClose: EventEmitter<void>;
@@ -179,7 +171,6 @@ export class TipManager {
 
   hideTipManager = (): void => {
     this.closed = true;
-    this.calciteTipManagerToggle.emit();
     this.calciteTipManagerClose.emit();
   };
 


### PR DESCRIPTION
BREAKING CHANGE: Removed the `calciteTipManagerToggle` event, use `calciteTipManagerClose` instead.