### PR TITLE
refactor(accordion, combobox, dropdown, list, tree)!: Remove deprecated "multi" value

### DIFF
--- a/src/components/accordion-item/accordion-item.tsx
+++ b/src/components/accordion-item/accordion-item.tsx
@@ -95,7 +95,7 @@ export class AccordionItem implements ConditionalSlotComponent {
 
   connectedCallback(): void {
     this.parent = this.el.parentElement as HTMLCalciteAccordionElement;
-    this.selectionMode = getElementProp(this.el, "selection-mode", "multi");
+    this.selectionMode = getElementProp(this.el, "selection-mode", "multiple");
     this.iconType = getElementProp(this.el, "icon-type", "chevron");
     this.iconPosition = getElementProp(this.el, "icon-position", this.iconPosition);
 
@@ -283,7 +283,6 @@ export class AccordionItem implements ConditionalSlotComponent {
 
   private determineActiveItem(): void {
     switch (this.selectionMode) {
-      case "multi":
       case "multiple":
         if (this.el === this.requestedAccordionItem) {
           this.expanded = !this.expanded;

--- a/src/components/accordion/accordion.e2e.ts
+++ b/src/components/accordion/accordion.e2e.ts
@@ -29,7 +29,7 @@ describe("calcite-accordion", () => {
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("icon-position", "end");
     expect(element).toEqualAttribute("scale", "m");
-    expect(element).toEqualAttribute("selection-mode", "multi");
+    expect(element).toEqualAttribute("selection-mode", "multiple");
     expect(element).toEqualAttribute("icon-type", "chevron");
   });
 
@@ -98,7 +98,7 @@ describe("calcite-accordion", () => {
     ${accordionContent}
     </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
-    expect(element).toEqualAttribute("selection-mode", "multi");
+    expect(element).toEqualAttribute("selection-mode", "multiple");
     const item1 = await element.find("calcite-accordion-item[id='1']");
     const item2 = await element.find("calcite-accordion-item[id='2']");
     const item3 = await element.find("calcite-accordion-item[id='3']");

--- a/src/components/accordion/accordion.stories.ts
+++ b/src/components/accordion/accordion.stories.ts
@@ -56,7 +56,7 @@ const createAccordionAttributes: (options?: { exceptions: string[] }) => Attribu
       {
         name: "selection-mode",
         commit(): Attribute {
-          this.value = select("selection-mode", ["multi", "single", "single-persist", "multiple"], "multiple", group);
+          this.value = select("selection-mode", ["single", "single-persist", "multiple"], "multiple", group);
           delete this.build;
           return this;
         }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Prop, VNode } from "@stencil/core";
-import { AccordionSelectionMode, RequestedItem } from "./interfaces";
+import { RequestedItem } from "./interfaces";
 import { Appearance, Position, Scale } from "../interfaces";
-
+import { SelectionMode } from "../interfaces";
 /**
  * @slot - A slot for adding `calcite-accordion-item`s. `calcite-accordion` cannot be nested, however `calcite-accordion-item`s can.
  */
@@ -44,7 +44,10 @@ export class Accordion {
    * Specifies the selection mode - `"multiple"` (allow any number of open items), `"single"` (allow one open item),
    * or `"single-persist"` (allow and require one open item).
    */
-  @Prop({ reflect: true }) selectionMode: AccordionSelectionMode = "multi";
+  @Prop({ reflect: true }) selectionMode: Extract<
+    "single" | "single-persist" | "multiple",
+    SelectionMode
+  > = "multiple";
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/accordion/interfaces.ts
+++ b/src/components/accordion/interfaces.ts
@@ -1,5 +1,3 @@
 export interface RequestedItem {
   requestedAccordionItem: HTMLCalciteAccordionItemElement;
 }
-
-export type AccordionSelectionMode = "multi" | "single" | "single-persist" | "multiple";

--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -200,7 +200,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   }
 
   render(): VNode {
-    const isSingleSelect = getElementProp(this.el, "selection-mode", "multi") === "single";
+    const isSingleSelect = getElementProp(this.el, "selection-mode", "multiple") === "single";
     const classes = {
       [CSS.label]: true,
       [CSS.selected]: this.selected,

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -19,7 +19,7 @@ export const simple = (): string => html`
       label="demo combobox"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "multiple")}"
+      selection-mode="${select("selection-mode", ["multiple", "single", "ancestors"], "multiple")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -51,7 +51,7 @@ export const single = (): string => html`
   <div style="width:150px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "single")}"
+      selection-mode="${select("selection-mode", ["multiple", "single", "ancestors"], "single")}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -81,7 +81,7 @@ export const multiple = (): string => html`
       label="demo combobox"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "multiple")}"
+      selection-mode="${select("selection-mode", ["multiple", "single", "ancestors"], "multiple")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -107,7 +107,7 @@ export const nestedItems = (): string => html`
     <calcite-combobox
       open
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "multiple")}"
+      selection-mode="${select("selection-mode", ["multiple", "single", "ancestors"], "multiple")}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -222,7 +222,7 @@ export const flipPositioning_TestOnly = (): string => html`
       max-items="${number("max-items", 6)}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["single", "ancestors"], "multiple")}"
+      selection-mode="${select("selection-mode", ["multiple", "single", "ancestors"], "multiple")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -257,7 +257,7 @@ export const darkThemeRTL_TestOnly = (): string => html`
   <div style="width:400px;max-width:100%;padding:100px">
     <calcite-combobox
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["single", "ancestors"], "multiple")}"
+      selection-mode="${select("selection-mode", ["multiple", "single", "ancestors"], "multiple")}"
       class="calcite-theme-dark"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -19,7 +19,7 @@ export const simple = (): string => html`
       label="demo combobox"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["multi", "single", "ancestors", "multiple"], "multiple")}"
+      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "multiple")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -51,7 +51,7 @@ export const single = (): string => html`
   <div style="width:150px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["multi", "single", "ancestors", "multiple"], "single")}"
+      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "single")}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -81,7 +81,7 @@ export const multiple = (): string => html`
       label="demo combobox"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["multi", "single", "ancestors", "multiple"], "multiple")}"
+      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "multiple")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -107,7 +107,7 @@ export const nestedItems = (): string => html`
     <calcite-combobox
       open
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["multi", "single", "ancestors", "multiple"], "multiple")}"
+      selection-mode="${select("selection-mode", ["single", "ancestors", "multiple"], "multiple")}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
@@ -222,7 +222,7 @@ export const flipPositioning_TestOnly = (): string => html`
       max-items="${number("max-items", 6)}"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"
-      selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
+      selection-mode="${select("selection-mode", ["single", "ancestors"], "multiple")}"
       scale="${select("scale", ["s", "m", "l"], "m")}"
       ${boolean("disabled", false)}
       ${boolean("allow-custom-values", false)}
@@ -257,7 +257,7 @@ export const darkThemeRTL_TestOnly = (): string => html`
   <div style="width:400px;max-width:100%;padding:100px">
     <calcite-combobox
       label="demo combobox"
-      selection-mode="${select("selection-mode", ["multi", "single", "ancestors"], "multi")}"
+      selection-mode="${select("selection-mode", ["single", "ancestors"], "multiple")}"
       class="calcite-theme-dark"
       placeholder="${text("placeholder", "placeholder")}"
       label="${text("label (for screen readers)", "demo")}"

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -29,8 +29,8 @@ import {
   updateAfterClose
 } from "../../utils/floating-ui";
 import { guid } from "../../utils/guid";
-import { Scale } from "../interfaces";
-import { ComboboxSelectionMode, ComboboxChildElement } from "./interfaces";
+import { Scale, SelectionMode } from "../interfaces";
+import { ComboboxChildElement } from "./interfaces";
 import { ComboboxChildSelector, ComboboxItem, ComboboxItemGroup } from "./resources";
 import { getItemAncestors, getItemChildren, hasActiveChildren } from "./utils";
 import { LabelableComponent, connectLabel, disconnectLabel, getLabelText } from "../../utils/label";
@@ -193,7 +193,10 @@ export class Combobox
    * - single: only one selection)
    * - ancestors: like multiple, but show ancestors of selected items as selected, only deepest children shown in chips
    */
-  @Prop({ reflect: true }) selectionMode: ComboboxSelectionMode = "multi";
+  @Prop({ reflect: true }) selectionMode: Extract<
+    "single" | "ancestors" | "multiple",
+    SelectionMode
+  > = "multiple";
 
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";

--- a/src/components/combobox/interfaces.ts
+++ b/src/components/combobox/interfaces.ts
@@ -3,6 +3,4 @@ export interface listItem {
   value: string;
 }
 
-export type ComboboxSelectionMode = "single" | "multi" | "ancestors" | "multiple";
-
 export type ComboboxChildElement = HTMLCalciteComboboxItemElement | HTMLCalciteComboboxItemGroupElement;

--- a/src/components/combobox/usage/Multiple.md
+++ b/src/components/combobox/usage/Multiple.md
@@ -1,5 +1,5 @@
 ```html
-<calcite-combobox label="Mulit selection-mode combobox" selection-mode="multi">
+<calcite-combobox label="Mulit selection-mode combobox" selection-mode="multiple">
   <calcite-combobox-item value="Trees" text-label="Trees">
     <calcite-combobox-item
       value="CommercialDamageAssessment - Damage to Commercial Buildings & Damage to Commercial Buildings"

--- a/src/components/dropdown-group/dropdown-group.tsx
+++ b/src/components/dropdown-group/dropdown-group.tsx
@@ -10,10 +10,10 @@ import {
   VNode
 } from "@stencil/core";
 import { getElementProp } from "../../utils/dom";
-import { RequestedItem, SelectionMode } from "./interfaces";
+import { RequestedItem } from "./interfaces";
 import { Scale } from "../interfaces";
 import { CSS } from "./resources";
-
+import { SelectionMode } from "../interfaces";
 /**
  * @slot - A slot for adding `calcite-dropdown-item`s.
  */
@@ -43,11 +43,12 @@ export class DropdownGroup {
 
   /**
    * Specifies the component's selection mode, where
-   * `"multi"` allows any number of (or no) selected `calcite-dropdown-item`s,
+   * `"multiple"` allows any number of (or no) selected `calcite-dropdown-item`s,
    * `"single"` allows and requires one selected `calcite-dropdown-item`, and
    * `"none"` does not allow selection on `calcite-dropdown-item`s.
    */
-  @Prop({ reflect: true }) selectionMode: SelectionMode = "single";
+  @Prop({ reflect: true }) selectionMode: Extract<"single" | "none" | "multiple", SelectionMode> =
+    "single";
 
   /**
    * Specifies the size of the component.

--- a/src/components/dropdown-group/interfaces.ts
+++ b/src/components/dropdown-group/interfaces.ts
@@ -1,4 +1,3 @@
-export type SelectionMode = "multi" | "single" | "none" | "multiple";
 export interface RequestedItem {
   requestedDropdownItem: HTMLCalciteDropdownItemElement;
   requestedDropdownGroup: HTMLCalciteDropdownGroupElement;

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -15,13 +15,14 @@ import { ItemKeyboardEvent } from "../dropdown/interfaces";
 
 import { FlipContext } from "../interfaces";
 import { CSS } from "./resources";
-import { RequestedItem, SelectionMode } from "../dropdown-group/interfaces";
+import { RequestedItem } from "../dropdown-group/interfaces";
 import {
   setUpLoadableComponent,
   setComponentLoaded,
   LoadableComponent,
   componentLoaded
 } from "../../utils/loadable";
+import { SelectionMode } from "../interfaces";
 
 /**
  * @slot - A slot for adding text.
@@ -179,7 +180,7 @@ export class DropdownItem implements LoadableComponent {
       ? null
       : this.selectionMode === "single"
       ? "menuitemradio"
-      : this.selectionMode === "multiple" || this.selectionMode === "multi"
+      : this.selectionMode === "multiple"
       ? "menuitemcheckbox"
       : "menuitem";
 
@@ -194,8 +195,7 @@ export class DropdownItem implements LoadableComponent {
             [CSS.containerSmall]: scale === "s",
             [CSS.containerMedium]: scale === "m",
             [CSS.containerLarge]: scale === "l",
-            [CSS.containerMulti]:
-              this.selectionMode === "multiple" || this.selectionMode === "multi",
+            [CSS.containerMulti]: this.selectionMode === "multiple",
             [CSS.containerSingle]: this.selectionMode === "single",
             [CSS.containerNone]: this.selectionMode === "none"
           }}
@@ -203,11 +203,7 @@ export class DropdownItem implements LoadableComponent {
           {this.selectionMode !== "none" ? (
             <calcite-icon
               class="dropdown-item-icon"
-              icon={
-                this.selectionMode === "multiple" || this.selectionMode === "multi"
-                  ? "check"
-                  : "bullet-point"
-              }
+              icon={this.selectionMode === "multiple" ? "check" : "bullet-point"}
               scale="s"
             />
           ) : null}
@@ -283,7 +279,7 @@ export class DropdownItem implements LoadableComponent {
   private requestedDropdownItem: HTMLCalciteDropdownItemElement;
 
   /** what selection mode is the parent dropdown group in */
-  private selectionMode: SelectionMode;
+  private selectionMode: Extract<"none" | "single" | "multiple", SelectionMode>;
 
   /** if href is requested, track the rendered child link*/
   private childLink: HTMLAnchorElement;
@@ -304,7 +300,6 @@ export class DropdownItem implements LoadableComponent {
 
   private determineActiveItem(): void {
     switch (this.selectionMode) {
-      case "multi":
       case "multiple":
         if (this.el === this.requestedDropdownItem) {
           this.selected = !this.selected;

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -30,7 +30,7 @@ export const simple = (): string => html`
   >
     <calcite-button slot="trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group
-      selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+      selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
       group-title="Sort by"
     >
       <calcite-dropdown-item>Relevance</calcite-dropdown-item>
@@ -51,7 +51,7 @@ export const simpleAutoWidth = (): string => html`
   >
     <calcite-button slot="trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group
-      selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+      selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
       group-title="Sort by"
     >
       <calcite-dropdown-item>Relevance</calcite-dropdown-item>
@@ -75,7 +75,7 @@ export const simpleFullWidth = (): string => html`
     >
       <calcite-button width="full" slot="trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group
-        selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+        selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
         group-title="Sort by"
       >
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
@@ -98,7 +98,7 @@ export const withIcons = (): string => html`
   >
     <calcite-button slot="trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group
-      selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+      selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
       group-title="Icon Start"
     >
       <calcite-dropdown-item icon-start="list">List</calcite-dropdown-item>
@@ -106,7 +106,7 @@ export const withIcons = (): string => html`
       <calcite-dropdown-item icon-start="table">Table</calcite-dropdown-item>
     </calcite-dropdown-group>
     <calcite-dropdown-group
-      selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+      selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
       group-title="Icon End"
     >
       <calcite-dropdown-item icon-end="list">List</calcite-dropdown-item>
@@ -114,7 +114,7 @@ export const withIcons = (): string => html`
       <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
     </calcite-dropdown-group>
     <calcite-dropdown-group
-      selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+      selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
       group-title="Icon Both"
     >
       <calcite-dropdown-item icon-start="list" icon-end="data-check">List</calcite-dropdown-item>
@@ -207,7 +207,7 @@ export const darkThemeRTL_TestOnly = (): string => html`
       <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
       <calcite-dropdown-item href="http://google.com" target="_blank" title="Test title">A link</calcite-dropdown-item>
     </calcite-dropdown-group>
-    <calcite-dropdown-group group-title="Select multi" selection-mode="multi">
+    <calcite-dropdown-group group-title="Select multi" selection-mode="multiple">
       <calcite-dropdown-item icon-end="list">List</calcite-dropdown-item>
       <calcite-dropdown-item icon-end="grid" selected>Grid</calcite-dropdown-item>
       <calcite-dropdown-item icon-end="table">Table</calcite-dropdown-item>
@@ -301,7 +301,7 @@ export const scrollingWithoutMaxItems_TestOnly = (): string => html`
   <calcite-dropdown open>
     <calcite-button slot="trigger">Open Dropdown</calcite-button>
     <calcite-dropdown-group
-      selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+      selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
       group-title="Sort by"
     >
       <calcite-dropdown-item>Relevance</calcite-dropdown-item>
@@ -403,7 +403,7 @@ export const alignedCenter_TestOnly = (): string => html`
     >
       <calcite-button slot="trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group
-        selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+        selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
         group-title="Sort by"
       >
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>
@@ -432,7 +432,7 @@ export const alignedCenterRTL_TestOnly = (): string => html`
     >
       <calcite-button slot="trigger">Open Dropdown</calcite-button>
       <calcite-dropdown-group
-        selection-mode="${select("group selection mode", ["single", "multi", "none", "multiple"], "single")}"
+        selection-mode="${select("group selection mode", ["single", "none", "multiple"], "single")}"
         group-title="Sort by"
       >
         <calcite-dropdown-item>Relevance</calcite-dropdown-item>

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -7,6 +7,7 @@ export type Kind = "brand" | "danger" | "info" | "inverse" | "neutral" | "warnin
 export type Layout = "horizontal" | "vertical" | "grid";
 export type LogicalFlowPosition = "inline-start" | "inline-end" | "block-start" | "block-end";
 export type Position = "start" | "end";
+export type SelectionMode = "single" | "none" | "children" | "multichildren" | "ancestors" | "multiple";
 export type Scale = "s" | "m" | "l";
 export type Status = "invalid" | "valid" | "idle";
 export type ThemeClass = "calcite-theme-light" | "calcite-theme-dark" | "calcite-theme-auto";

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -14,9 +14,9 @@ import {
 import { SLOTS, CSS, ICONS } from "./resources";
 import { getElementDir, slotChangeHasAssignedElement, toAriaBoolean } from "../../utils/dom";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
-
 import { getDepth, getListItemChildren, updateListItemChildren } from "./utils";
-import { SelectionAppearance, SelectionMode } from "../list/resources";
+import { SelectionAppearance } from "../list/resources";
+import { SelectionMode } from "../interfaces";
 
 const focusMap = new Map<HTMLCalciteListElement, number>();
 
@@ -124,7 +124,8 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
    *
    * @internal
    */
-  @Prop({ mutable: true }) selectionMode: SelectionMode = null;
+  @Prop({ mutable: true }) selectionMode: Extract<"none" | "multiple" | "single", SelectionMode> =
+    null;
 
   /**
    * Specifies the selection appearance - `"icon"` (displays a checkmark or dot) or `"border"` (displays a border).

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -11,9 +11,9 @@ import {
   Event,
   EventEmitter
 } from "@stencil/core";
-import { CSS, debounceTimeout, SelectionAppearance, SelectionMode } from "./resources";
+import { CSS, debounceTimeout, SelectionAppearance } from "./resources";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
-
+import { SelectionMode } from "../interfaces";
 import { createObserver } from "../../utils/observers";
 import { getListItemChildren, updateListItemChildren } from "../list-item/utils";
 import { toAriaBoolean } from "../../utils/dom";
@@ -113,7 +113,8 @@ export class List implements InteractiveComponent, LoadableComponent {
   /**
    * Specifies the selection mode - `"multiple"` (allow any number of selected items), `"single"` (allows and require one selected item), `"none"` (no selected items).
    */
-  @Prop({ reflect: true }) selectionMode: SelectionMode = "none";
+  @Prop({ reflect: true }) selectionMode: Extract<"none" | "multiple" | "single", SelectionMode> =
+    "none";
 
   /**
    * Specifies the selection appearance - `"icon"` (displays a checkmark or dot) or `"border"` (displays a border).

--- a/src/components/list/resources.ts
+++ b/src/components/list/resources.ts
@@ -9,5 +9,3 @@ export const CSS = {
 export const debounceTimeout = 100;
 
 export type SelectionAppearance = "border" | "icon";
-
-export type SelectionMode = "single" | "multiple" | "none";

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -11,7 +11,6 @@ import {
   VNode
 } from "@stencil/core";
 import { TreeItemSelectDetail } from "./interfaces";
-import { TreeSelectionMode } from "../tree/interfaces";
 import {
   nodeListToArray,
   getElementDir,
@@ -20,7 +19,7 @@ import {
   toAriaBoolean
 } from "../../utils/dom";
 
-import { Scale } from "../interfaces";
+import { Scale, SelectionMode } from "../interfaces";
 import { CSS, SLOTS, ICONS } from "./resources";
 import { CSS_UTILITY } from "../../utils/resources";
 import {
@@ -105,14 +104,12 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
   /**
    * @internal
    */
-  @Prop({ mutable: true, reflect: true }) selectionMode: TreeSelectionMode;
+  @Prop({ mutable: true, reflect: true }) selectionMode: SelectionMode;
 
   @Watch("selectionMode")
   getselectionMode(): void {
     this.isSelectionMultiLike =
-      this.selectionMode === "multiple" ||
-      this.selectionMode === "multi" ||
-      this.selectionMode === "multichildren";
+      this.selectionMode === "multiple" || this.selectionMode === "multichildren";
   }
 
   //--------------------------------------------------------------------------
@@ -179,9 +176,7 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
     const rtl = getElementDir(this.el) === "rtl";
     const showBulletPoint = this.selectionMode === "single" || this.selectionMode === "children";
     const showCheckmark =
-      this.selectionMode === "multi" ||
-      this.selectionMode === "multiple" ||
-      this.selectionMode === "multichildren";
+      this.selectionMode === "multiple" || this.selectionMode === "multichildren";
     const showBlank = this.selectionMode === "none" && !this.hasChildren;
     const chevron = this.hasChildren ? (
       <calcite-icon

--- a/src/components/tree/interfaces.ts
+++ b/src/components/tree/interfaces.ts
@@ -1,1 +1,0 @@
-export type TreeSelectionMode = "single" | "multi" | "none" | "children" | "multichildren" | "ancestors" | "multiple";

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -49,7 +49,7 @@ export default {
   ...storyFilters()
 };
 
-const selectionModes = ["single", "multi", "children", "multichildren", "ancestors", "none", "multiple"];
+const selectionModes = ["single", "children", "multichildren", "ancestors", "none", "multiple"];
 
 export const simple = (): string => html`
   <calcite-tree

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -11,8 +11,7 @@ import {
 } from "@stencil/core";
 import { focusElement, getRootNode, nodeListToArray } from "../../utils/dom";
 import { TreeItemSelectDetail } from "../tree-item/interfaces";
-import { TreeSelectionMode } from "./interfaces";
-import { Scale } from "../interfaces";
+import { Scale, SelectionMode } from "../interfaces";
 import { getEnabledSiblingItem } from "./utils";
 
 /**
@@ -53,9 +52,8 @@ export class Tree {
    * Customize how the component's selection works.
    *
    * @default "single"
-   * @see [TreeSelectionMode](https://github.com/Esri/calcite-components/blob/master/src/components/tree/interfaces.ts#L5)
    */
-  @Prop({ mutable: true, reflect: true }) selectionMode: TreeSelectionMode = "single";
+  @Prop({ mutable: true, reflect: true }) selectionMode: SelectionMode = "single";
 
   /**
    * Specifies the component's selected items.
@@ -85,9 +83,7 @@ export class Tree {
           this.child
             ? undefined
             : (
-                this.selectionMode === "multi" ||
-                this.selectionMode === "multiple" ||
-                this.selectionMode === "multichildren"
+                this.selectionMode === "multiple" || this.selectionMode === "multichildren"
               ).toString()
         }
         role={!this.child ? "tree" : undefined}
@@ -165,18 +161,14 @@ export class Tree {
     const shouldModifyToCurrentSelection =
       !isNoneSelectionMode &&
       event.detail.modifyCurrentSelection &&
-      (this.selectionMode === "multi" ||
-        this.selectionMode === "multiple" ||
-        this.selectionMode === "multichildren");
+      (this.selectionMode === "multiple" || this.selectionMode === "multichildren");
 
     const shouldSelectChildren =
       this.selectionMode === "multichildren" || this.selectionMode === "children";
 
     const shouldClearCurrentSelection =
       !shouldModifyToCurrentSelection &&
-      (((this.selectionMode === "single" ||
-        this.selectionMode === "multi" ||
-        this.selectionMode === "multiple") &&
+      (((this.selectionMode === "single" || this.selectionMode === "multiple") &&
         childItems.length <= 0) ||
         this.selectionMode === "children" ||
         this.selectionMode === "multichildren");

--- a/src/demos/dropdown.html
+++ b/src/demos/dropdown.html
@@ -210,7 +210,7 @@
         <div class="child right-aligned-text">icon-start + multi select</div>
 
         <div class="child">
-          <calcite-dropdown scale="s" selection-mode="multi">
+          <calcite-dropdown scale="s" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale S</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
@@ -221,7 +221,7 @@
         </div>
 
         <div class="child">
-          <calcite-dropdown scale="m" selection-mode="multi">
+          <calcite-dropdown scale="m" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale M</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
@@ -232,7 +232,7 @@
         </div>
 
         <div class="child">
-          <calcite-dropdown scale="l" selection-mode="multi">
+          <calcite-dropdown scale="l" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale L</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
@@ -248,7 +248,7 @@
         <div class="child right-aligned-text">icon-start + multi select</div>
 
         <div class="child">
-          <calcite-dropdown scale="s" selection-mode="multi">
+          <calcite-dropdown scale="s" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale S</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
@@ -259,7 +259,7 @@
         </div>
 
         <div class="child">
-          <calcite-dropdown scale="m" selection-mode="multi">
+          <calcite-dropdown scale="m" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale M</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
@@ -270,7 +270,7 @@
         </div>
 
         <div class="child">
-          <calcite-dropdown scale="l" selection-mode="multi">
+          <calcite-dropdown scale="l" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale L</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-start="list-bullet" active>List</calcite-dropdown-item>
@@ -286,7 +286,7 @@
         <div class="child right-aligned-text">icon-end + multi select</div>
 
         <div class="child">
-          <calcite-dropdown scale="s" selection-mode="multi">
+          <calcite-dropdown scale="s" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale S</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-end="list-bullet" active>List</calcite-dropdown-item>
@@ -297,7 +297,7 @@
         </div>
 
         <div class="child">
-          <calcite-dropdown scale="m" selection-mode="multi">
+          <calcite-dropdown scale="m" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale M</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-end="list-bullet" active>List</calcite-dropdown-item>
@@ -308,7 +308,7 @@
         </div>
 
         <div class="child">
-          <calcite-dropdown scale="l" selection-mode="multi">
+          <calcite-dropdown scale="l" selection-mode="multiple">
             <calcite-button icon-end="hamburger" appearance="outline" slot="trigger">Scale L</calcite-button>
             <calcite-dropdown-group group-title="View">
               <calcite-dropdown-item icon-end="list-bullet" active>List</calcite-dropdown-item>
@@ -697,7 +697,7 @@
               <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
               <calcite-dropdown-item>Title</calcite-dropdown-item>
             </calcite-dropdown-group>
-            <calcite-dropdown-group selection-mode="multi" group-title="Selection Mode: Multi">
+            <calcite-dropdown-group selection-mode="multiple" group-title="Selection Mode: Multi">
               <calcite-dropdown-item active>Maps</calcite-dropdown-item>
               <calcite-dropdown-item>Layers</calcite-dropdown-item>
               <calcite-dropdown-item active>Data</calcite-dropdown-item>
@@ -716,7 +716,7 @@
               <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
               <calcite-dropdown-item>Title</calcite-dropdown-item>
             </calcite-dropdown-group>
-            <calcite-dropdown-group selection-mode="multi" group-title="Selection Mode: Multi">
+            <calcite-dropdown-group selection-mode="multiple" group-title="Selection Mode: Multi">
               <calcite-dropdown-item active>Maps</calcite-dropdown-item>
               <calcite-dropdown-item>Layers</calcite-dropdown-item>
               <calcite-dropdown-item active>Data</calcite-dropdown-item>
@@ -735,7 +735,7 @@
               <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
               <calcite-dropdown-item>Title</calcite-dropdown-item>
             </calcite-dropdown-group>
-            <calcite-dropdown-group selection-mode="multi" group-title="Selection Mode: Multi">
+            <calcite-dropdown-group selection-mode="multiple" group-title="Selection Mode: Multi">
               <calcite-dropdown-item active>Maps</calcite-dropdown-item>
               <calcite-dropdown-item>Layers</calcite-dropdown-item>
               <calcite-dropdown-item active>Data</calcite-dropdown-item>
@@ -754,7 +754,7 @@
               <calcite-dropdown-item active>Date modified</calcite-dropdown-item>
               <calcite-dropdown-item>Title</calcite-dropdown-item>
             </calcite-dropdown-group>
-            <calcite-dropdown-group selection-mode="multi" group-title="Selection Mode: Multi">
+            <calcite-dropdown-group selection-mode="multiple" group-title="Selection Mode: Multi">
               <calcite-dropdown-item active>Maps</calcite-dropdown-item>
               <calcite-dropdown-item>Layers</calcite-dropdown-item>
               <calcite-dropdown-item active>Data</calcite-dropdown-item>


### PR DESCRIPTION
BREAKING CHANGE: Removes `multi` value of `selection-mode`.

Removes the `multi` value for `selection-mode` property, use `multiple` instead.