### PR TITLE
refactor(input)!: remove deprecated event payload

### DIFF
--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -366,7 +366,7 @@ export class ColorPicker
 
   private handleChannelInput = (event: CustomEvent): void => {
     const input = event.currentTarget as HTMLCalciteInputElement;
-    const internalInput = event.detail.nativeEvent.target as HTMLInputElement;
+    const internalInput = input?.shadowRoot.querySelector("input") as HTMLInputElement;
     const channelIndex = Number(input.getAttribute("data-channel-index"));
 
     const limit =

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -366,7 +366,6 @@ export class ColorPicker
 
   private handleChannelInput = (event: CustomEvent): void => {
     const input = event.currentTarget as HTMLCalciteInputElement;
-    const internalInput = input?.shadowRoot.querySelector("input") as HTMLInputElement;
     const channelIndex = Number(input.getAttribute("data-channel-index"));
 
     const limit =
@@ -386,7 +385,10 @@ export class ColorPicker
     }
 
     input.value = inputValue;
-    internalInput.value = inputValue;
+
+    // TODO: refactor calcite-input so we don't need to sync the internals
+    // https://github.com/Esri/calcite-components/issues/6100
+    input.internalSyncChildElValue();
   };
 
   // using @Listen as a workaround for VDOM listener not firing

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -560,6 +560,18 @@ export class Input
       this.childEl?.select();
     }
   }
+
+  // TODO: refactor so we don't need to sync the internals in color-picker
+  // https://github.com/Esri/calcite-components/issues/6100
+  /** @internal */
+  @Method()
+  async internalSyncChildElValue(): Promise<void> {
+    if (this.type === "number") {
+      this.childNumberEl.value = this.value;
+    } else {
+      this.childEl.value = this.value;
+    }
+  }
   //--------------------------------------------------------------------------
   //
   //  Private Methods

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,4 +1,4 @@
-import { DeprecatedEventPayload, Scale, Status } from "../interfaces";
+import { Scale, Status } from "../interfaces";
 import {
   Component,
   Element,
@@ -412,7 +412,7 @@ export class Input
   /** the computed icon to render */
   private requestedIcon?: string;
 
-  private nudgeNumberValueIntervalId;
+  private nudgeNumberValueIntervalId: number;
 
   mutationObserver = createObserver("mutation", () => this.setDisabledAction());
 
@@ -523,13 +523,10 @@ export class Input
    */
   @Event({ cancelable: false }) calciteInternalInputBlur: EventEmitter<void>;
 
-  // TODO: refactor color-picker to not use the deprecated
-  // nativeEvent payload property in handleChannelInput()
   /**
    * Fires each time a new `value` is typed.
-   * NOTE: `nativeEvent` payload property is deprecated
    */
-  @Event({ cancelable: true }) calciteInputInput: EventEmitter<DeprecatedEventPayload>;
+  @Event({ cancelable: true }) calciteInputInput: EventEmitter<void>;
 
   /**
    * Fires each time a new `value` is typed and committed.
@@ -855,11 +852,11 @@ export class Input
     event.stopPropagation();
   };
 
-  private setChildElRef = (el) => {
+  private setChildElRef = (el: HTMLInputElement | HTMLTextAreaElement) => {
     this.childEl = el;
   };
 
-  private setChildNumberElRef = (el) => {
+  private setChildNumberElRef = (el: HTMLInputElement) => {
     this.childNumberEl = el;
   };
 
@@ -954,9 +951,7 @@ export class Input
     this.previousValueOrigin = origin;
 
     if (nativeEvent) {
-      const calciteInputInputEvent = this.calciteInputInput.emit({
-        nativeEvent
-      });
+      const calciteInputInputEvent = this.calciteInputInput.emit();
       if (calciteInputInputEvent.defaultPrevented) {
         this.value = this.previousValue;
         this.localizedValue =

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -13,7 +13,3 @@ export type Status = "invalid" | "valid" | "idle";
 export type ThemeClass = "calcite-theme-light" | "calcite-theme-dark" | "calcite-theme-auto";
 export type ThemeName = "light" | "dark" | "auto";
 export type Width = "auto" | "half" | "full";
-
-// used to help track of event payloads to remove at 1.0.0 – see https://github.com/Esri/calcite-components/issues/3781
-/* Note : should be removed before `1.0 */
-export type DeprecatedEventPayload = any;


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated event payload

- Removed the `nativeEvent` payload property which was being used internally. 