### PR TITLE
ci: remove version placeholders from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -51,7 +51,6 @@ body:
     attributes:
       label: Reproduction Version
       description: The latest version that reproduces the issue.
-      placeholder: 1.0.0-beta.99
     validations:
       required: true
   - type: input
@@ -77,7 +76,6 @@ body:
     attributes:
       label: Regression?
       description: Please provide the last working version if the issue is a regression.
-      placeholder: 1.0.4
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,7 +45,6 @@ body:
     attributes:
       label: Reproduction Version
       description: The latest version that reproduces the issue.
-      placeholder: 1.0.4
     validations:
       required: true
   - type: textarea
@@ -64,7 +63,6 @@ body:
     attributes:
       label: Regression?
       description: Please provide the last working version if the issue is a regression.
-      placeholder: 1.0.0-beta.99
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
**Related Issue:** #

## Summary
Removes the placeholders for the repro/regression version fields since it looks like it was prefilled