### PR TITLE
refactor(dropdown, dropdown-item)!: Remove deprecated properties

### DIFF
--- a/src/components/dropdown-item/dropdown-item.scss
+++ b/src/components/dropdown-item/dropdown-item.scss
@@ -182,7 +182,7 @@
   @apply opacity-100;
 }
 
-:host([active]) .dropdown-item-icon {
+:host([selected]) .dropdown-item-icon {
   color: theme("backgroundColor.brand");
   @apply opacity-100;
 }

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -8,8 +8,7 @@ import {
   Listen,
   Method,
   Prop,
-  VNode,
-  Watch
+  VNode
 } from "@stencil/core";
 import { getElementProp, toAriaBoolean } from "../../utils/dom";
 import { ItemKeyboardEvent } from "../dropdown/interfaces";
@@ -47,25 +46,8 @@ export class DropdownItem implements LoadableComponent {
   //
   //--------------------------------------------------------------------------
 
-  /**
-   * When `true`, the component is selected.
-   *
-   * @deprecated Use `selected` instead.
-   */
-  @Prop({ reflect: true, mutable: true }) active = false;
-
-  @Watch("active")
-  activeHandler(value: boolean): void {
-    this.selected = value;
-  }
-
   /** When `true`, the component is selected. */
   @Prop({ reflect: true, mutable: true }) selected = false;
-
-  @Watch("selected")
-  selectedHandler(value: boolean): void {
-    this.active = value;
-  }
 
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl: FlipContext;
@@ -139,12 +121,6 @@ export class DropdownItem implements LoadableComponent {
   }
 
   connectedCallback(): void {
-    const isSelected = this.selected || this.active;
-
-    if (isSelected) {
-      this.activeHandler(isSelected);
-      this.selectedHandler(isSelected);
-    }
     this.initialize();
   }
 

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -229,10 +229,6 @@ describe("calcite-dropdown", () => {
     const item2 = await element.find("calcite-dropdown-item[id='item-2']");
     const item3 = await element.find("calcite-dropdown-item[id='item-3']");
 
-    //active prop is deprecated
-    expect(item1).not.toHaveAttribute("active");
-    expect(item3).not.toHaveAttribute("active");
-
     expect(item1).not.toHaveAttribute("selected");
     expect(item2).toHaveAttribute("selected");
     expect(item3).not.toHaveAttribute("selected");
@@ -284,11 +280,6 @@ describe("calcite-dropdown", () => {
       mostRecentId: "item-3"
     });
 
-    // active prop is deprecated
-    expect(item1).toHaveAttribute("active");
-    expect(item2).not.toHaveAttribute("active");
-    expect(item3).toHaveAttribute("active");
-
     expect(item1).toHaveAttribute("selected");
     expect(item2).not.toHaveAttribute("selected");
     expect(item3).toHaveAttribute("selected");
@@ -333,11 +324,6 @@ describe("calcite-dropdown", () => {
       mostRecentId: "item-3"
     });
 
-    //active prop is deprecated
-    expect(item1).not.toHaveAttribute("active");
-    expect(item2).not.toHaveAttribute("active");
-    expect(item3).toHaveAttribute("active");
-
     expect(item1).not.toHaveAttribute("selected");
     expect(item2).not.toHaveAttribute("selected");
     expect(item3).toHaveAttribute("selected");
@@ -376,11 +362,6 @@ describe("calcite-dropdown", () => {
     await item3.click();
     await page.waitForChanges();
     await assertSelectedItems(page, { expectedItemIds: [], mostRecentId: "item-3" });
-
-    //active prop is deprecated
-    expect(item1).not.toHaveAttribute("active");
-    expect(item2).not.toHaveAttribute("active");
-    expect(item3).not.toHaveAttribute("active");
 
     expect(item1).not.toHaveAttribute("selected");
     expect(item2).not.toHaveAttribute("selected");
@@ -487,17 +468,6 @@ describe("calcite-dropdown", () => {
       expectedItemIds: ["item-1", "item-3", "item-6"],
       mostRecentId: "item-9"
     });
-
-    //active is deprecated
-    expect(item1).toHaveAttribute("active");
-    expect(item2).not.toHaveAttribute("active");
-    expect(item3).toHaveAttribute("active");
-    expect(item4).not.toHaveAttribute("active");
-    expect(item5).not.toHaveAttribute("active");
-    expect(item6).toHaveAttribute("active");
-    expect(item7).not.toHaveAttribute("active");
-    expect(item8).not.toHaveAttribute("active");
-    expect(item9).not.toHaveAttribute("active");
 
     expect(item1).toHaveAttribute("selected");
     expect(item2).not.toHaveAttribute("selected");
@@ -1169,7 +1139,7 @@ describe("calcite-dropdown", () => {
     const calciteDropdownBeforeOpenSpy = await element.spyOnEvent("calciteDropdownBeforeOpen");
     const calciteDropdownOpenSpy = await element.spyOnEvent("calciteDropdownOpen");
 
-    await element.setProperty("active", true);
+    element.setProperty("open", true);
     await page.waitForChanges();
 
     expect(await element.getProperty("open")).toBe(true);
@@ -1187,7 +1157,7 @@ describe("calcite-dropdown", () => {
     const calciteDropdownBeforeCloseSpy = await element.spyOnEvent("calciteDropdownBeforeClose");
     const calciteDropdownCloseSpy = await element.spyOnEvent("calciteDropdownClose");
 
-    await element.setProperty("active", false);
+    element.setProperty("open", false);
     await page.waitForChanges();
 
     await calciteDropdownBeforeCloseEvent;

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -311,7 +311,7 @@ export const noScrollingWhenMaxItemsEqualsItems_TestOnly = (): string => html` <
   <calcite-button slot="dropdown-trigger">Activate Dropdown</calcite-button>
   <calcite-dropdown-group selection-mode="single" group-title="Selection Mode: Single">
     <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-    <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+    <calcite-dropdown-item selected>Date modified</calcite-dropdown-item>
     <calcite-dropdown-item>Title</calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-dropdown>`;
@@ -411,12 +411,12 @@ export const flipPlacements_TestOnly = (): string => html`
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group group-title="Sort by">
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+        <calcite-dropdown-item selected>Date modified</calcite-dropdown-item>
         <calcite-dropdown-item>Title</calcite-dropdown-item>
       </calcite-dropdown-group>
       <calcite-dropdown-group group-title="Sort by">
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-        <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+        <calcite-dropdown-item selected>Date modified</calcite-dropdown-item>
         <calcite-dropdown-item>Title</calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -66,18 +66,6 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
 
   /**
    * When `true`, displays and positions the component.
-   *
-   * @deprecated use `open` instead.
-   */
-  @Prop({ reflect: true, mutable: true }) active = false;
-
-  @Watch("active")
-  activeHandler(value: boolean): void {
-    this.open = value;
-  }
-
-  /**
-   * When `true`, displays and positions the component.
    */
   @Prop({ reflect: true, mutable: true }) open = false;
 
@@ -89,7 +77,6 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
       } else {
         updateAfterClose(this.floatingEl);
       }
-      this.active = value;
       return;
     }
 
@@ -203,9 +190,6 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
     this.reposition(true);
     if (this.open) {
       this.openHandler(this.open);
-    }
-    if (this.active) {
-      this.activeHandler(this.active);
     }
     connectOpenCloseComponent(this);
   }

--- a/src/components/dropdown/usage/Basic.md
+++ b/src/components/dropdown/usage/Basic.md
@@ -3,7 +3,7 @@
   <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
   <calcite-dropdown-group>
     <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-    <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
+    <calcite-dropdown-item selected>Date modified</calcite-dropdown-item>
     <calcite-dropdown-item>Title</calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-dropdown>

--- a/src/components/dropdown/usage/Disabling-close-on-select.md
+++ b/src/components/dropdown/usage/Disabling-close-on-select.md
@@ -5,7 +5,7 @@ You can choose to leave the dropdown open when an item is selected with the `dis
   <calcite-button id="trigger" slot="dropdown-trigger">Open dropdown</calcite-button>
   <calcite-dropdown-group id="group-1" selection-mode="single">
     <calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>
-    <calcite-dropdown-item id="item-2" active> Dropdown Item Content </calcite-dropdown-item>
+    <calcite-dropdown-item id="item-2" selected> Dropdown Item Content </calcite-dropdown-item>
     <calcite-dropdown-item id="item-3"> Dropdown Item Content </calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-dropdown>

--- a/src/components/dropdown/usage/Groups.md
+++ b/src/components/dropdown/usage/Groups.md
@@ -5,17 +5,17 @@ You can combine groups in a single dropdown, with varying selection modes:
   <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
   <calcite-dropdown-group group-title="Select one">
     <calcite-dropdown-item>Apple</calcite-dropdown-item>
-    <calcite-dropdown-item active>Orange</calcite-dropdown-item>
+    <calcite-dropdown-item selected>Orange</calcite-dropdown-item>
     <calcite-dropdown-item>Grape</calcite-dropdown-item>
   </calcite-dropdown-group>
   <calcite-dropdown-group group-title="Select multi" selection-mode="multi">
     <calcite-dropdown-item>Asparagus</calcite-dropdown-item>
-    <calcite-dropdown-item active>Potato</calcite-dropdown-item>
+    <calcite-dropdown-item selected>Potato</calcite-dropdown-item>
     <calcite-dropdown-item>Yam</calcite-dropdown-item>
   </calcite-dropdown-group>
   <calcite-dropdown-group group-title="Select none (useful for actions)" selection-mode="none">
     <calcite-dropdown-item>Plant beans</calcite-dropdown-item>
-    <calcite-dropdown-item active>Add peas</calcite-dropdown-item>
+    <calcite-dropdown-item selected>Add peas</calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-dropdown>
 ```

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -146,9 +146,9 @@ export class SplitButton implements InteractiveComponent {
           <div class={CSS.divider} />
         </div>
         <calcite-dropdown
-          active={this.active}
           disabled={this.disabled}
           onClick={this.calciteSplitButtonSecondaryClickHandler}
+          open={this.active}
           overlayPositioning={this.overlayPositioning}
           placement="bottom-end"
           scale={this.scale}


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated properties.

- Removed the property `active` on `calcite-dropdown-item`, use `selected` instead.
- Removed the property `active`, on `calcite-dropdown`, use `open` instead.