### PR TITLE
chore: bump stencil and downgrade e2e action runner

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -8,7 +8,7 @@ on:
     branches: [master]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN copyright.txt",
       "dependencies": {
         "@floating-ui/dom": "1.0.8",
-        "@stencil/core": "2.19.3",
+        "@stencil/core": "2.20.0",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "focus-trap": "7.2.0",
@@ -3979,9 +3979,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.19.3.tgz",
-      "integrity": "sha512-rb6pBWTfD5xDg5M/uEJUeclatE/tqBE3zCCNrEB47AtdkNCzC9fOikdzCYbpdAEpU6GvC60REFr0bd8QFUjn3Q==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
+      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -38769,9 +38769,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.19.3.tgz",
-      "integrity": "sha512-rb6pBWTfD5xDg5M/uEJUeclatE/tqBE3zCCNrEB47AtdkNCzC9fOikdzCYbpdAEpU6GvC60REFr0bd8QFUjn3Q=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
+      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw=="
     },
     "@stencil/eslint-plugin": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.0.8",
-    "@stencil/core": "2.19.3",
+    "@stencil/core": "2.20.0",
     "@types/color": "3.0.3",
     "color": "4.2.3",
     "focus-trap": "7.2.0",


### PR DESCRIPTION
**Related Issue:** #5941
**Stencil Issue**: https://github.com/ionic-team/stencil/issues/3853

## Summary
Downgrading Stencil didn't fix the ECONNREFUSED errors in the e2e test CI. After more investigating it turns out GitHub just recently bumped their action runner's  `ubuntu-latest` version from Ubuntu `v20.04` to `v22.04`. 
- Downgrades The runner's Ubuntu version back to `v20.04`. 
- Reupgrades Stencil to `v2.20`

## Resources
- https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/
- https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/

