### PR TITLE
docs: fix slot creation for deprecated components

### DIFF
--- a/src/components/pick-list-group/pick-list-group.tsx
+++ b/src/components/pick-list-group/pick-list-group.tsx
@@ -9,10 +9,9 @@ import { constrainHeadingLevel, Heading, HeadingLevel } from "../functional/Head
 import { CSS, SLOTS } from "./resources";
 
 /**
+ * @deprecated Use the `list` component instead.
  * @slot - A slot for adding `calcite-pick-list-item` elements.
  */
-
-/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-group",
   styleUrl: "pick-list-group.scss",

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -37,11 +37,10 @@ import { PickListItemMessages } from "./assets/pick-list-item/t9n";
 import { CSS, ICONS, SLOTS } from "./resources";
 
 /**
+ * @deprecated Use the `list` component instead.
  * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component.
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
-
-/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list-item",
   styleUrl: "pick-list-item.scss",

--- a/src/components/pick-list/pick-list.tsx
+++ b/src/components/pick-list/pick-list.tsx
@@ -45,11 +45,10 @@ import {
 import List from "./shared-list-render";
 
 /**
+ * @deprecated Use the `list` component instead.
  * @slot - A slot for adding `calcite-pick-list-item` or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
-
-/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-pick-list",
   styleUrl: "pick-list.scss",

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -29,11 +29,10 @@ import { ICON_TYPES } from "../pick-list/resources";
 import { ICONS, SLOTS } from "./resources";
 
 /**
+ * @deprecated Use the `list` component instead.
  * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component.
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component.
  */
-
-/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list-item",
   styleUrl: "value-list-item.scss",

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -57,11 +57,10 @@ import { CSS, ICON_TYPES } from "./resources";
 import { getHandleAndItemElement, getScreenReaderText } from "./utils";
 
 /**
+ * @deprecated Use the `list` component instead.
  * @slot - A slot for adding `calcite-value-list-item` elements. List items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button and menu combination for performing actions, such as sorting.
  */
-
-/** @deprecated Use the `list` component instead. */
 @Component({
   tag: "calcite-value-list",
   styleUrl: "value-list.scss",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Mitigates slots populated in our docs for deprecated components.

Refer to [additional context](https://github.com/Esri/calcite-components/pull/6418#issuecomment-1416241405) from a PR closed earlier regarding formatting.