### PR TITLE
fix(accordion, accordion-item): now wraps long words in header (title & description)

### DIFF
--- a/src/components/accordion-item/accordion-item.scss
+++ b/src/components/accordion-item/accordion-item.scss
@@ -102,7 +102,7 @@
     items-center
     duration-150
     ease-in-out;
-  word-break: break-word;
+  @include word-break();
 }
 
 :host .content {

--- a/src/components/accordion-item/accordion-item.scss
+++ b/src/components/accordion-item/accordion-item.scss
@@ -102,6 +102,7 @@
     items-center
     duration-150
     ease-in-out;
+  word-break: break-word;
 }
 
 :host .content {

--- a/src/components/accordion/accordion.stories.ts
+++ b/src/components/accordion/accordion.stories.ts
@@ -264,28 +264,42 @@ export const withIconStartAndEnd_TestOnly = (): string =>
     `
   );
 
-export const mediumIconForLargeAccordionItem_TestOnly = (): string => html`
-  <calcite-accordion scale="l" style="width: 400px">
-    <calcite-accordion-item heading="Accordion Item" scale="l"></calcite-accordion-item>
-    <calcite-accordion-item
-      heading="Accordion Item IconStart/End"
-      icon-start="plane"
-      icon-end="plane"
-      scale="l"
-    ></calcite-accordion-item>
-    <calcite-accordion-item heading="Accordion Item" scale="l" description="A great subtitle"></calcite-accordion-item>
-    <calcite-accordion-item
-      heading="Accordion Item IconStart/End"
-      icon-start="plane"
-      icon-end="plane"
-      scale="l"
-      description="A great subtitle"
-    ></calcite-accordion-item>
-    <calcite-accordion-item
-      heading="Accordion Item IconStart/End with a potentially two line title"
-      icon-start="banana"
-      icon-end="banana"
-      scale="l"
-    ></calcite-accordion-item>
-  </calcite-accordion>
+const useCases = [
+  { icon: "", heading: "Simple item with heading", description: "" },
+  { icon: "", heading: "Simple item with heading", description: "Simple item with description" },
+  {
+    icon: "embark",
+    heading:
+      "Embark_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_",
+    description: "Extra long heading with underscores and icons m /scale l"
+  },
+  {
+    icon: "car",
+    heading: "Extra long description with underscores and icons m /scale l",
+    description:
+      "Car_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_Watercraft_title_is_super_long_what_do_we_do_now_"
+  },
+  {
+    icon: "plane",
+    heading: "Extra long description and icons m /scale l",
+    description:
+      "Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets. Planes, helicopters, and jets."
+  }
+];
+
+const accordionItems = useCases
+  .map(
+    (useCase): string =>
+      html`<calcite-accordion-item
+        icon-start="${useCase.icon}"
+        icon-end="${useCase.icon}"
+        scale="l"
+        heading="${useCase.heading}"
+        description="${useCase.description}"
+      ></calcite-accordion-item>`
+  )
+  .join("");
+
+export const longHeading_MediumIconForLargeAccordionItem = (): string => html`
+  <calcite-accordion scale="l" style="width: 600px"> ${accordionItems} </calcite-accordion>
 `;

--- a/src/components/accordion/accordion.stories.ts
+++ b/src/components/accordion/accordion.stories.ts
@@ -300,6 +300,6 @@ const accordionItems = useCases
   )
   .join("");
 
-export const longHeading_MediumIconForLargeAccordionItem = (): string => html`
+export const longHeading_MediumIconForLargeAccordionItem_testOnly = (): string => html`
   <calcite-accordion scale="l" style="width: 600px"> ${accordionItems} </calcite-accordion>
 `;

--- a/src/components/accordion/accordion.stories.ts
+++ b/src/components/accordion/accordion.stories.ts
@@ -264,7 +264,7 @@ export const withIconStartAndEnd_TestOnly = (): string =>
     `
   );
 
-const useCases = [
+const iconHeaderUseCasesArr: { icon: string; heading: string; description: string }[] = [
   { icon: "", heading: "Simple item with heading", description: "" },
   { icon: "", heading: "Simple item with heading", description: "Simple item with description" },
   {
@@ -287,9 +287,9 @@ const useCases = [
   }
 ];
 
-const accordionItems = useCases
+const accordionItemsIconHeaderUseCases = iconHeaderUseCasesArr
   .map(
-    (useCase): string =>
+    (useCase) =>
       html`<calcite-accordion-item
         icon-start="${useCase.icon}"
         icon-end="${useCase.icon}"
@@ -300,6 +300,6 @@ const accordionItems = useCases
   )
   .join("");
 
-export const longHeading_MediumIconForLargeAccordionItem_testOnly = (): string => html`
-  <calcite-accordion scale="l" style="width: 600px"> ${accordionItems} </calcite-accordion>
+export const longHeading_MediumIconForLargeAccordionItem_TestOnly = (): string => html`
+  <calcite-accordion scale="l" style="width: 600px"> ${accordionItemsIconHeaderUseCases} </calcite-accordion>
 `;


### PR DESCRIPTION
**Related Issue:** #5683

## Summary
The `accordion-item header` longer `title`/`description` no longer extends outside the container instead of wrapping.

Note: Tailwind's `break-words` implements the `overflow-wrap: break-word` CSS property, but it seems to have no impact for me in Chrome. Used  our `word-break() mixin` instead to achieve the desired effect.

Provided a `_TestOnly` screenshot that simulates long words with underscores.

