### PR TITLE
refactor(stepper-item)!: Remove deprecated properties

### DIFF
--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -57,25 +57,12 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
   //--------------------------------------------------------------------------
 
   /**
-   *  When `true`, the component is selected.
-   *
-   * @deprecated Use `selected` instead.
-   */
-  @Prop({ reflect: true, mutable: true }) active = false;
-
-  @Watch("active")
-  activeHandler(value: boolean): void {
-    this.selected = value;
-  }
-
-  /**
    * When `true`, the component is selected.
    */
   @Prop({ reflect: true, mutable: true }) selected = false;
 
   @Watch("selected")
-  selectedHandler(value: boolean): void {
-    this.active = value;
+  selectedHandler(): void {
     if (this.selected) {
       this.emitRequestedItem();
     }
@@ -90,22 +77,8 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
-  /**
-   * The component header text.
-   *
-   * @deprecated use `heading` instead.
-   */
-  @Prop() itemTitle?: string;
-
   /** The component header text. */
   @Prop() heading?: string;
-
-  /**
-   * A description for the component. Displays below the header text.
-   *
-   * @deprecated use `description` instead.
-   */
-  @Prop() itemSubtitle?: string;
 
   /** A description for the component. Displays below the header text. */
   @Prop() description: string;
@@ -191,13 +164,6 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
 
   connectedCallback(): void {
     connectLocalized(this);
-    const { selected, active } = this;
-
-    if (selected) {
-      this.active = selected;
-    } else if (active) {
-      this.selected = active;
-    }
   }
 
   componentWillLoad(): void {
@@ -236,7 +202,7 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
   render(): VNode {
     return (
       <Host
-        aria-expanded={toAriaBoolean(this.active)}
+        aria-expanded={toAriaBoolean(this.selected)}
         onClick={this.handleItemClick}
         onKeyDown={this.keyDownHandler}
       >
@@ -256,8 +222,8 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
               </div>
             ) : null}
             <div class="stepper-item-header-text">
-              <span class="stepper-item-heading">{this.heading || this.itemTitle}</span>
-              <span class="stepper-item-description">{this.description || this.itemSubtitle}</span>
+              <span class="stepper-item-heading">{this.heading}</span>
+              <span class="stepper-item-description">{this.description}</span>
             </div>
           </div>
           <div class="stepper-item-content">

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -7,16 +7,16 @@ describe("calcite-stepper", () => {
   it("renders", () =>
     renders(
       html`<calcite-stepper>
-        <calcite-stepper-item item-title="Step 1" id="step-1">
+        <calcite-stepper-item heading="Step 1" id="step-1">
           <div>Step 1 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 2" id="step-2">
+        <calcite-stepper-item heading="Step 2" id="step-2">
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item heading="Step 3" id="step-3">
           <div>Step 3 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 4" id="step-4">
+        <calcite-stepper-item heading="Step 4" id="step-4">
           <div>Step 4 content</div>
         </calcite-stepper-item>
       </calcite-stepper>`,
@@ -26,16 +26,16 @@ describe("calcite-stepper", () => {
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-stepper>
-      <calcite-stepper-item item-title="Step 1" id="step-1">
+      <calcite-stepper-item heading="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 2" id="step-2">
+      <calcite-stepper-item heading="Step 2" id="step-2">
         <div>Step 2 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 3" id="step-3">
+      <calcite-stepper-item heading="Step 3" id="step-3">
         <div>Step 3 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 4" id="step-4">
+      <calcite-stepper-item heading="Step 4" id="step-4">
         <div>Step 4 content</div>
       </calcite-stepper-item>
     </calcite-stepper>`);
@@ -49,16 +49,16 @@ describe("calcite-stepper", () => {
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-stepper layout="vertical" scale="l" numbered icon>
-      <calcite-stepper-item item-title="Step 1" id="step-1">
+      <calcite-stepper-item heading="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 2" id="step-2">
+      <calcite-stepper-item heading="Step 2" id="step-2">
         <div>Step 2 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 3" id="step-3">
+      <calcite-stepper-item heading="Step 3" id="step-3">
         <div>Step 3 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 4" id="step-4">
+      <calcite-stepper-item heading="Step 4" id="step-4">
         <div>Step 4 content</div>
       </calcite-stepper-item>
     </calcite-stepper>`);
@@ -74,16 +74,16 @@ describe("calcite-stepper", () => {
   it("adds selected attribute to requested item", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-stepper layout="vertical" scale="l" numbered icon>
-      <calcite-stepper-item item-title="Step 1" id="step-1">
+      <calcite-stepper-item heading="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 2" id="step-2">
+      <calcite-stepper-item heading="Step 2" id="step-2">
         <div>Step 2 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 3" id="step-3" selected>
+      <calcite-stepper-item heading="Step 3" id="step-3" selected>
         <div>Step 3 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 4" id="step-4">
+      <calcite-stepper-item heading="Step 4" id="step-4">
         <div>Step 4 content</div>
       </calcite-stepper-item>
     </calcite-stepper>`);
@@ -107,16 +107,16 @@ describe("calcite-stepper", () => {
   it("adds active attribute to first item if none are requested", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-stepper layout="vertical" scale="l" numbered icon>
-      <calcite-stepper-item item-title="Step 1" id="step-1">
+      <calcite-stepper-item heading="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 2" id="step-2">
+      <calcite-stepper-item heading="Step 2" id="step-2">
         <div>Step 2 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 3" id="step-3">
+      <calcite-stepper-item heading="Step 3" id="step-3">
         <div>Step 3 content</div>
       </calcite-stepper-item>
-      <calcite-stepper-item item-title="Step 4" id="step-4">
+      <calcite-stepper-item heading="Step 4" id="step-4">
         <div>Step 4 content</div>
       </calcite-stepper-item>
     </calcite-stepper>`);
@@ -141,16 +141,16 @@ describe("calcite-stepper", () => {
     it("navigates correctly with nextStep and prevStep methods", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-stepper>
-        <calcite-stepper-item item-title="Step 1" id="step-1">
+        <calcite-stepper-item heading="Step 1" id="step-1">
           <div>Step 1 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 2" id="step-2" selected>
+        <calcite-stepper-item heading="Step 2" id="step-2" selected>
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item heading="Step 3" id="step-3">
           <div>Step 3 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 4" id="step-4">
+        <calcite-stepper-item heading="Step 4" id="step-4">
           <div>Step 4 content</div>
         </calcite-stepper-item>
       </calcite-stepper>`);
@@ -208,13 +208,13 @@ describe("calcite-stepper", () => {
     it("navigates disabled items correctly with nextStep and prevStep methods", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-stepper>
-        <calcite-stepper-item item-title="Step 1" id="step-1" selected>
+        <calcite-stepper-item heading="Step 1" id="step-1" selected>
           <div>Step 1 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 2" id="step-2" disabled>
+        <calcite-stepper-item heading="Step 2" id="step-2" disabled>
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item heading="Step 3" id="step-3">
           <div>Step 3 content</div>
         </calcite-stepper-item>
       </calcite-stepper>`);
@@ -261,16 +261,16 @@ describe("calcite-stepper", () => {
     it("navigates correctly with startStep and endStep methods", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-stepper>
-        <calcite-stepper-item item-title="Step 1" id="step-1">
+        <calcite-stepper-item heading="Step 1" id="step-1">
           <div>Step 1 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 2" id="step-2">
+        <calcite-stepper-item heading="Step 2" id="step-2">
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item heading="Step 3" id="step-3">
           <div>Step 3 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 4" id="step-4">
+        <calcite-stepper-item heading="Step 4" id="step-4">
           <div>Step 4 content</div>
         </calcite-stepper-item>
       </calcite-stepper>`);
@@ -316,16 +316,16 @@ describe("calcite-stepper", () => {
     it("navigates disabled items correctly with startStep and endStep methods", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-stepper>
-        <calcite-stepper-item item-title="Step 1" id="step-1" disabled>
+        <calcite-stepper-item heading="Step 1" id="step-1" disabled>
           <div>Step 1 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 2" id="step-2">
+        <calcite-stepper-item heading="Step 2" id="step-2">
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item heading="Step 3" id="step-3">
           <div id="step-3 >>> .stepper-item-content">Step 3 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 4" id="step-4" disabled>
+        <calcite-stepper-item heading="Step 4" id="step-4" disabled>
           <div>Step 4 content</div>
         </calcite-stepper-item>
       </calcite-stepper>`);
@@ -371,16 +371,16 @@ describe("calcite-stepper", () => {
     it("navigates to requested step with goToStep method", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-stepper>
-        <calcite-stepper-item item-title="Step 1" id="step-1">
+        <calcite-stepper-item heading="Step 1" id="step-1">
           <div>Step 1 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 2" id="step-2">
+        <calcite-stepper-item heading="Step 2" id="step-2">
           <div>Step 2 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 3" id="step-3">
+        <calcite-stepper-item heading="Step 3" id="step-3">
           <div>Step 3 content</div>
         </calcite-stepper-item>
-        <calcite-stepper-item item-title="Step 4" id="step-4">
+        <calcite-stepper-item heading="Step 4" id="step-4">
           <div>Step 4 content</div>
         </calcite-stepper-item>
       </calcite-stepper>`);
@@ -426,16 +426,16 @@ describe("calcite-stepper", () => {
     it("next/previous methods work when placed inside shadow DOM (#992)", async () => {
       const templateHTML = html`
         <calcite-stepper id="stepper">
-          <calcite-stepper-item id="item-1" selected item-title="Add info" item-subtitle="Subtitle lorem ipsum" complete
+          <calcite-stepper-item id="item-1" selected heading="Add info" description="Subtitle lorem ipsum" complete
             >Step 1 Content here lorem ipsum</calcite-stepper-item
           >
-          <calcite-stepper-item id="item-2" item-title="Add data" item-subtitle="Error example" error
+          <calcite-stepper-item id="item-2" heading="Add data" description="Error example" error
             >Step 2 Content here error</calcite-stepper-item
           >
-          <calcite-stepper-item id="item-3" item-title="Upload images" item-subtitle="Subtitle lorem ipsum">
+          <calcite-stepper-item id="item-3" heading="Upload images" description="Subtitle lorem ipsum">
             Step 3 Content here dolor set amet et geographica</calcite-stepper-item
           >
-          <calcite-stepper-item id="item-4" item-title="Review" item-subtitle="Disabled example" disabled
+          <calcite-stepper-item id="item-4" heading="Review" description="Disabled example" disabled
             >Step 4 Content here</calcite-stepper-item
           >
         </calcite-stepper>
@@ -549,16 +549,16 @@ describe("calcite-stepper", () => {
         const page = await newE2EPage();
         await page.setContent(
           html`<calcite-stepper layout="${layout}">
-            <calcite-stepper-item item-title="Step 1" id="step-1">
+            <calcite-stepper-item heading="Step 1" id="step-1">
               <div>Step 1 content</div>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 2" id="step-2">
+            <calcite-stepper-item heading="Step 2" id="step-2">
               <div>Step 2 content</div>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 3" id="step-3" disabled>
+            <calcite-stepper-item heading="Step 3" id="step-3" disabled>
               <div>Step 3 content</div>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 4" id="step-4">
+            <calcite-stepper-item heading="Step 4" id="step-4">
               <div>Step 4 content</div>
             </calcite-stepper-item>
           </calcite-stepper>`
@@ -571,10 +571,10 @@ describe("calcite-stepper", () => {
         const page = await newE2EPage();
         await page.setContent(
           html`<calcite-stepper layout="${layout}">
-            <calcite-stepper-item item-title="Step 1" id="step-1"></calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 2" id="step-2"></calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 3" id="step-3" disabled></calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 4" id="step-4"></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 1" id="step-1"></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 2" id="step-2"></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 3" id="step-3" disabled></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 4" id="step-4"></calcite-stepper-item>
           </calcite-stepper>`
         );
 
@@ -591,16 +591,16 @@ describe("calcite-stepper", () => {
         const page = await newE2EPage();
         await page.setContent(
           html`<calcite-stepper layout="${layout}">
-            <calcite-stepper-item item-title="Step 1" id="step-1">
+            <calcite-stepper-item heading="Step 1" id="step-1">
               <div>Step 1 content</div>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 2" id="step-2">
+            <calcite-stepper-item heading="Step 2" id="step-2">
               <div>Step 2 content</div>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 3" id="step-3" disabled>
+            <calcite-stepper-item heading="Step 3" id="step-3" disabled>
               <div>Step 3 content</div>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 4" id="step-4">
+            <calcite-stepper-item heading="Step 4" id="step-4">
               <div>Step 4 content</div>
             </calcite-stepper-item>
           </calcite-stepper>`
@@ -613,10 +613,10 @@ describe("calcite-stepper", () => {
         const page = await newE2EPage();
         await page.setContent(
           html`<calcite-stepper layout="${layout}">
-            <calcite-stepper-item item-title="Step 1" id="step-1"></calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 2" id="step-2"></calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 3" id="step-3" disabled></calcite-stepper-item>
-            <calcite-stepper-item item-title="Step 4" id="step-4"></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 1" id="step-1"></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 2" id="step-2"></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 3" id="step-3" disabled></calcite-stepper-item>
+            <calcite-stepper-item heading="Step 4" id="step-4"></calcite-stepper-item>
           </calcite-stepper>`
         );
 

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -2,7 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { renders, hidden } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 
-// todo test the automatic setting of first item to active
+// todo test the automatic setting of first item to selected
 describe("calcite-stepper", () => {
   it("renders", () =>
     renders(
@@ -91,20 +91,16 @@ describe("calcite-stepper", () => {
     const step2 = await page.find("#step-2");
     const step3 = await page.find("#step-3");
     const step4 = await page.find("#step-4");
-    expect(step1).not.toHaveAttribute("active");
     expect(step1).not.toHaveAttribute("selected");
 
-    expect(step2).not.toHaveAttribute("active");
     expect(step2).not.toHaveAttribute("selected");
 
-    expect(step3).toHaveAttribute("active");
     expect(step3).toHaveAttribute("selected");
 
-    expect(step4).not.toHaveAttribute("active");
     expect(step4).not.toHaveAttribute("selected");
   });
 
-  it("adds active attribute to first item if none are requested", async () => {
+  it("adds selected attribute to first item if none are requested", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-stepper layout="vertical" scale="l" numbered icon>
       <calcite-stepper-item heading="Step 1" id="step-1">
@@ -124,16 +120,12 @@ describe("calcite-stepper", () => {
     const step2 = await page.find("#step-2");
     const step3 = await page.find("#step-3");
     const step4 = await page.find("#step-4");
-    expect(step1).toHaveAttribute("active");
     expect(step1).toHaveAttribute("selected");
 
-    expect(step2).not.toHaveAttribute("active");
     expect(step2).not.toHaveAttribute("selected");
 
-    expect(step3).not.toHaveAttribute("active");
     expect(step3).not.toHaveAttribute("selected");
 
-    expect(step4).not.toHaveAttribute("active");
     expect(step4).not.toHaveAttribute("selected");
   });
 
@@ -163,13 +155,9 @@ describe("calcite-stepper", () => {
       const step2Content = await page.find("#step-2 >>> .stepper-item-content");
       const step3Content = await page.find("#step-3 >>> .stepper-item-content");
       const step4Content = await page.find("#step-4 >>> .stepper-item-content");
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).toHaveAttribute("active");
       expect(step2).toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(true);
@@ -177,13 +165,9 @@ describe("calcite-stepper", () => {
       expect(await step4Content.isVisible()).toBe(false);
       await element.callMethod("nextStep");
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).toHaveAttribute("active");
       expect(step3).toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(false);
@@ -191,13 +175,9 @@ describe("calcite-stepper", () => {
       expect(await step4Content.isVisible()).toBe(false);
       await element.callMethod("prevStep");
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).toHaveAttribute("active");
       expect(step2).toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(true);
@@ -225,33 +205,24 @@ describe("calcite-stepper", () => {
       const step1Content = await page.find("#step-1 >>> .stepper-item-content");
       const step2Content = await page.find("#step-2 >>> .stepper-item-content");
       const step3Content = await page.find("#step-3 >>> .stepper-item-content");
-      expect(step1).toHaveAttribute("active");
       expect(step1).toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(true);
       expect(await step2Content.isVisible()).toBe(false);
       expect(await step3Content.isVisible()).toBe(false);
       await element.callMethod("nextStep");
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
-      expect(step1).not.toHaveAttribute("active");
-      expect(step2).not.toHaveAttribute("active");
-      expect(step2).not.toHaveAttribute("active");
-      expect(step3).toHaveAttribute("active");
-      expect(step3).toHaveAttribute("active");
+      expect(step1).not.toHaveAttribute("selected");
+      expect(step2).not.toHaveAttribute("selected");
+      expect(step3).toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(false);
       expect(await step3Content.isVisible()).toBe(true);
       await element.callMethod("prevStep");
       await page.waitForChanges();
-      expect(step1).toHaveAttribute("active");
       expect(step1).toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(true);
       expect(await step2Content.isVisible()).toBe(false);
@@ -285,13 +256,9 @@ describe("calcite-stepper", () => {
       const step4Content = await page.find("#step-4 >>> .stepper-item-content");
       await element.callMethod("startStep");
       await page.waitForChanges();
-      expect(step1).toHaveAttribute("active");
       expect(step1).toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(true);
       expect(await step2Content.isVisible()).toBe(false);
@@ -299,13 +266,9 @@ describe("calcite-stepper", () => {
       expect(await step4Content.isVisible()).toBe(false);
       await element.callMethod("endStep");
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).toHaveAttribute("active");
       expect(step4).toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(false);
@@ -340,13 +303,9 @@ describe("calcite-stepper", () => {
       const step4Content = await page.find("#step-4 >>> .stepper-item-content");
       await element.callMethod("endStep");
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).toHaveAttribute("active");
       expect(step3).toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(false);
@@ -354,13 +313,9 @@ describe("calcite-stepper", () => {
       expect(await step4Content.isVisible()).toBe(false);
       await element.callMethod("startStep");
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).toHaveAttribute("active");
       expect(step2).toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(true);
@@ -395,13 +350,9 @@ describe("calcite-stepper", () => {
       const step4Content = await page.find("#step-4 >>> .stepper-item-content");
       await element.callMethod("goToStep", 4);
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).not.toHaveAttribute("active");
       expect(step2).not.toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).toHaveAttribute("active");
       expect(step4).toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(false);
@@ -409,13 +360,9 @@ describe("calcite-stepper", () => {
       expect(await step4Content.isVisible()).toBe(true);
       await element.callMethod("goToStep", 2);
       await page.waitForChanges();
-      expect(step1).not.toHaveAttribute("active");
       expect(step1).not.toHaveAttribute("selected");
-      expect(step2).toHaveAttribute("active");
       expect(step2).toHaveAttribute("selected");
-      expect(step3).not.toHaveAttribute("active");
       expect(step3).not.toHaveAttribute("selected");
-      expect(step4).not.toHaveAttribute("active");
       expect(step4).not.toHaveAttribute("selected");
       expect(await step1Content.isVisible()).toBe(false);
       expect(await step2Content.isVisible()).toBe(true);
@@ -496,7 +443,7 @@ describe("calcite-stepper", () => {
       let expectedEvents = 0;
 
       // non user interaction
-      firstItem.setProperty("active", true);
+      firstItem.setProperty("selected", true);
       await page.waitForChanges();
       expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
 

--- a/src/components/stepper/stepper.stories.ts
+++ b/src/components/stepper/stepper.stories.ts
@@ -23,30 +23,30 @@ export const simple = (): string => html`
     ${boolean("icon", true)}
   >
     <calcite-stepper-item
-      heading="${text("heading", "Choose method")}"
-      description="${text("description", "Add members without sending invitations")}"
+      heading="${text("heading-1", "Choose method")}"
+      description="${text("description-1", "Add members without sending invitations")}"
       complete
     >
       <calcite-notice active width="full"><div slot="message">Step 1 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Compile member list")}"
-      description="${text("description", "")}"
+      heading="${text("heading-2", "Compile member list")}"
+      description="${text("description-2", "")}"
       complete
       error
     >
       <calcite-notice active width="full"><div slot="message">Step 2 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Set member properties")}"
-      description="${text("idescription", "")}"
+      heading="${text("heading-3", "Set member properties")}"
+      description="${text("description-3", "")}"
       selected
     >
       <calcite-notice active width="full"><div slot="message">Step 3 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Confirm and complete")}"
-      description="${text("description", "Disabled example")}"
+      heading="${text("heading-4", "Confirm and complete")}"
+      description="${text("description-4", "Disabled example")}"
       disabled
     >
       <calcite-notice active width="full"><div slot="message">Step 4 Content Goes Here</div></calcite-notice>
@@ -61,27 +61,27 @@ export const simple = (): string => html`
     ${boolean("icon", true)}
   >
     <calcite-stepper-item
-      heading="${text("heading", "Choose method")}"
-      description="${text("description", "Add members without sending invitations")}"
+      heading="${text("heading-1", "Choose method")}"
+      description="${text("description-1", "Add members without sending invitations")}"
       complete
     >
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Compile member list")}"
-      description="${text("description", "")}"
+      heading="${text("heading-2", "Compile member list")}"
+      description="${text("description-2", "")}"
       complete
       error
     >
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Set member properties")}"
-      description="${text("description", "")}"
+      heading="${text("heading-3", "Set member properties")}"
+      description="${text("description-3", "")}"
       selected
     >
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Confirm and complete")}"
-      description="${text("description", "Disabled example")}"
+      heading="${text("heading-4", "Confirm and complete")}"
+      description="${text("description-4", "Disabled example")}"
       disabled
     >
     </calcite-stepper-item>
@@ -99,30 +99,30 @@ export const darkThemeRTL_TestOnly = (): string => html`
     ${boolean("icon", true)}
   >
     <calcite-stepper-item
-      heading="${text("heading", "Choose method")}"
-      description="${text("description", "Add members without sending invitations")}"
+      heading="${text("heading-1", "Choose method")}"
+      description="${text("description-1", "Add members without sending invitations")}"
       complete
     >
       <calcite-notice active width="full"><div slot=message">Step 1 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Compile member list")}"
-      description="${text("description", "")}"
+      heading="${text("heading-2", "Compile member list")}"
+      description="${text("description-2", "")}"
       complete
       error
     >
       <calcite-notice active width="full"><div slot="message">Step 2 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Set member properties")}"
-      description="${text("description", "")}"
+      heading="${text("heading-3", "Set member properties")}"
+      description="${text("description-3", "")}"
       selected
     >
       <calcite-notice active width="full"><div slot="message">Step 3 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      heading="${text("heading", "Confirm and complete")}"
-      description="${text("description", "Disabled example")}"
+      heading="${text("heading-4", "Confirm and complete")}"
+      description="${text("description-4", "Disabled example")}"
       disabled
     >
       <calcite-notice active width="full"><div slot="message">Step 4 Content Goes Here</div></calcite-notice>

--- a/src/components/stepper/stepper.stories.ts
+++ b/src/components/stepper/stepper.stories.ts
@@ -23,30 +23,30 @@ export const simple = (): string => html`
     ${boolean("icon", true)}
   >
     <calcite-stepper-item
-      item-title="${text("item-1-title", "Choose method")}"
-      item-subtitle="${text("item-1-subtitle", "Add members without sending invitations")}"
+      heading="${text("heading", "Choose method")}"
+      description="${text("description", "Add members without sending invitations")}"
       complete
     >
       <calcite-notice active width="full"><div slot="message">Step 1 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-2-title", "Compile member list")}"
-      item-subtitle="${text("item-2-subtitle", "")}"
+      heading="${text("heading", "Compile member list")}"
+      description="${text("description", "")}"
       complete
       error
     >
       <calcite-notice active width="full"><div slot="message">Step 2 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-3-title", "Set member properties")}"
-      item-subtitle="${text("item-3-subtitle", "")}"
-      active
+      heading="${text("heading", "Set member properties")}"
+      description="${text("idescription", "")}"
+      selected
     >
       <calcite-notice active width="full"><div slot="message">Step 3 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-4-title", "Confirm and complete")}"
-      item-subtitle="${text("item-4-subtitle", "Disabled example")}"
+      heading="${text("heading", "Confirm and complete")}"
+      description="${text("description", "Disabled example")}"
       disabled
     >
       <calcite-notice active width="full"><div slot="message">Step 4 Content Goes Here</div></calcite-notice>
@@ -61,27 +61,27 @@ export const simple = (): string => html`
     ${boolean("icon", true)}
   >
     <calcite-stepper-item
-      item-title="${text("item-1-title", "Choose method")}"
-      item-subtitle="${text("item-1-subtitle", "Add members without sending invitations")}"
+      heading="${text("heading", "Choose method")}"
+      description="${text("description", "Add members without sending invitations")}"
       complete
     >
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-2-title", "Compile member list")}"
-      item-subtitle="${text("item-2-subtitle", "")}"
+      heading="${text("heading", "Compile member list")}"
+      description="${text("description", "")}"
       complete
       error
     >
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-3-title", "Set member properties")}"
-      item-subtitle="${text("item-3-subtitle", "")}"
+      heading="${text("heading", "Set member properties")}"
+      description="${text("description", "")}"
       selected
     >
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-4-title", "Confirm and complete")}"
-      item-subtitle="${text("item-4-subtitle", "Disabled example")}"
+      heading="${text("heading", "Confirm and complete")}"
+      description="${text("description", "Disabled example")}"
       disabled
     >
     </calcite-stepper-item>
@@ -99,30 +99,30 @@ export const darkThemeRTL_TestOnly = (): string => html`
     ${boolean("icon", true)}
   >
     <calcite-stepper-item
-      item-title="${text("item-1-title", "Choose method")}"
-      item-subtitle="${text("item-1-subtitle", "Add members without sending invitations")}"
+      heading="${text("heading", "Choose method")}"
+      description="${text("description", "Add members without sending invitations")}"
       complete
     >
       <calcite-notice active width="full"><div slot=message">Step 1 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-2-title", "Compile member list")}"
-      item-subtitle="${text("item-2-subtitle", "")}"
+      heading="${text("heading", "Compile member list")}"
+      description="${text("description", "")}"
       complete
       error
     >
       <calcite-notice active width="full"><div slot="message">Step 2 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-3-title", "Set member properties")}"
-      item-subtitle="${text("item-3-subtitle", "")}"
-      active
+      heading="${text("heading", "Set member properties")}"
+      description="${text("description", "")}"
+      selected
     >
       <calcite-notice active width="full"><div slot="message">Step 3 Content Goes Here</div></calcite-notice>
     </calcite-stepper-item>
     <calcite-stepper-item
-      item-title="${text("item-4-title", "Confirm and complete")}"
-      item-subtitle="${text("item-4-subtitle", "Disabled example")}"
+      heading="${text("heading", "Confirm and complete")}"
+      description="${text("description", "Disabled example")}"
       disabled
     >
       <calcite-notice active width="full"><div slot="message">Step 4 Content Goes Here</div></calcite-notice>
@@ -134,22 +134,22 @@ export const darkThemeRTL_TestOnly = (): string => html`
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
 
 export const overriddenWidth_TestOnly = (): string => html` <calcite-stepper numbered style="width: 50vw">
-  <calcite-stepper-item item-title="Choose method" item-subtitle="Add members without sending invitations" complete>
+  <calcite-stepper-item heading="Choose method" description="Add members without sending invitations" complete>
     <calcite-notice active width="full">
       <div slot="message">Step 1 Content Goes Here</div>
     </calcite-notice>
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="Compile member list" complete error>
+  <calcite-stepper-item heading="Compile member list" complete error>
     <calcite-notice active width="full">
       <div slot="message">Step 2 Content Goes Here</div>
     </calcite-notice>
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="Set member properties" item-subtitle="" active="">
+  <calcite-stepper-item heading="Set member properties" description="" selected>
     <calcite-notice active width="full">
       <div slot="message">Step 3 Content Goes Here</div>
     </calcite-notice>
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="Confirm and complete" item-subtitle="Disabled example" disabled="">
+  <calcite-stepper-item heading="Confirm and complete" description="Disabled example" disabled="">
     <calcite-notice active width="full">
       <div slot="message">Step 4 Content Goes Here</div>
     </calcite-notice>
@@ -157,10 +157,10 @@ export const overriddenWidth_TestOnly = (): string => html` <calcite-stepper num
 </calcite-stepper>`;
 
 export const disabled_TestOnly = (): string => html`<calcite-stepper>
-  <calcite-stepper-item item-title="item1" complete>1</calcite-stepper-item>
-  <calcite-stepper-item item-title="item2">2</calcite-stepper-item>
-  <calcite-stepper-item item-title="item3" active>3</calcite-stepper-item>
-  <calcite-stepper-item item-title="item4" disabled>4</calcite-stepper-item>
+  <calcite-stepper-item heading="item1" complete>1</calcite-stepper-item>
+  <calcite-stepper-item heading="item2">2</calcite-stepper-item>
+  <calcite-stepper-item heading="item3" selected>3</calcite-stepper-item>
+  <calcite-stepper-item heading="item4" disabled>4</calcite-stepper-item>
 </calcite-stepper>`;
 
 export const arabicNumberingSystem_TestOnly = (): string => html` <calcite-stepper
@@ -170,22 +170,22 @@ export const arabicNumberingSystem_TestOnly = (): string => html` <calcite-stepp
   dir="rtl"
   scale="s"
 >
-  <calcite-stepper-item item-title="الخطوةالاولى" complete>
+  <calcite-stepper-item heading="الخطوةالاولى" complete>
     <calcite-notice active width="full">
       <div slot="message">الخطوة الأولى للمحتوى هنا</div>
     </calcite-notice>
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="الخطوة الثانية" complete>
+  <calcite-stepper-item heading="الخطوة الثانية" complete>
     <calcite-notice active width="full">
       <div slot="message">الخطوة الثانية للمحتوى هنا</div>
     </calcite-notice>
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+  <calcite-stepper-item heading="الخطوة الثالثة" description="بعض النصوص الفرعية" selected>
     <calcite-notice active width="full">
       <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
     </calcite-notice>
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="الخطوة الرابعة">
+  <calcite-stepper-item heading="الخطوة الرابعة">
     <calcite-notice active width="full">
       <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
     </calcite-notice>

--- a/src/components/stepper/usage/Basic.md
+++ b/src/components/stepper/usage/Basic.md
@@ -1,13 +1,13 @@
 ```html
 <calcite-stepper icon numbered id="my-example-stepper">
-  <calcite-stepper-item item-title="Choose method" item-subtitle="Add members without sending invitations" complete>
+  <calcite-stepper-item heading="Choose method" description="Add members without sending invitations" complete>
     Step 1 Content Goes Here
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="Compile member list" error> Step 2 Content Goes Here </calcite-stepper-item>
-  <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+  <calcite-stepper-item heading="Compile member list" error> Step 2 Content Goes Here </calcite-stepper-item>
+  <calcite-stepper-item heading="Set member properties" description="Some subtext" selected>
     Step 3 Content Goes Here
   </calcite-stepper-item>
-  <calcite-stepper-item item-title="Confirm and complete" item-subtitle="Disabled example" disabled>
+  <calcite-stepper-item heading="Confirm and complete" description="Disabled example" disabled>
     Step 4 Content Goes Here
   </calcite-stepper-item>
 </calcite-stepper>

--- a/src/demos/stepper.html
+++ b/src/demos/stepper.html
@@ -57,22 +57,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered icon scale="s">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" error>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -87,11 +87,11 @@
 
         <div class="child-flex">
           <calcite-stepper numbered scale="s">
-            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Compile member list" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+            <calcite-stepper-item heading="Confirm and complete"> </calcite-stepper-item>
           </calcite-stepper>
         </div>
       </div>
@@ -102,22 +102,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered scale="s">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -132,22 +132,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="s">
-            <calcite-stepper-item item-title="الخطوةالاولى" complete>
+            <calcite-stepper-item heading="الخطوةالاولى" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الأولى للمحتوى هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الثانية" complete>
+            <calcite-stepper-item heading="الخطوة الثانية" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الثانية للمحتوى هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+            <calcite-stepper-item heading="الخطوة الثالثة" description="بعض النصوص الفرعية" active>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الرابعة">
+            <calcite-stepper-item heading="الخطوة الرابعة">
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
               </calcite-notice>
@@ -162,22 +162,22 @@
 
         <div class="child-flex">
           <calcite-stepper scale="s">
-            <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-stepper-item heading="Choose method" complete disabled>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-stepper-item heading="Compile member list" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
+            <calcite-stepper-item heading="Another thing!" disabled id="demo-make-non-disabled">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -204,22 +204,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered icon scale="m">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" error>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -234,11 +234,11 @@
 
         <div class="child-flex">
           <calcite-stepper numbered scale="m">
-            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Compile member list" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+            <calcite-stepper-item heading="Confirm and complete"> </calcite-stepper-item>
           </calcite-stepper>
         </div>
       </div>
@@ -249,22 +249,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered scale="m">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -279,22 +279,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="m">
-            <calcite-stepper-item item-title="الخطوةالاولى" complete>
+            <calcite-stepper-item heading="الخطوةالاولى" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الأولى للمحتوى هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الثانية" complete>
+            <calcite-stepper-item heading="الخطوة الثانية" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الثانية للمحتوى هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+            <calcite-stepper-item heading="الخطوة الثالثة" description="بعض النصوص الفرعية" active>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الرابعة">
+            <calcite-stepper-item heading="الخطوة الرابعة">
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
               </calcite-notice>
@@ -309,22 +309,22 @@
 
         <div class="child-flex">
           <calcite-stepper scale="m">
-            <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-stepper-item heading="Choose method" complete disabled>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-stepper-item heading="Compile member list" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
+            <calcite-stepper-item heading="Another thing!" disabled id="demo-make-non-disabled">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -351,22 +351,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered icon scale="l">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" error>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -381,11 +381,11 @@
 
         <div class="child-flex">
           <calcite-stepper numbered scale="l">
-            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Compile member list" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+            <calcite-stepper-item heading="Confirm and complete"> </calcite-stepper-item>
           </calcite-stepper>
         </div>
       </div>
@@ -396,22 +396,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered scale="l">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -426,22 +426,22 @@
 
         <div class="child-flex">
           <calcite-stepper numbered numbering-system="arab" lang="ar" dir="rtl" scale="l">
-            <calcite-stepper-item item-title="الخطوةالاولى" complete>
+            <calcite-stepper-item heading="الخطوةالاولى" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الأولى للمحتوى هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الثانية" complete>
+            <calcite-stepper-item heading="الخطوة الثانية" complete>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الثانية للمحتوى هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الثالثة" item-subtitle="بعض النصوص الفرعية" active>
+            <calcite-stepper-item heading="الخطوة الثالثة" description="بعض النصوص الفرعية" active>
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الثالثة المحتوى يذهب هنا</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="الخطوة الرابعة">
+            <calcite-stepper-item heading="الخطوة الرابعة">
               <calcite-notice active width="full">
                 <div slot="message">الخطوة الرابعة المحتوى يذهب هنا</div>
               </calcite-notice>
@@ -456,22 +456,22 @@
 
         <div class="child-flex">
           <calcite-stepper scale="l">
-            <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-stepper-item heading="Choose method" complete disabled>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-stepper-item heading="Compile member list" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
+            <calcite-stepper-item heading="Another thing!" disabled id="demo-make-non-disabled">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -496,22 +496,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered icon scale="s" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" error>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -521,22 +521,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered icon scale="m" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" error>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -546,22 +546,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered icon scale="l" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" error>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -576,31 +576,31 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered scale="s" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Compile member list" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+            <calcite-stepper-item heading="Confirm and complete"> </calcite-stepper-item>
           </calcite-stepper>
         </div>
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered scale="m" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Compile member list" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+            <calcite-stepper-item heading="Confirm and complete"> </calcite-stepper-item>
           </calcite-stepper>
         </div>
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered scale="l" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete> </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Choose method" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Compile member list" complete> </calcite-stepper-item>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete"> </calcite-stepper-item>
+            <calcite-stepper-item heading="Confirm and complete"> </calcite-stepper-item>
           </calcite-stepper>
         </div>
       </div>
@@ -611,22 +611,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered scale="s" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -636,22 +636,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered scale="m" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -661,22 +661,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper numbered scale="l" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete>
+            <calcite-stepper-item heading="Choose method" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" complete>
+            <calcite-stepper-item heading="Compile member list" complete>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Confirm and complete">
+            <calcite-stepper-item heading="Confirm and complete">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -691,22 +691,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper scale="s" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-stepper-item heading="Choose method" complete disabled>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-stepper-item heading="Compile member list" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
+            <calcite-stepper-item heading="Another thing!" disabled id="demo-make-non-disabled">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -716,22 +716,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper scale="m" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-stepper-item heading="Choose method" complete disabled>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-stepper-item heading="Compile member list" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
+            <calcite-stepper-item heading="Another thing!" disabled id="demo-make-non-disabled">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>
@@ -741,22 +741,22 @@
 
         <div class="vertical-child-flex">
           <calcite-stepper scale="l" layout="vertical">
-            <calcite-stepper-item item-title="Choose method" complete disabled>
+            <calcite-stepper-item heading="Choose method" complete disabled>
               <calcite-notice active width="full">
                 <div slot="message">Step 1 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Compile member list" error>
+            <calcite-stepper-item heading="Compile member list" error>
               <calcite-notice active width="full">
                 <div slot="message">Step 2 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Set member properties" item-subtitle="Some subtext" active>
+            <calcite-stepper-item heading="Set member properties" description="Some subtext" active>
               <calcite-notice active width="full">
                 <div slot="message">Step 3 Content Goes Here</div>
               </calcite-notice>
             </calcite-stepper-item>
-            <calcite-stepper-item item-title="Another thing!" disabled id="demo-make-non-disabled">
+            <calcite-stepper-item heading="Another thing!" disabled id="demo-make-non-disabled">
               <calcite-notice active width="full">
                 <div slot="message">Step 4 Content Goes Here</div>
               </calcite-notice>


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated properties.

- Removed the property `active`, use `selected` instead.
- Removed the property `itemTitle`, use `heading` instead.
- Removed the property `itemSubtitle`, use `description` instead.