### PR TITLE
fix(focus-trap): prevent host from receiving initial focus

### DIFF
--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -271,3 +271,35 @@ export async function skipAnimations(page: E2EPage): Promise<void> {
     content: `:root { --calcite-duration-factor: 0; }`
   });
 }
+
+interface MatchesFocusedElementOptions {
+  /**
+   * Set this to true when the focused element is expected to reside in the shadow DOM
+   */
+  shadowed: boolean;
+}
+
+/**
+ * This util helps determine if a selector matches the currently focused element.
+ *
+ * @param page – the E2E page
+ * @param selector – selector of element to match
+ * @param options - options to customize the utility behavior
+ */
+export async function isElementFocused(
+  page: E2EPage,
+  selector: string,
+  options?: MatchesFocusedElementOptions
+): Promise<boolean> {
+  const shadowed = options?.shadowed;
+
+  return page.evaluate(
+    (selector: string, shadowed: boolean): boolean => {
+      const targetDoc = shadowed ? document.activeElement?.shadowRoot : document;
+
+      return !!targetDoc?.activeElement?.matches(selector);
+    },
+    selector,
+    shadowed
+  );
+}

--- a/src/utils/focusTrapComponent.spec.ts
+++ b/src/utils/focusTrapComponent.spec.ts
@@ -12,7 +12,6 @@ describe("focusTrapComponent", () => {
 
     connectFocusTrap(fakeComponent);
 
-    expect(fakeComponent.focusTrapEl.tabIndex).toBe(-1);
     expect(fakeComponent.focusTrap).toBeDefined();
     expect(fakeComponent.focusTrap.active).toBe(false);
 
@@ -33,15 +32,5 @@ describe("focusTrapComponent", () => {
 
     deactivateFocusTrap(fakeComponent);
     expect(deactivateSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("focusTrapEl with tabIndex`", () => {
-    const fakeComponent = {} as any;
-    fakeComponent.focusTrapEl = document.createElement("div");
-    fakeComponent.focusTrapEl.tabIndex = 0;
-
-    connectFocusTrap(fakeComponent);
-    expect(fakeComponent.focusTrapEl.tabIndex).toBe(0);
-    expect(fakeComponent.focusTrap).toBeDefined();
   });
 });

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -42,10 +42,6 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     return;
   }
 
-  if (!focusTrapEl.hasAttribute("tabindex")) {
-    focusTrapEl.setAttribute("tabindex", "-1");
-  }
-
   const focusTrapOptions: FocusTrapOptions = {
     allowOutsideClick: true,
     clickOutsideDeactivates: (event: MouseEvent | TouchEvent) => {


### PR DESCRIPTION
**Related Issue:** #6454 

## Summary

This fixes an issue caused by setting the `tabindex` attribute on the host element instead of the property ([previous behavior](https://github.com/Esri/calcite-components/pull/6434)). 

### Notes

* When `tabindex` was set, `focus-trap` seemed to move focus to the host as focus fallback even if focus was already set within the focus trap. We should look into only setting the host as focus fallback if there is no focusable content within the trap.
* The `tabindex` setting logic was removed instead of being rolled back because the [previous version](https://github.com/Esri/calcite-components/blob/059d6eee6a8dc0a0d74db6e113d30cafebac25bb/src/utils/focusTrapComponent.ts#L33-L35) was misleading and would never be invoked (`HTMLElement.tabIndex` [is always an integer](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/tabIndex#value)).
* Some focus-related tests were fixed as they were not properly set up and produced false positives. 
* A test util was added to help match elements against the focused element.