### PR TITLE
refactor(tree)!: remove `event.detail` payload from events

### DIFF
--- a/src/components/tree/interfaces.ts
+++ b/src/components/tree/interfaces.ts
@@ -1,5 +1,1 @@
-export interface TreeSelectDetail {
-  selected: HTMLCalciteTreeItemElement[];
-}
-
 export type TreeSelectionMode = "single" | "multi" | "none" | "children" | "multichildren" | "ancestors" | "multiple";

--- a/src/components/tree/tree.e2e.ts
+++ b/src/components/tree/tree.e2e.ts
@@ -298,35 +298,25 @@ describe("calcite-tree", () => {
           </calcite-tree>`
         });
 
+        const tree = await page.find("calcite-tree");
+
         const [item1, item2] = await page.findAll("calcite-tree-item");
 
-        type TestWindow = GlobalTestProps<{
-          selectedIds: string[];
-        }>;
-
-        await page.evaluateHandle(() =>
-          document.addEventListener("calciteTreeSelect", ({ detail }: CustomEvent) => {
-            (window as TestWindow).selectedIds = detail.selected.map((item) => item.id);
-          })
-        );
-
-        const getSelectedIds = async (): Promise<any> => page.evaluate(() => (window as TestWindow).selectedIds);
-
         await item1.click();
 
-        expect(await getSelectedIds()).toEqual(["1"]);
+        expect(await tree.getProperty("selectedItems")).toEqual(["1"]);
 
         await item2.click();
 
-        expect(await getSelectedIds()).toEqual(["1", "2"]);
+        expect(await tree.getProperty("selectedItems")).toEqual(["1", "2"]);
 
         await item2.click();
 
-        expect(await getSelectedIds()).toEqual(["1"]);
+        expect(await tree.getProperty("selectedItems")).toEqual(["1"]);
 
         await item1.click();
 
-        expect(await getSelectedIds()).toEqual([]);
+        expect(await tree.getProperty("selectedItems")).toEqual([]);
       });
 
       it("contains current selection when selection=multichildren", async () => {
@@ -344,35 +334,25 @@ describe("calcite-tree", () => {
           </calcite-tree>`
         );
 
+        const tree = await page.find("calcite-tree");
+
         const [item1, item2, item3, item4] = await page.findAll("calcite-tree-item");
-
-        type TestWindow = GlobalTestProps<{
-          selectedIds: string[];
-        }>;
-
-        await page.evaluateHandle(() =>
-          document.addEventListener("calciteTreeSelect", ({ detail }: CustomEvent) => {
-            (window as TestWindow).selectedIds = detail.selected.map((item) => item.id);
-          })
-        );
-
-        const getSelectedIds = async (): Promise<any> => page.evaluate(() => (window as TestWindow).selectedIds);
 
         await item1.click();
 
-        expect(await getSelectedIds()).toEqual(["1"]);
+        expect(tree.getProperty("selectedItems")).toEqual(["1"]);
 
         await item2.click();
 
-        expect(await getSelectedIds()).toEqual(["1", "2", "4"]);
+        expect(tree.getProperty("selectedItems")).toEqual(["1", "2", "4"]);
 
         await item3.click();
 
-        expect(await getSelectedIds()).toEqual(["1", "2", "4"]);
+        expect(tree.getProperty("selectedItems")).toEqual(["1", "2", "4"]);
 
         await item4.click();
 
-        expect(await getSelectedIds()).toEqual(["1", "2"]);
+        expect(tree.getProperty("selectedItems")).toEqual(["1", "2"]);
       });
     });
 
@@ -421,30 +401,18 @@ describe("calcite-tree", () => {
           </calcite-tree>
         `);
 
-        type TestWindow = GlobalTestProps<{
-          selectedIds: string[];
-        }>;
-
-        await page.evaluateHandle(() =>
-          document.addEventListener("calciteTreeSelect", ({ detail }: CustomEvent) => {
-            (window as TestWindow).selectedIds = detail.selected.map((item) => item.id);
-          })
-        );
-
-        const getSelectedIds = async (): Promise<any> => page.evaluate(() => (window as TestWindow).selectedIds);
-
         const tree = await page.find(`calcite-tree`);
         const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
         const [item1, item2] = await page.findAll(`calcite-tree-item`);
 
         await item1.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(1);
-        expect(await getSelectedIds()).toEqual(["1"]);
+        expect(tree.getProperty("selectedItems")).toEqual(["1"]);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
 
         await item2.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(2);
-        expect(await getSelectedIds()).toEqual(["2"]);
+        expect(tree.getProperty("selectedItems")).toEqual(["2"]);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
       });
     });

--- a/src/components/tree/tree.e2e.ts
+++ b/src/components/tree/tree.e2e.ts
@@ -304,15 +304,15 @@ describe("calcite-tree", () => {
 
         await item1.click();
 
-        expect(await tree.getProperty("selectedItems")).toEqual(["1"]);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
 
         await item2.click();
 
-        expect(await tree.getProperty("selectedItems")).toEqual(["1", "2"]);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(2);
 
         await item2.click();
 
-        expect(await tree.getProperty("selectedItems")).toEqual(["1"]);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
 
         await item1.click();
 
@@ -340,19 +340,19 @@ describe("calcite-tree", () => {
 
         await item1.click();
 
-        expect(tree.getProperty("selectedItems")).toEqual(["1"]);
+        expect(tree.getProperty("selectedItems")).toHaveLength(1);
 
         await item2.click();
 
-        expect(tree.getProperty("selectedItems")).toEqual(["1", "2", "4"]);
+        expect(tree.getProperty("selectedItems")).toHaveLength(3);
 
         await item3.click();
 
-        expect(tree.getProperty("selectedItems")).toEqual(["1", "2", "4"]);
+        expect(tree.getProperty("selectedItems")).toHaveLength(3);
 
         await item4.click();
 
-        expect(tree.getProperty("selectedItems")).toEqual(["1", "2"]);
+        expect(tree.getProperty("selectedItems")).toHaveLength(2);
       });
     });
 
@@ -407,12 +407,12 @@ describe("calcite-tree", () => {
 
         await item1.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(1);
-        expect(tree.getProperty("selectedItems")).toEqual(["1"]);
+        expect(tree.getProperty("selectedItems")).toHaveLength(1);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
 
         await item2.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(2);
-        expect(tree.getProperty("selectedItems")).toEqual(["2"]);
+        expect(tree.getProperty("selectedItems")).toHaveLength(1);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
       });
     });

--- a/src/components/tree/tree.e2e.ts
+++ b/src/components/tree/tree.e2e.ts
@@ -340,19 +340,19 @@ describe("calcite-tree", () => {
 
         await item1.click();
 
-        expect(tree.getProperty("selectedItems")).toHaveLength(1);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
 
         await item2.click();
 
-        expect(tree.getProperty("selectedItems")).toHaveLength(3);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(3);
 
         await item3.click();
 
-        expect(tree.getProperty("selectedItems")).toHaveLength(3);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(3);
 
         await item4.click();
 
-        expect(tree.getProperty("selectedItems")).toHaveLength(2);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(2);
       });
     });
 
@@ -407,12 +407,12 @@ describe("calcite-tree", () => {
 
         await item1.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(1);
-        expect(tree.getProperty("selectedItems")).toHaveLength(1);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
 
         await item2.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(2);
-        expect(tree.getProperty("selectedItems")).toHaveLength(1);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
       });
     });

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -11,7 +11,7 @@ import {
 } from "@stencil/core";
 import { focusElement, getRootNode, nodeListToArray } from "../../utils/dom";
 import { TreeItemSelectDetail } from "../tree-item/interfaces";
-import { TreeSelectDetail, TreeSelectionMode } from "./interfaces";
+import { TreeSelectionMode } from "./interfaces";
 import { Scale } from "../interfaces";
 import { getEnabledSiblingItem } from "./utils";
 
@@ -56,6 +56,13 @@ export class Tree {
    * @see [TreeSelectionMode](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L5)
    */
   @Prop({ mutable: true, reflect: true }) selectionMode: TreeSelectionMode = "single";
+
+  /**
+   * Specifies the component's selected items.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) selectedItems: HTMLCalciteTreeItemElement[] = [];
 
   //--------------------------------------------------------------------------
   //
@@ -228,13 +235,13 @@ export class Tree {
       }
     }
 
-    const selected = isNoneSelectionMode
+    this.selectedItems = isNoneSelectionMode
       ? [target]
       : (nodeListToArray(this.el.querySelectorAll("calcite-tree-item")).filter(
           (i) => i.selected
         ) as HTMLCalciteTreeItemElement[]);
 
-    this.calciteTreeSelect.emit({ selected });
+    this.calciteTreeSelect.emit();
 
     event.stopPropagation();
   }
@@ -373,13 +380,11 @@ export class Tree {
       ancestor.selected = !indeterminate;
     });
 
-    this.calciteTreeSelect.emit({
-      selected: (
-        nodeListToArray(
-          this.el.querySelectorAll("calcite-tree-item")
-        ) as HTMLCalciteTreeItemElement[]
-      ).filter((i) => i.selected)
-    });
+    this.selectedItems = (
+      nodeListToArray(this.el.querySelectorAll("calcite-tree-item")) as HTMLCalciteTreeItemElement[]
+    ).filter((i) => i.selected);
+
+    this.calciteTreeSelect.emit();
   }
   //--------------------------------------------------------------------------
   //
@@ -388,11 +393,9 @@ export class Tree {
   //--------------------------------------------------------------------------
 
   /**
-   * Fires when the user selects/deselects `calcite-tree-items`. An object including an array of selected items will be passed in the event's `detail` property.
-   *
-   * @see [TreeSelectDetail](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L1)
+   * Fires when the user selects/deselects `calcite-tree-items`.
    */
-  @Event({ cancelable: false }) calciteTreeSelect: EventEmitter<TreeSelectDetail>;
+  @Event({ cancelable: false }) calciteTreeSelect: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/src/demos/tree.html
+++ b/src/demos/tree.html
@@ -503,8 +503,8 @@
             const tree_small = document.getElementById("tree-events-demo-tree-small");
             const result_small = document.getElementById("tree-events-demo-result-small");
             tree_small.addEventListener("calciteTreeSelect", function (e) {
-              console.log(e.detail.selected);
-              result_small.textContent = e.detail.selected.length + " Selected";
+              console.log(e.target.selectedItems);
+              result_small.textContent = e.target.selectedItems.length + " Selected";
             });
           })();
 
@@ -512,8 +512,8 @@
             const tree_medium = document.getElementById("tree-events-demo-tree-medium");
             const result_medium = document.getElementById("tree-events-demo-result-medium");
             tree_medium.addEventListener("calciteTreeSelect", function (e) {
-              console.log(e.detail.selected);
-              result_medium.textContent = e.detail.selected.length + " Selected";
+              console.log(e.target.selectedItems);
+              result_medium.textContent = e.target.selectedItems.length + " Selected";
             });
           })();
         </script>


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from events and added `selectedItems` property.

- Added property `selectedItems`.
- Removed the `event.detail` property on the event `calciteTreeSelect`, use `event.target` instead.