### PR TITLE
refactor(rating)!: remove `event.detail` payload from events

### DIFF
--- a/src/components/rating/rating.e2e.ts
+++ b/src/components/rating/rating.e2e.ts
@@ -334,15 +334,9 @@ describe("calcite-rating", () => {
     await labels[3].click();
     expect(element).toEqualAttribute("value", "4");
     expect(changeEvent).toHaveReceivedEventTimes(2);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 4
-    });
     await labels[3].click();
     expect(element).toEqualAttribute("value", "0");
     expect(changeEvent).toHaveReceivedEventTimes(3);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 0
-    });
   });
 
   it("can be edited with keyboard like a set of radio inputs", async () => {

--- a/src/components/rating/rating.e2e.ts
+++ b/src/components/rating/rating.e2e.ts
@@ -331,9 +331,6 @@ describe("calcite-rating", () => {
     await labels[0].click();
     expect(element).toEqualAttribute("value", "1");
     expect(changeEvent).toHaveReceivedEventTimes(1);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 1
-    });
     await labels[3].click();
     expect(element).toEqualAttribute("value", "4");
     expect(changeEvent).toHaveReceivedEventTimes(2);
@@ -358,46 +355,22 @@ describe("calcite-rating", () => {
     expect(changeEvent).toHaveReceivedEventTimes(0);
     await element.press(" ");
     expect(changeEvent).toHaveReceivedEventTimes(1);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 0
-    });
     await page.keyboard.press("ArrowRight");
     expect(changeEvent).toHaveReceivedEventTimes(2);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 2
-    });
     await page.keyboard.press("ArrowLeft");
     expect(changeEvent).toHaveReceivedEventTimes(3);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 1
-    });
     await page.keyboard.press("ArrowLeft");
     expect(changeEvent).toHaveReceivedEventTimes(4);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 5
-    });
     await page.keyboard.press("ArrowRight");
     expect(changeEvent).toHaveReceivedEventTimes(5);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 1
-    });
     await page.keyboard.press("Enter");
     expect(changeEvent).toHaveReceivedEventTimes(6);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 0
-    });
     await labels[3].click();
     expect(element).toEqualAttribute("value", "4");
     expect(changeEvent).toHaveReceivedEventTimes(7);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 4
-    });
     await labels[3].click();
     expect(element).toEqualAttribute("value", "0");
     expect(changeEvent).toHaveReceivedEventTimes(8);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 0
-    });
   });
 
   it("cannot be cleared/reset when required props is set true", async () => {
@@ -415,15 +388,9 @@ describe("calcite-rating", () => {
     await labels[3].click();
     expect(element).toEqualAttribute("value", "4");
     expect(changeEvent).toHaveReceivedEventTimes(1);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 4
-    });
     await labels[3].click();
     expect(element).toEqualAttribute("value", "4");
     expect(changeEvent).toHaveReceivedEventTimes(1);
-    expect(changeEvent).toHaveReceivedEventDetail({
-      value: 4
-    });
   });
 
   it("disables click interaction when readonly is requested", async () => {

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -169,7 +169,7 @@ export class Rating
   /**
    * Fires when the component's value changes.
    */
-  @Event({ cancelable: false }) calciteRatingChange: EventEmitter<{ value: number }>;
+  @Event({ cancelable: false }) calciteRatingChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //
@@ -280,7 +280,7 @@ export class Rating
 
   private updateValue(value: number) {
     this.value = value;
-    this.calciteRatingChange.emit({ value });
+    this.calciteRatingChange.emit();
   }
 
   private onKeyboardPressed = (event: KeyboardEvent): void => {


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from events.

- Removed the `event.detail` property on the event `calciteRatingChange`, use `event.target` instead.