### PR TITLE
fix(action): ensure consistent width to accommodate indicator when displaying text

### DIFF
--- a/src/components/action/action.scss
+++ b/src/components/action/action.scss
@@ -70,6 +70,7 @@
 
   .text-container--visible {
     @apply w-auto flex-auto opacity-100;
+    margin-inline-end: theme("spacing.4");
   }
 }
 
@@ -212,9 +213,6 @@
   .button--text-visible {
     &::after {
       inset-block-end: auto;
-    }
-    .text-container--visible {
-      margin-inline-end: theme("spacing.4");
     }
   }
   .button:hover::after,

--- a/src/components/action/action.stories.ts
+++ b/src/components/action/action.stories.ts
@@ -198,6 +198,10 @@ export const alignmentStartAndLargeScaleAndTextOverflow_TestOnly = (): string =>
     )}
   </div>`;
 
+export const indicatorTextEnabled_TestOnly = (): string => html`
+  <calcite-action indicator active text="click-me" text-enabled icon="gear"></calcite-action>
+`;
+
 export const arabicLocale_TestOnly = (): string => html`
   <calcite-action
     dir="rtl"


### PR DESCRIPTION
**Related Issue:** #5375 

## Summary

Updates layout to include space for indicator when `text-enabled` is set.