### PR TITLE
ci(pr-bot): prevent from removing existing labels

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const { title, labels, number} = context.payload.pull_request;
+            const { title, number } = context.payload.pull_request;
 
             const conventionalCommitRegex =
               /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w ,-]+\))?(!?:\s+)([\w ]+[\s\S]*)/i;
@@ -47,16 +47,13 @@ jobs:
             const match = title.match(conventionalCommitRegex);
             if (match && match.length > 1) {
               // commit type is in the first match group
-              const newLabel = getLabelName(match[1]);
-              // make sure there aren't any duplicates
-              const updatedLabels = labels.map((l) => l.name).filter((l) => l !== newLabel);
-              updatedLabels.push(newLabel);
+              const typeLabel = getLabelName(match[1]);
 
-              await github.rest.issues.setLabels({
+              await github.rest.issues.addLabels({
                 issue_number: number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: updatedLabels,
+                labels: [typeLabel],
               });
 
               function getLabelName(type) {


### PR DESCRIPTION
**Related Issue:** #

## Summary

There is a timing error, where if you sync a branch and change a label right afterwards, your change will be undone. This is because the `pr-bot` was adding the conventional commit type label to the existing ones, but when it started the run your change diudn't exist yet.

![image](https://user-images.githubusercontent.com/10986395/204685262-02fd953a-8904-40fe-b010-3b8c04e9d993.png)

I found an API endpoint that just adds labels, without the potential to accidently remove existing ones.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
