### PR TITLE
chore(types): Adds missing value to SelectionMode

### DIFF
--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -7,7 +7,14 @@ export type Kind = "brand" | "danger" | "info" | "inverse" | "neutral" | "warnin
 export type Layout = "horizontal" | "vertical" | "grid";
 export type LogicalFlowPosition = "inline-start" | "inline-end" | "block-start" | "block-end";
 export type Position = "start" | "end";
-export type SelectionMode = "single" | "none" | "children" | "multichildren" | "ancestors" | "multiple";
+export type SelectionMode =
+  | "single"
+  | "none"
+  | "children"
+  | "single-persist"
+  | "multichildren"
+  | "ancestors"
+  | "multiple";
 export type Scale = "s" | "m" | "l";
 export type Status = "invalid" | "valid" | "idle";
 export type ThemeClass = "calcite-theme-light" | "calcite-theme-dark" | "calcite-theme-auto";


### PR DESCRIPTION
Adds a missing value to SelectionMode type - no errors are thrown when you try to extract a value that doesn't exist in the type. Not sure if there's a way to validate the requested Extract values?

For example:   
`@Prop({ reflect: true }) selectionMode: Extract<"single" | "single-persist" | "multiple", SelectionMode> = "multiple";`

doesn't throw an error since the default `multiple` exists in the defined type, however:

`@Prop({ reflect: true }) selectionMode: Extract<"single" | "single-persist" | "multiple", SelectionMode> = "single-persist";`

would have thrown an error. 