### PR TITLE
chore(color-picker): add missing message in `en` bundle

### DIFF
--- a/src/components/color-picker/assets/color-picker/t9n/messages_en.json
+++ b/src/components/color-picker/assets/color-picker/t9n/messages_en.json
@@ -9,6 +9,7 @@
   "hex": "Hex",
   "hue": "Hue",
   "noColor": "No color",
+  "opacity": "Opacity",
   "r": "R",
   "red": "Red",
   "rgb": "RGB",


### PR DESCRIPTION

## Summary

This PR will add missing message in `en` bundle of `calcite-color-picker`.