### PR TITLE
chore(docs): Cleanup local index page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -342,7 +342,7 @@
 
         <div>
           <a href="/demos/shell/">
-            <calcite-action scale=" s" text="Shell" alignment="start" text-enabled appearance="solid"> </calcite-action>
+            <calcite-action scale="s" text="Shell" alignment="start" text-enabled appearance="solid"> </calcite-action>
           </a>
         </div>
 


### PR DESCRIPTION
Truly the smallest PR for a busted scale value I introduced earlier - once you see it you can't unsee it:

<img width="429" alt="Screen Shot 2022-12-16 at 9 20 20 PM" src="https://user-images.githubusercontent.com/4733155/208226642-eb1f63af-fd88-4ee8-8860-41b3dc627b33.png">

