### PR TITLE
ci: make sure action doesn't remove existing team label

### DIFF
--- a/.github/workflows/add-esri-product-label.yml
+++ b/.github/workflows/add-esri-product-label.yml
@@ -58,15 +58,14 @@ jobs:
 
               /** remove any existing product label(s) */
               const existingProductLabels = currentLabels
-                .filter((l) => /Issues logged by/.test(l.description))
-                .map((l) => l.name)
+                .filter((l) => /Issues logged by/.test(l.description) && l.name !== product)
                 .forEach(
-                  async (name) =>
+                  async (l) =>
                     await github.rest.issues.removeLabel({
                       issue_number,
                       owner,
                       repo,
-                      name,
+                      name: l.name,
                     })
                 );
 


### PR DESCRIPTION
**Related Issue:** #6192

## Summary
Fixes the team labeler action toggling labels
![image](https://user-images.githubusercontent.com/10986395/210446597-f863e4e1-f827-4f4c-a38c-f0ebed0a8e36.png)
