### PR TITLE
refactor(radio-button-group)!: remove `event.detail` payload from event and add property

### DIFF
--- a/src/components/radio-button-group/radio-button-group.e2e.ts
+++ b/src/components/radio-button-group/radio-button-group.e2e.ts
@@ -419,7 +419,7 @@ describe("calcite-radio-button-group", () => {
     `);
 
     const getSelectedItemValue = async (): Promise<string> => {
-      return await page.evaluate((): Promise<string> => {
+      return await page.evaluate((): string => {
         return document.querySelector("calcite-radio-button-group")?.selectedItem?.value || "";
       });
     };

--- a/src/components/radio-button-group/radio-button-group.e2e.ts
+++ b/src/components/radio-button-group/radio-button-group.e2e.ts
@@ -418,6 +418,12 @@ describe("calcite-radio-button-group", () => {
       </calcite-radio-button-group>
     `);
 
+    const getSelectedItemValue = async (): Promise<string> => {
+      return await page.evaluate((): Promise<string> => {
+        return document.querySelector("calcite-radio-button-group")?.selectedItem?.value || "";
+      });
+    };
+
     const group = await page.find("calcite-radio-button-group");
     const firstRadio = await page.find('calcite-radio-button[value="one"]');
     const secondRadio = await page.find('calcite-radio-button[value="two"]');
@@ -429,14 +435,14 @@ describe("calcite-radio-button-group", () => {
 
     await firstRadio.click();
     expect(changeEvent).toHaveReceivedEventTimes(1);
-    expect(changeEvent).toHaveReceivedEventDetail("one");
+    expect(await getSelectedItemValue()).toBe("one");
 
     await secondRadio.click();
     expect(changeEvent).toHaveReceivedEventTimes(2);
-    expect(changeEvent).toHaveReceivedEventDetail("two");
+    expect(await getSelectedItemValue()).toBe("two");
 
     await thirdRadio.click();
     expect(changeEvent).toHaveReceivedEventTimes(3);
-    expect(changeEvent).toHaveReceivedEventDetail("three");
+    expect(await getSelectedItemValue()).toBe("three");
   });
 });

--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -68,6 +68,13 @@ export class RadioButtonGroup {
   /** When `true`, the component must have a value in order for the form to submit. */
   @Prop({ reflect: true }) required = false;
 
+  /**
+   * Specifies the component's selected item.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) selectedItem: HTMLCalciteRadioButtonElement = null;
+
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
@@ -107,6 +114,7 @@ export class RadioButtonGroup {
 
   private passPropsToRadioButtons = (): void => {
     const radioButtons = this.el.querySelectorAll("calcite-radio-button");
+    this.selectedItem = Array.from(radioButtons).find((radioButton) => radioButton.checked) || null;
     if (radioButtons.length > 0) {
       radioButtons.forEach((radioButton) => {
         radioButton.disabled = this.disabled || radioButton.disabled;
@@ -127,7 +135,7 @@ export class RadioButtonGroup {
   /**
    * Fires when the component has changed.
    */
-  @Event({ cancelable: false }) calciteRadioButtonGroupChange: EventEmitter<any>;
+  @Event({ cancelable: false }) calciteRadioButtonGroupChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //
@@ -137,7 +145,8 @@ export class RadioButtonGroup {
 
   @Listen("calciteRadioButtonChange")
   radioButtonChangeHandler(event: CustomEvent): void {
-    this.calciteRadioButtonGroupChange.emit((event.target as HTMLCalciteRadioButtonElement).value);
+    this.selectedItem = event.target as HTMLCalciteRadioButtonElement;
+    this.calciteRadioButtonGroupChange.emit();
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from event and added `selectedItem` property.

- Added property `selectedItem`.
- Removed the `event.detail` property on the event `calciteRadioButtonGroupChange`, use `event.target` and the property `selectedItem` instead.