### PR TITLE
docs(flow-item): make showBackButton internal

### DIFF
--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -124,7 +124,7 @@ export class FlowItem
    *
    * @internal
    */
-  @Prop({ reflect: true }) showBackButton = false;
+  @Prop() showBackButton = false;
 
   /**
    * Specifies the width of the component.

--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -120,8 +120,9 @@ export class FlowItem
   @Prop({ mutable: true }) messages: FlowItemMessages;
 
   /**
-   * When true, displays a back button in the header.
    * When `true`, displays a back button in the component's header.
+   *
+   * @internal
    */
   @Prop({ reflect: true }) showBackButton = false;
 


### PR DESCRIPTION
**Related Issue:** #6178

## Summary

Makes the showBackButton property used by the parent flow internal