### PR TITLE
chore: add esri monitor team label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -109,6 +109,7 @@ body:
         - ArcGIS Map Viewer
         - ArcGIS Marketplace
         - ArcGIS Mission
+        - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Scene Viewer

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -103,6 +103,7 @@ body:
         - ArcGIS Map Viewer
         - ArcGIS Marketplace
         - ArcGIS Mission
+        - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Scene Viewer

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -70,6 +70,7 @@ body:
         - ArcGIS Map Viewer
         - ArcGIS Marketplace
         - ArcGIS Mission
+        - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Scene Viewer

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -71,6 +71,7 @@ body:
         - ArcGIS Map Viewer
         - ArcGIS Marketplace
         - ArcGIS Mission
+        - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Scene Viewer


### PR DESCRIPTION
**Related Issue:** #6131

## Summary
Adds a label in the issue templates for the ArcGIS Monitor team for:
- a11y issues 
- bugs 
- enhancements, and
- new components 