### PR TITLE
test(chromatic): add delay and disable animation on some stories

### DIFF
--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -7,7 +7,10 @@ import { html } from "../../../support/formatting";
 export default {
   title: "Components/Alert",
   parameters: {
-    notes: readme
+    notes: readme,
+    chromatic: {
+      delay: 500
+    }
   },
   ...storyFilters()
 };
@@ -153,6 +156,11 @@ queue_NoTest.parameters = {
 };
 
 export const darkThemeRTL_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-alert
     class="calcite-theme-dark"
     ${boolean("icon", true)}
@@ -176,6 +184,11 @@ export const darkThemeRTL_TestOnly = (): string => html`
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
 
 export const actionsEndNoQueue_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-alert label="this is a default danger with icon and link" scale="l" color="red" icon open>
     <div slot="title">Hello there!</div>
     <div slot="message">Do you really want to proceed?</div>
@@ -185,6 +198,11 @@ export const actionsEndNoQueue_TestOnly = (): string => html`
 `;
 
 export const actionsEndQueued_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-alert id="one" label="One" scale="l" color="red" icon open>
     <div slot="title">Hello there, alert one!</div>
     <div slot="message">Do you really want to proceed?</div>
@@ -205,6 +223,11 @@ export const actionsEndQueued_TestOnly = (): string => html`
 `;
 
 export const autoDismissableRetainsCloseButton_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-alert auto-dismiss auto-dismiss-duration="medium" open scale="m" color="blue">
     <div slot="title">Here's a general bit of information</div>
     <div slot="message">Some kind of contextually relevant content</div>

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -20,7 +20,8 @@ export default {
     notes: readme,
     chromatic: {
       // https://www.chromatic.com/docs/threshold
-      diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3
+      diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3,
+      delay: 500
     }
   },
   ...storyFilters()

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -10,7 +10,10 @@ import { html } from "../../../support/formatting";
 export default {
   title: "Components/Buttons/Dropdown",
   parameters: {
-    notes: [readme1, readme2, readme3]
+    notes: [readme1, readme2, readme3],
+    chromatic: {
+      delay: 500
+    }
   },
   ...storyFilters()
 };
@@ -181,6 +184,11 @@ export const itemsAsLinks = (): string => html`
 `;
 
 export const darkThemeRTL_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-dropdown
     dir="rtl"
     open
@@ -251,6 +259,11 @@ export const itemsAsLinksDarkTheme = (): string => html`
 itemsAsLinksDarkTheme.parameters = { themes: themesDarkDefault };
 
 export const scrollingAfterCertainItems_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-dropdown
     open
     placement="${select("placement", menuPlacements, defaultMenuPlacement)}"
@@ -280,6 +293,11 @@ export const scrollingAfterCertainItems_TestOnly = (): string => html`
 `;
 
 export const scrollingWithoutMaxItems_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-dropdown open>
     <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group
@@ -308,6 +326,11 @@ export const scrollingWithoutMaxItems_TestOnly = (): string => html`
 `;
 
 export const noScrollingWhenMaxItemsEqualsItems_TestOnly = (): string => html` <calcite-dropdown max-items="3" open>
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-button slot="dropdown-trigger">Activate Dropdown</calcite-button>
   <calcite-dropdown-group selection-mode="single" group-title="Selection Mode: Single">
     <calcite-dropdown-item>Relevance</calcite-dropdown-item>
@@ -316,25 +339,35 @@ export const noScrollingWhenMaxItemsEqualsItems_TestOnly = (): string => html` <
   </calcite-dropdown-group>
 </calcite-dropdown>`;
 
-export const disabled_TestOnly = (): string => html` <calcite-dropdown disabled>
-  <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
-  <calcite-dropdown-group group-title="First group">
-    <calcite-dropdown-item>1</calcite-dropdown-item>
-    <calcite-dropdown-item>2</calcite-dropdown-item>
-    <calcite-dropdown-item>3</calcite-dropdown-item>
-    <calcite-dropdown-item>4</calcite-dropdown-item>
-    <calcite-dropdown-item>5</calcite-dropdown-item>
-  </calcite-dropdown-group>
-  <calcite-dropdown-group group-title="Second group">
-    <calcite-dropdown-item>6</calcite-dropdown-item>
-    <calcite-dropdown-item>7</calcite-dropdown-item>
-    <calcite-dropdown-item>8</calcite-dropdown-item>
-    <calcite-dropdown-item>9</calcite-dropdown-item>
-    <calcite-dropdown-item>10</calcite-dropdown-item>
-  </calcite-dropdown-group>
-</calcite-dropdown>`;
+export const disabled_TestOnly = (): string => html` <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <calcite-dropdown disabled>
+    <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
+    <calcite-dropdown-group group-title="First group">
+      <calcite-dropdown-item>1</calcite-dropdown-item>
+      <calcite-dropdown-item>2</calcite-dropdown-item>
+      <calcite-dropdown-item>3</calcite-dropdown-item>
+      <calcite-dropdown-item>4</calcite-dropdown-item>
+      <calcite-dropdown-item>5</calcite-dropdown-item>
+    </calcite-dropdown-group>
+    <calcite-dropdown-group group-title="Second group">
+      <calcite-dropdown-item>6</calcite-dropdown-item>
+      <calcite-dropdown-item>7</calcite-dropdown-item>
+      <calcite-dropdown-item>8</calcite-dropdown-item>
+      <calcite-dropdown-item>9</calcite-dropdown-item>
+      <calcite-dropdown-item>10</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>`;
 
 export const flipPositioning_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <div style="margin:10px;">
     <calcite-dropdown width="m" placement="${select("placement", menuPlacements, "top")}" open>
       <calcite-button slot="dropdown-trigger">Open Dropdown</calcite-button>
@@ -353,6 +386,11 @@ flipPositioning_TestOnly.parameters = {
 };
 
 export const alignedCenter_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <div style="text-align:center">
     <calcite-dropdown
       open
@@ -377,6 +415,11 @@ export const alignedCenter_TestOnly = (): string => html`
 `;
 
 export const alignedCenterRTL_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <div dir="rtl" style="text-align:center">
     <calcite-dropdown
       open
@@ -401,6 +444,14 @@ export const alignedCenterRTL_TestOnly = (): string => html`
 `;
 
 export const flipPlacements_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+    .my-dropdown {
+      margin-top: 50px;
+    }
+  </style>
   <style>
     .my-dropdown {
       margin-top: 50px;

--- a/src/components/list/list.stories.ts
+++ b/src/components/list/list.stories.ts
@@ -10,7 +10,10 @@ import { select, text } from "@storybook/addon-knobs";
 export default {
   title: "Components/List",
   parameters: {
-    notes: [readme, itemReadme, groupReadme]
+    notes: [readme, itemReadme, groupReadme],
+    chromatic: {
+      delay: 500
+    }
   },
   ...storyFilters()
 };

--- a/src/components/loader/loader.stories.ts
+++ b/src/components/loader/loader.stories.ts
@@ -6,8 +6,7 @@ import { html } from "../../../support/formatting";
 export default {
   title: "Components/Loader",
   parameters: {
-    notes: readme,
-    chromatic: { disableSnapshot: true }
+    notes: readme
   },
   ...storyFilters()
 };
@@ -22,17 +21,78 @@ export const simple_NoTest = (): string => html`
   />
 `;
 
+simple_NoTest.parameters = {
+  chromatic: { disableSnapshot: true }
+};
+
+export const simple_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <calcite-loader
+    active
+    type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("no-padding", false)}
+    value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
+  />
+`;
+
 export const inline_NoTest = (): string => html`
-<div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
-<calcite-loader
-  scale="${select("scale", ["s", "m", "l"], "m")}"
-  inline
-  active
-/></calcite-loader><span style="margin:0 10px">Next to some text</span>
-</div>
+  <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
+  <calcite-loader
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    inline
+    active
+  /></calcite-loader><span style="margin:0 10px">Next to some text</span>
+  </div>
+`;
+
+inline_NoTest.parameters = {
+  chromatic: { disableSnapshot: true }
+};
+
+export const inline_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <div style="display: inline-flex;align-items: center;justify-content: center;width: 100%;">
+  <calcite-loader
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    inline
+    active
+  /></calcite-loader><span style="margin:0 10px">Next to some text</span>
+  </div>
 `;
 
 export const customTheme_NoTest = (): string => html`
+  <calcite-loader
+    type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
+    scale="${select("scale", ["s", "m", "l"], "m")}"
+    ${boolean("no-padding", false)}
+    value="${number("value", 0, { range: true, min: 0, max: 100, step: 1 })}"
+    style="
+    --calcite-ui-brand: ${color("calcite-ui-blue-1", "#50ba5f")};
+    --calcite-ui-brand-hover: ${color("calcite-ui-blue-2", "#1a6324")};
+    --calcite-ui-brand-press: ${color("calcite-ui-blue-3", "#338033")};"
+    active
+  />
+`;
+
+customTheme_NoTest.parameters = {
+  chromatic: { disableSnapshot: true }
+};
+
+export const customTheme_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <calcite-loader
     type="${select("type", ["determinate", "indeterminate"], "indeterminate")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"

--- a/src/components/modal/modal.stories.ts
+++ b/src/components/modal/modal.stories.ts
@@ -7,7 +7,10 @@ import { html } from "../../../support/formatting";
 export default {
   title: "Components/Modal",
   parameters: {
-    notes: readme
+    notes: readme,
+    chromatic: {
+      delay: 500
+    }
   },
   ...storyFilters()
 };

--- a/src/components/pagination/pagination.stories.ts
+++ b/src/components/pagination/pagination.stories.ts
@@ -8,7 +8,10 @@ import { storyFilters } from "../../../.storybook/helpers";
 export default {
   title: "Components/Pagination",
   parameters: {
-    notes: readme
+    notes: readme,
+    chromatic: {
+      delay: 500
+    }
   },
   ...storyFilters()
 };

--- a/src/components/popover/popover.stories.ts
+++ b/src/components/popover/popover.stories.ts
@@ -20,7 +20,10 @@ const nestedReferenceElementHTML = `Ut enim ad minim veniam, quis <calcite-butto
 export default {
   title: "Components/Popover",
   parameters: {
-    notes: [readme]
+    notes: [readme],
+    chromatic: {
+      delay: 500
+    }
   },
   ...storyFilters()
 };
@@ -44,24 +47,29 @@ export const simple = (): string => html`
   </div>
 `;
 
-export const darkThemeRTL_TestOnly = (): string => html` <div style="width: 400px;">
-  ${referenceElementHTML}
-  <calcite-popover
-    ${boolean("closable", false)}
-    ${boolean("disable-flip", false)}
-    ${boolean("disable-pointer", false)}
-    reference-element="reference-element"
-    placement="${select("placement", placements, defaultPopoverPlacement)}"
-    offset-distance="${number("offset-distance", 6)}"
-    offset-skidding="${number("offset-skidding", 0)}"
-    ${boolean("open", true)}
-    text-close="${text("text-close", "Close")}"
-    dir="${select("dir", ["ltr", "rtl"], "rtl")}"
-    class="calcite-theme-dark"
-  >
-    ${contentHTML}
-  </calcite-popover>
-</div>`;
+export const darkThemeRTL_TestOnly = (): string => html` <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-popover
+      ${boolean("closable", false)}
+      ${boolean("disable-flip", false)}
+      ${boolean("disable-pointer", false)}
+      reference-element="reference-element"
+      placement="${select("placement", placements, defaultPopoverPlacement)}"
+      offset-distance="${number("offset-distance", 6)}"
+      offset-skidding="${number("offset-skidding", 0)}"
+      ${boolean("open", true)}
+      text-close="${text("text-close", "Close")}"
+      dir="${select("dir", ["ltr", "rtl"], "rtl")}"
+      class="calcite-theme-dark"
+    >
+      ${contentHTML}
+    </calcite-popover>
+  </div>`;
 
 darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };
 
@@ -89,6 +97,11 @@ export const nested = (): string => html`
 `;
 
 export const flipPlacements_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <div style="height: 100px; overflow:scroll; width: 200px;">
     <div class="my-popover-reference">
       <calcite-button title="Reference Element" id="reference-element">nostrud exercitation</calcite-button>
@@ -103,6 +116,11 @@ export const flipPlacements_TestOnly = (): string => html`
 `;
 
 export const scaleConsistencyPopoverHeadingActionSlottedIcon_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
   <div style="width: 400px;">
     ${referenceElementHTML}
     <calcite-popover

--- a/src/components/progress/progress.stories.ts
+++ b/src/components/progress/progress.stories.ts
@@ -30,4 +30,4 @@ export const darkThemeRTL_TestOnly = (): string => html`
   ></calcite-progress>
 `;
 
-darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault, chromatic: { disableSnapshot: true } };
+darkThemeRTL_TestOnly.parameters = { themes: themesDarkDefault };

--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -10,7 +10,8 @@ export default {
     notes: readme,
     chromatic: {
       // https://www.chromatic.com/docs/threshold
-      diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3
+      diffThreshold: Number(process.env.CHROMATIC_DIFF_THRESHOLD) || 0.3,
+      delay: 500
     }
   },
   ...storyFilters()


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/4825#issuecomment-1335921930

## Summary
Adds a chromatic snapshot delay to the components giving false positives. I also disabled animation for some of the floating-ui components, but only the NoTest ones so it doesn't effect the hosted stories. If the delay doesn't help I'll set the diffThreshold to `1` for the specific stories that fail, until I can do some additional digging.