### PR TITLE
fix(value-list): add back instructions for screen reader when drag handle is activated

### DIFF
--- a/src/components/value-list-item/interfaces.ts
+++ b/src/components/value-list-item/interfaces.ts
@@ -1,0 +1,4 @@
+export interface ListItemAndHandle {
+  item: HTMLCalciteValueListItemElement;
+  handle: HTMLSpanElement;
+}

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -187,7 +187,7 @@ export class ValueListItem
   /**
    * @internal
    */
-  @Event({ cancelable: true })
+  @Event({ cancelable: false })
   calciteValueListItemDragHandleBlur: EventEmitter<ListItemAndHandle>;
 
   @Listen("calciteListItemChange")

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -199,7 +199,6 @@ export class ValueListItem
 
   handleKeyDown = (event: KeyboardEvent): void => {
     if (event.key === " ") {
-      event.preventDefault();
       this.handleActivated = !this.handleActivated;
     }
   };

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -185,11 +185,10 @@ export class ValueListItem
   @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>; // wrapped pick-list-item emits this
 
   /**
-   * Fires when the drag handle is focused
    * @internal
    */
   @Event({ cancelable: true })
-  calciteValueListItemDragHandleFocused: EventEmitter<ListItemAndHandle>;
+  calciteValueListItemDragHandleBlur: EventEmitter<ListItemAndHandle>;
 
   @Listen("calciteListItemChange")
   calciteListItemChangeHandler(event: CustomEvent): void {
@@ -214,14 +213,11 @@ export class ValueListItem
 
   handleBlur = (): void => {
     this.handleActivated = false;
+    this.calciteValueListItemDragHandleBlur.emit({ item: this.el, handle: this.handleEl });
   };
 
   handleSelectChange = (event: CustomEvent): void => {
     this.selected = event.detail.selected;
-  };
-
-  handleFocusIn = (): void => {
-    this.calciteValueListItemDragHandleFocused.emit({ item: this.el, handle: this.handleEl });
   };
 
   // --------------------------------------------------------------------------
@@ -259,7 +255,6 @@ export class ValueListItem
           }}
           data-js-handle
           onBlur={this.handleBlur}
-          onFocusin={this.handleFocusIn}
           onKeyDown={this.handleKeyDown}
           ref={(el) => (this.handleEl = el as HTMLSpanElement)}
           role="button"

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../utils/loadable";
 import { CSS, SLOTS as PICK_LIST_SLOTS } from "../pick-list-item/resources";
 import { ICON_TYPES } from "../pick-list/resources";
+import { ListItemAndHandle } from "./interfaces";
 import { ICONS, SLOTS } from "./resources";
 
 /**
@@ -117,6 +118,8 @@ export class ValueListItem
 
   pickListItem: HTMLCalcitePickListItemElement = null;
 
+  handleEl: HTMLSpanElement;
+
   guid = `calcite-value-list-item-${guid()}`;
 
   // --------------------------------------------------------------------------
@@ -181,6 +184,13 @@ export class ValueListItem
    */
   @Event({ cancelable: true }) calciteListItemRemove: EventEmitter<void>; // wrapped pick-list-item emits this
 
+  /**
+   * Fires when the drag handle is focused
+   * @internal
+   */
+  @Event({ cancelable: true })
+  calciteValueListItemDragHandleFocused: EventEmitter<ListItemAndHandle>;
+
   @Listen("calciteListItemChange")
   calciteListItemChangeHandler(event: CustomEvent): void {
     // adjust item payload from wrapped item before bubbling
@@ -208,6 +218,10 @@ export class ValueListItem
 
   handleSelectChange = (event: CustomEvent): void => {
     this.selected = event.detail.selected;
+  };
+
+  handleFocusIn = (): void => {
+    this.calciteValueListItemDragHandleFocused.emit({ item: this.el, handle: this.handleEl });
   };
 
   // --------------------------------------------------------------------------
@@ -245,7 +259,9 @@ export class ValueListItem
           }}
           data-js-handle
           onBlur={this.handleBlur}
+          onFocusin={this.handleFocusIn}
           onKeyDown={this.handleKeyDown}
+          ref={(el) => (this.handleEl = el as HTMLSpanElement)}
           role="button"
           tabindex="0"
         >

--- a/src/components/value-list/value-list.e2e.ts
+++ b/src/components/value-list/value-list.e2e.ts
@@ -248,7 +248,7 @@ describe("calcite-value-list", () => {
       expect(await ninth.getProperty("value")).toBe("f");
     });
 
-    it.skip("is drag and drop list accessible", async () => {
+    it("is drag and drop list accessible", async () => {
       const page = await createSimpleValueList();
       let startIndex = 0;
 

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -356,6 +356,8 @@ export class ValueList<
       this.updateScreenReaderText(getScreenReaderText(item, "commit", this));
     }
 
+    event.preventDefault();
+
     if (!handle || !item.handleActivated) {
       keyDownHandler.call(this, event);
       return;
@@ -370,8 +372,6 @@ export class ValueList<
     if ((event.key !== "ArrowUp" && event.key !== "ArrowDown") || items.length <= 1) {
       return;
     }
-
-    event.preventDefault();
 
     const { el } = this;
     const nextIndex = moveItemIndex(this, item, event.key === "ArrowUp" ? "up" : "down");

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -52,6 +52,7 @@ import {
   setUpItems
 } from "../pick-list/shared-list-logic";
 import List from "../pick-list/shared-list-render";
+import { ListItemAndHandle } from "../value-list-item/interfaces";
 import { ValueListMessages } from "./assets/value-list/t9n";
 import { CSS, ICON_TYPES } from "./resources";
 import { getHandleAndItemElement, getScreenReaderText } from "./utils";
@@ -456,6 +457,14 @@ export class ValueList<
       this.updateHandleAriaLabel(handle, getScreenReaderText(item, "idle", this));
     }
   };
+
+  @Listen("calciteValueListItemDragHandleFocused")
+  handleValueListItemFocusIn(event: CustomEvent<ListItemAndHandle>): void {
+    const { item, handle } = event.detail;
+    if (!item?.handleActivated && item) {
+      this.updateHandleAriaLabel(handle, getScreenReaderText(item, "idle", this));
+    }
+  }
 
   render(): VNode {
     return (

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -458,8 +458,8 @@ export class ValueList<
     }
   };
 
-  @Listen("calciteValueListItemDragHandleFocused")
-  handleValueListItemFocusIn(event: CustomEvent<ListItemAndHandle>): void {
+  @Listen("calciteValueListItemDragHandleBlur")
+  handleValueListItemBlur(event: CustomEvent<ListItemAndHandle>): void {
     const { item, handle } = event.detail;
     if (!item?.handleActivated && item) {
       this.updateHandleAriaLabel(handle, getScreenReaderText(item, "idle", this));

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -464,6 +464,7 @@ export class ValueList<
     if (!item?.handleActivated && item) {
       this.updateHandleAriaLabel(handle, getScreenReaderText(item, "idle", this));
     }
+    event.stopPropagation();
   }
 
   render(): VNode {

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -356,12 +356,12 @@ export class ValueList<
       this.updateScreenReaderText(getScreenReaderText(item, "commit", this));
     }
 
-    event.preventDefault();
-
     if (!handle || !item.handleActivated) {
       keyDownHandler.call(this, event);
       return;
     }
+
+    event.preventDefault();
 
     const { items } = this;
 


### PR DESCRIPTION
**Related Issue:** #6401 

## Summary

This PR will add back instructions for screen reader when drag handle is activated via `Space` key. 

Sidebar: This will also cover #5739