### PR TITLE
refactor(pagination)!: rename properties.

### DIFF
--- a/src/05-custom-theme.stories.mdx
+++ b/src/05-custom-theme.stories.mdx
@@ -162,7 +162,7 @@ export const Template = () =>
           <calcite-chip appearance="transparent" kind="inverse">Inverse</calcite-chip>
           <calcite-chip appearance="outline-fill" kind="brand">Brand</calcite-chip>
         </div>
-        <calcite-pagination total="1200" num="100" start="1"></calcite-pagination>
+        <calcite-pagination total-items="1200" page-size="100" start-item-index="1"></calcite-pagination>
         <calcite-slider
           min="0"
           max="100"

--- a/src/05-custom-theme.stories.mdx
+++ b/src/05-custom-theme.stories.mdx
@@ -162,7 +162,7 @@ export const Template = () =>
           <calcite-chip appearance="transparent" kind="inverse">Inverse</calcite-chip>
           <calcite-chip appearance="outline-fill" kind="brand">Brand</calcite-chip>
         </div>
-        <calcite-pagination total-items="1200" page-size="100" start-item-index="1"></calcite-pagination>
+        <calcite-pagination total-items="1200" page-size="100" start-item="1"></calcite-pagination>
         <calcite-slider
           min="0"
           max="100"

--- a/src/components/pagination/pagination.e2e.ts
+++ b/src/components/pagination/pagination.e2e.ts
@@ -13,9 +13,9 @@ describe("calcite-pagination", () => {
   it("supports translations", () => t9n("calcite-pagination"));
 
   describe("page links", () => {
-    it("should render only one page when total is less than num", async () => {
+    it("should render only one page when totalItems is less than pageSize", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination total="10" num="11"></calcite-pagination>`);
+      await page.setContent(`<calcite-pagination total-items="10" page-size="11"></calcite-pagination>`);
       const links = await page.findAll(`calcite-pagination >>> .${CSS.page}`);
       expect(links.length).toBe(1);
     });
@@ -24,7 +24,7 @@ describe("calcite-pagination", () => {
   describe("ellipsis rendering", () => {
     it("should not render either ellipsis when total pages is less than or equal to 5", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination total="80"></calcite-pagination>`);
+      await page.setContent(`<calcite-pagination total-items="80"></calcite-pagination>`);
 
       const startEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisStart}`);
       const endEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisEnd}`);
@@ -33,14 +33,18 @@ describe("calcite-pagination", () => {
     });
     it("should render start ellipsis when total pages is over 5 and the selected page more than 4 from the starting page", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="101" total="140" num="20"></calcite-pagination>`);
+      await page.setContent(
+        `<calcite-pagination start-item-index="101" total-items="140" page-size="20"></calcite-pagination>`
+      );
 
       const startEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisStart}`);
       expect(startEllipsis).not.toBeNull();
     });
     it("should render end ellipsis when total pages is over 5 and the selected page more than 3 from the final page", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="801" total="1200" num="100"></calcite-pagination>`);
+      await page.setContent(
+        `<calcite-pagination start-item-index="801" total-items="1200" page-size="100"></calcite-pagination>`
+      );
       const endEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisEnd}`);
       expect(endEllipsis).not.toBeNull();
     });
@@ -50,7 +54,9 @@ describe("calcite-pagination", () => {
     let pagination: E2EElement;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="124" num="20"></calcite-pagination>`);
+      await page.setContent(
+        `<calcite-pagination start-item-index="1" total-items="124" page-size="20"></calcite-pagination>`
+      );
       pagination = await page.find("calcite-pagination");
     });
     it("next button should increase selected page by 1 when clicked", async () => {
@@ -72,7 +78,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
     it("previous button should decrease selected page by 1", async () => {
-      await pagination.setAttribute("start", "21");
+      await pagination.setAttribute("start-item-index", "21");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -85,7 +91,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(1);
     });
     it("next button should be disabled on last page", async () => {
-      await pagination.setAttribute("start", "121");
+      await pagination.setAttribute("start-item-index", "121");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -96,9 +102,9 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
     it("next button should be enabled if last page has only 1 result", async () => {
-      await pagination.setAttribute("total", "11");
-      await pagination.setAttribute("num", "10");
-      await pagination.setAttribute("start", "1");
+      await pagination.setAttribute("total-items", "11");
+      await pagination.setAttribute("page-size", "10");
+      await pagination.setAttribute("start-item-index", "1");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -112,7 +118,9 @@ describe("calcite-pagination", () => {
   describe("page buttons", () => {
     it("should switch selected page to the page that's clicked", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="36" num="10"></calcite-pagination>`);
+      await page.setContent(
+        `<calcite-pagination start-item-index="1" total-items="36" page-size="10"></calcite-pagination>`
+      );
       const toggleSpy = await page.spyOnEvent("calcitePaginationChange");
       const pages = await page.findAll("calcite-pagination >>> .page");
       await pages[1].click();
@@ -135,7 +143,9 @@ describe("calcite-pagination", () => {
     let pagination: E2EElement;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start="1" total="5" num="1"></calcite-pagination>`);
+      await page.setContent(
+        `<calcite-pagination start-item-index="1" total-items="5" page-size="1"></calcite-pagination>`
+      );
       pagination = await page.find("calcite-pagination");
     });
     it("should show the first page", async () => {
@@ -151,7 +161,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
     it("next button should be disabled on last page", async () => {
-      await pagination.setAttribute("start", "5");
+      await pagination.setAttribute("start-item-index", "5");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -185,7 +195,7 @@ describe("calcite-pagination", () => {
     beforeEach(async () => {
       page = await newE2EPage();
       await page.setContent(
-        html`<calcite-pagination lang="en" group-separator total="150000000" num="10"></calcite-pagination>`
+        html`<calcite-pagination lang="en" group-separator total-items="150000000" page-size="10"></calcite-pagination>`
       );
       element = await page.find("calcite-pagination");
 

--- a/src/components/pagination/pagination.e2e.ts
+++ b/src/components/pagination/pagination.e2e.ts
@@ -34,7 +34,7 @@ describe("calcite-pagination", () => {
     it("should render start ellipsis when total pages is over 5 and the selected page more than 4 from the starting page", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-pagination start-item-index="101" total-items="140" page-size="20"></calcite-pagination>`
+        `<calcite-pagination start-item="101" total-items="140" page-size="20"></calcite-pagination>`
       );
 
       const startEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisStart}`);
@@ -43,7 +43,7 @@ describe("calcite-pagination", () => {
     it("should render end ellipsis when total pages is over 5 and the selected page more than 3 from the final page", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-pagination start-item-index="801" total-items="1200" page-size="100"></calcite-pagination>`
+        `<calcite-pagination start-item="801" total-items="1200" page-size="100"></calcite-pagination>`
       );
       const endEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisEnd}`);
       expect(endEllipsis).not.toBeNull();
@@ -55,7 +55,7 @@ describe("calcite-pagination", () => {
     beforeEach(async () => {
       page = await newE2EPage();
       await page.setContent(
-        `<calcite-pagination start-item-index="1" total-items="124" page-size="20"></calcite-pagination>`
+        `<calcite-pagination start-item="1" total-items="124" page-size="20"></calcite-pagination>`
       );
       pagination = await page.find("calcite-pagination");
     });
@@ -78,7 +78,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
     it("previous button should decrease selected page by 1", async () => {
-      await pagination.setAttribute("start-item-index", "21");
+      await pagination.setAttribute("start-item", "21");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -91,7 +91,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(1);
     });
     it("next button should be disabled on last page", async () => {
-      await pagination.setAttribute("start-item-index", "121");
+      await pagination.setAttribute("start-item", "121");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -104,7 +104,7 @@ describe("calcite-pagination", () => {
     it("next button should be enabled if last page has only 1 result", async () => {
       await pagination.setAttribute("total-items", "11");
       await pagination.setAttribute("page-size", "10");
-      await pagination.setAttribute("start-item-index", "1");
+      await pagination.setAttribute("start-item", "1");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");
@@ -118,9 +118,7 @@ describe("calcite-pagination", () => {
   describe("page buttons", () => {
     it("should switch selected page to the page that's clicked", async () => {
       const page = await newE2EPage();
-      await page.setContent(
-        `<calcite-pagination start-item-index="1" total-items="36" page-size="10"></calcite-pagination>`
-      );
+      await page.setContent(`<calcite-pagination start-item="1" total-items="36" page-size="10"></calcite-pagination>`);
       const toggleSpy = await page.spyOnEvent("calcitePaginationChange");
       const pages = await page.findAll("calcite-pagination >>> .page");
       await pages[1].click();
@@ -143,9 +141,7 @@ describe("calcite-pagination", () => {
     let pagination: E2EElement;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(
-        `<calcite-pagination start-item-index="1" total-items="5" page-size="1"></calcite-pagination>`
-      );
+      await page.setContent(`<calcite-pagination start-item="1" total-items="5" page-size="1"></calcite-pagination>`);
       pagination = await page.find("calcite-pagination");
     });
     it("should show the first page", async () => {
@@ -161,7 +157,7 @@ describe("calcite-pagination", () => {
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
     it("next button should be disabled on last page", async () => {
-      await pagination.setAttribute("start-item-index", "5");
+      await pagination.setAttribute("start-item", "5");
       await page.waitForChanges();
 
       const toggleSpy = await pagination.spyOnEvent("calcitePaginationChange");

--- a/src/components/pagination/pagination.stories.ts
+++ b/src/components/pagination/pagination.stories.ts
@@ -19,21 +19,21 @@ export default {
 export const simple = (): string => html`
   <calcite-pagination
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    start="${number("start", 1)}"
+    start-item-index="${number("start-item-index", 1)}"
     lang="${select("lang", locales, "en")}"
-    total="${number("total", 123456789)}"
-    num="${number("num", 10)}"
+    total-items="${number("total-items", 123456789)}"
+    page-size="${number("page-size", 10)}"
   >
   </calcite-pagination>
 `;
 
 export const darkModeFrenchLocale_TestOnly = (): string => html`<calcite-pagination
   class="calcite-mode-dark"
-  start="1"
+  start-item-index="1"
   lang="fr"
   group-separator
-  total="123456789"
-  num="10"
+  total-items="123456789"
+  page-size="10"
 >
 </calcite-pagination>`;
 
@@ -41,11 +41,11 @@ darkModeFrenchLocale_TestOnly.parameters = { modes: modesDarkDefault };
 
 export const arabicNumberingSystemAndRTL_TestOnly = (): string => html`<calcite-pagination
   dir="rtl"
-  numbering-system="arab"
-  start="1"
+  page-sizebering-system="arab"
+  start-item-index="1"
   lang="fr"
-  total="123456789"
-  num="10"
+  total-items="123456789"
+  page-size="10"
 >
 </calcite-pagination>`;
 

--- a/src/components/pagination/pagination.stories.ts
+++ b/src/components/pagination/pagination.stories.ts
@@ -19,7 +19,7 @@ export default {
 export const simple = (): string => html`
   <calcite-pagination
     scale="${select("scale", ["s", "m", "l"], "m")}"
-    start-item-index="${number("start-item-index", 1)}"
+    start-item="${number("start-item", 1)}"
     lang="${select("lang", locales, "en")}"
     total-items="${number("total-items", 123456789)}"
     page-size="${number("page-size", 10)}"
@@ -29,7 +29,7 @@ export const simple = (): string => html`
 
 export const darkModeFrenchLocale_TestOnly = (): string => html`<calcite-pagination
   class="calcite-mode-dark"
-  start-item-index="1"
+  start-item="1"
   lang="fr"
   group-separator
   total-items="123456789"
@@ -42,7 +42,7 @@ darkModeFrenchLocale_TestOnly.parameters = { modes: modesDarkDefault };
 export const arabicNumberingSystemAndRTL_TestOnly = (): string => html`<calcite-pagination
   dir="rtl"
   page-sizebering-system="arab"
-  start-item-index="1"
+  start-item="1"
   lang="fr"
   total-items="123456789"
   page-size="10"

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -33,7 +33,7 @@ const maxPagesDisplayed = 5;
 export interface PaginationDetail {
   start: number;
   totalItems: number;
-  startItemIndex: number;
+  startItem: number;
 }
 
 @Component({
@@ -75,7 +75,7 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   @Prop() numberingSystem: NumberingSystem;
 
   /** Specifies the starting item number. */
-  @Prop({ mutable: true, reflect: true }) startItemIndex = 1;
+  @Prop({ mutable: true, reflect: true }) startItem = 1;
 
   /** Specifies the total number of items. */
   @Prop({ reflect: true }) totalItems = 0;
@@ -161,13 +161,13 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   /** Go to the next page of results. */
   @Method()
   async nextPage(): Promise<void> {
-    this.startItemIndex = Math.min(this.getLastStart(), this.startItemIndex + this.pageSize);
+    this.startItem = Math.min(this.getLastStart(), this.startItem + this.pageSize);
   }
 
   /** Go to the previous page of results. */
   @Method()
   async previousPage(): Promise<void> {
-    this.startItemIndex = Math.max(1, this.startItemIndex - this.pageSize);
+    this.startItem = Math.max(1, this.startItem - this.pageSize);
   }
 
   // --------------------------------------------------------------------------
@@ -196,11 +196,11 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   };
 
   private showLeftEllipsis() {
-    return Math.floor(this.startItemIndex / this.pageSize) > 3;
+    return Math.floor(this.startItem / this.pageSize) > 3;
   }
 
   private showRightEllipsis() {
-    return (this.totalItems - this.startItemIndex) / this.pageSize > 3;
+    return (this.totalItems - this.startItem) / this.pageSize > 3;
   }
 
   private emitUpdate() {
@@ -224,17 +224,17 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
       end = lastStart - this.pageSize;
     } else {
       // if we're within max pages of page 1
-      if (this.startItemIndex / this.pageSize < maxPagesDisplayed - 1) {
+      if (this.startItem / this.pageSize < maxPagesDisplayed - 1) {
         nextStart = 1 + this.pageSize;
         end = 1 + 4 * this.pageSize;
       } else {
         // if we're within max pages of last page
-        if (this.startItemIndex + 3 * this.pageSize >= this.totalItems) {
+        if (this.startItem + 3 * this.pageSize >= this.totalItems) {
           nextStart = lastStart - 4 * this.pageSize;
           end = lastStart - this.pageSize;
         } else {
-          nextStart = this.startItemIndex - this.pageSize;
-          end = this.startItemIndex + this.pageSize;
+          nextStart = this.startItem - this.pageSize;
+          end = this.startItem + this.pageSize;
         }
       }
     }
@@ -262,10 +262,10 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
       <button
         class={{
           [CSS.page]: true,
-          [CSS.selected]: start === this.startItemIndex
+          [CSS.selected]: start === this.startItem
         }}
         onClick={() => {
-          this.startItemIndex = start;
+          this.startItem = start;
           this.emitUpdate();
         }}
       >
@@ -287,12 +287,10 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   }
 
   render(): VNode {
-    const { totalItems, pageSize, startItemIndex } = this;
-    const prevDisabled = pageSize === 1 ? startItemIndex <= pageSize : startItemIndex < pageSize;
+    const { totalItems, pageSize, startItem } = this;
+    const prevDisabled = pageSize === 1 ? startItem <= pageSize : startItem < pageSize;
     const nextDisabled =
-      pageSize === 1
-        ? startItemIndex + pageSize > totalItems
-        : startItemIndex + pageSize > totalItems;
+      pageSize === 1 ? startItem + pageSize > totalItems : startItem + pageSize > totalItems;
     return (
       <Fragment>
         <button

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -32,8 +32,8 @@ import { CSS } from "./resources";
 const maxPagesDisplayed = 5;
 export interface PaginationDetail {
   start: number;
-  total: number;
-  num: number;
+  totalItems: number;
+  startItemIndex: number;
 }
 
 @Component({
@@ -67,7 +67,7 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   }
 
   /** Specifies the number of items per page. */
-  @Prop({ reflect: true }) num = 20;
+  @Prop({ reflect: true }) pageSize = 20;
 
   /**
    * Specifies the Unicode numeral system used by the component for localization.
@@ -75,10 +75,10 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   @Prop() numberingSystem: NumberingSystem;
 
   /** Specifies the starting item number. */
-  @Prop({ mutable: true, reflect: true }) start = 1;
+  @Prop({ mutable: true, reflect: true }) startItemIndex = 1;
 
   /** Specifies the total number of items. */
-  @Prop({ reflect: true }) total = 0;
+  @Prop({ reflect: true }) totalItems = 0;
 
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -161,13 +161,13 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   /** Go to the next page of results. */
   @Method()
   async nextPage(): Promise<void> {
-    this.start = Math.min(this.getLastStart(), this.start + this.num);
+    this.startItemIndex = Math.min(this.getLastStart(), this.startItemIndex + this.pageSize);
   }
 
   /** Go to the previous page of results. */
   @Method()
   async previousPage(): Promise<void> {
-    this.start = Math.max(1, this.start - this.num);
+    this.startItemIndex = Math.max(1, this.startItemIndex - this.pageSize);
   }
 
   // --------------------------------------------------------------------------
@@ -177,8 +177,11 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   // --------------------------------------------------------------------------
 
   private getLastStart(): number {
-    const { total, num } = this;
-    const lastStart = total % num === 0 ? total - num : Math.floor(total / num) * num;
+    const { totalItems, pageSize } = this;
+    const lastStart =
+      totalItems % pageSize === 0
+        ? totalItems - pageSize
+        : Math.floor(totalItems / pageSize) * pageSize;
     return lastStart + 1;
   }
 
@@ -193,11 +196,11 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   };
 
   private showLeftEllipsis() {
-    return Math.floor(this.start / this.num) > 3;
+    return Math.floor(this.startItemIndex / this.pageSize) > 3;
   }
 
   private showRightEllipsis() {
-    return (this.total - this.start) / this.num > 3;
+    return (this.totalItems - this.startItemIndex) / this.pageSize > 3;
   }
 
   private emitUpdate() {
@@ -216,22 +219,22 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
     let nextStart: number;
 
     // if we don't need ellipses render the whole set
-    if (this.total / this.num <= maxPagesDisplayed) {
-      nextStart = 1 + this.num;
-      end = lastStart - this.num;
+    if (this.totalItems / this.pageSize <= maxPagesDisplayed) {
+      nextStart = 1 + this.pageSize;
+      end = lastStart - this.pageSize;
     } else {
       // if we're within max pages of page 1
-      if (this.start / this.num < maxPagesDisplayed - 1) {
-        nextStart = 1 + this.num;
-        end = 1 + 4 * this.num;
+      if (this.startItemIndex / this.pageSize < maxPagesDisplayed - 1) {
+        nextStart = 1 + this.pageSize;
+        end = 1 + 4 * this.pageSize;
       } else {
         // if we're within max pages of last page
-        if (this.start + 3 * this.num >= this.total) {
-          nextStart = lastStart - 4 * this.num;
-          end = lastStart - this.num;
+        if (this.startItemIndex + 3 * this.pageSize >= this.totalItems) {
+          nextStart = lastStart - 4 * this.pageSize;
+          end = lastStart - this.pageSize;
         } else {
-          nextStart = this.start - this.num;
-          end = this.start + this.num;
+          nextStart = this.startItemIndex - this.pageSize;
+          end = this.startItemIndex + this.pageSize;
         }
       }
     }
@@ -239,14 +242,14 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
     const pages = [];
     while (nextStart <= end) {
       pages.push(nextStart);
-      nextStart = nextStart + this.num;
+      nextStart = nextStart + this.pageSize;
     }
 
     return pages.map((page) => this.renderPage(page));
   }
 
   renderPage(start: number): VNode {
-    const page = Math.floor(start / this.num) + (this.num === 1 ? 0 : 1);
+    const page = Math.floor(start / this.pageSize) + (this.pageSize === 1 ? 0 : 1);
     numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,
@@ -259,10 +262,10 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
       <button
         class={{
           [CSS.page]: true,
-          [CSS.selected]: start === this.start
+          [CSS.selected]: start === this.startItemIndex
         }}
         onClick={() => {
-          this.start = start;
+          this.startItemIndex = start;
           this.emitUpdate();
         }}
       >
@@ -272,21 +275,24 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
   }
 
   renderLeftEllipsis(): VNode {
-    if (this.total / this.num > maxPagesDisplayed && this.showLeftEllipsis()) {
+    if (this.totalItems / this.pageSize > maxPagesDisplayed && this.showLeftEllipsis()) {
       return <span class={`${CSS.ellipsis} ${CSS.ellipsisStart}`}>&hellip;</span>;
     }
   }
 
   renderRightEllipsis(): VNode {
-    if (this.total / this.num > maxPagesDisplayed && this.showRightEllipsis()) {
+    if (this.totalItems / this.pageSize > maxPagesDisplayed && this.showRightEllipsis()) {
       return <span class={`${CSS.ellipsis} ${CSS.ellipsisEnd}`}>&hellip;</span>;
     }
   }
 
   render(): VNode {
-    const { total, num, start } = this;
-    const prevDisabled = num === 1 ? start <= num : start < num;
-    const nextDisabled = num === 1 ? start + num > total : start + num > total;
+    const { totalItems, pageSize, startItemIndex } = this;
+    const prevDisabled = pageSize === 1 ? startItemIndex <= pageSize : startItemIndex < pageSize;
+    const nextDisabled =
+      pageSize === 1
+        ? startItemIndex + pageSize > totalItems
+        : startItemIndex + pageSize > totalItems;
     return (
       <Fragment>
         <button
@@ -300,7 +306,7 @@ export class Pagination implements LocalizedComponent, LocalizedComponent, T9nCo
         >
           <calcite-icon flipRtl icon="chevronLeft" scale="s" />
         </button>
-        {total > num ? this.renderPage(1) : null}
+        {totalItems > pageSize ? this.renderPage(1) : null}
         {this.renderLeftEllipsis()}
         {this.renderPages()}
         {this.renderRightEllipsis()}

--- a/src/components/pagination/usage/Basic.md
+++ b/src/components/pagination/usage/Basic.md
@@ -12,5 +12,5 @@ For example, after querying the search API, you'll get back a response similar t
 ```
 
 ```html
-<calcite-pagination start="1" num="100" total="2021"></calcite-pagination>
+<calcite-pagination start-item-index="1" page-size="100" total-items="2021"></calcite-pagination>
 ```

--- a/src/components/pagination/usage/Basic.md
+++ b/src/components/pagination/usage/Basic.md
@@ -12,5 +12,5 @@ For example, after querying the search API, you'll get back a response similar t
 ```
 
 ```html
-<calcite-pagination start-item-index="1" page-size="100" total-items="2021"></calcite-pagination>
+<calcite-pagination start-item="1" page-size="100" total-items="2021"></calcite-pagination>
 ```

--- a/src/demos/pagination.html
+++ b/src/demos/pagination.html
@@ -40,21 +40,14 @@
           <div class="child">small</div>
 
           <div class="child">
-            <calcite-pagination total-items="300" page-size="100" start-item-index="1" scale="s"></calcite-pagination>
+            <calcite-pagination total-items="300" page-size="100" start-item="1" scale="s"></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination total-items="1200" page-size="100" start-item-index="1" scale="s"
-              >Hello</calcite-pagination
-            >
+            <calcite-pagination total-items="1200" page-size="100" start-item="1" scale="s">Hello</calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination
-              total-items="150000"
-              page-size="100"
-              start-item-index="5400"
-              scale="s"
-            ></calcite-pagination>
+            <calcite-pagination total-items="150000" page-size="100" start-item="5400" scale="s"></calcite-pagination>
           </div>
         </div>
 
@@ -63,21 +56,14 @@
           <div class="child">medium</div>
 
           <div class="child">
-            <calcite-pagination total-items="300" page-size="100" start-item-index="1" scale="m"></calcite-pagination>
+            <calcite-pagination total-items="300" page-size="100" start-item="1" scale="m"></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination total-items="1200" page-size="100" start-item-index="1" scale="m"
-              >Hello</calcite-pagination
-            >
+            <calcite-pagination total-items="1200" page-size="100" start-item="1" scale="m">Hello</calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination
-              total-items="150000"
-              page-size="100"
-              start-item-index="5400"
-              scale="m"
-            ></calcite-pagination>
+            <calcite-pagination total-items="150000" page-size="100" start-item="5400" scale="m"></calcite-pagination>
           </div>
         </div>
 
@@ -86,21 +72,14 @@
           <div class="child">large</div>
 
           <div class="child">
-            <calcite-pagination total-items="300" page-size="100" start-item-index="1" scale="l"></calcite-pagination>
+            <calcite-pagination total-items="300" page-size="100" start-item="1" scale="l"></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination total-items="1200" page-size="100" start-item-index="1" scale="l"
-              >Hello</calcite-pagination
-            >
+            <calcite-pagination total-items="1200" page-size="100" start-item="1" scale="l">Hello</calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination
-              total-items="150000"
-              page-size="100"
-              start-item-index="5400"
-              scale="l"
-            ></calcite-pagination>
+            <calcite-pagination total-items="150000" page-size="100" start-item="5400" scale="l"></calcite-pagination>
           </div>
         </div>
       </div>
@@ -114,18 +93,12 @@
               group-separator
               total-items="300"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="s"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination
-              lang="fr"
-              group-separator
-              total-items="1200"
-              page-size="100"
-              start-item-index="1"
-              scale="s"
+            <calcite-pagination lang="fr" group-separator total-items="1200" page-size="100" start-item="1" scale="s"
               >Hello
             </calcite-pagination>
           </div>
@@ -136,7 +109,7 @@
               group-separator
               total-items="150000"
               page-size="100"
-              start-item-index="5400"
+              start-item="5400"
               scale="s"
             >
             </calcite-pagination>
@@ -153,18 +126,12 @@
               group-separator
               total-items="300"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="m"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination
-              lang="fr"
-              group-separator
-              total-items="1200"
-              page-size="100"
-              start-item-index="1"
-              scale="m"
+            <calcite-pagination lang="fr" group-separator total-items="1200" page-size="100" start-item="1" scale="m"
               >Hello
             </calcite-pagination>
           </div>
@@ -175,7 +142,7 @@
               group-separator
               total-items="150000"
               page-size="100"
-              start-item-index="5400"
+              start-item="5400"
               scale="m"
             >
             </calcite-pagination>
@@ -192,18 +159,12 @@
               group-separator
               total-items="300"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="l"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination
-              lang="fr"
-              group-separator
-              total-items="1200"
-              page-size="100"
-              start-item-index="1"
-              scale="l"
+            <calcite-pagination lang="fr" group-separator total-items="1200" page-size="100" start-item="1" scale="l"
               >Hello
             </calcite-pagination>
           </div>
@@ -214,7 +175,7 @@
               group-separator
               total-items="150000"
               page-size="100"
-              start-item-index="5400"
+              start-item="5400"
               scale="l"
             >
             </calcite-pagination>
@@ -231,7 +192,7 @@
               numbering-system="arab"
               total-items="300"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="s"
             ></calcite-pagination>
           </div>
@@ -241,7 +202,7 @@
               numbering-system="arab"
               total-items="1200"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="s"
               >Hello
             </calcite-pagination>
@@ -253,7 +214,7 @@
               numbering-system="arab"
               total-items="150000"
               page-size="100"
-              start-item-index="5400"
+              start-item="5400"
               scale="s"
             >
             </calcite-pagination>
@@ -270,7 +231,7 @@
               numbering-system="arab"
               total-items="300"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="m"
             ></calcite-pagination>
           </div>
@@ -280,7 +241,7 @@
               numbering-system="arab"
               total-items="1200"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="m"
               >Hello
             </calcite-pagination>
@@ -292,7 +253,7 @@
               numbering-system="arab"
               total-items="150000"
               page-size="100"
-              start-item-index="5400"
+              start-item="5400"
               scale="m"
             >
             </calcite-pagination>
@@ -309,7 +270,7 @@
               numbering-system="arab"
               total-items="300"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="l"
             ></calcite-pagination>
           </div>
@@ -319,7 +280,7 @@
               numbering-system="arab"
               total-items="1200"
               page-size="100"
-              start-item-index="1"
+              start-item="1"
               scale="l"
               >Hello
             </calcite-pagination>
@@ -331,7 +292,7 @@
               numbering-system="arab"
               total-items="150000"
               page-size="100"
-              start-item-index="5400"
+              start-item="5400"
               scale="l"
             >
             </calcite-pagination>

--- a/src/demos/pagination.html
+++ b/src/demos/pagination.html
@@ -40,14 +40,21 @@
           <div class="child">small</div>
 
           <div class="child">
-            <calcite-pagination total="300" num="100" start="1" scale="s"></calcite-pagination>
+            <calcite-pagination total-items="300" page-size="100" start-item-index="1" scale="s"></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination total="1200" num="100" start="1" scale="s">Hello</calcite-pagination>
+            <calcite-pagination total-items="1200" page-size="100" start-item-index="1" scale="s"
+              >Hello</calcite-pagination
+            >
           </div>
 
           <div class="child">
-            <calcite-pagination total="150000" num="100" start="5400" scale="s"></calcite-pagination>
+            <calcite-pagination
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="s"
+            ></calcite-pagination>
           </div>
         </div>
 
@@ -56,14 +63,21 @@
           <div class="child">medium</div>
 
           <div class="child">
-            <calcite-pagination total="300" num="100" start="1" scale="m"></calcite-pagination>
+            <calcite-pagination total-items="300" page-size="100" start-item-index="1" scale="m"></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination total="1200" num="100" start="1" scale="m">Hello</calcite-pagination>
+            <calcite-pagination total-items="1200" page-size="100" start-item-index="1" scale="m"
+              >Hello</calcite-pagination
+            >
           </div>
 
           <div class="child">
-            <calcite-pagination total="150000" num="100" start="5400" scale="m"></calcite-pagination>
+            <calcite-pagination
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="m"
+            ></calcite-pagination>
           </div>
         </div>
 
@@ -72,14 +86,21 @@
           <div class="child">large</div>
 
           <div class="child">
-            <calcite-pagination total="300" num="100" start="1" scale="l"></calcite-pagination>
+            <calcite-pagination total-items="300" page-size="100" start-item-index="1" scale="l"></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination total="1200" num="100" start="1" scale="l">Hello</calcite-pagination>
+            <calcite-pagination total-items="1200" page-size="100" start-item-index="1" scale="l"
+              >Hello</calcite-pagination
+            >
           </div>
 
           <div class="child">
-            <calcite-pagination total="150000" num="100" start="5400" scale="l"></calcite-pagination>
+            <calcite-pagination
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="l"
+            ></calcite-pagination>
           </div>
         </div>
       </div>
@@ -91,20 +112,33 @@
             <calcite-pagination
               lang="fr"
               group-separator
-              total="300"
-              num="100"
-              start="1"
+              total-items="300"
+              page-size="100"
+              start-item-index="1"
               scale="s"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination lang="fr" group-separator total="1200" num="100" start="1" scale="s"
+            <calcite-pagination
+              lang="fr"
+              group-separator
+              total-items="1200"
+              page-size="100"
+              start-item-index="1"
+              scale="s"
               >Hello
             </calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination lang="fr" group-separator total="150000" num="100" start="5400" scale="s">
+            <calcite-pagination
+              lang="fr"
+              group-separator
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="s"
+            >
             </calcite-pagination>
           </div>
         </div>
@@ -117,20 +151,33 @@
             <calcite-pagination
               lang="fr"
               group-separator
-              total="300"
-              num="100"
-              start="1"
+              total-items="300"
+              page-size="100"
+              start-item-index="1"
               scale="m"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination lang="fr" group-separator total="1200" num="100" start="1" scale="m"
+            <calcite-pagination
+              lang="fr"
+              group-separator
+              total-items="1200"
+              page-size="100"
+              start-item-index="1"
+              scale="m"
               >Hello
             </calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination lang="fr" group-separator total="150000" num="100" start="5400" scale="m">
+            <calcite-pagination
+              lang="fr"
+              group-separator
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="m"
+            >
             </calcite-pagination>
           </div>
         </div>
@@ -143,20 +190,33 @@
             <calcite-pagination
               lang="fr"
               group-separator
-              total="300"
-              num="100"
-              start="1"
+              total-items="300"
+              page-size="100"
+              start-item-index="1"
               scale="l"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination lang="fr" group-separator total="1200" num="100" start="1" scale="l"
+            <calcite-pagination
+              lang="fr"
+              group-separator
+              total-items="1200"
+              page-size="100"
+              start-item-index="1"
+              scale="l"
               >Hello
             </calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination lang="fr" group-separator total="150000" num="100" start="5400" scale="l">
+            <calcite-pagination
+              lang="fr"
+              group-separator
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="l"
+            >
             </calcite-pagination>
           </div>
         </div>
@@ -169,20 +229,33 @@
             <calcite-pagination
               lang="ar"
               numbering-system="arab"
-              total="300"
-              num="100"
-              start="1"
+              total-items="300"
+              page-size="100"
+              start-item-index="1"
               scale="s"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination lang="ar" numbering-system="arab" total="1200" num="100" start="1" scale="s"
+            <calcite-pagination
+              lang="ar"
+              numbering-system="arab"
+              total-items="1200"
+              page-size="100"
+              start-item-index="1"
+              scale="s"
               >Hello
             </calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination lang="ar" numbering-system="arab" total="150000" num="100" start="5400" scale="s">
+            <calcite-pagination
+              lang="ar"
+              numbering-system="arab"
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="s"
+            >
             </calcite-pagination>
           </div>
         </div>
@@ -195,20 +268,33 @@
             <calcite-pagination
               lang="ar"
               numbering-system="arab"
-              total="300"
-              num="100"
-              start="1"
+              total-items="300"
+              page-size="100"
+              start-item-index="1"
               scale="m"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination lang="ar" numbering-system="arab" total="1200" num="100" start="1" scale="m"
+            <calcite-pagination
+              lang="ar"
+              numbering-system="arab"
+              total-items="1200"
+              page-size="100"
+              start-item-index="1"
+              scale="m"
               >Hello
             </calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination lang="ar" numbering-system="arab" total="150000" num="100" start="5400" scale="m">
+            <calcite-pagination
+              lang="ar"
+              numbering-system="arab"
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="m"
+            >
             </calcite-pagination>
           </div>
         </div>
@@ -221,20 +307,33 @@
             <calcite-pagination
               lang="ar"
               numbering-system="arab"
-              total="300"
-              num="100"
-              start="1"
+              total-items="300"
+              page-size="100"
+              start-item-index="1"
               scale="l"
             ></calcite-pagination>
           </div>
           <div class="child">
-            <calcite-pagination lang="ar" numbering-system="arab" total="1200" num="100" start="1" scale="l"
+            <calcite-pagination
+              lang="ar"
+              numbering-system="arab"
+              total-items="1200"
+              page-size="100"
+              start-item-index="1"
+              scale="l"
               >Hello
             </calcite-pagination>
           </div>
 
           <div class="child">
-            <calcite-pagination lang="ar" numbering-system="arab" total="150000" num="100" start="5400" scale="l">
+            <calcite-pagination
+              lang="ar"
+              numbering-system="arab"
+              total-items="150000"
+              page-size="100"
+              start-item-index="5400"
+              scale="l"
+            >
             </calcite-pagination>
           </div>
         </div>


### PR DESCRIPTION
**Related Issue:** #6285 

BREAKING CHANGE: Rename properties.

- Removed the property `num`, use `pageSize` instead.
- Removed the property `total`, use `totalItems` instead.
- Removed the property `start`, use `startItem` instead.
