### PR TITLE
build(deps): bump calcite-ui-icons from 3.20.7 to 3.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.1.0",
-        "@esri/calcite-ui-icons": "3.20.7",
+        "@esri/calcite-ui-icons": "3.21.0",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil/eslint-plugin": "0.4.0",
         "@stencil/postcss": "2.1.0",
@@ -2403,9 +2403,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.20.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.7.tgz",
-      "integrity": "sha512-zX/eHOxIV+gnC6QPbYgqAgZnW6ftQrNbaH08hsVuuOPIUke/HUS2o+y/pp7x9/+eh/moa9Fannto+6tHpV7HYQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.21.0.tgz",
+      "integrity": "sha512-L7gUEVYsosgtTh2xmKzXesap5mJ23qRFcMRsCUMxUvnLzCu2P6K4mlq2Yj+2WDYPvIDVjYnFU2mqtr76z1ipxw==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -34397,9 +34397,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.20.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.20.7.tgz",
-      "integrity": "sha512-zX/eHOxIV+gnC6QPbYgqAgZnW6ftQrNbaH08hsVuuOPIUke/HUS2o+y/pp7x9/+eh/moa9Fannto+6tHpV7HYQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.21.0.tgz",
+      "integrity": "sha512-L7gUEVYsosgtTh2xmKzXesap5mJ23qRFcMRsCUMxUvnLzCu2P6K4mlq2Yj+2WDYPvIDVjYnFU2mqtr76z1ipxw==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.1.0",
-    "@esri/calcite-ui-icons": "3.20.7",
+    "@esri/calcite-ui-icons": "3.21.0",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil/eslint-plugin": "0.4.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates [calcite-ui-icons](https://www.npmjs.com/package/@esri/calcite-ui-icons) to `3.21.0` for the upcoming patch release, which includes [additional icons Esri teams are interested in](https://github.com/Esri/calcite-ui-icons/releases/tag/v3.21.0).