### PR TITLE
test(floating-ui): fix type errors

### DIFF
--- a/src/utils/floating-ui.spec.ts
+++ b/src/utils/floating-ui.spec.ts
@@ -19,7 +19,7 @@ import { waitForAnimationFrame } from "../tests/utils";
 
 import * as floatingUIDOM from "@floating-ui/dom";
 
-(floatingUIDOM as any).computePosition = async (referenceEl: HTMLElement, floatingEl: HTMLElement) => {
+(floatingUIDOM as any).computePosition = async (_: HTMLElement, floatingEl: HTMLElement) => {
   floatingEl.style.transform = "some value";
   floatingEl.style.top = "0";
   floatingEl.style.left = "0";
@@ -222,7 +222,7 @@ it("should have correct value for defaultOffsetDistance", () => {
 });
 
 it("should filter computed placements", () => {
-  expect(new Set(filterComputedPlacements(placements, document.createElement("div")))).toEqual(
+  expect(new Set(filterComputedPlacements([...placements], document.createElement("div")))).toEqual(
     new Set(effectivePlacements)
   );
 });


### PR DESCRIPTION
**Related Issue:** #5939

## Summary
I kept getting type errors coming from `floating-ui.spec.ts` when trying to run the demos. After some quick maths I determined fixing them would be faster than restarting the dev server every 15 minutes

![image](https://user-images.githubusercontent.com/10986395/206635861-d566d6fd-cfe8-47ea-8d5b-e101fd3b351a.png)

One of them was my fault from the PR linked above, I made the `placements` array a const so it could be used as a type but didn't check the spec tests. Not sure where the `referenceEl` error came from but renaming the param fixed it.