### PR TITLE
refactor(tabs, tab-nav, tab-title, tab)!: Remove deprecated properties and values.

### DIFF
--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -972,16 +972,16 @@ export class ColorPicker implements InteractiveComponent, LoadableComponent {
 
   private renderChannelsTabTitle = (channelMode: this["channelMode"]): VNode => {
     const { channelMode: activeChannelMode, intlRgb, intlHsv } = this;
-    const active = channelMode === activeChannelMode;
+    const selected = channelMode === activeChannelMode;
     const label = channelMode === "rgb" ? intlRgb : intlHsv;
 
     return (
       <calcite-tab-title
-        active={active}
         class={CSS.colorMode}
         data-color-mode={channelMode}
         key={channelMode}
         onCalciteTabsActivate={this.handleTabActivate}
+        selected={selected}
       >
         {label}
       </calcite-tab-title>
@@ -1006,7 +1006,7 @@ export class ColorPicker implements InteractiveComponent, LoadableComponent {
       intlValue
     } = this;
 
-    const active = channelMode === activeChannelMode;
+    const selected = channelMode === activeChannelMode;
     const isRgb = channelMode === "rgb";
     const channelLabels = isRgb ? [intlR, intlG, intlB] : [intlH, intlS, intlV];
     const channelAriaLabels = isRgb
@@ -1015,7 +1015,7 @@ export class ColorPicker implements InteractiveComponent, LoadableComponent {
     const direction = getElementDir(this.el);
 
     return (
-      <calcite-tab active={active} class={CSS.control} key={channelMode}>
+      <calcite-tab class={CSS.control} key={channelMode} selected={selected}>
         {/* channel order should not be mirrored */}
         <div class={CSS.channels} dir="ltr">
           {channels.map((channel, index) =>

--- a/src/components/tab-nav/readme.md
+++ b/src/components/tab-nav/readme.md
@@ -11,7 +11,7 @@ The tab-nav groups several [calcite-tab-title](../tab-title) components and buil
 When tab-nav is the only parent, tab-title can inherit its `scale` and `position` from tab-nav:
 
 ```html
-<calcite-tab-nav scale="l" position="below">
+<calcite-tab-nav scale="l" position="bottom">
   <calcite-tab-title>Layers</calcite-tab-title>
   <calcite-tab-title>Maps</calcite-tab-title>
   <calcite-tab-title selected>Data</calcite-tab-title>

--- a/src/components/tab-nav/readme.md
+++ b/src/components/tab-nav/readme.md
@@ -14,7 +14,7 @@ When tab-nav is the only parent, tab-title can inherit its `scale` and `position
 <calcite-tab-nav scale="l" position="below">
   <calcite-tab-title>Layers</calcite-tab-title>
   <calcite-tab-title>Maps</calcite-tab-title>
-  <calcite-tab-title active>Data</calcite-tab-title>
+  <calcite-tab-title selected>Data</calcite-tab-title>
 </calcite-tab-nav>
 ```
 

--- a/src/components/tab-nav/tab-nav.e2e.ts
+++ b/src/components/tab-nav/tab-nav.e2e.ts
@@ -19,7 +19,7 @@ describe("calcite-tab-nav", () => {
     const activeEventSpy = await page.spyOnEvent("calciteTabChange");
     const firstTabTitle = await page.find("calcite-tab-title");
 
-    firstTabTitle.setProperty("active", true);
+    firstTabTitle.setProperty("selected", true);
     await page.waitForChanges();
     expect(activeEventSpy).toHaveReceivedEventTimes(0);
 
@@ -30,9 +30,9 @@ describe("calcite-tab-nav", () => {
     expect(activeEventSpy).toHaveReceivedEventTimes(2);
   });
 
-  describe("active indicator", () => {
+  describe("selected indicator", () => {
     const tabTitles = html`
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
@@ -87,7 +87,7 @@ describe("calcite-tab-nav", () => {
       it("should render with small scale", async () => {
         const page = await newE2EPage({
           html: `<calcite-tab-nav scale='s'>
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
             <calcite-tab-title>Tab 3 Title</calcite-tab-title>
             <calcite-tab-title>Tab 4 Title</calcite-tab-title>
@@ -103,7 +103,7 @@ describe("calcite-tab-nav", () => {
       it("should render with medium scale", async () => {
         const page = await newE2EPage({
           html: `<calcite-tab-nav scale='m'>
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
             <calcite-tab-title>Tab 3 Title</calcite-tab-title>
             <calcite-tab-title>Tab 4 Title</calcite-tab-title>
@@ -119,7 +119,7 @@ describe("calcite-tab-nav", () => {
       it("should render with medium scale", async () => {
         const page = await newE2EPage({
           html: `<calcite-tab-nav scale='l'>
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
             <calcite-tab-title>Tab 3 Title</calcite-tab-title>
             <calcite-tab-title>Tab 4 Title</calcite-tab-title>

--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -41,19 +41,9 @@
     ease-out;
 }
 
-:host([position="below"]) .tab-nav-active-indicator {
-  inset-block-end: unset;
-  @apply top-0;
-}
-
 :host([position="bottom"]) .tab-nav-active-indicator {
   inset-block-end: unset;
   @apply top-0;
-}
-
-:host([position="below"]) .tab-nav-active-indicator-container {
-  @apply top-0;
-  inset-block-end: unset;
 }
 
 :host([position="bottom"]) .tab-nav-active-indicator-container {
@@ -63,11 +53,6 @@
 
 :host([bordered]) .tab-nav-active-indicator-container {
   inset-block-end: unset; // display active blue line above instead of below
-}
-
-:host([bordered][position="below"]) .tab-nav-active-indicator-container {
-  inset-block-end: 0; // display active blue line below instead of above
-  inset-block-start: unset;
 }
 
 :host([bordered][position="bottom"]) .tab-nav-active-indicator-container {

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -146,7 +146,7 @@ export class TabNav {
     // if every tab title is active select the first tab.
     if (
       this.tabTitles.length &&
-      this.tabTitles.every((title) => !title.active) &&
+      this.tabTitles.every((title) => !title.selected) &&
       !this.selectedTab
     ) {
       this.tabTitles[0].getTabIdentifier().then((tab) => {
@@ -252,7 +252,7 @@ export class TabNav {
    */
   @Listen("calciteInternalTabTitleRegister")
   updateTabTitles(event: CustomEvent<TabID>): void {
-    if ((event.target as HTMLCalciteTabTitleElement).active) {
+    if ((event.target as HTMLCalciteTabTitleElement).selected) {
       this.selectedTab = event.detail;
     }
   }

--- a/src/components/tab-nav/usage/Basic.md
+++ b/src/components/tab-nav/usage/Basic.md
@@ -1,9 +1,9 @@
 When tab-nav is the only parent, tab-title can inherit its `scale` and `position` from tab-nav:
 
 ```html
-<calcite-tab-nav scale="l" position="below">
+<calcite-tab-nav scale="l" position="bottom">
   <calcite-tab-title>Layers</calcite-tab-title>
   <calcite-tab-title>Maps</calcite-tab-title>
-  <calcite-tab-title active>Data</calcite-tab-title>
+  <calcite-tab-title selected>Data</calcite-tab-title>
 </calcite-tab-nav>
 ```

--- a/src/components/tab-title/tab-title.e2e.ts
+++ b/src/components/tab-title/tab-title.e2e.ts
@@ -61,7 +61,7 @@ describe("calcite-tab-title", () => {
   });
 
   describe("when parent element is tab-nav", () => {
-    describe("when position is above, default", () => {
+    describe("when position is top, default", () => {
       it("should render with bottom border on hover", async () => {
         const page = await newE2EPage({
           html: `
@@ -77,26 +77,6 @@ describe("calcite-tab-title", () => {
         const containerStyles = await container.getComputedStyle();
         expect(containerStyles["border-top-width"]).toEqual("0px");
         expect(containerStyles["border-bottom-width"]).not.toEqual("0px");
-      });
-    });
-
-    describe("when position is below (deprecated)", () => {
-      it("should render with top border on hover", async () => {
-        const page = await newE2EPage({
-          html: `
-          <calcite-tab-nav position="below">
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title id="for-hover">Tab 2 Title</calcite-tab-title>
-          </calcite-tab-nav>
-          `
-        });
-        const element = await page.find("#for-hover");
-        await element.hover();
-
-        const container = await page.find("#for-hover >>> .container");
-        const containerStyles = await container.getComputedStyle();
-        expect(containerStyles["border-top-width"]).not.toEqual("0px");
-        expect(containerStyles["border-bottom-width"]).toEqual("0px");
       });
     });
 

--- a/src/components/tab-title/tab-title.e2e.ts
+++ b/src/components/tab-title/tab-title.e2e.ts
@@ -85,7 +85,7 @@ describe("calcite-tab-title", () => {
         const page = await newE2EPage({
           html: `
           <calcite-tab-nav position="bottom">
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title id="for-hover">Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>
           `
@@ -104,7 +104,7 @@ describe("calcite-tab-title", () => {
       it("should inherit small scale from tab-nav", async () => {
         const page = await newE2EPage({
           html: `<calcite-tab-nav scale="s">
-            <calcite-tab-title active>Tab Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>`
         });
@@ -119,7 +119,7 @@ describe("calcite-tab-title", () => {
       it("should inherit medium scale from tab-nav", async () => {
         const page = await newE2EPage({
           html: `<calcite-tab-nav scale="m">
-            <calcite-tab-title active>Tab Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>`
         });
@@ -134,7 +134,7 @@ describe("calcite-tab-title", () => {
       it("should inherit large scale from tab-nav", async () => {
         const page = await newE2EPage({
           html: `<calcite-tab-nav scale="l">
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>`
         });
@@ -153,7 +153,7 @@ describe("calcite-tab-title", () => {
       it("should inherit default m scale", async () => {
         const page = await newE2EPage({
           html: `<calcite-tabs>
-            <calcite-tab-title active>Tab Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
           </calcite-tabs>`
         });
@@ -164,7 +164,7 @@ describe("calcite-tab-title", () => {
       it("should inherit small scale from tabs", async () => {
         const page = await newE2EPage({
           html: `<calcite-tabs scale="s">
-            <calcite-tab-title active>Tab Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
           </calcite-tabs>`
         });
@@ -175,7 +175,7 @@ describe("calcite-tab-title", () => {
       it("should inherit large scale from tabs", async () => {
         const page = await newE2EPage({
           html: `<calcite-tabs scale="l">
-            <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title>Tab 2 Title</calcite-tab-title>
           </calcite-tabs>`
         });
@@ -192,12 +192,12 @@ describe("calcite-tab-title", () => {
         <calcite-tabs>
           <calcite-tab-nav slot="tab-nav">
             <calcite-tab-title class="title-1">Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title class="title-2" active>Tab 2 Title</calcite-tab-title>
+            <calcite-tab-title class="title-2" selected>Tab 2 Title</calcite-tab-title>
             <calcite-tab-title>Tab 3 Title</calcite-tab-title>
             <calcite-tab-title>Tab 4 Title</calcite-tab-title>
           </calcite-tab-nav>
           <calcite-tab>Tab 1 Content</calcite-tab>
-          <calcite-tab active>Tab 2 Content</calcite-tab>
+          <calcite-tab selected>Tab 2 Content</calcite-tab>
           <calcite-tab>Tab 3 Content</calcite-tab>
           <calcite-tab>Tab 4 Content</calcite-tab>
         </calcite-tabs>
@@ -206,7 +206,7 @@ describe("calcite-tab-title", () => {
       const tabTitle1 = await page.find(".title-1");
       const tabTitle2 = await page.find(".title-2");
 
-      expect(await (await page.find("calcite-tab-title[active]")).innerText).toEqual("Tab 2 Title");
+      expect(await (await page.find("calcite-tab-title[selected]")).innerText).toEqual("Tab 2 Title");
       expect(
         await page.evaluate(() => {
           return (
@@ -217,12 +217,12 @@ describe("calcite-tab-title", () => {
         })
       ).not.toEqual("0px");
 
-      // toggle new active tab-title
-      await tabTitle2.removeAttribute("active");
-      await tabTitle1.setAttribute("active", true);
+      // toggle new selected tab-title
+      await tabTitle2.removeAttribute("selected");
+      await tabTitle1.setAttribute("selected", true);
       await page.waitForChanges();
 
-      expect(await (await page.find("calcite-tab-title[active]")).innerText).toEqual("Tab 1 Title");
+      expect(await (await page.find("calcite-tab-title[selected]")).innerText).toEqual("Tab 1 Title");
       expect(
         await page.evaluate(() => {
           return (

--- a/src/components/tab-title/tab-title.scss
+++ b/src/components/tab-title/tab-title.scss
@@ -10,13 +10,6 @@
   margin: auto;
 }
 
-:host([position="below"]) .container {
-  @apply border-t-color-transparent
-    border-b-0
-    border-t-2;
-  border-block-start-style: solid;
-}
-
 :host([position="bottom"]) .container {
   @apply border-t-color-transparent
     border-b-0
@@ -127,10 +120,6 @@
   box-shadow: inset 0px -2px var(--calcite-ui-foreground-1);
 }
 
-:host([bordered][selected][position="below"]) {
-  box-shadow: inset 0 2px 0 var(--calcite-ui-foreground-1);
-}
-
 :host([bordered][selected][position="bottom"]) {
   box-shadow: inset 0 2px 0 var(--calcite-ui-foreground-1);
 }
@@ -153,10 +142,6 @@
   border-block-end-style: unset;
   border-inline-start: 1px solid transparent;
   border-inline-end: 1px solid transparent;
-}
-
-:host([bordered][position="below"]) .container {
-  border-block-start-style: unset;
 }
 
 :host([bordered][position="bottom"]) .container {
@@ -200,20 +185,12 @@
     border-block-end-style: solid;
   }
 
-  :host([bordered][position="below"]) .container {
-    border-block-start-style: solid;
-  }
-
   :host([bordered][position="bottom"]) .container {
     border-block-start-style: solid;
   }
 
   :host([bordered][selected]) .container {
     border-block-end-style: none;
-  }
-
-  :host([bordered][position="below"][selected]) .container {
-    border-block-start-style: none;
   }
 
   :host([bordered][position="bottom"][selected]) .container {

--- a/src/components/tab-title/tab-title.tsx
+++ b/src/components/tab-title/tab-title.tsx
@@ -48,26 +48,11 @@ export class TabTitle implements InteractiveComponent {
    * When `true`, the component and its respective `calcite-tab` contents are selected.
    *
    * Only one tab can be selected within the `calcite-tabs` parent.
-   *
-   * @deprecated Use `selected` instead.
-   */
-  @Prop({ reflect: true, mutable: true }) active = false;
-
-  @Watch("active")
-  activeHandler(value: boolean): void {
-    this.selected = value;
-  }
-
-  /**
-   * When `true`, the component and its respective `calcite-tab` contents are selected.
-   *
-   * Only one tab can be selected within the `calcite-tabs` parent.
    */
   @Prop({ reflect: true, mutable: true }) selected = false;
 
   @Watch("selected")
-  selectedHandler(value: boolean): void {
-    this.active = value;
+  selectedHandler(): void {
     if (this.selected) {
       this.emitActiveTab(false);
     }
@@ -119,14 +104,6 @@ export class TabTitle implements InteractiveComponent {
   //--------------------------------------------------------------------------
 
   connectedCallback(): void {
-    const { selected, active } = this;
-
-    if (selected) {
-      this.active = selected;
-    } else if (active) {
-      this.activeHandler(active);
-    }
-
     this.setupTextContentObserver();
     this.parentTabNavEl = this.el.closest("calcite-tab-nav");
     this.parentTabsEl = this.el.closest("calcite-tabs");

--- a/src/components/tab/interfaces.ts
+++ b/src/components/tab/interfaces.ts
@@ -1,6 +1,6 @@
 export interface TabChangeEventDetail {
   /**
-   * The tab that just became active
+   * The tab that just became selected
    */
   tab: number | string;
 }

--- a/src/components/tab/tab.e2e.ts
+++ b/src/components/tab/tab.e2e.ts
@@ -14,7 +14,6 @@ describe("calcite-tab", () => {
   it("has defaults", async () =>
     defaults("calcite-tab", [
       { propertyName: "tab", defaultValue: undefined },
-      { propertyName: "active", defaultValue: false },
       { propertyName: "selected", defaultValue: false },
       { propertyName: "scale", defaultValue: undefined }
     ]));

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -9,8 +9,7 @@ import {
   h,
   State,
   Host,
-  VNode,
-  Watch
+  VNode
 } from "@stencil/core";
 import { TabChangeEventDetail } from "./interfaces";
 import { guid } from "../../utils/guid";
@@ -51,27 +50,8 @@ export class Tab {
    * When `true`, the component's contents are selected.
    *
    * Only one tab can be selected within the `calcite-tabs` parent.
-   *
-   * @deprecated Use `selected` instead.
-   */
-  @Prop({ reflect: true, mutable: true }) active = false;
-
-  @Watch("active")
-  activeHandler(value: boolean): void {
-    this.selected = value;
-  }
-
-  /**
-   * When `true`, the component's contents are selected.
-   *
-   * Only one tab can be selected within the `calcite-tabs` parent.
    */
   @Prop({ reflect: true, mutable: true }) selected = false;
-
-  @Watch("selected")
-  selectedHandler(value: boolean): void {
-    this.active = value;
-  }
 
   /**
    * @internal
@@ -100,12 +80,6 @@ export class Tab {
 
   connectedCallback(): void {
     this.parentTabsEl = this.el.closest("calcite-tabs");
-    const isSelected = this.selected || this.active;
-
-    if (isSelected) {
-      this.activeHandler(isSelected);
-      this.selectedHandler(isSelected);
-    }
   }
 
   componentDidLoad(): void {

--- a/src/components/tabs/interfaces.ts
+++ b/src/components/tabs/interfaces.ts
@@ -1,3 +1,3 @@
 export type TabID = string | number;
-export type TabPosition = "above" | "below" | "top" | "bottom";
+export type TabPosition = "top" | "bottom";
 export type TabLayout = "center" | "inline";

--- a/src/components/tabs/readme.md
+++ b/src/components/tabs/readme.md
@@ -11,11 +11,11 @@
 ```html
 <calcite-tabs>
   <calcite-tab-nav slot="tab-nav">
-    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+    <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
     <calcite-tab-title>Tab 2 Title</calcite-tab-title>
   </calcite-tab-nav>
 
-  <calcite-tab active>Tab 1 Content</calcite-tab>
+  <calcite-tab selected>Tab 1 Content</calcite-tab>
   <calcite-tab>Tab 2 Content</calcite-tab>
 </calcite-tabs>
 ```
@@ -28,12 +28,12 @@
     <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
     <calcite-tab-title tab="tab2">Tab 2 Title</calcite-tab-title>
     <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
-    <calcite-tab-title tab="tab4" active>Tab 4 Title</calcite-tab-title>
+    <calcite-tab-title tab="tab4" selected>Tab 4 Title</calcite-tab-title>
   </calcite-tab-nav>
   <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
   <calcite-tab tab="tab2">Tab 2 Content</calcite-tab>
   <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
-  <calcite-tab tab="tab4" active>Tab 4 Content</calcite-tab>
+  <calcite-tab tab="tab4" selected>Tab 4 Content</calcite-tab>
 </calcite-tabs>
 ```
 

--- a/src/components/tabs/tabs.e2e.ts
+++ b/src/components/tabs/tabs.e2e.ts
@@ -5,12 +5,12 @@ import { html } from "../../../support/formatting";
 describe("calcite-tabs", () => {
   const tabsContent = `
     <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
-    <calcite-tab active>Tab 1 Content</calcite-tab>
+    <calcite-tab selected>Tab 1 Content</calcite-tab>
     <calcite-tab>Tab 2 Content</calcite-tab>
     <calcite-tab>Tab 3 Content</calcite-tab>
     <calcite-tab>Tab 4 Content</calcite-tab>
@@ -36,13 +36,13 @@ describe("calcite-tabs", () => {
     await page.setContent(`
       <calcite-tabs>
         <calcite-tab-nav slot="tab-nav">
-          <calcite-tab-title id="title-1" active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title id="title-1" selected>Tab 1 Title</calcite-tab-title>
           <calcite-tab-title id="title-2" >Tab 2 Title</calcite-tab-title>
           <calcite-tab-title id="title-3" >Tab 3 Title</calcite-tab-title>
           <calcite-tab-title id="title-4" >Tab 4 Title</calcite-tab-title>
         </calcite-tab-nav>
 
-        <calcite-tab id="tab-1" active>Tab 1 Content</calcite-tab>
+        <calcite-tab id="tab-1" selected>Tab 1 Content</calcite-tab>
         <calcite-tab id="tab-2">Tab 2 Content</calcite-tab>
         <calcite-tab id="tab-3">Tab 3 Content</calcite-tab>
         <calcite-tab id="tab-4">Tab 4 Content</calcite-tab>
@@ -73,13 +73,13 @@ describe("calcite-tabs", () => {
     await page.setContent(`
       <calcite-tabs>
         <calcite-tab-nav slot="tab-nav">
-          <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
           <calcite-tab-title id="insert-after-title">Tab 2 Title</calcite-tab-title>
           <calcite-tab-title>Tab 3 Title</calcite-tab-title>
           <calcite-tab-title>Tab 4 Title</calcite-tab-title>
         </calcite-tab-nav>
 
-        <calcite-tab active>Tab 1 Content</calcite-tab>
+        <calcite-tab selected>Tab 1 Content</calcite-tab>
         <calcite-tab id="insert-after-tab">Tab 2 Content</calcite-tab>
         <calcite-tab>Tab 3 Content</calcite-tab>
         <calcite-tab>Tab 4 Content</calcite-tab>
@@ -214,10 +214,10 @@ describe("calcite-tabs", () => {
     const wrappedTabTemplateHTML = html`
       <calcite-tabs>
         <calcite-tab-nav slot="tab-nav">
-          <calcite-tab-title id="title-1" active>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title id="title-1" selected>Tab 1 Title</calcite-tab-title>
           <calcite-tab-title id="title-2">Tab 2 Title</calcite-tab-title>
         </calcite-tab-nav>
-        <calcite-tab id="tab-1" active>Tab 1 Content</calcite-tab>
+        <calcite-tab id="tab-1" selected>Tab 1 Content</calcite-tab>
         <calcite-tab id="tab-2">Tab 2 Content</calcite-tab>
       </calcite-tabs>
     `;
@@ -254,8 +254,8 @@ describe("calcite-tabs", () => {
         await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
         await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
-        const titleTab = wrapper.shadowRoot.querySelector("calcite-tab-title[active]").id;
-        const contentTab = wrapper.shadowRoot.querySelector("calcite-tab[active]").id;
+        const titleTab = wrapper.shadowRoot.querySelector("calcite-tab-title[selected]").id;
+        const contentTab = wrapper.shadowRoot.querySelector("calcite-tab[selected]").id;
         return { titleTab, contentTab };
       },
       [wrappedTabTemplateHTML]
@@ -297,12 +297,12 @@ describe("calcite-tabs", () => {
     await page.waitForChanges();
 
     const parentTabA = await page.find("#parentTabA");
-    const childTitle = (await parentTabA.find("calcite-tab-title[active]")).getAttribute("id");
-    const childContent = (await parentTabA.find("calcite-tab[active]")).getAttribute("id");
+    const childTitle = (await parentTabA.find("calcite-tab-title[selected]")).getAttribute("id");
+    const childContent = (await parentTabA.find("calcite-tab[selected]")).getAttribute("id");
 
     const parentTabs = await page.find("#parentTabs");
-    const parentTitle = (await parentTabs.find("calcite-tab-title[active]")).getAttribute("id");
-    const parentContent = (await parentTabs.find("calcite-tab[active]")).getAttribute("id");
+    const parentTitle = (await parentTabs.find("calcite-tab-title[selected]")).getAttribute("id");
+    const parentContent = (await parentTabs.find("calcite-tab[selected]")).getAttribute("id");
 
     expect(childTitle).toBe("kidB");
     expect(childContent).toBe("kidBTab");

--- a/src/components/tabs/tabs.e2e.ts
+++ b/src/components/tabs/tabs.e2e.ts
@@ -183,25 +183,6 @@ describe("calcite-tabs", () => {
       expect(indicatorStyles.bottom).not.toEqual("0px");
     });
 
-    it("should render tab-nav's blue active indicator on bottom when position is below (deprecated)", async () => {
-      const page = await newE2EPage({
-        html: `
-        <calcite-tabs bordered position="below">
-          <calcite-tab-nav slot="tab-nav">
-            <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" >Tab 2 Title</calcite-tab-title>
-          </calcite-tab-nav>
-          <calcite-tab>Tab 1 Content</calcite-tab>
-          <calcite-tab>Tab 2 Content</calcite-tab>
-        </calcite-tabs>
-        `
-      });
-      const indicator = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator-container");
-      const indicatorStyles = await indicator.getComputedStyle();
-      expect(indicatorStyles.bottom).toEqual("0px");
-      expect(indicatorStyles.top).not.toEqual("0px");
-    });
-
     it("should render tab-nav's blue active indicator on bottom when position is bottom", async () => {
       const page = await newE2EPage({
         html: `

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -7,20 +7,8 @@
   background-color: var(--calcite-ui-foreground-1);
 }
 
-:host([bordered]:not([position="below"])) ::slotted(calcite-tab-nav) {
-  margin-block-end: -1px;
-}
-
 :host([bordered]:not([position="bottom"])) ::slotted(calcite-tab-nav) {
   margin-block-end: -1px;
-}
-
-:host([bordered][position="below"]) ::slotted(calcite-tab-nav) {
-  margin-block-start: -1px;
-}
-
-:host([bordered][position="below"]) {
-  box-shadow: inset 0 1px 0 var(--calcite-ui-border-1), inset 0 -1px 0 var(--calcite-ui-border-1);
 }
 
 :host([bordered][position="bottom"]) {
@@ -43,10 +31,6 @@
   @apply p-4;
 }
 
-:host([position="below"]) {
-  @apply flex-col-reverse;
-}
-
 :host([position="bottom"]) {
   @apply flex-col-reverse;
 }
@@ -60,22 +44,11 @@ section {
   border-block-start-style: solid;
 }
 
-:host([position="below"]) section {
-  @apply border-b-color-1
-    flex-col-reverse
-    border-t-0
-    border-b;
-}
-
 :host([position="bottom"]) section {
   @apply border-b-color-1
     flex-col-reverse
     border-t-0
     border-b;
-}
-
-:host([position="below"]:not([bordered])) section {
-  border-block-end-style: solid;
 }
 
 :host([position="bottom"]:not([bordered])) section {
@@ -86,10 +59,6 @@ section {
   :host([bordered]) section {
     @apply border-t-0
       border-b;
-  }
-  :host([position="below"][bordered]) section {
-    @apply border-t
-      border-b-0;
   }
   :host([position="bottom"][bordered]) section {
     @apply border-t

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -24,7 +24,7 @@ export const simple = stepStory(
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >
       <calcite-tab-nav slot="tab-nav">
-        <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+        <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
         <calcite-tab-title id="reference-element">Tab 2 Title</calcite-tab-title>
         <calcite-tab-title disabled>Disabled Tab</calcite-tab-title>
         <calcite-tab-title>Tab 4 Title</calcite-tab-title>
@@ -55,12 +55,12 @@ export const simpleDarkThemeRTL_TestOnly = (): string => html`
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title disabled>Disabled Tab</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
-    <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab selected><p>Tab 1 Content</p></calcite-tab>
     <calcite-tab><p>Tab 2 Content</p></calcite-tab>
     <calcite-tab><p>Tab 3 Content</p></calcite-tab>
     <calcite-tab><p>Tab 4 Content</p></calcite-tab>
@@ -79,12 +79,12 @@ export const bordered = (): string => html`
       <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
       <calcite-tab-title tab="tab2">Tab 2 Title</calcite-tab-title>
       <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab4" active>Tab 4 Title</calcite-tab-title>
+      <calcite-tab-title tab="tab4" selected>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
     <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
     <calcite-tab tab="tab2">Tab 2 Content</calcite-tab>
     <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
-    <calcite-tab tab="tab4" active>Tab 4 Content</calcite-tab>
+    <calcite-tab tab="tab4" selected>Tab 4 Content</calcite-tab>
   </calcite-tabs>
 `;
 
@@ -101,12 +101,12 @@ export const borderedDarkThemeRTL_TestOnly = (): string => html`
       <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
       <calcite-tab-title tab="tab2">Tab 2 Title</calcite-tab-title>
       <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
-      <calcite-tab-title tab="tab4" active>Tab 4 Title</calcite-tab-title>
+      <calcite-tab-title tab="tab4" selected>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
     <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
     <calcite-tab tab="tab2">Tab 2 Content</calcite-tab>
     <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
-    <calcite-tab tab="tab4" active>Tab 4 Content</calcite-tab>
+    <calcite-tab tab="tab4" selected>Tab 4 Content</calcite-tab>
   </calcite-tabs>
 `;
 borderedDarkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
@@ -120,7 +120,7 @@ export const withIcons = (): string => html`
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active icon-start="${select("tab 1 icon-start", iconNames, selectedIcon)}"
+      <calcite-tab-title selected icon-start="${select("tab 1 icon-start", iconNames, selectedIcon)}"
         >Tab 1 Title</calcite-tab-title
       >
       <calcite-tab-title icon-end="${select("tab 2 icon-end", iconNames, selectedIcon)}">Tab 2 Title</calcite-tab-title>
@@ -132,7 +132,7 @@ export const withIcons = (): string => html`
       <calcite-tab-title icon-start="${select("tab 4 icon-start", iconNames, selectedIcon)}"></calcite-tab-title>
     </calcite-tab-nav>
 
-    <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab selected><p>Tab 1 Content</p></calcite-tab>
     <calcite-tab><p>Tab 2 Content</p></calcite-tab>
     <calcite-tab><p>Tab 3 Content</p></calcite-tab>
     <calcite-tab><p>Tab 4 Content</p></calcite-tab>
@@ -147,13 +147,13 @@ export const setWidth = (): string => html`
     scale="${select("scale", ["s", "m", "l"], "m")}"
     >
     <calcite-tab-nav slot="tab-nav">
-      <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       <calcite-tab-title id="reference-element">Tab 2 Title</calcite-tab-title>
       <calcite-tab-title>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title>Tab 4 Title</calcite-tab-title>
     </calcite-tab-nav>
 
-    <calcite-tab active>
+    <calcite-tab selected>
       <p>Tab 1 Content</p><br />
     </calcite-tab>
     <calcite-tab><p>Tab 2 Content</p>
@@ -176,7 +176,7 @@ export const justTabNav = (): string => html`
     <calcite-tab-title>Tab 1 Title</calcite-tab-title>
     <calcite-tab-title>Tab 2 Title</calcite-tab-title>
     <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-    <calcite-tab-title active>Tab 4 Title</calcite-tab-title>
+    <calcite-tab-title selected>Tab 4 Title</calcite-tab-title>
   </calcite-tab-nav>
 `;
 
@@ -202,12 +202,12 @@ export const disabledTabs_TestOnly = (): string => {
   return `
       <calcite-tabs>
         <calcite-tab-nav slot="tab-nav">
-          <calcite-tab-title active ${tab1disabled ? "disabled" : ""}>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title selected ${tab1disabled ? "disabled" : ""}>Tab 1 Title</calcite-tab-title>
           <calcite-tab-title ${tab2disabled ? "disabled" : ""}>Tab 2 Title</calcite-tab-title>
           <calcite-tab-title ${tab3disabled ? "disabled" : ""}>Tab 3 Title</calcite-tab-title>
         </calcite-tab-nav>
 
-        <calcite-tab active><p>Tab 1 Content</p></calcite-tab>
+        <calcite-tab selected><p>Tab 1 Content</p></calcite-tab>
         <calcite-tab><p>Tab 2 Content</p></calcite-tab>
         <calcite-tab><p>Tab 3 Content</p></calcite-tab>
       </calcite-tabs>
@@ -233,11 +233,11 @@ export const WithIconStart_TestOnly = stepStory(
   (): string => html`
     <calcite-tabs>
       <calcite-tab-nav slot="tab-nav">
-        <calcite-tab-title active id="tab-title">Boats</calcite-tab-title>
+        <calcite-tab-title selected id="tab-title">Boats</calcite-tab-title>
         <calcite-tab-title>Ships</calcite-tab-title>
         <calcite-tab-title>Yachts</calcite-tab-title>
       </calcite-tab-nav>
-      <calcite-tab active><calcite-button id="btn">Add indicator</calcite-button></calcite-tab>
+      <calcite-tab selected><calcite-button id="btn">Add indicator</calcite-button></calcite-tab>
       <calcite-tab>Tab 2 content</calcite-tab>
       <calcite-tab>Tab 3 content</calcite-tab>
     </calcite-tabs>

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -20,7 +20,7 @@ export const simple = stepStory(
   (): string => html`
     <calcite-tabs
       layout="${select("layout", ["inline", "center"], "inline")}"
-      position="${select("position", ["above", "below"], "above")}"
+      position="${select("position", ["top", "bottom"], "top")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
     >
       <calcite-tab-nav slot="tab-nav">
@@ -30,7 +30,7 @@ export const simple = stepStory(
         <calcite-tab-title>Tab 4 Title</calcite-tab-title>
       </calcite-tab-nav>
 
-      <calcite-tab active>
+      <calcite-tab selected>
         <p>Tab 1 Content</p><br />
       </calcite-tab>
       <calcite-tab><p>Tab 2 Content</p>
@@ -51,7 +51,7 @@ export const simpleDarkThemeRTL_TestOnly = (): string => html`
     dir="rtl"
     class="calcite-theme-dark"
     layout="${select("layout", ["inline", "center"], "inline")}"
-    position="${select("position", ["above", "below"], "above")}"
+    position="${select("position", ["top", "bottom"], "top")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     <calcite-tab-nav slot="tab-nav">
@@ -71,7 +71,7 @@ simpleDarkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
 export const bordered = (): string => html`
   <calcite-tabs
     layout="${select("layout", ["inline", "center"], "inline")}"
-    position="${select("position", ["above", "below"], "above")}"
+    position="${select("position", ["top", "bottom"], "top")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     bordered
   >
@@ -91,7 +91,7 @@ export const bordered = (): string => html`
 export const borderedDarkThemeRTL_TestOnly = (): string => html`
   <calcite-tabs
     layout="inline"
-    position="${select("position", ["above", "below"], "above")}"
+    position="${select("position", ["top", "bottom"], "top")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     bordered
     dir="rtl"
@@ -116,7 +116,7 @@ const selectedIcon = iconNames[0];
 export const withIcons = (): string => html`
   <calcite-tabs
     layout="${select("layout", ["inline", "center"], "inline")}"
-    position="${select("position", ["above", "below"], "above")}"
+    position="${select("position", ["top", "bottom"], "top")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
   >
     <calcite-tab-nav slot="tab-nav">
@@ -143,7 +143,7 @@ export const setWidth = (): string => html`
   <div style="width: 400px;">
     <calcite-tabs
     layout="${select("layout", ["inline", "center"], "inline")}"
-    position="${select("position", ["above", "below"], "above")}"
+    position="${select("position", ["top", "bottom"], "top")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     >
     <calcite-tab-nav slot="tab-nav">
@@ -170,7 +170,7 @@ export const setWidth = (): string => html`
 
 export const justTabNav = (): string => html`
   <calcite-tab-nav
-    position="${select("position", ["above", "below"], "below")}"
+    position="${select("position", ["top", "bottom"], "top")}"
     scale="${select("scale", ["s", "m", "l"], "l")}"
   >
     <calcite-tab-title>Tab 1 Title</calcite-tab-title>

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -33,8 +33,7 @@ export class Tabs {
   @Prop({ reflect: true }) layout: TabLayout = "inline";
 
   /**
-   * Specifies the position of the component in relation to the `calcite-tab`s. The `"above"` and `"below"` values are deprecated.
-   *
+   * Specifies the position of the component in relation to the `calcite-tab`s.
    */
   @Prop({ reflect: true }) position: TabPosition = "top";
 

--- a/src/components/tabs/usage/Basic.md
+++ b/src/components/tabs/usage/Basic.md
@@ -3,11 +3,11 @@
 ```html
 <calcite-tabs>
   <calcite-tab-nav slot="tab-nav">
-    <calcite-tab-title active>Tab 1 Title</calcite-tab-title>
+    <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
     <calcite-tab-title>Tab 2 Title</calcite-tab-title>
   </calcite-tab-nav>
 
-  <calcite-tab active>Tab 1 Content</calcite-tab>
+  <calcite-tab selected>Tab 1 Content</calcite-tab>
   <calcite-tab>Tab 2 Content</calcite-tab>
 </calcite-tabs>
 ```

--- a/src/components/tabs/usage/Bordered.md
+++ b/src/components/tabs/usage/Bordered.md
@@ -4,11 +4,11 @@
     <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
     <calcite-tab-title tab="tab2">Tab 2 Title</calcite-tab-title>
     <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
-    <calcite-tab-title tab="tab4" active>Tab 4 Title</calcite-tab-title>
+    <calcite-tab-title tab="tab4" selected>Tab 4 Title</calcite-tab-title>
   </calcite-tab-nav>
   <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
   <calcite-tab tab="tab2">Tab 2 Content</calcite-tab>
   <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
-  <calcite-tab tab="tab4" active>Tab 4 Content</calcite-tab>
+  <calcite-tab tab="tab4" selected>Tab 4 Content</calcite-tab>
 </calcite-tabs>
 ```

--- a/src/demos/tabs.html
+++ b/src/demos/tabs.html
@@ -20,6 +20,7 @@
       .flex-wrap {
         flex-wrap: wrap;
       }
+
       .child {
         display: inline-flex;
         flex: 0 0 20%;
@@ -74,9 +75,9 @@
         </div>
       </div>
 
-      <!-- tab position: above (default)-->
+      <!-- tab position: top (default)-->
       <div class="flex-wrap">
-        <div class="child right-aligned-text">tab position: above (default)</div>
+        <div class="child right-aligned-text">tab position: top (default)</div>
 
         <div class="child">
           <calcite-tabs scale="s">
@@ -118,12 +119,12 @@
         </div>
       </div>
 
-      <!-- tab position: below-->
+      <!-- tab position: bottom -->
       <div class="flex-wrap">
-        <div class="child right-aligned-text">tab position: below</div>
+        <div class="child right-aligned-text">tab position: bottom</div>
 
         <div class="child">
-          <calcite-tabs scale="s" position="below">
+          <calcite-tabs scale="s" position="bottom">
             <calcite-tab-nav slot="tab-nav">
               <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
               <calcite-tab-title>Tab 2 Title</calcite-tab-title>
@@ -136,7 +137,7 @@
         </div>
 
         <div class="child">
-          <calcite-tabs scale="m" position="below">
+          <calcite-tabs scale="m" position="bottom">
             <calcite-tab-nav slot="tab-nav">
               <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
               <calcite-tab-title>Tab 2 Title</calcite-tab-title>
@@ -149,7 +150,7 @@
         </div>
 
         <div class="child">
-          <calcite-tabs scale="l" position="below">
+          <calcite-tabs scale="l" position="bottom">
             <calcite-tab-nav slot="tab-nav">
               <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
               <calcite-tab-title>Tab 2 Title</calcite-tab-title>
@@ -329,12 +330,12 @@
         </div>
       </div>
 
-      <!-- tab position: below with border + icon-start + icon end:  -->
+      <!-- tab position: bottom with border + icon-start + icon end:  -->
       <div class="flex-wrap">
-        <div class="child right-aligned-text">tab position: below with border + icon-start + icon end</div>
+        <div class="child right-aligned-text">tab position: bottom with border + icon-start + icon end</div>
 
         <div class="child">
-          <calcite-tabs bordered scale="s" position="below">
+          <calcite-tabs bordered scale="s" position="bottom">
             <calcite-tab-nav slot="tab-nav">
               <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" selected>Tab 1 Title</calcite-tab-title>
               <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 2 Title</calcite-tab-title>
@@ -345,7 +346,7 @@
         </div>
 
         <div class="child">
-          <calcite-tabs bordered scale="m" position="below">
+          <calcite-tabs bordered scale="m" position="bottom">
             <calcite-tab-nav slot="tab-nav">
               <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" selected>Tab 1 Title</calcite-tab-title>
               <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 2 Title</calcite-tab-title>
@@ -356,7 +357,7 @@
         </div>
 
         <div class="child">
-          <calcite-tabs bordered scale="l" position="below">
+          <calcite-tabs bordered scale="l" position="bottom">
             <calcite-tab-nav slot="tab-nav">
               <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" selected>Tab 1 Title</calcite-tab-title>
               <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 2 Title</calcite-tab-title>


### PR DESCRIPTION
BREAKING CHANGE: Removed deprecated properties and values.

- Removed the property `active` from `calcite-tab-title`, use `selected` instead.
- Removed the property `active` from `calcite-tab`, use `selected` instead.
- Removed the `above` value from the `position` property on `calcite-tabs`, use `top` instead.
- Removed the `below` value from the `position` property on `calcite-tabs`, use `bottom` instead.