### PR TITLE
refactor: move ref prop last to ensure ref node is in sync

### DIFF
--- a/conventions/README.md
+++ b/conventions/README.md
@@ -153,6 +153,20 @@ It is recommended to reflect properties that fit the following criteria:
 
 Doing so will give developers more flexibility when querying the DOM. This is important in framework environments where we can't safely assume components will have their attributes set vs properties.
 
+### `ref` usage
+
+Due to a [bug in Stencil](https://github.com/ionic-team/stencil/issues/4074), `ref` should be set as the last property in JSX to ensure the node's attributes/properties are up to date.
+
+```jsx
+<div
+  class={CSS.foo}
+  // ...
+  tabIndex={0}
+  // eslint-disable-next-line react/jsx-sort-props
+  ref={this.storeSomeElementRef}
+/>
+```
+
 ## Focus support
 
 Components with focusable content, must implement the following pattern:

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -330,10 +330,11 @@ export class ActionBar
         intlCollapse={messages.collapse}
         intlExpand={messages.expand}
         position={position}
-        ref={this.setExpandToggleRef}
         scale={scale}
         toggle={toggleExpand}
         tooltip={tooltip}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setExpandToggleRef}
       />
     ) : null;
 

--- a/src/components/action-menu/action-menu.tsx
+++ b/src/components/action-menu/action-menu.tsx
@@ -270,10 +270,11 @@ export class ActionMenu implements LoadableComponent {
         <calcite-action
           class={CSS.defaultTrigger}
           icon={ICONS.menu}
-          ref={this.setDefaultMenuButtonEl}
           scale={scale}
           text={label}
           textEnabled={expanded}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.setDefaultMenuButtonEl}
         />
       </slot>
     );

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -223,10 +223,11 @@ export class ActionPad
         intlCollapse={messages.collapse}
         intlExpand={messages.expand}
         position={position}
-        ref={this.setExpandToggleRef}
         scale={scale}
         toggle={toggleExpand}
         tooltip={tooltip}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setExpandToggleRef}
       />
     ) : null;
 

--- a/src/components/action/action.tsx
+++ b/src/components/action/action.tsx
@@ -302,6 +302,7 @@ export class Action
           class={buttonClasses}
           disabled={disabled}
           id={buttonId}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={(buttonEl): HTMLButtonElement => (this.buttonEl = buttonEl)}
         >
           {this.renderIconContainer()}

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -216,8 +216,9 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
         aria-label={this.messages.close}
         class="alert-close"
         onClick={this.closeAlert}
-        ref={(el) => (this.closeButton = el)}
         type="button"
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.closeButton = el)}
       >
         <calcite-icon icon="x" scale={this.scale === "l" ? "m" : "s"} />
       </button>
@@ -268,6 +269,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
           }}
           onPointerEnter={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseOver : null}
           onPointerLeave={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseLeave : null}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.setTransitionEl}
         >
           {requestedIcon ? (

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -252,11 +252,12 @@ export class Button
         href={childElType === "a" && this.href}
         name={childElType === "button" && this.name}
         onClick={this.handleClick}
-        ref={(el) => (this.childEl = el)}
         rel={childElType === "a" && this.rel}
         tabIndex={this.disabled || this.loading ? -1 : null}
         target={childElType === "a" && this.target}
         type={childElType === "button" && this.type}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.childEl = el)}
       >
         {loaderNode}
         {this.iconStart ? iconStartEl : null}

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -250,9 +250,10 @@ export class Checkbox
           class="toggle"
           onBlur={this.onToggleBlur}
           onFocus={this.onToggleFocus}
-          ref={(toggleEl) => (this.toggleEl = toggleEl)}
           role="checkbox"
           tabIndex={this.disabled ? undefined : 0}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={(toggleEl) => (this.toggleEl = toggleEl)}
         >
           <svg aria-hidden="true" class="check-svg" viewBox="0 0 16 16">
             <path d={this.getPath()} />

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -246,6 +246,7 @@ export class Chip
         aria-label={this.messages.dismissLabel}
         class={CSS.close}
         onClick={this.closeClickHandler}
+        // eslint-disable-next-line react/jsx-sort-props
         ref={(el) => (this.closeButton = el)}
       >
         <calcite-icon

--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -227,9 +227,10 @@ export class ColorPickerHexInput implements LoadableComponent {
           onKeyDown={this.handleKeyDown}
           onPaste={this.onPaste}
           prefixText="#"
-          ref={this.storeInputRef}
           scale={this.scale}
           value={hexInputValue}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.storeInputRef}
         />
         {hexInputValue ? (
           <calcite-color-picker-swatch

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -739,6 +739,7 @@ export class ColorPicker
             onPointerEnter={this.handleColorFieldAndSliderPointerEnterOrMove}
             onPointerLeave={this.handleColorFieldAndSliderPointerLeave}
             onPointerMove={this.handleColorFieldAndSliderPointerEnterOrMove}
+            // eslint-disable-next-line react/jsx-sort-props
             ref={this.initColorFieldAndSlider}
           />
           <div
@@ -748,10 +749,11 @@ export class ColorPicker
             aria-valuenow={(vertical ? color?.saturationv() : color?.value()) || "0"}
             class={{ [CSS.scope]: true, [CSS.colorFieldScope]: true }}
             onKeyDown={this.handleColorFieldScopeKeyDown}
-            ref={this.storeColorFieldScope}
             role="slider"
             style={{ top: `${colorFieldScopeTop || 0}px`, left: `${colorFieldScopeLeft || 0}px` }}
             tabindex="0"
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.storeColorFieldScope}
           />
           <div
             aria-label={messages.hue}
@@ -760,10 +762,11 @@ export class ColorPicker
             aria-valuenow={color?.round().hue() || DEFAULT_COLOR.round().hue()}
             class={{ [CSS.scope]: true, [CSS.hueScope]: true }}
             onKeyDown={this.handleHueScopeKeyDown}
-            ref={this.storeHueScope}
             role="slider"
             style={{ top: `${hueTop}px`, left: `${hueLeft}px` }}
             tabindex="0"
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.storeHueScope}
           />
         </div>
         {hideHex && hideChannels ? null : (

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -1142,8 +1142,9 @@ export class Combobox
           onFocus={this.comboboxFocusHandler}
           onInput={this.inputHandler}
           placeholder={placeholder}
-          ref={(el) => (this.textInput = el as HTMLInputElement)}
           type="text"
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={(el) => (this.textInput = el as HTMLInputElement)}
         />
       </span>
     );
@@ -1177,9 +1178,14 @@ export class Combobox
           "floating-ui-container": true,
           "floating-ui-container--active": open
         }}
+        // eslint-disable-next-line react/jsx-sort-props
         ref={setFloatingEl}
       >
-        <div class={classes} ref={setContainerEl}>
+        <div
+          class={classes}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={setContainerEl}
+        >
           <ul class={{ list: true, "list--hide": !open }}>
             <slot />
           </ul>
@@ -1243,8 +1249,9 @@ export class Combobox
           }}
           onClick={this.clickHandler}
           onKeyDown={this.keydownHandler}
-          ref={this.setReferenceEl}
           role="combobox"
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.setReferenceEl}
         >
           <div class="grid-input">
             {this.renderIconStart()}

--- a/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -163,9 +163,10 @@ export class DatePickerMonthHeader {
               onInput={this.onYearInput}
               onKeyDown={this.onYearKey}
               pattern="\d*"
-              ref={(el) => (this.yearInput = el)}
               type="text"
               value={localizedYear}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={(el) => (this.yearInput = el)}
             />
             {suffix && <span class={CSS.suffix}>{suffix}</span>}
           </span>

--- a/src/components/date-picker-month/date-picker-month.tsx
+++ b/src/components/date-picker-month/date-picker-month.tsx
@@ -436,16 +436,17 @@ export class DatePickerMonth {
         onCalciteInternalDayHover={this.dayHover}
         range={!!this.startDate && !!this.endDate && !sameDate(this.startDate, this.endDate)}
         rangeHover={this.isRangeHover(date)}
+        scale={this.scale}
+        selected={this.isSelected(date)}
+        startOfRange={this.isStartOfRange(date)}
+        value={date}
+        // eslint-disable-next-line react/jsx-sort-props
         ref={(el: HTMLCalciteDatePickerDayElement) => {
           // when moving via keyboard, focus must be updated on active date
           if (ref && active && this.activeFocus) {
             el?.focus();
           }
         }}
-        scale={this.scale}
-        selected={this.isSelected(date)}
-        startOfRange={this.isStartOfRange(date)}
-        value={date}
       />
     );
   }

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -166,10 +166,11 @@ export class DropdownItem implements LoadableComponent {
         aria-label={this.label}
         class={CSS.link}
         href={this.href}
-        ref={(el) => (this.childLink = el)}
         rel={this.rel}
         tabIndex={-1}
         target={this.target}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.childLink = el)}
       >
         {slottedContent}
       </a>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -225,6 +225,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
           id={`${guid}-menubutton`}
           onClick={this.openCalciteDropdown}
           onKeyDown={this.keyDownHandler}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.setReferenceEl}
         >
           <slot
@@ -238,6 +239,7 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
         <div
           aria-hidden={toAriaBoolean(!open)}
           class="calcite-dropdown-wrapper"
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.setFloatingEl}
         >
           <div
@@ -248,8 +250,9 @@ export class Dropdown implements InteractiveComponent, OpenCloseComponent, Float
               [FloatingCSS.animationActive]: open
             }}
             id={`${guid}-menu`}
-            ref={this.setScrollerAndTransitionEl}
             role="menu"
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.setScrollerAndTransitionEl}
           >
             <slot onSlotchange={this.updateGroups} />
           </div>

--- a/src/components/fab/fab.tsx
+++ b/src/components/fab/fab.tsx
@@ -147,14 +147,15 @@ export class Fab implements InteractiveComponent, LoadableComponent {
         kind={kind}
         label={label}
         loading={loading}
-        ref={(buttonEl): void => {
-          this.buttonEl = buttonEl;
-        }}
         round={true}
         scale={scale}
         title={title}
         type="button"
         width="auto"
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(buttonEl): void => {
+          this.buttonEl = buttonEl;
+        }}
       >
         {this.textEnabled ? this.text : null}
       </calcite-button>

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -252,12 +252,13 @@ export class Filter
               onCalciteInputInput={this.inputHandler}
               onKeyDown={this.keyDownHandler}
               placeholder={this.placeholder}
-              ref={(el): void => {
-                this.textInput = el;
-              }}
               scale={scale}
               type="text"
               value={this.value}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={(el): void => {
+                this.textInput = el;
+              }}
             />
           </label>
         </div>

--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -280,10 +280,11 @@ export class FlowItem
         icon={icon}
         key="flow-back-button"
         onClick={backButtonClick}
-        ref={this.setBackRef}
         scale="s"
         slot="header-actions-start"
         text={label}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setBackRef}
       />
     ) : null;
   }
@@ -316,6 +317,7 @@ export class FlowItem
           messageOverrides={messages}
           onCalcitePanelClose={this.handlePanelClose}
           onCalcitePanelScroll={this.handlePanelScroll}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.setContainerRef}
         >
           {this.renderBackButton()}

--- a/src/components/functional/ExpandToggle.tsx
+++ b/src/components/functional/ExpandToggle.tsx
@@ -92,12 +92,13 @@ export const ExpandToggle: FunctionalComponent<ExpandToggleProps> = ({
     <calcite-action
       icon={expanded ? expandIcon : collapseIcon}
       onClick={toggle}
-      ref={(referenceElement): HTMLCalciteActionElement =>
-        setTooltipReference({ tooltip, referenceElement, expanded, ref })
-      }
       scale={scale}
       text={expandText}
       textEnabled={expanded}
+      // eslint-disable-next-line react/jsx-sort-props
+      ref={(referenceElement): HTMLCalciteActionElement =>
+        setTooltipReference({ tooltip, referenceElement, expanded, ref })
+      }
     />
   );
 

--- a/src/components/handle/handle.tsx
+++ b/src/components/handle/handle.tsx
@@ -127,12 +127,13 @@ export class Handle implements LoadableComponent {
         class={{ [CSS.handle]: true, [CSS.handleActivated]: this.activated }}
         onBlur={this.handleBlur}
         onKeyDown={this.handleKeyDown}
-        ref={(el): void => {
-          this.handleButton = el;
-        }}
         role="button"
         tabindex="0"
         title={this.textTitle}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el): void => {
+          this.handleButton = el;
+        }}
       >
         <calcite-icon icon={ICONS.drag} scale="s" />
       </span>

--- a/src/components/inline-editable/inline-editable.tsx
+++ b/src/components/inline-editable/inline-editable.tsx
@@ -175,13 +175,14 @@ export class InlineEditable
             kind="neutral"
             label={this.messages.enableEditing}
             onClick={this.enableEditingHandler}
-            ref={(el) => (this.enableEditingButton = el)}
             scale={this.scale}
             style={{
               opacity: this.editingEnabled ? "0" : "1",
               width: this.editingEnabled ? "0" : "inherit"
             }}
             type="button"
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={(el) => (this.enableEditingButton = el)}
           />
           {this.shouldShowControls && [
             <div class={CSS.cancelEditingButtonWrapper}>
@@ -193,9 +194,10 @@ export class InlineEditable
                 kind="neutral"
                 label={this.messages.cancelEditing}
                 onClick={this.cancelEditingHandler}
-                ref={(el) => (this.cancelEditingButton = el)}
                 scale={this.scale}
                 type="button"
+                // eslint-disable-next-line react/jsx-sort-props
+                ref={(el) => (this.cancelEditingButton = el)}
               />
             </div>,
             <calcite-button
@@ -207,9 +209,10 @@ export class InlineEditable
               label={this.messages.confirmChanges}
               loading={this.loading}
               onClick={this.confirmChangesHandler}
-              ref={(el) => (this.confirmEditingButton = el)}
               scale={this.scale}
               type="button"
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={(el) => (this.confirmEditingButton = el)}
             />
           ]}
         </div>

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -465,7 +465,11 @@ export class InputDatePicker
         {this.localeData && (
           <div aria-expanded={toAriaBoolean(this.open)} class="input-container" role="application">
             {
-              <div class="input-wrapper" ref={this.setStartWrapper}>
+              <div
+                class="input-wrapper"
+                // eslint-disable-next-line react/jsx-sort-props
+                ref={this.setStartWrapper}
+              >
                 <calcite-input
                   class={`input ${
                     this.layout === "vertical" && this.range ? `no-bottom-border` : ``
@@ -480,9 +484,10 @@ export class InputDatePicker
                   onCalciteInternalInputFocus={this.startInputFocus}
                   placeholder={this.localeData?.placeholder}
                   readOnly={readOnly}
-                  ref={this.setStartInput}
                   scale={this.scale}
                   type="text"
+                  // eslint-disable-next-line react/jsx-sort-props
+                  ref={this.setStartInput}
                 />
               </div>
             }
@@ -492,6 +497,7 @@ export class InputDatePicker
                 [CSS.menu]: true,
                 [CSS.menuActive]: this.open
               }}
+              // eslint-disable-next-line react/jsx-sort-props
               ref={this.setFloatingEl}
             >
               <div
@@ -501,6 +507,7 @@ export class InputDatePicker
                   [FloatingCSS.animation]: true,
                   [FloatingCSS.animationActive]: this.open
                 }}
+                // eslint-disable-next-line react/jsx-sort-props
                 ref={this.setTransitionEl}
               >
                 <calcite-date-picker
@@ -539,7 +546,11 @@ export class InputDatePicker
               </div>
             )}
             {this.range && (
-              <div class="input-wrapper" ref={this.setEndWrapper}>
+              <div
+                class="input-wrapper"
+                // eslint-disable-next-line react/jsx-sort-props
+                ref={this.setEndWrapper}
+              >
                 <calcite-input
                   class={{
                     input: true,
@@ -554,9 +565,10 @@ export class InputDatePicker
                   onCalciteInternalInputFocus={this.endInputFocus}
                   placeholder={this.localeData?.placeholder}
                   readOnly={readOnly}
-                  ref={this.setEndInput}
                   scale={this.scale}
                   type="text"
+                  // eslint-disable-next-line react/jsx-sort-props
+                  ref={this.setEndInput}
                 />
               </div>
             )}

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -967,9 +967,10 @@ export class InputNumber
         onKeyUp={this.inputNumberKeyUpHandler}
         placeholder={this.placeholder || ""}
         readOnly={this.readOnly}
-        ref={this.setChildNumberElRef}
         type="text"
         value={this.localizedValue}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setChildNumberElRef}
       />
     );
 

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -635,11 +635,12 @@ export class InputText
         pattern={this.pattern}
         placeholder={this.placeholder || ""}
         readOnly={this.readOnly}
-        ref={this.setChildElRef}
         required={this.required ? true : null}
         tabIndex={this.disabled || (this.inlineEditableEl && !this.editingEnabled) ? -1 : null}
         type="text"
         value={this.value}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setChildElRef}
       />
     );
 

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -502,9 +502,10 @@ export class InputTimePicker
             onCalciteInternalInputBlur={this.calciteInternalInputBlurHandler}
             onCalciteInternalInputFocus={this.calciteInternalInputFocusHandler}
             readOnly={this.readOnly}
-            ref={this.setCalciteInputEl}
             scale={this.scale}
             step={this.step}
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.setCalciteInputEl}
           />
         </div>
         <calcite-popover
@@ -514,19 +515,21 @@ export class InputTimePicker
           open={this.open}
           overlayPositioning={this.overlayPositioning}
           placement={this.placement}
-          ref={this.setCalcitePopoverEl}
           referenceElement={this.referenceElementId}
           triggerDisabled={true}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.setCalcitePopoverEl}
         >
           <calcite-time-picker
             lang={this.effectiveLocale}
             messageOverrides={this.messagesOverrides}
             numberingSystem={this.numberingSystem}
             onCalciteInternalTimePickerChange={this.timePickerChangeHandler}
-            ref={this.setCalciteTimePickerEl}
             scale={this.scale}
             step={this.step}
             value={this.value}
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.setCalciteTimePickerEl}
           />
         </calcite-popover>
         <HiddenFormInputSlot component={this} />

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1100,9 +1100,10 @@ export class Input
           pattern={this.pattern}
           placeholder={this.placeholder || ""}
           readOnly={this.readOnly}
-          ref={this.setChildNumberElRef}
           type="text"
           value={this.localizedValue}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.setChildNumberElRef}
         />
       ) : null;
 
@@ -1136,7 +1137,6 @@ export class Input
               pattern={this.pattern}
               placeholder={this.placeholder || ""}
               readOnly={this.readOnly}
-              ref={this.setChildElRef}
               required={this.required ? true : null}
               step={this.step}
               tabIndex={
@@ -1144,6 +1144,8 @@ export class Input
               }
               type={this.type}
               value={this.value}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={this.setChildElRef}
             />,
             this.isTextarea ? (
               <div class={CSS.resizeIconWrapper}>

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -118,11 +118,12 @@ export class Link implements InteractiveComponent, LoadableComponent {
           download={Tag === "a" && (download === "" || download) ? download : null}
           href={Tag === "a" && this.href}
           onClick={this.childElClickHandler}
-          ref={this.storeTagRef}
           rel={Tag === "a" && this.rel}
           role={role}
           tabIndex={tabIndex}
           target={Tag === "a" && this.target}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.storeTagRef}
         >
           {this.iconStart ? iconStartEl : null}
           <slot />

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -298,8 +298,9 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
         class={CSS.actionsStart}
         hidden={!hasActionsStart}
         key="actions-start-container"
-        ref={(el) => (this.actionsStartEl = el)}
         role="gridcell"
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.actionsStartEl = el)}
       >
         <slot name={SLOTS.actionsStart} onSlotchange={this.handleActionsStartSlotChange} />
       </td>
@@ -314,8 +315,9 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
         class={CSS.actionsEnd}
         hidden={!hasActionsEnd}
         key="actions-end-container"
-        ref={(el) => (this.actionsEndEl = el)}
         role="gridcell"
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.actionsEndEl = el)}
       >
         <slot name={SLOTS.actionsEnd} onSlotchange={this.handleActionsEndSlotChange} />
       </td>
@@ -388,8 +390,9 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
         }}
         key="content-container"
         onClick={this.itemClicked}
-        ref={(el) => (this.contentEl = el)}
         role="gridcell"
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.contentEl = el)}
       >
         {content}
       </td>
@@ -430,10 +433,11 @@ export class ListItem implements InteractiveComponent, LoadableComponent {
           }}
           onFocus={this.focusCellNull}
           onKeyDown={this.handleItemKeyDown}
-          ref={(el) => (this.containerEl = el)}
           role="row"
           style={{ "--calcite-list-item-spacing-indent-multiplier": `${this.visualLevel}` }}
           tabIndex={active ? 0 : -1}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={(el) => (this.containerEl = el)}
         >
           {this.renderSelected()}
           {this.renderOpen()}

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -278,8 +278,9 @@ export class List implements InteractiveComponent, LoadableComponent {
                     items={dataForFilter}
                     onCalciteFilterChange={this.handleFilter}
                     placeholder={filterPlaceholder}
-                    ref={(el) => (this.filterEl = el)}
                     value={filterText}
+                    // eslint-disable-next-line react/jsx-sort-props
+                    ref={(el) => (this.filterEl = el)}
                   />
                 </th>
               </tr>

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -215,6 +215,7 @@ export class Modal
               [CSS.modal]: true,
               [CSS.modalOpen]: this.isOpen
             }}
+            // eslint-disable-next-line react/jsx-sort-props
             ref={this.setTransitionEl}
           >
             <div class={CSS.header}>
@@ -228,6 +229,7 @@ export class Modal
                 [CSS.content]: true,
                 [CSS.contentNoFooter]: !this.hasFooter
               }}
+              // eslint-disable-next-line react/jsx-sort-props
               ref={(el) => (this.modalContent = el)}
             >
               <slot name={SLOTS.content} />
@@ -262,8 +264,9 @@ export class Modal
         class={CSS.close}
         key="button"
         onClick={this.close}
-        ref={(el) => (this.closeButtonEl = el)}
         title={this.messages.close}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.closeButtonEl = el)}
       >
         <calcite-icon
           icon={ICONS.close}

--- a/src/components/notice/notice.tsx
+++ b/src/components/notice/notice.tsx
@@ -156,6 +156,7 @@ export class Notice
         aria-label={this.messages.close}
         class={CSS.close}
         onClick={this.close}
+        // eslint-disable-next-line react/jsx-sort-props
         ref={(el) => (this.closeButton = el)}
       >
         <calcite-icon icon="x" scale={this.scale === "l" ? "m" : "s"} />

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -393,8 +393,9 @@ export class Panel
         aria-label={text}
         icon={ICONS.close}
         onClick={close}
-        ref={this.setCloseRef}
         text={text}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setCloseRef}
       />
     ) : null;
 
@@ -510,6 +511,7 @@ export class Panel
           [CSS.contentHeight]: hasFab
         }}
         onScroll={this.panelScrollHandler}
+        // eslint-disable-next-line react/jsx-sort-props
         ref={this.setPanelScrollEl}
       >
         {containerNode}
@@ -535,8 +537,9 @@ export class Panel
         class={CSS.container}
         hidden={closed}
         onKeyDown={panelKeyDownHandler}
-        ref={this.setContainerRef}
         tabIndex={closable ? 0 : -1}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.setContainerRef}
       >
         {this.renderHeaderNode()}
         {this.renderContent()}

--- a/src/components/pick-list-item/pick-list-item.tsx
+++ b/src/components/pick-list-item/pick-list-item.tsx
@@ -380,8 +380,9 @@ export class PickListItem
           class={CSS.label}
           onClick={this.pickListClickHandler}
           onKeyDown={this.pickListKeyDownHandler}
-          ref={(focusEl): HTMLLabelElement => (this.focusEl = focusEl)}
           tabIndex={0}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={(focusEl): HTMLLabelElement => (this.focusEl = focusEl)}
         >
           <div
             aria-checked={toAriaBoolean(this.selected)}

--- a/src/components/pick-list/shared-list-render.tsx
+++ b/src/components/pick-list/shared-list-render.tsx
@@ -43,7 +43,12 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes<any>
     <Host aria-busy={toAriaBoolean(loading)} role="menu" {...rest}>
       <section>
         {dragEnabled ? (
-          <span aria-live="assertive" class="assistive-text" ref={storeAssistiveEl} />
+          <span
+            aria-live="assertive"
+            class="assistive-text"
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={storeAssistiveEl}
+          />
         ) : null}
         <header class={{ [CSS.sticky]: true }}>
           {filterEnabled ? (
@@ -53,8 +58,9 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes<any>
               items={dataForFilter}
               onCalciteFilterChange={handleFilterEvent}
               placeholder={filterPlaceholder}
-              ref={setFilterEl}
               value={filterText}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={setFilterEl}
             />
           ) : null}
           <slot name={SLOTS.menuActions} />

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -534,9 +534,10 @@ export class Popover
         <calcite-action
           class={CSS.closeButton}
           onClick={this.hide}
-          ref={(closeButtonEl) => (this.closeButtonEl = closeButtonEl)}
           scale={this.scale}
           text={messages.close}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={(closeButtonEl) => (this.closeButtonEl = closeButtonEl)}
         >
           <calcite-icon icon="x" scale={this.scale === "l" ? "m" : this.scale} />
         </calcite-action>
@@ -564,7 +565,13 @@ export class Popover
     const { effectiveReferenceElement, heading, label, open, pointerDisabled } = this;
     const displayed = effectiveReferenceElement && open;
     const hidden = !displayed;
-    const arrowNode = !pointerDisabled ? <div class={CSS.arrow} ref={this.storeArrowEl} /> : null;
+    const arrowNode = !pointerDisabled ? (
+      <div
+        class={CSS.arrow}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.storeArrowEl}
+      />
+    ) : null;
 
     return (
       <Host
@@ -580,6 +587,7 @@ export class Popover
             [FloatingCSS.animation]: true,
             [FloatingCSS.animationActive]: displayed
           }}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.setTransitionEl}
         >
           {arrowNode}

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -443,9 +443,10 @@ export class RadioButton
           class={CSS.container}
           onBlur={this.onContainerBlur}
           onFocus={this.onContainerFocus}
-          ref={this.setContainerEl}
           role="radio"
           tabIndex={tabIndex}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.setContainerEl}
         >
           <div class="radio" />
         </div>

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -276,6 +276,9 @@ export class Rating
                       name={this.guid}
                       onChange={this.handleInputChange}
                       onKeyDown={this.handleInputKeyDown}
+                      type="radio"
+                      value={value}
+                      // eslint-disable-next-line react/jsx-sort-props
                       ref={(el) => {
                         this.inputRefs[idx] = el;
                         return (
@@ -283,8 +286,6 @@ export class Rating
                           (this.inputFocusRef = el as HTMLInputElement)
                         );
                       }}
-                      type="radio"
-                      value={value}
                     />
                     <StarIcon full={selected || average} scale={this.scale} />
                     {partial && (

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -367,6 +367,7 @@ export class Select
           class={CSS.select}
           disabled={this.disabled}
           onChange={this.handleInternalSelectChange}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.storeSelectRef}
         >
           <slot />

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -180,8 +180,9 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
         class={{ [CSS.content]: true, [CSS.contentDetached]: detached }}
         hidden={collapsed}
         key="content"
-        ref={this.storeContentEl}
         style={allowResizing && contentWidth ? { width: `${contentWidth}px` } : null}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.storeContentEl}
       >
         {this.renderHeader()}
         <div class={CSS.contentBody}>
@@ -200,10 +201,11 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
         class={CSS.separator}
         key="separator"
         onKeyDown={this.separatorKeyDown}
-        ref={this.connectSeparator}
         role="separator"
         tabIndex={0}
         touch-action="none"
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.connectSeparator}
       />
     ) : null;
 

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -275,10 +275,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <div class="handle" />
       </div>
@@ -300,10 +301,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <span aria-hidden="true" class={handleLabelValueClasses}>
           {displayedValue}
@@ -334,10 +336,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <div class="handle" />
         <span aria-hidden="true" class={handleLabelValueClasses}>
@@ -369,10 +372,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <div class="handle" />
         <div class="handle-extension" />
@@ -396,10 +400,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <div class="handle-extension" />
         <div class="handle" />
@@ -423,10 +428,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <span aria-hidden="true" class={handleLabelValueClasses}>
           {displayedValue}
@@ -459,10 +465,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = maxProp)}
         onPointerDown={(event) => this.pointerDownDragStart(event, maxProp)}
-        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
         role="slider"
         style={{ right: rightThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.maxHandle = el as HTMLDivElement)}
       >
         <div class="handle-extension" />
         <div class="handle" />
@@ -494,10 +501,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={(event) => this.pointerDownDragStart(event, "minValue")}
-        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
       >
         <div class="handle" />
       </div>
@@ -519,10 +527,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={(event) => this.pointerDownDragStart(event, "minValue")}
-        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
       >
         <span aria-hidden="true" class={handleLabelMinValueClasses}>
           {displayedMinValue}
@@ -553,10 +562,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={(event) => this.pointerDownDragStart(event, "minValue")}
-        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
       >
         <div class="handle" />
         <span aria-hidden="true" class={handleLabelMinValueClasses}>
@@ -588,10 +598,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={(event) => this.pointerDownDragStart(event, "minValue")}
-        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
       >
         <div class="handle-extension" />
         <div class="handle" />
@@ -615,10 +626,11 @@ export class Slider
         onBlur={() => (this.activeProp = null)}
         onFocus={() => (this.activeProp = "minValue")}
         onPointerDown={(event) => this.pointerDownDragStart(event, "minValue")}
-        ref={(el) => (this.minHandle = el as HTMLDivElement)}
         role="slider"
         style={{ left: leftThumbOffset }}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={(el) => (this.minHandle = el as HTMLDivElement)}
       >
         <div class="handle-extension" />
         <div class="handle" />
@@ -645,7 +657,11 @@ export class Slider
           }}
         >
           {this.renderGraph()}
-          <div class="track" ref={this.storeTrackRef}>
+          <div
+            class="track"
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.storeTrackRef}
+          >
             <div
               class="track__range"
               onPointerDown={(event) => this.pointerDownDragStart(event, "minMaxValue")}

--- a/src/components/stepper-item/stepper-item.tsx
+++ b/src/components/stepper-item/stepper-item.tsx
@@ -206,11 +206,12 @@ export class StepperItem implements InteractiveComponent, LocalizedComponent, Lo
         <div class="container">
           <div
             class="stepper-item-header"
-            ref={(el) => (this.headerEl = el)}
             tabIndex={
               /* additional tab index logic needed because of display: contents */
               this.layout === "horizontal" && !this.disabled ? 0 : null
             }
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={(el) => (this.headerEl = el)}
           >
             {this.icon ? this.renderIcon() : null}
             {this.numbered ? <div class="stepper-item-number">{this.renderNumbers()}.</div> : null}

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -190,9 +190,10 @@ export class Switch
           aria-checked={toAriaBoolean(this.checked)}
           aria-label={getLabelText(this)}
           class="container"
-          ref={this.setSwitchEl}
           role="switch"
           tabIndex={0}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.setSwitchEl}
         >
           <div class="track">
             <div class="handle" />

--- a/src/components/tab-nav/tab-nav.tsx
+++ b/src/components/tab-nav/tab-nav.tsx
@@ -178,16 +178,19 @@ export class TabNav {
         <div
           class="tab-nav"
           onScroll={this.handleContainerScroll}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={(el: HTMLDivElement) => (this.tabNavEl = el)}
         >
           <div
             class="tab-nav-active-indicator-container"
+            // eslint-disable-next-line react/jsx-sort-props
             ref={(el) => (this.activeIndicatorContainerEl = el)}
           >
             <div
               class="tab-nav-active-indicator"
-              ref={(el) => (this.activeIndicatorEl = el as HTMLElement)}
               style={indicatorStyle}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={(el) => (this.activeIndicatorEl = el as HTMLElement)}
             />
           </div>
           <slot />

--- a/src/components/tab-title/tab-title.tsx
+++ b/src/components/tab-title/tab-title.tsx
@@ -179,6 +179,7 @@ export class TabTitle implements InteractiveComponent {
             [CSS.iconPresent]: this.iconStart || this.iconEnd ? true : null,
             [CSS.containerHasText]: this.hasText
           }}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={(el) => this.resizeObserver?.observe(el)}
         >
           {this.iconStart ? iconStartEl : null}

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -781,9 +781,10 @@ export class TimePicker
             }}
             onFocus={this.focusHandler}
             onKeyDown={this.hourKeyDownHandler}
-            ref={this.setHourEl}
             role="spinbutton"
             tabIndex={0}
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.setHourEl}
           >
             {this.localizedHour || "--"}
           </span>
@@ -829,9 +830,10 @@ export class TimePicker
             }}
             onFocus={this.focusHandler}
             onKeyDown={this.minuteKeyDownHandler}
-            ref={this.setMinuteEl}
             role="spinbutton"
             tabIndex={0}
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={this.setMinuteEl}
           >
             {this.localizedMinute || "--"}
           </span>
@@ -877,9 +879,10 @@ export class TimePicker
               }}
               onFocus={this.focusHandler}
               onKeyDown={this.secondKeyDownHandler}
-              ref={this.setSecondEl}
               role="spinbutton"
               tabIndex={0}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={this.setSecondEl}
             >
               {this.localizedSecond || "--"}
             </span>
@@ -935,9 +938,10 @@ export class TimePicker
               }}
               onFocus={this.focusHandler}
               onKeyDown={this.meridiemKeyDownHandler}
-              ref={this.setMeridiemEl}
               role="spinbutton"
               tabIndex={0}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={this.setMeridiemEl}
             >
               {this.localizedMeridiem || "--"}
             </span>

--- a/src/components/tip-manager/tip-manager.tsx
+++ b/src/components/tip-manager/tip-manager.tsx
@@ -296,8 +296,9 @@ export class TipManager {
         class={CSS.container}
         hidden={closed}
         onKeyDown={this.tipManagerKeyDownHandler}
-        ref={this.storeContainerRef}
         tabIndex={0}
+        // eslint-disable-next-line react/jsx-sort-props
+        ref={this.storeContainerRef}
       >
         <header class={CSS.header}>
           <Heading class={CSS.heading} level={headingLevel}>

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -337,9 +337,14 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
             [FloatingCSS.animation]: true,
             [FloatingCSS.animationActive]: displayed
           }}
+          // eslint-disable-next-line react/jsx-sort-props
           ref={this.setTransitionEl}
         >
-          <div class={CSS.arrow} ref={(arrowEl) => (this.arrowEl = arrowEl)} />
+          <div
+            class={CSS.arrow}
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={(arrowEl) => (this.arrowEl = arrowEl)}
+          />
           <div class={CSS.container}>
             <slot />
           </div>

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -318,6 +318,7 @@ export class TreeItem
                 [CSS_UTILITY.rtl]: rtl
               }}
               data-selection-mode={this.selectionMode}
+              // eslint-disable-next-line react/jsx-sort-props
               ref={(el) => (this.defaultSlotWrapper = el as HTMLElement)}
             >
               {chevron}
@@ -337,8 +338,9 @@ export class TreeItem
             }}
             data-test-id="calcite-tree-children"
             onClick={this.childrenClickHandler}
-            ref={(el) => this.setTransitionEl(el)}
             role={this.hasChildren ? "group" : undefined}
+            // eslint-disable-next-line react/jsx-sort-props
+            ref={(el) => this.setTransitionEl(el)}
           >
             <slot name={SLOTS.children} />
           </div>

--- a/src/components/value-list-item/value-list-item.tsx
+++ b/src/components/value-list-item/value-list-item.tsx
@@ -268,10 +268,11 @@ export class ValueListItem
           metadata={this.metadata}
           nonInteractive={this.nonInteractive}
           onCalciteListItemChange={this.handleSelectChange}
-          ref={this.getPickListRef}
           removable={this.removable}
           selected={this.selected}
           value={this.value}
+          // eslint-disable-next-line react/jsx-sort-props
+          ref={this.getPickListRef}
         >
           {this.renderActionsStart()}
           {this.renderActionsEnd()}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This updates `ref` usage to work around a [Stencil bug](https://github.com/ionic-team/stencil/issues/4074) where the ref node can be out of sync.

**Note**: this also updates the conventions doc with this info.