### PR TITLE
fix(vite): resolve lazying loading error in dist build

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -127,6 +127,7 @@ export const create: () => Config = () => ({
     name: "calcite-hydrated"
   },
   preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-components/blob/master/LICENSE.md for details.\nv${version}`,
+  experimentalImportInjection: true,
   extras: {
     scriptDataOpts: true
   }


### PR DESCRIPTION
**Related Issue:** #6419

## Summary

Resolves errors that occurs when lazy loading the components in Vite using the `dist` build.

https://stenciljs.com/docs/config-extras#experimentalimportinjection

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/10986395/217410136-df5acf6b-c617-4de5-806b-2aa84a9b0b08.png)

The doc linked above mentions an increase in bundle size, here is the before and after using my `build-sizes` npm package.

### Before

```
-----------------------------
|> Application Build Sizes <|
-----------------------------
Build
 --> file count: 9178
 --> size: 12.07 MB
 --> size on disk: 13.75 MB
-----------------------------
Main JS bundle
 --> name: calcite-color-picker_3.cjs.entry.js
 --> size: 100.12 KB
 --> gzip size: 24.33 KB
 --> brotli size: 21.01 KB
-----------------------------
```

### After

```
-----------------------------
|> Application Build Sizes <|
-----------------------------
Build
 --> file count: 9316
 --> size: 12.35 MB
 --> size on disk: 14.49 MB
-----------------------------
Main JS bundle
 --> name: calcite-color-picker_3.cjs.entry.js
 --> size: 100.12 KB
 --> gzip size: 24.33 KB
 --> brotli size: 21.01 KB
-----------------------------
```
