### PR TITLE
fix(tile-select): fix click not firing in custom-elements build

### DIFF
--- a/src/components/tile-select/tile-select.tsx
+++ b/src/components/tile-select/tile-select.tsx
@@ -203,7 +203,7 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
   }
 
   @Listen("click")
-  click(event: MouseEvent): void {
+  clickHandler(event: MouseEvent): void {
     const target = event.target as HTMLElement;
     const targets = ["calcite-tile", "calcite-tile-select"];
     if (targets.includes(target.localName)) {
@@ -212,7 +212,7 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
   }
 
   @Listen("pointerenter")
-  mouseenter(): void {
+  pointerEnterHandler(): void {
     if (this.input.localName === "calcite-radio-button") {
       (this.input as HTMLCalciteRadioButtonElement).hovered = true;
     }
@@ -222,7 +222,7 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
   }
 
   @Listen("pointerleave")
-  mouseleave(): void {
+  pointerLeaveHandler(): void {
     if (this.input.localName === "calcite-radio-button") {
       (this.input as HTMLCalciteRadioButtonElement).hovered = false;
     }


### PR DESCRIPTION
**Related Issue:** #6185 

## Summary

Renames event handlers to prevent click listener not firing when the tile-select area was clicked in the `dist-custom-elements` output target. This seems like a Stencil bug caused when an event handler is identical to its listened event name (needs further investigation to confirm cc @benelan).