### PR TITLE
docs: update setFocus method across components

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -228,7 +228,7 @@ export class ActionBar
   }
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    */
   @Method()
   async setFocus(): Promise<void> {

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -170,7 +170,7 @@ export class ActionPad
   // --------------------------------------------------------------------------
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    */
   @Method()
   async setFocus(): Promise<void> {

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -355,7 +355,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /** Sets focus on the component's "close" button (the first focusable item). */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -151,7 +151,7 @@ export class Chip
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /** When `closable` is `true`, sets focus on the component's "close" button (the first focusable item). */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -639,7 +639,7 @@ export class ColorPicker
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /** Sets focus on the component's first focusable element. */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/inline-editable/inline-editable.tsx
+++ b/src/components/inline-editable/inline-editable.tsx
@@ -289,6 +289,7 @@ export class InlineEditable
   //
   //--------------------------------------------------------------------------
 
+  /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -235,7 +235,7 @@ export class List implements InteractiveComponent, LoadableComponent {
   //
   // --------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /** Sets focus on the component's first focusable element. */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -208,7 +208,7 @@ export class Notice
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component. */
+  /** Sets focus on the component's first focusable element. */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -319,7 +319,7 @@ export class Panel
   // --------------------------------------------------------------------------
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    */
   @Method()
   async setFocus(): Promise<void> {

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -268,7 +268,7 @@ export class PickList<
   }
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    *
    * @param focusId
    */

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -383,7 +383,7 @@ export class Popover
   }
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    */
   @Method()
   async setFocus(): Promise<void> {

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -260,6 +260,7 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
   //
   //--------------------------------------------------------------------------
 
+  /** Sets focus on the component. */
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -284,7 +284,7 @@ export class TimePicker
   //--------------------------------------------------------------------------
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    */
   @Method()
   async setFocus(): Promise<void> {

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -412,7 +412,7 @@ export class ValueList<
   }
 
   /**
-   * Sets focus on the component.
+   * Sets focus on the component's first focusable element.
    *
    * @param focusId
    */


### PR DESCRIPTION
**Related Issue:** #6139

## Summary
Adds context ~to the `panel` and `popover` docs~ **across our components** for the `setFocus` refactor. ~~Where when called will set focus on the component's first focusable element.~~ 

Where when called will either set focus on the component or its first focusable element. Some components first focusable element will be a close button.

Unchanged components with `setFocus` where focus is set on the component, such as `calcite-action`, and the context of "Set focus on the component" is still valid.