### PR TITLE
docs: context to name prop for form submission

### DIFF
--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -159,7 +159,11 @@ export class Combobox
     this.setMaxScrollerHeight();
   }
 
-  /** Specifies the name of the component on form submission. */
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   */
   @Prop({ reflect: true }) name: string;
 
   /** When `true`, allows entry of custom values, which are not in the original set of items. */

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -221,7 +221,9 @@ export class InputDatePicker
   }
 
   /**
-   * Specifies the name of the component on form submission.
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
    */
   @Prop({ reflect: true }) name: string;
 

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -199,6 +199,8 @@ export class InputNumber
   /**
    * Specifies the name of the component.
    *
+   * Required to pass the component's `value` on form submission.
+   *
    * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
    */
   @Prop({ reflect: true }) name: string;

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -139,6 +139,8 @@ export class InputText
   /**
    * Specifies the name of the component.
    *
+   * Required to pass the component's `value` on form submission.
+   *
    * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
    */
   @Prop({ reflect: true }) name: string;

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -199,7 +199,9 @@ export class Input
   @Prop({ reflect: true }) minLength: number;
 
   /**
-   * Specifies the name of the component on form submission.
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
    *
    * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
    */
@@ -235,7 +237,7 @@ export class Input
   @Prop({ mutable: true, reflect: true }) status: Status = "idle";
 
   /**
-   * Specifies the granularity the component's value must adhere to.
+   * Specifies the granularity the component's `value` must adhere to.
    *
    * @mdn [step](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step)
    */

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -95,7 +95,11 @@ export class RadioButton
    */
   @Prop() label?: string;
 
-  /** Specifies the name of the component, passed from the `calcite-radio-button-group` on form submission. */
+  /**
+   * Specifies the name of the component. Can be inherited from `calcite-radio-button-group`.
+   *
+   * Required to pass the component's `value` on form submission.
+   */
   @Prop({ reflect: true }) name: string;
 
   @Watch("name")

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -88,7 +88,11 @@ export class Rating
     /* wired up by t9n util */
   }
 
-  /** Specifies the name of the component on form submission. */
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   */
   @Prop({ reflect: true }) name: string;
 
   /** When `true`, the component's value can be read, but cannot be modified. */

--- a/src/components/segmented-control/segmented-control.tsx
+++ b/src/components/segmented-control/segmented-control.tsx
@@ -74,7 +74,9 @@ export class SegmentedControl
   @Prop({ reflect: true }) layout: Layout = "horizontal";
 
   /**
-   * Specifies the name of the component on form submission.
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
    */
   @Prop({ reflect: true }) name: string;
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -73,7 +73,9 @@ export class Select
   @Prop() label!: string;
 
   /**
-   * Specifies the name of the component on form submission.
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
    */
   @Prop({ reflect: true }) name: string;
 

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -137,7 +137,11 @@ export class Slider
    */
   @Prop({ reflect: true }) mirrored = false;
 
-  /** Specifies the name of the component on form submission. */
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   */
   @Prop({ reflect: true }) name: string;
 
   /**

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -55,7 +55,11 @@ export class Switch
   /** Accessible name for the component. */
   @Prop() label: string;
 
-  /** Specifies the name of the component on form submission. */
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   */
   @Prop({ reflect: true }) name: string;
 
   /** Specifies the size of the component. */


### PR DESCRIPTION
**Related Issue:** #5284

## Summary
1. Adds context to the `name` prop on components used for form submission.
2. Also, includes a missing backtick on a `value` prop for the `input` component.