### PR TITLE
fix(slider): range slider thumb on all touch-enabled devices now follows touch gesture

### DIFF
--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -34,8 +34,11 @@
   font-size: var(--calcite-slider-container-font-size);
 }
 
+// disable browser swipe navigation to next/previous page to prevent
+// interference with the slide thumb intended functionality to follow touch gesture
 :host {
   @apply block;
+  touch-action: none;
 }
 
 .container {

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -34,11 +34,8 @@
   font-size: var(--calcite-slider-container-font-size);
 }
 
-// disable browser swipe navigation to next/previous page to prevent
-// interference with the slide thumb intended functionality to follow touch gesture
 :host {
   @apply block;
-  touch-action: none;
 }
 
 .container {
@@ -50,6 +47,8 @@
   --calcite-slider-full-handle-height: calc(
     var(--calcite-slider-handle-size) + var(--calcite-slider-handle-extension-height)
   );
+  touch-action: none;
+  // disable browser swipe navigation to prevent interference with the slide thumb following a touch gesture
 }
 
 @include disabled() {


### PR DESCRIPTION
**Related Issue:** #4290

## Summary

Replicated the issue on a PC tablet (Dell Precision 5560 per use case) and noticed that the slider was being blocked by the browser swipe gesture. Happened on several browsers tested on this device (Chrome 110.0.5481, MicrosoftEdge 11.0.1587).

https://user-images.githubusercontent.com/19231036/222330979-31a80b8e-4ab8-41d1-aaa5-812248e6e838.mp4


Solved by disabling browser swipe navigation to next/previous page to prevent interference with the slide thumb intended functionality to follow touch gesture. The fix will apply to all touch-enabled devices, including iOS and and tablets running other operating systems. 

Can't see a way to automatically test it in our setup, maybe we could add a wiki or confluence page for the slider behavior on other devices (any slider part should use touch-action: none because ...).
