### PR TITLE
fix(tree): expanded item renders correctly on initial load

### DIFF
--- a/src/components/tree-item/resources.ts
+++ b/src/components/tree-item/resources.ts
@@ -5,7 +5,8 @@ export const CSS = {
   nodeContainer: "node-container",
   childrenContainer: "children-container",
   bulletPointIcon: "bullet-point",
-  checkmarkIcon: "checkmark"
+  checkmarkIcon: "checkmark",
+  treeItemExpanded: "tree-item--expanded"
 };
 
 export const SLOTS = {

--- a/src/components/tree-item/resources.ts
+++ b/src/components/tree-item/resources.ts
@@ -6,7 +6,7 @@ export const CSS = {
   childrenContainer: "children-container",
   bulletPointIcon: "bullet-point",
   checkmarkIcon: "checkmark",
-  treeItemExpanded: "tree-item--expanded"
+  itemExpanded: "item--expanded"
 };
 
 export const SLOTS = {

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -104,7 +104,7 @@
 
 .children-container {
   @apply relative h-0 overflow-hidden;
-  margin-inline-start: theme("margin.3");
+  margin-inline-start: theme("margin.5");
   transform: scaleY(0);
   opacity: 0;
   transition: var(--calcite-animation-timing) $easing-function, opacity var(--calcite-animation-timing) $easing-function,

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -111,7 +111,7 @@
     all var(--calcite-animation-timing) ease-in-out; // note that we're transitioning transform, not height!
   transform-origin: top; // keep the top of the element in the same place. this is optional.
 
-  :host([expanded]) > & {
+  .tree-item--expanded > & {
     @apply overflow-visible;
     opacity: 1;
     block-size: auto;
@@ -216,7 +216,7 @@
     transform: rotate(180deg);
   }
 
-  :host([expanded]) > .node-container > & {
+  .tree-item--expanded > .node-container > & {
     transform: rotate(90deg);
   }
 }

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -104,7 +104,7 @@
 
 .children-container {
   @apply relative h-0 overflow-hidden;
-  margin-inline-start: theme("margin.5");
+  margin-inline-start: theme("margin.3");
   transform: scaleY(0);
   opacity: 0;
   transition: var(--calcite-animation-timing) $easing-function, opacity var(--calcite-animation-timing) $easing-function,
@@ -139,8 +139,8 @@
   }
 }
 
-:host([selected]) > .node-container,
-:host([selected]) > .node-container:hover {
+:host([selected]) .node-container,
+:host([selected]) .node-container:hover {
   @apply text-color-1 font-medium;
 
   .bullet-point,
@@ -151,38 +151,38 @@
 }
 
 :host([selection-mode="none"]:not([has-children])) {
-  &:host([scale="s"]) > .node-container {
+  &:host([scale="s"]) .node-container {
     padding-inline-start: theme("padding.2");
   }
-  &:host([scale="m"]) > .node-container {
+  &:host([scale="m"]) .node-container {
     padding-inline-start: theme("padding.4");
   }
-  &:host([scale="l"]) > .node-container {
+  &:host([scale="l"]) .node-container {
     padding-inline-start: theme("padding.6");
   }
 }
 
 // ancestors selection-mode, dropdown without children
 :host(:not([has-children])) {
-  &:host([scale="s"]) > .node-container[data-selection-mode="ancestors"] .checkbox {
+  &:host([scale="s"]) .node-container[data-selection-mode="ancestors"] .checkbox {
     padding-inline-start: theme("padding.5");
   }
-  &:host([scale="m"]) > .node-container[data-selection-mode="ancestors"] .checkbox {
+  &:host([scale="m"]) .node-container[data-selection-mode="ancestors"] .checkbox {
     padding-inline-start: theme("padding.6");
   }
-  &:host([scale="l"]) > .node-container[data-selection-mode="ancestors"] .checkbox {
+  &:host([scale="l"]) .node-container[data-selection-mode="ancestors"] .checkbox {
     padding-inline-start: 1.75rem;
   }
 }
 // ancestors selection-mode, dropdown with children
-:host([has-children]) > .node-container[data-selection-mode="ancestors"] {
+:host([has-children]) .node-container[data-selection-mode="ancestors"] {
   .checkbox {
     margin-inline-start: 0;
   }
 }
 
 // dropdown with children
-:host([has-children]) > .node-container {
+:host([has-children]) .node-container {
   .bullet-point,
   .checkmark {
     @apply hidden;
@@ -190,14 +190,14 @@
 }
 
 // dropdown expanded and not selected
-:host([has-children][expanded]:not([selected]):not([selection-mode="none"])) > .node-container {
+:host([has-children][expanded]:not([selected]):not([selection-mode="none"])) .node-container {
   ::slotted(*) {
     @apply text-color-1 font-medium;
   }
 }
 
 // dropdown selected (for children, multichildren selected parents)
-:host([has-children][selected]) > .node-container {
+:host([has-children][selected]) .node-container {
   &[data-selection-mode="children"],
   &[data-selection-mode="multichildren"] {
     color: var(--calcite-ui-brand);

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -111,7 +111,7 @@
     all var(--calcite-animation-timing) ease-in-out; // note that we're transitioning transform, not height!
   transform-origin: top; // keep the top of the element in the same place. this is optional.
 
-  .tree-item--expanded > & {
+  .item--expanded > & {
     @apply overflow-visible;
     opacity: 1;
     block-size: auto;
@@ -216,7 +216,7 @@
     transform: rotate(180deg);
   }
 
-  .tree-item--expanded > .node-container > & {
+  .item--expanded > .node-container > & {
     transform: rotate(90deg);
   }
 }

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -71,7 +71,6 @@ export class TreeItem
   expandedHandler(newValue: boolean): void {
     this.updateParentIsExpanded(this.el, newValue);
     onToggleOpenCloseComponent(this, true);
-    this.treeItemNeverExpanded = false;
   }
 
   /**
@@ -201,8 +200,8 @@ export class TreeItem
   componentWillLoad(): void {
     if (this.expanded) {
       onToggleOpenCloseComponent(this, true);
-      requestAnimationFrame(() => (this.treeItemNeverExpanded = false));
     }
+    requestAnimationFrame(() => (this.transitionListenersAddedOnInitialLoad = true));
   }
 
   componentDidLoad(): void {
@@ -274,7 +273,7 @@ export class TreeItem
     ) : null;
 
     const hidden = !(this.parentExpanded || this.depth === 1);
-    const isExpanded = this.treeItemNeverExpanded ? false : this.expanded;
+    const isExpanded = this.transitionListenersAddedOnInitialLoad ? this.expanded : false;
 
     return (
       <Host
@@ -437,7 +436,7 @@ export class TreeItem
    *
    * @private
    */
-  @State() treeItemNeverExpanded = true;
+  @State() transitionListenersAddedOnInitialLoad = false;
 
   childrenSlotWrapper!: HTMLElement;
 

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -198,7 +198,7 @@ export class TreeItem
 
   componentWillLoad(): void {
     if (this.expanded) {
-      onToggleOpenCloseComponent(this, true);
+      onToggleOpenCloseComponent(this, true, true);
     }
   }
 

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -201,7 +201,7 @@ export class TreeItem
     if (this.expanded) {
       onToggleOpenCloseComponent(this, true);
     }
-    requestAnimationFrame(() => (this.transitionListenersAddedOnInitialLoad = true));
+    requestAnimationFrame(() => (this.updateAfterInitialRender = true));
   }
 
   componentDidLoad(): void {
@@ -273,7 +273,7 @@ export class TreeItem
     ) : null;
 
     const hidden = !(this.parentExpanded || this.depth === 1);
-    const isExpanded = this.transitionListenersAddedOnInitialLoad ? this.expanded : false;
+    const isExpanded = this.updateAfterInitialRender && this.expanded;
 
     return (
       <Host
@@ -283,7 +283,7 @@ export class TreeItem
         calcite-hydrated-hidden={hidden}
         role="treeitem"
       >
-        <div class={{ [CSS.treeItemExpanded]: isExpanded }}>
+        <div class={{ [CSS.itemExpanded]: isExpanded }}>
           <div
             class={{
               [CSS.nodeContainer]: true,
@@ -436,7 +436,7 @@ export class TreeItem
    *
    * @private
    */
-  @State() transitionListenersAddedOnInitialLoad = false;
+  @State() updateAfterInitialRender = false;
 
   childrenSlotWrapper!: HTMLElement;
 

--- a/src/utils/openCloseComponent.ts
+++ b/src/utils/openCloseComponent.ts
@@ -72,13 +72,8 @@ function transitionEnd(event: TransitionEvent): void {
  *
  * @param component
  * @param nonOpenCloseComponent
- * @param initialRender
  */
-export function onToggleOpenCloseComponent(
-  component: OpenCloseComponent,
-  nonOpenCloseComponent = false,
-  initialRender = false
-): void {
+export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpenCloseComponent = false): void {
   readTask((): void => {
     if (component.transitionEl) {
       const allTransitionPropsArray = getComputedStyle(component.transitionEl).transition.split(" ");
@@ -86,7 +81,7 @@ export function onToggleOpenCloseComponent(
         (item) => item === component.openTransitionProp
       );
       const transitionDuration = allTransitionPropsArray[openTransitionPropIndex + 1];
-      if (transitionDuration === "0s" || initialRender) {
+      if (transitionDuration === "0s") {
         (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
           ? component.onBeforeOpen()
           : component.onBeforeClose();

--- a/src/utils/openCloseComponent.ts
+++ b/src/utils/openCloseComponent.ts
@@ -72,8 +72,13 @@ function transitionEnd(event: TransitionEvent): void {
  *
  * @param component
  * @param nonOpenCloseComponent
+ * @param initialRender
  */
-export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpenCloseComponent = false): void {
+export function onToggleOpenCloseComponent(
+  component: OpenCloseComponent,
+  nonOpenCloseComponent = false,
+  initialRender = false
+): void {
   readTask((): void => {
     if (component.transitionEl) {
       const allTransitionPropsArray = getComputedStyle(component.transitionEl).transition.split(" ");
@@ -81,7 +86,7 @@ export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpe
         (item) => item === component.openTransitionProp
       );
       const transitionDuration = allTransitionPropsArray[openTransitionPropIndex + 1];
-      if (transitionDuration === "0s") {
+      if (transitionDuration === "0s" || initialRender) {
         (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
           ? component.onBeforeOpen()
           : component.onBeforeClose();


### PR DESCRIPTION
**Related Issue:** #6284

## Summary

This issue only occurs on the `custom-elements` and `dist` output builds, not the CDN. It is a timing issue where the item is expanded on initial load before the transition event listeners that handle styling are added. The fix uses a flag to make sure the transition start/end event listeners are added on initial load before the tree item expands.