### PR TITLE
fix(popover): fix heading padding for m and l scales

### DIFF
--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -24,16 +24,16 @@
 :host([scale="m"]) {
   .heading {
     @apply text-0-wrap
-    px-3
-    py-4;
+    px-4
+    py-3;
   }
 }
 
 :host([scale="l"]) {
   .heading {
     @apply text-1-wrap
-    px-4
-    py-5;
+    px-5
+    py-4;
   }
 }
 

--- a/src/components/popover/popover.stories.ts
+++ b/src/components/popover/popover.stories.ts
@@ -139,3 +139,66 @@ export const scaleConsistencyPopoverHeadingActionSlottedIcon_TestOnly = (): stri
     </calcite-popover>
   </div>
 `;
+
+export const smallScaleLayout_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-popover
+      heading="these 🥨s are making me thirsty"
+      reference-element="reference-element"
+      placement="auto"
+      open
+      closable
+      scale="s"
+    >
+      ${contentHTML}
+    </calcite-popover>
+  </div>
+`;
+
+export const mediumScaleLayout_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-popover
+      heading="these 🥨s are making me thirsty"
+      reference-element="reference-element"
+      placement="auto"
+      open
+      closable
+      scale="m"
+    >
+      ${contentHTML}
+    </calcite-popover>
+  </div>
+`;
+
+export const largeScaleLayout_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-duration-factor: 0;
+    }
+  </style>
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-popover
+      heading="these 🥨s are making me thirsty"
+      reference-element="reference-element"
+      placement="auto"
+      open
+      closable
+      scale="l"
+    >
+      ${contentHTML}
+    </calcite-popover>
+  </div>
+`;


### PR DESCRIPTION
**Related Issue:** #5803 

## Summary

Fixes the x and y padding applied to the popover's heading (they were inverted).

**Note**: I included simple test stories for s, m and l scales. I can tweak these as needed based on our Chromatic setup.