### PR TITLE
build(deps): bump calcite-ui-icons from 3.20.5 to 3.20.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.0.1",
-        "@esri/calcite-ui-icons": "3.20.5",
+        "@esri/calcite-ui-icons": "3.20.7",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil/eslint-plugin": "0.4.0",
         "@stencil/postcss": "2.1.0",
@@ -2403,9 +2403,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.5.tgz",
-      "integrity": "sha512-HoHt6I3gzVg557dPY+g+ilUt1EQSbqtkn+hI5qjhrcxQu3kur+VuEDLkaiS9MYpWyNNh2CE2hffPtOYl5m8wvA==",
+      "version": "3.20.7",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.7.tgz",
+      "integrity": "sha512-zX/eHOxIV+gnC6QPbYgqAgZnW6ftQrNbaH08hsVuuOPIUke/HUS2o+y/pp7x9/+eh/moa9Fannto+6tHpV7HYQ==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -33709,11 +33709,14 @@
       }
     },
     "node_modules/webpack/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -36095,9 +36098,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.5.tgz",
-      "integrity": "sha512-HoHt6I3gzVg557dPY+g+ilUt1EQSbqtkn+hI5qjhrcxQu3kur+VuEDLkaiS9MYpWyNNh2CE2hffPtOYl5m8wvA==",
+      "version": "3.20.7",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.7.tgz",
+      "integrity": "sha512-zX/eHOxIV+gnC6QPbYgqAgZnW6ftQrNbaH08hsVuuOPIUke/HUS2o+y/pp7x9/+eh/moa9Fannto+6tHpV7HYQ==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.0.1",
-    "@esri/calcite-ui-icons": "3.20.5",
+    "@esri/calcite-ui-icons": "3.20.7",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
#6131 - Updates calcite ui icons to 3.20.7 