### PR TITLE
refactor(chip)!: Renamed property and updated values

### DIFF
--- a/src/05-custom-theme.stories.mdx
+++ b/src/05-custom-theme.stories.mdx
@@ -153,18 +153,14 @@ export const Template = () =>
           </label>
         </div>
         <div>
-          <calcite-chip>Grey</calcite-chip>
-          <calcite-chip color="red">Red</calcite-chip>
-          <calcite-chip color="yellow">Yellow</calcite-chip>
-          <calcite-chip color="green">Green</calcite-chip>
-          <calcite-chip color="blue">Blue</calcite-chip>
+          <calcite-chip>Neutral</calcite-chip>
+          <calcite-chip kind="inverse">Inverse</calcite-chip>
+          <calcite-chip kind="brand">Brand</calcite-chip>
         </div>
         <div>
-          <calcite-chip appearance="transparent">Grey</calcite-chip>
-          <calcite-chip appearance="transparent" color="red">Red</calcite-chip>
-          <calcite-chip appearance="transparent" color="yellow">Yellow</calcite-chip>
-          <calcite-chip appearance="transparent" color="green">Green</calcite-chip>
-          <calcite-chip appearance="transparent" color="blue">Red</calcite-chip>
+          <calcite-chip appearance="transparent">Neutral</calcite-chip>
+          <calcite-chip appearance="transparent" kind="inverse">Inverse</calcite-chip>
+          <calcite-chip appearance="outline-fill" kind="brand">Brand</calcite-chip>
         </div>
         <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
         <calcite-slider

--- a/src/components/chip/chip.e2e.ts
+++ b/src/components/chip/chip.e2e.ts
@@ -31,27 +31,27 @@ describe("calcite-chip", () => {
 
     const element = await page.find("calcite-chip");
     expect(element).toEqualAttribute("appearance", "solid");
-    expect(element).toEqualAttribute("color", "grey");
+    expect(element).toEqualAttribute("kind", "neutral");
     expect(element).toEqualAttribute("scale", "m");
   });
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip appearance="transparent" color="blue" scale="l">Chip content</calcite-chip>`);
+    await page.setContent(`<calcite-chip appearance="outline" kind="brand" scale="l">Chip content</calcite-chip>`);
 
     const element = await page.find("calcite-chip");
-    expect(element).toEqualAttribute("appearance", "transparent");
-    expect(element).toEqualAttribute("color", "blue");
+    expect(element).toEqualAttribute("appearance", "outline");
+    expect(element).toEqualAttribute("kind", "brand");
     expect(element).toEqualAttribute("scale", "l");
   });
 
-  it("renders transparent chip when appearance='transparent'", async () => {
+  it("renders outline-fill chip when appearance='outline-fill'", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip appearance="transparent" color="blue" scale="l">Chip content</calcite-chip>`);
+    await page.setContent(`<calcite-chip appearance="outline-fill" kind="brand" scale="l">Chip content</calcite-chip>`);
 
     const element = await page.find("calcite-chip");
-    expect(element).toEqualAttribute("appearance", "transparent");
-    expect(element).toEqualAttribute("color", "blue");
+    expect(element).toEqualAttribute("appearance", "outline-fill");
+    expect(element).toEqualAttribute("kind", "brand");
     expect(element).toEqualAttribute("scale", "l");
   });
 
@@ -84,8 +84,8 @@ describe("calcite-chip", () => {
       <calcite-chip
         class="layers"
         icon="layer"
-        appearance="transparent"
-        color="green"
+        appearance="solid"
+        kind="neutral"
         closable
       >
         Layers

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -6,16 +6,16 @@
   --calcite-chip-spacing-unit-s: theme("spacing.1");
   .image-container {
     @apply h-5 w-5;
-    padding-inline-start: 1px;
+    padding-inline-start: theme("spacing[0.5]");
   }
 }
 :host([scale="m"]) {
   @apply text-n1 h-8;
   --calcite-chip-spacing-unit-l: theme("spacing.3");
-  --calcite-chip-spacing-unit-s: 6px;
+  --calcite-chip-spacing-unit-s: calc(theme("spacing.3") / 2);
   .image-container {
     @apply h-6 w-6;
-    padding-inline-start: theme("padding.1");
+    padding-inline-start: theme("spacing.1");
   }
 }
 
@@ -55,31 +55,67 @@
   padding-inline: var(--calcite-chip-spacing-unit-l);
 }
 
-:host([icon]) .content--slotted .title {
-  padding-inline: var(--calcite-chip-spacing-unit-l);
+:host([closable][icon]) .container:not(.content--slotted) .title {
+  padding-inline: 0 var(--calcite-chip-spacing-unit-s);
+}
+
+:host(:not([closable])) .container:not(.content--slotted) .chip-icon {
+  margin-inline: auto;
+}
+
+:host([scale="s"][closable]) .container:not(.content--slotted) .image-container {
+  margin-inline-end: theme("spacing[0.5]");
+}
+
+:host([scale="m"][closable]) .container:not(.content--slotted) .image-container {
+  margin-inline-end: theme("spacing.1");
+}
+
+:host([scale="l"][closable]) .container:not(.content--slotted) .image-container {
+  margin-inline-end: theme("spacing.2");
+}
+
+:host([scale="s"]:not([closable])) .container:not(.content--slotted) {
+  @apply w-6 h-6;
+  & .image-container {
+    padding-inline: theme("spacing[0.5]");
+  }
+}
+
+:host([scale="m"]:not([closable])) .container:not(.content--slotted) {
+  @apply w-8 h-8;
+  & .image-container {
+    padding-inline: theme("spacing.1");
+  }
+}
+
+:host([scale="l"]:not([closable])) .container:not(.content--slotted) {
+  @apply w-11 h-11;
+  & .image-container {
+    padding-inline: calc(theme("spacing.3") / 2);
+  }
 }
 
 :host([closable]) .content--slotted .title {
   padding-inline: var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s);
 }
 
-:host([closable][icon]) .container:not(.content--slotted) .title {
-  padding-inline: 0 var(--calcite-chip-spacing-unit-s);
+:host([scale="s"]) button {
+  inline-size: theme("spacing.4");
+  block-size: theme("spacing.4");
+  margin-inline-end: theme("spacing[0.5]");
 }
 
-:host([icon]:not([closable])) .container:not(.content--slotted) .chip-icon {
-  margin-block: 0;
-  margin-inline: auto;
+:host([scale="m"]) button {
+  inline-size: theme("spacing.6");
+  block-size: theme("spacing.6");
+  margin-inline-end: theme("spacing.1");
 }
 
-:host([scale="s"][icon]:not([closable])) .container:not(.content--slotted) {
-  @apply w-6 h-6;
-}
-:host([scale="m"][icon]:not([closable])) .container:not(.content--slotted) {
-  @apply w-8 h-8;
-}
-:host([scale="l"][icon]:not([closable])) .container:not(.content--slotted) {
-  @apply w-11 h-11;
+:host([scale="l"]) button {
+  inline-size: theme("spacing.8");
+  block-size: theme("spacing.8");
+  margin-inline-end: theme("spacing.2");
 }
 
 :host button {
@@ -99,7 +135,6 @@
   align-content: center;
   justify-content: center;
 
-  // close button focus styles
   --calcite-chip-transparent-hover: var(--calcite-button-transparent-hover);
   --calcite-chip-transparent-press: var(--calcite-button-transparent-press);
   &:hover {
@@ -112,27 +147,6 @@
   &:active {
     background-color: var(--calcite-chip-transparent-press);
   }
-}
-:host([closable]) .content--slotted .title {
-  padding-inline: var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s);
-}
-
-:host([scale="s"]) button {
-  inline-size: 16px;
-  block-size: 16px;
-  margin-inline-end: 2px;
-}
-
-:host([scale="m"]) button {
-  inline-size: 24px;
-  block-size: 24px;
-  margin-inline-end: 4px;
-}
-
-:host([scale="l"]) button {
-  inline-size: 32px;
-  block-size: 32px;
-  margin-inline-end: 8px;
 }
 
 //slotted image

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -6,6 +6,7 @@
   --calcite-chip-spacing-unit-s: theme("spacing.1");
   .image-container {
     @apply h-5 w-5;
+    padding-inline-start: 1px;
   }
 }
 :host([scale="m"]) {
@@ -24,7 +25,7 @@
   --calcite-chip-spacing-unit-s: theme("spacing.2");
   .image-container {
     @apply h-8 w-8;
-    padding-inline-start: theme("spacing.1");
+    padding-inline-start: theme("spacing.2");
   }
 }
 
@@ -45,22 +46,40 @@
   @apply inline-flex h-full max-w-full items-center;
 }
 
-.title {
+:host .title {
   @apply truncate;
+  padding-block: 0;
 }
 
-:host span {
-  padding-block: 0;
+:host .content--slotted .title {
   padding-inline: var(--calcite-chip-spacing-unit-l);
 }
 
-:host([closable]) span {
+:host([icon]) .content--slotted .title {
+  padding-inline: var(--calcite-chip-spacing-unit-l);
+}
+
+:host([closable]) .content--slotted .title {
   padding-inline: var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s);
 }
 
-:host([icon]:not([closable])) span {
-  padding-block: 0;
-  padding-inline: var(--calcite-chip-spacing-unit-l);
+:host([closable][icon]) .container:not(.content--slotted) .title {
+  padding-inline: 0 var(--calcite-chip-spacing-unit-s);
+}
+
+:host([icon]:not([closable])) .container:not(.content--slotted) .chip-icon {
+  margin-block: 0;
+  margin-inline: auto;
+}
+
+:host([scale="s"][icon]:not([closable])) .container:not(.content--slotted) {
+  @apply w-6 h-6;
+}
+:host([scale="m"][icon]:not([closable])) .container:not(.content--slotted) {
+  @apply w-8 h-8;
+}
+:host([scale="l"][icon]:not([closable])) .container:not(.content--slotted) {
+  @apply w-11 h-11;
 }
 
 :host button {
@@ -68,22 +87,17 @@
     transition-default
     text-color-1
     m-0
-    inline-flex
-    max-h-full
-    min-h-full
     cursor-pointer
     items-center
-    self-stretch
     border-none
     bg-transparent;
   -webkit-appearance: none;
-  border-start-start-radius: 0;
-  border-start-end-radius: 50px;
-  border-end-end-radius: 50px;
-  border-end-start-radius: 0;
-  padding-block: 0;
+  display: flex;
+  border-radius: 50%;
   padding-inline: var(--calcite-chip-spacing-unit-s);
   color: inherit;
+  align-content: center;
+  justify-content: center;
 
   // close button focus styles
   --calcite-chip-transparent-hover: var(--calcite-button-transparent-hover);
@@ -98,6 +112,27 @@
   &:active {
     background-color: var(--calcite-chip-transparent-press);
   }
+}
+:host([closable]) .content--slotted .title {
+  padding-inline: var(--calcite-chip-spacing-unit-l) var(--calcite-chip-spacing-unit-s);
+}
+
+:host([scale="s"]) button {
+  inline-size: 16px;
+  block-size: 16px;
+  margin-inline-end: 2px;
+}
+
+:host([scale="m"]) button {
+  inline-size: 24px;
+  block-size: 24px;
+  margin-inline-end: 4px;
+}
+
+:host([scale="l"]) button {
+  inline-size: 32px;
+  block-size: 32px;
+  margin-inline-end: 8px;
 }
 
 //slotted image
@@ -118,38 +153,13 @@
     ease-in-out;
   margin-inline-end: 0;
   margin-inline-start: var(--calcite-chip-spacing-unit-l);
-  border-start-start-radius: 0;
-  border-start-end-radius: 50px;
-  border-end-end-radius: 50px;
-  border-end-start-radius: 0;
 }
 
-// solid
-:host([color="blue"]) {
-  border-color: transparent;
-  background-color: var(--calcite-ui-info);
-  color: var(--calcite-ui-text-inverse);
+:host {
+  @apply text-color-1 bg-transparent;
 }
 
-:host([color="red"]) {
-  border-color: transparent;
-  background-color: var(--calcite-ui-danger);
-  color: var(--calcite-ui-text-inverse);
-}
-
-:host([color="yellow"]) {
-  border-color: transparent;
-  background-color: var(--calcite-ui-warning);
-  color: $blk-220;
-}
-
-:host([color="green"]) {
-  border-color: transparent;
-  background-color: var(--calcite-ui-success);
-  color: $blk-220;
-}
-
-:host([color="grey"]) {
+:host([kind="neutral"]) {
   border-color: transparent;
   background-color: var(--calcite-ui-foreground-2);
   color: var(--calcite-ui-text-1);
@@ -163,52 +173,76 @@
   }
 }
 
-:host([appearance="clear"]),
-:host([appearance="transparent"]) {
-  @apply text-color-1 bg-transparent;
-}
+:host([kind="inverse"]) {
+  border-color: transparent;
+  background-color: var(--calcite-ui-inverse);
+  @apply text-color-inverse;
 
-// clear is deprecated. use transparent instead.
-:host([color="blue"][appearance="clear"]),
-:host([color="blue"][appearance="transparent"]) {
-  border-color: var(--calcite-ui-info);
+  button,
+  .close-icon {
+    @apply text-color-inverse;
+  }
+
   .chip-icon {
-    color: var(--calcite-ui-icon-color, var(--calcite-ui-info));
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-text-inverse));
   }
 }
 
-:host([color="red"][appearance="clear"]),
-:host([color="red"][appearance="transparent"]) {
-  border-color: var(--calcite-ui-danger);
+:host([kind="brand"]) {
+  border-color: transparent;
+  background-color: var(--calcite-ui-brand);
+  color: var(--calcite-ui-text-inverse);
+  button,
+  .close-icon {
+    @apply text-color-inverse;
+  }
+
   .chip-icon {
-    color: var(--calcite-ui-icon-color, var(--calcite-ui-danger));
+    color: var(--calcite-ui-icon-color, var(--calcite-ui-text-inverse));
   }
 }
 
-:host([color="yellow"][appearance="clear"]),
-:host([color="yellow"][appearance="transparent"]) {
-  border-color: var(--calcite-ui-warning);
-  .chip-icon {
-    color: var(--calcite-ui-icon-color, var(--calcite-ui-warning));
+:host([appearance="outline-fill"]),
+:host([appearance="outline"]) {
+  @apply text-color-1 bg-foreground-1;
+  button,
+  .close-icon {
+    @apply text-color-3;
   }
-}
-
-:host([color="green"][appearance="clear"]),
-:host([color="green"][appearance="transparent"]) {
-  border-color: var(--calcite-ui-success);
-  .chip-icon {
-    color: var(--calcite-ui-icon-color, var(--calcite-ui-success));
-  }
-}
-
-:host([color="grey"][appearance="clear"]),
-:host([color="grey"][appearance="transparent"]) {
-  border-color: var(--calcite-ui-border-1);
   .chip-icon {
     color: var(--calcite-ui-icon-color, var(--calcite-ui-text-3));
   }
 }
 
+:host([appearance="outline-fill"]) {
+  @apply bg-foreground-1;
+}
+
+:host([appearance="outline"]) {
+  @apply bg-transparent;
+}
+
+:host([kind="neutral"][appearance="outline-fill"]),
+:host([kind="neutral"][appearance="outline"]) {
+  border-color: var(--calcite-ui-border-1);
+}
+
+:host([kind="inverse"][appearance="outline-fill"]),
+:host([kind="inverse"][appearance="outline"]) {
+  border-color: var(--calcite-ui-border-inverse);
+}
+
+:host([kind="brand"][appearance="outline-fill"]),
+:host([kind="brand"][appearance="outline"]) {
+  border-color: var(--calcite-ui-brand);
+}
+
+:host([kind="brand"][appearance="solid"]),
+:host([kind="inverse"][appearance="solid"]) {
+  button {
+    outline-color: var(--calcite-ui-text-inverse);
+  }
+}
 :host([closed]) {
   display: none;
 }

--- a/src/components/chip/chip.stories.ts
+++ b/src/components/chip/chip.stories.ts
@@ -17,8 +17,8 @@ export const simple = (): string => html`
   <div style="background-color:white;padding:100px">
     <calcite-chip
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      appearance="${select("appearance", ["solid", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      appearance="${select("appearance", ["outline", "outline-fill", "solid"], "solid")}"
+      kind="${select("kind", ["brand", "inverse", "neutral"], "neutral")}"
       ${boolean("closable", false)}
       >My great chip</calcite-chip
     >
@@ -30,8 +30,8 @@ export const withIcon = (): string => html`
     <calcite-chip
       icon="${select("icon", iconNames, iconNames[0])}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      appearance="${select("appearance", ["solid", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      appearance="${select("appearance", ["outline", "outline-fill", "solid"], "solid")}"
+      kind="${select("kind", ["brand", "inverse", "neutral"], "neutral")}"
       ${boolean("closable", false)}
     >
       My great chip</calcite-chip
@@ -43,8 +43,8 @@ export const withImage = (): string => html`
   <div style="background-color:white;padding:100px">
     <calcite-chip
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      appearance="${select("appearance", ["solid", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      appearance="${select("appearance", ["outline", "outline-fill", "solid"], "solid")}"
+      kind="${select("kind", ["brand", "inverse", "neutral"], "neutral")}"
       ${boolean("closable", false)}
     >
       <img alt="" slot="image" src="${placeholderImage({ width: 50, height: 50 })}" />
@@ -60,8 +60,8 @@ export const withAvatar = (): string => {
     <div style="background-color:white;padding:100px">
       <calcite-chip
         scale="${scale}"
-        appearance="${select("appearance", ["solid", "transparent"], "solid")}"
-        color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+        appearance="${select("appearance", ["outline", "outline-fill", "solid"], "solid")}"
+        kind="${select("kind", ["brand", "inverse", "neutral"], "neutral")}"
         ${boolean("closable", false)}
       >
         <calcite-avatar
@@ -84,8 +84,8 @@ export const darkThemeRTL_TestOnly = (): string => html`
     <calcite-chip
       class="calcite-theme-dark"
       scale="${select("scale", ["s", "m", "l"], "m")}"
-      appearance="${select("appearance", ["solid", "transparent"], "solid")}"
-      color="${select("color", ["blue", "red", "yellow", "green", "grey"], "grey")}"
+      appearance="${select("appearance", ["outline", "outline-fill", "solid"], "solid")}"
+      kind="${select("kind", ["brand", "inverse", "neutral"], "neutral")}"
       ${boolean("closable", false)}
       >My great chip</calcite-chip
     >

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -230,7 +230,12 @@ export class Chip
 
   render(): VNode {
     const iconEl = (
-      <calcite-icon class={CSS.chipIcon} flipRtl={this.iconFlipRtl} icon={this.icon} scale="s" />
+      <calcite-icon
+        class={CSS.chipIcon}
+        flipRtl={this.iconFlipRtl}
+        icon={this.icon}
+        scale={this.scale === "l" ? "m" : "s"}
+      />
     );
 
     const closeButton = (
@@ -241,7 +246,11 @@ export class Chip
         onClick={this.closeClickHandler}
         ref={(el) => (this.closeButton = el)}
       >
-        <calcite-icon class={CSS.closeIcon} icon={ICONS.close} scale="s" />
+        <calcite-icon
+          class={CSS.closeIcon}
+          icon={ICONS.close}
+          scale={this.scale === "l" ? "m" : "s"}
+        />
       </button>
     );
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -187,7 +187,8 @@ export class Chip
   private updateHasContent() {
     const slottedContent = this.el.textContent.trim().length > 0 || this.el.childNodes.length > 0;
     this.hasContent =
-      this.el.childNodes.length === 1 && this.el.childNodes[0]?.nodeName === "#text"
+      (getSlotted(this.el, SLOTS.image) || this.el.childNodes.length === 1) &&
+      this.el.childNodes[0]?.nodeName === "#text"
         ? this.el.textContent?.trim().length > 0
         : slottedContent;
   }

--- a/src/components/chip/interfaces.ts
+++ b/src/components/chip/interfaces.ts
@@ -1,1 +1,0 @@
-export type ChipColor = "blue" | "red" | "yellow" | "green" | "grey";

--- a/src/components/chip/resources.ts
+++ b/src/components/chip/resources.ts
@@ -3,7 +3,9 @@ export const CSS = {
   close: "close",
   imageContainer: "image-container",
   chipIcon: "chip-icon",
-  closeIcon: "close-icon"
+  closeIcon: "close-icon",
+  contentSlotted: "content--slotted",
+  container: "container"
 };
 
 export const SLOTS = {

--- a/src/components/chip/usage/Basic.md
+++ b/src/components/chip/usage/Basic.md
@@ -1,3 +1,3 @@
 ```html
-<calcite-chip value="Global" closable icon="globe" appearance="clear" color="green">Global</calcite-chip>
+<calcite-chip value="Global" closable icon="globe" appearance="outline" kind="brand">Global</calcite-chip>
 ```

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -1,9 +1,10 @@
 /* Note: using `.d.ts` file extension will exclude it from the output build */
 export type Alignment = "start" | "center" | "end";
 /* Note: "clear" has been deprecated and should be removed before 1.0 */
-export type Appearance = "solid" | "clear" | "outline" | "transparent" | "minimal";
+export type Appearance = "clear" | "minimal" | "outline" | "outline-fill" | "solid" | "transparent";
 export type Columns = 1 | 2 | 3 | 4 | 5 | 6;
 export type FlipContext = "both" | "start" | "end";
+export type Kind = "brand" | "danger" | "info" | "inverse" | "neutral" | "warning" | "success";
 export type Layout = "horizontal" | "vertical" | "grid";
 export type LogicalFlowPosition = "inline-start" | "inline-end" | "block-start" | "block-end";
 export type Position = "start" | "end";

--- a/src/demos/chip.html
+++ b/src/demos/chip.html
@@ -41,8 +41,76 @@
         display: flex;
         align-items: center;
         flex-direction: column;
-
         gap: 16px;
+      }
+
+      /* theming override examples */
+
+      .themed-children calcite-chip:first-of-type {
+        --calcite-ui-brand: var(--calcite-ui-danger);
+        --calcite-ui-text-1: var(--calcite-ui-danger);
+        --calcite-ui-border-1: var(--calcite-ui-danger);
+        --calcite-ui-foreground-1: rgba(255, 0, 0, 0.15);
+      }
+
+      .themed-children calcite-chip:nth-of-type(2) {
+        --calcite-ui-brand: var(--calcite-ui-success);
+        --calcite-ui-text-1: var(--calcite-ui-success);
+        --calcite-ui-border-1: var(--calcite-ui-success);
+        --calcite-ui-foreground-1: rgba(0, 128, 0, 0.15);
+      }
+
+      .themed-children calcite-chip:nth-of-type(3) {
+        --calcite-ui-brand: var(--calcite-ui-info);
+        --calcite-ui-text-1: var(--calcite-ui-info);
+        --calcite-ui-border-1: var(--calcite-ui-info);
+        --calcite-ui-foreground-1: rgba(0, 0, 255, 0.15);
+      }
+
+      .themed-children calcite-chip:nth-of-type(4) {
+        --calcite-ui-brand: orange;
+        --calcite-ui-text-1: orange;
+        --calcite-ui-border-1: orange;
+        --calcite-ui-foreground-1: rgba(255, 165, 0, 0.15);
+      }
+
+      .themed-children calcite-chip:nth-of-type(5) {
+        --calcite-ui-brand: purple;
+        --calcite-ui-text-1: purple;
+        --calcite-ui-border-1: purple;
+        --calcite-ui-foreground-1: rgba(128, 0, 128, 0.15);
+      }
+
+      .themed-children calcite-chip:nth-of-type(6) {
+        --calcite-ui-brand: pink;
+        --calcite-ui-text-1: pink;
+        --calcite-ui-border-1: pink;
+        --calcite-ui-foreground-1: rgba(255, 192, 203, 0.15);
+      }
+
+      .themed-children calcite-chip:nth-of-type(7) {
+        --calcite-ui-brand: teal;
+        --calcite-ui-text-1: teal;
+        --calcite-ui-border-1: teal;
+        --calcite-ui-foreground-1: rgba(0, 128, 128, 0.15);
+      }
+
+      .themed-children-card calcite-chip:first-of-type {
+        --calcite-ui-foreground-2: rgb(222 239 220);
+        --calcite-ui-text-1: var(--calcite-ui-success);
+        --calcite-ui-icon-color: var(--calcite-ui-success);
+      }
+
+      .themed-children-card calcite-chip:nth-of-type(2) {
+        --calcite-ui-foreground-2: rgb(221 238 249);
+        --calcite-ui-text-1: var(--calcite-ui-info);
+        --calcite-ui-icon-color: var(--calcite-ui-info);
+      }
+
+      .themed-children-card calcite-chip:nth-of-type(3) {
+        --calcite-ui-foreground-2: rgb(221 238 249);
+        --calcite-ui-text-1: var(--calcite-ui-info);
+        --calcite-ui-icon-color: var(--calcite-ui-info);
       }
     </style>
     <script src="_assets/head.js"></script>
@@ -450,6 +518,149 @@
             >
             </calcite-chip>
           </div>
+        </div>
+      </div>
+      <hr />
+      <!-- Examples -->
+      <div class="parent">
+        <div class="child right-aligned-text">Theming example</div>
+
+        <div class="child themed-children">
+          <div class="chip-group">
+            <calcite-chip kind="brand" value="calcite chip">AWS</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip">Azure</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip">Maintained</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip">Host</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip">Test</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip">Priority - High</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip">Archived</calcite-chip>
+          </div>
+        </div>
+
+        <div class="child themed-children">
+          <div class="chip-group">
+            <calcite-chip value="calcite chip" appearance="outline">AWS</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline">Azure</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline">Maintained</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline">Host</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline">Test</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline">Priority - High</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline">Archived</calcite-chip>
+          </div>
+        </div>
+        <div class="child themed-children">
+          <div class="chip-group">
+            <calcite-chip value="calcite chip" appearance="outline-fill">AWS</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill">Azure</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill">Maintained</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill">Host</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill">Test</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill">Priority - High</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill">Archived</calcite-chip>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <div class="parent">
+        <div class="child right-aligned-text">Used as chip in combobox</div>
+        <div class="child">
+          <div style="width: 800px; max-width: 80%; height: 300px; max-height: 80vh; margin: 0 auto">
+            <calcite-combobox label="test" placeholder="Select item" max-items="6" scale="l" open>
+              <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude"></calcite-combobox-item>
+              <calcite-combobox-item icon="article" value="article" text-label="Article"></calcite-combobox-item>
+              <calcite-combobox-item
+                icon="attachment"
+                value="attachment"
+                text-label="Attachment"
+              ></calcite-combobox-item>
+              <calcite-combobox-item icon="beaker" value="beaker" text-label="Beaker"></calcite-combobox-item>
+              <calcite-combobox-item icon="bell" selected value="bell" text-label="Bell"></calcite-combobox-item>
+              <calcite-combobox-item icon="bookmark" value="bookmark" text-label="Bookmark"></calcite-combobox-item>
+              <calcite-combobox-item
+                icon="brightness"
+                value="brightness"
+                text-label="Brightness"
+              ></calcite-combobox-item>
+              <calcite-combobox-item icon="calendar" value="calendar" text-label="Calendar"></calcite-combobox-item>
+              <calcite-combobox-item icon="camera" value="camera" text-label="Camera"></calcite-combobox-item>
+              <calcite-combobox-item icon="car" selected value="car" text-label="Car"></calcite-combobox-item>
+              <calcite-combobox-item icon="clock" value="clock" text-label="Clock"></calcite-combobox-item>
+            </calcite-combobox>
+          </div>
+        </div>
+      </div>
+      <hr />
+
+      <div class="parent">
+        <div class="child right-aligned-text">Used as badges in a card</div>
+        <div class="child">
+          <div style="width: 280px; margin: 0 auto">
+            <calcite-card selectable>
+              <img slot="thumbnail" alt="Sample image alt" src="https://placeimg.com/280/200/nature" />
+              <h3 slot="title">My great Workforce project that might wrap two lines</h3>
+              <span slot="subtitle">Johnathan Smith</span>
+              <calcite-chip-group class="themed-children-card" scale="s" slot="footer-leading" style="flex-flow: row">
+                <calcite-chip id="badge-1" value="calcite chip" icon="check-circle" scale="s"> </calcite-chip>
+                <calcite-chip id="badge-2" value="calcite chip" icon="globe" scale="s"> </calcite-chip>
+                <calcite-chip id="badge-3" value="calcite chip" icon="security" scale="s"> </calcite-chip>
+              </calcite-chip-group>
+              <div slot="footer-trailing" style="display: flex; align-items: center">
+                <calcite-chip id="badge-4" value="calcite chip" icon="user" scale="s" slot="footer-trailing">
+                </calcite-chip>
+                <calcite-action scale="s" icon="ellipsis" style="margin-inline-start: 4px"></calcite-action>
+              </div>
+            </calcite-card>
+          </div>
+        </div>
+        <calcite-tooltip reference-element="badge-1" placement="bottom" offset-distance="8"> </calcite-tooltip>
+        <calcite-tooltip reference-element="badge-2" placement="bottom" offset-distance="8">Something </calcite-tooltip>
+        <calcite-tooltip reference-element="badge-3" placement="bottom" offset-distance="8"
+          >Something else
+        </calcite-tooltip>
+        <calcite-tooltip reference-element="badge-4" placement="bottom" offset-distance="8"
+          >Permission level
+        </calcite-tooltip>
+      </div>
+      <div class="parent">
+        <div class="child right-aligned-text">Used as badges in a wider card</div>
+        <div class="child">
+          <div style="width: 1000px; margin: 0 auto">
+            <calcite-card thumbnail-position="inline-start" selectable>
+              <img
+                slot="thumbnail"
+                alt="Sample image alt"
+                src="https://placeimg.com/400/200/nature"
+                style="width: 340px; height: 200px"
+              />
+              <h3 slot="title">My great Workforce project that might wrap two lines</h3>
+              <span slot="subtitle">Johnathan Smith</span>
+              <calcite-chip-group class="themed-children-card" scale="s" slot="footer-leading" style="flex-flow: row">
+                <calcite-chip id="badge-1" value="calcite chip" icon="check-circle" scale="s">
+                  authoritative</calcite-chip
+                >
+                <calcite-chip id="badge-2" value="calcite chip" icon="globe" scale="s">authoritative </calcite-chip>
+                <calcite-chip id="badge-3" value="calcite chip" icon="security" scale="s"> authoritative</calcite-chip>
+              </calcite-chip-group>
+              <div slot="footer-trailing" style="display: flex; align-items: center">
+                <calcite-chip id="badge-4" value="calcite chip" icon="user" scale="s" slot="footer-trailing"
+                  >authoritative
+                </calcite-chip>
+                <calcite-action scale="s" icon="ellipsis" style="margin-inline-start: 4px"></calcite-action>
+              </div>
+            </calcite-card>
+          </div>
+          <calcite-tooltip reference-element="badge-1" placement="bottom" offset-distance="8"
+            >Authoritative
+          </calcite-tooltip>
+          <calcite-tooltip reference-element="badge-2" placement="bottom" offset-distance="8"
+            >Something
+          </calcite-tooltip>
+          <calcite-tooltip reference-element="badge-3" placement="bottom" offset-distance="8"
+            >Something else
+          </calcite-tooltip>
+          <calcite-tooltip reference-element="badge-4" placement="bottom" offset-distance="8"
+            >Permission level
+          </calcite-tooltip>
         </div>
       </div>
     </demo-dom-swapper>

--- a/src/demos/chip.html
+++ b/src/demos/chip.html
@@ -193,15 +193,15 @@
         <div class="child">
           <div class="chip-group">
             <calcite-chip value="chip" scale="s">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
             <calcite-chip value="chip" scale="m" kind="inverse">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
             <calcite-chip value="chip" scale="l" kind="brand">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
           </div>
@@ -210,15 +210,15 @@
         <div class="child">
           <div class="chip-group">
             <calcite-chip value="chip" appearance="outline" scale="s">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
             <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
             <calcite-chip value="chip" scale="l" appearance="outline" kind="brand">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
           </div>
@@ -227,15 +227,15 @@
         <div class="child">
           <div class="chip-group">
             <calcite-chip value="chip" appearance="outline-fill" scale="s">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
             <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
             <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand">
-              <img slot="image" src="https://placekitten.com/50/50" />
+              <img slot="image" src="https://placekitten.com/80/80" />
               Siamese Cat
             </calcite-chip>
           </div>
@@ -629,6 +629,284 @@
               scale="l"
               kind="brand"
             >
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Just avatar -->
+      <div class="parent">
+        <div class="child right-aligned-text">Just Avatar</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value=" chip" appearance="outline-fill" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip value=" chip" appearance="outline-fill" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip value=" chip" appearance="outline-fill" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Slotted avatar -->
+      <div class="parent">
+        <div class="child right-aligned-text">Just avatar (closable)</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" appearance="outline" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Just image -->
+      <div class="parent">
+        <div class="child right-aligned-text">Just Image</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline" scale="s">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value=" chip" appearance="outline-fill" scale="s">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip value=" chip" appearance="outline-fill" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip value=" chip" appearance="outline-fill" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Slotted image -->
+      <div class="parent">
+        <div class="child right-aligned-text">Just image (closable)</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" scale="s">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip closable value="chip" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip closable value="chip" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" appearance="outline" scale="s">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="s">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/80/80" />
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/80/80" />
             </calcite-chip>
           </div>
         </div>

--- a/src/demos/chip.html
+++ b/src/demos/chip.html
@@ -8,18 +8,24 @@
     <style>
       .parent {
         display: flex;
-        width: 60%;
+        width: 100%;
         align-items: center;
         padding: 25px 0;
       }
 
+      .demo {
+        background: var(--calcite-ui-background) !important;
+      }
+
       .child {
-        flex: 0 0 15%;
+        flex: 0 0 20%;
         margin: 0 25px;
         color: var(--calcite-ui-text-3);
         font-family: var(--calcite-sans-family);
         font-size: var(--calcite-font-size-0);
         font-weight: var(--calcite-font-weight-medium);
+        flex-direction: column;
+        display: flex;
       }
 
       .right-aligned-text {
@@ -29,6 +35,14 @@
       hr {
         margin: 25px 0;
         border-top: 1px solid var(--calcite-ui-border-2);
+      }
+
+      .chip-group {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+
+        gap: 16px;
       }
     </style>
     <script src="_assets/head.js"></script>
@@ -41,9 +55,9 @@
       <!-- Header -->
       <div class="parent">
         <div class="child"></div>
-        <div class="child">Small</div>
-        <div class="child">Medium</div>
-        <div class="child">Large</div>
+        <div class="child">Solid (default)</div>
+        <div class="child">Outline</div>
+        <div class="child">Outline-fill</div>
       </div>
 
       <!-- Basic -->
@@ -51,15 +65,56 @@
         <div class="child right-aligned-text">Basic</div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" id="one" scale="s" closable> Apple </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s">Apple</calcite-chip>
+            <calcite-chip value="chip" scale="m" kind="inverse">Apple</calcite-chip>
+            <calcite-chip value="chip" scale="l" kind="brand">Apple</calcite-chip>
+          </div>
         </div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="m" closable> Apple </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s" appearance="outline">Apple</calcite-chip>
+            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse">Apple</calcite-chip>
+            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand">Apple</calcite-chip>
+          </div>
         </div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="l" closable> Apple </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s" appearance="outline-fill">Apple</calcite-chip>
+            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse">Apple</calcite-chip>
+            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand">Apple</calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Closable -->
+      <div class="parent">
+        <div class="child right-aligned-text">Basic</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable scale="s">Apple</calcite-chip>
+            <calcite-chip value="chip" closable scale="m" kind="inverse">Apple</calcite-chip>
+            <calcite-chip value="chip" closable scale="l" kind="brand">Apple</calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable scale="s" appearance="outline">Apple</calcite-chip>
+            <calcite-chip value="chip" closable scale="m" appearance="outline" kind="inverse">Apple</calcite-chip>
+            <calcite-chip value="chip" closable scale="l" appearance="outline" kind="brand">Apple</calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable scale="s" appearance="outline-fill">Apple</calcite-chip>
+            <calcite-chip value="chip" closable scale="m" appearance="outline-fill" kind="inverse">Apple</calcite-chip>
+            <calcite-chip value="chip" closable scale="l" appearance="outline-fill" kind="brand">Apple</calcite-chip>
+          </div>
         </div>
       </div>
 
@@ -68,24 +123,54 @@
         <div class="child right-aligned-text">Slotted image</div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="s" active>
-            <img slot="image" src="https://placekitten.com/50/50" />
-            Siamese Cat
-          </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" kind="inverse">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" kind="brand">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+          </div>
         </div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="m" active>
-            <img slot="image" src="https://placekitten.com/50/50" />
-            Siamese Cat
-          </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline" scale="s">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+          </div>
         </div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="l" active>
-            <img slot="image" src="https://placekitten.com/50/50" />
-            Siamese Cat
-          </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline-fill" scale="s">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand">
+              <img slot="image" src="https://placekitten.com/50/50" />
+              Siamese Cat
+            </calcite-chip>
+          </div>
         </div>
       </div>
 
@@ -94,499 +179,279 @@
         <div class="child right-aligned-text">Slotted avatar</div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="s" active>
-            <calcite-avatar
-              slot="image"
-              scale="s"
-              user-id="52e44e112b1f429182515dba79b71eb8"
-              username="au"
-            ></calcite-avatar>
-            Another User
-          </calcite-chip>
+          <div class="chip-group">
+            <calcite-chip value="chip" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+          </div>
         </div>
 
         <div class="child">
-          <calcite-chip value="calcite chip" scale="m" active>
-            <calcite-avatar
-              slot="image"
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline-fill" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline-fill" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip value="chip" appearance="outline-fill" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Icon -->
+      <div class="parent">
+        <div class="child right-aligned-text">Icon</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" icon="embark" scale="s"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" scale="m" kind="inverse"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" scale="l" kind="brand"> Maritime </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" icon="embark" appearance="outline" scale="s"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" appearance="outline" scale="m" kind="inverse">
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" icon="embark" appearance="outline" scale="l" kind="brand">
+              Maritime
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="s"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="m" kind="inverse">
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="l" kind="brand">
+              Maritime
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Icon (closable)-->
+      <div class="parent">
+        <div class="child right-aligned-text">Icon (closable)</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable icon="embark" scale="s"> Maritime </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" scale="m" kind="inverse"> Maritime </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" scale="l" kind="brand"> Maritime </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="s"> Maritime </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="m" kind="inverse">
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="l" kind="brand">
+              Maritime
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="s">
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="m" kind="inverse">
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="l" kind="brand">
+              Maritime
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Just icon -->
+      <div class="parent">
+        <div class="child right-aligned-text">Just Icon</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" icon="drone-flying-wing" scale="s"> </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" scale="m" kind="inverse"> </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" scale="l" kind="brand"> </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline" scale="s"> </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline" scale="m" kind="inverse">
+            </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline" scale="l" kind="brand">
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline-fill" scale="s"> </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline-fill" scale="m" kind="inverse">
+            </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline-fill" scale="l" kind="brand">
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
+      <!-- Just icon (closable) -->
+      <div class="parent">
+        <div class="child right-aligned-text">Just Icon (closable)</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="s"> </calcite-chip>
+            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="m" kind="inverse">
+            </calcite-chip>
+            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="l" kind="brand">
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" closable icon="drone-flying-wing" appearance="outline" scale="s">
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              appearance="outline"
               scale="m"
-              user-id="52e44e112b1f429182515dba79b71eb8"
-              username="au"
-            ></calcite-avatar>
-            Another User
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" scale="l" active>
-            <calcite-avatar
-              slot="image"
+              kind="inverse"
+            >
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              appearance="outline"
               scale="l"
-              user-id="52e44e112b1f429182515dba79b71eb8"
-              username="au"
-            ></calcite-avatar>
-            Another User
-          </calcite-chip>
+              kind="brand"
+            >
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" closable icon="drone-flying-wing" appearance="outline-fill" scale="s">
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              appearance="outline-fill"
+              scale="m"
+              kind="inverse"
+            >
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              appearance="outline-fill"
+              scale="l"
+              kind="brand"
+            >
+            </calcite-chip>
+          </div>
         </div>
       </div>
-
-      <!-- Icon attribute -->
-      <div class="parent">
-        <div class="child right-aligned-text">Icon attribute</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="check-circle" scale="s"> Check circle </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="drone-fixed-wing" scale="m"> Drone </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="embark" scale="l"> Ship </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Icon attribute closable -->
-      <div class="parent">
-        <div class="child right-aligned-text">Icon attribute closable</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="check-circle" scale="s" closable> Check circle </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="drone-fixed-wing" scale="m" closable> Drone </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="embark" scale="l" closable> Ship </calcite-chip>
-        </div>
-      </div>
-
-      <hr />
-      <!-- A horizontal line -->
-
-      <!-- Solid Grey (default) -->
-      <div class="parent">
-        <div class="child right-aligned-text">Solid Grey (default)</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="s"> Grey (default) </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="m"> Grey (default) </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="l"> Grey (default) </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Yellow-->
-      <div class="parent">
-        <div class="child right-aligned-text">Yellow</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="s"> Yellow </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="m"> Yellow </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="l"> Yellow </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Green -->
-      <div class="parent">
-        <div class="child right-aligned-text">Green</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="s"> Green </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="m"> Green </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="l"> Green </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Blue -->
-      <div class="parent">
-        <div class="child right-aligned-text">Blue</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="s"> Blue </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="m"> Blue </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="l"> Blue </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Red -->
-      <div class="parent">
-        <div class="child right-aligned-text">Red</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="s"> Red </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="m"> Red </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="l"> Red </calcite-chip>
-        </div>
-      </div>
-
-      <hr />
-      <!-- A horizontal line -->
-
-      <!-- Solid Grey (default) closable -->
-      <div class="parent">
-        <div class="child right-aligned-text">Solid grey (default) closable</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="s" closable> Grey (default) </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="m" closable> Grey (default) </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="l" closable> Grey (default) </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Yellow-->
-      <div class="parent">
-        <div class="child right-aligned-text">Yellow</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="s" closable> Yellow </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="m" closable> Yellow </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="l" closable> Yellow </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Green -->
-      <div class="parent">
-        <div class="child right-aligned-text">Green</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="s" closable> Green </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="m" closable> Green </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="l" closable> Green </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Blue -->
-      <div class="parent">
-        <div class="child right-aligned-text">Blue</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="s" closable> Blue </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="m" closable> Blue </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="l" closable> Blue </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Red -->
-      <div class="parent">
-        <div class="child right-aligned-text">Red</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="s" closable> Red </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="m" closable> Red </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="l" closable> Red </calcite-chip>
-        </div>
-      </div>
-
-      <hr />
-      <!-- A horizontal line -->
-
-      <!-- Transparent Grey (default) -->
-      <div class="parent">
-        <div class="child right-aligned-text">Transparent Grey(default)</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="s" appearance="transparent">
-            Grey (default)
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="m" appearance="transparent">
-            Grey (default)
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="l" appearance="transparent">
-            Grey (default)
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Yellow-->
-      <div class="parent">
-        <div class="child right-aligned-text">Yellow</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="s" appearance="transparent">
-            Yellow
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="m" appearance="transparent">
-            Yellow
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="l" appearance="transparent">
-            Yellow
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Green -->
-      <div class="parent">
-        <div class="child right-aligned-text">Green</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="s" appearance="transparent">
-            Green
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="m" appearance="transparent">
-            Green
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="l" appearance="transparent">
-            Green
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Blue -->
-      <div class="parent">
-        <div class="child right-aligned-text">Blue</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="s" appearance="transparent">
-            Blue
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="m" appearance="transparent">
-            Blue
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="l" appearance="transparent">
-            Blue
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Red -->
-      <div class="parent">
-        <div class="child right-aligned-text">Red</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="s" appearance="transparent">
-            Red
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="m" appearance="transparent">
-            Red
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="l" appearance="transparent">
-            Red
-          </calcite-chip>
-        </div>
-      </div>
-
-      <hr />
-      <!-- A horizontal line -->
-
-      <!-- Grey (default) closable -->
-      <div class="parent">
-        <div class="child right-aligned-text">Solid grey(default) closable</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="s" appearance="transparent" closable>
-            Grey (default)
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="m" appearance="transparent" closable>
-            Grey (default)
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" scale="l" appearance="transparent" closable>
-            Grey (default)
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Yellow-->
-      <div class="parent">
-        <div class="child right-aligned-text">Yellow</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="s" appearance="transparent" closable>
-            Yellow
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="m" appearance="transparent" closable>
-            Yellow
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="yellow" scale="l" appearance="transparent" closable>
-            Yellow
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Green -->
-      <div class="parent">
-        <div class="child right-aligned-text">Green</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="s" appearance="transparent" closable>
-            Green
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="m" appearance="transparent" closable>
-            Green
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="green" scale="l" appearance="transparent" closable>
-            Green
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Blue -->
-      <div class="parent">
-        <div class="child right-aligned-text">Blue</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="s" appearance="transparent" closable>
-            Blue
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="m" appearance="transparent" closable>
-            Blue
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="blue" scale="l" appearance="transparent" closable>
-            Blue
-          </calcite-chip>
-        </div>
-      </div>
-
-      <!-- Red -->
-      <div class="parent">
-        <div class="child right-aligned-text">Red</div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="s" appearance="transparent" closable>
-            Red
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="m" appearance="transparent" closable>
-            Red
-          </calcite-chip>
-        </div>
-
-        <div class="child">
-          <calcite-chip value="calcite chip" icon="globe" color="red" scale="l" appearance="transparent" closable>
-            Red
-          </calcite-chip>
-        </div>
-      </div>
-
-      <hr />
-      <!-- A horizontal line -->
-
-      <script>
-        window.onload = () => {
-          const one = document.querySelector("#one");
-          one.addEventListener("calciteChipClose", () => {
-            console.log("dismissed chip");
-          });
-        };
-      </script>
     </demo-dom-swapper>
   </body>
 </html>

--- a/src/demos/chip.html
+++ b/src/demos/chip.html
@@ -343,6 +343,119 @@
         </div>
       </div>
 
+      <!-- Slotted avatar and icon -->
+      <div class="parent">
+        <div class="child right-aligned-text">Slotted avatar and icon</div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip icon="premium-content-user-credit" value="chip" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip icon="premium-content-user-credit" value="chip" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip icon="premium-content-user-credit" value="chip" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline" scale="m" kind="inverse">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline" scale="l" kind="brand">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline-fill" scale="s">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip
+              icon="premium-content-user-credit"
+              value="chip"
+              appearance="outline-fill"
+              scale="m"
+              kind="inverse"
+            >
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+            <calcite-chip
+              icon="premium-content-user-credit"
+              value="chip"
+              appearance="outline-fill"
+              scale="l"
+              kind="brand"
+            >
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+              Another User
+            </calcite-chip>
+          </div>
+        </div>
+      </div>
+
       <!-- Icon -->
       <div class="parent">
         <div class="child right-aligned-text">Icon</div>


### PR DESCRIPTION
BREAKING CHANGE: Renamed `color` property and updated values, and updated `appearance` values.

- Renamed the property `color`, use `kind` instead.
- Updated the accepted values of `kind` to `brand`, `inverse`, and `neutral` (default).
- Updated the accepted values of `appearance` to , `outline`, `outline-fill` and `solid` (default).