### PR TITLE
refactor(radio-group)!: remove `event.detail` payload from events

### DIFF
--- a/src/components/radio-group/radio-group.e2e.ts
+++ b/src/components/radio-group/radio-group.e2e.ts
@@ -102,7 +102,6 @@ describe("calcite-radio-group", () => {
 
     await first.click();
     expect(eventSpy).toHaveReceivedEventTimes(1);
-    expect(eventSpy).toHaveReceivedEventDetail("1");
     expect(await getSelectedItemValue(page)).toBe("1");
 
     // does not emit from programmatic changes
@@ -113,7 +112,6 @@ describe("calcite-radio-group", () => {
 
     await second.click();
     expect(eventSpy).toHaveReceivedEventTimes(2);
-    expect(eventSpy).toHaveReceivedEventDetail("2");
     expect(await getSelectedItemValue(page)).toBe("2");
   });
 

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -250,7 +250,7 @@ export class RadioGroup
   //--------------------------------------------------------------------------
 
   /** Fires when the selected option changes, where the event detail is the new value. */
-  @Event({ cancelable: false }) calciteRadioGroupChange: EventEmitter<string>;
+  @Event({ cancelable: false }) calciteRadioGroupChange: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //
@@ -313,7 +313,7 @@ export class RadioGroup
         match = item;
 
         if (emit) {
-          this.calciteRadioGroupChange.emit(match.value);
+          this.calciteRadioGroupChange.emit();
         }
       }
     });


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from events.

- Removed the `event.detail` property on the event `calciteRadioGroupChange`, use `event.target` instead.