### PR TITLE
fix(date-picker): display correct day for first day of month in `ar` locale

### DIFF
--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -277,10 +277,16 @@ export class DatePickerMonth {
     const date = lastDate.getDate();
     const day = lastDate.getDay();
     const days = [];
-    if (day - 6 === startOfWeek) {
+
+    if (day === (startOfWeek + 6) % 7) {
       return days;
     }
-    for (let i = lastDate.getDay() - startOfWeek; i >= 0; i--) {
+
+    if (day === startOfWeek) {
+      return [date];
+    }
+
+    for (let i = (7 + day - startOfWeek) % 7; i >= 0; i--) {
       days.push(date - i);
     }
     return days;


### PR DESCRIPTION
**Related Issue:** # 6128

## Summary

This PR will display correct day for first day  the month in `ar` locale. 
 
_Note: No changes expected for other locales._