### PR TITLE
build(deps): downgrade stencil due to e2e errors in ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN copyright.txt",
       "dependencies": {
         "@floating-ui/dom": "1.0.8",
-        "@stencil/core": "2.20.0",
+        "@stencil/core": "2.19.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "focus-trap": "7.2.0",
@@ -3979,9 +3979,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.19.3.tgz",
+      "integrity": "sha512-rb6pBWTfD5xDg5M/uEJUeclatE/tqBE3zCCNrEB47AtdkNCzC9fOikdzCYbpdAEpU6GvC60REFr0bd8QFUjn3Q==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -35083,9 +35083,15 @@
       }
     },
     "node_modules/webpack/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "dependencies": {
+        "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
+      }
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
@@ -38763,9 +38769,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw=="
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.19.3.tgz",
+      "integrity": "sha512-rb6pBWTfD5xDg5M/uEJUeclatE/tqBE3zCCNrEB47AtdkNCzC9fOikdzCYbpdAEpU6GvC60REFr0bd8QFUjn3Q=="
     },
     "@stencil/eslint-plugin": {
       "version": "0.4.0",
@@ -44805,7 +44811,10 @@
       }
     },
     "chokidar2": {
-      "version": "file:node_modules/webpack/node_modules/watchpack/chokidar2"
+      "version": "file:node_modules/webpack/node_modules/watchpack/chokidar2",
+      "requires": {
+        "chokidar": "^2.1.8"
+      }
     },
     "chownr": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.0.8",
-    "@stencil/core": "2.20.0",
+    "@stencil/core": "2.19.3",
     "@types/color": "3.0.3",
     "color": "4.2.3",
     "focus-trap": "7.2.0",


### PR DESCRIPTION
**Related Issue:** #5906

## Summary

We are getting ECONNREFUSED puppeteer errors in our e2e PR check coming from Stencil:
https://github.com/Esri/calcite-components/actions/runs/3643107114/jobs/6150969791#step:6:5592

We just bumped our stencil version recently so I'm hoping this fixes it.  :crossed_fingers: 

Although there is an existing issue from before 2.20 came out, and I've been getting these same errors on my  Ubuntu-based distro forever now
https://github.com/ionic-team/stencil/issues/3853