### PR TITLE
chore(deps): bump stylelint-use-logical-spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "storybook-rtl-addon": "0.3.3",
         "stylelint": "14.16.0",
         "stylelint-config-recommended-scss": "8.0.0",
-        "stylelint-use-logical-spec": "4.1.0",
+        "stylelint-use-logical-spec": "5.0.0",
         "tailwindcss": "3.2.4",
         "ts-jest": "27.1.5",
         "ts-node": "10.9.1",
@@ -29331,9 +29331,9 @@
       }
     },
     "node_modules/stylelint-use-logical-spec": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-4.1.0.tgz",
-      "integrity": "sha512-uZ5mOST2gZ2QDUhX5JwXMojSibWrHw774wUvLr+OcGluXeh8WYp8AzS0d2ilqrX6Ao2xGCARUAA3pEO7y4kDgg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-5.0.0.tgz",
+      "integrity": "sha512-uLF876lrsGVWFPQ8haGhfDfsTyAzPoJq2AAExuSzE2V1uC8uCmuy6S66NseiEwcf0AGqWzS56kPVzF/hVvWIjA==",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
@@ -55418,9 +55418,9 @@
       }
     },
     "stylelint-use-logical-spec": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-4.1.0.tgz",
-      "integrity": "sha512-uZ5mOST2gZ2QDUhX5JwXMojSibWrHw774wUvLr+OcGluXeh8WYp8AzS0d2ilqrX6Ao2xGCARUAA3pEO7y4kDgg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-5.0.0.tgz",
+      "integrity": "sha512-uLF876lrsGVWFPQ8haGhfDfsTyAzPoJq2AAExuSzE2V1uC8uCmuy6S66NseiEwcf0AGqWzS56kPVzF/hVvWIjA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "storybook-rtl-addon": "0.3.3",
     "stylelint": "14.16.0",
     "stylelint-config-recommended-scss": "8.0.0",
-    "stylelint-use-logical-spec": "4.1.0",
+    "stylelint-use-logical-spec": "5.0.0",
     "tailwindcss": "3.2.4",
     "ts-jest": "27.1.5",
     "ts-node": "10.9.1",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

The latest version fixes the following [bug](https://github.com/Jordan-Hall/stylelint-use-logical-spec/issues/28):

```scss
padding: var(--calcite-modal-content-padding, var(--calcite-modal-padding-internal));
```

_⬇️ after autofix_

```scss
// invalid syntax
padding-block: var(--calcite-modal-content-padding, ; padding-inline: var(--calcite-modal-padding-internal)); 
```