### PR TITLE
test(custom-theme): use placeholderImage

### DIFF
--- a/src/05-custom-theme.stories.mdx
+++ b/src/05-custom-theme.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Description, Canvas, Story } from "@storybook/addon-docs";
 import { color } from "@storybook/addon-knobs";
-
+import { placeholderImage } from "../.storybook/placeholderImage"
 import markdown from "./custom-theme.md";
 
 <Meta title="Theming/Custom Theme" />
@@ -123,7 +123,12 @@ export const Template = () =>
       <div class="demo-column">
         <div>
           <calcite-card selected selectable>
-            <img alt="" slot="thumbnail" src="https://placem.at/places?w=260&h=160&txt=0" style="width: 260px;" />
+            <img
+              alt="thumbnail"
+              slot="thumbnail"
+              style="width:260px"
+              src="${placeholderImage({ width: 260, height: 160 })}"
+            />
             <h3 slot="title">Selectable card</h3>
             <calcite-link slot="footer-leading">Lead füt</calcite-link>
             <calcite-link slot="footer-trailing">Trail füt</calcite-link>


### PR DESCRIPTION
**Related Issue:** #5812

## Summary
The image service we were using for the card's thumbnail in the custom theme story is/was down, which caused CI failures. For example:
https://www.chromatic.com/test?appId=6266d45509d7eb004aa254fb&id=6386b5d2e340d812b9c9a134

I switched it out to use our placeholderImage util.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
