### PR TITLE
refactor(action-menu): remove event `calciteActionMenuOpenChange`

### DIFF
--- a/src/components/action-bar/action-bar.e2e.ts
+++ b/src/components/action-bar/action-bar.e2e.ts
@@ -269,15 +269,15 @@ describe("calcite-action-bar", () => {
     expect(await groups[0].getProperty("menuOpen")).toBe(false);
     expect(await groups[1].getProperty("menuOpen")).toBe(true);
 
-    const calciteActionMenuOpenChangeEvent = page.waitForEvent("calciteActionMenuOpenChange");
+    const calciteActionMenuOpenEvent = page.waitForEvent("calciteActionMenuOpen");
 
     await page.$eval("calcite-action-group", (firstActionGroup: HTMLCalciteActionGroupElement) => {
       firstActionGroup.menuOpen = true;
-      const event = new CustomEvent("calciteActionMenuOpenChange", { bubbles: true });
+      const event = new CustomEvent("calciteActionMenuOpen", { bubbles: true });
       firstActionGroup.dispatchEvent(event);
     });
 
-    await calciteActionMenuOpenChangeEvent;
+    await calciteActionMenuOpenEvent;
 
     await page.waitForChanges();
 

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -214,7 +214,7 @@ export class ActionBar implements ConditionalSlotComponent, LoadableComponent {
   //
   // --------------------------------------------------------------------------
 
-  actionMenuOpenChangeHandler = (event: CustomEvent<void>): void => {
+  actionMenuOpenHandler = (event: CustomEvent<void>): void => {
     if ((event.target as HTMLCalciteActionGroupElement).menuOpen) {
       const composedPath = event.composedPath();
       Array.from(this.el.querySelectorAll("calcite-action-group")).forEach((group) => {
@@ -331,7 +331,7 @@ export class ActionBar implements ConditionalSlotComponent, LoadableComponent {
 
   render(): VNode {
     return (
-      <Host onCalciteActionMenuOpenChange={this.actionMenuOpenChangeHandler}>
+      <Host onCalciteActionMenuOpen={this.actionMenuOpenHandler}>
         <slot />
         {this.renderBottomActionGroup()}
       </Host>

--- a/src/components/action-group/action-group.tsx
+++ b/src/components/action-group/action-group.tsx
@@ -108,7 +108,7 @@ export class ActionGroup implements ConditionalSlotComponent {
         expanded={expanded}
         flipPlacements={["left", "right"]}
         label={intlMore || TEXT.more}
-        onCalciteActionMenuOpenChange={this.setMenuOpen}
+        onCalciteActionMenuOpen={this.setMenuOpen}
         open={menuOpen}
         placement={layout === "horizontal" ? "bottom-start" : "leading-start"}
         scale={scale}

--- a/src/components/action-menu/action-menu.e2e.ts
+++ b/src/components/action-menu/action-menu.e2e.ts
@@ -74,7 +74,7 @@ describe("calcite-action-menu", () => {
       }
     ]));
 
-  it("should emit 'calciteActionMenuOpenChange' event", async () => {
+  it("should emit 'calciteActionMenuOpen' event", async () => {
     const page = await newE2EPage({
       html: `<calcite-action-menu>
       <calcite-action text="Add" icon="plus"></calcite-action>
@@ -83,7 +83,7 @@ describe("calcite-action-menu", () => {
 
     await page.waitForChanges();
 
-    const clickSpy = await page.spyOnEvent("calciteActionMenuOpenChange");
+    const clickSpy = await page.spyOnEvent("calciteActionMenuOpen");
 
     const actionMenu = await page.find("calcite-action-menu");
 

--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -94,7 +94,7 @@ export class ActionMenu implements LoadableComponent {
     if (this.menuButtonEl) {
       this.menuButtonEl.active = open;
     }
-    this.calciteActionMenuOpenChange.emit();
+    this.calciteActionMenuOpen.emit();
 
     this.setTooltipReferenceElement();
   }
@@ -128,7 +128,7 @@ export class ActionMenu implements LoadableComponent {
    * Emits when the `open` property has changed.
    *
    */
-  @Event({ cancelable: false }) calciteActionMenuOpenChange: EventEmitter<void>;
+  @Event({ cancelable: false }) calciteActionMenuOpen: EventEmitter<void>;
 
   @Listen("pointerdown", { target: "window" })
   closeCalciteActionMenuOnClick(event: PointerEvent): void {

--- a/src/components/action-pad/action-pad.e2e.ts
+++ b/src/components/action-pad/action-pad.e2e.ts
@@ -199,7 +199,7 @@ describe("calcite-action-pad", () => {
 
   it("has slots", () => slots("calcite-action-pad", SLOTS));
 
-  it("'calciteActionMenuOpenChange' event should set other 'calcite-action-group' - 'menuOpen' to false", async () => {
+  it("'calciteActionMenuOpen' event should set other 'calcite-action-group' - 'menuOpen' to false", async () => {
     const page = await newE2EPage({
       html: `<calcite-action-pad>
           <calcite-action-group>
@@ -220,7 +220,7 @@ describe("calcite-action-pad", () => {
         </calcite-action-pad>`
     });
 
-    const eventSpy = await page.spyOnEvent("calciteActionMenuOpenChange", "window");
+    const eventSpy = await page.spyOnEvent("calciteActionMenuOpen", "window");
 
     await page.waitForChanges();
 

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -157,7 +157,7 @@ export class ActionPad implements ConditionalSlotComponent, LoadableComponent {
   //
   // --------------------------------------------------------------------------
 
-  actionMenuOpenChangeHandler = (event: CustomEvent<void>): void => {
+  actionMenuOpenHandler = (event: CustomEvent<void>): void => {
     if ((event.target as HTMLCalciteActionGroupElement).menuOpen) {
       const composedPath = event.composedPath();
       Array.from(this.el.querySelectorAll("calcite-action-group")).forEach((group) => {
@@ -224,7 +224,7 @@ export class ActionPad implements ConditionalSlotComponent, LoadableComponent {
 
   render(): VNode {
     return (
-      <Host onCalciteActionMenuOpenChange={this.actionMenuOpenChangeHandler}>
+      <Host onCalciteActionMenuOpen={this.actionMenuOpenHandler}>
         <div class={CSS.container}>
           <slot />
           {this.renderBottomActionGroup()}


### PR DESCRIPTION
BREAKING CHANGE: Removed event.

- Removed the event `calciteActionMenuOpenChange`, use `calciteActionMenuOpen` instead.