### PR TITLE
docs(contributing): estimate labels and guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,16 @@ Milestones are used to manage sprints, which are two weeks long. Sprint mileston
 
 ### Estimates
 
-Estimates are used to determine how much work needs to go into an issue. The total estimate helps the product managers triage issues effectively so developers are not overwhelmed during sprints. If you are not on the team, please do not add estimates when creating cases. You can add an estimate label to your ticket `estimate-` to track your estimate. Here are some guidelines for the numbering system:
+Estimates are used to determine how much work needs to go into an issue. The total estimate helps product managers triage issues effectively so developers are not overwhelmed during sprints. If you are not on the team, please do not add estimates when creating cases. Here are some guidelines for time estimates using an `estimate-#` label for tracking:
 
-- **1:** Fixing a typo, small syntax issue, or tweaking a css property. Something that can be done in a couple minutes.
-- **5:** Fixing bugs or adding small features that don't require comprehensive planning.
-- **13:** Issues that are more complicated and need some workflow or design planning. These issues usually need additional unit tests written.
-- **40:** If an issue is this complicated it should be converted into an epic.
+- `estimate - 1`: Very small fix or change, a one line update.
+- `estimate - 2`: Small fix or update, does not require updates to tests.
+- `estimate - 3`: A day or two of work, may require changes to tests.
+- `estimate - 5`: A few days of work, requires updates to tests.
+- `estimate - 8`: Requires input from team, consider smaller steps.
+- `estimate - 13`: Requires planning and input from team, consider smaller steps.
+- `estimate - 21`: Requires planning, input from team members and possibly others.
+- `estimate - 34`: Issue should be converted into an epic. Requires all hands on deck.
 
 ### Epics
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Add contributing guidance for devs on time estimates pertaining to the `estimate-#` label. 

Adds estimates for: 
- 1
- 2
- 3
- 5
- 8
- 13
- 21, and
- 34

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
