### PR TITLE
refactor(popover)!: remove `toggle` method.

### DIFF
--- a/src/components/popover/PopoverManager.ts
+++ b/src/components/popover/PopoverManager.ts
@@ -58,18 +58,18 @@ export default class PopoverManager {
     const togglePopover = this.queryPopover(composedPath);
 
     if (togglePopover && !togglePopover.triggerDisabled) {
-      togglePopover.toggle();
+      togglePopover.open = !togglePopover.open;
     }
 
     Array.from(this.registeredElements.values())
       .filter(
         (popover) => popover !== togglePopover && popover.autoClose && popover.open && !composedPath.includes(popover)
       )
-      .forEach((popover) => popover.toggle(false));
+      .forEach((popover) => (popover.open = false));
   };
 
   private closeAllPopovers(): void {
-    Array.from(this.registeredElements.values()).forEach((popover) => popover.toggle(false));
+    Array.from(this.registeredElements.values()).forEach((popover) => (popover.open = false));
   }
 
   private keyHandler = (event: KeyboardEvent): void => {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -393,16 +393,6 @@ export class Popover
   }
 
   /**
-   * Toggles the component's open property.
-   *
-   * @param value
-   */
-  @Method()
-  async toggle(value = !this.open): Promise<void> {
-    this.open = value;
-  }
-
-  /**
    * Updates the element(s) that are used within the focus-trap of the component.
    */
   @Method()


### PR DESCRIPTION
BREAKING CHANGE: Removed the `toggle` method, use the `open` property instead.