### PR TITLE
refactor(tree)!: Remove deprecated `inputEnabled` property

### DIFF
--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -91,14 +91,6 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
   @Prop({ reflect: true, mutable: true }) lines: boolean;
 
   /**
-   * Displays checkboxes (set on parent).
-   *
-   * @internal
-   * @deprecated Use `selectionMode="ancestors"` for checkbox input.
-   */
-  @Prop() inputEnabled: boolean;
-
-  /**
    * @internal
    */
   @Prop({ reflect: true, mutable: true }) scale: Scale;

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -42,13 +42,6 @@ export class Tree {
   @Prop({ mutable: true, reflect: true }) lines = false;
 
   /**
-   * Display input
-   *
-   * @deprecated Use `selectionMode="ancestors"` for checkbox input.
-   */
-  @Prop() inputEnabled = false;
-
-  /**
    * @internal
    */
   @Prop({ reflect: true, mutable: true }) child: boolean;


### PR DESCRIPTION
BREAKING CHANGE: Removed the `inputEnabled` property.

- Removed the property `inputEnabled`, use `selectionMode="ancestors"` instead.