### PR TITLE
test(heading): remove unnecessary dummy component for spec test

### DIFF
--- a/src/components/functional/Heading.spec.tsx
+++ b/src/components/functional/Heading.spec.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from "@stencil/core";
+import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
 import { constrainHeadingLevel, Heading } from "./Heading";
 
@@ -13,13 +13,10 @@ describe("constrainHeadingLevel", () => {
   });
 });
 
-@Component({ tag: "dummy-component" })
-class Dummy {}
-
 describe("Heading", () => {
   it("should render", async () => {
     const page = await newSpecPage({
-      components: [Dummy], // Required so we are feeding it a Dummy component
+      components: [],
       template: () => (
         <Heading class="test" level={1}>
           My Heading
@@ -32,7 +29,7 @@ describe("Heading", () => {
 
   it("should render a div", async () => {
     const page = await newSpecPage({
-      components: [Dummy], // Required so we are feeding it a Dummy component
+      components: [],
       template: () => <Heading class="test">My Heading</Heading>
     });
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Passing a component is not necessary for this spec page test, so this cleans that up. This came up after some digging around where local test runs (w/ `--watchAll`) would fail after making changes to code:

> [ ERROR ]  Rollup: Parse Error
           Unexpected token (Note that you need plugins to import files that are not JavaScript) 94: export {
           CalciteValueList, defineCustomElement as defineCustomElementCalciteValueList } from
           'CalciteValueList'; 95: export { CalciteValueListItem, defineCustomElement as
           defineCustomElementCalciteValueListItem } from 'CalciteValueListItem'; 96: export { {DummyComponent
           } from 'DummyComponent'; ^