### PR TITLE
refactor(input-date-picker): use Intl to get unique date separators

### DIFF
--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -20,7 +20,8 @@ import {
   dateFromISO,
   dateToISO,
   dateFromLocalizedString,
-  datePartsFromLocalizedString
+  datePartsFromLocalizedString,
+  dateSeparators
 } from "../../utils/date";
 import { HeadingLevel } from "../functional/Heading";
 import { CSS } from "./resources";
@@ -918,14 +919,12 @@ export class InputDatePicker
     );
   }
 
-  private commonDateSeparators = [".", "-", "/"];
-
   private formatNumerals = (value: string): string =>
     value
       ? value
           .split("")
           .map((char: string) =>
-            this.commonDateSeparators?.includes(char)
+            dateSeparators?.includes(char)
               ? this.localeData?.separator
               : numberKeys?.includes(char)
               ? numberStringFormatter?.numberFormatter?.format(Number(char))

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,11 +1,26 @@
 import { DateLocaleData } from "../components/date-picker/utils";
-import { numberStringFormatter } from "./locale";
+import { numberStringFormatter, locales } from "./locale";
 
 export interface HoverRange {
   focused: "end" | "start";
   start: Date;
   end: Date;
 }
+
+const getUniqueDateSeparators = () => {
+  const uniqueDateSeparators = new Set();
+  const dummyDate = new Date(2020, 4, 20);
+  locales.forEach((locale) => {
+    const dateTimeFormat = new Intl.DateTimeFormat(locale, { year: "numeric", month: "numeric", day: "numeric" });
+
+    const parts = dateTimeFormat.formatToParts(dummyDate);
+    const separator = parts.filter((part) => part.type === "literal")[0]?.value;
+    uniqueDateSeparators.add(separator);
+  });
+  return [...uniqueDateSeparators];
+};
+
+export const dateSeparators = getUniqueDateSeparators();
 
 /**
  * Check if date is within a min and max
@@ -199,7 +214,7 @@ export function parseDateString(
   const { day, month, year } = datePartsFromLocalizedString(string, localeData);
   return {
     day: parseInt(day),
-    month: parseInt(month) - 1, // this subtracts by 1 because the month in the Date contructor is zero-based https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
+    month: parseInt(month) - 1, // this subtracts by 1 because the month in the Date constructor is zero-based https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
     year: parseInt(year)
   };
 }


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/pull/6197#discussion_r1059175604

## Summary

Makes sure all date separators get converted into the one used by the component's `lang`. This shouldn't be necessary, but better safe than sorry. I _think_ fixing #6198 will make incorrect date separators automatically convert to the correct one when typing again. They seem to both be caused by lifecycle changes that stopped localizing/updating/rerendering the internal input's value per character typed, which is necessary for `numberingSystem` and the date separator conversion.