### PR TITLE
fix(vite): getting the dist build to work correctly with vite again

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -127,8 +127,8 @@ export const create: () => Config = () => ({
     name: "calcite-hydrated"
   },
   preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-components/blob/master/LICENSE.md for details.\nv${version}`,
-  experimentalImportInjection: true,
   extras: {
+    experimentalImportInjection: true,
     scriptDataOpts: true
   }
 });


### PR DESCRIPTION
**Related Issue:** #6419 

## Summary

This fixes an issue with lazy-loading components when using Calcite Components in a Vite project with the `dist` Stencil output target.

Here's how I verified this fix locally:

1. Clone the [vite example from `calcite-components-examples`](https://github.com/Esri/calcite-components-examples/tree/master/vite)
2. Run `npm install`
3. Replace the source code in `main.js` with:
```
import { defineCustomElements } from "@esri/calcite-components/dist/loader";
defineCustomElements(window);

import "@esri/calcite-components/dist/calcite/calcite.css";
```
4. Checkout this branch In the local copy of calcite, run `npm run build` to generate the new `dist` build from the updated stencil configuration.
5. Then run `npm link` from within `calcite-components`
6. Back in the vite project, run the command `npm link @esri/calcite-components` which will symlink the calcite dependency in npm to resolve file path imports to the locally-installed calcite-components instance instead of the npm-downloaded copy.
7. Run `npm run dev` from within the vite project.
8. Open the browser at the provided URL and you should see a calcite button and banana icon and an active loader component on the page with no errors in the browser console.