### PR TITLE
docs(pick-list, value-list): Deprecate events

### DIFF
--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -180,6 +180,8 @@ export class PickList<
 
   /**
    * Emits when any of the `calcite-pick-list-item` selections have changed.
+   *
+   * @deprecated – This event will be removed in a future release.
    */
   @Event({ cancelable: false }) calciteListChange: EventEmitter<
     Map<string, HTMLCalcitePickListItemElement>

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -237,6 +237,8 @@ export class ValueList<
 
   /**
    * Emits when any of the list item selections have changed.
+   *
+   * @deprecated – This event will be removed in a future release.
    */
   @Event({ cancelable: false }) calciteListChange: EventEmitter<
     Map<string, HTMLCalciteValueListItemElement>
@@ -244,6 +246,8 @@ export class ValueList<
 
   /**
    * Emits when the order of the list has changed.
+   *
+   * @deprecated – This event will be removed in a future release.
    */
   @Event({ cancelable: false }) calciteListOrderChange: EventEmitter<any[]>;
 


### PR DESCRIPTION
docs(pick-list, value-list): Deprecate events `calciteListOrderChange` and `calciteListChange`. #6007