### PR TITLE
ci: update user-defined priority

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -79,6 +79,20 @@ body:
     validations:
       required: false
   - type: dropdown
+    id: priority-impact
+    validations:
+      required: true
+    attributes:
+      label: Priority impact
+      multiple: false
+      description: What is the impact to you, your team, or organization? Use discretion and only select "need" or "emergency" priorities for high user impact and quality issues. For instance, would someone notice, in a bad way, if this issue were present in the release?
+      options:
+        - p4 - not time sensitive
+        - p3 - want for upcoming milestone
+        - p2 - want for current milestone
+        - p1 - need for current milestone
+        - p0 - emergency
+  - type: dropdown
     id: esri-team
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -74,7 +74,8 @@ body:
       multiple: false
       description: What is the impact to you, your team, or organization? Use discretion and only select "need" or "emergency" priorities for high user impact and quality issues. For instance, would someone notice, in a bad way, if this issue were present in the release?
       options:
-        - p3 - not time sensitive
+        - p4 - not time sensitive
+        - p3 - want for upcoming milestone
         - p2 - want for current milestone
         - p1 - need for current milestone
         - p0 - emergency

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -48,7 +48,7 @@ body:
     attributes:
       label: Priority impact
       multiple: false
-      description: What is the impact to you, your team, or organization? Use discretion and only select "need" priority for high user impact and quality issues. For instance, would someone notice, in a bad way, if this enhancement were present in the release?
+      description: What is the impact of the enhancement to you, your team, or organization? Use discretion and only select the "need" priority for high user impact and quality issues in the component(s).
       options:
         - p4 - not time sensitive
         - p3 - want for upcoming milestone

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -42,6 +42,19 @@ body:
     validations:
       required: false
   - type: dropdown
+    id: priority-impact
+    validations:
+      required: true
+    attributes:
+      label: Priority impact
+      multiple: false
+      description: What is the impact to you, your team, or organization? Use discretion and only select "need" priority for high user impact and quality issues. For instance, would someone notice, in a bad way, if this enhancement were present in the release?
+      options:
+        - p4 - not time sensitive
+        - p3 - want for upcoming milestone
+        - p2 - want for current milestone
+        - p1 - need for current milestone
+  - type: dropdown
     id: esri-team
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -43,6 +43,19 @@ body:
     validations:
       required: false
   - type: dropdown
+    id: priority-impact
+    validations:
+      required: true
+    attributes:
+      label: Priority impact
+      multiple: false
+      description: What is the impact to you, your team, or organization? Use discretion and only select "need" priority for high user impact and quality issues. For instance, would someone notice, in a bad way, if this new component were present in the release?
+      options:
+        - p4 - not time sensitive
+        - p3 - want for upcoming milestone
+        - p2 - want for current milestone
+        - p1 - need for current milestone
+  - type: dropdown
     id: esri-team
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Priority impact
       multiple: false
-      description: What is the impact to you, your team, or organization? Use discretion and only select "need" priority for high user impact and quality issues. For instance, would someone notice, in a bad way, if this new component were present in the release?
+      description: How important is the new component request to you, your team, or organization? Use discretion and only select the "need" priority for high user impact.
       options:
         - p4 - not time sensitive
         - p3 - want for upcoming milestone

--- a/.github/workflows/add-priority-label.yml
+++ b/.github/workflows/add-priority-label.yml
@@ -1,4 +1,4 @@
-name: Add Bug Priority Label
+name: Add Priority Label
 on:
   issues:
     types: [opened, edited]
@@ -22,7 +22,7 @@ jobs:
               return;
             }
 
-            const bugPriorityRegex = new RegExp(
+            const addPriorityRegex = new RegExp(
               action === "edited"
                 ? // the way GitHub parses the issue body into plaintext
                   // requires this exact format for edits
@@ -32,35 +32,35 @@ jobs:
               "m"
             );
 
-            const bugPriorityRegexMatch = body.match(bugPriorityRegex);
+            const addPriorityRegexMatch = body.match(addPriorityRegex);
 
-            const bugPriority = (
-              bugPriorityRegexMatch && bugPriorityRegexMatch[0] ? bugPriorityRegexMatch[0] : ""
+            const addPriorityLabel = (
+              addPriorityRegexMatch && addPriorityRegexMatch[0] ? addPriorityRegexMatch[0] : ""
             ).trim();
 
-            if (bugPriority && bugPriority !== "N/A") {
+            if (addPriorityLabel && addPriorityLabel !== "N/A") {
               /** Creates a label if it does not exist */
               try {
                 await github.rest.issues.getLabel({
                   owner,
                   repo,
-                  name: bugPriority,
+                  name: addPriorityLabel,
                 });
               } catch (error) {
                 await github.rest.issues.createLabel({
                   owner,
                   repo,
-                  name: bugPriority,
+                  name: addPriorityLabel,
                   color: "bb7fe0",
-                  description: `User set priority status of ${bugPriority}`,
+                  description: `User set priority status of ${addPriorityLabel}`,
                 });
               }
 
-              /** add new bug priority label */
+              /** add new priority label */
               await github.rest.issues.addLabels({
                 issue_number,
                 owner,
                 repo,
-                labels: [bugPriority],
+                labels: [addPriorityLabel],
               });
             }


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
We received some feedback after Dev Office Hours asking for an additional option for priority, specifically around an upcoming milestone (e.g. one of our next "major" releases).

#### Changes for inclusion:

1. Updates the priority dropdown to include a new option for folks:
    - **_Proposed change_** - `p4 - not time sensitive`
    - **_New change_** - `p3 - want for upcoming milestone`
    - `p2 - want for current milestone`
    - `p1 - need for current milestone`
    - `p0 - emergency`
3. Also adds the priority dropdown to the following requests:
    - accessibility bugs
    - enhancements (no `p0 - emergency` option)
    - new components (no `p0 - emergency` option)

**Note: will update the labels once approved, and prior to merging.**

Original PR for context: https://github.com/Esri/calcite-components/pull/6513