### PR TITLE
refactor(date-picker)!: remove `event.detail` payload from events

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -22,7 +22,6 @@ import {
 } from "../../utils/date";
 import { HeadingLevel } from "../functional/Heading";
 
-import { DateRangeChange } from "./interfaces";
 import { TEXT } from "./resources";
 import {
   connectLocalized,
@@ -194,14 +193,14 @@ export class DatePicker implements LocalizedComponent {
   /**
    * Emits when a user changes the component's date. For `range` events, use `calciteDatePickerRangeChange`.
    */
-  @Event({ cancelable: false }) calciteDatePickerChange: EventEmitter<Date>;
+  @Event({ cancelable: false }) calciteDatePickerChange: EventEmitter<void>;
 
   /**
    * Emits when a user changes the component's date `range`. For components without `range` use `calciteDatePickerChange`.
    *
    * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/date-picker/interfaces.ts#L1)
    */
-  @Event({ cancelable: false }) calciteDatePickerRangeChange: EventEmitter<DateRangeChange>;
+  @Event({ cancelable: false }) calciteDatePickerRangeChange: EventEmitter<void>;
 
   /**
    * Active start date.
@@ -518,10 +517,7 @@ export class DatePicker implements LocalizedComponent {
     this.startAsDate = startDate;
     this.mostRecentRangeValue = this.startAsDate;
     if (emit) {
-      this.calciteDatePickerRangeChange.emit({
-        startDate,
-        endDate: this.endAsDate
-      });
+      this.calciteDatePickerRangeChange.emit();
     }
   }
 
@@ -535,10 +531,7 @@ export class DatePicker implements LocalizedComponent {
     this.endAsDate = endDate ? setEndOfDay(endDate) : endDate;
     this.mostRecentRangeValue = this.endAsDate;
     if (emit) {
-      this.calciteDatePickerRangeChange.emit({
-        startDate: this.startAsDate,
-        endDate
-      });
+      this.calciteDatePickerRangeChange.emit();
     }
   }
 
@@ -590,7 +583,7 @@ export class DatePicker implements LocalizedComponent {
       this.value = isoDate || "";
       this.valueAsDate = date || null;
       this.activeDate = date || null;
-      this.calciteDatePickerChange.emit(date);
+      this.calciteDatePickerChange.emit();
       return;
     }
 
@@ -631,7 +624,7 @@ export class DatePicker implements LocalizedComponent {
         this.endAsDate = this.activeEndDate = this.end = undefined;
       }
     }
-    this.calciteDatePickerChange.emit(date);
+    this.calciteDatePickerChange.emit();
   };
 
   /**

--- a/src/components/date-picker/interfaces.d.ts
+++ b/src/components/date-picker/interfaces.d.ts
@@ -1,0 +1,5 @@
+// @deprecated remove this file before 1.0
+export interface DateRangeChange {
+  startDate: Date;
+  endDate: Date;
+}

--- a/src/components/date-picker/interfaces.ts
+++ b/src/components/date-picker/interfaces.ts
@@ -1,4 +1,0 @@
-export interface DateRangeChange {
-  startDate: Date;
-  endDate: Date;
-}

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -861,14 +861,14 @@ export class InputDatePicker
    *
    * @param event CalciteDatePicker custom change event
    */
-  handleDateChange = (event: CustomEvent<Date>): void => {
+  handleDateChange = (event: CustomEvent<void>): void => {
     if (this.range) {
       return;
     }
 
     event.stopPropagation();
 
-    this.setValue(event.detail);
+    this.setValue((event.target as HTMLCalciteDatePickerElement).valueAsDate as Date);
     this.localizeInputValues();
   };
 
@@ -890,16 +890,16 @@ export class InputDatePicker
     );
   }
 
-  private handleDateRangeChange = (event: CustomEvent<DateRangeChange>): void => {
-    if (!this.range || !event.detail) {
+  private handleDateRangeChange = (event: CustomEvent<void>): void => {
+    if (!this.range) {
       return;
     }
 
     event.stopPropagation();
 
-    const { startDate, endDate } = event.detail;
+    const value = (event.target as HTMLCalciteDatePickerElement).valueAsDate as Date[];
 
-    this.setRangeValue([startDate, endDate]);
+    this.setRangeValue(value);
     this.localizeInputValues();
 
     if (this.shouldFocusRangeEnd()) {

--- a/src/demos/date-picker.html
+++ b/src/demos/date-picker.html
@@ -125,7 +125,7 @@
             const dateSample = document.getElementById("dateSample");
             const dateDisplay = document.getElementById("dateDisplay");
             dateSample.addEventListener("calciteDatePickerChange", function (e) {
-              dateDisplay.innerHTML = e.detail;
+              dateDisplay.innerHTML = e.target.valueAsDate;
             });
           </script>
         </div>
@@ -140,7 +140,7 @@
             const dateSample_m = document.getElementById("dateSample_m");
             const dateDisplay_m = document.getElementById("dateDisplay_m");
             dateSample_m.addEventListener("calciteDatePickerChange", function (e) {
-              dateDisplay_m.innerHTML = e.detail;
+              dateDisplay_m.innerHTML = e.target.valueAsDate;
             });
           </script>
         </div>
@@ -155,7 +155,7 @@
             const dateSample_l = document.getElementById("dateSample_l");
             const dateDisplay_l = document.getElementById("dateDisplay_l");
             dateSample_l.addEventListener("calciteDatePickerChange", function (e) {
-              dateDisplay_l.innerHTML = e.detail;
+              dateDisplay_l.innerHTML = e.target.valueAsDate;
             });
           </script>
         </div>


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from events.

- Removed the `event.detail` property on the event `calciteDatePickerChange`, use `event.target` instead.
- Removed the `event.detail` property on the event `calciteDatePickerRangeChange`, use `event.target` instead.