### PR TITLE
fix(input-time-picker, time-picker): render when input-time-picker or time-picker's step property changes

### DIFF
--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -6,10 +6,10 @@ import {
   disabled,
   focusable,
   formAssociated,
+  hidden,
   labelable,
   reflects,
-  renders,
-  hidden
+  renders
 } from "../../tests/commonTests";
 
 describe("calcite-input-time-picker", () => {
@@ -371,4 +371,28 @@ describe("calcite-input-time-picker", () => {
 
   it("is form-associated", () =>
     formAssociated("calcite-input-time-picker", { testValue: "03:23", submitsOnEnter: true }));
+
+  it("toggles seconds display when step is < 60", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-input-time-picker value="11:00:00"></calcite-input-time-picker>`
+    });
+
+    const inputTimePicker = await page.find("calcite-input-time-picker");
+    const input = await page.find("calcite-input-time-picker >>> calcite-input");
+
+    expect(await inputTimePicker.getProperty("value")).toBe("11:00:00");
+    expect(await input.getProperty("value")).toBe("11:00 AM");
+
+    inputTimePicker.setProperty("step", 1);
+    await page.waitForChanges();
+
+    expect(await inputTimePicker.getProperty("value")).toBe("11:00:00");
+    expect(await input.getProperty("value")).toBe("11:00:00 AM");
+
+    inputTimePicker.setProperty("step", 60);
+    await page.waitForChanges();
+
+    expect(await inputTimePicker.getProperty("value")).toBe("11:00:00");
+    expect(await input.getProperty("value")).toBe("11:00 AM");
+  });
 });

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -199,7 +199,8 @@ export class InputTimePicker
   @State() effectiveLocale = "";
 
   @Watch("effectiveLocale")
-  effectiveLocaleWatcher(): void {
+  @Watch("step")
+  valueRelatedPropChange(): void {
     this.setInputValue(
       localizeTimeString({
         value: this.value,

--- a/src/components/time-picker/time-picker.e2e.ts
+++ b/src/components/time-picker/time-picker.e2e.ts
@@ -1060,4 +1060,23 @@ describe("calcite-time-picker", () => {
   });
 
   it("suuports translation", () => t9n("<calcite-time-picker></calcite-time-picker>"));
+
+  it("toggles seconds display when step is < 60", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-time-picker value="11:00:00"></calcite-time-picker>`
+    });
+    const timePicker = await page.find("calcite-time-picker");
+
+    expect(await page.find(`calcite-time-picker >>> .${CSS.second}`)).toBeNull();
+
+    timePicker.setProperty("step", 1);
+    await page.waitForChanges();
+
+    expect(await page.find(`calcite-time-picker >>> .${CSS.second}`)).not.toBeNull();
+
+    timePicker.setProperty("step", 60);
+    await page.waitForChanges();
+
+    expect(await page.find(`calcite-time-picker >>> .${CSS.second}`)).toBeNull();
+  });
 });

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -88,6 +88,11 @@ export class TimePicker
   /** Specifies the granularity the `value` must adhere to (in seconds). */
   @Prop({ reflect: true }) step = 60;
 
+  @Watch("step")
+  stepChange(): void {
+    this.updateShowSecond();
+  }
+
   /**
    * Specifies the Unicode numeral system used by the component for localization.
    *
@@ -176,7 +181,7 @@ export class TimePicker
 
   @State() second: string;
 
-  @State() showSecond: boolean = this.step < 60;
+  @State() showSecond: boolean;
 
   @State() defaultMessages: TimePickerMessages;
 
@@ -300,6 +305,10 @@ export class TimePicker
   //  Private Methods
   //
   // --------------------------------------------------------------------------
+
+  private updateShowSecond(): void {
+    this.showSecond = this.step < 60;
+  }
 
   private async focusPart(target: TimePart): Promise<void> {
     await componentLoaded(this);
@@ -711,6 +720,7 @@ export class TimePicker
     connectLocalized(this);
     this.updateLocale();
     connectMessages(this);
+    this.updateShowSecond();
     this.meridiemOrder = this.getMeridiemOrder(
       getTimeParts({
         value: "0:00:00",


### PR DESCRIPTION
**Related Issue:** #6039 

## Summary

The `step` property toggles the display of the seconds in the UI. This adds some watchers to trigger rendering when the prop is updated.
