### PR TITLE
feat(list-item): Add content slot for specialized content

### DIFF
--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -69,6 +69,20 @@ describe("calcite-list-item", () => {
     expect(contentNode).toBeNull();
   });
 
+  it("renders custom content in place of label and description", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-list-item label="test" description="test"><div slot="content">My custom content</div></calcite-list-item>`
+    });
+
+    const contentNode = await page.find(`calcite-list-item >>> .${CSS.content}`);
+
+    expect(contentNode).toBeNull();
+
+    const customContentNode = await page.find(`calcite-list-item >>> .${CSS.customContent}`);
+
+    expect(customContentNode).not.toBeNull();
+  });
+
   it("emits calciteListItemSelect on click", async () => {
     const page = await newE2EPage({
       html: `<calcite-list-item label="hello" description="world"></calcite-list-item>`

--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -74,6 +74,8 @@ describe("calcite-list-item", () => {
       html: `<calcite-list-item label="test" description="test"><div slot="content">My custom content</div></calcite-list-item>`
     });
 
+    await page.waitForChanges();
+
     const contentNode = await page.find(`calcite-list-item >>> .${CSS.content}`);
 
     expect(contentNode).toBeNull();

--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -59,7 +59,8 @@ td:focus {
   @apply focus-normal z-sticky;
 }
 
-.content {
+.content,
+.custom-content {
   @apply text-n2-wrap
     flex
     flex-auto

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -175,6 +175,8 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
 
   @State() hasActionsEnd = false;
 
+  @State() hasContent = false;
+
   @State() hasContentStart = false;
 
   @State() hasContentEnd = false;
@@ -321,6 +323,15 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
     );
   }
 
+  renderContent(): VNode {
+    const { hasContent } = this;
+    return (
+      <div class={CSS.content} hidden={!hasContent}>
+        <slot name={SLOTS.content} onSlotchange={this.handleContentSlotChange} />
+      </div>
+    );
+  }
+
   renderContentEnd(): VNode {
     const { hasContentEnd } = this;
     return (
@@ -330,10 +341,10 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
     );
   }
 
-  renderContent(): VNode {
-    const { label, description } = this;
+  renderContentProperties(): VNode {
+    const { label, description, hasContent } = this;
 
-    return !!label || !!description ? (
+    return !hasContent && (!!label || !!description) ? (
       <div class={CSS.content} key="content">
         {label ? (
           <div class={CSS.label} key="label">
@@ -350,9 +361,14 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
   }
 
   renderContentContainer(): VNode {
-    const { description, label, selectionMode } = this;
-    const hasCenterContent = !!label || !!description;
-    const content = [this.renderContentStart(), this.renderContent(), this.renderContentEnd()];
+    const { description, label, selectionMode, hasContent } = this;
+    const hasCenterContent = hasContent || !!label || !!description;
+    const content = [
+      this.renderContentStart(),
+      this.renderContent(),
+      this.renderContentProperties(),
+      this.renderContentEnd()
+    ];
 
     return (
       <td
@@ -434,6 +450,10 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
   //  Private Methods
   //
   // --------------------------------------------------------------------------
+
+  handleContentSlotChange = (event: Event): void => {
+    this.hasContent = slotChangeHasAssignedElement(event);
+  };
 
   handleActionsStartSlotChange = (event: Event): void => {
     this.hasActionsStart = slotChangeHasAssignedElement(event);

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -33,6 +33,7 @@ import {
  * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
  * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the component.
  * @slot content-start - A slot for adding non-actionable elements before the label and description of the component.
+ * @slot content - A slot for adding non-actionable centered content in place of the label and description of the component.
  * @slot content-end - A slot for adding non-actionable elements after the label and description of the component.
  * @slot actions-end - A slot for adding actionable `calcite-action` elements after the content of the component.
  */

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -33,7 +33,7 @@ import {
  * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
  * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the component.
  * @slot content-start - A slot for adding non-actionable elements before the label and description of the component.
- * @slot content - A slot for adding non-actionable centered content in place of the label and description of the component.
+ * @slot content - A slot for adding non-actionable, centered content in place of the `label` and `description` of the component.
  * @slot content-end - A slot for adding non-actionable elements after the label and description of the component.
  * @slot actions-end - A slot for adding actionable `calcite-action` elements after the content of the component.
  */

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -175,7 +175,7 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
 
   @State() hasActionsEnd = false;
 
-  @State() hasContent = false;
+  @State() hasCustomContent = false;
 
   @State() hasContentStart = false;
 
@@ -323,10 +323,10 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
     );
   }
 
-  renderContent(): VNode {
-    const { hasContent } = this;
+  renderCustomContent(): VNode {
+    const { hasCustomContent } = this;
     return (
-      <div class={CSS.content} hidden={!hasContent}>
+      <div class={CSS.customContent} hidden={!hasCustomContent}>
         <slot name={SLOTS.content} onSlotchange={this.handleContentSlotChange} />
       </div>
     );
@@ -342,9 +342,9 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
   }
 
   renderContentProperties(): VNode {
-    const { label, description, hasContent } = this;
+    const { label, description, hasCustomContent } = this;
 
-    return !hasContent && (!!label || !!description) ? (
+    return !hasCustomContent && (!!label || !!description) ? (
       <div class={CSS.content} key="content">
         {label ? (
           <div class={CSS.label} key="label">
@@ -361,11 +361,11 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
   }
 
   renderContentContainer(): VNode {
-    const { description, label, selectionMode, hasContent } = this;
-    const hasCenterContent = hasContent || !!label || !!description;
+    const { description, label, selectionMode, hasCustomContent } = this;
+    const hasCenterContent = hasCustomContent || !!label || !!description;
     const content = [
       this.renderContentStart(),
-      this.renderContent(),
+      this.renderCustomContent(),
       this.renderContentProperties(),
       this.renderContentEnd()
     ];
@@ -452,7 +452,7 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
   // --------------------------------------------------------------------------
 
   handleContentSlotChange = (event: Event): void => {
-    this.hasContent = slotChangeHasAssignedElement(event);
+    this.hasCustomContent = slotChangeHasAssignedElement(event);
   };
 
   handleActionsStartSlotChange = (event: Event): void => {

--- a/src/components/list-item/resources.ts
+++ b/src/components/list-item/resources.ts
@@ -8,6 +8,7 @@ export const CSS = {
   nestedContainer: "nested-container",
   nestedContainerHidden: "nested-container--hidden",
   content: "content",
+  customContent: "custom-content",
   actionsStart: "actions-start",
   contentStart: "content-start",
   label: "label",

--- a/src/components/list-item/resources.ts
+++ b/src/components/list-item/resources.ts
@@ -21,6 +21,7 @@ export const CSS = {
 export const SLOTS = {
   actionsStart: "actions-start",
   contentStart: "content-start",
+  content: "content",
   contentEnd: "content-end",
   actionsEnd: "actions-end"
 };

--- a/src/components/list/list.stories.ts
+++ b/src/components/list/list.stories.ts
@@ -305,3 +305,24 @@ export const disabled_TestOnly = (): string => html`<calcite-list disabled>
     "
   ></calcite-list-item>
 </calcite-list>`;
+
+export const customContent_TestOnly = (): string => html`<calcite-list disabled>
+  <calcite-list-item>
+    <div slot="content">
+      <strong>Cras iaculis ultricies nulla.</strong>
+      <div>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</div>
+    </div></calcite-list-item
+  >
+  <calcite-list-item disabled>
+    <div slot="content">
+      <strong>Cras iaculis ultricies nulla.</strong>
+      <div>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</div>
+    </div></calcite-list-item
+  >
+  <calcite-list-item
+    ><div slot="content">
+      <strong>Cras iaculis ultricies nulla.</strong>
+      <div>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</div>
+    </div></calcite-list-item
+  >
+</calcite-list>`;


### PR DESCRIPTION
**Related Issue:** #3032

## Summary

feat(list-item): Add slot for specialized content #3032

- Adds a new `content` slot to the `list-item` for customized content.
- `content` slot takes precedence over `label` and `description` properties.