### PR TITLE
fix(alert, combobox, dropdown, input-date-picker, popover, tooltip): prefers-reduced-motion no longer prevents open/close components from emitting before + open/close events

### DIFF
--- a/src/assets/styles/_animation.scss
+++ b/src/assets/styles/_animation.scss
@@ -74,6 +74,16 @@
 
 @media (prefers-reduced-motion: reduce) {
   :root {
-    --calcite-internal-duration-factor: 0;
+    // [workaround] using 0.01 to ensure `openCloseComponent` utils work consistently
+    // this should be removed once https://github.com/Esri/calcite-components/issues/6604 is addressed
+    --calcite-internal-duration-factor: 0.01;
   }
+}
+
+/* helper to properly scale internal durations */
+@function scaleDuration($animationVar, $factor) {
+  @return calc(
+    calc(var($animationVar) / var(--calcite-internal-duration-factor)) *
+      calc($factor / var(--calcite-internal-duration-factor))
+  );
 }

--- a/src/components/block/block.scss
+++ b/src/components/block/block.scss
@@ -16,6 +16,7 @@
 
 @include disabled();
 
+@import "../../assets/styles/animation";
 @import "../../assets/styles/header";
 
 .header {
@@ -106,7 +107,7 @@ calcite-handle {
 }
 
 .status-icon.loading {
-  animation: spin calc(var(--calcite-internal-animation-timing-slow) * 2) linear infinite;
+  animation: spin scaleDuration(--calcite-internal-animation-timing-slow, 2) linear infinite;
 }
 
 @keyframes spin {

--- a/src/components/loader/loader.scss
+++ b/src/components/loader/loader.scss
@@ -9,9 +9,17 @@
  * @prop --calcite-loader-padding : Specifies the padding of the loader.
  */
 
+@import "../../assets/styles/animation";
+
 $stroke-width: 3;
 $loader-scale: 54;
 $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --calcite-internal-duration-factor: 0;
+  }
+}
 
 :host {
   @apply relative mx-auto hidden items-center justify-center opacity-100;
@@ -21,7 +29,7 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   stroke-width: $stroke-width;
   fill: none;
   transform: scale(1, 1);
-  animation: loader-color-shift calc(var(--calcite-internal-animation-timing-slow) * 2) alternate-reverse infinite
+  animation: loader-color-shift scaleDuration(--calcite-internal-animation-timing-slow, 2) alternate-reverse infinite
     linear;
   padding-block: var(--calcite-loader-padding, theme("spacing.16"));
 }
@@ -191,9 +199,9 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   }
 }
 
-@include generateSegment(1, 10, 40, calc(var(--calcite-internal-animation-timing-slow) * 2.4));
-@include generateSegment(2, 20, 30, calc(var(--calcite-internal-animation-timing-slow) * 3.2));
-@include generateSegment(3, 05, 45, calc(var(--calcite-internal-animation-timing-slow) * 3.867));
+@include generateSegment(1, 10, 40, scaleDuration(--calcite-internal-animation-timing-slow, 2.4));
+@include generateSegment(2, 20, 30, scaleDuration(--calcite-internal-animation-timing-slow, 3.2));
+@include generateSegment(3, 05, 45, scaleDuration(--calcite-internal-animation-timing-slow, 3.867));
 
 @keyframes loader-color-shift {
   0% {

--- a/src/components/progress/progress.scss
+++ b/src/components/progress/progress.scss
@@ -1,3 +1,5 @@
+@import "../../assets/styles/animation";
+
 :host {
   @apply relative block w-full;
 }
@@ -28,7 +30,7 @@
 
 .indeterminate {
   @apply w-1/5;
-  animation: looping-progress-bar-ani calc(var(--calcite-internal-animation-timing-medium) * 11) linear infinite;
+  animation: looping-progress-bar-ani scaleDuration(--calcite-internal-animation-timing-medium, 11) linear infinite;
 }
 
 .reversed {


### PR DESCRIPTION
**Related Issue:** #6582 

## Summary

This restores a workaround to get open/close components to emit before+open/close events when `prefers-reduced-motion` is enabled. Also, a Sass utility was added help scale durations for animations that require fine-tuning. This technically restores some animation, but it is very reduced:

### `calcite-block`

![block-reduced-motion](https://user-images.githubusercontent.com/197440/225195863-f64faee5-ba13-4f6c-925a-2de1caef0718.gif)

### `calcite-loader`
![loader-reduced-motion](https://user-images.githubusercontent.com/197440/225195875-a938f628-1a19-48a8-b6a8-f6967bc05a21.gif)

### `calcite-progress`

![progress-reduced-motion](https://user-images.githubusercontent.com/197440/225195853-7509681d-5c1d-46f7-b103-3dacf3c5bb6b.gif)

I _think_ this still aligns with the expected behavior of `prefers-reduced-motion`, but we should check to just in case. cc @geospatialem 