### PR TITLE
fix(modal): no longer loses focus trap after clicking inside the component.

### DIFF
--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -389,11 +389,7 @@ describe("calcite-modal accessibility checks", () => {
         <calcite-modal aria-labelledby="modal-title" close-button-disabled open>
           <div slot="header" id="modal-title">Modal title</div>
           <div slot="content">
-            <p>
-              Modal content lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-              labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-              aliquip ex ea commodo consequat.
-            </p>
+            <p>Modal content.</p>
             <calcite-button icon-start="plus" id="plus" round></calcite-button>
           </div>
           <calcite-button slot="back" color="neutral" width="full">Back</calcite-button>

--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -382,6 +382,50 @@ describe("calcite-modal accessibility checks", () => {
     expect(document.activeElement).toEqual($button1);
   });
 
+  it("traps focus within the modal when user clicks inside the modal", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`
+        <calcite-modal aria-labelledby="modal-title" close-button-disabled open>
+          <div slot="header" id="modal-title">Modal title</div>
+          <div slot="content">
+            <p>
+              Modal content lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+              labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+              aliquip ex ea commodo consequat.
+            </p>
+            <calcite-button icon-start="plus" id="plus" round></calcite-button>
+          </div>
+          <calcite-button slot="back" color="neutral" width="full">Back</calcite-button>
+          <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+          <calcite-button slot="primary" width="full">Save</calcite-button>
+        </calcite-modal>
+      `
+    );
+
+    const contentEl = await page.find(`div[slot="content"]`);
+    const backButtonEl = await page.find(`calcite-button[slot="back"]`);
+
+    await page.keyboard.press("Tab");
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("plus");
+
+    await page.keyboard.press("Tab");
+    expect(await page.evaluate(() => document.activeElement.slot)).toBe("back");
+
+    await page.keyboard.press("Tab");
+    expect(await page.evaluate(() => document.activeElement.slot)).toBe("secondary");
+
+    await page.keyboard.press("Tab");
+    expect(await page.evaluate(() => document.activeElement.slot)).toBe("primary");
+
+    await contentEl.click();
+    await page.waitForChanges();
+    await backButtonEl.click();
+    await page.waitForChanges();
+
+    expect(await page.evaluate(() => document.activeElement.slot)).toBe("back");
+  });
+
   describe("setFocus", () => {
     const createModalHTML = (contentHTML?: string, attrs?: string) =>
       `<calcite-modal open ${attrs}>${contentHTML}</calcite-modal>`;

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -735,8 +735,8 @@ describe("calcite-popover", () => {
       }));
   });
 
-  // refer to https://github.com/Esri/calcite-components/issues/5993 for context
   it("should focus input element in the page with popover when user click", async () => {
+    // refer to https://github.com/Esri/calcite-components/issues/5993 for context
     const page = await newE2EPage();
     await page.setContent(html` <calcite-shell content-behind>
         <calcite-shell-panel slot="panel-end">

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -734,4 +734,48 @@ describe("calcite-popover", () => {
         shadowFocusTargetSelector: `.${CSS.closeButton}`
       }));
   });
+
+  // refer to https://github.com/Esri/calcite-components/issues/5993 for context
+  it("should focus input element in the page with popover when user click", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html` <calcite-shell content-behind>
+        <calcite-shell-panel slot="panel-end">
+          <calcite-label>
+            value
+            <calcite-input-number value="0" min="0" max="10" id="shell-input"></calcite-input-number>
+          </calcite-label>
+          <calcite-button id="button">open popover</calcite-button>
+        </calcite-shell-panel>
+      </calcite-shell>
+
+      <calcite-popover reference-element="button">
+        <calcite-panel heading="popover panel header" closable="true" style="height: 400px">
+          <calcite-input-number value="5" min="0" max="10" id="popover-input"></calcite-input-number>
+        </calcite-panel>
+      </calcite-popover>`);
+
+    const popover = await page.find("calcite-popover");
+    expect(await popover.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("calcite-button#button");
+    await referenceElement.click();
+    await page.waitForChanges();
+    expect(await popover.getProperty("open")).toBe(true);
+
+    const inputElInPopover = await page.find("calcite-input-number#popover-input");
+    await inputElInPopover.click();
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("popover-input");
+
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type("12345");
+    expect(await inputElInPopover.getProperty("value")).toBe("12345");
+
+    const inputElInShell = await page.find("calcite-input-number#shell-input");
+    await inputElInShell.click();
+    expect(await page.evaluate(() => document.activeElement.id)).toBe("shell-input");
+
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type("12345");
+    expect(await inputElInShell.getProperty("value")).toBe("12345");
+  });
 });

--- a/src/utils/focusTrapComponent.spec.ts
+++ b/src/utils/focusTrapComponent.spec.ts
@@ -41,7 +41,7 @@ describe("focusTrapComponent", () => {
     fakeComponent.focusTrapEl.tabIndex = 0;
 
     connectFocusTrap(fakeComponent);
-    expect(fakeComponent.focusTrapEl.tabIndex).toBe(-1);
+    expect(fakeComponent.focusTrapEl.tabIndex).toBe(0);
     expect(fakeComponent.focusTrap).toBeDefined();
   });
 });

--- a/src/utils/focusTrapComponent.spec.ts
+++ b/src/utils/focusTrapComponent.spec.ts
@@ -41,7 +41,7 @@ describe("focusTrapComponent", () => {
     fakeComponent.focusTrapEl.tabIndex = 0;
 
     connectFocusTrap(fakeComponent);
-    expect(fakeComponent.focusTrapEl.tabIndex).toBe(0);
+    expect(fakeComponent.focusTrapEl.tabIndex).toBe(-1);
     expect(fakeComponent.focusTrap).toBeDefined();
   });
 });

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -42,15 +42,13 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     return;
   }
 
-  if (focusTrapEl.tabIndex === null) {
-    focusTrapEl.setAttribute("tabindex", "-1");
-  }
+  focusTrapEl.setAttribute("tabindex", "-1");
 
   const focusTrapOptions: FocusTrapOptions = {
+    allowOutsideClick: true,
     clickOutsideDeactivates: (event: MouseEvent | TouchEvent) => {
       return !event.composedPath().find((el) => (el as HTMLElement) === focusTrapEl);
     },
-    allowOutsideClick: true,
     document: focusTrapEl.ownerDocument,
     escapeDeactivates: false,
     fallbackFocus: focusTrapEl,

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -41,13 +41,13 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
   if (!focusTrapEl) {
     return;
   }
-
-  if (focusTrapEl.tabIndex == null) {
-    focusTrapEl.tabIndex = -1;
-  }
+  console.log(focusTrapEl.ownerDocument);
+  focusTrapEl.setAttribute("tabindex", "-1");
 
   const focusTrapOptions: FocusTrapOptions = {
-    clickOutsideDeactivates: true,
+    clickOutsideDeactivates: (event: MouseEvent | TouchEvent) => {
+      return !event.composedPath().find((el) => (el as HTMLElement) === focusTrapEl);
+    },
     document: focusTrapEl.ownerDocument,
     escapeDeactivates: false,
     fallbackFocus: focusTrapEl,

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -41,8 +41,10 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
   if (!focusTrapEl) {
     return;
   }
-  console.log(focusTrapEl.ownerDocument);
-  focusTrapEl.setAttribute("tabindex", "-1");
+
+  if (focusTrapEl.tabIndex === null) {
+    focusTrapEl.setAttribute("tabindex", "-1");
+  }
 
   const focusTrapOptions: FocusTrapOptions = {
     clickOutsideDeactivates: (event: MouseEvent | TouchEvent) => {

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -42,7 +42,7 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     return;
   }
 
-  if (focusTrapEl.getAttribute("tabindex") !== "-1") {
+  if (!focusTrapEl.hasAttribute("tabindex")) {
     focusTrapEl.setAttribute("tabindex", "-1");
   }
 

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -42,7 +42,7 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     return;
   }
 
-  if (focusTrapEl.tabIndex === null) {
+  if (focusTrapEl.getAttribute("tabindex") !== "-1") {
     focusTrapEl.setAttribute("tabindex", "-1");
   }
 

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -42,7 +42,9 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     return;
   }
 
-  focusTrapEl.setAttribute("tabindex", "-1");
+  if (focusTrapEl.tabIndex === null) {
+    focusTrapEl.setAttribute("tabindex", "-1");
+  }
 
   const focusTrapOptions: FocusTrapOptions = {
     allowOutsideClick: true,

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -50,6 +50,7 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     clickOutsideDeactivates: (event: MouseEvent | TouchEvent) => {
       return !event.composedPath().find((el) => (el as HTMLElement) === focusTrapEl);
     },
+    allowOutsideClick: true,
     document: focusTrapEl.ownerDocument,
     escapeDeactivates: false,
     fallbackFocus: focusTrapEl,


### PR DESCRIPTION
**Related Issue:** #6281 

## Summary
This PR will fix `focusTrap` issue when user clicks inside the `modal`. When user clicks inside the modal, `focusTrap` behavior wont be affected.