### PR TITLE
docs(scrim): remove extraneous line

### DIFF
--- a/src/components/scrim/scrim.tsx
+++ b/src/components/scrim/scrim.tsx
@@ -27,8 +27,6 @@ export class Scrim implements LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
 
   /**
-   
-  /**
    * When `true`, a busy indicator is displayed.
    */
   @Prop({ reflect: true }) loading = false;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes the extraneous `/**` from the docs. ❌

![image](https://user-images.githubusercontent.com/5023024/210004338-32235f86-1bb8-4113-a2c6-225ac97f9767.png)

Looks like one line was missed with the [`intl` prop cleanup](https://github.com/Esri/calcite-components/commit/7dd5a387890709821c8059de8e8009feafb82a03#diff-1cbaac05a0c00caf59b9867d23256a9cc0e9cf8c9ad332d00ec914f943641396).
