### PR TITLE
fix(tree-item): reverses regression to bring back focus when navigating with keyboard

### DIFF
--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -102,10 +102,10 @@
 // focus styles
 :host {
   @apply focus-base;
-  &:focus,
-  &:active {
-    @apply focus-inset outline-none;
-  }
+}
+
+:host(:focus:not([disabled])) {
+  @apply focus-inset outline-none;
 }
 
 slot[name="actions-end"]::slotted(*),

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -104,7 +104,7 @@
   @apply focus-base;
 }
 
-:host(:focus:not([disabled])) {
+:host(:focus) {
   @apply focus-inset outline-none;
 }
 


### PR DESCRIPTION
**Related Issue:** #6376

## Summary
Reverses regression to bring back focus when navigating with the keyboard and a small cleanup on the existing code. 
