### PR TITLE
refactor(input-date-picker,date-picker)!: Removing deprecated locale properties

### DIFF
--- a/src/components/date-picker/date-picker.e2e.ts
+++ b/src/components/date-picker/date-picker.e2e.ts
@@ -239,7 +239,7 @@ describe("calcite-date-picker", () => {
     expect(changedEvent).toHaveReceivedEventTimes(1);
   });
 
-  describe("when the locale is set to Slovak calendar", () => {
+  describe("when the lang is set to Slovak calendar", () => {
     it("should start the week on Monday", async () => {
       const page = await newE2EPage({
         html: `<calcite-date-picker scale="m" lang="sk" value="2000-11-27"></calcite-date-picker>`

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -62,9 +62,9 @@ const createAttributes: (options?: { exceptions: string[] }) => Attributes = ({ 
         }
       },
       {
-        name: "locale",
+        name: "lang",
         commit(): Attribute {
-          this.value = select("locale", locales, "en");
+          this.value = select("lang", locales, "en");
           delete this.build;
           return this;
         }
@@ -181,12 +181,12 @@ export const darkThemeRTL_TestOnly = (): string =>
 
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
 
-export const bgLocale_TestOnly = (): string =>
+export const bgLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create("calcite-date-picker", createAttributes({ exceptions: ["lang"] }).concat([{ name: "lang", value: "bg" }]))}
   </div>`;
 
-export const ptPTLocale_TestOnly = (): string =>
+export const ptPTLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -194,7 +194,7 @@ export const ptPTLocale_TestOnly = (): string =>
     )}
   </div>`;
 
-export const germanLocale_TestOnly = (): string =>
+export const germanLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -205,7 +205,7 @@ export const germanLocale_TestOnly = (): string =>
     )}
   </div>`;
 
-export const spanishLocale_TestOnly = (): string =>
+export const spanishLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -216,7 +216,7 @@ export const spanishLocale_TestOnly = (): string =>
     )}
   </div>`;
 
-export const norwegianLocale_TestOnly = (): string =>
+export const norwegianLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -227,7 +227,7 @@ export const norwegianLocale_TestOnly = (): string =>
     )}
   </div>`;
 
-export const britishLocale_TestOnly = (): string =>
+export const britishLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -238,7 +238,7 @@ export const britishLocale_TestOnly = (): string =>
     )}
   </div>`;
 
-export const chineseLocale_TestOnly = (): string =>
+export const chineseLang_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -249,7 +249,7 @@ export const chineseLocale_TestOnly = (): string =>
     )}
   </div>`;
 
-export const arabLocaleNumberingSystem_TestOnly = (): string =>
+export const arabLangNumberingSystem_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",
@@ -260,7 +260,7 @@ export const arabLocaleNumberingSystem_TestOnly = (): string =>
     )}
   </div>`;
 
-export const thaiLocaleNumberingSystem_TestOnly = (): string =>
+export const thaiLangNumberingSystem_TestOnly = (): string =>
   html`<div style="width: 400px">
     ${create(
       "calcite-date-picker",

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -158,14 +158,6 @@ export class DatePicker implements LocalizedComponent {
   @Prop() intlYear: string = TEXT.year;
 
   /**
-   * Specifies the BCP 47 language tag for the desired language and country format.
-   *
-   * @deprecated set the global `lang` attribute on the element instead.
-   * @mdn [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-   */
-  @Prop() locale: string;
-
-  /**
    * Specifies the Unicode numeral system used by the component for localization. This property cannot be dynamically changed.
    *
    */

--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -260,7 +260,7 @@ describe("calcite-input-date-picker", () => {
     expect(await calendar.isVisible()).toBe(true);
   });
 
-  it("syncs locale changes to internal date-picker", async () => {
+  it("syncs lang changes to internal date-picker", async () => {
     const lang = "en";
     const newLang = "ar";
     const month = 4;

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -264,14 +264,6 @@ export class InputDatePicker
   @Prop() intlYear: string = TEXT.year;
 
   /**
-   * Specifies the BCP 47 language tag for the desired language and country format.
-   *
-   * @deprecated set the global `lang` attribute on the element instead.
-   * @mdn [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-   */
-  @Prop() locale: string;
-
-  /**
    * Specifies the Unicode numeral system used by the component for localization. This property cannot be dynamically changed.
    *
    */


### PR DESCRIPTION
BREAKING CHANGE: Removed the `locale` property, use `lang` instead.