### PR TITLE
fix(tree): restore wrapping in tree-item text content

### DIFF
--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -166,7 +166,7 @@ slot[name="actions-end"]::slotted(*) {
 }
 
 .node-container {
-  @apply relative flex items-center;
+  @apply relative flex items-center min-w-0;
   padding-block: var(--calcite-tree-padding-y);
   padding-inline: 0;
 

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -212,6 +212,14 @@ export const iconStartAndActionsEnd = (): string => html`
   </div>
 `;
 
+export const treeItemTextContentWraps_TestOnly = (): string => html`
+  <calcite-tree style="width: 300px">
+    <calcite-tree-item>
+      <span>Possibly_long_tree_item_name_because_it_is_a_user_generated_layer_name</span>
+    </calcite-tree-item>
+  </calcite-tree>
+`;
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-tree
     class="calcite-mode-dark"


### PR DESCRIPTION
**Related Issue:** #6512 

## Summary

Updates styles to restore text wrapping. Thanks @nwhittaker for the fix suggestion!