### PR TITLE
ci(release): lint readme and changelog before committing

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -6,7 +6,7 @@
     "changelog": true
   },
   "scripts": {
-    "precommit": "ts-node --esm ./support/prepReleaseCommit.ts"
+    "precommit": "ts-node --esm ./support/prepReleaseCommit.ts && npm run lint:md && git add readme.md CHANGELOG.md"
   },
   "header": "# Changelog\n\nThis document maintains a list of released versions and changes introduced by them.\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)\n\n"
 }


### PR DESCRIPTION
**Related Issue:** #6355

## Summary
I added markdown lint in the PR above but it isn't running during releases because we have `standard-version` set to `noVerify`. So this is manually linting the readme/changelog before committing.