### PR TITLE
refactor(chip)!: Rename event

### DIFF
--- a/src/components/chip/chip.e2e.ts
+++ b/src/components/chip/chip.e2e.ts
@@ -16,7 +16,7 @@ describe("calcite-chip", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-chip closable>cheetos</calcite-chip>`);
 
-    const eventSpy = await page.spyOnEvent("calciteChipDismiss", "window");
+    const eventSpy = await page.spyOnEvent("calciteChipClose", "window");
 
     const closeButton = await page.find(`calcite-chip >>> .${CSS.close}`);
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -117,7 +117,7 @@ export class Chip implements ConditionalSlotComponent, LoadableComponent {
    *
    * **Note:**: The `el` event payload props is deprecated, please use the event's `target`/`currentTarget` instead.
    */
-  @Event({ cancelable: false }) calciteChipDismiss: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: false }) calciteChipClose: EventEmitter<DeprecatedEventPayload>;
 
   // --------------------------------------------------------------------------
   //
@@ -127,7 +127,7 @@ export class Chip implements ConditionalSlotComponent, LoadableComponent {
 
   closeClickHandler = (event: MouseEvent): void => {
     event.preventDefault();
-    this.calciteChipDismiss.emit(this.el);
+    this.calciteChipClose.emit(this.el);
     this.closed = true;
   };
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -113,7 +113,7 @@ export class Chip implements ConditionalSlotComponent, LoadableComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * Fires when the dismiss button is clicked.
+   * Fires when the close button is clicked.
    *
    * **Note:**: The `el` event payload props is deprecated, please use the event's `target`/`currentTarget` instead.
    */

--- a/src/components/chip/readme.md
+++ b/src/components/chip/readme.md
@@ -26,9 +26,9 @@
 
 ## Events
 
-| Event                | Description                                                                                                                                               | Type               |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `calciteChipDismiss` | Fires when the dismiss button is clicked. **Note:**: The `el` event payload props is deprecated, please use the event's `target`/`currentTarget` instead. | `CustomEvent<any>` |
+| Event              | Description                                                                                                                                               | Type               |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `calciteChipClose` | Fires when the dismiss button is clicked. **Note:**: The `el` event payload props is deprecated, please use the event's `target`/`currentTarget` instead. | `CustomEvent<any>` |
 
 ## Methods
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -432,7 +432,7 @@ describe("calcite-combobox", () => {
 
       const chip = await page.find("calcite-combobox >>> calcite-chip");
 
-      chip.triggerEvent("calciteChipDismiss");
+      chip.triggerEvent("calciteChipClose");
 
       await page.waitForChanges();
 

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -620,7 +620,7 @@ export class Combobox
     await this.reposition(true);
   };
 
-  calciteChipDismissHandler = (comboboxItem: HTMLCalciteComboboxItemElement): void => {
+  calciteChipCloseHandler = (comboboxItem: HTMLCalciteComboboxItemElement): void => {
     this.open = false;
 
     const selection = this.items.find((item) => item === comboboxItem);
@@ -1030,7 +1030,7 @@ export class Combobox
           icon={item.icon}
           id={item.guid ? `${chipUidPrefix}${item.guid}` : null}
           key={item.textLabel}
-          onCalciteChipDismiss={() => this.calciteChipDismissHandler(item)}
+          onCalciteChipClose={() => this.calciteChipCloseHandler(item)}
           scale={scale}
           title={label}
           value={item.value}

--- a/src/demos/chip.html
+++ b/src/demos/chip.html
@@ -582,7 +582,7 @@
       <script>
         window.onload = () => {
           const one = document.querySelector("#one");
-          one.addEventListener("calciteChipDismiss", () => {
+          one.addEventListener("calciteChipClose", () => {
             console.log("dismissed chip");
           });
         };


### PR DESCRIPTION
BREAKING CHANGE: Renamed event.

- Renamed the event `calciteChipDismiss`, use `calciteChipClose` instead.