### PR TITLE
test(modal): Skip unstable test

### DIFF
--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -83,7 +83,7 @@ describe("opening and closing behavior", () => {
     };
   };
 
-  it("opens and closes", async () => {
+  it.skip("opens and closes", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-modal style="transition: opacity ${DURATIONS.test}s"></calcite-modal>`);
     const modal = await page.find("calcite-modal");


### PR DESCRIPTION
## Summary

test(modal): Skip unstable test.

Test type

e2e
Which Component(s)

modal
Unstable Test

● opening and closing behavior › opens and closes

expected event "calciteModalOpen" to have been called 0 times, but was called 1 time

  105 |
  106 |     expect(beforeOpenSpy).toHaveReceivedEventTimes(1);
> 107 |     expect(openSpy).toHaveReceivedEventTimes(0);
      |                     ^
  108 |     expect(beforeCloseSpy).toHaveReceivedEventTimes(0);
  109 |     expect(closeSpy).toHaveReceivedEventTimes(0);
  110 |     await page.waitForFunction(getTransitionTransform, {}, "calcite-modal", `.${CSS.modal}`, "matrix");

  at Object.<anonymous> (src/components/modal/modal.e2e.ts:107:21)
      at runMicrotasks (<anonymous>)

Test Suites: 1 failed, 1 skipped, 108 passed, 109 of 110 total
Tests: 1 failed, 25 skipped, 2463 passed, 2489 total
Snapshots: 0 total
Time: 522.92 s
Ran all test suites.

