### PR TITLE
ci: add user-defined priority

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -65,6 +65,19 @@ body:
       description: Please provide the last working version if the issue is a regression.
     validations:
       required: false
+  - type: dropdown
+    id: priority-impact
+    validations:
+      required: true
+    attributes:
+      label: Priority impact
+      multiple: false
+      description: What is the impact to you, your team, or organization? Use discretion and only select "need" or "emergency" priorities for high user impact and quality issues. For instance, would someone notice, in a bad way, if this issue were present in the release?
+      options:
+        - p3 - not time sensitive
+        - p2 - want for current milestone
+        - p1 - need for current milestone
+        - p0 - emergency
   - type: textarea
     id: impact
     attributes:

--- a/.github/workflows/add-bug-priority-label.yml
+++ b/.github/workflows/add-bug-priority-label.yml
@@ -46,7 +46,7 @@ jobs:
                   repo,
                   name: bugPriority,
                 });
-              } catch (e) {
+              } catch (error) {
                 await github.rest.issues.createLabel({
                   owner,
                   repo,

--- a/.github/workflows/add-bug-priority-label.yml
+++ b/.github/workflows/add-bug-priority-label.yml
@@ -1,0 +1,66 @@
+name: Add Bug Priority Label
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const {
+              repo: { owner, repo },
+              payload: {
+                action,
+                issue: { body, labels: currentLabels, number: issue_number },
+              },
+            } = context;
+
+            if (!body) {
+              console.log("could not determine the issue body");
+              return;
+            }
+
+            const bugPriorityRegex = new RegExp(
+              action === "edited"
+                ? // the way GitHub parses the issue body into plaintext
+                  // requires this exact format for edits
+                  "(?<=### Priority impact\r\n\r\n).+"
+                : // otherwise it depends on the submitter's OS
+                  "(?<=### Priority impact[\r\n|\r|\n]{2}).+$",
+              "m"
+            );
+
+            const bugPriorityRegexMatch = body.match(bugPriorityRegex);
+
+            const bugPriority = (
+              bugPriorityRegexMatch && bugPriorityRegexMatch[0] ? bugPriorityRegexMatch[0] : ""
+            ).trim();
+
+            if (bugPriority && bugPriority !== "N/A") {
+              /** Creates a label if it does not exist */
+              try {
+                await github.rest.issues.getLabel({
+                  owner,
+                  repo,
+                  name: bugPriority,
+                });
+              } catch (e) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: bugPriority,
+                  color: "bb7fe0",
+                  description: `User set priority status of ${bugPriority}`,
+                });
+              }
+
+              /** add new bug priority label */
+              await github.rest.issues.addLabels({
+                issue_number,
+                owner,
+                repo,
+                labels: [bugPriority],
+              });
+            }


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
1. Adds a dropdown to the bug issue template so users can select a priority impact from a dropdown menu, which includes:
        - `p3 - not time sensitive`
        - `p2 - want for current milestone`
        - `p1 - need for current milestone`
        - `p0 - emergency`

2. Adds an action that automatically adds a label (and will create a label if its not yet created) similar to the `add-esri-product-label.yml`

cc @brittneytewks 