### PR TITLE
refactor(panel, shell-panel)!: Update available css variables

### DIFF
--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -13,7 +13,6 @@ import {
 } from "@stencil/core";
 import { getElementDir } from "../../utils/dom";
 import { HeadingLevel } from "../functional/Heading";
-import { Scale } from "../interfaces";
 import { CSS, ICONS, SLOTS } from "./resources";
 import { SLOTS as PANEL_SLOTS } from "../panel/resources";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
@@ -88,11 +87,6 @@ export class FlowItem
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 
   /**
-   * Specifies the maximum height of the component.
-   */
-  @Prop({ reflect: true }) heightScale: Scale;
-
-  /**
    * When `true`, a busy indicator is displayed.
    */
   @Prop({ reflect: true }) loading = false;
@@ -124,11 +118,6 @@ export class FlowItem
    * When `true`, displays a back button in the component's header.
    */
   @Prop({ reflect: true }) showBackButton = false;
-
-  /**
-   * Specifies the width of the component.
-   */
-  @Prop({ reflect: true }) widthScale: Scale;
 
   //--------------------------------------------------------------------------
   //
@@ -306,11 +295,9 @@ export class FlowItem
       disabled,
       heading,
       headingLevel,
-      heightScale,
       loading,
       menuOpen,
       messages,
-      widthScale,
       backButtonEl
     } = this;
     const label = messages.back;
@@ -323,14 +310,12 @@ export class FlowItem
           disabled={disabled}
           heading={heading}
           headingLevel={headingLevel}
-          heightScale={heightScale}
           loading={loading}
           menuOpen={menuOpen}
           messageOverrides={messages}
           onCalcitePanelClose={this.handlePanelClose}
           onCalcitePanelScroll={this.handlePanelScroll}
           ref={this.setContainerRef}
-          widthScale={widthScale}
         >
           {this.renderBackButton()}
           <slot name={SLOTS.headerActionsStart} slot={PANEL_SLOTS.headerActionsStart} />

--- a/src/components/panel/panel.e2e.ts
+++ b/src/components/panel/panel.e2e.ts
@@ -213,47 +213,6 @@ describe("calcite-panel", () => {
     expect(await footer.isVisible()).toBe(false);
   });
 
-  it("should update width based on the multipier CSS variable", async () => {
-    const multipier = 2;
-
-    const page = await newE2EPage();
-    await page.setViewport({ width: 1600, height: 1200 });
-
-    await page.setContent(`
-      <calcite-panel width-scale="m">
-        test
-      </calcite-panel>
-    `);
-
-    await page.waitForChanges();
-
-    const content = await page.find(`calcite-panel >>> .${CSS.container}`);
-    const style = await content.getComputedStyle("width");
-    const widthDefault = parseFloat(style["width"]);
-
-    const page2 = await newE2EPage();
-    await page2.setViewport({ width: 1600, height: 1200 });
-
-    await page2.setContent(`
-      <style>
-        :root {
-          --calcite-panel-width-multiplier: ${multipier};
-        }
-      </style>
-      <calcite-panel width-scale="m">
-        test multiplied
-      </calcite-panel>
-    `);
-
-    await page2.waitForChanges();
-
-    const content2 = await page2.find(`calcite-panel >>> .${CSS.container}`);
-    const style2 = await content2.getComputedStyle("width");
-    const width2 = parseFloat(style2["width"]);
-
-    expect(width2).toEqual(widthDefault * multipier);
-  });
-
   it("should set tabIndex of -1 on a non-scrollable panel", async () => {
     const page = await newE2EPage();
 

--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -1,22 +1,8 @@
-/**
- * CSS Custom Properties
- *
- * These properties can be overridden using the component's tag as selector.
- *
- * @prop --calcite-panel-max-height: The maximum height of the component.
- * @prop --calcite-panel-max-width: The maximum width of the component.
- * @prop --calcite-panel-min-width: The minimum width of the component.
- */
-
 :host {
   @extend %component-host;
   @apply relative flex w-full flex-auto overflow-hidden;
 
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
-  --calcite-panel-max-height: unset;
-  --calcite-panel-width: 100%;
-  --calcite-panel-min-width: unset;
-  --calcite-panel-max-width: unset;
 }
 
 @include disabled();
@@ -26,41 +12,7 @@
 .container {
   @apply bg-background m-0 flex w-full flex-auto flex-col items-stretch p-0;
 
-  max-block-size: var(--calcite-panel-max-height);
-  inline-size: var(--calcite-panel-width);
-  max-inline-size: var(--calcite-panel-max-width);
-  min-inline-size: var(--calcite-panel-min-width);
   transition: max-block-size var(--calcite-animation-timing), inline-size var(--calcite-animation-timing);
-}
-
-:host([height-scale="s"]) {
-  --calcite-panel-max-height: 40vh;
-}
-
-:host([height-scale="m"]) {
-  --calcite-panel-max-height: 60vh;
-}
-
-:host([height-scale="l"]) {
-  --calcite-panel-max-height: 80vh;
-}
-
-:host([width-scale="s"]) {
-  --calcite-panel-width: calc(var(--calcite-panel-width-multiplier) * 12vw);
-  --calcite-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 300px);
-  --calcite-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 150px);
-}
-
-:host([width-scale="m"]) {
-  --calcite-panel-width: calc(var(--calcite-panel-width-multiplier) * 20vw);
-  --calcite-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 420px);
-  --calcite-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 240px);
-}
-
-:host([width-scale="l"]) {
-  --calcite-panel-width: calc(var(--calcite-panel-width-multiplier) * 45vw);
-  --calcite-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 680px);
-  --calcite-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 340px);
 }
 
 .container[hidden] {

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -13,7 +13,6 @@ import {
 } from "@stencil/core";
 import { CSS, ICONS, SLOTS } from "./resources";
 import { focusFirstTabbable, toAriaBoolean } from "../../utils/dom";
-import { Scale } from "../interfaces";
 import { HeadingLevel, Heading } from "../functional/Heading";
 import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
@@ -75,16 +74,6 @@ export class Panel
    * Specifies the number at which section headings should start.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
-
-  /**
-   * Specifies the maximum height of the component.
-   */
-  @Prop({ reflect: true }) heightScale: Scale;
-
-  /**
-   * Specifies the width of the component.
-   */
-  @Prop({ reflect: true }) widthScale: Scale;
 
   /**
    * When `true`, a busy indicator is displayed.

--- a/src/components/shell-panel/shell-panel.e2e.ts
+++ b/src/components/shell-panel/shell-panel.e2e.ts
@@ -146,8 +146,8 @@ describe("calcite-shell-panel", () => {
     expect(detachedElement).not.toBeNull();
   });
 
-  it("should update width based on the multipier CSS variable", async () => {
-    const multipier = 2;
+  it("should update width based on the requested CSS variable override", async () => {
+    const override = "678px";
 
     const page = await newE2EPage();
 
@@ -159,15 +159,13 @@ describe("calcite-shell-panel", () => {
 
     await page.waitForChanges();
 
-    const content = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
-    const style = await content.getComputedStyle();
-    const widthDefault = parseFloat(style["width"]);
-
     const page2 = await newE2EPage();
     await page2.setContent(`
       <style>
         :root {
-          --calcite-panel-width-multiplier: ${multipier};
+          --calcite-shell-panel-min-width: ${override};
+          --calcite-shell-panel-max-width: ${override};
+          --calcite-shell-panel-width: ${override};
         }
       </style>
       <calcite-shell-panel>
@@ -181,7 +179,7 @@ describe("calcite-shell-panel", () => {
     const style2 = await content2.getComputedStyle();
     const width2 = parseFloat(style2["width"]);
 
-    expect(width2).toEqual(widthDefault * multipier);
+    expect(`${width2}px`).toEqual(override);
   });
 
   it("calcite-panel should render at the same height as the content__body.", async () => {

--- a/src/components/shell-panel/shell-panel.scss
+++ b/src/components/shell-panel/shell-panel.scss
@@ -1,9 +1,51 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-shell-panel-width: The width of the component.
+ * @prop --calcite-shell-panel-max-width: The maximum width of the component.
+ * @prop --calcite-shell-panel-min-width: The minimum width of the component.
+ * @prop --calcite-shell-panel-detached-max-height: The maximum height of the component when `detached` is true.
+ *
+ */
+
 :host {
   @apply pointer-events-none
     flex
     flex-initial
     items-stretch;
   --calcite-shell-panel-detached-max-height: unset;
+}
+
+:host([width-scale="s"]) .content {
+  --calcite-shell-panel-width-internal: var(--calcite-shell-panel-width, 12vw);
+  --calcite-shell-panel-max-width-internal: var(--calcite-shell-panel-max-width, 300px);
+  --calcite-shell-panel-min-width-internal: var(--calcite-shell-panel-min-width, 150px);
+}
+
+:host([width-scale="m"]) .content {
+  --calcite-shell-panel-width-internal: var(--calcite-shell-panel-width, 20vw);
+  --calcite-shell-panel-max-width-internal: var(--calcite-shell-panel-max-width, 420px);
+  --calcite-shell-panel-min-width-internal: var(--calcite-shell-panel-min-width, 240px);
+}
+
+:host([width-scale="l"]) .content {
+  --calcite-shell-panel-width-internal: var(--calcite-shell-panel-width, 45vw);
+  --calcite-shell-panel-max-width-internal: var(--calcite-shell-panel-max-width, 680px);
+  --calcite-shell-panel-min-width-internal: var(--calcite-shell-panel-min-width, 340px);
+}
+
+:host([detached-height-scale="s"]) .content--detached {
+  --calcite-shell-panel-detached-max-height-internal: var(--calcite-shell-panel-detached-max-height, 40vh);
+}
+
+:host([detached-height-scale="m"]) .content--detached {
+  --calcite-shell-panel-detached-max-height-internal: var(--calcite-shell-panel-detached-max-height, 60vh);
+}
+
+:host([detached-height-scale="l"]) .content--detached {
+  --calcite-shell-panel-detached-max-height-internal: var(--calcite-shell-panel-detached-max-height, 80vh);
 }
 
 .container {
@@ -80,9 +122,9 @@
   self-stretch
   p-0;
 
-  inline-size: var(--calcite-shell-panel-width);
-  max-inline-size: var(--calcite-shell-panel-max-width);
-  min-inline-size: var(--calcite-shell-panel-min-width);
+  inline-size: var(--calcite-shell-panel-width-internal);
+  max-inline-size: var(--calcite-shell-panel-max-width-internal);
+  min-inline-size: var(--calcite-shell-panel-min-width-internal);
   transition: max-block-size var(--calcite-animation-timing), max-inline-size var(--calcite-animation-timing);
 }
 
@@ -101,36 +143,6 @@
   overflow-hidden;
 }
 
-:host([width-scale="s"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-panel-width-multiplier) * 12vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 300px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 150px);
-}
-
-:host([width-scale="m"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-panel-width-multiplier) * 20vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 420px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 240px);
-}
-
-:host([width-scale="l"]) .content {
-  --calcite-shell-panel-width: calc(var(--calcite-panel-width-multiplier) * 45vw);
-  --calcite-shell-panel-max-width: calc(var(--calcite-panel-width-multiplier) * 680px);
-  --calcite-shell-panel-min-width: calc(var(--calcite-panel-width-multiplier) * 340px);
-}
-
-:host([detached-height-scale="s"]) .content--detached {
-  --calcite-shell-panel-detached-max-height: 40vh;
-}
-
-:host([detached-height-scale="m"]) .content--detached {
-  --calcite-shell-panel-detached-max-height: 60vh;
-}
-
-:host([detached-height-scale="l"]) .content--detached {
-  --calcite-shell-panel-detached-max-height: 80vh;
-}
-
 .content--detached {
   @apply shadow-0
   mx-2
@@ -140,7 +152,7 @@
   overflow-hidden
   rounded;
 
-  max-block-size: var(--calcite-shell-panel-detached-max-height);
+  max-block-size: var(--calcite-shell-panel-detached-max-height-internal);
   ::slotted(calcite-panel),
   ::slotted(calcite-flow) {
     max-block-size: unset;


### PR DESCRIPTION
BREAKING CHANGE: Update available css variables

- Removes width, height, and multiplier css variables for Panel - the component will now fill available space.
- Documents public css variables for Shell Panel