### PR TITLE
fix(flow): Allow nested flow-items.

### DIFF
--- a/src/components/flow/flow.e2e.ts
+++ b/src/components/flow/flow.e2e.ts
@@ -243,13 +243,13 @@ describe("calcite-flow", () => {
       <${itemTag}>Valid item</${itemTag}>
       <${itemTag}>Valid item</${itemTag}>
       <div>
-        <${itemTag}>Allowed item <${itemTag}>Disallowed item</${itemTag}></${itemTag}>
+        <${itemTag}>Allowed item <${itemTag}>Allowed item</${itemTag}><calcite-flow><${itemTag}>Disallowed item</${itemTag}></calcite-flow></${itemTag}>
       </div>
     </calcite-flow>`);
 
         const items = await page.findAll(itemTag);
 
-        expect(items).toHaveLength(4);
+        expect(items).toHaveLength(5);
 
         expect(items[0].getAttribute("hidden")).toBe("");
         expect(await items[0].getProperty("showBackButton")).toBe(false);
@@ -257,11 +257,14 @@ describe("calcite-flow", () => {
         expect(items[1].getAttribute("hidden")).toBe("");
         expect(await items[1].getProperty("showBackButton")).toBe(false);
 
-        expect(items[2].getAttribute("hidden")).toBe(null);
-        expect(await items[2].getProperty("showBackButton")).toBe(true);
+        expect(items[2].getAttribute("hidden")).toBe("");
+        expect(await items[2].getProperty("showBackButton")).toBe(false);
 
         expect(items[3].getAttribute("hidden")).toBe(null);
         expect(await items[3].getProperty("showBackButton")).toBe(false);
+
+        expect(items[4].getAttribute("hidden")).toBe(null);
+        expect(await items[4].getProperty("showBackButton")).toBe(false);
       });
     }
   });

--- a/src/components/flow/flow.tsx
+++ b/src/components/flow/flow.tsx
@@ -101,7 +101,7 @@ export class Flow {
     const newItems: HTMLCalciteFlowItemElement[] = Array.from(
       el.querySelectorAll("calcite-flow-item")
     ).filter(
-      (flowItem) => !flowItem.matches("calcite-flow-item calcite-flow-item")
+      (flowItem) => !flowItem.matches("calcite-flow-item calcite-flow calcite-flow-item")
     ) as HTMLCalciteFlowItemElement[];
 
     const oldItemCount = items.length;


### PR DESCRIPTION
**Related Issue:** #5896

## Summary

fix(flow): Allow nested flow-items.

Allows nesting `flow`s inside other `flows` and the flow should only query items that are not nested inside another flow.