### PR TITLE
refactor(combobox-item)!: remove `toggleSelected` method.

### DIFF
--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -4,7 +4,6 @@ import {
   Event,
   EventEmitter,
   Host,
-  Method,
   Prop,
   h,
   Watch,
@@ -123,29 +122,16 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
 
   // --------------------------------------------------------------------------
   //
-  //  Public Methods
+  //  Private Methods
   //
   // --------------------------------------------------------------------------
 
-  /**
-   * Used to toggle the selection state. By default this won't trigger an event.
-   * The first argument allows the value to be coerced, rather than swapping values.
-   *
-   * @param coerce
-   */
-  @Method()
-  async toggleSelected(coerce?: boolean): Promise<void> {
+  toggleSelected(coerce?: boolean): Promise<void> {
     if (this.disabled) {
       return;
     }
     this.selected = typeof coerce === "boolean" ? coerce : !this.selected;
   }
-
-  // --------------------------------------------------------------------------
-  //
-  //  Private Methods
-  //
-  // --------------------------------------------------------------------------
 
   itemClickHandler = (event: MouseEvent): void => {
     event.preventDefault();

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -1289,7 +1289,8 @@ describe("calcite-combobox", () => {
     </calcite-combobox>`);
     const item = await page.find("calcite-combobox-item");
 
-    await item.callMethod("toggleSelected");
+    item.setProperty("selected", true);
+    await page.waitForChanges();
     const focusedId = await page.evaluate(() => {
       const el = document.activeElement;
       return el.id;


### PR DESCRIPTION
BREAKING CHANGE: Removed the `toggleSelected` method, use the `selected` property instead.