### PR TITLE
docs(list,pick-list,value-list): remove duplicate read only refs

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -104,7 +104,7 @@ export class List implements InteractiveComponent, LoadableComponent {
   @Prop() openable = false;
 
   /**
-   * **read-only** The currently selected items
+   * The currently selected items.
    *
    * @readonly
    */

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -69,14 +69,14 @@ export class PickList<
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * **read-only** The currently filtered items
+   * The currently filtered items.
    *
    * @readonly
    */
   @Prop({ mutable: true }) filteredItems: HTMLCalcitePickListItemElement[] = [];
 
   /**
-   * **read-only** The currently filtered items
+   * The currently filtered data.
    *
    * @readonly
    */

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -87,14 +87,14 @@ export class ValueList<
   @Prop({ reflect: true }) dragEnabled = false;
 
   /**
-   * **read-only** The currently filtered items
+   * The currently filtered items.
    *
    * @readonly
    */
   @Prop({ mutable: true }) filteredItems: HTMLCalciteValueListItemElement[] = [];
 
   /**
-   * **read-only** The currently filtered items
+   * The currently filtered data.
    *
    * @readonly
    */


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Removes duplicate references to read only, where we can rely on the JSDoc tag for our docs site.

![image](https://user-images.githubusercontent.com/5023024/210674445-32f33c0b-7ac3-42bd-ace3-5f0a5a94a12d.png)