### PR TITLE
fix(filter, list): filter properly on initialization

### DIFF
--- a/src/components/filter/filter.e2e.ts
+++ b/src/components/filter/filter.e2e.ts
@@ -173,24 +173,36 @@ describe("calcite-filter", () => {
       });
     });
 
-    it.skip("updates filtered items after filtering", async () => {
-      const filterChangeSpy = await page.spyOnEvent("calciteFilterChange");
-      const waitForEvent = page.waitForEvent("calciteFilterChange");
+    it("updates filtered items after filtering", async () => {
       const filter = await page.find("calcite-filter");
+      const filterChangeSpy = await page.spyOnEvent("calciteFilterChange");
+      await page.waitForTimeout(DEBOUNCE_TIMEOUT);
+      await page.waitForChanges();
+
+      expect(filterChangeSpy).toHaveReceivedEventTimes(0);
+      assertMatchingItems(await filter.getProperty("filteredItems"), [
+        "harry",
+        "matt",
+        "franco",
+        "katy",
+        "jon",
+        "regex"
+      ]);
+
+      const filterChangeEvent = page.waitForEvent("calciteFilterChange");
       await filter.callMethod("setFocus");
       await filter.type("developer");
-      await waitForEvent;
+      await filterChangeEvent;
 
       expect(filterChangeSpy).toHaveReceivedEventTimes(1);
-
       assertMatchingItems(await filter.getProperty("filteredItems"), ["harry", "matt", "franco", "jon"]);
 
-      await page.evaluate(() => {
-        const filter = document.querySelector("calcite-filter");
+      await page.$eval("calcite-filter", (filter: HTMLCalciteFilterElement): void => {
         filter.items = filter.items.slice(3);
       });
-
       await page.waitForTimeout(DEBOUNCE_TIMEOUT);
+      await page.waitForChanges();
+
       assertMatchingItems(await filter.getProperty("filteredItems"), ["jon"]);
       expect(filterChangeSpy).toHaveReceivedEventTimes(1);
     });

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -152,7 +152,6 @@ export class Filter
   async componentWillLoad(): Promise<void> {
     setUpLoadableComponent(this);
     this.updateFiltered(filter(this.items, this.value));
-    this.filter(this.value);
     await setUpMessages(this);
   }
 

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -149,10 +149,30 @@ describe("calcite-list", () => {
     const page = await newE2EPage({
       html: html`
         <calcite-list filter-enabled filter-text="match">
-          <calcite-list-item id="label-match" label="match" description="description" value="value"></calcite-list-item>
-          <calcite-list-item id="description-match" label="label" description="match" value="value"></calcite-list-item>
-          <calcite-list-item id="value-match" label="label" description="description" value="match"></calcite-list-item>
-          <calcite-list-item id="nope" label="label" description="description" value="value"></calcite-list-item>
+          <calcite-list-item
+            id="label-match"
+            label="match"
+            description="description-1"
+            value="value-1"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="description-match"
+            label="label-2"
+            description="match"
+            value="value-1"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="value-match"
+            label="label-3"
+            description="description-3"
+            value="match"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="no-match"
+            label="label-4"
+            description="description-4"
+            value="value-4"
+          ></calcite-list-item>
         </calcite-list>
       `
     });

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -391,7 +391,7 @@ export class List implements InteractiveComponent, LoadableComponent {
     }));
   };
 
-  private updateListItems = debounce((): void => {
+  private updateListItems(): void {
     const { selectionAppearance, selectionMode } = this;
     const items = this.queryListItems();
     items.forEach((item) => {
@@ -406,7 +406,7 @@ export class List implements InteractiveComponent, LoadableComponent {
     this.setActiveListItem();
     this.updateSelectedItems();
     this.updateFilteredItems();
-  }, debounceTimeout);
+  }
 
   queryListItems = (): HTMLCalciteListItemElement[] => {
     return Array.from(this.el.querySelectorAll(listItemSelector));


### PR DESCRIPTION
**Related Issue:** #6523

## Summary

This fixes initial filtering on consumers of `calcite-filter`. 

### Notable changes

#### `list`

* `updateListItems` (private) is no longer debounced to allow updated values to be passed to the internal filter. This was also called whenever the items are modified (`MutationObserver`), so this could be revisited later if we see noticeable impact on performance
* Corrected assertion where filteredItems and filteredData were not matching (one reflects the other)
* Added new test

#### `filter`

* Removed a duplicate `filter` call that would interfere with the initial one – (introduced [here](https://github.com/Esri/calcite-components/pull/5471), possibly an oversight)
* Restored skipped test
* Updated test to cover filtering with default filter text


