### PR TITLE
fix(popover, modal): deactivate focus trap on outside click

### DIFF
--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -37,8 +37,7 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
   }
 
   const focusTrapOptions: FocusTrapOptions = {
-    allowOutsideClick: true,
-    clickOutsideDeactivates: false,
+    clickOutsideDeactivates: true,
     document: focusTrapEl.ownerDocument,
     escapeDeactivates: false,
     fallbackFocus: focusTrapEl,


### PR DESCRIPTION
**Related Issue:** #5993

## Summary

fix(popover, modal): deactivate focus trap on outside click.

https://github.com/focus-trap/focus-trap/blob/master/README.md