### PR TITLE
fix(tree): prevent tree-item content from being clipped

### DIFF
--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -58,7 +58,7 @@
   @apply text-0h;
 
   .node-actions-container {
-    @apply min-h-[3rem];
+    @apply min-h-[2.75rem];
     .node-container {
       .checkbox,
       .chevron,

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -24,7 +24,6 @@
   .node-actions-container {
     @apply min-h-[1.5rem];
     .node-container {
-      --calcite-tree-padding-y: theme("padding.1");
       .checkbox,
       .chevron,
       .checkmark,
@@ -47,7 +46,6 @@
   .node-actions-container {
     @apply min-h-[2rem];
     .node-container {
-      --calcite-tree-padding-y: theme("padding.2");
       .checkbox,
       .chevron,
       .checkmark,
@@ -70,7 +68,6 @@
   .node-actions-container {
     @apply min-h-[3rem];
     .node-container {
-      --calcite-tree-padding-y: theme("padding.3");
       .checkbox,
       .chevron,
       .checkmark,
@@ -167,8 +164,6 @@ slot[name="actions-end"]::slotted(*) {
 
 .node-container {
   @apply relative flex items-center;
-  padding-block: var(--calcite-tree-padding-y);
-  padding-inline: 0;
 
   .checkmark,
   .bullet-point {

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -22,6 +22,7 @@
   @apply text-n2h;
 
   .node-actions-container {
+    @apply min-h-[1.5rem];
     .node-container {
       --calcite-tree-padding-y: theme("padding.1");
       .checkbox,
@@ -44,6 +45,7 @@
   @apply text-n1h;
 
   .node-actions-container {
+    @apply min-h-[2rem];
     .node-container {
       --calcite-tree-padding-y: theme("padding.2");
       .checkbox,
@@ -66,6 +68,7 @@
   @apply text-0h;
 
   .node-actions-container {
+    @apply min-h-[3rem];
     .node-container {
       --calcite-tree-padding-y: theme("padding.3");
       .checkbox,

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -32,9 +32,6 @@
         margin-inline: theme("margin.3");
       }
     }
-    .actions-end {
-      @apply h-6 inline-flex;
-    }
   }
 }
 
@@ -54,9 +51,6 @@
         margin-inline: theme("margin.3");
       }
     }
-    .actions-end {
-      @apply h-8 inline-flex;
-    }
   }
 }
 
@@ -75,9 +69,6 @@
       .icon-start {
         margin-inline: theme("margin.3");
       }
-    }
-    .actions-end {
-      @apply h-12 inline-flex;
     }
   }
 }
@@ -128,14 +119,8 @@
   @apply focus-inset outline-none;
 }
 
-slot[name="actions-end"]::slotted(*) {
-  @apply flex self-stretch flex-row items-center overflow-visible;
-}
-
 .actions-end {
-  // Revisit: We don't normally clip actions to accommodate component heights, it’s inconsistent with how we normally handle slots.
-  // This also results in clipping the top/bottom of the blue focus outline.
-  @apply overflow-hidden;
+  @apply flex self-stretch flex-row items-center;
 }
 
 .checkbox {

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -22,7 +22,6 @@
   @apply text-n2h;
 
   .node-actions-container {
-    @apply h-6;
     .node-container {
       --calcite-tree-padding-y: theme("padding.1");
       .checkbox,
@@ -36,7 +35,7 @@
       }
     }
     .actions-end {
-      @apply inline-flex;
+      @apply h-6 inline-flex;
     }
   }
 }
@@ -45,7 +44,6 @@
   @apply text-n1h;
 
   .node-actions-container {
-    @apply h-8;
     .node-container {
       --calcite-tree-padding-y: theme("padding.2");
       .checkbox,
@@ -59,7 +57,7 @@
       }
     }
     .actions-end {
-      @apply inline-flex;
+      @apply h-8 inline-flex;
     }
   }
 }
@@ -68,7 +66,6 @@
   @apply text-0h;
 
   .node-actions-container {
-    @apply h-12;
     .node-container {
       --calcite-tree-padding-y: theme("padding.3");
       .checkbox,
@@ -82,7 +79,7 @@
       }
     }
     .actions-end {
-      @apply inline-flex;
+      @apply h-12 inline-flex;
     }
   }
 }

--- a/src/components/tree-item/tree-item.scss
+++ b/src/components/tree-item/tree-item.scss
@@ -9,10 +9,8 @@
   @apply hidden;
 }
 
-// Revisit: We don't normally clip actions to accommodate component heights, it’s inconsistent with how we normally handle slots.
-// This also results in clipping the top/bottom of the blue focus outline.
 .node-actions-container {
-  @apply overflow-hidden flex justify-between;
+  @apply flex justify-between;
 }
 
 @include calciteHydratedHidden();
@@ -132,6 +130,12 @@
 
 slot[name="actions-end"]::slotted(*) {
   @apply flex self-stretch flex-row items-center overflow-visible;
+}
+
+.actions-end {
+  // Revisit: We don't normally clip actions to accommodate component heights, it’s inconsistent with how we normally handle slots.
+  // This also results in clipping the top/bottom of the blue focus outline.
+  @apply overflow-hidden;
 }
 
 .checkbox {

--- a/src/components/tree/tree.stories.ts
+++ b/src/components/tree/tree.stories.ts
@@ -212,6 +212,38 @@ export const iconStartAndActionsEnd = (): string => html`
   </div>
 `;
 
+export const treeItemContentIsNotClipped_TestOnly = (): string => html`
+  <style>
+    .string-value {
+      white-space: pre-wrap;
+    }
+  </style>
+  <calcite-tree>
+    <calcite-tree-item>
+      <div>
+        <span>content from tree item below should not be clipped 👇</span><span>:&nbsp;</span
+        ><span class="string-value">✂️ 🚫clipped ✂️</span>
+      </div>
+    </calcite-tree-item>
+
+    <calcite-tree-item>
+      <div>
+        <span>value</span><span>:&nbsp;</span
+        ><!-- formatting (single-lining JSON) hides the issue, so we disable it -->
+        <!-- prettier-ignore -->
+        <span class="string-value">{
+          "spatialReference": {
+            "latestWkid": 3857,
+            "wkid": 102100
+          },
+          "x": -8443894.052,
+          "y": 5664504.875700004
+        }</span>
+      </div>
+    </calcite-tree-item>
+  </calcite-tree>
+`;
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-tree
     class="calcite-mode-dark"


### PR DESCRIPTION
**Related Issue:** #6514 

## Summary

This drops any clipping and also ensures the min-height of tree-items adheres to the design spec while still allowing items to grow if needed to accommodate their content.

cc @SkyeSeitz @ashetland 