### PR TITLE
feat: support setting form ID on form components

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,6 +1,5 @@
 import { Build, Component, Element, h, Method, Prop, State, VNode, Watch } from "@stencil/core";
-import { closestElementCrossShadowBoundary } from "../../utils/dom";
-import { FormOwner, resetForm, submitForm } from "../../utils/form";
+import { findAssociatedForm, FormOwner, resetForm, submitForm } from "../../utils/form";
 import { InteractiveComponent, updateHostInteraction } from "../../utils/interactive";
 import { connectLabel, disconnectLabel, getLabelText, LabelableComponent } from "../../utils/label";
 import {
@@ -74,6 +73,14 @@ export class Button
 
   /**  When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
+
+  /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
 
   /**
    * Specifies the URL of the linked resource, which can be set as an absolute or relative path.
@@ -173,7 +180,7 @@ export class Button
     this.hasLoader = this.loading;
     this.setupTextContentObserver();
     connectLabel(this);
-    this.formEl = closestElementCrossShadowBoundary<HTMLFormElement>(this.el, "form");
+    this.formEl = findAssociatedForm(this);
   }
 
   disconnectedCallback(): void {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -75,9 +75,9 @@ export class Button
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -56,6 +56,14 @@ export class Checkbox
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
+  /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
   /** The `id` attribute of the component. When omitted, a globally unique identifier is used. */
   @Prop({ reflect: true, mutable: true }) guid: string;
 

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -57,9 +57,9 @@ export class Checkbox
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -140,9 +140,9 @@ export class Combobox
   }
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -139,6 +139,14 @@ export class Combobox
     }
   }
 
+  /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
   /** Accessible name for the component. */
   @Prop() label!: string;
 

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -103,6 +103,14 @@ export class InputDatePicker
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, the component's value can be read, but controls are not accessible and the value cannot be modified.
    *
    * @mdn [readOnly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -103,9 +103,9 @@ export class InputDatePicker
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -123,9 +123,9 @@ export class InputNumber
   }
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -123,6 +123,14 @@ export class InputNumber
   }
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, number values are displayed with a group separator corresponding to the language and country format.
    */
   @Prop({ reflect: true }) groupSeparator = false;

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -102,9 +102,9 @@ export class InputText
   }
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -102,6 +102,14 @@ export class InputText
   }
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, the component will not be visible.
    *
    * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -91,9 +91,9 @@ export class InputTimePicker
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -91,6 +91,14 @@ export class InputTimePicker
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, the component's value can be read, but controls are not accessible and the value cannot be modified.
    *
    * @mdn [readOnly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -125,9 +125,9 @@ export class Input
   }
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -125,6 +125,14 @@ export class Input
   }
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, number values are displayed with a group separator corresponding to the language and country format.
    */
   @Prop({ reflect: true }) groupSeparator = false;

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -75,6 +75,14 @@ export class RadioButton
    */
   @Prop({ mutable: true, reflect: true }) focused = false;
 
+  /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
   /** The `id` of the component. When omitted, a globally unique identifier is used. */
   @Prop({ reflect: true, mutable: true }) guid: string;
 

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -76,9 +76,9 @@ export class RadioButton
   @Prop({ mutable: true, reflect: true }) focused = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -72,6 +72,14 @@ export class Rating
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * Made into a prop for testing purposes only
    *
    * @internal

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -72,9 +72,9 @@ export class Rating
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/segmented-control/segmented-control.tsx
+++ b/src/components/segmented-control/segmented-control.tsx
@@ -64,9 +64,9 @@ export class SegmentedControl
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/segmented-control/segmented-control.tsx
+++ b/src/components/segmented-control/segmented-control.tsx
@@ -64,6 +64,14 @@ export class SegmentedControl
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, the component must have a value in order for the form to submit.
    *
    * @internal

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -67,9 +67,9 @@ export class Select
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -67,6 +67,14 @@ export class Select
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * Accessible name for the component.
    *
    */

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -82,6 +82,14 @@ export class Slider
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, number values are displayed with a group separator corresponding to the language and country format.
    */
   @Prop({ reflect: true }) groupSeparator = false;

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -82,9 +82,9 @@ export class Slider
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -52,6 +52,14 @@ export class Switch
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
+  /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
   /** Accessible name for the component. */
   @Prop() label: string;
 

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -53,9 +53,9 @@ export class Switch
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -96,6 +96,14 @@ export class TextArea
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   */
+  @Prop({ reflect: true })
+  form: string;
+
+  /**
    * When `true`, number values are displayed with a group separator corresponding to the language and country format.
    */
   @Prop({ reflect: true }) groupSeparator = false;
@@ -117,6 +125,7 @@ export class TextArea
    *
    * @internal
    */
+  // eslint-disable-next-line @stencil-community/strict-mutable -- updated by t9n module
   @Prop({ mutable: true }) messages: TextAreaMessages;
 
   /**
@@ -179,6 +188,7 @@ export class TextArea
   /**
    * Use this property to override individual strings used by the component.
    */
+  // eslint-disable-next-line @stencil-community/strict-mutable -- updated by t9n module
   @Prop({ mutable: true }) messageOverrides: Partial<TextAreaMessages>;
 
   @Watch("messageOverrides")

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -96,9 +96,9 @@ export class TextArea
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form that will be associated with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -510,212 +510,429 @@ interface FormAssociatedOptions {
  * @param {FormAssociatedOptions} options - form associated options
  */
 export async function formAssociated(componentTagOrHtml: TagOrHTML, options: FormAssociatedOptions): Promise<void> {
-  const componentTag = getTag(componentTagOrHtml);
-  const componentHtml = ensureName(
-    isHTML(componentTagOrHtml) ? componentTagOrHtml : `<${componentTag}></${componentTag}>`
-  );
+  async function testAncestorFormAssociated(): Promise<void> {
+    const componentTag = getTag(componentTagOrHtml);
+    const componentHtml = ensureName(
+      isHTML(componentTagOrHtml) ? componentTagOrHtml : `<${componentTag}></${componentTag}>`
+    );
 
-  function ensureName(html: string): string {
-    return html.includes("name=") ? html : html.replace(componentTag, `${componentTag} name="testName" `);
-  }
+    function ensureName(html: string): string {
+      return html.includes("name=") ? html : html.replace(componentTag, `${componentTag} name="testName" `);
+    }
 
-  const page = await newE2EPage({
-    html: html`<form>
-      ${componentHtml}
-      <!--
+    const page = await newE2EPage({
+      html: html`<form>
+        ${componentHtml}
+        <!--
           keeping things simple by using submit-type input
           this should cover button and calcite-button submit cases
           -->
-      <input id="submitter" type="submit" />
-    </form>`
-  });
+        <input id="submitter" type="submit" />
+      </form>`
+    });
 
-  await page.waitForChanges();
-
-  const component = await page.find(componentTag);
-  const checkable =
-    typeof options.testValue === "boolean" && (await page.$eval(componentTag, (component) => "checked" in component));
-  const resettablePropName = checkable ? "checked" : "value";
-  const initialValue = await component.getProperty(resettablePropName);
-  const name = await component.getProperty("name");
-
-  await assertValueSubmissionType();
-  await assertValueResetOnFormReset();
-  await assertValueSubmittedOnFormSubmit();
-
-  if (options.submitsOnEnter) {
-    await assertFormSubmitOnEnter();
-  }
-
-  async function assertValueSubmissionType(): Promise<void> {
-    const inputType = options.inputType ?? "text";
-
-    const hiddenFormInputType = await page.evaluate(
-      async (inputName: string, hiddenFormInputSlotName: string): Promise<string> => {
-        const hiddenFormInput = document.querySelector<HTMLInputElement>(
-          `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`
-        );
-
-        return hiddenFormInput.type;
-      },
-      name,
-      hiddenFormInputSlotName
-    );
-
-    if (checkable) {
-      expect(hiddenFormInputType).toMatch(/radio|checkbox/);
-    } else {
-      expect(hiddenFormInputType).toMatch(inputType);
-    }
-  }
-
-  async function assertValueResetOnFormReset(): Promise<void> {
-    component.setProperty(resettablePropName, options.testValue);
     await page.waitForChanges();
 
-    await page.$eval("form", (form: HTMLFormElement) => form.reset());
-    await page.waitForChanges();
+    const component = await page.find(componentTag);
+    const checkable =
+      typeof options.testValue === "boolean" && (await page.$eval(componentTag, (component) => "checked" in component));
+    const resettablePropName = checkable ? "checked" : "value";
+    const initialValue = await component.getProperty(resettablePropName);
+    const name = await component.getProperty("name");
 
-    expect(await component.getProperty(resettablePropName)).toBe(initialValue);
-  }
+    await assertValueSubmissionType();
+    await assertValueResetOnFormReset();
+    await assertValueSubmittedOnFormSubmit();
 
-  async function assertValueSubmittedOnFormSubmit(): Promise<void> {
-    const stringifiedTestValue = stringifyTestValue(options.testValue);
-
-    if (checkable) {
-      component.setProperty("checked", true);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toEqual("on");
-
-      component.setProperty("value", options.testValue);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toEqual(stringifiedTestValue);
-
-      component.setProperty("disabled", true);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toBe(null);
-
-      component.setProperty("checked", true);
-      component.setProperty("disabled", false);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toEqual(stringifiedTestValue);
-
-      component.setProperty("checked", false);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toBe(null);
-    } else {
-      component.setProperty("required", true);
-      component.setProperty("value", null);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toBe(
-        options.inputType === "color"
-          ? // `input[type="color"]` will set its value to #000000 when set to an invalid value
-            // see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color#value
-            "#000000"
-          : undefined
-      );
-
-      component.setProperty("required", false);
-      component.setProperty("value", options.testValue);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
-
-      component.setProperty("disabled", true);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toBe(null);
-
-      component.setProperty("disabled", false);
-      component.setProperty("value", options.testValue);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
-
-      component.setProperty("value", options.testValue);
-      await page.waitForChanges();
-      expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+    if (options.submitsOnEnter) {
+      await assertFormSubmitOnEnter();
     }
 
-    type SubmitValueResult = ReturnType<FormData["get"]> | ReturnType<FormData["getAll"] | undefined>;
+    async function assertValueSubmissionType(): Promise<void> {
+      const inputType = options.inputType ?? "text";
 
-    /**
-     * This method will submit the form and return the submitted value:
-     *
-     * For single-value components, it will return a string or null if the value was not submitted
-     * For multi-value components, it will return an array of strings
-     *
-     * If the input cannot be submitted because it is invalid, undefined will be returned
-     */
-    async function submitAndGetValue(): Promise<SubmitValueResult> {
-      return page.$eval(
-        "form",
-        async (
-          form: HTMLFormElement,
-          inputName: string,
-          hiddenFormInputSlotName: string
-        ): Promise<SubmitValueResult> => {
-          const hiddenFormInput = document.querySelector(
+      const hiddenFormInputType = await page.evaluate(
+        async (inputName: string, hiddenFormInputSlotName: string): Promise<string> => {
+          const hiddenFormInput = document.querySelector<HTMLInputElement>(
             `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`
           );
 
-          let resolve: (value: SubmitValueResult) => void;
-          const submitPromise = new Promise<SubmitValueResult>((yes) => (resolve = yes));
-
-          function handleFormSubmit(event: Event): void {
-            event.preventDefault();
-            const formData = new FormData(form);
-            const values = formData.getAll(inputName);
-
-            if (values.length > 1) {
-              resolve(values as string[]);
-              return;
-            }
-
-            resolve(formData.get(inputName));
-            hiddenFormInput.removeEventListener("invalid", handleInvalidInput);
-          }
-
-          function handleInvalidInput(): void {
-            resolve(undefined);
-            form.removeEventListener("submit", handleFormSubmit);
-          }
-
-          form.addEventListener("submit", handleFormSubmit, { once: true });
-          hiddenFormInput.addEventListener("invalid", handleInvalidInput, { once: true });
-
-          document.querySelector<HTMLInputElement>("#submitter").click();
-
-          return submitPromise;
+          return hiddenFormInput.type;
         },
         name,
         hiddenFormInputSlotName
       );
+
+      if (checkable) {
+        expect(hiddenFormInputType).toMatch(/radio|checkbox/);
+      } else {
+        expect(hiddenFormInputType).toMatch(inputType);
+      }
+    }
+
+    async function assertValueResetOnFormReset(): Promise<void> {
+      component.setProperty(resettablePropName, options.testValue);
+      await page.waitForChanges();
+
+      await page.$eval("form", (form: HTMLFormElement) => form.reset());
+      await page.waitForChanges();
+
+      expect(await component.getProperty(resettablePropName)).toBe(initialValue);
+    }
+
+    async function assertValueSubmittedOnFormSubmit(): Promise<void> {
+      const stringifiedTestValue = stringifyTestValue(options.testValue);
+
+      if (checkable) {
+        component.setProperty("checked", true);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual("on");
+
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(stringifiedTestValue);
+
+        component.setProperty("disabled", true);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(null);
+
+        component.setProperty("checked", true);
+        component.setProperty("disabled", false);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(stringifiedTestValue);
+
+        component.setProperty("checked", false);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(null);
+      } else {
+        component.setProperty("required", true);
+        component.setProperty("value", null);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(
+          options.inputType === "color"
+            ? // `input[type="color"]` will set its value to #000000 when set to an invalid value
+              // see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color#value
+              "#000000"
+            : undefined
+        );
+
+        component.setProperty("required", false);
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+
+        component.setProperty("disabled", true);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(null);
+
+        component.setProperty("disabled", false);
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+      }
+
+      type SubmitValueResult = ReturnType<FormData["get"]> | ReturnType<FormData["getAll"] | undefined>;
+
+      /**
+       * This method will submit the form and return the submitted value:
+       *
+       * For single-value components, it will return a string or null if the value was not submitted
+       * For multi-value components, it will return an array of strings
+       *
+       * If the input cannot be submitted because it is invalid, undefined will be returned
+       */
+      async function submitAndGetValue(): Promise<SubmitValueResult> {
+        return page.$eval(
+          "form",
+          async (
+            form: HTMLFormElement,
+            inputName: string,
+            hiddenFormInputSlotName: string
+          ): Promise<SubmitValueResult> => {
+            const hiddenFormInput = document.querySelector(
+              `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`
+            );
+
+            let resolve: (value: SubmitValueResult) => void;
+            const submitPromise = new Promise<SubmitValueResult>((yes) => (resolve = yes));
+
+            function handleFormSubmit(event: Event): void {
+              event.preventDefault();
+              const formData = new FormData(form);
+              const values = formData.getAll(inputName);
+
+              if (values.length > 1) {
+                resolve(values as string[]);
+                return;
+              }
+
+              resolve(formData.get(inputName));
+              hiddenFormInput.removeEventListener("invalid", handleInvalidInput);
+            }
+
+            function handleInvalidInput(): void {
+              resolve(undefined);
+              form.removeEventListener("submit", handleFormSubmit);
+            }
+
+            form.addEventListener("submit", handleFormSubmit, { once: true });
+            hiddenFormInput.addEventListener("invalid", handleInvalidInput, { once: true });
+
+            document.querySelector<HTMLInputElement>("#submitter").click();
+
+            return submitPromise;
+          },
+          name,
+          hiddenFormInputSlotName
+        );
+      }
+    }
+
+    async function assertFormSubmitOnEnter(): Promise<void> {
+      type TestWindow = GlobalTestProps<{
+        called: boolean;
+      }>;
+
+      await page.$eval("form", (form: HTMLFormElement) => {
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          (window as TestWindow).called = true;
+        });
+      });
+
+      const stringifiedTestValue = stringifyTestValue(options.testValue);
+
+      await component.setProperty("value", stringifiedTestValue);
+      await component.callMethod("setFocus");
+      await page.keyboard.press("Enter");
+      const called = await page.evaluate(() => (window as TestWindow).called);
+
+      expect(called).toBe(true);
+    }
+
+    function stringifyTestValue(value: any): string | string[] {
+      return Array.isArray(value) ? value.map((value) => value.toString()) : value.toString();
     }
   }
 
-  async function assertFormSubmitOnEnter(): Promise<void> {
-    type TestWindow = GlobalTestProps<{
-      called: boolean;
-    }>;
+  async function testIdFormAssociated(): Promise<void> {
+    const componentTag = getTag(componentTagOrHtml);
+    const componentHtml = ensureForm(
+      ensureName(isHTML(componentTagOrHtml) ? componentTagOrHtml : `<${componentTag}></${componentTag}>`)
+    );
 
-    await page.$eval("form", (form: HTMLFormElement) => {
-      form.addEventListener("submit", (event) => {
-        event.preventDefault();
-        (window as TestWindow).called = true;
-      });
+    function ensureName(html: string): string {
+      return html.includes("name=") ? html : html.replace(componentTag, `${componentTag} name="testName" `);
+    }
+
+    function ensureForm(html: string): string {
+      return html.includes("form=") ? html : html.replace(componentTag, `${componentTag} form="test-form" `);
+    }
+
+    const page = await newE2EPage({
+      html: html`<form id="test-form"></form>
+        ${componentHtml}
+        <!--
+        keeping things simple by using submit-type input
+        this should cover button and calcite-button submit cases
+        -->
+        <input id="submitter" form="test-form" type="submit" />`
     });
 
-    const stringifiedTestValue = stringifyTestValue(options.testValue);
+    await page.waitForChanges();
 
-    await component.setProperty("value", stringifiedTestValue);
-    await component.callMethod("setFocus");
-    await page.keyboard.press("Enter");
-    const called = await page.evaluate(() => (window as TestWindow).called);
+    const component = await page.find(componentTag);
+    const checkable =
+      typeof options.testValue === "boolean" && (await page.$eval(componentTag, (component) => "checked" in component));
+    const resettablePropName = checkable ? "checked" : "value";
+    const initialValue = await component.getProperty(resettablePropName);
+    const name = await component.getProperty("name");
 
-    expect(called).toBe(true);
+    await assertValueSubmissionType();
+    await assertValueResetOnFormReset();
+    await assertValueSubmittedOnFormSubmit();
+
+    if (options.submitsOnEnter) {
+      await assertFormSubmitOnEnter();
+    }
+
+    async function assertValueSubmissionType(): Promise<void> {
+      const inputType = options.inputType ?? "text";
+
+      const hiddenFormInputType = await page.evaluate(
+        async (inputName: string, hiddenFormInputSlotName: string): Promise<string> => {
+          const hiddenFormInput = document.querySelector<HTMLInputElement>(
+            `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`
+          );
+
+          return hiddenFormInput.type;
+        },
+        name,
+        hiddenFormInputSlotName
+      );
+
+      if (checkable) {
+        expect(hiddenFormInputType).toMatch(/radio|checkbox/);
+      } else {
+        expect(hiddenFormInputType).toMatch(inputType);
+      }
+    }
+
+    async function assertValueResetOnFormReset(): Promise<void> {
+      component.setProperty(resettablePropName, options.testValue);
+      await page.waitForChanges();
+
+      await page.$eval("form", (form: HTMLFormElement) => form.reset());
+      await page.waitForChanges();
+
+      expect(await component.getProperty(resettablePropName)).toBe(initialValue);
+    }
+
+    async function assertValueSubmittedOnFormSubmit(): Promise<void> {
+      const stringifiedTestValue = stringifyTestValue(options.testValue);
+
+      if (checkable) {
+        component.setProperty("checked", true);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual("on");
+
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(stringifiedTestValue);
+
+        component.setProperty("disabled", true);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(null);
+
+        component.setProperty("checked", true);
+        component.setProperty("disabled", false);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(stringifiedTestValue);
+
+        component.setProperty("checked", false);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(null);
+      } else {
+        component.setProperty("required", true);
+        component.setProperty("value", null);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(
+          options.inputType === "color"
+            ? // `input[type="color"]` will set its value to #000000 when set to an invalid value
+              // see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color#value
+              "#000000"
+            : undefined
+        );
+
+        component.setProperty("required", false);
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+
+        component.setProperty("disabled", true);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toBe(null);
+
+        component.setProperty("disabled", false);
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+
+        component.setProperty("value", options.testValue);
+        await page.waitForChanges();
+        expect(await submitAndGetValue()).toEqual(options?.expectedSubmitValue || stringifiedTestValue);
+      }
+
+      type SubmitValueResult = ReturnType<FormData["get"]> | ReturnType<FormData["getAll"] | undefined>;
+
+      /**
+       * This method will submit the form and return the submitted value:
+       *
+       * For single-value components, it will return a string or null if the value was not submitted
+       * For multi-value components, it will return an array of strings
+       *
+       * If the input cannot be submitted because it is invalid, undefined will be returned
+       */
+      async function submitAndGetValue(): Promise<SubmitValueResult> {
+        return page.$eval(
+          "form",
+          async (
+            form: HTMLFormElement,
+            inputName: string,
+            hiddenFormInputSlotName: string
+          ): Promise<SubmitValueResult> => {
+            const hiddenFormInput = document.querySelector(
+              `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`
+            );
+
+            let resolve: (value: SubmitValueResult) => void;
+            const submitPromise = new Promise<SubmitValueResult>((yes) => (resolve = yes));
+
+            function handleFormSubmit(event: Event): void {
+              event.preventDefault();
+              const formData = new FormData(form);
+              const values = formData.getAll(inputName);
+
+              if (values.length > 1) {
+                resolve(values as string[]);
+                return;
+              }
+
+              resolve(formData.get(inputName));
+              hiddenFormInput.removeEventListener("invalid", handleInvalidInput);
+            }
+
+            function handleInvalidInput(): void {
+              resolve(undefined);
+              form.removeEventListener("submit", handleFormSubmit);
+            }
+
+            form.addEventListener("submit", handleFormSubmit, { once: true });
+            hiddenFormInput.addEventListener("invalid", handleInvalidInput, { once: true });
+
+            document.querySelector<HTMLInputElement>("#submitter").click();
+
+            return submitPromise;
+          },
+          name,
+          hiddenFormInputSlotName
+        );
+      }
+    }
+
+    async function assertFormSubmitOnEnter(): Promise<void> {
+      type TestWindow = GlobalTestProps<{
+        called: boolean;
+      }>;
+
+      await page.$eval("form", (form: HTMLFormElement) => {
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          (window as TestWindow).called = true;
+        });
+      });
+
+      const stringifiedTestValue = stringifyTestValue(options.testValue);
+
+      await component.setProperty("value", stringifiedTestValue);
+      await component.callMethod("setFocus");
+      await page.keyboard.press("Enter");
+      const called = await page.evaluate(() => (window as TestWindow).called);
+
+      expect(called).toBe(true);
+    }
+
+    function stringifyTestValue(value: any): string | string[] {
+      return Array.isArray(value) ? value.map((value) => value.toString()) : value.toString();
+    }
   }
 
-  function stringifyTestValue(value: any): string | string[] {
-    return Array.isArray(value) ? value.map((value) => value.toString()) : value.toString();
-  }
+  await testAncestorFormAssociated();
+  await testIdFormAssociated();
 }
 
 interface TabAndClickTargets {

--- a/src/utils/form.spec.ts
+++ b/src/utils/form.spec.ts
@@ -1,9 +1,11 @@
-import { FormOwner, submitForm } from "./form";
+import { findAssociatedForm, FormOwner, resetForm, submitForm } from "./form";
 
 describe("form", () => {
-  it("has a `submitForm()` util", () => {
+  it("has a `submitForm()` util", async () => {
     const formEl = document.createElement("form");
-    const formOwner: FormOwner = { formEl };
+    const form = null;
+    const el = document.createElement("div");
+    const formOwner: FormOwner = { formEl, form, el };
     const submitSpy = jest.fn();
     formEl.requestSubmit = submitSpy;
 
@@ -18,5 +20,45 @@ describe("form", () => {
 
     expect(submitted).toBe(false);
     expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("has a `resetForm()` util", async () => {
+    const formEl = document.createElement("form");
+    const form = null;
+    const el = document.createElement("div");
+    const formOwner: FormOwner = { formEl, form, el };
+    const resetSpy = jest.fn();
+    formEl.reset = resetSpy;
+
+    resetForm(formOwner);
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+
+    formOwner.formEl = null;
+
+    resetForm(formOwner);
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe("`findAssociatedForm()`", () => {
+    it("finds form via ancestry", async () => {
+      const formEl = document.createElement("form");
+      const form = null;
+      const el = document.createElement("div");
+      formEl.append(el);
+      const formOwner: FormOwner = { formEl, form, el };
+
+      expect(findAssociatedForm(formOwner)).toBe(formEl);
+    });
+
+    it("finds form via ID", async () => {
+      const formEl = document.createElement("form");
+      formEl.id = "test-form";
+      const form = "test-form";
+      const el = document.createElement("div");
+      document.append(formEl, el);
+      const formOwner: FormOwner = { formEl, form, el };
+
+      expect(findAssociatedForm(formOwner)).toBe(formEl);
+    });
   });
 });

--- a/src/utils/form.spec.ts
+++ b/src/utils/form.spec.ts
@@ -52,8 +52,9 @@ describe("form", () => {
 
     it("finds form via ID", async () => {
       const formEl = document.createElement("form");
-      formEl.id = "test-form";
-      const form = "test-form";
+      const formId = "test-form";
+      formEl.id = formId;
+      const form = formId;
       const el = document.createElement("div");
       document.append(formEl, el);
       const formOwner: FormOwner = { formEl, form, el };

--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -19,9 +19,9 @@ export interface FormOwner {
   readonly el: HTMLElement;
 
   /**
-   * The ID of the form owner to associate this component with.
+   * The ID of the form to associate with the component.
    *
-   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor `<form>` element, if any.
    *
    * Note that this prop should use the @Prop decorator.
    */

--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -1,5 +1,5 @@
 import "form-request-submit-polyfill/form-request-submit-polyfill";
-import { closestElementCrossShadowBoundary } from "./dom";
+import { closestElementCrossShadowBoundary, queryElementRoots } from "./dom";
 import { FunctionalComponent, h } from "@stencil/core";
 
 /**
@@ -14,7 +14,23 @@ export const hiddenFormInputSlotName = "hidden-form-input";
  */
 export interface FormOwner {
   /**
+   * The host element.
+   */
+  readonly el: HTMLElement;
+
+  /**
+   * The ID of the form owner to associate this component with.
+   *
+   * When not set, this component will be associated with its ancestor `<form>` element, if any.
+   *
+   * Note that this prop should use the @Prop decorator.
+   */
+  form: string;
+
+  /**
    * The form this component is associated with.
+   *
+   * @internal
    */
   formEl: HTMLFormElement;
 }
@@ -36,11 +52,6 @@ export interface FormComponent<T = any> extends FormOwner {
    * @todo remove optional in follow-up PR
    */
   required?: boolean;
-
-  /**
-   * The host element.
-   */
-  readonly el: HTMLElement;
 
   /**
    * The name used to submit the value to the associated form.
@@ -102,10 +113,26 @@ function isCheckable(component: FormComponent): component is CheckableFormCompon
 const onFormResetMap = new WeakMap<HTMLElement, FormComponent["onFormReset"]>();
 const formComponentSet = new WeakSet<HTMLElement>();
 
+/**
+ * This helps determine if our form component is part of a composite form-associated component.
+ *
+ * @param form
+ * @param formComponentEl
+ */
 function hasRegisteredFormComponentParent(
   form: HTMLFormElement,
   formComponentEl: HTMLElement
 ): boolean {
+  // if we have a parent component using the form ID attribute, we assume it is form-associated
+  const hasParentComponentWithFormIdSet = closestElementCrossShadowBoundary(
+    formComponentEl.parentElement,
+    "[form]"
+  );
+
+  if (hasParentComponentWithFormIdSet) {
+    return true;
+  }
+
   // we use events as a way to test for nested form-associated components across shadow bounds
   const formComponentRegisterEventName = "calciteInternalFormComponentRegister";
 
@@ -166,14 +193,13 @@ export function resetForm(component: FormOwner): void {
  */
 export function connectForm<T>(component: FormComponent<T>): void {
   const { el, value } = component;
+  const associatedForm = findAssociatedForm(component);
 
-  const form = closestElementCrossShadowBoundary<HTMLFormElement>(el, "form");
-
-  if (!form || hasRegisteredFormComponentParent(form, el)) {
+  if (!associatedForm || hasRegisteredFormComponentParent(associatedForm, el)) {
     return;
   }
 
-  component.formEl = form;
+  component.formEl = associatedForm;
   component.defaultValue = value;
 
   if (isCheckable(component)) {
@@ -181,9 +207,22 @@ export function connectForm<T>(component: FormComponent<T>): void {
   }
 
   const boundOnFormReset = (component.onFormReset || onFormReset).bind(component);
-  form.addEventListener("reset", boundOnFormReset);
+  associatedForm.addEventListener("reset", boundOnFormReset);
   onFormResetMap.set(component.el, boundOnFormReset);
   formComponentSet.add(el);
+}
+
+/**
+ * Utility method to find a form-component's associated form element.
+ *
+ * @param component
+ */
+export function findAssociatedForm(component: FormOwner): HTMLFormElement | null {
+  const { el, form } = component;
+
+  return form
+    ? queryElementRoots<HTMLFormElement>(el, { id: form })
+    : closestElementCrossShadowBoundary<HTMLFormElement>(el, "form");
 }
 
 function onFormReset<T>(this: FormComponent<T>): void {
@@ -315,7 +354,7 @@ function defaultSyncHiddenFormInput(
   input: HTMLInputElement,
   value: string
 ): void {
-  const { defaultValue, disabled, name, required } = component;
+  const { defaultValue, disabled, form, name, required } = component;
 
   // keep in sync to prevent losing reset value
   input.defaultValue = defaultValue;
@@ -323,6 +362,13 @@ function defaultSyncHiddenFormInput(
   input.name = name;
   input.required = required;
   input.tabIndex = -1;
+
+  // we set the attr as the prop is read-only
+  if (form) {
+    input.setAttribute("form", form);
+  } else {
+    input.removeAttribute("form");
+  }
 
   if (isCheckable(component)) {
     input.checked = component.checked;


### PR DESCRIPTION
**Related Issue:** #5164 

## Summary

This allows developers to associate form components by providing the form ID. 

### Notes

* the form must be available in the DOM before the component is attached to the DOM
* components will not look up ancestors for form if the ID is invalid or if the form is not found

### Follow-up

I'll DRY up some duplication in the `commonTests#formAssociated` test helper in a separate PR. I went this route to expedite testing.