### PR TITLE
fix(combobox-item): bumping the scale of icon to M when parent combobox is scale L

### DIFF
--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -86,6 +86,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
 
   isNested: boolean;
 
+  /** Specifies the scale of the combobox-item controlled by parent, defaults to m */
   scale: Scale = "m";
 
   // --------------------------------------------------------------------------
@@ -168,7 +169,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
         }}
         flipRtl={iconFlipRtl}
         icon={icon || iconPath}
-        scale="s"
+        scale={this.scale === "l" ? "m" : "s"}
       />
     );
   }

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -414,3 +414,18 @@ export const optionListMinWidthMatchesInputWhenOverlayPositioningIsFixed_TestOnl
     </calcite-combobox>
   </div>
 `;
+
+export const mediumIconForLargeComoboboxItem_TestOnly = (): string => html`
+  <calcite-combobox open scale="l">
+    <calcite-combobox-item
+      icon="altitude"
+      value="altitude"
+      text-label="Altitude"
+      selected
+      scale="l"
+    ></calcite-combobox-item>
+    <calcite-combobox-item icon="article" value="article" text-label="Article" scale="l"></calcite-combobox-item>
+    <calcite-combobox-item value="altitude" text-label="Altitude" scale="l"></calcite-combobox-item>
+    <calcite-combobox-item value="article" text-label="Article" scale="l"></calcite-combobox-item>
+  </calcite-combobox>
+`;


### PR DESCRIPTION

**Related Issue:** #5698

Bumping the scale of the icon to M when the parent `combobox-item` is scale="l" for a visual distinction between larger and smaller components without affecting the height of the `combobox-item` when icon(s) are added or removed. Added a _testOnly snapshot.
