### PR TITLE
refactor(combobox)!: remove `event.detail` payload from events

### DIFF
--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -120,7 +120,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(true);
     expect(await items[3].isVisible()).toBe(true);
 
-    expect(await filterEventSpy.lastEvent.detail.visibleItems.length).toBe(4);
+    expect(await filterEventSpy.lastEvent.currentTarget.visibleItems.length).toBe(4);
 
     await input.press("i");
     await page.waitForChanges();
@@ -131,7 +131,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(false);
     expect(await items[3].isVisible()).toBe(true);
 
-    expect(await filterEventSpy.lastEvent.detail.visibleItems.length).toBe(3);
+    expect(await filterEventSpy.lastEvent.currentTarget.visibleItems.length).toBe(3);
 
     await input.press("n");
     await page.waitForChanges();
@@ -142,7 +142,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(false);
     expect(await items[3].isVisible()).toBe(false);
 
-    expect(await filterEventSpy.lastEvent.detail.visibleItems.length).toBe(2);
+    expect(await filterEventSpy.lastEvent.currentTarget.visibleItems.length).toBe(2);
   });
 
   it("should control max items displayed", async () => {
@@ -463,7 +463,7 @@ describe("calcite-combobox", () => {
       const label = await page.find("calcite-combobox >>> .label");
 
       expect(label.textContent).toBe("K");
-      expect(eventSpy.lastEvent.detail.selectedItems.length).toBe(1);
+      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(1);
       expect(await item.getProperty("selected")).toBe(true);
     });
 
@@ -492,7 +492,7 @@ describe("calcite-combobox", () => {
       const label = await page.find("calcite-combobox >>> .label");
 
       expect(label.textContent).toBe("K");
-      expect(eventSpy.lastEvent.detail.selectedItems.length).toBe(1);
+      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(1);
       expect(await item1.getProperty("selected")).toBe(false);
       expect(await item2.getProperty("selected")).toBe(true);
     });
@@ -522,7 +522,7 @@ describe("calcite-combobox", () => {
       const item3 = await page.find("calcite-combobox-item:last-child");
       const chips = await page.findAll("calcite-combobox >>> calcite-chip");
 
-      expect(eventSpy.lastEvent.detail.selectedItems.length).toBe(3);
+      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(3);
       expect(chips[2].textContent).toBe("K");
       expect(await item1.getProperty("selected")).toBe(true);
       expect(await item2.getProperty("selected")).toBe(true);
@@ -773,7 +773,7 @@ describe("calcite-combobox", () => {
       await event;
 
       expect(eventSpy).toHaveReceivedEventTimes(1);
-      expect(eventSpy.lastEvent.detail.selectedItems.length).toBe(1);
+      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(1);
     });
 
     it("should have 2 selectedItems when not in single select", async () => {
@@ -800,7 +800,7 @@ describe("calcite-combobox", () => {
       await event;
 
       expect(eventSpy).toHaveReceivedEventTimes(1);
-      expect(eventSpy.lastEvent.detail.selectedItems.length).toBe(2);
+      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(2);
     });
   });
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -120,7 +120,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(true);
     expect(await items[3].isVisible()).toBe(true);
 
-    expect(await filterEventSpy.lastEvent.currentTarget.visibleItems.length).toBe(4);
+    expect((await combobox.getProperty("visibleItems")).length).toBe(4);
 
     await input.press("i");
     await page.waitForChanges();
@@ -131,7 +131,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(false);
     expect(await items[3].isVisible()).toBe(true);
 
-    expect(await filterEventSpy.lastEvent.currentTarget.visibleItems.length).toBe(3);
+    expect((await combobox.getProperty("visibleItems")).length).toBe(3);
 
     await input.press("n");
     await page.waitForChanges();
@@ -142,7 +142,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(false);
     expect(await items[3].isVisible()).toBe(false);
 
-    expect(await filterEventSpy.lastEvent.currentTarget.visibleItems.length).toBe(2);
+    expect((await combobox.getProperty("visibleItems")).length).toBe(2);
   });
 
   it("should control max items displayed", async () => {
@@ -450,7 +450,6 @@ describe("calcite-combobox", () => {
           </calcite-combobox>
         `
       );
-      const eventSpy = await page.spyOnEvent("calciteComboboxChange");
       const input = await page.find("calcite-combobox >>> input");
 
       await input.click();
@@ -463,7 +462,10 @@ describe("calcite-combobox", () => {
       const label = await page.find("calcite-combobox >>> .label");
 
       expect(label.textContent).toBe("K");
-      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(1);
+
+      const combobox = await page.find("calcite-combobox");
+
+      expect((await combobox.getProperty("selectedItems")).length).toBe(1);
       expect(await item.getProperty("selected")).toBe(true);
     });
 
@@ -478,7 +480,7 @@ describe("calcite-combobox", () => {
           </calcite-combobox>
         `
       );
-      const eventSpy = await page.spyOnEvent("calciteComboboxChange");
+      const combobox = await page.find("calcite-combobox");
       const input = await page.find("calcite-combobox >>> input");
 
       await input.click();
@@ -492,7 +494,7 @@ describe("calcite-combobox", () => {
       const label = await page.find("calcite-combobox >>> .label");
 
       expect(label.textContent).toBe("K");
-      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(1);
+      expect((await combobox.getProperty("selectedItems")).length).toBe(1);
       expect(await item1.getProperty("selected")).toBe(false);
       expect(await item2.getProperty("selected")).toBe(true);
     });
@@ -508,7 +510,7 @@ describe("calcite-combobox", () => {
           </calcite-combobox>
         `
       );
-      const eventSpy = await page.spyOnEvent("calciteComboboxChange");
+      const combobox = await page.find("calcite-combobox");
       const input = await page.find("calcite-combobox >>> input");
 
       await input.click();
@@ -522,7 +524,7 @@ describe("calcite-combobox", () => {
       const item3 = await page.find("calcite-combobox-item:last-child");
       const chips = await page.findAll("calcite-combobox >>> calcite-chip");
 
-      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(3);
+      expect((await combobox.getProperty("selectedItems")).length).toBe(3);
       expect(chips[2].textContent).toBe("K");
       expect(await item1.getProperty("selected")).toBe(true);
       expect(await item2.getProperty("selected")).toBe(true);
@@ -772,8 +774,10 @@ describe("calcite-combobox", () => {
       await two.click();
       await event;
 
+      const combobox = await page.find("calcite-combobox");
+
       expect(eventSpy).toHaveReceivedEventTimes(1);
-      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(1);
+      expect((await combobox.getProperty("selectedItems")).length).toBe(1);
     });
 
     it("should have 2 selectedItems when not in single select", async () => {
@@ -800,7 +804,7 @@ describe("calcite-combobox", () => {
       await event;
 
       expect(eventSpy).toHaveReceivedEventTimes(1);
-      expect(eventSpy.lastEvent.currentTarget.selectedItems.length).toBe(2);
+      expect((await element.getProperty("selectedItems")).length).toBe(2);
     });
   });
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -120,7 +120,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(true);
     expect(await items[3].isVisible()).toBe(true);
 
-    expect((await combobox.getProperty("visibleItems")).length).toBe(4);
+    expect((await combobox.getProperty("filteredItems")).length).toBe(4);
 
     await input.press("i");
     await page.waitForChanges();
@@ -131,7 +131,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(false);
     expect(await items[3].isVisible()).toBe(true);
 
-    expect((await combobox.getProperty("visibleItems")).length).toBe(3);
+    expect((await combobox.getProperty("filteredItems")).length).toBe(3);
 
     await input.press("n");
     await page.waitForChanges();
@@ -142,7 +142,7 @@ describe("calcite-combobox", () => {
     expect(await items[2].isVisible()).toBe(false);
     expect(await items[3].isVisible()).toBe(false);
 
-    expect((await combobox.getProperty("visibleItems")).length).toBe(2);
+    expect((await combobox.getProperty("filteredItems")).length).toBe(2);
   });
 
   it("should control max items displayed", async () => {

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -220,6 +220,27 @@ export class Combobox
     this.reposition(true);
   }
 
+  /**
+   * Specifies the component's selected items.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) selectedItems: HTMLCalciteComboboxItemElement[] = [];
+
+  @Watch("selectedItems")
+  selectedItemsHandler(): void {
+    this.internalValueChangeFlag = true;
+    this.value = this.getValue();
+    this.internalValueChangeFlag = false;
+  }
+
+  /**
+   * Specifies the component's visible items.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) visibleItems: HTMLCalciteComboboxItemElement[] = [];
+
   //--------------------------------------------------------------------------
   //
   //  Event Listeners
@@ -295,15 +316,10 @@ export class Combobox
   /**
    * Fires when the selected item(s) changes.
    */
-  @Event({ cancelable: false }) calciteComboboxChange: EventEmitter<{
-    selectedItems: HTMLCalciteComboboxItemElement[];
-  }>;
+  @Event({ cancelable: false }) calciteComboboxChange: EventEmitter<void>;
 
   /** Fires when text is added to filter the options list. */
-  @Event({ cancelable: false }) calciteComboboxFilterChange: EventEmitter<{
-    visibleItems: HTMLCalciteComboboxItemElement[];
-    text: string;
-  }>;
+  @Event({ cancelable: false }) calciteComboboxFilterChange: EventEmitter<void>;
 
   /**
    * Fires when a selected item in the component is dismissed via its `calcite-chip`.
@@ -393,17 +409,6 @@ export class Combobox
   @State() items: HTMLCalciteComboboxItemElement[] = [];
 
   @State() groupItems: HTMLCalciteComboboxItemGroupElement[] = [];
-
-  @State() selectedItems: HTMLCalciteComboboxItemElement[] = [];
-
-  @Watch("selectedItems")
-  selectedItemsHandler(): void {
-    this.internalValueChangeFlag = true;
-    this.value = this.getValue();
-    this.internalValueChangeFlag = false;
-  }
-
-  @State() visibleItems: HTMLCalciteComboboxItemElement[] = [];
 
   @State() needsIcon: boolean;
 
@@ -761,13 +766,12 @@ export class Combobox
       });
 
       this.visibleItems = this.getVisibleItems();
-      this.calciteComboboxFilterChange.emit({ visibleItems: [...this.visibleItems], text: text });
+      this.calciteComboboxFilterChange.emit();
     }, 100);
   })();
 
   internalComboboxChangeEvent = (): void => {
-    const { selectedItems } = this;
-    this.calciteComboboxChange.emit({ selectedItems });
+    this.calciteComboboxChange.emit();
   };
 
   private emitComboboxChange = debounce(this.internalComboboxChangeEvent, 0);

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -235,11 +235,11 @@ export class Combobox
   }
 
   /**
-   * Specifies the component's visible items.
+   * Specifies the component's filtered items.
    *
    * @readonly
    */
-  @Prop({ mutable: true }) visibleItems: HTMLCalciteComboboxItemElement[] = [];
+  @Prop({ mutable: true }) filteredItems: HTMLCalciteComboboxItemElement[] = [];
 
   //--------------------------------------------------------------------------
   //
@@ -263,7 +263,7 @@ export class Combobox
     }
 
     const target = event.target as HTMLCalciteComboboxItemElement;
-    const newIndex = this.visibleItems.indexOf(target);
+    const newIndex = this.filteredItems.indexOf(target);
     this.updateActiveItemIndex(newIndex);
     this.toggleSelection(target, target.selected);
   }
@@ -546,7 +546,7 @@ export class Combobox
           return;
         }
         event.preventDefault();
-        this.updateActiveItemIndex(this.visibleItems.length - 1);
+        this.updateActiveItemIndex(this.filteredItems.length - 1);
         this.scrollToActiveItem();
         if (!this.comboboxInViewport()) {
           this.el.scrollIntoView();
@@ -558,7 +558,7 @@ export class Combobox
         break;
       case "Enter":
         if (this.activeItemIndex > -1) {
-          this.toggleSelection(this.visibleItems[this.activeItemIndex]);
+          this.toggleSelection(this.filteredItems[this.activeItemIndex]);
           event.preventDefault();
         } else if (this.activeChipIndex > -1) {
           this.removeActiveChip();
@@ -765,7 +765,7 @@ export class Combobox
         }
       });
 
-      this.visibleItems = this.getVisibleItems();
+      this.filteredItems = this.getfilteredItems();
       this.calciteComboboxFilterChange.emit();
     }, 100);
   })();
@@ -824,7 +824,7 @@ export class Combobox
     }
   }
 
-  getVisibleItems(): HTMLCalciteComboboxItemElement[] {
+  getfilteredItems(): HTMLCalciteComboboxItemElement[] {
     return this.items.filter((item) => !item.hidden);
   }
 
@@ -857,7 +857,7 @@ export class Combobox
     this.groupItems = this.getGroupItems();
     this.data = this.getData();
     this.selectedItems = this.getSelectedItems();
-    this.visibleItems = this.getVisibleItems();
+    this.filteredItems = this.getfilteredItems();
     this.needsIcon = this.getNeedsIcon();
     if (!this.allowCustomValues) {
       this.setMaxScrollerHeight();
@@ -964,7 +964,7 @@ export class Combobox
   }
 
   private scrollToActiveItem = (): void => {
-    const activeItem = this.visibleItems[this.activeItemIndex];
+    const activeItem = this.filteredItems[this.activeItemIndex];
     const height = this.calculateSingleItemHeight(activeItem);
     const { offsetHeight, scrollTop } = this.listContainerEl;
     if (offsetHeight + scrollTop < activeItem.offsetTop + height) {
@@ -975,7 +975,7 @@ export class Combobox
   };
 
   shiftActiveItemIndex(delta: number): void {
-    const { length } = this.visibleItems;
+    const { length } = this.filteredItems;
     const newIndex = (this.activeItemIndex + length + delta) % length;
     this.updateActiveItemIndex(newIndex);
     this.scrollToActiveItem();
@@ -984,7 +984,7 @@ export class Combobox
   updateActiveItemIndex(index: number): void {
     this.activeItemIndex = index;
     let activeDescendant: string = null;
-    this.visibleItems.forEach((el, i) => {
+    this.filteredItems.forEach((el, i) => {
       if (i === index) {
         el.active = true;
         activeDescendant = `${itemUidPrefix}${el.guid}`;
@@ -1095,7 +1095,7 @@ export class Combobox
   }
 
   renderListBoxOptions(): VNode[] {
-    return this.visibleItems.map((item) => (
+    return this.filteredItems.map((item) => (
       <li
         aria-selected={toAriaBoolean(item.selected)}
         id={item.guid ? `${itemUidPrefix}${item.guid}` : null}


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from events and added properties `selectedItems` and `filteredItems`.

- Removed the `event.detail` property on the event `calciteComboboxChange`, use `event.target.selectedItems` instead.
- Removed the `event.detail` property on the event `calciteComboboxFilterChange`, use `event.target.filteredItems` or `event.target.value`   instead.