### PR TITLE
ci(next): fix commit message

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,12 +1,10 @@
 {
   "commitAll": true,
-  "noVerify": true,
-  "releaseCommitMessageFormat": "{{currentTag}}",
   "skip": {
     "changelog": true
   },
   "scripts": {
-    "precommit": "ts-node --esm ./support/prepReleaseCommit.ts && npm run lint:md && git add readme.md CHANGELOG.md"
+    "precommit": "ts-node --esm ./support/prepReleaseCommit.ts"
   },
   "header": "# Changelog\n\nThis document maintains a list of released versions and changes introduced by them.\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)\n\n"
 }


### PR DESCRIPTION
**Related Issue:** #6406

## Summary
The commit messages for `next` releases are goofed. This removes our custom `{{currentTag}}` commit message and replaces it with the default: `chore(release): {{currentTag}}`.

It also removes `noVerify` so we can remove `npm run lint:md` because it will be done by `lint-staged`.

The commit message was fine before the PR linked above. No idea why this is happening but it's probably a `standard-version` bug
