### PR TITLE
docs: make placement type defaults accessible to docs-json

### DIFF
--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -16,7 +16,12 @@ import { Fragment, VNode } from "@stencil/core/internal";
 import { getRoundRobinIndex } from "../../utils/array";
 import { guid } from "../../utils/guid";
 import { Scale } from "../interfaces";
-import { LogicalPlacement, EffectivePlacement, OverlayPositioning } from "../../utils/floating-ui";
+import {
+  LogicalPlacement,
+  EffectivePlacement,
+  OverlayPositioning,
+  defaultAutoPlacement
+} from "../../utils/floating-ui";
 import { isActivationKey } from "../../utils/key";
 import {
   setUpLoadableComponent,
@@ -110,10 +115,8 @@ export class ActionMenu implements LoadableComponent {
 
   /**
    * Determines where the component will be positioned relative to the `referenceElement`.
-   *
-   * @see [LogicalPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/floating-ui.ts#L25)
    */
-  @Prop({ reflect: true }) placement: LogicalPlacement = "auto";
+  @Prop({ reflect: true }) placement: LogicalPlacement = defaultAutoPlacement;
 
   /**
    * Specifies the size of the component's trigger `calcite-action`.

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -15,7 +15,12 @@ import {
 import { guid } from "../../utils/guid";
 import { formatTimeString, isValidTime, localizeTimeString } from "../../utils/time";
 import { Scale } from "../interfaces";
-import { FloatingUIComponent, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
+import {
+  defaultAutoPlacement,
+  FloatingUIComponent,
+  LogicalPlacement,
+  OverlayPositioning
+} from "../../utils/floating-ui";
 import { connectLabel, disconnectLabel, getLabelText, LabelableComponent } from "../../utils/label";
 import {
   connectForm,
@@ -196,10 +201,8 @@ export class InputTimePicker
 
   /**
    * Determines where the popover will be positioned relative to the input.
-   *
-   * @see [LogicalPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/floating-ui.ts#L25)
    */
-  @Prop({ reflect: true }) placement: LogicalPlacement = "auto";
+  @Prop({ reflect: true }) placement: LogicalPlacement = defaultAutoPlacement;
 
   /** Specifies the granularity the component's `value` must adhere to (in seconds). */
   @Prop() step = 60;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -12,7 +12,7 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CSS, ARIA_CONTROLS, ARIA_EXPANDED, TEXT, defaultPopoverPlacement } from "./resources";
+import { CSS, ARIA_CONTROLS, ARIA_EXPANDED, TEXT } from "./resources";
 import {
   FloatingCSS,
   OverlayPositioning,
@@ -25,7 +25,8 @@ import {
   filterComputedPlacements,
   ReferenceElement,
   reposition,
-  updateAfterClose
+  updateAfterClose,
+  defaultAutoPlacement
 } from "../../utils/floating-ui";
 import {
   FocusTrapComponent,
@@ -175,10 +176,8 @@ export class Popover
 
   /**
    * Determines where the component will be positioned relative to the `referenceElement`.
-   *
-   * @see [LogicalPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/floating-ui.ts#L25)
    */
-  @Prop({ reflect: true }) placement: LogicalPlacement = defaultPopoverPlacement;
+  @Prop({ reflect: true }) placement: LogicalPlacement = defaultAutoPlacement;
 
   @Watch("placement")
   placementHandler(): void {

--- a/src/components/popover/resources.ts
+++ b/src/components/popover/resources.ts
@@ -15,6 +15,5 @@ export const TEXT = {
   close: "Close"
 };
 
-export const defaultPopoverPlacement = "auto";
 export const ARIA_CONTROLS = "aria-controls";
 export const ARIA_EXPANDED = "aria-expanded";

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -23,7 +23,8 @@ import {
   ReferenceElement,
   reposition,
   FloatingCSS,
-  updateAfterClose
+  updateAfterClose,
+  defaultAutoPlacement
 } from "../../utils/floating-ui";
 import { queryElementRoots, toAriaBoolean } from "../../utils/dom";
 import {
@@ -110,10 +111,8 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
 
   /**
    * Determines where the component will be positioned relative to the `referenceElement`.
-   *
-   * @see [LogicalPlacement](https://github.com/Esri/calcite-components/blob/master/src/utils/floating-ui.ts#L25)
    */
-  @Prop({ reflect: true }) placement: LogicalPlacement = "auto";
+  @Prop({ reflect: true }) placement: LogicalPlacement = defaultAutoPlacement;
 
   @Watch("placement")
   placementHandler(): void {

--- a/src/utils/floating-ui.ts
+++ b/src/utils/floating-ui.ts
@@ -154,6 +154,7 @@ export type MenuPlacement = Extract<
   "top-start" | "top" | "top-end" | "bottom-start" | "bottom" | "bottom-end"
 >;
 
+export const defaultAutoPlacement: LogicalPlacement = "auto";
 export const defaultMenuPlacement: MenuPlacement = "bottom-start";
 
 export interface FloatingUIComponent {


### PR DESCRIPTION
**Related Issue:** #5923

## Summary

Create a type for the "auto" default placement type so that it is accessible to docs-json