### PR TITLE
docs: format form refs across components

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -77,7 +77,7 @@ export class Button
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -59,7 +59,7 @@ export class Checkbox
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -142,7 +142,7 @@ export class Combobox
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -105,7 +105,7 @@ export class InputDatePicker
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-number/input-number.tsx
+++ b/src/components/input-number/input-number.tsx
@@ -125,7 +125,7 @@ export class InputNumber
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-text/input-text.tsx
+++ b/src/components/input-text/input-text.tsx
@@ -104,7 +104,7 @@ export class InputText
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -93,7 +93,7 @@ export class InputTimePicker
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -127,7 +127,7 @@ export class Input
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/radio-button/radio-button.tsx
+++ b/src/components/radio-button/radio-button.tsx
@@ -78,7 +78,7 @@ export class RadioButton
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/rating/rating.tsx
+++ b/src/components/rating/rating.tsx
@@ -74,7 +74,7 @@ export class Rating
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/segmented-control/segmented-control.tsx
+++ b/src/components/segmented-control/segmented-control.tsx
@@ -66,7 +66,7 @@ export class SegmentedControl
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -69,7 +69,7 @@ export class Select
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -84,7 +84,7 @@ export class Slider
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -55,7 +55,7 @@ export class Switch
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -98,7 +98,7 @@ export class TextArea
   /**
    * The ID of the form that will be associated with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    */
   @Prop({ reflect: true })
   form: string;

--- a/src/utils/form.tsx
+++ b/src/utils/form.tsx
@@ -21,7 +21,7 @@ export interface FormOwner {
   /**
    * The ID of the form to associate with the component.
    *
-   * When not set, the component will be associated with its ancestor `<form>` element, if any.
+   * When not set, the component will be associated with its ancestor form element, if any.
    *
    * Note that this prop should use the @Prop decorator.
    */


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Reformats the form references across components to reside outside of `<code>` in the docs, which were trying to add a `<form>` info the doc site. 

Change includes:

> `<form>` to form

### Update
![image](https://user-images.githubusercontent.com/5023024/230218812-69864c76-80c0-4e03-b2cc-6c8df582870d.png)

### Before the update
![image](https://user-images.githubusercontent.com/5023024/230218639-d9d6f58f-0f8f-4fbd-b147-f1c52153560b.png)

