### PR TITLE
docs: consistent slot messaging across components

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -46,9 +46,9 @@ import {
 } from "../../utils/loadable";
 
 /**
- * @slot - A slot for adding `calcite-action`s that will appear at the top of the action bar.
- * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the action bar, above the collapse/expand button.
- * @slot expand-tooltip - Used to set the tooltip for the expand toggle.
+ * @slot - A slot for adding `calcite-action`s that will appear at the top of the component.
+ * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the component, above the collapse/expand button.
+ * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */
 @Component({
   tag: "calcite-action-bar",

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -38,7 +38,7 @@ import {
 
 /**
  * @slot - A slot for adding `calcite-action`s to the component.
- * @slot expand-tooltip - Used to set the `calcite-tooltip` for the expand toggle.
+ * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */
 @Component({
   tag: "calcite-action-pad",

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -58,7 +58,7 @@ import { MenuPlacement } from "../../utils/floating-ui";
  * @slot title - A slot for adding a title to the component.
  * @slot message - A slot for adding main text to the component.
  * @slot link - A slot for adding a `calcite-action` to take from the component such as: "undo", "try again", "link to page", etc.
- * @slot actions-end - A slot for adding actions to the end of the component. It is recommended to use two or fewer actions.
+ * @slot actions-end - A slot for adding `calcite-action`s to the end of the component. It is recommended to use two or fewer actions.
  */
 
 @Component({

--- a/src/components/block-section/block-section.tsx
+++ b/src/components/block-section/block-section.tsx
@@ -28,7 +28,7 @@ import { BlockSectionMessages } from "./assets/block-section/t9n";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
 
 /**
- * @slot - A slot for adding content to the component.
+ * @slot - A slot for adding custom content.
  */
 @Component({
   tag: "calcite-block-section",

--- a/src/components/block/block.tsx
+++ b/src/components/block/block.tsx
@@ -32,10 +32,10 @@ import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../..
 import { BlockMessages } from "./assets/block/t9n";
 
 /**
- * @slot - A slot for adding content to the component.
+ * @slot - A slot for adding custom content.
  * @slot icon - A slot for adding a leading header icon with `calcite-icon`.
  * @slot control - A slot for adding a single HTML input element in a header.
- * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a dropdown.
+ * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a dropdown menu.
  */
 @Component({
   tag: "calcite-block",

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -46,7 +46,7 @@ import { RequestedItem } from "../dropdown-group/interfaces";
 import { isActivationKey } from "../../utils/key";
 
 /**
- * @slot - A slot for adding `calcite-dropdown-group` components. Every `calcite-dropdown-item` must have a parent `calcite-dropdown-group`, even if the `groupTitle` property is not set.
+ * @slot - A slot for adding `calcite-dropdown-group` elements. Every `calcite-dropdown-item` must have a parent `calcite-dropdown-group`, even if the `groupTitle` property is not set.
  * @slot trigger - A slot for the element that triggers the `calcite-dropdown`.
  */
 @Component({

--- a/src/components/flow/flow.tsx
+++ b/src/components/flow/flow.tsx
@@ -4,7 +4,7 @@ import { FlowDirection } from "./interfaces";
 import { createObserver } from "../../utils/observers";
 
 /**
- * @slot - A slot for adding `calcite-flow-item` to the component.
+ * @slot - A slot for adding `calcite-flow-item` elements to the component.
  */
 @Component({
   tag: "calcite-flow",

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -45,8 +45,8 @@ import {
 /**
  * @slot title - A slot for adding the title.
  * @slot message - A slot for adding the message.
- * @slot link - A slot for adding actions to take, such as: undo, try again, link to page, etc.
- * @slot actions-end - A slot for adding actions to the end of the component. It is recommended to use two or less actions.
+ * @slot link - A slot for adding a `calcite-action` to take, such as: "undo", "try again", "link to page", etc.
+ * @slot actions-end - A slot for adding `calcite-action`s to the end of the component. It is recommended to use two or less actions.
  */
 
 @Component({

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -19,7 +19,7 @@ import {
 import { ShellPanelMessages } from "./assets/shell-panel/t9n";
 
 /**
- * @slot - A slot for adding content to the component.
+ * @slot - A slot for adding custom content.
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  */
 @Component({

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../utils/conditionalSlot";
 
 /**
- * @slot - A slot for adding content to the component. This content will appear between any leading and trailing panels added to the component, such as a map.
+ * @slot - A slot for adding custom content. This content will appear between any leading and trailing panels added to the component, such as a map.
  * @slot header - A slot for adding header content. This content will be positioned at the top of the component.
  * @slot footer - A slot for adding footer content. This content will be positioned at the bottom of the component.
  * @slot panel-start - A slot for adding the starting `calcite-shell-panel`.

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -16,7 +16,7 @@ import { NumberingSystem } from "../../utils/locale";
 import { focusElementInGroup } from "../../utils/dom";
 
 /**
- * @slot - A slot for adding `calcite-stepper-item`s.
+ * @slot - A slot for adding `calcite-stepper-item` elements.
  */
 @Component({
   tag: "calcite-stepper",

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -17,7 +17,7 @@ import { nodeListToArray } from "../../utils/dom";
 import { Scale } from "../interfaces";
 
 /**
- * @slot - A slot for adding content to the component.
+ * @slot - A slot for adding custom content.
  */
 @Component({
   tag: "calcite-tab",

--- a/src/components/tile-select-group/tile-select-group.tsx
+++ b/src/components/tile-select-group/tile-select-group.tsx
@@ -3,7 +3,7 @@ import { TileSelectGroupLayout } from "./interfaces";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot for adding `calcite-tile-select`s.
+ * @slot - A slot for adding `calcite-tile-select` elements.
  */
 @Component({
   tag: "calcite-tile-select-group",

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -30,7 +30,7 @@ import {
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 
 /**
- * @slot - A slot for adding the component's content.
+ * @slot - A slot for adding text.
  * @slot children - A slot for adding nested `calcite-tree` elements.
  */
 @Component({

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -29,8 +29,8 @@ import {
 } from "../../utils/loadable";
 
 /**
- * @slot actions-end - A slot for adding actions or content to the end side of the component.
- * @slot actions-start - A slot for adding actions or content to the start side of the component.
+ * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component.
+ * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
 @Component({
   tag: "calcite-value-list-item",


### PR DESCRIPTION
**Related Issue:** #3097  

## Summary
Adds consistency to slot documentation across components. Particular focus on default slots to describe as "A slot for adding custom content". 

Also includes an in-depth review and update across all component slots.