### PR TITLE
fix(input-time-picker, input-date-picker): picker UI and state updates when changing locales

### DIFF
--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -257,6 +257,39 @@ describe("calcite-input-date-picker", () => {
     expect(await calendar.isVisible()).toBe(true);
   });
 
+  it("syncs locale changes to internal date-picker", async () => {
+    const lang = "en";
+    const newLang = "ar";
+    const month = 4;
+    const langMonthTranslation = (await import(`../date-picker/assets/date-picker/nls/${lang}.json`)).months.wide[
+      month - 1
+    ];
+    const newLangMonthTranslation = (await import(`../date-picker/assets/date-picker/nls/${newLang}.json`)).months.wide[
+      month - 1
+    ];
+
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-date-picker lang=${lang} value="2020-${month}-19"></calcite-input-date-picker>`
+    );
+    const inputDatePicker = await page.find("calcite-input-date-picker");
+
+    const getLocalizedMonth = async () =>
+      await page.evaluate(
+        async () =>
+          document
+            .querySelector("calcite-input-date-picker")
+            .shadowRoot.querySelector("calcite-date-picker")
+            .shadowRoot.querySelector("calcite-date-picker-month-header")
+            .shadowRoot.querySelector(".month").textContent
+      );
+
+    expect(await getLocalizedMonth()).toEqual(langMonthTranslation);
+    inputDatePicker.setProperty("lang", newLang);
+    await page.waitForChanges();
+    expect(await getLocalizedMonth()).toEqual(newLangMonthTranslation);
+  });
+
   it("allows clicking a date in the calendar popup", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-input-date-picker value="2023-01-31"></calcite-input-date-picker>`);

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -562,7 +562,6 @@ export class InputDatePicker
                   disabled={disabled}
                   icon="calendar"
                   label={getLabelText(this)}
-                  lang={effectiveLocale}
                   number-button-type="none"
                   numberingSystem={numberingSystem}
                   onCalciteInputInput={this.calciteInternalInputInputHandler}
@@ -601,7 +600,6 @@ export class InputDatePicker
                   intlNextMonth={this.intlNextMonth}
                   intlPrevMonth={this.intlPrevMonth}
                   intlYear={this.intlYear}
-                  lang={effectiveLocale}
                   max={this.max}
                   maxAsDate={this.maxAsDate}
                   min={this.min}
@@ -638,7 +636,6 @@ export class InputDatePicker
                   }}
                   disabled={disabled}
                   icon="calendar"
-                  lang={effectiveLocale}
                   number-button-type="none"
                   numberingSystem={numberingSystem}
                   onCalciteInputInput={this.calciteInternalInputInputHandler}
@@ -875,7 +872,11 @@ export class InputDatePicker
     if (!Build.isBrowser) {
       return;
     }
-
+    numberStringFormatter.numberFormatOptions = {
+      numberingSystem: this.numberingSystem,
+      locale: this.effectiveLocale,
+      useGrouping: false
+    };
     this.localeData = await getLocaleData(this.effectiveLocale);
   }
 
@@ -1039,17 +1040,12 @@ export class InputDatePicker
     );
   }
 
-  private commonDateSeparators = [".", "-", "/"];
-
   private formatNumerals = (value: string): string =>
     value
       ? value
           .split("")
           .map((char: string) =>
-            // convert common separators to the locale's
-            this.commonDateSeparators.includes(char)
-              ? this.localeData.separator
-              : numberKeys.includes(char)
+            numberKeys.includes(char)
               ? numberStringFormatter.numberFormatter.format(Number(char))
               : char
           )

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -1040,12 +1040,17 @@ export class InputDatePicker
     );
   }
 
+  private commonDateSeparators = [".", "-", "/"];
+
   private formatNumerals = (value: string): string =>
     value
       ? value
           .split("")
           .map((char: string) =>
-            numberKeys.includes(char)
+            // convert common separators to the locale's
+            this.commonDateSeparators.includes(char)
+              ? this.localeData.separator
+              : numberKeys.includes(char)
               ? numberStringFormatter.numberFormatter.format(Number(char))
               : char
           )

--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -267,6 +267,38 @@ describe("calcite-input-time-picker", () => {
     expect(inputTimePickerValue).toBe(expectedValue);
   });
 
+  it("value displays correctly in the time-picker after changing locales", async () => {
+    const lang = "en";
+    const newLang = "ar";
+    const time = "11:59";
+    const numberingSystem = "latn";
+
+    const page = await newE2EPage({
+      html: `<calcite-input-time-picker lang="${lang}" numbering-system="${numberingSystem}" value="${time}"></calcite-input-time-picker>`
+    });
+    const inputTimePicker = await page.find("calcite-input-time-picker");
+
+    const getLocalizedTime = async () =>
+      await page.evaluate(
+        async () =>
+          document.querySelector("calcite-input-time-picker").shadowRoot.querySelector("calcite-time-picker").value
+      );
+
+    const langLocalized = localizeTimeString({ value: time, locale: lang, numberingSystem, includeSeconds: false });
+    expect(await getLocalizedTime()).toBe(langLocalized.substring(0, langLocalized.indexOf(" ")));
+
+    inputTimePicker.setProperty("lang", newLang);
+    await page.waitForChanges();
+
+    const newLangLocalized = localizeTimeString({
+      value: time,
+      locale: newLang,
+      numberingSystem,
+      includeSeconds: false
+    });
+    expect(await getLocalizedTime()).toBe(newLangLocalized.substring(0, newLangLocalized.indexOf(" ")));
+  });
+
   it("appropriately triggers calciteInputTimePickerChange event when the user types a value", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-input-time-picker step="1"></calcite-input-time-picker>`);

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -595,7 +595,6 @@ export class InputTimePicker
             intlSecond={this.intlSecond}
             intlSecondDown={this.intlSecondDown}
             intlSecondUp={this.intlSecondUp}
-            lang={this.effectiveLocale}
             numberingSystem={this.numberingSystem}
             onCalciteInternalTimePickerChange={this.timePickerChangeHandler}
             ref={this.setCalciteTimePickerEl}


### PR DESCRIPTION
**Related Issue:** #5855 

## Summary
The effectiveLocale is kept up to date using a MutationObserver, so it doesn't need to be passed down via attribute.

The `input-date-picker` e2e test I added for coverage is kinda funky, but I couldn't think of another way to make sure the internals are being localized. If you have any other ideas I'm happy to add to or change it.

<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
