### PR TITLE
revert(focus-trap): drop focus-trap options causing inconsistent focus behavior

### DIFF
--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -734,48 +734,4 @@ describe("calcite-popover", () => {
         shadowFocusTargetSelector: `.${CSS.closeButton}`
       }));
   });
-
-  it("should focus input element in the page with popover when user click", async () => {
-    // refer to https://github.com/Esri/calcite-components/issues/5993 for context
-    const page = await newE2EPage();
-    await page.setContent(html` <calcite-shell content-behind>
-        <calcite-shell-panel slot="panel-end">
-          <calcite-label>
-            value
-            <calcite-input-number value="0" min="0" max="10" id="shell-input"></calcite-input-number>
-          </calcite-label>
-          <calcite-button id="button">open popover</calcite-button>
-        </calcite-shell-panel>
-      </calcite-shell>
-
-      <calcite-popover reference-element="button">
-        <calcite-panel heading="popover panel header" closable="true" style="height: 400px">
-          <calcite-input-number value="5" min="0" max="10" id="popover-input"></calcite-input-number>
-        </calcite-panel>
-      </calcite-popover>`);
-
-    const popover = await page.find("calcite-popover");
-    expect(await popover.getProperty("open")).toBe(false);
-
-    const referenceElement = await page.find("calcite-button#button");
-    await referenceElement.click();
-    await page.waitForChanges();
-    expect(await popover.getProperty("open")).toBe(true);
-
-    const inputElInPopover = await page.find("calcite-input-number#popover-input");
-    await inputElInPopover.click();
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("popover-input");
-
-    await page.keyboard.press("Backspace");
-    await page.keyboard.type("12345");
-    expect(await inputElInPopover.getProperty("value")).toBe("12345");
-
-    const inputElInShell = await page.find("calcite-input-number#shell-input");
-    await inputElInShell.click();
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("shell-input");
-
-    await page.keyboard.press("Backspace");
-    await page.keyboard.type("12345");
-    expect(await inputElInShell.getProperty("value")).toBe("12345");
-  });
 });

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -271,35 +271,3 @@ export async function skipAnimations(page: E2EPage): Promise<void> {
     content: `:root { --calcite-duration-factor: 0; }`
   });
 }
-
-interface MatchesFocusedElementOptions {
-  /**
-   * Set this to true when the focused element is expected to reside in the shadow DOM
-   */
-  shadowed: boolean;
-}
-
-/**
- * This util helps determine if a selector matches the currently focused element.
- *
- * @param page – the E2E page
- * @param selector – selector of element to match
- * @param options - options to customize the utility behavior
- */
-export async function isElementFocused(
-  page: E2EPage,
-  selector: string,
-  options?: MatchesFocusedElementOptions
-): Promise<boolean> {
-  const shadowed = options?.shadowed;
-
-  return page.evaluate(
-    (selector: string, shadowed: boolean): boolean => {
-      const targetDoc = shadowed ? document.activeElement?.shadowRoot : document;
-
-      return !!targetDoc?.activeElement?.matches(selector);
-    },
-    selector,
-    shadowed
-  );
-}

--- a/src/utils/focusTrapComponent.spec.ts
+++ b/src/utils/focusTrapComponent.spec.ts
@@ -12,6 +12,7 @@ describe("focusTrapComponent", () => {
 
     connectFocusTrap(fakeComponent);
 
+    expect(fakeComponent.focusTrapEl.tabIndex).toBe(-1);
     expect(fakeComponent.focusTrap).toBeDefined();
     expect(fakeComponent.focusTrap.active).toBe(false);
 
@@ -32,5 +33,15 @@ describe("focusTrapComponent", () => {
 
     deactivateFocusTrap(fakeComponent);
     expect(deactivateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("focusTrapEl with tabIndex`", () => {
+    const fakeComponent = {} as any;
+    fakeComponent.focusTrapEl = document.createElement("div");
+    fakeComponent.focusTrapEl.tabIndex = 0;
+
+    connectFocusTrap(fakeComponent);
+    expect(fakeComponent.focusTrapEl.tabIndex).toBe(0);
+    expect(fakeComponent.focusTrap).toBeDefined();
   });
 });

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -42,11 +42,12 @@ export function connectFocusTrap(component: FocusTrapComponent): void {
     return;
   }
 
+  if (focusTrapEl.tabIndex == null) {
+    focusTrapEl.tabIndex = -1;
+  }
+
   const focusTrapOptions: FocusTrapOptions = {
-    allowOutsideClick: true,
-    clickOutsideDeactivates: (event: MouseEvent | TouchEvent) => {
-      return !event.composedPath().find((el) => (el as HTMLElement) === focusTrapEl);
-    },
+    clickOutsideDeactivates: true,
     document: focusTrapEl.ownerDocument,
     escapeDeactivates: false,
     fallbackFocus: focusTrapEl,


### PR DESCRIPTION
**Related Issue:** #6281 #6454

## Summary

Reverts 764609de7b8c96aa331e364ca790eefdb44dd1ab and df144dc30e66d7e11fda326f289c6b8c931c34f8 to give us more time to look into other scenarios where focus is being blocked after updating focus-trap configuration.
