### PR TITLE
chore(date-picker): Remove unused deprecated interface.

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -174,8 +174,6 @@ export class DatePicker implements LocalizedComponent, T9nComponent {
 
   /**
    * Emits when a user changes the component's date `range`. For components without `range` use `calciteDatePickerChange`.
-   *
-   * @see [DateRangeChange](https://github.com/Esri/calcite-components/blob/master/src/components/date-picker/interfaces.ts#L1)
    */
   @Event({ cancelable: false }) calciteDatePickerRangeChange: EventEmitter<void>;
 

--- a/src/components/date-picker/interfaces.d.ts
+++ b/src/components/date-picker/interfaces.d.ts
@@ -1,5 +1,0 @@
-// @deprecated remove this file before 1.0
-export interface DateRangeChange {
-  startDate: Date;
-  endDate: Date;
-}


### PR DESCRIPTION
chore(date-picker): Remove unused deprecated interface.