### PR TITLE
refactor(input-time-picker)!: Remove deprecated active property

### DIFF
--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -35,7 +35,6 @@ describe("calcite-input-time-picker", () => {
 
   it("reflects", async () =>
     reflects(`calcite-input-time-picker`, [
-      { propertyName: "active", value: true },
       { propertyName: "open", value: true },
       { propertyName: "disabled", value: true },
       { propertyName: "scale", value: "m" }
@@ -373,24 +372,4 @@ describe("calcite-input-time-picker", () => {
 
   it("is form-associated", () =>
     formAssociated("calcite-input-time-picker", { testValue: "03:23", submitsOnEnter: true }));
-
-  it("should set active prop to same value as open and vice-versa", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`<calcite-input-time-picker value="14:59"></calcite-input-time-picker>`);
-
-    const inputTimePicker = await page.find("calcite-input-time-picker");
-
-    expect(await inputTimePicker.getProperty("active")).toBe(false);
-    expect(await inputTimePicker.getProperty("open")).toBe(false);
-
-    inputTimePicker.setProperty("open", true);
-    await page.waitForChanges();
-
-    expect(await inputTimePicker.getProperty("active")).toBe(true);
-
-    inputTimePicker.setProperty("active", false);
-    await page.waitForChanges();
-
-    expect(await inputTimePicker.getProperty("open")).toBe(false);
-  });
 });

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -69,25 +69,12 @@ export class InputTimePicker
   //
   //--------------------------------------------------------------------------
 
-  /**
-   * When `true`, the component is active.
-   *
-   * @deprecated Use `open` instead.
-   */
-  @Prop({ reflect: true, mutable: true }) active = false;
-
-  @Watch("active")
-  activeHandler(value: boolean): void {
-    this.open = value;
-  }
-
   /** When `true`, displays the `calcite-time-picker` component. */
 
   @Prop({ reflect: true, mutable: true }) open = false;
 
   @Watch("open")
   openHandler(value: boolean): void {
-    this.active = value;
     if (this.disabled || this.readOnly) {
       this.open = false;
       return;
@@ -505,18 +492,12 @@ export class InputTimePicker
   connectedCallback() {
     connectLocalized(this);
 
-    const { active, open } = this;
     if (this.value) {
       this.setValue({ value: isValidTime(this.value) ? this.value : undefined, origin: "loading" });
     }
+
     connectLabel(this);
     connectForm(this);
-
-    if (open) {
-      this.active = open;
-    } else if (active) {
-      this.open = active;
-    }
   }
 
   componentWillLoad(): void {


### PR DESCRIPTION
BREAKING CHANGE: Removed the `active` property, use `open` instead.