### PR TITLE
fix(button): neutral and outline button now has correct border color

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -463,7 +463,7 @@
   button,
   a {
     @apply text-color-1  bg-transparent;
-    border-color: theme("backgroundColor.foreground.3");
+    border-color: theme("borderColor.color.1");
     &:hover {
       box-shadow: inset 0 0 0 1px var(--calcite-ui-foreground-3);
     }

--- a/src/components/button/button.stories.ts
+++ b/src/components/button/button.stories.ts
@@ -156,3 +156,6 @@ export const darkModeRTL_TestOnly = (): string => html`
 `;
 
 darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
+
+export const outlineNeutralBorderColor_TestOnly = (): string =>
+  html`<calcite-button appearance="outline" kind="neutral">Test</calcite-button>`;


### PR DESCRIPTION
**Related Issue:** #5331

## Summary
When `Button` is `appearance="outline"` and `color="neutral"`, the border color is set to `borderColor.color.1`.