### PR TITLE
feat(panel): Allow Panel to fill height of parent

### DIFF
--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -1,6 +1,6 @@
 :host {
   @extend %component-host;
-  @apply relative flex w-full flex-auto overflow-hidden;
+  @apply relative flex w-full h-full flex-auto overflow-hidden;
 
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
 }


### PR DESCRIPTION
Adds a rule to make panel respect an explicitly set height of the parent container.

Before: 
![Screen Shot 2023-01-09 at 9 56 26 AM](https://user-images.githubusercontent.com/4733155/211375411-5e1dcc96-27db-42fb-affd-14d3987dcb42.png)

After:
![Screen Shot 2023-01-09 at 9 56 16 AM](https://user-images.githubusercontent.com/4733155/211375412-d604cad9-ec74-4d81-898e-8f740fb706ea.png)
