### PR TITLE
fix(tabs): fix error when tabs is resized before initial render

### DIFF
--- a/src/components/tab-nav/tab-nav.e2e.ts
+++ b/src/components/tab-nav/tab-nav.e2e.ts
@@ -186,4 +186,17 @@ describe("calcite-tab-nav", () => {
     await page.keyboard.press("Home");
     expect(await page.evaluate(() => document.activeElement.id)).toBe("tab1");
   });
+
+  it("does not throw when placed within panel (#6310)", async () => {
+    async function runTest() {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-panel>
+        this is the minimal HTML to reproduce this issue
+        <calcite-tab-nav></calcite-tab-nav>
+      </calcite-panel>`);
+      await page.waitForChanges();
+    }
+
+    await expect(runTest()).resolves.toBeUndefined();
+  });
 });

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -303,6 +303,10 @@ export class TabNav {
   animationActiveDuration = 0.3;
 
   resizeObserver = createObserver("resize", () => {
+    if (!this.activeIndicatorEl) {
+      return;
+    }
+
     // remove active indicator transition duration during resize to prevent wobble
     this.activeIndicatorEl.style.transitionDuration = "0s";
     this.updateActiveWidth();


### PR DESCRIPTION
**Related Issue:** #6310

## Summary

This prevents resize logic from running if the indicator element has not been rendered and stored internally.