### PR TITLE
fix(alert): Correctly dismiss after hovering

### DIFF
--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -168,7 +168,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
       window.clearTimeout(this.autoCloseTimeoutId);
       this.autoCloseTimeoutId = window.setTimeout(
         () => this.closeAlert(),
-        DURATIONS[this.autoCloseDuration] - (Date.now() - this.initialOpenTime)
+        DURATIONS[this.autoCloseDuration]
       );
     }
   }
@@ -436,6 +436,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     if (this.queue?.[0] === this.el) {
       this.openAlert();
       if (this.autoClose && !this.autoCloseTimeoutId) {
+        this.initialOpenTime = Date.now();
         this.autoCloseTimeoutId = window.setTimeout(
           () => this.closeAlert(),
           DURATIONS[this.autoCloseDuration]
@@ -476,7 +477,6 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   private openAlert(): void {
     window.clearTimeout(this.queueTimeout);
     this.queueTimeout = window.setTimeout(() => (this.queued = false), 300);
-    this.initialOpenTime = Date.now();
   }
 
   private actionsEndSlotChangeHandler = (event: Event): void => {

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -168,7 +168,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
       window.clearTimeout(this.autoCloseTimeoutId);
       this.autoCloseTimeoutId = window.setTimeout(
         () => this.closeAlert(),
-        DURATIONS[this.autoCloseDuration] - (Date.now() - this.trackTimer)
+        DURATIONS[this.autoCloseDuration] - (Date.now() - this.initialOpenTime)
       );
     }
   }
@@ -266,8 +266,8 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
             [placement]: true,
             [CSS.slottedInShell]: this.slottedInShell
           }}
-          onPointerOut={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseLeave : null}
-          onPointerOver={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseOver : null}
+          onPointerEnter={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseOver : null}
+          onPointerLeave={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseLeave : null}
           ref={this.setTransitionEl}
         >
           {requestedIcon ? (
@@ -404,9 +404,13 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   private queueTimeout: number;
 
-  private trackTimer: number;
+  private initialOpenTime: number;
 
-  private remainingPausedTimeout = 0;
+  private lastMouseOverBegin: number;
+
+  private totalOpenTime = 0;
+
+  private totalHoverTime = 0;
 
   /** the computed icon to render */
   /* @internal */
@@ -432,7 +436,6 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     if (this.queue?.[0] === this.el) {
       this.openAlert();
       if (this.autoClose && !this.autoCloseTimeoutId) {
-        this.trackTimer = Date.now();
         this.autoCloseTimeoutId = window.setTimeout(
           () => this.closeAlert(),
           DURATIONS[this.autoCloseDuration]
@@ -473,6 +476,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   private openAlert(): void {
     window.clearTimeout(this.queueTimeout);
     this.queueTimeout = window.setTimeout(() => (this.queued = false), 300);
+    this.initialOpenTime = Date.now();
   }
 
   private actionsEndSlotChangeHandler = (event: Event): void => {
@@ -481,13 +485,15 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   private handleMouseOver = (): void => {
     window.clearTimeout(this.autoCloseTimeoutId);
-    this.remainingPausedTimeout = DURATIONS[this.autoCloseDuration] - Date.now() - this.trackTimer;
+    this.totalOpenTime = Date.now() - this.initialOpenTime;
+    this.lastMouseOverBegin = Date.now();
   };
 
   private handleMouseLeave = (): void => {
-    this.autoCloseTimeoutId = window.setTimeout(
-      () => this.closeAlert(),
-      this.remainingPausedTimeout
-    );
+    const hoverDuration = Date.now() - this.lastMouseOverBegin;
+    const timeRemaining =
+      DURATIONS[this.autoCloseDuration] - this.totalOpenTime + this.totalHoverTime;
+    this.totalHoverTime = this.totalHoverTime ? hoverDuration + this.totalHoverTime : hoverDuration;
+    this.autoCloseTimeoutId = window.setTimeout(() => this.closeAlert(), timeRemaining);
   };
 }


### PR DESCRIPTION
**Related Issue:** #6222 

## Summary
This should fix the problem described in the issue - it now handles multiple "hover on and off" events and, at least in local testing, seems to handle large queues that may be present pretty well. The events used were changed to fire less often, and there's an accrued timer of hover time that now is used to determine remaining duration before dismissal.

The watcher for changing the duration now resets it to the default, so unless a user interacts with the alert, it may display for a bit longer. Although, I can't think of a use case where this would be changed while an alert is open, we do use it in demos, and we could refactor this code to better support that if needed.

https://user-images.githubusercontent.com/4733155/210485461-c77e8948-af76-4c61-b965-306fc0a9d973.mov

