### PR TITLE
feat(radio-group): Add appearance type

### DIFF
--- a/src/components/radio-group-item/radio-group-item.scss
+++ b/src/components/radio-group-item/radio-group-item.scss
@@ -60,10 +60,15 @@
   color: theme("backgroundColor.background");
 }
 
-:host([checked]) .label--outline {
-  @apply bg-transparent border-color-brand;
+:host([checked]) .label--outline,
+:host([checked]) .label--outline-fill {
+  @apply bg-foreground-1 border-color-brand;
   box-shadow: inset 0 0 0 1px theme("backgroundColor.brand");
   color: theme("backgroundColor.brand");
+}
+
+:host([checked]) .label--outline {
+  @apply bg-transparent;
 }
 
 ::slotted(input) {
@@ -74,7 +79,8 @@
   :host([checked]) label {
     background-color: highlight;
   }
-  :host([checked]) .label--outline {
+  :host([checked]) .label--outline,
+  :host([checked]) .label--outline-fill {
     @apply outline-none;
   }
   :host([checked]) label:not([class~="label--outline"]) .radio-group-item-icon {

--- a/src/components/radio-group-item/radio-group-item.tsx
+++ b/src/components/radio-group-item/radio-group-item.tsx
@@ -60,7 +60,7 @@ export class RadioGroupItem {
   render(): VNode {
     const { checked, value } = this;
     const scale: Scale = getElementProp(this.el, "scale", "m");
-    const appearance: Extract<"outline" | "solid", Appearance> = getElementProp(
+    const appearance: Extract<"outline" | "outline-fill" | "solid", Appearance> = getElementProp(
       this.el,
       "appearance",
       "solid"
@@ -95,7 +95,8 @@ export class RadioGroupItem {
             "label--scale-m": scale === "m",
             "label--scale-l": scale === "l",
             "label--horizontal": layout === "horizontal",
-            "label--outline": appearance === "outline"
+            "label--outline": appearance === "outline",
+            "label--outline-fill": appearance === "outline-fill"
           }}
         >
           {this.iconStart ? iconStartEl : null}

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -5,6 +5,10 @@
   outline-offset: -1px;
 }
 
+:host([appearance="outline"]) {
+  @apply bg-transparent;
+}
+
 @include disabled();
 
 :host([layout="vertical"]) {

--- a/src/components/radio-group/radio-group.stories.ts
+++ b/src/components/radio-group/radio-group.stories.ts
@@ -16,7 +16,7 @@ export default {
 export const simple = (): string => html`
   <calcite-radio-group
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-    appearance="${select("appearance", ["solid", "outline"], "solid")}"
+    appearance="${select("appearance", ["solid", "outline", "outline-fill"], "solid")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["auto", "full"], "auto")}"
     ${boolean("disabled", false)}
@@ -34,7 +34,7 @@ export const fullWidthWithIcons = (): string => html`
       My great radio group
       <calcite-radio-group
         layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-        appearance="${select("appearance", ["solid", "outline"], "solid")}"
+        appearance="${select("appearance", ["solid", "outline", "outline-fill"], "solid")}"
         width="${select("width", ["auto", "full"], "full")}"
         ${boolean("disabled", false)}
       >
@@ -51,7 +51,7 @@ export const darkThemeRTL_TestOnly = (): string => html`
     class="calcite-theme-dark"
     dir="rtl"
     layout="${select("layout", ["horizontal", "vertical"], "horizontal")}"
-    appearance="${select("appearance", ["solid", "outline"], "solid")}"
+    appearance="${select("appearance", ["solid", "outline", "outline-fill"], "solid")}"
     scale="${select("scale", ["s", "m", "l"], "m")}"
     width="${select("width", ["auto", "full"], "auto")}"
     ${boolean("disabled", false)}

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -57,7 +57,8 @@ export class RadioGroup
   //--------------------------------------------------------------------------
 
   /** Specifies the appearance style of the component. */
-  @Prop({ reflect: true }) appearance: Extract<"outline" | "solid", Appearance> = "solid";
+  @Prop({ reflect: true }) appearance: Extract<"outline" | "outline-fill" | "solid", Appearance> =
+    "solid";
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;

--- a/src/demos/radio-group.html
+++ b/src/demos/radio-group.html
@@ -88,6 +88,38 @@
         </div>
       </div>
 
+      <!-- outline-fill -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="s">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="m">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="l">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+
       <!-- outline -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline</div>
@@ -163,6 +195,46 @@
         </div>
       </div>
 
+      <!-- outline-fill wrapped with calcite label -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill wrapped with calcite label</div>
+
+        <div class="child-flex">
+          <calcite-label>
+            <span> my great radio group </span>
+            <calcite-radio-group appearance="outline-fill" scale="s">
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            <span> my great radio group </span>
+            <calcite-radio-group appearance="outline-fill" scale="m">
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            <span> my great radio group </span>
+            <calcite-radio-group appearance="outline-fill" scale="l">
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
+          </calcite-label>
+        </div>
+      </div>
       <!-- outline wrapped with calcite label -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline wrapped with calcite label</div>
@@ -235,6 +307,35 @@
         </div>
       </div>
 
+      <!-- outline-fill icons -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill icons</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="s">
+            <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="m">
+            <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="l">
+            <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+
       <!-- outline icons -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline icons</div>
@@ -263,7 +364,6 @@
           </calcite-radio-group>
         </div>
       </div>
-
       <hr />
 
       <!-- solid icon position-end -->
@@ -295,6 +395,33 @@
         </div>
       </div>
 
+      <!-- outline-fill icon position-end -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill icon position-end</div>
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="s">
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="m">
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="l">
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
       <!-- outline icon position-end -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline icon position-end</div>
@@ -347,6 +474,35 @@
 
         <div class="child-flex">
           <calcite-radio-group disabled scale="l">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+
+      <!-- outline-fill disabled -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill disabled</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" disabled scale="s">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" disabled scale="m">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" disabled scale="l">
             <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
             <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
             <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
@@ -414,6 +570,34 @@
         </div>
       </div>
 
+      <!-- outline-fill none checked -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill none checked</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="s">
+            <calcite-radio-group-item value="React"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Angular"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="m">
+            <calcite-radio-group-item value="React"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Angular"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" scale="l">
+            <calcite-radio-group-item value="React"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Angular"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
       <!-- outline none checked -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline none checked</div>
@@ -482,6 +666,37 @@
         </div>
       </div>
 
+      <!-- outline-fill -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="s">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="m">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="l">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+            <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
       <!-- outline -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline</div>
@@ -557,6 +772,46 @@
         </div>
       </div>
 
+      <!-- outline-fill wrapped with calcite label -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill wrapped with calcite label</div>
+
+        <div class="child-flex">
+          <calcite-label>
+            My Great Radio Group
+            <calcite-radio-group appearance="outline-fill" layout="vertical" scale="s">
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            My Great Radio Group
+            <calcite-radio-group appearance="outline-fill" layout="vertical" scale="m">
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            My Great Radio Group
+            <calcite-radio-group appearance="outline-fill" layout="vertical" scale="l">
+              <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+              <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+              <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+              <calcite-radio-group-item value="vue">Vue</calcite-radio-group-item>
+            </calcite-radio-group>
+          </calcite-label>
+        </div>
+      </div>
       <!-- outline wrapped with calcite label -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline wrapped with calcite label</div>
@@ -597,7 +852,6 @@
           </calcite-label>
         </div>
       </div>
-
       <hr />
 
       <!-- solid icons -->
@@ -629,6 +883,34 @@
         </div>
       </div>
 
+      <!-- outline-fill icons -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill icons</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="s">
+            <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="m">
+            <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="l">
+            <calcite-radio-group-item icon="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
       <!-- outline icons -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline icons</div>
@@ -657,7 +939,6 @@
           </calcite-radio-group>
         </div>
       </div>
-
       <hr />
 
       <!-- solid icon position-end -->
@@ -682,6 +963,34 @@
 
         <div class="child-flex">
           <calcite-radio-group layout="vertical" scale="l">
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+
+      <!-- outline-fill icon position-end -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill icon position-end</div>
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="s">
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="m">
+            <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
+            <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="l">
             <calcite-radio-group-item icon-end="car" value="car" checked>Car</calcite-radio-group-item>
             <calcite-radio-group-item icon-end="plane" value="plane">Plane</calcite-radio-group-item>
             <calcite-radio-group-item icon-end="biking" value="bicycle">Bicycle</calcite-radio-group-item>
@@ -741,6 +1050,35 @@
 
         <div class="child-flex">
           <calcite-radio-group disabled layout="vertical" scale="l">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+
+      <!-- outline-fill disabled -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill disabled</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" disabled layout="vertical" scale="s">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" disabled layout="vertical" scale="m">
+            <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
+            <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
+            <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" disabled layout="vertical" scale="l">
             <calcite-radio-group-item value="react" checked>React</calcite-radio-group-item>
             <calcite-radio-group-item value="ember">Ember</calcite-radio-group-item>
             <calcite-radio-group-item value="angular">Angular</calcite-radio-group-item>
@@ -808,6 +1146,34 @@
         </div>
       </div>
 
+      <!-- outline-fill none checked -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill none checked</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="s">
+            <calcite-radio-group-item value="React"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Angular"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="m">
+            <calcite-radio-group-item value="React"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Angular"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="l">
+            <calcite-radio-group-item value="React"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Angular"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
       <!-- outline none checked -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline none checked</div>
@@ -853,6 +1219,20 @@
         </div>
       </div>
 
+      <!-- outline-fill full-width -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill full-width</div>
+
+        <div class="width-child-flex">
+          <calcite-radio-group width="full" appearance="outline-fill">
+            <calcite-radio-group-item checked value="React"> React </calcite-radio-group-item>
+            <calcite-radio-group-item value="Ember"> Ember </calcite-radio-group-item>
+            <calcite-radio-group-item value="Longer text wraps."> Longer text wraps. </calcite-radio-group-item>
+            <calcite-radio-group-item value="Longer text wraps yep"> Longer text wraps yep </calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+
       <!-- outline full-width -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline full-width</div>
@@ -868,6 +1248,62 @@
       </div>
 
       <hr />
+      <!-- iconStart & iconEnd -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">solid none checked</div>
+
+        <div class="child-flex">
+          <calcite-radio-group layout="vertical" scale="s">
+            <calcite-radio-group-item value="Car" icon-start="car" icon-end="car"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Plane" icon-start="plane" icon-end="plane"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Biking" icon-start="biking" icon-end="biking"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group layout="vertical" scale="m">
+            <calcite-radio-group-item value="Car" icon-start="car" icon-end="car"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Plane" icon-start="plane" icon-end="plane"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Biking" icon-start="biking" icon-end="biking"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group layout="vertical" scale="l">
+            <calcite-radio-group-item value="Car" icon-start="car" icon-end="car"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Plane" icon-start="plane" icon-end="plane"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Biking" icon-start="biking" icon-end="biking"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
+      <!-- iconStart & iconEnd -->
+      <div class="parent-flex">
+        <div class="child-flex right-aligned-text">outline-fill none checked</div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="s">
+            <calcite-radio-group-item value="Car" icon-start="car" icon-end="car"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Plane" icon-start="plane" icon-end="plane"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Biking" icon-start="biking" icon-end="biking"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="m">
+            <calcite-radio-group-item value="Car" icon-start="car" icon-end="car"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Plane" icon-start="plane" icon-end="plane"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Biking" icon-start="biking" icon-end="biking"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+
+        <div class="child-flex">
+          <calcite-radio-group appearance="outline-fill" layout="vertical" scale="l">
+            <calcite-radio-group-item value="Car" icon-start="car" icon-end="car"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Plane" icon-start="plane" icon-end="plane"></calcite-radio-group-item>
+            <calcite-radio-group-item value="Biking" icon-start="biking" icon-end="biking"></calcite-radio-group-item>
+          </calcite-radio-group>
+        </div>
+      </div>
       <!-- iconStart & iconEnd -->
       <div class="parent-flex">
         <div class="child-flex right-aligned-text">outline none checked</div>


### PR DESCRIPTION
Adds `outline-fill` value for `appearance` property

-- 

As shown in this comment, adds another appearance value to `radio-group` cc @SkyeSeitz @ashetland 

https://github.com/Esri/calcite-components/issues/6095#issuecomment-1357968324