### PR TITLE
refactor(stepper)!: remove event.detail payload from event and add property

### DIFF
--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -440,6 +440,12 @@ describe("calcite-stepper", () => {
       const eventSpy = await element.spyOnEvent("calciteStepperItemChange");
       const firstItem = await page.find("#step-1");
 
+      const getSelectedItemId = async (): Promise<string> => {
+        return await page.evaluate((): string => {
+          return document.querySelector("calcite-stepper")?.selectedItem?.id || "";
+        });
+      };
+
       let expectedEvents = 0;
 
       // non user interaction
@@ -454,7 +460,7 @@ describe("calcite-stepper", () => {
 
       await page.$eval("#step-2", itemClicker);
       expect(eventSpy).toHaveReceivedEventTimes(++expectedEvents);
-      expect(eventSpy.lastEvent.detail.position).toBe(1);
+      expect(await getSelectedItemId()).toBe("step-2");
 
       if (hasContent) {
         await page.$eval("#step-1", (item: HTMLCalciteStepperItemElement) =>
@@ -463,7 +469,7 @@ describe("calcite-stepper", () => {
 
         if (layout === "vertical") {
           expect(eventSpy).toHaveReceivedEventTimes(++expectedEvents);
-          expect(eventSpy.lastEvent.detail.position).toBe(0);
+          expect(await getSelectedItemId()).toBe("step-1");
         } else {
           // no events since horizontal layout moves content outside of item selection hit area
           expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
@@ -476,7 +482,7 @@ describe("calcite-stepper", () => {
 
       await page.$eval("#step-4", itemClicker);
       expect(eventSpy).toHaveReceivedEventTimes(++expectedEvents);
-      expect(eventSpy.lastEvent.detail.position).toBe(3);
+      expect(await getSelectedItemId()).toBe("step-4");
 
       await element.callMethod("prevStep");
       await page.waitForChanges();

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -158,6 +158,7 @@ export class Stepper {
 
     if (typeof position === "number") {
       this.currentPosition = position;
+      this.selectedItem = event.target as HTMLCalciteStepperItemElement;
     }
 
     this.calciteInternalStepperItemChange.emit({
@@ -166,8 +167,7 @@ export class Stepper {
   }
 
   @Listen("calciteInternalUserRequestedStepperItemSelect")
-  handleUserRequestedStepperItemSelect(event: CustomEvent<StepperItemChangeEventDetail>): void {
-    this.selectedItem = event.target as HTMLCalciteStepperItemElement;
+  handleUserRequestedStepperItemSelect(): void {
     this.calciteStepperItemChange.emit();
   }
 

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -52,6 +52,13 @@ export class Stepper {
    */
   @Prop({ reflect: true }) numberingSystem?: NumberingSystem;
 
+  /**
+   * Specifies the component's selected item.
+   *
+   * @readonly
+   */
+  @Prop({ mutable: true }) selectedItem: HTMLCalciteStepperItemElement = null;
+
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
@@ -66,7 +73,7 @@ export class Stepper {
    *
    */
   @Event({ cancelable: false })
-  calciteStepperItemChange: EventEmitter<StepperItemChangeEventDetail>;
+  calciteStepperItemChange: EventEmitter<void>;
 
   /**
    * Fires when the active `calcite-stepper-item` changes.
@@ -160,11 +167,8 @@ export class Stepper {
 
   @Listen("calciteInternalUserRequestedStepperItemSelect")
   handleUserRequestedStepperItemSelect(event: CustomEvent<StepperItemChangeEventDetail>): void {
-    const { position } = event.detail;
-
-    this.calciteStepperItemChange.emit({
-      position
-    });
+    this.selectedItem = event.target as HTMLCalciteStepperItemElement;
+    this.calciteStepperItemChange.emit();
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
BREAKING CHANGE: Removed `event.detail` payload from event and added `selectedItem` property.

- Added property `selectedItem`.
- Removed the `event.detail` property on the event `calciteStepperItemChange`, use `event.target` and the property `selectedItem` instead.