### PR TITLE
fix(select): bumping scale of chevron icon to M when host is scale l

### DIFF
--- a/src/components/select/select.stories.ts
+++ b/src/components/select/select.stories.ts
@@ -148,7 +148,9 @@ export const darkModeRTL_TestOnly = (): string =>
 
 darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
 
-export const disabled_TestOnly = (): string => html`<calcite-select disabled>
-  <calcite-option label="first" value="1"></calcite-option>
-  <calcite-option label="second" value="2"></calcite-option>
-</calcite-select>`;
+export const disabledAndLargeScaleGetsMediumChevron_TestOnly = (): string => html`
+  <calcite-select disabled scale="l">
+    <calcite-option label="first" value="1"></calcite-option>
+    <calcite-option label="second" value="2"></calcite-option>
+  </calcite-select>
+`;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -354,7 +354,7 @@ export class Select
   renderChevron(): VNode {
     return (
       <div class={CSS.iconContainer}>
-        <calcite-icon class={CSS.icon} icon="chevron-down" scale="s" />
+        <calcite-icon class={CSS.icon} icon="chevron-down" scale={this.scale === "l" ? "m" : "s"} />
       </div>
     );
   }


### PR DESCRIPTION
**Related Issue:** #5698

## Summary
Bumping the scale of the chevron to M when host is scale="l" for a visual distinction between larger and smaller components without affecting the height of the component when icon(s) are added or removed. Added a _testOnly snapshot.
