### PR TITLE
refactor(input-message)!: remove deprecated property

### DIFF
--- a/src/components/input-message/input-message.e2e.ts
+++ b/src/components/input-message/input-message.e2e.ts
@@ -8,7 +8,7 @@ describe("calcite-input-message", () => {
     await renders(`<calcite-input-message></calcite-input-message>`, { display: "flex", visible: true });
   });
 
-  it("honors hidden attribute", async () => hidden(`<calcite-input-message active>Text</calcite-input-message>`));
+  it("honors hidden attribute", async () => hidden(`<calcite-input-message>Text</calcite-input-message>`));
 
   it("is accessible", async () => accessible(`<calcite-input-message>Text</calcite-input-message>`));
   it("is accessible with icon", async () => accessible(`<calcite-input-message icon>Text</calcite-input-message>`));

--- a/src/components/input-message/input-message.tsx
+++ b/src/components/input-message/input-message.tsx
@@ -26,14 +26,6 @@ export class InputMessage {
   //
   //--------------------------------------------------------------------------
 
-  /**
-   * When `true`, the component is active.
-   *
-   * @deprecated use global `hidden` attribute instead.
-   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-   */
-  @Prop({ reflect: true }) active = false;
-
   /** Specifies an icon to display. */
   @Prop({ reflect: true }) icon: boolean | string;
 
@@ -42,13 +34,6 @@ export class InputMessage {
 
   /** Specifies the status of the input field, which determines message and icons. */
   @Prop({ reflect: true, mutable: true }) status: Status = "idle";
-
-  /**
-   * Specifies the appearance of a slotted message - `"default"` (displayed under the component), or `"floating"` (positioned absolutely under the component).
-   *
-   * @deprecated The `"floating"` type is no longer supported.
-   */
-  @Prop({ reflect: true }) type: "default";
 
   @Watch("status")
   @Watch("icon")
@@ -69,7 +54,7 @@ export class InputMessage {
   }
 
   render(): VNode {
-    const hidden = !this.active;
+    const hidden = this.el.hidden;
     return (
       <Host calcite-hydrated-hidden={hidden}>
         {this.renderIcon(this.requestedIcon)}

--- a/src/components/input-message/usage/Basic.md
+++ b/src/components/input-message/usage/Basic.md
@@ -2,7 +2,7 @@
 <calcite-label status="“invalid”">
   My great label
   <calcite-input placeholder="“Enter" your information”></calcite-input>
-  <calcite-input-message active
+  <calcite-input-message
     >That's not going to work out.
     <calcite-button appearance="inline" href="">Learn more</calcite-button></calcite-input-message
   >

--- a/src/components/input/input.stories.ts
+++ b/src/components/input/input.stories.ts
@@ -63,10 +63,7 @@ export const withInputMessage = (): string => html`
       placeholder="${text("placeholder", "Placeholder text", "Input")}"
     >
     </calcite-input>
-    <calcite-input-message
-      ${boolean("active", true)}
-      ${boolean("icon", false)}
-      icon="${select("icon", iconNames, "", "Input Message")}"
+    <calcite-input-message ${boolean("icon", false)} icon="${select("icon", iconNames, "", "Input Message")}"
       >${text("input message text", "My great input message", "Input Message")}</calcite-input-message
     >
   </div>

--- a/src/components/input/usage/With-label.md
+++ b/src/components/input/usage/With-label.md
@@ -4,6 +4,6 @@ Using a wrapping `calcite-label` component lets consumers set the status attribu
 <calcite-label status="invalid" for="invalid-input">
   Invalid input
   <calcite-input id="invalid-input" placeholder="Filter your files" value="adfo2h2"></calcite-input>
-  <calcite-input-message active icon> Something doesn't look right </calcite-input-message>
+  <calcite-input-message icon> Something doesn't look right </calcite-input-message>
 </calcite-label>
 ```

--- a/src/components/input/usage/With-message.md
+++ b/src/components/input/usage/With-message.md
@@ -2,8 +2,6 @@
 <calcite-label for="info">
   My great label
   <calcite-input id="info" placeholder="Enter your information"></calcite-input>
-  <calcite-input-message icon="3d-glasses" active>
-    Here's something you should know about this input
-  </calcite-input-message>
+  <calcite-input-message icon="3d-glasses"> Here's something you should know about this input </calcite-input-message>
 </calcite-label>
 ```

--- a/src/components/label/usage/Basic.md
+++ b/src/components/label/usage/Basic.md
@@ -4,6 +4,6 @@ It also allows consumers to set a `status` attribute for child `calcite-input` a
 <calcite-label status="invalid">
   Invalid input
   <calcite-input type="search" placeholder="Filter your files" value="adfo2h2"></calcite-input>
-  <calcite-input-message active icon> Something doesn't look right </calcite-input-message>
+  <calcite-input-message icon> Something doesn't look right </calcite-input-message>
 </calcite-label>
 ```

--- a/src/demos/input-number.html
+++ b/src/demos/input-number.html
@@ -358,7 +358,7 @@
           <calcite-label scale="s" status="invalid">
             Invalid input
             <calcite-input-number placeholder="Placeholder" scale="s" value="123" step="1"></calcite-input-number>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -366,7 +366,7 @@
           <calcite-label status="invalid">
             Invalid input
             <calcite-input-number placeholder="Placeholder" scale="m" value="123" step="1"></calcite-input-number>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -374,7 +374,7 @@
           <calcite-label scale="l" status="invalid">
             Invalid input
             <calcite-input-number placeholder="Placeholder" scale="l" value="123" step="1"></calcite-input-number>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>

--- a/src/demos/input-text.html
+++ b/src/demos/input-text.html
@@ -195,21 +195,21 @@
         <div class="child-flex">
           <calcite-label scale="s" status="idle">
             <calcite-input-text placeholder="Placeholder" scale="s"> </calcite-input-text>
-            <calcite-input-message scale="s" active icon> Info message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Info message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label status="idle">
             <calcite-input-text placeholder="Placeholder" scale="m"> </calcite-input-text>
-            <calcite-input-message scale="m" active icon> Info message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Info message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l" status="idle">
             <calcite-input-text placeholder="Placeholder" scale="l"> </calcite-input-text>
-            <calcite-input-message scale="l" active icon> Info message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Info message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -220,21 +220,21 @@
         <div class="child-flex">
           <calcite-label scale="s" status="valid">
             <calcite-input-text placeholder="Placeholder" scale="s"> </calcite-input-text>
-            <calcite-input-message scale="s" active icon> Success message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Success message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label status="valid">
             <calcite-input-text placeholder="Placeholder" scale="m"> </calcite-input-text>
-            <calcite-input-message scale="m" active icon> Success message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Success message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l" status="valid">
             <calcite-input-text placeholder="Placeholder" scale="l"> </calcite-input-text>
-            <calcite-input-message scale="l" active icon> Success message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Success message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -245,27 +245,21 @@
         <div class="child-flex">
           <calcite-label scale="s">
             <calcite-input-text placeholder="Placeholder" scale="s"> </calcite-input-text>
-            <calcite-input-message scale="s" active icon="exclamation-mark-triangle">
-              Warning message
-            </calcite-input-message>
+            <calcite-input-message scale="s" icon="exclamation-mark-triangle"> Warning message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label>
             <calcite-input-text placeholder="Placeholder" scale="m"> </calcite-input-text>
-            <calcite-input-message scale="m" active icon="exclamation-mark-triangle">
-              Warning message
-            </calcite-input-message>
+            <calcite-input-message scale="m" icon="exclamation-mark-triangle"> Warning message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l">
             <calcite-input-text placeholder="Placeholder" scale="l"> </calcite-input-text>
-            <calcite-input-message scale="l" active icon="exclamation-mark-triangle">
-              Warning message
-            </calcite-input-message>
+            <calcite-input-message scale="l" icon="exclamation-mark-triangle"> Warning message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -276,21 +270,21 @@
         <div class="child-flex">
           <calcite-label scale="s" status="invalid">
             <calcite-input-text placeholder="Placeholder" scale="s"> </calcite-input-text>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label status="invalid">
             <calcite-input-text placeholder="Placeholder" scale="m"> </calcite-input-text>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l" status="invalid">
             <calcite-input-text placeholder="Placeholder" scale="l"> </calcite-input-text>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -321,7 +315,7 @@
           <calcite-label scale="s" status="invalid">
             Input Label
             <calcite-input-text placeholder="Placeholder" scale="s"></calcite-input-text>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -329,7 +323,7 @@
           <calcite-label status="invalid">
             Input Label
             <calcite-input-text placeholder="Placeholder" scale="m"></calcite-input-text>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -337,7 +331,7 @@
           <calcite-label scale="l" status="invalid">
             Input Label
             <calcite-input-text placeholder="Placeholder" scale="l"></calcite-input-text>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -354,7 +348,7 @@
               prefix-text="Prefix"
               suffix-text="Suffix"
             ></calcite-input-text>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -367,7 +361,7 @@
               prefix-text="Prefix"
               suffix-text="Suffix"
             ></calcite-input-text>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -380,7 +374,7 @@
               prefix-text="Prefix"
               suffix-text="Suffix"
             ></calcite-input-text>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>

--- a/src/demos/input.html
+++ b/src/demos/input.html
@@ -952,21 +952,21 @@
         <div class="child-flex">
           <calcite-label scale="s" status="idle">
             <calcite-input type="text" placeholder="Placeholder" scale="s"> </calcite-input>
-            <calcite-input-message scale="s" active icon> Info message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Info message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label status="idle">
             <calcite-input type="text" placeholder="Placeholder" scale="m"> </calcite-input>
-            <calcite-input-message scale="m" active icon> Info message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Info message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l" status="idle">
             <calcite-input type="text" placeholder="Placeholder" scale="l"> </calcite-input>
-            <calcite-input-message scale="l" active icon> Info message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Info message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -977,21 +977,21 @@
         <div class="child-flex">
           <calcite-label scale="s" status="valid">
             <calcite-input type="text" placeholder="Placeholder" scale="s"> </calcite-input>
-            <calcite-input-message scale="s" active icon> Success message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Success message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label status="valid">
             <calcite-input type="text" placeholder="Placeholder" scale="m"> </calcite-input>
-            <calcite-input-message scale="m" active icon> Success message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Success message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l" status="valid">
             <calcite-input type="text" placeholder="Placeholder" scale="l"> </calcite-input>
-            <calcite-input-message scale="l" active icon> Success message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Success message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1002,27 +1002,21 @@
         <div class="child-flex">
           <calcite-label scale="s">
             <calcite-input type="text" placeholder="Placeholder" scale="s"> </calcite-input>
-            <calcite-input-message scale="s" active icon="exclamation-mark-triangle">
-              Warning message
-            </calcite-input-message>
+            <calcite-input-message scale="s" icon="exclamation-mark-triangle"> Warning message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label>
             <calcite-input type="text" placeholder="Placeholder" scale="m"> </calcite-input>
-            <calcite-input-message scale="m" active icon="exclamation-mark-triangle">
-              Warning message
-            </calcite-input-message>
+            <calcite-input-message scale="m" icon="exclamation-mark-triangle"> Warning message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l">
             <calcite-input type="text" placeholder="Placeholder" scale="l"> </calcite-input>
-            <calcite-input-message scale="l" active icon="exclamation-mark-triangle">
-              Warning message
-            </calcite-input-message>
+            <calcite-input-message scale="l" icon="exclamation-mark-triangle"> Warning message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1033,21 +1027,21 @@
         <div class="child-flex">
           <calcite-label scale="s" status="invalid">
             <calcite-input type="text" placeholder="Placeholder" scale="s"> </calcite-input>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label status="invalid">
             <calcite-input type="text" placeholder="Placeholder" scale="m"> </calcite-input>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
         <div class="child-flex">
           <calcite-label scale="l" status="invalid">
             <calcite-input type="text" placeholder="Placeholder" scale="l"> </calcite-input>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1078,7 +1072,7 @@
           <calcite-label scale="s" status="invalid">
             Input Label
             <calcite-input type="text" placeholder="Placeholder" scale="s"></calcite-input>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1086,7 +1080,7 @@
           <calcite-label status="invalid">
             Input Label
             <calcite-input type="text" placeholder="Placeholder" scale="m"></calcite-input>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1094,7 +1088,7 @@
           <calcite-label scale="l" status="invalid">
             Input Label
             <calcite-input type="text" placeholder="Placeholder" scale="l"></calcite-input>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1112,7 +1106,7 @@
               prefix-text="Prefix"
               suffix-text="Suffix"
             ></calcite-input>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1126,7 +1120,7 @@
               prefix-text="Prefix"
               suffix-text="Suffix"
             ></calcite-input>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1140,7 +1134,7 @@
               prefix-text="Prefix"
               suffix-text="Suffix"
             ></calcite-input>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1152,7 +1146,7 @@
           <calcite-label scale="s" status="invalid">
             Input Label
             <calcite-input type="color" value="#0000ff" scale="s"></calcite-input>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1160,7 +1154,7 @@
           <calcite-label status="invalid">
             Input Label
             <calcite-input type="color" value="#0000ff" scale="m"></calcite-input>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1168,7 +1162,7 @@
           <calcite-label scale="l" status="invalid">
             Input Label
             <calcite-input type="color" value="#0000ff" scale="l"></calcite-input>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1180,7 +1174,7 @@
           <calcite-label scale="s" status="invalid">
             Input Label
             <calcite-input type="number" placeholder="Placeholder" scale="s" value="123" step="1"></calcite-input>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1188,7 +1182,7 @@
           <calcite-label status="invalid">
             Input Label
             <calcite-input type="number" placeholder="Placeholder" scale="m" value="123" step="1"></calcite-input>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1196,7 +1190,7 @@
           <calcite-label scale="l" status="invalid">
             Input Label
             <calcite-input type="number" placeholder="Placeholder" scale="l" value="123" step="1"></calcite-input>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>
@@ -1208,7 +1202,7 @@
           <calcite-label scale="s" status="invalid">
             File input
             <calcite-input type="file" placeholder="No file chosen" scale="s"></calcite-input>
-            <calcite-input-message scale="s" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="s" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1216,7 +1210,7 @@
           <calcite-label status="invalid">
             File input
             <calcite-input type="file" placeholder="No file chosen" scale="m"></calcite-input>
-            <calcite-input-message scale="m" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="m" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
 
@@ -1224,7 +1218,7 @@
           <calcite-label scale="l" status="invalid">
             File input
             <calcite-input type="file" placeholder="No file chosen" scale="l"></calcite-input>
-            <calcite-input-message scale="l" active icon> Error message </calcite-input-message>
+            <calcite-input-message scale="l" icon> Error message </calcite-input-message>
           </calcite-label>
         </div>
       </div>


### PR DESCRIPTION
    - Removed `active` property, use the global `hidden` attribute instead.

BREAKING CHANGE: removed deprecated `active` property in favor of `hidden`