### PR TITLE
fix(split-button): no longer displays divider for transparent with inverse kind

### DIFF
--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -42,6 +42,7 @@
   }
   &:host([kind="inverse"]) {
     --calcite-split-button-divider: theme("colors.background.foreground.1");
+    --calcite-split-button-background: transparent;
   }
 }
 

--- a/src/components/split-button/split-button.stories.ts
+++ b/src/components/split-button/split-button.stories.ts
@@ -119,3 +119,7 @@ export const disabled_TestOnly = (): string => html`<calcite-split-button disabl
     <calcite-dropdown-item>Option 4</calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-split-button>`;
+
+export const transparentWithInverseKind_TestOnly = (): string =>
+  html`<calcite-split-button scale="s" primary-text="Button" appearance="transparent" kind="inverse">
+  </calcite-split-button>`;


### PR DESCRIPTION
**Related Issue:** #6332 

## Summary
This PR will remove the divider background color when `appearance="transparent"` with `kind="color"`

Before the change:
![1C7438FB-84F4-4C5C-9135-C0EE715C386E_4_5005_c](https://user-images.githubusercontent.com/88453586/214867508-16cb0881-c156-438d-8399-a22706de356e.jpeg)

After the change:
![A9BB5658-7012-44AA-B252-4ACF55E1FA74_4_5005_c](https://user-images.githubusercontent.com/88453586/214868097-51e6bc17-ce05-422c-acc3-d08dce79c466.jpeg)
