### PR TITLE
fix(tile): adds styling to `tile` where `link` is present for additional distinction

### DIFF
--- a/src/components/tile/tile.scss
+++ b/src/components/tile/tile.scss
@@ -77,6 +77,12 @@
     ease-in-out;
   }
 }
+:host([href]) {
+  .heading {
+    @apply underline;
+    color: var(--calcite-ui-text-link);
+  }
+}
 :host(:not([embed])) {
   @apply p-3;
   box-shadow: 0 0 0 1px var(--calcite-ui-border-2);

--- a/src/components/tile/tile.scss
+++ b/src/components/tile/tile.scss
@@ -77,7 +77,8 @@
     ease-in-out;
   }
 }
-:host([href]) {
+:host([href]),
+:host([href]:hover) {
   .heading {
     @apply underline;
     color: var(--calcite-ui-text-link);


### PR DESCRIPTION
**Related Issue:** #5608

## Summary

`Tile` with `Link` used coloring of the icon to indicate that the tile contains a link, which isn't sufficient differentiation 
for users with color blindness. The PR adds styling to the link `heading` as well, making it both colored and underlined. 