### PR TITLE
chore(linting): block commits if there are unused imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,7 @@
       }
     ],
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "curly": "error",
     "jest/expect-expect": "off",
     "jest/no-export": "warn",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Change `@typescript-eslint/no-unused-vars` rule severity to `error` to prevent unused imports from being committed.
