### PR TITLE
ci(browserlist): use legacy-peer-deps flag on uninstall

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           npm install --save-dev caniuse-lite --legacy-peer-deps
           npx update-browserslist-db@latest
-          npm uninstall caniuse-lite
+          npm uninstall --legacy-peer-deps caniuse-lite
       - name: create pull request
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
**Related Issue:** #5512

## Summary
The fix I did in the PR linked above is getting the workflow through the browserlist check. But now we are getting the stencil eslint plugin peer dep error on the uninstall. I'm not sure if the `--legacy-peer-deps` flag does anything for `npm uninstall`, but its worth a shot. 

Error: https://github.com/Esri/calcite-components/actions/runs/3610821906/jobs/6084842550#step:4:48