### PR TITLE
refactor(input-time-picker)!: remove string payload from event.

### DIFF
--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -213,7 +213,7 @@ export class InputTimePicker
   /**
    * Fires when the time value is changed as a result of user input.
    */
-  @Event({ cancelable: true }) calciteInputTimePickerChange: EventEmitter<string>;
+  @Event({ cancelable: true }) calciteInputTimePickerChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/input-time-picker/readme.md
+++ b/src/components/input-time-picker/readme.md
@@ -34,9 +34,9 @@
 
 ## Events
 
-| Event                          | Description                                                     | Type                  |
-| ------------------------------ | --------------------------------------------------------------- | --------------------- |
-| `calciteInputTimePickerChange` | Fires when the time value is changed as a result of user input. | `CustomEvent<string>` |
+| Event                          | Description                                                     | Type                |
+| ------------------------------ | --------------------------------------------------------------- | ------------------- |
+| `calciteInputTimePickerChange` | Fires when the time value is changed as a result of user input. | `CustomEvent<void>` |
 
 ## Methods
 


### PR DESCRIPTION
BREAKING CHANGE: Removed event payload information.

- Removed the event payload from `calciteInputTimePickerChange` event. 