### PR TITLE
docs: fix deprecated tag to be in line with Calcite JSDoc guidance

### DIFF
--- a/src/components/pick-list-group/pick-list-group.tsx
+++ b/src/components/pick-list-group/pick-list-group.tsx
@@ -12,7 +12,7 @@ import { CSS, SLOTS } from "./resources";
  * @slot - A slot for adding `calcite-pick-list-item` elements.
  */
 
-/** @futureBreaking Use the `list` component instead. */
+/** @futureBreaking Deprecated in 1.0.3. Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-group",
   styleUrl: "pick-list-group.scss",

--- a/src/components/pick-list-group/pick-list-group.tsx
+++ b/src/components/pick-list-group/pick-list-group.tsx
@@ -12,7 +12,7 @@ import { CSS, SLOTS } from "./resources";
  * @slot - A slot for adding `calcite-pick-list-item` elements.
  */
 
-/** @deprecated Use the `list` component instead. */
+/** @futureBreaking Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-group",
   styleUrl: "pick-list-group.scss",

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -41,7 +41,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
 
-/** @futureBreaking Use the `list` component instead. */
+/** @futureBreaking Deprecated in 1.0.3. Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-item",
   styleUrl: "pick-list-item.scss",

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -41,7 +41,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
 
-/** @deprecated Use the `list` component instead. */
+/** @futureBreaking Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-item",
   styleUrl: "pick-list-item.scss",

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -49,7 +49,7 @@ import List from "./shared-list-render";
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
 
-/** @deprecated Use the `list` component instead. */
+/** @futureBreaking Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list",
   styleUrl: "pick-list.scss",

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -49,7 +49,7 @@ import List from "./shared-list-render";
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
 
-/** @futureBreaking Use the `list` component instead. */
+/** @futureBreaking Deprecated in 1.0.3. Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list",
   styleUrl: "pick-list.scss",

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -33,7 +33,7 @@ import { ICONS, SLOTS } from "./resources";
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
 
-/** @deprecated Use the `list` component instead. */
+/** @futureBreaking Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list-item",
   styleUrl: "value-list-item.scss",

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -33,7 +33,7 @@ import { ICONS, SLOTS } from "./resources";
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
 
-/** @futureBreaking Use the `list` component instead. */
+/** @futureBreaking Deprecated in 1.0.3. Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list-item",
   styleUrl: "value-list-item.scss",

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -61,7 +61,7 @@ import { getHandleAndItemElement, getScreenReaderText } from "./utils";
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
 
-/** @deprecated Use the `list` component instead. */
+/** @futureBreaking Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list",
   styleUrl: "value-list.scss",

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -61,7 +61,7 @@ import { getHandleAndItemElement, getScreenReaderText } from "./utils";
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
 
-/** @futureBreaking Use the `list` component instead. */
+/** @futureBreaking Deprecated in 1.0.3. Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list",
   styleUrl: "value-list.scss",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates the `@deprecated` tag to the `@futureBreaking` tag for the `pick-list-*` and `value-list-*` components.

Noticed the `@deprecated` tag was creating an issue with loading in the slots on our doc site, so hoping this PR:
1. Loads the slots appropiately, and
2. Provides clarity with our direction using the `@featureBreaking` JSDoc tag.

cc @jcfranco for awareness