### PR TITLE
fix(modal): close button does not change header height

### DIFF
--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -148,7 +148,6 @@
     border-none
     bg-transparent;
   border-start-end-radius: theme("borderRadius.DEFAULT");
-  padding-block: var(--calcite-modal-padding-internal);
   padding-inline: var(--calcite-modal-padding-internal);
   flex: 0 0 auto;
   calcite-icon {


### PR DESCRIPTION
**Related Issue:** #1707


## Summary
`padding-block` was changing the header height for me when toggling the back button. Removing it didn't seem to change the close button positioning in any way. `padding-inline` was added in #5210 for reference