### PR TITLE
docs(segmented-control): update event description for calciteSegmentedControlChange

### DIFF
--- a/src/components/segmented-control/segmented-control.tsx
+++ b/src/components/segmented-control/segmented-control.tsx
@@ -251,7 +251,7 @@ export class SegmentedControl
   //
   //--------------------------------------------------------------------------
 
-  /** Fires when the selected option changes, where the event detail is the new value. */
+  /** Fires when the `calcite-segmented-control-item` changes. */
   @Event({ cancelable: false }) calciteSegmentedControlChange: EventEmitter<void>;
 
   // --------------------------------------------------------------------------

--- a/src/components/segmented-control/segmented-control.tsx
+++ b/src/components/segmented-control/segmented-control.tsx
@@ -251,7 +251,7 @@ export class SegmentedControl
   //
   //--------------------------------------------------------------------------
 
-  /** Fires when the `calcite-segmented-control-item` changes. */
+  /** Fires when the `calcite-segmented-control-item` selection changes. */
   @Event({ cancelable: false }) calciteSegmentedControlChange: EventEmitter<void>;
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #6427 

## Summary
Adds context to the event description and removes the `event.detail` reference, where the payload is now set by `event.target`.
