### PR TITLE
test(date): add test for dateToISO utility function

### DIFF
--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -863,9 +863,9 @@ export class InputDatePicker
     const oldValueIsArray = Array.isArray(oldValue);
     const valueIsArray = Array.isArray(value);
 
-    const newStartDate = valueIsArray ? value[0] : "";
+    const newStartDate = valueIsArray ? value[0] : null;
     const newStartDateISO = valueIsArray ? dateToISO(newStartDate) : "";
-    const newEndDate = valueIsArray ? value[1] : "";
+    const newEndDate = valueIsArray ? value[1] : null;
     const newEndDateISO = valueIsArray ? dateToISO(newEndDate) : "";
 
     const newValue = newStartDateISO || newEndDateISO ? [newStartDateISO, newEndDateISO] : "";

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -854,18 +854,18 @@ export class InputDatePicker
     inputEl.value = newValue;
   };
 
-  private setRangeValue = (value: Date[] | string): void => {
+  private setRangeValue = (valueAsDate: Date[]): void => {
     if (!this.range) {
       return;
     }
 
     const { value: oldValue } = this;
     const oldValueIsArray = Array.isArray(oldValue);
-    const valueIsArray = Array.isArray(value);
+    const valueIsArray = Array.isArray(valueAsDate);
 
-    const newStartDate = valueIsArray ? value[0] : null;
+    const newStartDate = valueIsArray ? valueAsDate[0] : null;
     const newStartDateISO = valueIsArray ? dateToISO(newStartDate) : "";
-    const newEndDate = valueIsArray ? value[1] : null;
+    const newEndDate = valueIsArray ? valueAsDate[1] : null;
     const newEndDateISO = valueIsArray ? dateToISO(newEndDate) : "";
 
     const newValue = newStartDateISO || newEndDateISO ? [newStartDateISO, newEndDateISO] : "";

--- a/src/utils/date.spec.ts
+++ b/src/utils/date.spec.ts
@@ -1,5 +1,15 @@
 import { DateLocaleData } from "../components/date-picker/utils";
-import { dateFromISO, dateFromRange, getOrder, inRange, nextMonth, parseDateString, prevMonth, sameDate } from "./date";
+import {
+  dateFromISO,
+  dateFromRange,
+  dateToISO,
+  getOrder,
+  inRange,
+  nextMonth,
+  parseDateString,
+  prevMonth,
+  sameDate
+} from "./date";
 
 import arabic from "../components/date-picker/assets/date-picker/nls/ar.json";
 import english from "../components/date-picker/assets/date-picker/nls/en.json";
@@ -60,6 +70,23 @@ describe("dateFromISO", () => {
   it("defaults to first of any missing units", () => {
     expect(dateFromISO("2011-11").getTime()).toEqual(new Date(2011, 10, 1).getTime());
     expect(dateFromISO("2011").getTime()).toEqual(new Date(2011, 0, 1).getTime());
+  });
+});
+
+describe("dateToISO", () => {
+  it("returns empty string from bad input", () => {
+    expect(dateToISO("")).toEqual("");
+    expect(dateToISO("asdflkjasdhoui")).toEqual("");
+  });
+  it("correctly returns string in simplified ISO format (YYYY-MM-DD)", () => {
+    const date = new Date(2011, 10, 29);
+    const expectedValue = "2011-11-29";
+    expect(dateToISO(date)).toEqual(expectedValue);
+  });
+  it("correctly returns zero-padded month and day values when less than 10", () => {
+    const date = new Date(2011, 2, 5);
+    const expectedValue = "2011-03-05";
+    expect(dateToISO(date)).toEqual(expectedValue);
   });
 });
 

--- a/src/utils/date.spec.ts
+++ b/src/utils/date.spec.ts
@@ -75,8 +75,8 @@ describe("dateFromISO", () => {
 
 describe("dateToISO", () => {
   it("returns empty string from bad input", () => {
-    expect(dateToISO("")).toEqual("");
-    expect(dateToISO("asdflkjasdhoui")).toEqual("");
+    expect(dateToISO("" as any)).toEqual("");
+    expect(dateToISO("asdflkjasdhoui" as any)).toEqual("");
   });
   it("correctly returns string in simplified ISO format (YYYY-MM-DD)", () => {
     const date = new Date(2011, 10, 29);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -127,9 +127,6 @@ export function datePartsFromLocalizedString(
  * @param date
  */
 export function dateToISO(date?: Date | string): string {
-  if (typeof date === "string") {
-    return date;
-  }
   if (date instanceof Date) {
     return new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().split("T")[0];
   }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -126,7 +126,7 @@ export function datePartsFromLocalizedString(
  *
  * @param date
  */
-export function dateToISO(date?: Date | string): string {
+export function dateToISO(date?: Date): string {
   if (date instanceof Date) {
     return new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().split("T")[0];
   }


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/pull/6289#pullrequestreview-1252734747

## Summary

Adds a spec test for `dateToISO`.  Also updates the function to return a proper empty string value when any non-`Date` value is passed in.