### PR TITLE
refactor(radio-group-item)!: Remove deprecated properties

### DIFF
--- a/src/components/radio-group-item/radio-group-item.e2e.ts
+++ b/src/components/radio-group-item/radio-group-item.e2e.ts
@@ -37,14 +37,6 @@ describe("calcite-radio-group-item", () => {
     expect(label).toEqualText("test-value");
   });
 
-  it("renders icon if requested (deprecated)", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-radio-group-item icon="car">Content</calcite-accordion-item>`);
-    const icon = await page.find("calcite-radio-group-item >>> .radio-group-item-icon");
-    expect(icon).not.toBe(null);
-  });
-
   it("renders icon at start if requested", async () => {
     const page = await newE2EPage();
     await page.setContent(`
@@ -110,9 +102,7 @@ describe("calcite-radio-group-item", () => {
 
       const element = await page.find("calcite-radio-group-item");
       expect(element).not.toHaveAttribute("checked");
-      expect(element).not.toHaveAttribute("icon");
       expect(element).not.toHaveAttribute("icon-flip-rtl");
-      expect(element).toEqualAttribute("icon-position", "start");
       expect(element).not.toHaveAttribute("value");
       expect(element).not.toHaveAttribute("icon-start");
       expect(element).not.toHaveAttribute("icon-end");

--- a/src/components/radio-group-item/radio-group-item.scss
+++ b/src/components/radio-group-item/radio-group-item.scss
@@ -90,34 +90,6 @@
   line-height: inherit;
 }
 
-// icon positioning and styles
-:host([icon-position="start"]) .label--scale-s .radio-group-item-icon {
-  margin-inline-end: theme("margin.2");
-}
-
-:host([icon-position="end"]) .label--scale-s .radio-group-item-icon {
-  margin-inline-end: unset;
-  margin-inline-start: theme("margin.2");
-}
-
-:host([icon-position="start"]) .label--scale-m .radio-group-item-icon {
-  margin-inline-end: theme("margin.3");
-}
-
-:host([icon-position="end"]) .label--scale-m .radio-group-item-icon {
-  margin-inline-end: unset;
-  margin-inline-start: theme("margin.3");
-}
-
-:host([icon-position="start"]) .label--scale-l .radio-group-item-icon {
-  margin-inline-end: theme("margin.4");
-}
-
-:host([icon-position="end"]) .label--scale-l .radio-group-item-icon {
-  margin-inline-end: unset;
-  margin-inline-start: theme("margin.4");
-}
-
 :host([icon-start]) .label--scale-s .radio-group-item-icon {
   margin-inline-end: theme("margin.2");
 }

--- a/src/components/radio-group-item/radio-group-item.tsx
+++ b/src/components/radio-group-item/radio-group-item.tsx
@@ -11,7 +11,7 @@ import {
 } from "@stencil/core";
 import { getElementProp, toAriaBoolean } from "../../utils/dom";
 import { RadioAppearance } from "../radio-group/interfaces";
-import { Position, Layout, Scale } from "../interfaces";
+import { Layout, Scale } from "../interfaces";
 import { SLOTS, CSS } from "./resources";
 
 @Component({
@@ -43,22 +43,8 @@ export class RadioGroupItem {
     this.calciteInternalRadioGroupItemChange.emit();
   }
 
-  /**
-   * Specifies an icon to display.
-   *
-   * @deprecated Use either `iconStart` or `iconEnd` but do not combine them with `icon` and `iconPosition`.
-   */
-  @Prop({ reflect: true }) icon?: string;
-
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
-
-  /**
-   * Specifies the placement of the icon.
-   *
-   * @deprecated Use either `iconStart` or `iconEnd` but do not combine them with `icon` and `iconPosition`.
-   */
-  @Prop({ reflect: true }) iconPosition?: Position = "start";
 
   /** Specifies an icon to display at the start of the component. */
   @Prop({ reflect: true }) iconStart?: string;
@@ -98,20 +84,6 @@ export class RadioGroupItem {
       />
     ) : null;
 
-    const iconEl = (
-      <calcite-icon
-        class={CSS.radioGroupItemIcon}
-        flipRtl={this.iconFlipRtl}
-        icon={this.icon}
-        key="icon"
-        scale="s"
-      />
-    );
-
-    const iconAtStart =
-      this.icon && this.iconPosition === "start" && !this.iconStart ? iconEl : null;
-    const iconAtEnd = this.icon && this.iconPosition === "end" && !this.iconEnd ? iconEl : null;
-
     return (
       <Host aria-checked={toAriaBoolean(checked)} aria-label={value} role="radio">
         <label
@@ -123,11 +95,9 @@ export class RadioGroupItem {
             "label--outline": appearance === "outline"
           }}
         >
-          {iconAtStart}
           {this.iconStart ? iconStartEl : null}
           <slot>{value}</slot>
           <slot name={SLOTS.input} />
-          {iconAtEnd}
           {this.iconEnd ? iconEndEl : null}
         </label>
       </Host>

--- a/src/components/radio-group/radio-group.stories.ts
+++ b/src/components/radio-group/radio-group.stories.ts
@@ -38,9 +38,9 @@ export const fullWidthWithIcons = (): string => html`
         width="${select("width", ["auto", "full"], "full")}"
         ${boolean("disabled", false)}
       >
-        <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
-        <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
-        <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+        <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+        <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+        <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
       </calcite-radio-group>
     </calcite-label>
   </div>
@@ -73,14 +73,8 @@ export const disabled_TestOnly = (): string => html`<calcite-radio-group disable
 </calcite-radio-group>`;
 
 export const WithIconStartAndEnd = (): string => html` <calcite-radio-group scale="s">
-  <calcite-radio-group-item icon-start="car" icon-end="car" value="car" checked icon="plane" icon-positon="end"
-    >Car</calcite-radio-group-item
-  >
-  <calcite-radio-group-item icon-end="plane" value="plane" icon="banana" icon-positon="start"
-    >Plane</calcite-radio-group-item
-  >
-  <calcite-radio-group-item icon-start="biking" icon-end="biking" value="bicycle" icon="car" icon-positon="start"
-    >Bicycle</calcite-radio-group-item
-  >
+  <calcite-radio-group-item icon-start="car" icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+  <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+  <calcite-radio-group-item icon-start="biking" icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
   <calcite-radio-group-item value="nothing">Nothing</calcite-radio-group-item>
 </calcite-radio-group>`;

--- a/src/components/radio-group/radio-group.stories.ts
+++ b/src/components/radio-group/radio-group.stories.ts
@@ -38,9 +38,9 @@ export const fullWidthWithIcons = (): string => html`
         width="${select("width", ["auto", "full"], "full")}"
         ${boolean("disabled", false)}
       >
-        <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
-        <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
-        <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+        <calcite-radio-group-item icon-start="car" value="car" checked>Car</calcite-radio-group-item>
+        <calcite-radio-group-item icon-start="plane" value="plane">Plane</calcite-radio-group-item>
+        <calcite-radio-group-item icon-start="biking" value="bicycle">Bicycle</calcite-radio-group-item>
       </calcite-radio-group>
     </calcite-label>
   </div>
@@ -74,7 +74,7 @@ export const disabled_TestOnly = (): string => html`<calcite-radio-group disable
 
 export const WithIconStartAndEnd = (): string => html` <calcite-radio-group scale="s">
   <calcite-radio-group-item icon-start="car" icon-end="car" value="car" checked>Car</calcite-radio-group-item>
-  <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+  <calcite-radio-group-item icon-start="plane" icon-end="plane" value="plane">Plane</calcite-radio-group-item>
   <calcite-radio-group-item icon-start="biking" icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
   <calcite-radio-group-item value="nothing">Nothing</calcite-radio-group-item>
 </calcite-radio-group>`;

--- a/src/demos/radio-group.html
+++ b/src/demos/radio-group.html
@@ -272,31 +272,25 @@
 
         <div class="child-flex">
           <calcite-radio-group scale="s">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group scale="m">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group scale="l">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
       </div>
@@ -306,31 +300,25 @@
         <div class="child-flex right-aligned-text">outline icon position-end</div>
         <div class="child-flex">
           <calcite-radio-group appearance="outline" scale="s">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group appearance="outline" scale="m">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group appearance="outline" scale="l">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
       </div>
@@ -678,31 +666,25 @@
 
         <div class="child-flex">
           <calcite-radio-group layout="vertical" scale="s">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group layout="vertical" scale="m">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group layout="vertical" scale="l">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
       </div>
@@ -712,31 +694,25 @@
         <div class="child-flex right-aligned-text">outline icon position-end</div>
         <div class="child-flex">
           <calcite-radio-group appearance="outline" layout="vertical" scale="s">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group appearance="outline" layout="vertical" scale="m">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
 
         <div class="child-flex">
           <calcite-radio-group appearance="outline" layout="vertical" scale="l">
-            <calcite-radio-group-item icon-position="end" icon="car" value="car" checked>Car</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="plane" value="plane">Plane</calcite-radio-group-item>
-            <calcite-radio-group-item icon-position="end" icon="biking" value="bicycle"
-              >Bicycle</calcite-radio-group-item
-            >
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
           </calcite-radio-group>
         </div>
       </div>


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated properties.

- Removed the property `icon`, use either `iconStart` or `iconEnd` instead.
- Removed the property `iconPosition`, use either `iconStart` or `iconEnd` instead.