### PR TITLE
ci: disable milestone automation due to process changes

### DIFF
--- a/.github/workflows/change-milestone.yml
+++ b/.github/workflows/change-milestone.yml
@@ -5,8 +5,9 @@
 # https://octokit.github.io/rest.js/v18#issues-list-for-repo
 name: Move Issues To Current Milestone
 on:
-  schedule:
-    - cron: "0 9 * * 1"
+  workflow_dispatch:
+  # schedule:
+  # - cron: "0 9 * * 1"
 jobs:
   move:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -1,10 +1,11 @@
 name: Close Completed Milestone
 on:
-  pull_request:
-    branches: [master]
-    types: [closed]
-  issues:
-    types: [closed, demilestoned]
+  workflow_dispatch:
+  # pull_request:
+  #   branches: [master]
+  #   types: [closed]
+  # issues:
+  #   types: [closed, demilestoned]
 jobs:
   close-milestone:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -1,8 +1,8 @@
 name: Create New Milestone
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 9 1,15 * *"
+  # schedule:
+  #   - cron: "0 9 1,15 * *"
 jobs:
   create-milestone:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Related Issue:** #

## Summary

I'm disabling some of the milestone automation for now. We recently changed the way we work with milestones, which is causing funky behavior.

The actions were created under the assumption that the only milestones with due dates would be for our 2 week sprints. I can change the actions if we are deciding to change how we use milestones, but we may want to wait for Brittney to return before making that decision, since that is her area of expertise.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
