### PR TITLE
docs(tree): specify selectionMode types

### DIFF
--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -49,7 +49,14 @@ export class Tree {
   @Prop({ mutable: true, reflect: true }) scale: Scale = "m";
 
   /**
-   * Customize how the component's selection works.
+   * Specifies the selection mode, where
+   * `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections,
+   * `"children"` allows any number of selections from one parent from corresponding parent and child selections,
+   * `"multichildren"` allows any number of selections from corresponding parent and child selections,
+   * `"multiple"` allows any number of selections,
+   * `"none"` allows no selections,
+   * `"single"` allows one selection, or
+   * `"single-persist"` allows and requires one selection.
    *
    * @default "single"
    */


### PR DESCRIPTION
**Related Issue:** #6429 

## Summary
Adds support and context to `tree`'s `selectionMode` property values. 📓 

![image](https://user-images.githubusercontent.com/5023024/229602153-4c571919-11c9-4ae0-9ad4-199caf753b2d.png)
![screen-2](https://user-images.githubusercontent.com/5023024/229601255-51d46e56-14fd-4c63-87eb-c57f4af69b89.png)
