### PR TITLE
docs(pick-list,pick-list-group,pick-list-item,value-list,value-list-item): deprecate components

### DIFF
--- a/src/components/pick-list-group/pick-list-group.tsx
+++ b/src/components/pick-list-group/pick-list-group.tsx
@@ -11,6 +11,8 @@ import {
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
  */
+
+/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-group",
   styleUrl: "pick-list-group.scss",

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -40,6 +40,8 @@ import {
  * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component.
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
+
+/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-item",
   styleUrl: "pick-list-item.scss",

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -48,6 +48,8 @@ import {
  * @slot - A slot for adding `calcite-pick-list-item` or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
+
+/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list",
   styleUrl: "pick-list.scss",

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -32,6 +32,8 @@ import {
  * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component.
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
+
+/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list-item",
   styleUrl: "value-list-item.scss",

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -60,6 +60,8 @@ import {
  * @slot - A slot for adding `calcite-value-list-item` elements. List items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
+
+/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list",
   styleUrl: "value-list.scss",


### PR DESCRIPTION
**Related Issue:** #6157

## Summary
In addition to documentation page deprecation notices, adds a JSDoc `@deprecation` tag to the following components:
- `pick-list`
- `pick-list-group`
- `pick-list-item`
- `value-list`
- `value-list-item`