### PR TITLE
fix(tree): prevent lines from expanded item from bleeding out of container

### DIFF
--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -126,7 +126,7 @@ slot[name="actions-end"]::slotted(*),
 }
 
 .children-container {
-  @apply h-0;
+  @apply relative h-0 overflow-hidden;
   margin-inline-start: theme("margin.5");
   transform: scaleY(0);
   opacity: 0;

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -121,6 +121,27 @@ export const selectionModeNone = (): string => html`
   >
 `;
 
+export const withLines_TestOnly = (): string => html`
+  <calcite-tree lines>
+    <calcite-tree-item> Child 1 </calcite-tree-item>
+    <calcite-tree-item expanded>
+      Child 2
+      <calcite-tree slot="children">
+        <calcite-tree-item> Grandchild 1 </calcite-tree-item>
+        <calcite-tree-item> Grandchild 2 </calcite-tree-item>
+        <calcite-tree-item expanded>
+          Grandchild 3
+          <calcite-tree slot="children">
+            <calcite-tree-item> Great-Grandchild 1 </calcite-tree-item>
+            <calcite-tree-item> Great-Grandchild 2 </calcite-tree-item>
+            <calcite-tree-item> Great-Grandchild 3 </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+`;
+
 export const actionsEndDropdownsAndIconStart_TestOnly = (): string => html`<calcite-tree
   style="width: 350px"
   scale="${select("scale", ["s", "m", "l"], "m")}"


### PR DESCRIPTION
**Related Issue:** #6367

## Summary

Restores styles needed to properly contain expanded item line that removed in https://github.com/Esri/calcite-components/pull/6005.
