### PR TITLE
fix(alert): ensure `border-radius` is consistent for prescribed `slots`

### DIFF
--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -191,8 +191,7 @@
   min-inline-size: 0;
   padding-block: var(--calcite-alert-spacing-token-small);
   padding-inline: 0 var(--calcite-alert-spacing-token-small);
-  border-end-start-radius: var(--calcite-border-radius);
-  border-end-end-radius: var(--calcite-border-radius);
+  border-radius: var(--calcite-border-radius);
 
   &:first-of-type:not(:only-child) {
     padding-inline-start: var(--calcite-alert-spacing-token-large);
@@ -209,6 +208,8 @@
     items-center
     self-stretch
     py-0;
+  border-start-start-radius: var(--calcite-border-radius);
+  border-end-start-radius: var(--calcite-border-radius);
 }
 
 .alert-close {
@@ -222,6 +223,7 @@
     py-0
     outline-none;
   border-end-end-radius: var(--calcite-border-radius);
+  border-start-end-radius: var(--calcite-border-radius);
 
   &:hover,
   &:focus {

--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -226,15 +226,19 @@ export const actionsEndQueued_TestOnly = (): string => html`
   </script>
 `;
 
-export const autoClosableeRetainsCloseButton_TestOnly = (): string => html`
+export const autoClosableRetainsCloseButtonAndRadius_TestOnly = (): string => html`
   <style>
     :root {
       --calcite-duration-factor: 0;
     }
   </style>
   <calcite-alert auto-close auto-close-duration="medium" open scale="m" kind="info">
-    <div slot="title">Here's a general bit of information</div>
-    <div slot="message">Some kind of contextually relevant content</div>
-    <calcite-link slot="link" title="my action" role="presentation"> Take action </calcite-link>
+    <div slot="message">Demo of an auto-close alert that retains the close button.</div>
+  </calcite-alert>
+  <calcite-alert open scale="m">
+    <div slot="title">Demo of an alert without an icon to show radius applied all around.</div>
+  </calcite-alert>
+  <calcite-alert open scale="m" icon>
+    <div slot="title">Demo of an alert with an icon to show radius applied all around.</div>
   </calcite-alert>
 `;

--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -226,19 +226,28 @@ export const actionsEndQueued_TestOnly = (): string => html`
   </script>
 `;
 
-export const autoClosableRetainsCloseButtonAndRadius_TestOnly = (): string => html`
+export const autoClosableRetainsCloseButton_TestOnly = (): string => html`
   <style>
     :root {
       --calcite-duration-factor: 0;
     }
   </style>
   <calcite-alert auto-close auto-close-duration="medium" open scale="m" kind="info">
-    <div slot="message">Demo of an auto-close alert that retains the close button.</div>
+    <div slot="Title">Demo of an auto-close alert that retains the close button.</div>
+    <div slot="message">Do you really want to proceed?</div>
+    <calcite-link slot="link" title="my link">My Link</calcite-link>
   </calcite-alert>
-  <calcite-alert open scale="m">
-    <div slot="title">Demo of an alert without an icon to show radius applied all around.</div>
+`;
+
+export const radius_TestOnly = (): string => html`
+  <calcite-alert open scale="m" placement="top">
+    <div slot="title">Demo of an alert without an icon to show working radius applied all around.</div>
+    <div slot="message">Do you really want to proceed?</div>
+    <calcite-link slot="link" title="my link">My Link</calcite-link>
   </calcite-alert>
-  <calcite-alert open scale="m" icon>
+  <calcite-alert open scale="m" icon placement="bottom" placement="bottom">
     <div slot="title">Demo of an alert with an icon to show radius applied all around.</div>
+    <div slot="message">Do you really want to proceed?</div>
+    <calcite-link slot="link" title="my link">My Link</calcite-link>
   </calcite-alert>
 `;

--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -238,16 +238,3 @@ export const autoClosableRetainsCloseButton_TestOnly = (): string => html`
     <calcite-link slot="link" title="my link">My Link</calcite-link>
   </calcite-alert>
 `;
-
-export const radius_TestOnly = (): string => html`
-  <calcite-alert open scale="m" placement="top">
-    <div slot="title">Demo of an alert without an icon to show working radius applied all around.</div>
-    <div slot="message">Do you really want to proceed?</div>
-    <calcite-link slot="link" title="my link">My Link</calcite-link>
-  </calcite-alert>
-  <calcite-alert open scale="m" icon placement="bottom" placement="bottom">
-    <div slot="title">Demo of an alert with an icon to show radius applied all around.</div>
-    <div slot="message">Do you really want to proceed?</div>
-    <calcite-link slot="link" title="my link">My Link</calcite-link>
-  </calcite-alert>
-`;

--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -233,8 +233,8 @@ export const autoClosableRetainsCloseButton_TestOnly = (): string => html`
     }
   </style>
   <calcite-alert auto-close auto-close-duration="medium" open scale="m" kind="info">
-    <div slot="Title">Demo of an auto-close alert that retains the close button.</div>
-    <div slot="message">Do you really want to proceed?</div>
-    <calcite-link slot="link" title="my link">My Link</calcite-link>
+    <div slot="title">Here's a general bit of information</div>
+    <div slot="message">Some kind of contextually relevant content</div>
+    <calcite-link slot="link" title="my action" role="presentation"> Take action </calcite-link>
   </calcite-alert>
 `;

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -398,7 +398,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   @State() queued = false;
 
   /** the close button element */
-  private closeButton?: HTMLButtonElement;
+  private closeButton: HTMLButtonElement;
 
   private autoCloseTimeoutId: number = null;
 


### PR DESCRIPTION
**Related Issue:** #6348

## Summary
The bottom left corner radius was missing when the icon was present. Upon inspection, it was clear that slots added around content don't have the proper radius set and end up covering the radius on the host. For each occasion the slot is placed against either end of the host, I adjusted the relevant radius to match the host container. 

Because the close button is now always present, the cases addressed are the right side of the close button and the left side of the content (no icon) along with the left side of the icon (when placed in front of the content).

Added a screenshot for the radius with options where `icon` is present and absent.