### PR TITLE
refactor(input-number)!: remove deprecated property and event payload

### DIFF
--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -36,8 +36,7 @@ import {
   defaultNumberingSystem,
   LocalizedComponent,
   disconnectLocalized,
-  connectLocalized,
-  updateEffectiveLocale
+  connectLocalized
 } from "../../utils/locale";
 import { numberKeys } from "../../utils/key";
 import { isValidNumber, parseNumberString, sanitizeNumberString } from "../../utils/number";

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedEventPayload, Position, Scale, Status } from "../interfaces";
+import { Position, Scale, Status } from "../interfaces";
 import {
   Component,
   Element,
@@ -149,19 +149,6 @@ export class InputNumber
 
   /** When `true`, the component is in the loading state and `calcite-progress` is displayed. */
   @Prop({ reflect: true }) loading = false;
-
-  /**
-   * Specifies the BCP 47 language tag for the desired language and country format.
-   *
-   * @deprecated set the global `lang` attribute on the element instead.
-   * @mdn [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-   */
-  @Prop() locale: string;
-
-  @Watch("locale")
-  localeChanged(): void {
-    updateEffectiveLocale(this);
-  }
 
   /**
    * Specifies the Unicode numeral system used by the component for localization.
@@ -348,6 +335,15 @@ export class InputNumber
 
   @State() effectiveLocale = "";
 
+  @Watch("effectiveLocale")
+  effectiveLocaleWatcher(locale: string): void {
+    numberStringFormatter.numberFormatOptions = {
+      locale,
+      numberingSystem: this.numberingSystem,
+      useGrouping: false
+    };
+  }
+
   @State() localizedValue: string;
 
   //--------------------------------------------------------------------------
@@ -435,10 +431,8 @@ export class InputNumber
 
   /**
    * Fires each time a new value is typed.
-   *
-   * **Note:**: The `el` and `value` event payload props are deprecated, please use the event's `target`/`currentTarget` instead
    */
-  @Event({ cancelable: true }) calciteInputNumberInput: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: true }) calciteInputNumberInput: EventEmitter<void>;
 
   /**
    * Fires each time a new value is typed and committed.
@@ -796,11 +790,7 @@ export class InputNumber
     }
 
     if (nativeEvent) {
-      const calciteInputNumberInputEvent = this.calciteInputNumberInput.emit({
-        element: this.childNumberEl,
-        nativeEvent,
-        value: this.value
-      });
+      const calciteInputNumberInputEvent = this.calciteInputNumberInput.emit();
 
       if (calciteInputNumberInputEvent.defaultPrevented) {
         const previousLocalizedValue = numberStringFormatter.localize(this.previousValue);

--- a/src/demos/input-number.html
+++ b/src/demos/input-number.html
@@ -512,7 +512,7 @@
           let input = document.createElement("calcite-input-number");
           (locale === "ar" || locale === "he") && input.setAttribute("dir", "rtl");
           input.setAttribute("id", locale);
-          input.setAttribute("locale", locale);
+          input.setAttribute("lang", locale);
           input.setAttribute("name", locale);
           input.setAttribute("scale", "s");
           input.setAttribute("value", "1234.56");
@@ -529,7 +529,7 @@
           (locale === "ar" || locale === "he") && input.setAttribute("dir", "rtl");
           input.setAttribute("group-separator", true);
           input.setAttribute("id", `${locale}-group-separator`);
-          input.setAttribute("locale", locale);
+          input.setAttribute("lang", locale);
           input.setAttribute("name", `${locale}-group-separator`);
           input.setAttribute("scale", "s");
           input.setAttribute("value", "1234.56");


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated property and event payload

- Removed `locale` property, use `lang` instead.
- Removed `calciteInputNumberInput` event payload properties, use the event's `target`/`currentTarget` instead.