### PR TITLE
fix(modal): prevent error when calling setFocus on a recently rendered and opened modal (`dist-custom-elements`)

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -175,6 +175,10 @@ export async function focusElement(el: FocusableElement): Promise<void> {
  * @param {HTMLElement} element The html element containing tabbable elements.
  */
 export function focusFirstTabbable(element: HTMLElement): void {
+  if (!element) {
+    return;
+  }
+
   (tabbable(element, tabbableOptions)[0] || element).focus();
 }
 


### PR DESCRIPTION
**Related Issue:** #6188

## Summary

This is a workaround for modal throwing an error in the `dist-custom-elements` build when setting focus on the first focusable item after the component initially renders. Fortunately for modal, focus is set properly after the open animation.

The problem seems to be the focus-trap's element `ref` not being called on `componentDidLoad`, not even after using `requestAnimationFrame` as used in [this Ionic util](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L72-L79), nor `setTimeout` as suggested [here](https://github.com/ionic-team/stencil/issues/3246#issuecomment-1048802446). We'll investigate and open an issue if this is indeed a lifecycle bug.