### PR TITLE
docs(tooltip): assistive technology story support

### DIFF
--- a/src/components/tooltip/tooltip.stories.ts
+++ b/src/components/tooltip/tooltip.stories.ts
@@ -7,7 +7,7 @@ import { themesDarkDefault } from "../../../.storybook/utils";
 
 const contentHTML = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua`;
 
-const referenceElementHTML = `Ut enim ad minim veniam, quis <calcite-button appearance="transparent" kind="neutral" title="Reference element" id="reference-element">nostrud exercitation</calcite-button> ullamco laboris nisi ut aliquip ex ea commodo consequat.`;
+const referenceElementHTML = `Ut enim ad minim veniam, quis <calcite-button appearance="transparent" kind="neutral" id="reference-element">nostrud exercitation</calcite-button> ullamco laboris nisi ut aliquip ex ea commodo consequat.`;
 
 export default {
   title: "Components/Tooltip",
@@ -27,7 +27,7 @@ export const simple = (): string => html`
       offset-skidding="${number("offset-skidding", 0)}"
       ${boolean("open", false)}
     >
-      ${contentHTML}
+      <span> ${contentHTML} </span>
     </calcite-tooltip>
   </div>
 `;
@@ -42,7 +42,7 @@ export const open_TestOnly = (): string => html`
       offset-skidding="${number("offset-skidding", 0)}"
       ${boolean("open", true)}
     >
-      ${contentHTML}
+      <span> ${contentHTML} </span>
     </calcite-tooltip>
   </div>
 `;
@@ -59,7 +59,7 @@ export const darkThemeRTL_TestOnly = (): string => html`
       offset-skidding="${number("offset-skidding", 0)}"
       ${boolean("open", false)}
     >
-      ${contentHTML}
+      <span> ${contentHTML} </span>
     </calcite-tooltip>
   </div>
 `;

--- a/src/components/tooltip/usage/Basic.md
+++ b/src/components/tooltip/usage/Basic.md
@@ -2,8 +2,8 @@
 <calcite-tooltip placement="auto" reference-element="tooltip-button"
   >This is the message of the tooltip</calcite-tooltip
 >
-<p>
+<span>
   Lorem <a id="tooltip-button" href="#">ipsum</a> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
   incididunt ut labore et dolore magna aliqua.
-</p>
+</span>
 ```


### PR DESCRIPTION
**Related Issue:** #6211 

## Summary
- Adds assistive technology (AT) support with the tooltip content reference in a `span` element.
- Removes the button's `title` attribute.