### PR TITLE
refactor(dropdown)!: remove `event.detail` payload from events

### DIFF
--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -4,7 +4,6 @@ import dedent from "dedent";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 import { GlobalTestProps } from "../../tests/utils";
-import { Selection } from "./interfaces";
 
 describe("calcite-dropdown", () => {
   it("renders", () =>
@@ -52,11 +51,6 @@ describe("calcite-dropdown", () => {
      * IDs from items to assert selection
      */
     expectedItemIds: string[];
-
-    /**
-     * If testing on the event payload, the most recent ID is used to assert the
-     */
-    mostRecentId?: string;
   }
 
   /**
@@ -67,24 +61,14 @@ describe("calcite-dropdown", () => {
    * @param page
    * @param root0
    * @param root0.expectedItemIds
-   * @param root0.mostRecentId
    */
-  async function assertSelectedItems(
-    page: E2EPage,
-    { expectedItemIds, mostRecentId }: SelectedItemsAssertionOptions
-  ): Promise<void> {
+  async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
     await page.waitForTimeout(100);
     const selectedItemIds = await page.evaluate(() => {
       const dropdown = document.querySelector<HTMLCalciteDropdownElement>("calcite-dropdown");
       return dropdown.selectedItems.map((item) => item.id);
     });
 
-    if (mostRecentId) {
-      const selectedItemId = await page.evaluate(() => {
-        return (window as SelectionEventTestWindow).eventDetail.item.id;
-      });
-      expect(selectedItemId).toBe(mostRecentId);
-    }
     expect(selectedItemIds).toHaveLength(expectedItemIds.length);
 
     expectedItemIds.forEach((itemId, index) => expect(selectedItemIds[index]).toEqual(itemId));
@@ -260,24 +244,21 @@ describe("calcite-dropdown", () => {
     await item1.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-2"],
-      mostRecentId: "item-1"
+      expectedItemIds: ["item-1", "item-2"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item2.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1"],
-      mostRecentId: "item-2"
+      expectedItemIds: ["item-1"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-3"],
-      mostRecentId: "item-3"
+      expectedItemIds: ["item-1", "item-3"]
     });
 
     expect(item1).toHaveAttribute("selected");
@@ -312,16 +293,14 @@ describe("calcite-dropdown", () => {
     await item1.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1"],
-      mostRecentId: "item-1"
+      expectedItemIds: ["item-1"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-3"],
-      mostRecentId: "item-3"
+      expectedItemIds: ["item-3"]
     });
 
     expect(item1).not.toHaveAttribute("selected");
@@ -353,15 +332,15 @@ describe("calcite-dropdown", () => {
     await trigger.click();
     await item1.click();
     await page.waitForChanges();
-    await assertSelectedItems(page, { expectedItemIds: [], mostRecentId: "item-1" });
+    await assertSelectedItems(page, { expectedItemIds: [] });
     await trigger.click();
     await item2.click();
     await page.waitForChanges();
-    await assertSelectedItems(page, { expectedItemIds: [], mostRecentId: "item-2" });
+    await assertSelectedItems(page, { expectedItemIds: [] });
     await trigger.click();
     await item3.click();
     await page.waitForChanges();
-    await assertSelectedItems(page, { expectedItemIds: [], mostRecentId: "item-3" });
+    await assertSelectedItems(page, { expectedItemIds: [] });
 
     expect(item1).not.toHaveAttribute("selected");
     expect(item2).not.toHaveAttribute("selected");
@@ -417,56 +396,49 @@ describe("calcite-dropdown", () => {
     await item1.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-2", "item-5"],
-      mostRecentId: "item-1"
+      expectedItemIds: ["item-1", "item-2", "item-5"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item2.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-5"],
-      mostRecentId: "item-2"
+      expectedItemIds: ["item-1", "item-5"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-3", "item-5"],
-      mostRecentId: "item-3"
+      expectedItemIds: ["item-1", "item-3", "item-5"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item4.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-3", "item-4"],
-      mostRecentId: "item-4"
+      expectedItemIds: ["item-1", "item-3", "item-4"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item6.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-3", "item-6"],
-      mostRecentId: "item-6"
+      expectedItemIds: ["item-1", "item-3", "item-6"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item7.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-3", "item-6"],
-      mostRecentId: "item-7"
+      expectedItemIds: ["item-1", "item-3", "item-6"]
     });
     await trigger.click();
     await page.waitForChanges();
     await item9.click();
     await page.waitForChanges();
     await assertSelectedItems(page, {
-      expectedItemIds: ["item-1", "item-3", "item-6"],
-      mostRecentId: "item-9"
+      expectedItemIds: ["item-1", "item-3", "item-6"]
     });
 
     expect(item1).toHaveAttribute("selected");

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -11,7 +11,7 @@ import {
   VNode,
   Watch
 } from "@stencil/core";
-import { ItemKeyboardEvent, Selection } from "./interfaces";
+import { ItemKeyboardEvent } from "./interfaces";
 
 import { focusElement, isPrimaryPointerButton, toAriaBoolean } from "../../utils/dom";
 import {
@@ -287,7 +287,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   //--------------------------------------------------------------------------
 
   /** Fires when a `calcite-dropdown-item`'s selection changes. */
-  @Event({ cancelable: false }) calciteDropdownSelect: EventEmitter<Selection>;
+  @Event({ cancelable: false }) calciteDropdownSelect: EventEmitter<void>;
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   @Event({ cancelable: false }) calciteDropdownBeforeClose: EventEmitter<void>;
@@ -380,9 +380,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
   handleItemSelect(event: CustomEvent<RequestedItem>): void {
     this.updateSelectedItems();
     event.stopPropagation();
-    this.calciteDropdownSelect.emit({
-      item: event.detail.requestedDropdownItem
-    });
+    this.calciteDropdownSelect.emit();
     if (
       !this.closeOnSelectDisabled ||
       event.detail.requestedDropdownGroup.selectionMode === "none"

--- a/src/components/dropdown/interfaces.ts
+++ b/src/components/dropdown/interfaces.ts
@@ -1,10 +1,3 @@
 export interface ItemKeyboardEvent {
   keyboardEvent: KeyboardEvent;
 }
-
-export interface Selection {
-  /**
-   * The item that caused a selection event to emit.
-   */
-  item: HTMLCalciteDropdownItemElement;
-}


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from events.

- Removed the `event.detail` property on the event `calciteDropdownSelect`, use `event.target` instead.