### PR TITLE
ci: add npm script to remove js files compiled by tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "util:push-tags": "git push --atomic --follow-tags origin master",
     "util:sync-t9n-en-bundles": "ts-node --esm support/syncEnT9nBundles.ts",
     "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw 'dist/types' -e '<reference types=' && npm run util:clean-js-files",
-    "util:clean-js-files": "find -type f -name '*.js' -not -path './node_modules/*' -not -path './dist/*' -not -path './hydrate/*' -not -path './www/*' | xargs rm -rf"
+    "util:clean-js-files": "find src .storybook support -name '*.js' | xargs rm -rf && find . -maxdepth 1 -name '*.js' | xargs rm -rf"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "util:check-squash-mergeable-branch": "ts-node --esm support/checkSquashMergeableBranch.ts",
     "util:push-tags": "git push --atomic --follow-tags origin master",
     "util:sync-t9n-en-bundles": "ts-node --esm support/syncEnT9nBundles.ts",
-    "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw 'dist/types' -e '<reference types='"
+    "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw 'dist/types' -e '<reference types=' && npm run util:clean-js-files",
+    "util:clean-js-files": "find -type f -name '*.js' -not -path './node_modules/*' -not -path './dist/*' -not -path './hydrate/*' -not -path './www/*' | xargs rm -rf"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds an NPM script that removes all of the javascript files compiled by tsc when doing the type check before releases.