### PR TITLE
ci: fix timing issue in esri team labeler action

### DIFF
--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -57,16 +57,24 @@ jobs:
               }
 
               /** remove any existing product label(s) */
-              const labels = currentLabels
-                .filter((l) => !/Issues logged by/.test(l.description))
-                .map((l) => l.name);
+              const existingProductLabels = currentLabels
+                .filter((l) => /Issues logged by/.test(l.description))
+                .map((l) => l.name)
+                .forEach(
+                  async (name) =>
+                    await github.rest.issues.removeLabel({
+                      issue_number,
+                      owner,
+                      repo,
+                      name,
+                    })
+                );
 
-              labels.push(product);
-
-              await github.rest.issues.setLabels({
+              /** add new product label */
+              await github.rest.issues.addLabels({
                 issue_number,
                 owner,
                 repo,
-                labels,
+                labels: [product],
               });
             }


### PR DESCRIPTION
**Related Issue:** #5851

## Summary
The Esri product team labeler was running into the same timing issue as another action linked above.