### PR TITLE
refactor(time): add util to create and cache date time formats

### DIFF
--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,6 +1,8 @@
 import {
+  dateTimeFormatCache,
   defaultLocale,
   defaultNumberingSystem,
+  getDateTimeFormat,
   locales,
   numberingSystems,
   NumberStringFormatOptions,
@@ -127,5 +129,54 @@ describe("NumberStringFormat", () => {
         expect(delocalizedNumberString).toBe(numberString);
       });
     });
+  });
+});
+
+describe("getDateTimeFormat()", () => {
+  beforeEach(() => dateTimeFormatCache?.clear());
+
+  it("generates an instance of DateTimeFormat by locale", () => {
+    const enDateTimeFormat = getDateTimeFormat("en");
+    expect(enDateTimeFormat).toBeInstanceOf(Intl.DateTimeFormat);
+    expect(enDateTimeFormat.resolvedOptions().locale).toBe("en");
+
+    const esDateTimeFormat = getDateTimeFormat("es");
+    expect(esDateTimeFormat).toBeInstanceOf(Intl.DateTimeFormat);
+    expect(esDateTimeFormat.resolvedOptions().locale).toBe("es");
+  });
+
+  it("supports passing options", () => {
+    const options: Intl.DateTimeFormatOptions = { dateStyle: "full", numberingSystem: "latn" }; // using a subset and assuming other props will work the same
+    const enDateTimeFormat = getDateTimeFormat("en", options);
+
+    for (const [key, value] of Object.entries(options)) {
+      expect(enDateTimeFormat.resolvedOptions()[key]).toBe(value);
+    }
+  });
+
+  it("returns the same instance when given the same parameters", () => {
+    const simpleEnDateTimeFormat = getDateTimeFormat("en");
+
+    expect(simpleEnDateTimeFormat).toBe(getDateTimeFormat("en"));
+    expect(dateTimeFormatCache.size).toBe(1);
+
+    const options: Intl.DateTimeFormatOptions = { dateStyle: "full" };
+    const customizedEnDateTimeFormat = getDateTimeFormat("en", options);
+
+    expect(customizedEnDateTimeFormat).toBe(getDateTimeFormat("en", options));
+    expect(simpleEnDateTimeFormat).not.toBe(customizedEnDateTimeFormat);
+    expect(dateTimeFormatCache.size).toBe(2);
+
+    const simpleEsDateTimeFormat = getDateTimeFormat("es");
+
+    expect(simpleEsDateTimeFormat).toBe(getDateTimeFormat("es"));
+    expect(simpleEsDateTimeFormat).not.toBe(simpleEnDateTimeFormat);
+    expect(dateTimeFormatCache.size).toBe(1);
+
+    const customizedEsDateTimeFormat = getDateTimeFormat("es", options);
+
+    expect(customizedEsDateTimeFormat).toBe(getDateTimeFormat("es", options));
+    expect(simpleEsDateTimeFormat).not.toBe(customizedEsDateTimeFormat);
+    expect(dateTimeFormatCache.size).toBe(2);
   });
 });

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,4 +1,4 @@
-import { getSupportedLocale, getSupportedNumberingSystem, NumberingSystem } from "./locale";
+import { getDateTimeFormat, getSupportedNumberingSystem, NumberingSystem } from "./locale";
 import { isValidNumber } from "./number";
 export type HourCycle = "12" | "24";
 
@@ -31,20 +31,17 @@ function createLocaleDateTimeFormatter(
   numberingSystem: NumberingSystem,
   includeSeconds = true
 ): Intl.DateTimeFormat {
-  try {
-    const options: Intl.DateTimeFormatOptions = {
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZone: "UTC",
-      numberingSystem: getSupportedNumberingSystem(numberingSystem)
-    };
-    if (includeSeconds) {
-      options.second = "2-digit";
-    }
-    return new Intl.DateTimeFormat(getSupportedLocale(locale), options);
-  } catch (error) {
-    throw new Error(`Invalid locale supplied while attempting to create a DateTime formatter: ${locale}`);
+  const options: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    numberingSystem: getSupportedNumberingSystem(numberingSystem)
+  };
+  if (includeSeconds) {
+    options.second = "2-digit";
   }
+
+  return getDateTimeFormat(locale, options);
 }
 
 export function formatTimePart(number: number): string {


### PR DESCRIPTION
**Related Issue:** #4148 

## Summary

Adds util to reuse `Intl.DateTimeFormat` instances.

This came up while working on https://github.com/Esri/calcite-components/issues/5570 and decided to submit separately to link to #4148.

## Notes

* caching will be tied to single locale, once it changes, the cache will be cleared
* this removes error handling in `time.ts` when creating a `Intl.DateTimeFormat` as specifying an unsupported locale would be a user error.