### PR TITLE
fix(input, input-number, input-text): emit change value when clearing programmatically-set value

### DIFF
--- a/src/components/input-number/input-number.e2e.ts
+++ b/src/components/input-number/input-number.e2e.ts
@@ -12,7 +12,7 @@ import {
   renders,
   t9n
 } from "../../tests/commonTests";
-import { getElementXY } from "../../tests/utils";
+import { getElementXY, selectText } from "../../tests/utils";
 import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 
@@ -724,6 +724,15 @@ describe("calcite-input-number", () => {
       expect(await element.getProperty("value")).toBe(programmaticSetValue);
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
+
+      await element.callMethod("setFocus");
+      await selectText(element);
+      await page.keyboard.press("Backspace");
+      await page.keyboard.press("Tab");
+
+      expect(await element.getProperty("value")).toBe("");
+      expect(calciteInputNumberInput).toHaveReceivedEventTimes(11);
+      expect(calciteInputNumberChange).toHaveReceivedEventTimes(3);
     }
 
     it("emits events", () => assertChangeEvents());

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -832,7 +832,7 @@ export class InputNumber
     const newLocalizedValue = numberStringFormatter.localize(newValue);
     this.localizedValue = newLocalizedValue;
 
-    this.setPreviousNumberValue(previousValue || this.value);
+    this.setPreviousNumberValue(previousValue ?? this.value);
     this.previousValueOrigin = origin;
     this.userChangedValue = origin === "user" && this.value !== newValue;
     // don't sanitize the start of negative/decimal numbers, but

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -641,11 +641,7 @@ export class InputNumber
     const isShiftTabEvent = event.shiftKey && event.key === "Tab";
     if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
       if (event.key === "Enter") {
-        this.setNumberValue({
-          committing: true,
-          origin: "user",
-          value: this.value
-        });
+        this.emitChangeIfUserModified();
       }
       return;
     }

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -343,7 +343,7 @@ export class InputNumber
 
   private maxString?: string;
 
-  private previousEmittedValue: string;
+  private previousCommittedValue: string;
 
   private previousValue: string;
 
@@ -399,7 +399,7 @@ export class InputNumber
     connectLabel(this);
     connectForm(this);
 
-    this.setPreviousEmittedNumberValue(this.value);
+    this.setPreviousCommittedNumberValue(this.value);
     this.setPreviousNumberValue(this.value);
 
     this.warnAboutInvalidNumberValue(this.value);
@@ -559,10 +559,9 @@ export class InputNumber
   };
 
   private emitChangeIfUserModified = (): void => {
-    if (this.previousValueOrigin === "user" && this.value !== this.previousEmittedValue) {
+    if (this.previousValueOrigin === "user" && this.value !== this.previousCommittedValue) {
       this.calciteInputNumberChange.emit();
     }
-    this.previousEmittedValue = this.value;
   };
 
   private inputNumberBlurHandler = () => {
@@ -641,7 +640,11 @@ export class InputNumber
     const isShiftTabEvent = event.shiftKey && event.key === "Tab";
     if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
       if (event.key === "Enter") {
-        this.emitChangeIfUserModified();
+        this.setNumberValue({
+          committing: true,
+          origin: "user",
+          value: this.value
+        });
       }
       return;
     }
@@ -780,9 +783,9 @@ export class InputNumber
     this.childNumberEl.value = newInputValue;
   };
 
-  private setPreviousEmittedNumberValue = (newPreviousEmittedValue: string): void => {
-    this.previousEmittedValue = isValidNumber(newPreviousEmittedValue)
-      ? newPreviousEmittedValue
+  private setPreviousCommittedNumberValue = (newPreviousCommittedValue: string): void => {
+    this.previousCommittedValue = isValidNumber(newPreviousCommittedValue)
+      ? newPreviousCommittedValue
       : "";
   };
 
@@ -840,6 +843,7 @@ export class InputNumber
         this.value = this.previousValue;
         this.localizedValue = numberStringFormatter.localize(this.previousValue);
       } else if (committing) {
+        this.setPreviousCommittedNumberValue(this.value);
         this.emitChangeIfUserModified();
       }
     }

--- a/src/components/input-text/input-text.e2e.ts
+++ b/src/components/input-text/input-text.e2e.ts
@@ -11,6 +11,7 @@ import {
   renders,
   t9n
 } from "../../tests/commonTests";
+import { selectText } from "../../tests/utils";
 
 describe("calcite-input-text", () => {
   it("is labelable", async () => labelable("calcite-input-text"));
@@ -159,6 +160,15 @@ describe("calcite-input-text", () => {
     expect(await element.getProperty("value")).toBe(programmaticSetValue);
     expect(calciteInputTextInput).toHaveReceivedEventTimes(10);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(2);
+
+    await element.callMethod("setFocus");
+    await selectText(element);
+    await page.keyboard.press("Backspace");
+    await page.keyboard.press("Tab");
+
+    expect(await element.getProperty("value")).toBe("");
+    expect(calciteInputTextInput).toHaveReceivedEventTimes(11);
+    expect(calciteInputTextChange).toHaveReceivedEventTimes(3);
   });
 
   it("renders clear button when clearable is requested and value is populated at load", async () => {

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -271,7 +271,7 @@ export class InputText
     return this.clearable && this.value.length > 0;
   }
 
-  private previousCommittedValue: string;
+  private previousEmittedValue: string;
 
   private previousValue: string;
 
@@ -310,7 +310,7 @@ export class InputText
     if (this.inlineEditableEl) {
       this.editingEnabled = this.inlineEditableEl.editingEnabled || false;
     }
-    this.setPreviousCommittedValue(this.value);
+    this.setPreviousEmittedValue(this.value);
     this.setPreviousValue(this.value);
 
     connectLabel(this);
@@ -427,10 +427,10 @@ export class InputText
   };
 
   private emitChangeIfUserModified = (): void => {
-    if (this.previousValueOrigin === "user" && this.value !== this.previousCommittedValue) {
+    if (this.previousValueOrigin === "user" && this.value !== this.previousEmittedValue) {
       this.calciteInputTextChange.emit();
+      this.setPreviousEmittedValue(this.value);
     }
-    this.previousCommittedValue = this.value;
   };
 
   private inputTextBlurHandler = () => {
@@ -536,8 +536,8 @@ export class InputText
     this.childEl.value = newInputValue;
   };
 
-  private setPreviousCommittedValue = (newPreviousCommittedValue: string): void => {
-    this.previousCommittedValue = newPreviousCommittedValue;
+  private setPreviousEmittedValue = (newPreviousCommittedValue: string): void => {
+    this.previousEmittedValue = newPreviousCommittedValue;
   };
 
   private setPreviousValue = (newPreviousValue: string): void => {
@@ -564,6 +564,7 @@ export class InputText
 
     if (origin === "direct") {
       this.setInputValue(value);
+      this.setPreviousEmittedValue(value);
     }
 
     if (nativeEvent) {

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -472,11 +472,7 @@ export class InputText
       return;
     }
     if (event.key === "Enter") {
-      this.setValue({
-        committing: true,
-        origin: "user",
-        value: this.value
-      });
+      this.emitChangeIfUserModified();
     }
   };
 
@@ -536,12 +532,12 @@ export class InputText
     this.childEl.value = newInputValue;
   };
 
-  private setPreviousEmittedValue = (newPreviousCommittedValue: string): void => {
-    this.previousEmittedValue = newPreviousCommittedValue;
+  private setPreviousEmittedValue = (value: string): void => {
+    this.previousEmittedValue = value;
   };
 
-  private setPreviousValue = (newPreviousValue: string): void => {
-    this.previousValue = newPreviousValue;
+  private setPreviousValue = (value: string): void => {
+    this.previousValue = value;
   };
 
   private setValue = ({
@@ -557,7 +553,7 @@ export class InputText
     previousValue?: string;
     value: string;
   }): void => {
-    this.setPreviousValue(previousValue || this.value);
+    this.setPreviousValue(previousValue ?? this.value);
     this.previousValueOrigin = origin;
     this.userChangedValue = origin === "user" && value !== this.value;
     this.value = value;

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -271,7 +271,7 @@ export class InputText
     return this.clearable && this.value.length > 0;
   }
 
-  private previousEmittedValue: string;
+  private previousCommittedValue: string;
 
   private previousValue: string;
 
@@ -310,7 +310,7 @@ export class InputText
     if (this.inlineEditableEl) {
       this.editingEnabled = this.inlineEditableEl.editingEnabled || false;
     }
-    this.setPreviousEmittedValue(this.value);
+    this.setPreviousCommittedValue(this.value);
     this.setPreviousValue(this.value);
 
     connectLabel(this);
@@ -427,10 +427,10 @@ export class InputText
   };
 
   private emitChangeIfUserModified = (): void => {
-    if (this.previousValueOrigin === "user" && this.value !== this.previousEmittedValue) {
+    if (this.previousValueOrigin === "user" && this.value !== this.previousCommittedValue) {
       this.calciteInputTextChange.emit();
     }
-    this.previousEmittedValue = this.value;
+    this.previousCommittedValue = this.value;
   };
 
   private inputTextBlurHandler = () => {
@@ -472,7 +472,11 @@ export class InputText
       return;
     }
     if (event.key === "Enter") {
-      this.emitChangeIfUserModified();
+      this.setValue({
+        committing: true,
+        origin: "user",
+        value: this.value
+      });
     }
   };
 
@@ -532,8 +536,8 @@ export class InputText
     this.childEl.value = newInputValue;
   };
 
-  private setPreviousEmittedValue = (newPreviousEmittedValue: string): void => {
-    this.previousEmittedValue = newPreviousEmittedValue;
+  private setPreviousCommittedValue = (newPreviousCommittedValue: string): void => {
+    this.previousCommittedValue = newPreviousCommittedValue;
   };
 
   private setPreviousValue = (newPreviousValue: string): void => {

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -13,7 +13,7 @@ import {
 import { html } from "../../../support/formatting";
 import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
-import { getElementXY } from "../../tests/utils";
+import { getElementXY, selectText } from "../../tests/utils";
 import { KeyInput } from "puppeteer";
 
 describe("calcite-input", () => {
@@ -712,6 +712,15 @@ describe("calcite-input", () => {
       expect(await element.getProperty("value")).toBe(programmaticSetValue);
       expect(calciteInputInput).toHaveReceivedEventTimes(10);
       expect(calciteInputChange).toHaveReceivedEventTimes(2);
+
+      await element.callMethod("setFocus");
+      await selectText(element);
+      await page.keyboard.press("Backspace");
+      await page.keyboard.press("Tab");
+
+      expect(await element.getProperty("value")).toBe("");
+      expect(calciteInputInput).toHaveReceivedEventTimes(11);
+      expect(calciteInputChange).toHaveReceivedEventTimes(3);
     }
 
     it("emits when type is text", () => assertChangeEvents("text"));

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -681,11 +681,7 @@ export class Input
       return;
     }
     if (event.key === "Enter") {
-      this.setValue({
-        committing: true,
-        origin: "user",
-        value: this.value
-      });
+      this.emitChangeIfUserModified();
     }
   };
 
@@ -749,11 +745,7 @@ export class Input
     const isShiftTabEvent = event.shiftKey && event.key === "Tab";
     if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
       if (event.key === "Enter") {
-        this.setValue({
-          committing: true,
-          origin: "user",
-          value: this.value
-        });
+        this.emitChangeIfUserModified();
       }
       return;
     }

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -405,7 +405,7 @@ export class Input
 
   private maxString?: string;
 
-  private previousEmittedValue: string;
+  private previousCommittedValue: string;
 
   private previousValue: string;
 
@@ -458,8 +458,9 @@ export class Input
     connectLabel(this);
     connectForm(this);
 
-    this.setPreviousEmittedValue(this.value);
+    this.setPreviousCommittedValue(this.value);
     this.setPreviousValue(this.value);
+
     if (this.type === "number") {
       this.warnAboutInvalidNumberValue(this.value);
       this.setValue({
@@ -642,10 +643,9 @@ export class Input
   };
 
   private emitChangeIfUserModified = (): void => {
-    if (this.previousValueOrigin === "user" && this.value !== this.previousEmittedValue) {
+    if (this.previousValueOrigin === "user" && this.value !== this.previousCommittedValue) {
       this.calciteInputChange.emit();
     }
-    this.previousEmittedValue = this.value;
   };
 
   private inputBlurHandler = () => {
@@ -680,7 +680,11 @@ export class Input
       return;
     }
     if (event.key === "Enter") {
-      this.emitChangeIfUserModified();
+      this.setValue({
+        committing: true,
+        origin: "user",
+        value: this.value
+      });
     }
   };
 
@@ -744,7 +748,11 @@ export class Input
     const isShiftTabEvent = event.shiftKey && event.key === "Tab";
     if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
       if (event.key === "Enter") {
-        this.emitChangeIfUserModified();
+        this.setValue({
+          committing: true,
+          origin: "user",
+          value: this.value
+        });
       }
       return;
     }
@@ -898,13 +906,13 @@ export class Input
     this[`child${this.type === "number" ? "Number" : ""}El`].value = newInputValue;
   };
 
-  private setPreviousEmittedValue = (newPreviousEmittedValue: string): void => {
-    this.previousEmittedValue =
+  private setPreviousCommittedValue = (newPreviousCommittedValue: string): void => {
+    this.previousCommittedValue =
       this.type === "number"
-        ? isValidNumber(newPreviousEmittedValue)
-          ? newPreviousEmittedValue
+        ? isValidNumber(newPreviousCommittedValue)
+          ? newPreviousCommittedValue
           : ""
-        : newPreviousEmittedValue;
+        : newPreviousCommittedValue;
   };
 
   private setPreviousValue = (newPreviousValue: string): void => {
@@ -979,6 +987,7 @@ export class Input
             ? numberStringFormatter.localize(this.previousValue)
             : this.previousValue;
       } else if (committing) {
+        this.setPreviousCommittedValue(this.value);
         this.emitChangeIfUserModified();
       }
     }


### PR DESCRIPTION
**Related Issue:** #4232

## Summary

Updates value-setting code to treat programmatically-set values as the last emitted one, which is used to determine whether to emit or not.