### PR TITLE
docs(changelog): resort and modify indent levels and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,8 +169,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     `success`, and `warning`.
 
 - **tab-nav**: Removed `event.detail` payload from events.
+
   - Removed the `event.detail` property on the event `calciteTabChange`,
     use `event.target` instead.
+
 - **tab-title**: Removed `event.detail` payload from events.
 
   - Removed the `event.detail` property on the event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,76 +9,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### ⚠ BREAKING CHANGES
 
-- **input:** remove deprecated event payload
-
-  - Removed the `nativeEvent` payload property which was being used
-    internally.
-
-- **radio-group:** - Removed `minimal` appearance value, use `outline` instead.
-- **input-date-picker:** remove deprecated event
-
-  - Removed `calciteDatePickerRangeChange` event, use
-    `calciteInputDatePickerChange` instead.
-
-- **date-picker:** Removed `endAsDate` and `startAsDate` properties, use
-  `valueAsDate` instead
-
-  - Removed `endAsDate` and `startAsDate` properties, use `valueAsDate`
-    instead
-
-- **time-picker:** remove `target` parameter from `setFocus()`
-
-  - Removed `target` parameter from `setFocus()`, focus will be delegated
-    to the first focusable element instead.
-
-- **input-time-picker:** Removed deprecated `locale` property.
-
-  - Removed the property `locale`, use `lang` instead.
-
 - **accordion, combobox, dropdown, list, tree:** Removes `multi` value of `selection-mode`.
 
   - Removed the `multi` value for `selection-mode` property, use `multiple`
     instead.
 
-- **shell-panel:** Removed deprecated `intlResize` property.
+* **action,action-bar,action-group,action-pad,alert,block-section,block,button:** Removed deprecated `intl*` properties , use
+  `messageOverrides` property instead.
 
-  - Removed the property `intlResize`, use `messagesOverrides.resize`
-    instead.
+* **action-bar, action-pad:** Removed `focusId` paramter `setFocus`
+  method, focus is delegated to the first focusable element.
 
-* **modal:** Removed `backgroundColor` property.
-
-  - Removed the property `backgroundColor`, use the CSS variable
-    `--calcite-modal-content-background` instead.
-
-- **modal:** Removed `--calcite-modal-padding` CSS variable.
-
-  - Removed the `--calcite-modal-padding` CSS variable, use the
-    `--calcite-modal-content-padding` CSS variable instead.
-
-* **color-picker-hex-input:** removed `intl` properties.
-
-  - Removed, `intlHex` property, aria-label of color-picker-hex-input is
-    set to `hex` by default.
-  - Removed ,`intlNoColor` property.
-
-  _note: color-picker-hex-input is `internal` component._
-
-- **input-date-picker:** Removed the `start`, `end`, `startAsDate`, and
-  `endAsDate` properties.
-
-  - Removed the property `start`, use `value` instead.
-  - Removed the property `end`, use `value` instead.
-  - Removed the property `startAsDate`, use `valueAsDate` instead.
-  - Removed the property `endAsDate`, use `valueAsDate` instead.
-
-* **chip:** Renamed `color` property and updated values, and
-  updated `appearance` values.
+- **alert, notice:** Renamed `color` properties and updated values.
 
   - Renamed the property `color`, use `kind` instead.
-  - Updated the accepted values of `kind` to `brand`, `inverse`, and
-    `neutral` (default).
-  - Updated the accepted values of `appearance` to , `outline`,
-    `outline-fill` and `solid` (default).
+  - Updated the accepted values of `kind` to `brand`, `danger`, `info`,
+    `success`, and `warning`.
+
+* **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Sets internal heading HTML element to be a div by default. If users would like to retain an internal H1-H6 HTML element, they will need to set the headingLevel property on the component. Users already setting the headingLevel property are not affected. ([#5728](https://github.com/Esri/calcite-components/pull/5728)) ([38ca639](https://github.com/Esri/calcite-components/commit/38ca639010b8bd1d1fe32c9cf9b54dfc38cf9877)), closes [5099](https://github.com/Esri/calcite-components/issues/5099)
 
 * **button, fab, split-button:** Removed deprecated properties and values.
 
@@ -93,47 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `fab`: Updated the accepted values of `appearance` to `outline-fill`
     and `solid` (default).
 
-* **action-bar, action-pad:** Removed `focusId` paramter `setFocus`
-  method, focus is delegated to the first focusable element.
-
-* **notice:** Removed deprecated properties.
-
-  - Removed the property `active`, use `open` instead.
-  - Removed the property `dimissible`, use `closable` property instead.
-
-  - **modal**: Removed deprecated `intl\*` & accessible label properties.
-
-    - Removed the property `intlClose` , use `messsageOverrides.close`
-      instead.
-
-  - **notice**: Removed deprecated `intl\*` & accessible label properties.
-
-    - Removed the property `intlClose` , use `messsageOverrides.close`
-      instead.
-
-  - **pagination**: Removed deprecated `intl\*` & accessible label properties.
-
-    - Removed the property `textLabelNext` , use `messsageOverrides.next`
-      instead.
-    - Removed the property `textLabelPrevious` , use
-      `messsageOverrides.previous` instead.
-
-  - **panel**: Removed deprecated `intl\*` & accessible label properties.
-
-    - Removed the property `intlClose` , use `messsageOverrides.close`
-      instead.
-    - Removed the property `intlOptions`, use `messsageOverrides.options`
-      instead.
-
-  - **pick-list-item**: Removed deprecated `intl\*` & accessible label properties.
-
-    - Removed the property `intlRemove` , use `messsageOverrides.remove`
-      instead.
-
-  - **popover**: Removed deprecated `intl\*` & accessible label properties.
-
-    - Removed the property `intlClose` , use `messsageOverrides.close`
-      instead.
+* **chip,card,combobox,date-picker,flow,flow-item,filter, input-date-picker:** Removed deprecated `intl\*` & accessible label properties.
 
 - **chip,combobox-item:** Removed deprecated event payload.
 
@@ -142,136 +50,151 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the `event.detail` property on the event
     `calciteComboboxChipDismiss`, use `event.target` instead.
 
-- **radio-group:** Removed `event.detail` payload from events.
+* **dropdown, dropdown-item:** Removed deprecated properties.
 
-  - Removed the `event.detail` property on the event
-    `calciteRadioGroupChange`, use `event.target` instead.
+  - Removed the property `active` on `calcite-dropdown-item`, use
+    `selected` instead.
+  - Removed the property `active`, on `calcite-dropdown`, use `open`
+    instead.
 
-- **date-picker-month, date-picker-month-header:** Removed events.
+* **flow, flow-item:** Removed the `calciteFlowItemBackClick` event and
+  support for slotting `calcite-panel`s.
 
-  - Removed the event `calciteDatePickerSelect` on
-    `CalciteDatePickerMonthHeader`
-  - Removed the event `calciteDatePickerSelect` on
-    `CalciteDatePickerMonth`
-  - Removed the event `calciteDatePickerActiveDateChange` on
-    `CalciteDatePickerMonth`
-
-- **alert, notice:** Renamed `color` properties and updated values.
-
-  - Renamed the property `color`, use `kind` instead.
-  - Updated the accepted values of `kind` to `brand`, `danger`, `info`,
-    `success`, and `warning`.
-
-* **modal:** Renamed `color` property and updated values.
-
-  - Renamed the property `color`, use `kind` instead.
-  - Updated the accepted values of `kind` to `brand`, `danger`, `info`,
-    `success`, and `warning`.
-
-- **tab-nav**: Removed `event.detail` payload from events.
-
-  - Removed the `event.detail` property on the event `calciteTabChange`,
-    use `event.target` instead.
-
-- **tab-title**: Removed `event.detail` payload from events.
-
-  - Removed the `event.detail` property on the event
-    `calciteTabsActivate`, use `event.target` instead.
-
-- **tree:** Removed `event.detail` payload from events and added
-  `selectedItems` property.
-
-  - Added property `selectedItems`.
-  - Removed the `event.detail` property on the event `calciteTreeSelect`,
-    use `event.target` instead.
-
-* **pagination:** Removed `event.detail` payload from events.
-
-  - Removed the `event.detail` property on the event
-    `calcitePaginationChange`, use `event.target` instead.
-
-* **dropdown:** Removed `event.detail` payload from events.
-
-  - Removed the `event.detail` property on the event
-    `calciteDropdownSelect`, use `event.target` instead.
-
-* **rating:** Removed `event.detail` payload from events.
-
-  - Removed the `event.detail` property on the event
-    `calciteRatingChange`, use `event.target` instead.
+  - Removed support for slotting `calcite-panel` components, use the
+    `calcite-flow-item` component instead.
+  - Removed the event `calciteFlowItemBackClick`, use
+    `calciteFlowItemBack` instead.
 
 * **inline-editable,input,input-text,input-number:** Removed deprecated `intl\*` & accessible label properties.
 
-* **inline-editable:**
+  - **list, list-item, list-item-group:** To know when `calcite-list-item` content is selected, listen to the event `calciteListItemSelect` instead of `click`.
 
-  - Removed the property` intlEnableEditing`, use `messsageOverrides.enableEditing` instead.
-  - Removed the property `intlCancelEditing`, use `messageOverrides.cancelEditing` instead.
-  - Removed the property `intlConfirmChanges`, use `messageOverrides.confirmChanges` instead.
+  - `headingLevel` property on the `list` and `list-item-group` are no
+    longer necessary.
+  - `nonInteractive` property on the `list-item` is no longer necessary.
 
-* **input-number:**
+  - **list:**
 
-  - Removed the property `intlClear`, use `messsageOverrides.clear` instead.
-  - Removed the property `intlLoading`, use `messsageOverrides.loading` instead.
+    - Adds `label` property to specify an accessible name for the component.
+    - Adds `loading` property to show a busy indicator.
+    - Adds `selectionMode` and `selectionAppearance` properties to handle configuration of selection.
+    - Adds `filterEnabled`, `filteredData`, `filteredItems`, `filterText`, and `filterPlaceholder` properties to support filtering.
+    - Adds `calciteListFilter` event to notify when a filter has changed.
+    - Deprecates `headingLevel` property.
 
-* **input-text:**
+  - **list-item-group:**
 
-  - Removed the property `intlClear`, use `messsageOverrides.clear` instead.
-  - Removed the property `intlLoading`, use `messsageOverrides.loading` instead.
+    - Adds `disabled` property to prevent user interaction.
+    - Deprecates `headingLevel` property.
 
-* **input:**
+  - **list-item:**
+    - Adds `calciteListItemSelect` event to notify when list item content is selected.
+    - Adds `selected` and `value` properties to handle selection.
+    - Adds `open` property to show child components.
+    - Deprecates `nonInteractive` property.
 
-  - Removed the property `intlClear`, use `messsageOverrides.clear` instead.
-  - Removed the property `intlLoading`, use `messsageOverrides.loading` instead.
+* **loader, input-message:** use hidden native global attribute to toggle visibility on the components instead of the deprecated active prop.
+
+* **popover, dropdown, modal, pick-list-item, popover, value-list-item:** Renamed `disable*` properties.
 
 * **scrim,rating,time-picker,input-time-picker,value-list:** Removed deprecated `intl\*` & accessible label properties.
 
-* **rating:**
+* **tabs, tab-nav, tab-title, tab:**
 
-  - Removed the property `intlStars` , use `messsageOverrides.stars` instead.
-  - Removed the property `intlRating` , use `messsageOverrides.rating` instead.
+  - Removed the property `active` from `calcite-tab-title`, use `selected`
+    instead.
+  - Removed the property `active` from `calcite-tab`, use `selected`
+    instead.
+  - Removed the `above` value from the `position` property on
+    `calcite-tabs`, use `top` instead.
+  - Removed the `below` value from the `position` property on
+    `calcite-tabs`, use `bottom` instead.
 
-* **scrim:**
+* **accordion-item:** Removed the properties `active`, `itemTitle`,
+  `itemSubtitle`, and `icon`.
 
-  - Removed the property `intlLoading` , use `messsageOverrides.loading` instead.
+  - Removed the property `active`, use `expanded` instead.
+  - Removed the property `itemTitle`, use `heading` instead.
+  - Removed the property `itemSubtitle`, use `description` instead.
+  - Removed the property `icon`, use `iconStart` or `iconEnd` instead.
 
-* **time-picker:**
+* **action:**
 
-  - Removed the property `intlHour`, use `messsageOverrides.hour` instead.
-  - Removed the property `intlHourDown`, use `messsageOverrides.hourDown` instead.
-  - Removed the property `intlHourUp`, use `messsageOverrides.hourUp` instead.
-  - Removed the property `intlMeridiem`, use `messsageOverrides.meridiem` instead.
-  - Removed the property `intlMeridiemDown`, use `messsageOverrides.meridiemDown` instead.
-  - Removed the property `intlMeridiemUp`, use `messsageOverrides.meridiemUp` instead.
-  - Removed the property `intlMinute`, use `messsageOverrides.minute` instead.
-  - Removed the property `intlMinuteUp`, use `messsageOverrides.minuteUp` instead.
-  - Removed the property `intlMinuteDown`, use `messsageOverrides.minuteDown` instead.
-  - Removed the property `intlSecond`, use `messsageOverrides.second` instead.
-  - Removed the property `intlSecondUp`, use `messsageOverrides.secondUp` instead.
-  - Removed the property `intlSecondDown`, use `messsageOverrides.secondDown` instead.
+  - Removed the property `intlLoading` , use `messsageOverrides.loading`
+    instead.
+  - Removed the property `intlIndicator`, use `messageOverrides.indicator`
+    instead.
+  - Removed the `calciteActionClick` event and the `clear`
+    value for the `appearance` property. Listen to the `click` event instead of `calciteActionClick.
+  - Use the value `transparent` instead of `clear` for the property
+    `appearance`.
 
-* **input-time-picker:**
+* **action-bar:**
 
-  - Removed the property `intlHour`, use `messsageOverrides.hour` instead.
-  - Removed the property `intlHourDown`, use `messsageOverrides.hourDown` instead.
-  - Removed the property `intlHourUp`, use `messsageOverrides.hourUp` instead.
-  - Removed the property `intlMeridiem`, use `messsageOverrides.meridiem` instead.
-  - Removed the property `intlMeridiemDown`, use`messsageOverrides.meridiemDown` instead.
-  - Removed the property `intlMeridiemUp`, use `messsageOverrides.meridiemUp` instead.
-  - Removed the property `intlMinute`, use `messsageOverrides.minute` instead.
-  - Removed the property `intlMinuteUp`, use `messsageOverrides.minuteUp` instead.
-  - Removed the property `intlMinuteDown`, use `messsageOverrides.minuteDown` instead.
-  - Removed the property `intlSecond`, use `messsageOverrides.second` instead.
-  - Removed the property `intlSecondUp`, use `messsageOverrides.secondUp` instead.
-  - Removed the property `intlSecondDown`, use `messsageOverrides.secondDown` instead.
+  - Removed the property `intlExpand` , use `messsageOverrides.expand`
+    instead.
+  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
+    instead.
 
-* **value-list:**
+* **action-group:**
 
-  - Removed the property `intlDragHandleActive`, use `messsageOverrides.dragHandleActive` instead.
-  - Removed the property `intlDragHandleChange`, use `messsageOverrides.dragHandleChange` instead.
-  - Removed the property `intlDragHandleCommit`, use `messsageOverrides.dragHandleCommit` instead.
-  - Removed the property `intlDragHandleIdle`, use `messsageOverrides.dragHandleIdle` instead.
+  - Removed the property `intlMore` , use `messsageOverrides.more`
+    instead.
 
-* **chip,card,combobox,date-picker,flow,flow-item,filter, input-date-picker:** Removed deprecated `intl\*` & accessible label properties.
+* **action-menu:**
+
+  - Removed the event `calciteActionMenuOpenChange`, use
+    `calciteActionMenuOpen` instead.
+  - Removed the `event.detail` value from the
+    `calciteActionMenuOpenChange` event on the `action-menu` component.
+  - When listening to `calciteActionMenuOpenChange`, use the `open`
+    property on the `event.target` instead of `event.detail`.
+
+* **action-pad**:
+
+  - Removed the property `intlExpand` , use `messsageOverrides.expand`
+    instead.
+  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
+    instead.
+
+* **alert**:
+
+  - Removed the property `intlClose`, use `messageOverrides.close`
+    instead.
+  - Renamed the property `autoDismiss`, use `autoClose` instead.
+  - Renamed the property `autoDismissDuration`, use `autoCloseDuration`
+    instead.
+  - Removed the property `active`, use `open` instead.
+  - Removed the `*-leading` and `*-trailing` values for
+    component `placement` properties.
+  - There is no need for "_-leading" and "_-trailing" values anymore since
+    `*-start` and `*-end` are already flipped in right-to-left direction.
+
+* **block**:
+
+  - Removed the property `intlExpand` , use `messsageOverrides.expand`
+    instead.
+  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
+    instead.
+  - Removed the property `intlLoading` , use `messsageOverrides.loading`
+    instead.
+  - Removed the property `intlOptions`, use `messageOverrides.options`
+    instead.
+  - Removed the property `summary`, use `description` instead.
+  - Removed the property `disablePadding`, use the CSS variable
+    `--calcite-block-padding` instead.
+
+* **block-section:**
+
+  - Removed the property `intlExpand` , use `messsageOverrides.expand`
+    instead.
+  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
+    instead.
+
+* **button:**
+
+  - Removed the property `intlLoading` , use `messsageOverrides.loading`
+    instead.
 
 * **card**:
 
@@ -282,10 +205,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the property `intlDeselect` use `messageOverrides.deselect`
     instead.
 
-* **chip**:
+* **chip:**
 
+  - Renamed the property `color`, use `kind` instead.
+  - Updated the accepted values of `kind` to `brand`, `inverse`, and
+    `neutral` (default).
+  - Updated the accepted values of `appearance` to , `outline`,
+    `outline-fill` and `solid` (default).
   - Removed the property `dismissLabel` , use
     `messsageOverrides.dismissLabel ` instead.
+  - Renamed the event `calciteChipDismiss`, use `calciteChipClose`
+    instead.
+  - Removed the property `dismissible`, use `closable` instead.
+  - Use the value `transparent` instead of `clear` for `appearance`
+    property.
+
+* **color-picker-hex-input:**
+
+  - Removed, `intlHex` property, aria-label of color-picker-hex-input is
+    set to `hex` by default.
+  - Removed ,`intlNoColor` property.
+
+  _note: color-picker-hex-input is `internal` component._
 
 * **color-picker:**
 
@@ -321,216 +262,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   - Removed the property `intlRemoveTag` , use
     `messsageOverrides.removeTag` instead.
-
-* **date-picker:**
-
-  - Removed the property `intlNextMonth`, use `messageOverrides.nextMonth`
-    instead.
-  - Removed the property `intlPrevMonth`, use `messageOverrides.prevMonth`
-    instead.
-  - Removed the property `intlYear`, use `messageOverrides.year` instead.
-
-* **flow-item:**
-
-  - Removed the property `intlBack` , use `messsageOverrides.back`
-    instead.
-  - Removed the property `intlClose`, use `messageOverrides.close`
-    instead.
-  - Removed the property `intlOptions` , use `messsageOverrides.options`
-    instead.
-
-* **filter:**
-
-  - Removed the property `intlClear`, use `messsageOverrides.clear`
-    instead.
-  - Removed the property `intlLabel`, use `messageOverrides.label`
-    instead.
-
-* **input-date-picker:**
-
-  - Removed the property `intlNextMonth`, use `messageOverrides.nextMonth`
-    instead.
-  - Removed the property `intlPrevMonth`, use `messageOverrides.prevMonth`
-    instead.
-  - Removed the property `intlYear`, use `messageOverrides.year` instead.
-
-* **action,action-bar,action-group,action-pad,alert,block-section,block,button:** Removed deprecated `intl*` properties , use
-  `messageOverrides` property instead.
-
-* **action:**
-
-  - Removed the property `intlLoading` , use `messsageOverrides.loading`
-    instead.
-  - Removed the property `intlIndicator`, use `messageOverrides.indicator`
-    instead.
-
-* **action-bar:**
-
-  - Removed the property `intlExpand` , use `messsageOverrides.expand`
-    instead.
-  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
-    instead.
-
-* **action-group:**
-
-  - Removed the property `intlMore` , use `messsageOverrides.more`
-    instead.
-
-* **action-pad**:
-
-  - Removed the property `intlExpand` , use `messsageOverrides.expand`
-    instead.
-  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
-    instead.
-
-* **alert**:
-
-  - Removed the property `intlClose`, use `messageOverrides.close`
-    instead.
-
-* **block**:
-
-  - Removed the property `intlExpand` , use `messsageOverrides.expand`
-    instead.
-  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
-    instead.
-  - Removed the property `intlLoading` , use `messsageOverrides.loading`
-    instead.
-  - Removed the property `intlOptions`, use `messageOverrides.options`
-    instead.
-
-* **block-section:**
-
-  - Removed the property `intlExpand` , use `messsageOverrides.expand`
-    instead.
-  - Removed the property `intlCollapse`, use `messageOverrides.collapse`
-    instead.
-
-* **button:**
-
-  - Removed the property `intlLoading` , use `messsageOverrides.loading`
-    instead.
-
-* **popover, dropdown, modal, pick-list-item, value-list-item:** Renamed `disable*` properties.
-
-* **dropdown:**
-
-  - Renamed the property `disableCloseOnSelect`, use
-    `closeOnSelectDisabled` instead.
-
-* **modal:**
-
-  - Renamed the property `disableCloseButton`, use `closeButtonDisabled`
-    instead.
-  - Renamed the property `disableFocusTrap`, use `focusTrapDisabled`
-    instead.
-  - Renamed the property `disableOutsideClose`, use `outsideCloseDisabled`
-    instead.
-  - Renamed the property `disableEscape`, use `escapeDisabled` instead.
-
-* **pick-list-item:**
-
-  - Renamed the property `disableDeselect`, use `deselectDisabled`
-    instead.
-
-* **popover:**
-
-  - Renamed the property `disableFlip`, use `flipDisabled` instead.
-  - Renamed the property `disableFocusTrap`, use `focusTrapDisabled`
-    instead.
-  - Renamed the property `disablePointer`, use `pointerDisabled` instead.
-
-* **value-list-item:**
-
-  - Renamed the property `disableDeselect`, use `deselectDisabled`
-    instead.
-
-* **input-date-picker:** Removed the `calciteDatePickerChange` event, use
-  `calciteInputDatePickerChange` instead.
-
-* **date-picker:** Removed the `start` and `end` properties, set `value`
-  as an array with the start as the first value and the end as the second
-  value instead.
-
-* **combobox:** Renamed event.
-
   - Renamed the event `calciteComboboxChipDismiss`, use
     `calciteComboboxChipClose` instead.
-
-* **alert:** Renamed properties.
-
-  - Renamed the property `autoDismiss`, use `autoClose` instead.
-  - Renamed the property `autoDismissDuration`, use `autoCloseDuration`
-    instead.
-
-* **combobox:** Removed `event.detail` payload from events and added
-  properties `selectedItems` and `filteredItems`.
-
   - Removed the `event.detail` property on the event
     `calciteComboboxChange`, use `event.target.selectedItems` instead.
   - Removed the `event.detail` property on the event
     `calciteComboboxFilterChange`, use `event.target.filteredItems` or
     `event.target.value` instead.
-
-* **chip:** Renamed event.
-
-  - Renamed the event `calciteChipDismiss`, use `calciteChipClose`
-    instead.
-
-* **tip:** Renamed property.
-
-  - Renamed the property `nonDismissible`, use `closeDisabled` instead.
-
-* **date-picker:** Removed `event.detail` payload from events.
-
-  - Removed the `event.detail` property on the event
-    `calciteDatePickerChange`, use `event.target` instead.
-  - Removed the `event.detail` property on the event
-    `calciteDatePickerRangeChange`, use `event.target` instead.
-
-* **modal:** Removed deprecated properties and method.
-
-  - Removed the property `active`, use `open` instead.
-  - Removed the property noPadding, use `--calcite-modal-padding` CSS
-    property instead.
-  - Removed the method `focusElement`, use `setFocus` method instead.
-  - Removed the CSS property ` --calcite-modal-content-text`.
-  - Removed the CSS property `--calcite-modal-padding-large`.
-  - Removed the CSS property `--calcite-modal-title-text`.
-
-* **pagination:** Removed deprecated event.
-
-  - Removed the event `calcitePaginationUpdate` event, use
-    `calcitePaginationChange` event instead.
-
-* **loader:** Removed deprecated properties.
-
-  - Removed the property `active`, use global attribute `hidden` instead.
-  - Removed the property `noPadding`, use `--calcite-loader-padding` CSS
-    property instead.
-
-* **label:** The default display for label is now `flex` instead of
-  `inline`.
-
-  - Use `--calcite-label-margin-bottom` CSS variable to disable space when
-    in `layout` is `inline`.
-
-* **tabs:** Removed slot.
-
-  - Removed the slot `tab-nav`, use `title-group` instead.
-
-* **dropdown:** Removed slot.
-
-  - Removed the slot `dropdown-trigger`, use `trigger` instead.
-
-* **action-menu:** Removed event.
-
-  - Removed the event `calciteActionMenuOpenChange`, use
-    `calciteActionMenuOpen` instead.
-
-* **combobox:** Removed deprecated properties, events, and event
-  payload.
-
   - Removed the property `active`, use `open` instead.
   - Removed the event`calciteLookupChange`, use `calciteComboboxChange`
     event instead.
@@ -542,74 +280,137 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   - Removed the property `constant`, use `filterDisable` instead.
 
-* **action-menu:** Removed event.
+- **date-picker:**
 
-  - Removed the event `calciteActionMenuOpenChange`, use
-    `calciteActionMenuOpen` instead.
-
-* **input-message:** removed deprecated properties
-
-  - Removed `active` property, use the global `hidden` attribute instead.
-  - Removed `type` property, "floating" is no longer supported.
-
-* **input-text:** remove deprecated event payload
-
-  - Removed `calciteInputTextInput` event payload, use the event's
-    `target`/`currentTarget` instead.
-
-* **date-picker:** Removed deprecated properties
-
+  - Removed `endAsDate` and `startAsDate` properties, use `valueAsDate`
+    instead.
+  - Removed the property `intlNextMonth`, use `messageOverrides.nextMonth`
+    instead.
+  - Removed the property `intlPrevMonth`, use `messageOverrides.prevMonth`
+    instead.
+  - Removed the property `intlYear`, use `messageOverrides.year` instead.
+  - Removed the `start` and `end` properties, set `value`
+    as an array with the start as the first value and the end as the second
+    value instead.
+  - Removed the `event.detail` property on the event
+    `calciteDatePickerChange`, use `event.target` instead.
+  - Removed the `event.detail` property on the event
+    `calciteDatePickerRangeChange`, use `event.target` instead.
   - Removed the `locale` property, use `lang` instead.
 
-* **input-date-picker:** Removed deprecated properties
+- **date-picker-month, date-picker-month-header:**
 
-  - Removed the `active` property, use `open` instead.
-  - Removed the `locale` property, use `lang` instead.
+  - Removed the event `calciteDatePickerSelect` on
+    `CalciteDatePickerMonthHeader`
+  - Removed the event `calciteDatePickerSelect` on
+    `CalciteDatePickerMonth`
+  - Removed the event `calciteDatePickerActiveDateChange` on
+    `CalciteDatePickerMonth`
 
-* **input-time-picker:** Removed deprecated property
+* **dropdown:**
 
-  - Removed the `active` property, use `open` instead.
+  - Removed the `event.detail` property on the event
+    `calciteDropdownSelect`, use `event.target` instead.
+  - Renamed the property `disableCloseOnSelect`, use
+    `closeOnSelectDisabled` instead.
+  - Removed the slot `dropdown-trigger`, use `trigger` instead.
 
-* **time-picker:** Removed deprecated property
+* **filter:**
 
-  Removed the `locale` property, use `lang` instead.
+  - Removed the property `intlClear`, use `messsageOverrides.clear`
+    instead.
+  - Removed the property `intlLabel`, use `messageOverrides.label`
+    instead.
 
-* **input:** remove deprecated properties and event payload.
+* **flow-item:**
 
+  - Removed the property `intlBack` , use `messsageOverrides.back`
+    instead.
+  - Removed the property `intlClose`, use `messageOverrides.close`
+    instead.
+  - Removed the property `intlOptions` , use `messsageOverrides.options`
+    instead.
+
+* **handle:**
+
+  - Removed the `event.detail.handle` property on the event `calciteHandleNudge`, use `event.target` instead.
+
+* **inline-editable:**
+
+  - Removed the property` intlEnableEditing`, use `messsageOverrides.enableEditing` instead.
+  - Removed the property `intlCancelEditing`, use `messageOverrides.cancelEditing` instead.
+  - Removed the property `intlConfirmChanges`, use `messageOverrides.confirmChanges` instead.
+
+- **input:**
+
+  - Removed the `nativeEvent` payload property which was being used
+    internally.
+  - Removed the property `intlClear`, use `messsageOverrides.clear` instead.
+  - Removed the property `intlLoading`, use `messsageOverrides.loading` instead.
   - Removed `maxlength` property, use `maxLength` instead.
   - Removed `locale` property, use `lang` instead.
   - Removed `calciteInputInput`'s `el`/`value` event payload properties, use the event's `target`/`currentTarget` instead.
 
-* **handle:** Removed deprecated event payload property on `calciteHandleNudge`.
+- **input-date-picker:**
 
-  - Removed the `event.detail.handle` property on the event `calciteHandleNudge`, use `event.target` instead.
-
-* **tabs, tab-nav, tab-title, tab:** Removed deprecated properties and values.
-
-  - Removed the property `active` from `calcite-tab-title`, use `selected`
+  - Removed `calciteDatePickerRangeChange` event, use
+    `calciteInputDatePickerChange` instead.
+  - Removed the property `start`, use `value` instead.
+  - Removed the property `end`, use `value` instead.
+  - Removed the property `startAsDate`, use `valueAsDate` instead.
+  - Removed the property `endAsDate`, use `valueAsDate` instead.
+  - Removed the property `intlNextMonth`, use `messageOverrides.nextMonth`
     instead.
-  - Removed the property `active` from `calcite-tab`, use `selected`
+  - Removed the property `intlPrevMonth`, use `messageOverrides.prevMonth`
     instead.
-  - Removed the `above` value from the `position` property on
-    `calcite-tabs`, use `top` instead.
-  - Removed the `below` value from the `position` property on
-    `calcite-tabs`, use `bottom` instead.
+  - Removed the property `intlYear`, use `messageOverrides.year` instead.
+  - Removed the `calciteDatePickerChange` event, use
+    `calciteInputDatePickerChange` instead.
+  - Removed the `active` property, use `open` instead.
+  - Removed the `locale` property, use `lang` instead.
 
-* **switch:** Removed deprecated `switched` property and
-  `calciteSwitchChange` event payload.
+* **input-message:**
 
-  - Removed the property `switched`, use `checked` instead.
-  - Removed the `event.detail` from `calciteSwitchChange`, use
-    `event.target.checked` instead.
+  - Removed `active` property, use the global `hidden` attribute instead.
+  - Removed `type` property, "floating" is no longer supported.
 
-* **input-number:** remove deprecated property and event payload
+* **input-number:**
 
+  - Removed the property `intlClear`, use `messsageOverrides.clear` instead.
+  - Removed the property `intlLoading`, use `messsageOverrides.loading` instead.
   - Removed `locale` property, use `lang` instead.
   - Removed `calciteInputNumberInput` event payload properties, use the
     event's `target`/`currentTarget` instead.
 
-* **label:** Removed deprecated properties.
+* **input-text:**
 
+  - Removed the property `intlClear`, use `messsageOverrides.clear` instead.
+  - Removed the property `intlLoading`, use `messsageOverrides.loading` instead.
+  - Removed `calciteInputTextInput` event payload, use the event's
+    `target`/`currentTarget` instead.
+
+- **input-time-picker:**
+
+  - Removed the `active` property, use `open` instead.
+  - Removed the property `locale`, use `lang` instead.
+  - Removed the property `intlHour`, use `messsageOverrides.hour` instead.
+  - Removed the property `intlHourDown`, use `messsageOverrides.hourDown` instead.
+  - Removed the property `intlHourUp`, use `messsageOverrides.hourUp` instead.
+  - Removed the property `intlMeridiem`, use `messsageOverrides.meridiem` instead.
+  - Removed the property `intlMeridiemDown`, use`messsageOverrides.meridiemDown` instead.
+  - Removed the property `intlMeridiemUp`, use `messsageOverrides.meridiemUp` instead.
+  - Removed the property `intlMinute`, use `messsageOverrides.minute` instead.
+  - Removed the property `intlMinuteUp`, use `messsageOverrides.minuteUp` instead.
+  - Removed the property `intlMinuteDown`, use `messsageOverrides.minuteDown` instead.
+  - Removed the property `intlSecond`, use `messsageOverrides.second` instead.
+  - Removed the property `intlSecondUp`, use `messsageOverrides.secondUp` instead.
+  - Removed the property `intlSecondDown`, use `messsageOverrides.secondDown` instead.
+
+- **label:**
+
+  - The default display for label is now `flex` instead of
+    `inline`. Use `--calcite-label-margin-bottom` CSS variable to disable space when
+    in `layout` is `inline`.
   - Removed the property `status`, set the `status` property on the
     component the label is bound to instead.
   - Removed the property `disabled`, set the `disabled` property on the
@@ -617,72 +418,64 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the property `disableSpacing`, use the CSS variable
     `--calcite-label-margin-bottom` instead.
 
-* **stepper-item:** Removed deprecated properties.
+* **loader:**
 
-  - Removed the property `active`, use `selected` instead.
-  - Removed the property `itemTitle`, use `heading` instead.
-  - Removed the property `itemSubtitle`, use `description` instead.
+  - Removed the property `active`, use global attribute `hidden` instead.
+  - Removed the property `noPadding`, use `--calcite-loader-padding` CSS
+    property instead.
 
-* **radio-group-item:** Removed deprecated properties.
+* **modal:**
 
-  - Removed the property `icon`, use either `iconStart` or `iconEnd`
+  - Removed the property `backgroundColor`, use the CSS variable
+    `--calcite-modal-content-background` instead.
+  - Removed the `--calcite-modal-padding` CSS variable, use the
+    `--calcite-modal-content-padding` CSS variable instead.
+    - Removed the property `intlClose`, use `messsageOverrides.close`
+      instead.
+  - Renamed the property `color`, use `kind` instead.
+  - Updated the accepted values of `kind` to `brand`, `danger`, `info`,
+    `success`, and `warning`.
+  - Removed the property `active`, use `open` instead.
+  - Removed the property noPadding, use `--calcite-modal-padding` CSS
+    property instead.
+  - Removed the method `focusElement`, use `setFocus` method instead.
+  - Removed the CSS property ` --calcite-modal-content-text`.
+  - Removed the CSS property `--calcite-modal-padding-large`.
+  - Removed the CSS property `--calcite-modal-title-text`.
+  - Renamed the property `disableCloseButton`, use `closeButtonDisabled`
     instead.
-  - Removed the property `iconPosition`, use either `iconStart` or
-    `iconEnd` instead.
-
-* **split-button:** Removed the `event.detail` payload from the events
-  `calciteSplitButtonPrimaryClick` and `calciteSplitButtonSecondaryClick`.
-  Use separate mouse event listeners to get information about `click`
-  events.
-
-* **slider:** Removed deprecated event.
-
-  - Removed the event `calciteSliderUpdate`, use `calciteSliderInput`
+  - Renamed the property `disableFocusTrap`, use `focusTrapDisabled`
     instead.
-
-* **dropdown, dropdown-item:** Removed deprecated properties.
-
-  - Removed the property `active` on `calcite-dropdown-item`, use
-    `selected` instead.
-  - Removed the property `active`, on `calcite-dropdown`, use `open`
+  - Renamed the property `disableOutsideClose`, use `outsideCloseDisabled`
     instead.
+  - Renamed the property `disableEscape`, use `escapeDisabled` instead.
 
-* **tree:** Removed the `inputEnabled` property.
+* **notice:**
 
-  - Removed the property `inputEnabled`, use `selectionMode="ancestors"`
-    instead.
+  - Removed the property `active`, use `open` instead.
+  - Removed the property `dimissible`, use `closable` property instead.
 
-* **chip:** Removed the `dismissible` property and the `clear`
-  value for the `appearance` property.
+    - Removed the property `intlClose`, use `messsageOverrides.close`
+      instead.
 
-  - Removed the property `dismissible`, use `closable` instead.
-  - Use the value `transparent` instead of `clear` for `appearance`
-    property.
+  - **pagination**:
 
-* **action-menu:** Removed the `event.detail` value from the
-  `calciteActionMenuOpenChange` event on the `action-menu` component.
+    - Removed the property `textLabelNext` , use `messsageOverrides.next`
+      instead.
+    - Removed the property `textLabelPrevious` , use
+      `messsageOverrides.previous` instead.
 
-  - When listening to `calciteActionMenuOpenChange`, use the `open`
-    property on the `event.target` instead of `event.detail`.
+  - Removed the event `calcitePaginationUpdate` event, use
+    `calcitePaginationChange` event instead.
+  - Removed the `event.detail` property on the event
+    `calcitePaginationChange`, use `event.target` instead.
 
-* **block:** Removed the `summary` and `disablePadding` properties.
+  - **panel**:
 
-  - Removed the property `summary`, use `description` instead.
-  - Removed the property `disablePadding`, use the CSS variable
-    `--calcite-block-padding` instead.
-
-* **popover-manager:** Removed the `calcite-popover-manager` component. This
-  component is no longer necessary for `calcite-popover`s.
-
-* **accordion-item:** Removed the properties `active`, `itemTitle`,
-  `itemSubtitle`, and `icon`.
-
-  - Removed the property `active`, use `expanded` instead.
-  - Removed the property `itemTitle`, use `heading` instead.
-  - Removed the property `itemSubtitle`, use `description` instead.
-  - Removed the property `icon`, use `iconStart` or `iconEnd` instead.
-
-* **panel:** Removed deprecated events and properties.
+    - Removed the property `intlClose` , use `messsageOverrides.close`
+      instead.
+    - Removed the property `intlOptions`, use `messsageOverrides.options`
+      instead.
 
   - Removed the property `dismissed`, use `closed` instead.
   - Removed the property `dismissible`, use `closable` instead.
@@ -700,108 +493,178 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the event `calcitePanelBackClick`, use the `calcite-flow-item`
     component instead.
 
-* **popover:** Removed the `closeButton` and `dismissible` properties.
+  - **pick-list-item**:
 
+    - Removed the property `intlRemove`, use `messsageOverrides.remove`
+      instead.
+
+  - Renamed the property `disableDeselect`, use `deselectDisabled`
+    instead.
+
+  - **popover**:
+
+  - Removed the property `intlClose` , use `messsageOverrides.close`
+    instead.
+  - Renamed the property `disableFlip`, use `flipDisabled` instead.
+  - Renamed the property `disableFocusTrap`, use `focusTrapDisabled`
+    instead.
+  - Renamed the property `disablePointer`, use `pointerDisabled` instead.
   - Removed the property `closeButton`, use `closable` instead.
   - Removed the property `dismissible`, use `closable` instead.
 
-* **tooltip-manager:** Removed the `calcite-tooltip-manager` component. This
-  component is no longer necessary for `calcite-tooltip`s.
-* **alert:** Removed the deprecated `active` property.
+* **popover-manager:** Removed the `calcite-popover-manager` component. This
+  component is no longer necessary for `calcite-popover`s.
 
-  - Removed the property `active`, use `open` instead.
+- **radio-group:**
+  - Removed `minimal` appearance value, use `outline` instead.
+  - Removed the `event.detail` property on the event
+    `calciteRadioGroupChange`, use `event.target` instead.
 
-  - Removed the `*-leading` and `*-trailing` values for
-    component `placement` properties.
+* **radio-group-item:**
 
-  - There is no need for "_-leading" and "_-trailing" values anymore since
-    `*-start` and `*-end` are already flipped in right-to-left direction.
+  - Removed the property `icon`, use either `iconStart` or `iconEnd`
+    instead.
+  - Removed the property `iconPosition`, use either `iconStart` or
+    `iconEnd` instead.
 
-  - **list, list-item, list-item-group:** Removed the `headingLevel` and `nonInteractive`
-    properties.
+* **rating:**
 
-  - `headingLevel` property on the `list` and `list-item-group` is no
-    longer necessary.
-  - `nonInteractive` property on the `list-item` is no longer necessary.
+  - Removed the `event.detail` property on the event
+    `calciteRatingChange`, use `event.target` instead.
+  - Removed the property `intlStars` , use `messsageOverrides.stars` instead.
+  - Removed the property `intlRating` , use `messsageOverrides.rating` instead.
 
-* **shell:** Removed the `primary-panel` and `contextual-panel`
-  slots.
+* **scrim:**
+
+  - Removed the property `intlLoading` , use `messsageOverrides.loading` instead.
+
+* **shell:**
 
   - Removed the slot `primary-panel`, use `panel-start` instead.
   - Removed the slot `contextual-panel`, use `panel-end` instead.
 
-* **shell-panel:** Removed the `calciteShellPanelToggle` event.
+- **shell-panel:**
 
-  - Use a `ResizeObserver` on the component to listen for changes to its
-    size. (https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
+  - Removed the property `intlResize`, use `messagesOverrides.resize`
+    instead.
+  - Removed the `calciteShellPanelToggle` event. Use a `ResizeObserver` on the component to listen for changes to its size. (https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
 
-* **flow, flow-item:** Removed the `calciteFlowItemBackClick` event and
-  support for slotting `calcite-panel`s.
+* **slider:**
 
-  - Removed support for slotting `calcite-panel` components, use the
-    `calcite-flow-item` component instead.
-  - Removed the event `calciteFlowItemBackClick`, use
-    `calciteFlowItemBack` instead.
+  - Removed the event `calciteSliderUpdate`, use `calciteSliderInput`
+    instead.
 
-* **tip-manager:** Removed the `calciteTipManagerToggle` event, use
-  `calciteTipManagerClose` instead.
+* **split-button:**
 
-* **action:** Removed the `calciteActionClick` event and the `clear`
-  value for the `appearance` property.
+  - Removed the `event.detail` payload from the events
+    `calciteSplitButtonPrimaryClick` and `calciteSplitButtonSecondaryClick`.
+    Use separate mouse event listeners to get information about `click`
+    events.
 
-  - Listen to the `click` event instead of `calciteActionClick.
-  - Use the value `transparent` instead of `clear` for the property
-    `appearance`.
+* **stepper-item:**
 
-* **list, list-item, list-item-group:** To know when `calcite-list-item` content is selected, listen to the event `calciteListItemSelect` instead of `click`.
+  - Removed the property `active`, use `selected` instead.
+  - Removed the property `itemTitle`, use `heading` instead.
+  - Removed the property `itemSubtitle`, use `description` instead.
 
-  - `List`
-    - Adds `label` property to specify an accessible name for the component.
-    - Adds `loading` property to show a busy indicator.
-    - Adds `selectionMode` and `selectionAppearance` properties to handle configuration of selection.
-    - Adds `filterEnabled`, `filteredData`, `filteredItems`, `filterText`, and `filterPlaceholder` properties to support filtering.
-    - Adds `calciteListFilter` event to notify when a filter has changed.
-    - Deprecates `headingLevel` property.
-  - `ListItemGroup`
-    - Adds `disabled` property to prevent user interaction.
-    - Deprecates `headingLevel` property.
-  - `ListItem`
-    - Adds `calciteListItemSelect` event to notify when list item content is selected.
-    - Adds `selected` and `value` properties to handle selection.
-    - Adds `open` property to show child components.
-    - Deprecates `nonInteractive` property.
+* **switch:**
 
-* **calcite-loader, calcite-input-message:** use hidden native global attribute to toggle visibility on the components instead of the deprecated active prop.
-* **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Sets internal heading HTML element to be a div by default. If users would like to retain an internal H1-H6 HTML element, they will need to set the headingLevel property on the component. Users already setting the headingLevel property are not affected. ([#5728](https://github.com/Esri/calcite-components/pull/5728)) ([38ca639](https://github.com/Esri/calcite-components/commit/38ca639010b8bd1d1fe32c9cf9b54dfc38cf9877)), closes [5099](https://github.com/Esri/calcite-components/issues/5099)
+  - Removed the property `switched`, use `checked` instead.
+  - Removed the `event.detail` from `calciteSwitchChange`, use
+    `event.target.checked` instead.
+
+- **tab-nav**:
+
+  - Removed the `event.detail` property on the event `calciteTabChange`,
+    use `event.target` instead.
+
+- **tab-title**:
+
+  - Removed the `event.detail` property on the event
+    `calciteTabsActivate`, use `event.target` instead.
+
+* **tabs:**
+
+  - Removed the slot `tab-nav`, use `title-group` instead.
+
+- **time-picker:**
+
+  - Removed `target` parameter from `setFocus()`, focus will be delegated
+    to the first focusable element instead.
+  - Removed the property `intlHour`, use `messsageOverrides.hour` instead.
+  - Removed the property `intlHourDown`, use `messsageOverrides.hourDown` instead.
+  - Removed the property `intlHourUp`, use `messsageOverrides.hourUp` instead.
+  - Removed the property `intlMeridiem`, use `messsageOverrides.meridiem` instead.
+  - Removed the property `intlMeridiemDown`, use `messsageOverrides.meridiemDown` instead.
+  - Removed the property `intlMeridiemUp`, use `messsageOverrides.meridiemUp` instead.
+  - Removed the property `intlMinute`, use `messsageOverrides.minute` instead.
+  - Removed the property `intlMinuteUp`, use `messsageOverrides.minuteUp` instead.
+  - Removed the property `intlMinuteDown`, use `messsageOverrides.minuteDown` instead.
+  - Removed the property `intlSecond`, use `messsageOverrides.second` instead.
+  - Removed the property `intlSecondUp`, use `messsageOverrides.secondUp` instead.
+  - Removed the property `intlSecondDown`, use `messsageOverrides.secondDown` instead.
+  - Removed the `locale` property, use `lang` instead.
+
+* **tip:**
+
+  - Renamed the property `nonDismissible`, use `closeDisabled` instead.
+
+* **tip-manager:**
+
+  - Removed the `calciteTipManagerToggle` event, use
+    `calciteTipManagerClose` instead.
+
+* **tooltip-manager:** Removed the `calcite-tooltip-manager` component. This
+  component is no longer necessary for `calcite-tooltip`s.
+
+- **tree:**
+
+  - Added property `selectedItems`.
+  - Removed the `event.detail` property on the event `calciteTreeSelect`,
+    use `event.target` instead.
+  - Removed the property `inputEnabled`, use `selectionMode="ancestors"`
+    instead.
+
+* **value-list:**
+
+  - Removed the property `intlDragHandleActive`, use `messsageOverrides.dragHandleActive` instead.
+  - Removed the property `intlDragHandleChange`, use `messsageOverrides.dragHandleChange` instead.
+  - Removed the property `intlDragHandleCommit`, use `messsageOverrides.dragHandleCommit` instead.
+  - Removed the property `intlDragHandleIdle`, use `messsageOverrides.dragHandleIdle` instead.
+
+* **value-list-item:**
+
+  - Renamed the property `disableDeselect`, use `deselectDisabled`
+    instead.
 
 ### Features
 
-- **shell-panel:** add built-in translations ([#6079](https://github.com/Esri/calcite-components/issues/6079)) ([1c7ff2b](https://github.com/Esri/calcite-components/commit/1c7ff2b232bf19c160602371d96af253e0cf5a66)), closes [#6066](https://github.com/Esri/calcite-components/issues/6066)
+- **shell-panel:** Add built-in translations ([#6079](https://github.com/Esri/calcite-components/issues/6079)) ([1c7ff2b](https://github.com/Esri/calcite-components/commit/1c7ff2b232bf19c160602371d96af253e0cf5a66)), closes [#6066](https://github.com/Esri/calcite-components/issues/6066)
 
-* **tip,tip-manager:** add built-in translations ([#6074](https://github.com/Esri/calcite-components/issues/6074)) ([683cf07](https://github.com/Esri/calcite-components/commit/683cf07a916e6e9aa93fea8b7a2869fa0c531667)), closes [#6066](https://github.com/Esri/calcite-components/issues/6066)
+* **tip,tip-manager:** Add built-in translations ([#6074](https://github.com/Esri/calcite-components/issues/6074)) ([683cf07](https://github.com/Esri/calcite-components/commit/683cf07a916e6e9aa93fea8b7a2869fa0c531667)), closes [#6066](https://github.com/Esri/calcite-components/issues/6066)
 
 - **shell:** Add slots for Modal and Alert ([#5983](https://github.com/Esri/calcite-components/issues/5983)) ([d824bf7](https://github.com/Esri/calcite-components/commit/d824bf74cbda49c9796e090c04d0f7db0d772f8b))
 
-* add iconFlipRtl prop to all components with a convenience icon prop [#5496](https://github.com/Esri/calcite-components/issues/5496) ([#5878](https://github.com/Esri/calcite-components/issues/5878)) ([30a080b](https://github.com/Esri/calcite-components/commit/30a080b81d20163eba7e65e481ba3701b2bd39a1))
+* Add `iconFlipRtl` prop to all components with a convenience icon prop [#5496](https://github.com/Esri/calcite-components/issues/5496) ([#5878](https://github.com/Esri/calcite-components/issues/5878)) ([30a080b](https://github.com/Esri/calcite-components/commit/30a080b81d20163eba7e65e481ba3701b2bd39a1))
 
-- add built-in translations ([#5471](https://github.com/Esri/calcite-components/issues/5471)) ([d754b29](https://github.com/Esri/calcite-components/commit/d754b29467d40f8081eb7793fb13c1b4de9f7ebf)), closes [#4961](https://github.com/Esri/calcite-components/issues/4961)
+- Add built-in translations ([#5471](https://github.com/Esri/calcite-components/issues/5471)) ([d754b29](https://github.com/Esri/calcite-components/commit/d754b29467d40f8081eb7793fb13c1b4de9f7ebf)), closes [#4961](https://github.com/Esri/calcite-components/issues/4961)
 
 * **dropdown-item:** Add `calciteDropdownItemSelect` event ([#6015](https://github.com/Esri/calcite-components/issues/6015)) ([b565ac9](https://github.com/Esri/calcite-components/commit/b565ac97e0d8b63527767fa10a75dce78d7f5a4b)), closes [#5940](https://github.com/Esri/calcite-components/issues/5940) [#5940](https://github.com/Esri/calcite-components/issues/5940)
 
-* **input, input-number, input-text:** add inputMode and enterKeyHint properties ([#5976](https://github.com/Esri/calcite-components/issues/5976)) ([d567a9f](https://github.com/Esri/calcite-components/commit/d567a9fde5b3619f308133555ba0bae20ca85168)), closes [#5917](https://github.com/Esri/calcite-components/issues/5917)
+* **input, input-number, input-text:** Add inputMode and enterKeyHint properties ([#5976](https://github.com/Esri/calcite-components/issues/5976)) ([d567a9f](https://github.com/Esri/calcite-components/commit/d567a9fde5b3619f308133555ba0bae20ca85168)), closes [#5917](https://github.com/Esri/calcite-components/issues/5917)
 
-* **action:** add built-in translation support for indicator text ([#5895](https://github.com/Esri/calcite-components/issues/5895)) ([704db6d](https://github.com/Esri/calcite-components/commit/704db6dfbe3a875fbd5b20c9b0eb0975aca24258)), closes [#4813](https://github.com/Esri/calcite-components/issues/4813)
+* **action:** Add built-in translation support for indicator text ([#5895](https://github.com/Esri/calcite-components/issues/5895)) ([704db6d](https://github.com/Esri/calcite-components/commit/704db6dfbe3a875fbd5b20c9b0eb0975aca24258)), closes [#4813](https://github.com/Esri/calcite-components/issues/4813)
 
 * **list-item:** Add content slot for specialized content ([#5876](https://github.com/Esri/calcite-components/issues/5876)) ([a510773](https://github.com/Esri/calcite-components/commit/a510773ba87994010e84184f7709c84ce40f2d2c)), closes [#3032](https://github.com/Esri/calcite-components/issues/3032) [#3032](https://github.com/Esri/calcite-components/issues/3032)
 
-* **textarea:** add default message bundle ([#5870](https://github.com/Esri/calcite-components/issues/5870)) ([c7a8495](https://github.com/Esri/calcite-components/commit/c7a84955b4f3cd09dbf7315ea59e0edaa7be2a6c)), closes [#863](https://github.com/Esri/calcite-components/issues/863)
+* **textarea:** Add default message bundle ([#5870](https://github.com/Esri/calcite-components/issues/5870)) ([c7a8495](https://github.com/Esri/calcite-components/commit/c7a84955b4f3cd09dbf7315ea59e0edaa7be2a6c)), closes [#863](https://github.com/Esri/calcite-components/issues/863)
 
-* **input, input-text, input-number:** add attributes autocomplete, accept, multiple, pattern ([#5807](https://github.com/Esri/calcite-components/issues/5807)) ([feb4fce](https://github.com/Esri/calcite-components/commit/feb4fce9528920041d836446ef437f0f1c0e8ce2)), closes [#4079](https://github.com/Esri/calcite-components/issues/4079)
+* **input, input-text, input-number:** Add attributes `autocomplete`, `accept`, `multiple`, `pattern` ([#5807](https://github.com/Esri/calcite-components/issues/5807)) ([feb4fce](https://github.com/Esri/calcite-components/commit/feb4fce9528920041d836446ef437f0f1c0e8ce2)), closes [#4079](https://github.com/Esri/calcite-components/issues/4079)
 
-* **alert:** support actions-end ([#5750](https://github.com/Esri/calcite-components/issues/5750)) ([2447e16](https://github.com/Esri/calcite-components/commit/2447e167eb731f3a59775a5692530137bf9a70fd))
+* **alert:** Support `actions-end` ([#5750](https://github.com/Esri/calcite-components/issues/5750)) ([2447e16](https://github.com/Esri/calcite-components/commit/2447e167eb731f3a59775a5692530137bf9a70fd))
 * **list, list-item, list-item-group:** Adds support for selecting and filtering list items. Improves accessibility by using aria "treegrid" role. ([#4527](https://github.com/Esri/calcite-components/issues/4527)) ([f489c57](https://github.com/Esri/calcite-components/commit/f489c57095ec21df1f427176d2d635675eea95d3))
-* **pick-list, value-list:** Add calciteListFilter event, filteredItems prop, filterText prop and filteredData prop. ([#5681](https://github.com/Esri/calcite-components/issues/5681)) ([943d208](https://github.com/Esri/calcite-components/commit/943d2088b7cf447a12ebcd0babab145f543538a2)), closes [#4333](https://github.com/Esri/calcite-components/issues/4333)
-* **popover:** Add focus-trap to popover and disableFocusTrap property. ([#5725](https://github.com/Esri/calcite-components/issues/5725)) ([a8ef353](https://github.com/Esri/calcite-components/commit/a8ef353bc031630b373f2bdd1bdc1cafd7e35be9)), closes [#2133](https://github.com/Esri/calcite-components/issues/2133)
+* **pick-list, value-list:** Add `calciteListFilter` event, `filteredItems` prop, `filterText` prop and `filteredData` prop. ([#5681](https://github.com/Esri/calcite-components/issues/5681)) ([943d208](https://github.com/Esri/calcite-components/commit/943d2088b7cf447a12ebcd0babab145f543538a2)), closes [#4333](https://github.com/Esri/calcite-components/issues/4333)
+* **popover:** Add focus-trap to popover and `disableFocusTrap` property. ([#5725](https://github.com/Esri/calcite-components/issues/5725)) ([a8ef353](https://github.com/Esri/calcite-components/commit/a8ef353bc031630b373f2bdd1bdc1cafd7e35be9)), closes [#2133](https://github.com/Esri/calcite-components/issues/2133)
 * **popover:** Escape key should close open popovers. ([#5726](https://github.com/Esri/calcite-components/issues/5726)) ([2e2621d](https://github.com/Esri/calcite-components/commit/2e2621d57c4701f7a7e84f74d801c543ad4f45c0))
 * **tabs:** Add support for navigating with Home and End keys ([#5727](https://github.com/Esri/calcite-components/issues/5727)) ([823c429](https://github.com/Esri/calcite-components/commit/823c429439ec9f8cd1d6a1ff2aedf0b2da9c741b)), closes [#5661](https://github.com/Esri/calcite-components/issues/5661)
 * **tooltip:** Add tooltip open, close, beforeOpen, and beforeClose events ([#5772](https://github.com/Esri/calcite-components/issues/5772)) ([64b5675](https://github.com/Esri/calcite-components/commit/64b56751d68f69d31ea943415f5d0d08bae634cc)), closes [#5734](https://github.com/Esri/calcite-components/issues/5734)
@@ -816,15 +679,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * **loader:** Do not modify display when inline ([#6013](https://github.com/Esri/calcite-components/issues/6013)) ([2d91c89](https://github.com/Esri/calcite-components/commit/2d91c89778fd71f9492d3caad0750f779488d2cf)), closes [#5900](https://github.com/Esri/calcite-components/issues/5900) [#5900](https://github.com/Esri/calcite-components/issues/5900)
 
-* **popover, modal:** deactivate focus trap on outside click ([#5994](https://github.com/Esri/calcite-components/issues/5994)) ([2a66134](https://github.com/Esri/calcite-components/commit/2a661343f1ee9fc9afda347990f40d33ad41295d)), closes [#5993](https://github.com/Esri/calcite-components/issues/5993)
+* **popover, modal:** Deactivate focus trap on outside click ([#5994](https://github.com/Esri/calcite-components/issues/5994)) ([2a66134](https://github.com/Esri/calcite-components/commit/2a661343f1ee9fc9afda347990f40d33ad41295d)), closes [#5993](https://github.com/Esri/calcite-components/issues/5993)
 
-* **loader:** no longer animates when reduced motion is enabled ([#5981](https://github.com/Esri/calcite-components/issues/5981)) ([4d994e5](https://github.com/Esri/calcite-components/commit/4d994e5f845b828df8f37b61923fc5cceed3819a)), closes [#3489](https://github.com/Esri/calcite-components/issues/3489)
+* **loader:** No longer animates when reduced motion is enabled ([#5981](https://github.com/Esri/calcite-components/issues/5981)) ([4d994e5](https://github.com/Esri/calcite-components/commit/4d994e5f845b828df8f37b61923fc5cceed3819a)), closes [#3489](https://github.com/Esri/calcite-components/issues/3489)
 
 * **modal, popover:** Add `disableFocusTrap` property to toggle focus trapping. ([#5965](https://github.com/Esri/calcite-components/issues/5965)) ([7ee9e16](https://github.com/Esri/calcite-components/commit/7ee9e16fbc5a12c82f85a5e2fb07c0d1137d03ce))
 
 * **input, input-number, input-text:** Fix infinite loop crashing browser. [#5882](https://github.com/Esri/calcite-components/issues/5882) ([#5961](https://github.com/Esri/calcite-components/issues/5961)) ([190cfac](https://github.com/Esri/calcite-components/commit/190cfac2dbdc0c312ebf396d66894a07ae7086b9))
 
-* **alert:** auto-dismissible retains close button and dismisses timer while a user is hovering over ([#5872](https://github.com/Esri/calcite-components/issues/5872)) ([274b104](https://github.com/Esri/calcite-components/commit/274b10477f6aaf822d3cf2894b7848e36b36b057)), closes [#3338](https://github.com/Esri/calcite-components/issues/3338)
+* **alert:** Auto-dismissible retains close button and dismisses timer while a user is hovering over ([#5872](https://github.com/Esri/calcite-components/issues/5872)) ([274b104](https://github.com/Esri/calcite-components/commit/274b10477f6aaf822d3cf2894b7848e36b36b057)), closes [#3338](https://github.com/Esri/calcite-components/issues/3338)
 
 * **action:** Add screen reader support for `active` and `indicator` props ([#5875](https://github.com/Esri/calcite-components/issues/5875)) ([b6bcfa0](https://github.com/Esri/calcite-components/commit/b6bcfa03c9a20ae156634b14b2d8dd2834f29c40)), closes [#4813](https://github.com/Esri/calcite-components/issues/4813) [#4813](https://github.com/Esri/calcite-components/issues/4813)
 * **block:** Fix content spacing. [#5898](https://github.com/Esri/calcite-components/issues/5898) ([#5918](https://github.com/Esri/calcite-components/issues/5918)) ([f32ddaa](https://github.com/Esri/calcite-components/commit/f32ddaad88060cbeff60f87499a26560adeee66a))
@@ -837,30 +700,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * **list-item:** Add hover styling ([#5891](https://github.com/Esri/calcite-components/issues/5891)) ([063d6e9](https://github.com/Esri/calcite-components/commit/063d6e955eddb82a5b3ea2e93eca3aa03feef2ae)), closes [#5880](https://github.com/Esri/calcite-components/issues/5880)
 
-* **input-time-picker, input-date-picker:** internal pickers update when changing locales ([#5887](https://github.com/Esri/calcite-components/issues/5887)) ([9c2dc42](https://github.com/Esri/calcite-components/commit/9c2dc42e581b6399b909d41ce6ae5b77ffa12831)), closes [#5855](https://github.com/Esri/calcite-components/issues/5855)
+* **input-time-picker, input-date-picker:** Internal pickers update when changing locales ([#5887](https://github.com/Esri/calcite-components/issues/5887)) ([9c2dc42](https://github.com/Esri/calcite-components/commit/9c2dc42e581b6399b909d41ce6ae5b77ffa12831)), closes [#5855](https://github.com/Esri/calcite-components/issues/5855)
 
-* **modal:** restore deprecated scrim background css property ([#5868](https://github.com/Esri/calcite-components/issues/5868)) ([7717127](https://github.com/Esri/calcite-components/commit/7717127fd25510126ad7d2b3def2c9d00753d60f)), closes [#5866](https://github.com/Esri/calcite-components/issues/5866)
+* **modal:** Restore deprecated scrim background css property ([#5868](https://github.com/Esri/calcite-components/issues/5868)) ([7717127](https://github.com/Esri/calcite-components/commit/7717127fd25510126ad7d2b3def2c9d00753d60f)), closes [#5866](https://github.com/Esri/calcite-components/issues/5866)
 
-* **alert:** placement of link consistent with notice ([#5852](https://github.com/Esri/calcite-components/issues/5852)) ([56e35ab](https://github.com/Esri/calcite-components/commit/56e35ab3e07c9562d83eee04559a1e8b15662b3d)), closes [#5254](https://github.com/Esri/calcite-components/issues/5254)
+* **alert:** Placement of link consistent with notice ([#5852](https://github.com/Esri/calcite-components/issues/5852)) ([56e35ab](https://github.com/Esri/calcite-components/commit/56e35ab3e07c9562d83eee04559a1e8b15662b3d)), closes [#5254](https://github.com/Esri/calcite-components/issues/5254)
 
-* **pagination:** numberingSystem and lang properties work without groupSeparator ([#5828](https://github.com/Esri/calcite-components/issues/5828)) ([b21c5d0](https://github.com/Esri/calcite-components/commit/b21c5d02be14a6551af3a3381b9ca48dfd50c395)), closes [#5648](https://github.com/Esri/calcite-components/issues/5648)
+* **pagination:** `numberingSystem` and `lang` properties work without `groupSeparator` ([#5828](https://github.com/Esri/calcite-components/issues/5828)) ([b21c5d0](https://github.com/Esri/calcite-components/commit/b21c5d02be14a6551af3a3381b9ca48dfd50c395)), closes [#5648](https://github.com/Esri/calcite-components/issues/5648)
 
 * **combobox:** 5540 - handle focus ([#5774](https://github.com/Esri/calcite-components/issues/5774)) ([6a114b6](https://github.com/Esri/calcite-components/commit/6a114b6c614509ff774f30bf1a238758439127d6)), closes [#5540](https://github.com/Esri/calcite-components/issues/5540)
 
 * **tree-item:** Allow space and enter key events when selectionMode is "none" ([#5800](https://github.com/Esri/calcite-components/issues/5800)) ([2fa483b](https://github.com/Esri/calcite-components/commit/2fa483b64844b5046a9d60e66b5d6f187ab1d98e)), closes [#5735](https://github.com/Esri/calcite-components/issues/5735) [#5735](https://github.com/Esri/calcite-components/issues/5735)
 
-* **input-date-picker:** display updated valueAsDate in the two range inputs ([#5758](https://github.com/Esri/calcite-components/issues/5758)) ([ea93555](https://github.com/Esri/calcite-components/commit/ea93555c3e9a78b1ff3efb2865e1821a4d340f6d)), closes [#5207](https://github.com/Esri/calcite-components/issues/5207)
+* **input-date-picker:** Display updated valueAsDate in the two range inputs ([#5758](https://github.com/Esri/calcite-components/issues/5758)) ([ea93555](https://github.com/Esri/calcite-components/commit/ea93555c3e9a78b1ff3efb2865e1821a4d340f6d)), closes [#5207](https://github.com/Esri/calcite-components/issues/5207)
 
-* **block:** slow down loading icon spin ([#5778](https://github.com/Esri/calcite-components/issues/5778)) ([7b990dc](https://github.com/Esri/calcite-components/commit/7b990dc350b5b8a2fb5cea8a049e904761eec167)), closes [#5776](https://github.com/Esri/calcite-components/issues/5776)
+* **block:** Slow down loading icon spin ([#5778](https://github.com/Esri/calcite-components/issues/5778)) ([7b990dc](https://github.com/Esri/calcite-components/commit/7b990dc350b5b8a2fb5cea8a049e904761eec167)), closes [#5776](https://github.com/Esri/calcite-components/issues/5776)
 * setFocus methods should wait for the component to be loaded ([#5749](https://github.com/Esri/calcite-components/issues/5749)) ([06d4767](https://github.com/Esri/calcite-components/commit/06d4767dad8918e7677b9754f6ff26312d07cb96))
 * **block, date-picker, list-item-group, panel, pick-list-group, popover, tip, tip-manager:** Set default internal heading to a div. ([#5728](https://github.com/Esri/calcite-components/issues/5728)) ([38ca639](https://github.com/Esri/calcite-components/commit/38ca639010b8bd1d1fe32c9cf9b54dfc38cf9877)), closes [#5099](https://github.com/Esri/calcite-components/issues/5099)
 * **button, fab:** adjust padding on 'l' scale button to accommodate 'm' scale icon without change in height ([#5659](https://github.com/Esri/calcite-components/issues/5659)) ([d68d95c](https://github.com/Esri/calcite-components/commit/d68d95cda10ad819e52b048479780590f21ac479))
-* **calcite-loader, calcite-input-message:** drop active in favor of hidden ([#5761](https://github.com/Esri/calcite-components/issues/5761)) ([c2e05d1](https://github.com/Esri/calcite-components/commit/c2e05d149bfa3d0f7b81eff2b55405f792cab16c))
+* **calcite-loader, calcite-input-message:** Drop `active` in favor of `hidden` ([#5761](https://github.com/Esri/calcite-components/issues/5761)) ([c2e05d1](https://github.com/Esri/calcite-components/commit/c2e05d149bfa3d0f7b81eff2b55405f792cab16c))
 * **combobox:** Wrap and break text on long items ([#5672](https://github.com/Esri/calcite-components/issues/5672)) ([4a4d776](https://github.com/Esri/calcite-components/commit/4a4d7767e7cc39cc1561432c74d99d0783d3997a)), closes [#5419](https://github.com/Esri/calcite-components/issues/5419)
 * **flow-item:** Position back tooltip above ([#5688](https://github.com/Esri/calcite-components/issues/5688)) ([bb67992](https://github.com/Esri/calcite-components/commit/bb67992fa9f113709482a69fff0f36032dbfad35))
 * **inline-editable:** Add text-ellipsis when not editing ([#5679](https://github.com/Esri/calcite-components/issues/5679)) ([2524e6f](https://github.com/Esri/calcite-components/commit/2524e6f6a8cbc7c2a35c635ce34ad0c9dbc6874f)), closes [#5489](https://github.com/Esri/calcite-components/issues/5489)
-* **input-date-picker:** restores mouse clicks on date-picker popup ([#5760](https://github.com/Esri/calcite-components/issues/5760)) ([98f28c6](https://github.com/Esri/calcite-components/commit/98f28c6a9ae48b12bee7fc78fb7cdc4ceb456d3e))
-* **input, input-number:** decimals no longer contain groupSeparators and remove leading zeros ([#5490](https://github.com/Esri/calcite-components/issues/5490)) ([07142f3](https://github.com/Esri/calcite-components/commit/07142f35d1d6678bc28101245638046658922c22))
+* **input-date-picker:** Restores mouse clicks on date-picker popup ([#5760](https://github.com/Esri/calcite-components/issues/5760)) ([98f28c6](https://github.com/Esri/calcite-components/commit/98f28c6a9ae48b12bee7fc78fb7cdc4ceb456d3e))
+* **input, input-number:** Decimals no longer contain groupSeparators and remove leading zeros ([#5490](https://github.com/Esri/calcite-components/issues/5490)) ([07142f3](https://github.com/Esri/calcite-components/commit/07142f35d1d6678bc28101245638046658922c22))
 * **value-list-item:** Prevent scrolling when space is pressed on drag button ([#5709](https://github.com/Esri/calcite-components/issues/5709)) ([81d4c71](https://github.com/Esri/calcite-components/commit/81d4c71a815ff66ef540a77f223c2ffa31cc2899))
 
 ### Reverts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,8 +430,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     `--calcite-modal-content-background` instead.
   - Removed the `--calcite-modal-padding` CSS variable, use the
     `--calcite-modal-content-padding` CSS variable instead.
-    - Removed the property `intlClose`, use `messsageOverrides.close`
-      instead.
+  - Removed the property `intlClose`, use `messsageOverrides.close`
+    instead.
   - Renamed the property `color`, use `kind` instead.
   - Updated the accepted values of `kind` to `brand`, `danger`, `info`,
     `success`, and `warning`.
@@ -454,9 +454,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   - Removed the property `active`, use `open` instead.
   - Removed the property `dimissible`, use `closable` property instead.
-
-    - Removed the property `intlClose`, use `messsageOverrides.close`
-      instead.
+  - Removed the property `intlClose`, use `messsageOverrides.close`
+    instead.
 
 - **pagination**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the event `calciteFlowItemBackClick`, use
     `calciteFlowItemBack` instead.
 
-* **inline-editable,input,input-text,input-number:** Removed deprecated `intl\*` & accessible label properties.
+- **inline-editable,input,input-text,input-number:** Removed deprecated `intl\*` & accessible label properties.
 
-  - **list, list-item, list-item-group:** To know when `calcite-list-item` content is selected, listen to the event `calciteListItemSelect` instead of `click`.
+- **list, list-item, list-item-group:** To know when `calcite-list-item` content is selected, listen to the event `calciteListItemSelect` instead of `click`.
 
   - `headingLevel` property on the `list` and `list-item-group` are no
     longer necessary.
@@ -458,25 +458,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     - Removed the property `intlClose`, use `messsageOverrides.close`
       instead.
 
-  - **pagination**:
+- **pagination**:
 
-    - Removed the property `textLabelNext` , use `messsageOverrides.next`
-      instead.
-    - Removed the property `textLabelPrevious` , use
-      `messsageOverrides.previous` instead.
-
+  - Removed the property `textLabelNext` , use `messsageOverrides.next`
+    instead.
+  - Removed the property `textLabelPrevious` , use
+    `messsageOverrides.previous` instead.
   - Removed the event `calcitePaginationUpdate` event, use
     `calcitePaginationChange` event instead.
   - Removed the `event.detail` property on the event
     `calcitePaginationChange`, use `event.target` instead.
 
-  - **panel**:
+- **panel**:
 
-    - Removed the property `intlClose` , use `messsageOverrides.close`
-      instead.
-    - Removed the property `intlOptions`, use `messsageOverrides.options`
-      instead.
-
+  - Removed the property `intlClose` , use `messsageOverrides.close`
+    instead.
+  - Removed the property `intlOptions`, use `messsageOverrides.options`
+    instead.
   - Removed the property `dismissed`, use `closed` instead.
   - Removed the property `dismissible`, use `closable` instead.
   - Removed the property `summary`, use `description` instead.
@@ -493,15 +491,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the event `calcitePanelBackClick`, use the `calcite-flow-item`
     component instead.
 
-  - **pick-list-item**:
+- **pick-list-item**:
 
-    - Removed the property `intlRemove`, use `messsageOverrides.remove`
-      instead.
-
+  - Removed the property `intlRemove`, use `messsageOverrides.remove`
+    instead.
   - Renamed the property `disableDeselect`, use `deselectDisabled`
     instead.
 
-  - **popover**:
+- **popover**:
 
   - Removed the property `intlClose` , use `messsageOverrides.close`
     instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,38 +101,36 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Removed the property `active`, use `open` instead.
   - Removed the property `dimissible`, use `closable` property instead.
 
-- **modal,notice,pagination,panel,pick-list-item,popover:** Removed deprecated intl\* & accessible label properties.
-
-  - modal:
+  - **modal**: Removed deprecated `intl\*` & accessible label properties.
 
     - Removed the property `intlClose` , use `messsageOverrides.close`
       instead.
 
-  - notice:
+  - **notice**: Removed deprecated `intl\*` & accessible label properties.
 
     - Removed the property `intlClose` , use `messsageOverrides.close`
       instead.
 
-  - pagination:
+  - **pagination**: Removed deprecated `intl\*` & accessible label properties.
 
     - Removed the property `textLabelNext` , use `messsageOverrides.next`
       instead.
     - Removed the property `textLabelPrevious` , use
       `messsageOverrides.previous` instead.
 
-  - panel:
+  - **panel**: Removed deprecated `intl\*` & accessible label properties.
 
     - Removed the property `intlClose` , use `messsageOverrides.close`
       instead.
     - Removed the property `intlOptions`, use `messsageOverrides.options`
       instead.
 
-  - pick-list-item:
+  - **pick-list-item**: Removed deprecated `intl\*` & accessible label properties.
 
     - Removed the property `intlRemove` , use `messsageOverrides.remove`
       instead.
 
-  - popover:
+  - **popover**: Removed deprecated `intl\*` & accessible label properties.
 
     - Removed the property `intlClose` , use `messsageOverrides.close`
       instead.
@@ -170,14 +168,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Updated the accepted values of `kind` to `brand`, `danger`, `info`,
     `success`, and `warning`.
 
-- **tab-nav, tab-title:** Removed `event.detail` payload from events.
+- **tab-nav**: Removed `event.detail` payload from events.
+  - Removed the `event.detail` property on the event `calciteTabChange`,
+    use `event.target` instead.
+- **tab-title**: Removed `event.detail` payload from events.
 
-  - TabNav
-    - Removed the `event.detail` property on the event `calciteTabChange`,
-      use `event.target` instead.
-  - TabTitle
-    - Removed the `event.detail` property on the event
-      `calciteTabsActivate`, use `event.target` instead.
+  - Removed the `event.detail` property on the event
+    `calciteTabsActivate`, use `event.target` instead.
 
 - **tree:** Removed `event.detail` payload from events and added
   `selectedItems` property.


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Either this PR or #6109 will be incorporated in. The difference is the sorting/organization of the components (_see first bullet point below for organization details_).

**This is the recommended PR for merging (as long as developers agree) so those interpreting our change log can discern changes by component instead of having to sift through the entire 700+ line breaking changes between `beta.98` and `beta.99`.** 🚀 

- Adds major refactoring to the changelog so components show breaking changes more effectively.
  - Components now have all breaking changes grouped under their name once
  - Exceptions are grouped breaking changes where multiple components were listed (such as `list`, `list-item`, `list-group`) 
- Adds readability improvements to the changelog for the upcoming release.