### PR TITLE
refactor(locale): remove unused property from LocalizaedComponent

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -273,10 +273,9 @@ const mutationObserver = createObserver("mutation", (records) => {
     const el = record.target as HTMLElement;
 
     connectedComponents.forEach((component) => {
-      const hasOverridingLocale = !!(component.locale && !component.el.lang);
       const inUnrelatedSubtree = !containsCrossShadowBoundary(el, component.el);
 
-      if (hasOverridingLocale || inUnrelatedSubtree) {
+      if (inUnrelatedSubtree) {
         return;
       }
 
@@ -305,7 +304,6 @@ const mutationObserver = createObserver("mutation", (records) => {
 function getLocale(component: LocalizedComponent): string {
   return (
     component.el.lang ||
-    component.locale ||
     closestElementCrossShadowBoundary<HTMLElement>(component.el, "[lang]")?.lang ||
     document.documentElement.lang ||
     defaultLocale

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -202,16 +202,6 @@ export interface LocalizedComponent {
   el: HTMLElement;
 
   /**
-   * BCP 47 language tag for desired language and country format
-   *
-   * **Note**: this prop was added exclusively for backwards-compatibility
-   *
-   * @deprecated set the global `lang` attribute on the element instead.
-   * @mdn [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-   */
-  locale?: string;
-
-  /**
    * Used to store the effective locale to avoid multiple lookups.
    *
    * This is an internal property and should:


### PR DESCRIPTION
**Related Issue:** #

## Summary
All of the locale properties have been removed so this can be safely nuked 💣 