### PR TITLE
refactor(split-button)!: Remove deprecated `event.detail` on events

### DIFF
--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Prop, VNode, Watch } from "@stencil/core";
 import { CSS } from "./resources";
 import { ButtonAppearance, ButtonColor, DropdownIconType } from "../button/interfaces";
-import { DeprecatedEventPayload, FlipContext, Scale, Width } from "../interfaces";
+import { FlipContext, Scale, Width } from "../interfaces";
 import { OverlayPositioning } from "../../utils/floating-ui";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
@@ -90,19 +90,15 @@ export class SplitButton implements InteractiveComponent {
 
   /**
    * Fires when the primary button is clicked.
-   *
-   * **Note:** The event payload is deprecated, use separate mouse event listeners to get info about click.
    */
   @Event({ cancelable: false })
-  calciteSplitButtonPrimaryClick: EventEmitter<DeprecatedEventPayload>;
+  calciteSplitButtonPrimaryClick: EventEmitter<void>;
 
   /**
    * Fires when the dropdown menu is clicked.
-   *
-   * **Note:** The event payload is deprecated, use separate mouse event listeners to get info about click.
    */
   @Event({ cancelable: false })
-  calciteSplitButtonSecondaryClick: EventEmitter<DeprecatedEventPayload>;
+  calciteSplitButtonSecondaryClick: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //
@@ -171,11 +167,11 @@ export class SplitButton implements InteractiveComponent {
     );
   }
 
-  private calciteSplitButtonPrimaryClickHandler = (event: MouseEvent): CustomEvent =>
-    this.calciteSplitButtonPrimaryClick.emit(event);
+  private calciteSplitButtonPrimaryClickHandler = (): CustomEvent =>
+    this.calciteSplitButtonPrimaryClick.emit();
 
-  private calciteSplitButtonSecondaryClickHandler = (event: MouseEvent): CustomEvent =>
-    this.calciteSplitButtonSecondaryClick.emit(event);
+  private calciteSplitButtonSecondaryClickHandler = (): CustomEvent =>
+    this.calciteSplitButtonSecondaryClick.emit();
 
   private get dropdownIcon(): string {
     return this.dropdownIconType === "chevron"


### PR DESCRIPTION
BREAKING CHANGE: Removed the `event.detail` payload from the events `calciteSplitButtonPrimaryClick` and `calciteSplitButtonSecondaryClick`. Use separate mouse event listeners to get information about `click` events.