### PR TITLE
refactor(action-menu)!: remove event `calciteActionMenuOpenChange`

### DIFF
--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -125,7 +125,7 @@ export class ActionMenu implements LoadableComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * Emits when the `open` property has changed.
+   * Emits when the `open` property is toggled.
    *
    */
   @Event({ cancelable: false }) calciteActionMenuOpen: EventEmitter<void>;


### PR DESCRIPTION
BREAKING CHANGE: Removed event.

- Removed the event `calciteActionMenuOpenChange`, use `calciteActionMenuOpen` instead.