### PR TITLE
docs(modal): provide context to setFocus method

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -376,10 +376,8 @@ export class Modal
   //--------------------------------------------------------------------------
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's "close" button (the first focusable item).
    *
-   * By default, tries to focus on focusable content. If there is none, it will focus on the close button.
-   * To focus on the close button, use the `close-button` focus ID.
    */
   @Method()
   async setFocus(): Promise<void> {


### PR DESCRIPTION
**Related Issue:** #5856

## Summary
Add context to the `modal`s `setFocus` method where the focus will be set on the component's "close" button.