### PR TITLE
feat(popover, modal): Add the ability to update focus trap elements after initialization.

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -28,7 +28,8 @@ import {
   connectFocusTrap,
   activateFocusTrap,
   deactivateFocusTrap,
-  focusFirstTabbable
+  focusFirstTabbable,
+  updateFocusTrapElements
 } from "../../utils/focusTrapComponent";
 import {
   setUpLoadableComponent,
@@ -394,6 +395,14 @@ export class Modal
     }
 
     focusFirstTabbable(this);
+  }
+
+  /**
+   * Updates the element(s) that are used within the focus-trap of the component.
+   */
+  @Method()
+  async updateFocusTrapElements(): Promise<void> {
+    updateFocusTrapElements(this);
   }
 
   /**

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -33,7 +33,8 @@ import {
   connectFocusTrap,
   activateFocusTrap,
   deactivateFocusTrap,
-  focusFirstTabbable
+  focusFirstTabbable,
+  updateFocusTrapElements
 } from "../../utils/focusTrapComponent";
 
 import { guid } from "../../utils/guid";
@@ -411,6 +412,14 @@ export class Popover
   @Method()
   async toggle(value = !this.open): Promise<void> {
     this.open = value;
+  }
+
+  /**
+   * Updates the element(s) that are used within the focus-trap of the component.
+   */
+  @Method()
+  async updateFocusTrapElements(): Promise<void> {
+    updateFocusTrapElements(this);
   }
 
   // --------------------------------------------------------------------------

--- a/src/utils/focusTrapComponent.spec.ts
+++ b/src/utils/focusTrapComponent.spec.ts
@@ -1,4 +1,9 @@
-import { activateFocusTrap, connectFocusTrap, deactivateFocusTrap } from "./focusTrapComponent";
+import {
+  activateFocusTrap,
+  connectFocusTrap,
+  deactivateFocusTrap,
+  updateFocusTrapElements
+} from "./focusTrapComponent";
 
 describe("focusTrapComponent", () => {
   it("focusTrapComponent lifecycle", () => {
@@ -17,8 +22,14 @@ describe("focusTrapComponent", () => {
     const deactivateSpy = jest.fn();
     fakeComponent.focusTrap.deactivate = deactivateSpy;
 
+    const updateSpy = jest.fn();
+    fakeComponent.focusTrap.updateContainerElements = updateSpy;
+
     activateFocusTrap(fakeComponent);
     expect(activateSpy).toHaveBeenCalledTimes(1);
+
+    updateFocusTrapElements(fakeComponent);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
 
     deactivateFocusTrap(fakeComponent);
     expect(deactivateSpy).toHaveBeenCalledTimes(1);

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -105,6 +105,13 @@ export function focusFirstTabbable(component: FocusTrapComponent): void {
  * Helper to update the element(s) that are used within the FocusTrap component.
  *
  * @param {FocusTrapComponent} component The FocusTrap component.
+ * @example
+ * const modal = document.querySelector("calcite-modal");
+ * const input = document.createElement("calcite-input");
+ * content.appendChild(input);
+ * await input.componentOnReady();
+ * await modal.updateFocusTrapElements();
+ * requestAnimationFrame(() => input.setFocus());
  */
 export function updateFocusTrapElements(component: FocusTrapComponent): void {
   component.focusTrap?.updateContainerElements(component.focusTrapEl);

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -31,6 +31,11 @@ export interface FocusTrapComponent {
    * The focus trap element.
    */
   focusTrapEl: HTMLElement;
+
+  /**
+   * Method to update the element(s) that are used within the FocusTrap component.
+   */
+  updateFocusTrapElements: () => Promise<void>;
 }
 
 export type FocusTrap = _FocusTrap;
@@ -94,4 +99,13 @@ export function deactivateFocusTrap(component: FocusTrapComponent): void {
  */
 export function focusFirstTabbable(component: FocusTrapComponent): void {
   tabbable(component.focusTrapEl, tabbableOptions)[0]?.focus();
+}
+
+/**
+ * Helper to update the element(s) that are used within the FocusTrap component.
+ *
+ * @param {FocusTrapComponent} component The FocusTrap component.
+ */
+export function updateFocusTrapElements(component: FocusTrapComponent): void {
+  component.focusTrap?.updateContainerElements(component.focusTrapEl);
 }


### PR DESCRIPTION
**Related Issue:** #6140

## Summary

feat(popover, modal): Add the ability to update focus trap elements after initialization.

- Adds `updateFocusTrapElements` method to each `FocusTrap` component.
  - This method allows a user to update the focus trap elements after the focus trap has been initialized

## Example use case

```js
const modal = document.querySelector("calcite-modal");
const input = document.createElement("calcite-input");
content.appendChild(input);
await input.componentOnReady(); // To make sure the input has been rendered
await modal.updateFocusTrapElements(); // The new method to update focusable elements
requestAnimationFrame(() => input.setFocus()); // Wait for next frame to set focus
 ```