### PR TITLE
fix(date-picker): days previous to the currently hovered day when no range value exists display correctly with no hover styles

### DIFF
--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -480,8 +480,9 @@ export class DatePickerMonth {
       !insideRange &&
       ((!isStart && date >= this.endDate && (date < end || sameDate(date, end))) ||
         (isStart &&
-          (date < this.startDate || (this.endDate && sameDate(date, this.startDate))) &&
-          (date > start || sameDate(date, start))));
+          ((this.startDate && date < this.startDate) ||
+            (this.endDate && sameDate(date, this.startDate))) &&
+          ((start && date > start) || sameDate(date, start))));
     return cond1 || cond2;
   }
 }

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -386,15 +386,17 @@ export class DatePicker implements LocalizedComponent, T9nComponent {
           this.hoverRange.focused = "end";
         }
       } else {
-        if (date < start) {
-          this.hoverRange = {
-            focused: "start",
-            start: date,
-            end: start
-          };
-        } else {
-          this.hoverRange.end = date;
-          this.hoverRange.focused = "end";
+        if (start) {
+          if (date < start) {
+            this.hoverRange = {
+              focused: "start",
+              start: date,
+              end: start
+            };
+          } else {
+            this.hoverRange.end = date;
+            this.hoverRange.focused = "end";
+          }
         }
       }
     } else {


### PR DESCRIPTION
**Related Issue:** #6194 

## Summary

This PR fixes an issue where the days previous to the currently hovered day are highlighted incorrectly when no start or end value exists.  There should be no hover styles applied to any days other than the currently hovered day unless a start or an end date exists.