### PR TITLE
ci: more tweaks to prevent chromatic diffs for text aliasing

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -54,6 +54,6 @@ export const parameters = {
       order: ["Overview", "Components", "App Components"]
     },
     // https://www.chromatic.com/docs/threshold
-    diffThreshold: process.env.CHROMATIC_DIFF_THRESHOLD || 0.08
+    diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3
   }
 };

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -52,8 +52,10 @@ export const parameters = {
   options: {
     storySort: {
       order: ["Overview", "Components", "App Components"]
-    },
+    }
+  },
+  chromatic: {
     // https://www.chromatic.com/docs/threshold
-    diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3
+    diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.15
   }
 };

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -17,7 +17,11 @@ const { scale } = ATTRIBUTES;
 export default {
   title: "Components/Controls/DatePicker",
   parameters: {
-    notes: readme
+    notes: readme,
+    chromatic: {
+      // https://www.chromatic.com/docs/threshold
+      diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3
+    }
   },
   ...storyFilters()
 };

--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -7,7 +7,11 @@ import { html } from "../../../support/formatting";
 export default {
   title: "Components/Controls/Slider",
   parameters: {
-    notes: readme
+    notes: readme,
+    chromatic: {
+      // https://www.chromatic.com/docs/threshold
+      diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3
+    }
   },
   ...storyFilters()
 };


### PR DESCRIPTION
**Related Issue:** #

## Summary

Some more changes to stop text aliasing from triggering Chromatic diffs

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
