### PR TITLE
ci(chromatic): explicitly auto-accept changes to master as baseline

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true
+          autoAcceptChanges: master
         env:
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
           CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}


### PR DESCRIPTION
**Related Issue:** #

## Summary
Chromatic says in their [baseline doc](https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging) that squash merging and rebasing should automatically accept baseline changes.

But I just found some more doc on their [CLI page](https://www.chromatic.com/docs/custom-ci-provider#squashrebase-merge-and-the-main-branch) that says it may not work lol.

So I'm explicitly accepting changes to `master` as baseline, since they will be approved in PRs before merging. I swear, if this fixes it...