### PR TITLE
feat(action-bar, action-pad): Set layout property on child action-group elements.

### DIFF
--- a/src/components/action-bar/action-bar.e2e.ts
+++ b/src/components/action-bar/action-bar.e2e.ts
@@ -383,4 +383,24 @@ describe("calcite-action-bar", () => {
   });
 
   it("supports translation", () => t9n("calcite-action-bar"));
+
+  it("should set layout on child action-groups", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(html`<calcite-action-bar layout="horizontal">
+      <calcite-action-group></calcite-action-group>
+    </calcite-action-bar>`);
+    await page.waitForChanges();
+
+    const group = await page.find("calcite-action-group");
+
+    expect(await group.getProperty("layout")).toBe("horizontal");
+
+    const actionBar = await page.find("calcite-action-bar");
+
+    actionBar.setProperty("layout", "vertical");
+    await page.waitForChanges();
+
+    expect(await group.getProperty("layout")).toBe("vertical");
+  });
 });

--- a/src/components/action-bar/action-bar.stories.ts
+++ b/src/components/action-bar/action-bar.stories.ts
@@ -71,12 +71,12 @@ export const simple = (): string =>
 export const horizontal = (): string => html`
   <div style="width: 500px;">
     <calcite-action-bar layout="horizontal" style="width:100%">
-      <calcite-action-group layout="horizontal">
+      <calcite-action-group>
         <calcite-action text="Add" icon="plus"> </calcite-action>
         <calcite-action text="Save" icon="save"> </calcite-action>
         <calcite-action text="Layers" icon="layers"> </calcite-action>
       </calcite-action-group>
-      <calcite-action-group layout="horizontal">
+      <calcite-action-group>
         <calcite-action text="Add" icon="plus"> </calcite-action>
         <calcite-action text="Save" active icon="save"> </calcite-action>
         <calcite-action text="Layers" icon="layers"> </calcite-action>
@@ -89,12 +89,12 @@ export const horizontal = (): string => html`
 export const horizontalSmall = (): string => html`
   <div style="width: 250px;">
     <calcite-action-bar layout="horizontal" style="width:100%">
-      <calcite-action-group layout="horizontal">
+      <calcite-action-group>
         <calcite-action text="Add" icon="plus"> </calcite-action>
         <calcite-action text="Save" icon="save"> </calcite-action>
         <calcite-action text="Layers" icon="layers"> </calcite-action>
       </calcite-action-group>
-      <calcite-action-group layout="horizontal">
+      <calcite-action-group>
         <calcite-action text="Add" icon="plus"> </calcite-action>
         <calcite-action text="Save" active icon="save"> </calcite-action>
         <calcite-action text="Layers" icon="layers"> </calcite-action>

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -17,7 +17,7 @@ import {
   connectConditionalSlotComponent,
   disconnectConditionalSlotComponent
 } from "../../utils/conditionalSlot";
-import { getSlotted } from "../../utils/dom";
+import { getSlotted, slotChangeGetAssignedElements } from "../../utils/dom";
 import {
   componentLoaded,
   LoadableComponent,
@@ -331,11 +331,9 @@ export class ActionBar
   }
 
   handleDefaultSlotChange = (event: Event): void => {
-    const groups = (event.target as HTMLSlotElement)
-      .assignedElements({
-        flatten: true
-      })
-      .filter((el) => el?.matches("calcite-action-group")) as HTMLCalciteActionGroupElement[];
+    const groups = slotChangeGetAssignedElements(event).filter((el) =>
+      el?.matches("calcite-action-group")
+    ) as HTMLCalciteActionGroupElement[];
 
     this.setGroupLayout(groups);
   };

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -275,6 +275,9 @@ export class ActionBar
     const actions = queryActions(el);
     const actionCount = expandDisabled ? actions.length : actions.length + 1;
     const actionGroups = Array.from(el.querySelectorAll("calcite-action-group"));
+
+    this.setGroupLayout(actionGroups);
+
     const groupCount =
       getSlotted(el, SLOTS.bottomActions) || !expandDisabled
         ? actionGroups.length + 1
@@ -312,6 +315,20 @@ export class ActionBar
 
   setExpandToggleRef = (el: HTMLCalciteActionElement): void => {
     this.expandToggleEl = el;
+  };
+
+  setGroupLayout = (groups: HTMLCalciteActionGroupElement[]): void => {
+    groups.forEach((group) => (group.layout = this.layout));
+  };
+
+  handleDefaultSlotChange = (event: Event): void => {
+    const groups = (event.target as HTMLSlotElement)
+      .assignedElements({
+        flatten: true
+      })
+      .filter((el) => el?.matches("calcite-action-group")) as HTMLCalciteActionGroupElement[];
+
+    this.setGroupLayout(groups);
   };
 
   // --------------------------------------------------------------------------
@@ -352,7 +369,7 @@ export class ActionBar
   render(): VNode {
     return (
       <Host onCalciteActionMenuOpen={this.actionMenuOpenHandler}>
-        <slot />
+        <slot onSlotchange={this.handleDefaultSlotChange} />
         {this.renderBottomActionGroup()}
       </Host>
     );

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -322,15 +322,13 @@ export class ActionBar
     this.expandToggleEl = el;
   };
 
-  updateGroups = (): void => {
-    const actionGroups = Array.from(this.el.querySelectorAll("calcite-action-group"));
+  updateGroups(): void {
+    this.setGroupLayout(Array.from(this.el.querySelectorAll("calcite-action-group")));
+  }
 
-    this.setGroupLayout(actionGroups);
-  };
-
-  setGroupLayout = (groups: HTMLCalciteActionGroupElement[]): void => {
+  setGroupLayout(groups: HTMLCalciteActionGroupElement[]): void {
     groups.forEach((group) => (group.layout = this.layout));
-  };
+  }
 
   handleDefaultSlotChange = (event: Event): void => {
     const groups = (event.target as HTMLSlotElement)

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -93,6 +93,11 @@ export class ActionBar
    */
   @Prop({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "vertical";
 
+  @Watch("layout")
+  layoutHandler(): void {
+    this.updateGroups();
+  }
+
   /**
    * Disables automatically overflowing `calcite-action`s that won't fit into menus.
    */
@@ -315,6 +320,12 @@ export class ActionBar
 
   setExpandToggleRef = (el: HTMLCalciteActionElement): void => {
     this.expandToggleEl = el;
+  };
+
+  updateGroups = (): void => {
+    const actionGroups = Array.from(this.el.querySelectorAll("calcite-action-group"));
+
+    this.setGroupLayout(actionGroups);
   };
 
   setGroupLayout = (groups: HTMLCalciteActionGroupElement[]): void => {

--- a/src/components/action-group/action-group.e2e.ts
+++ b/src/components/action-group/action-group.e2e.ts
@@ -9,10 +9,10 @@ const actionGroupHTML = `<calcite-action-group scale="l">
 
 describe("calcite-action-group", () => {
   it("defaults", async () =>
-    defaults("calcite-action-bar", [
+    defaults("calcite-action-group", [
       {
         propertyName: "layout",
-        defaultValue: "horizontal"
+        defaultValue: "vertical"
       }
     ]));
 

--- a/src/components/action-group/action-group.e2e.ts
+++ b/src/components/action-group/action-group.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
 import { SLOTS } from "./resources";
 
 const actionGroupHTML = `<calcite-action-group scale="l">
@@ -8,6 +8,14 @@ const actionGroupHTML = `<calcite-action-group scale="l">
       </calcite-action-group>`;
 
 describe("calcite-action-group", () => {
+  it("defaults", async () =>
+    defaults("calcite-action-bar", [
+      {
+        propertyName: "layout",
+        defaultValue: "horizontal"
+      }
+    ]));
+
   it("renders", async () => renders("calcite-action-group", { display: "flex" }));
 
   it("focusable", async () => focusable(actionGroupHTML, { shadowFocusTargetSelector: "calcite-action" }));

--- a/src/components/action-group/action-group.tsx
+++ b/src/components/action-group/action-group.tsx
@@ -60,7 +60,7 @@ export class ActionGroup
   /**
    * Indicates the layout of the component.
    *
-   * @deprecated Use the `layout` property on the comoponent's parent component instead.
+   * @deprecated Use the `layout` property on the component's parent component instead.
    */
   @Prop({ reflect: true }) layout: Layout = "vertical";
 

--- a/src/components/action-group/action-group.tsx
+++ b/src/components/action-group/action-group.tsx
@@ -60,7 +60,7 @@ export class ActionGroup
   /**
    * Indicates the layout of the component.
    *
-   * @deprecated Use the `layout` property on the component's parent component instead.
+   * @deprecated Use the `layout` property on the component's parent instead.
    */
   @Prop({ reflect: true }) layout: Layout = "vertical";
 

--- a/src/components/action-group/action-group.tsx
+++ b/src/components/action-group/action-group.tsx
@@ -59,6 +59,8 @@ export class ActionGroup
 
   /**
    * Indicates the layout of the component.
+   *
+   * @deprecated Use the `layout` property on the comoponent's parent component instead.
    */
   @Prop({ reflect: true }) layout: Layout = "vertical";
 

--- a/src/components/action-pad/action-pad.e2e.ts
+++ b/src/components/action-pad/action-pad.e2e.ts
@@ -252,4 +252,24 @@ describe("calcite-action-pad", () => {
   });
 
   it("supports translation", () => t9n("calcite-action-pad"));
+
+  it("should set layout on child action-groups", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(html`<calcite-action-pad layout="horizontal">
+      <calcite-action-group></calcite-action-group>
+    </calcite-action-pad>`);
+    await page.waitForChanges();
+
+    const group = await page.find("calcite-action-group");
+
+    expect(await group.getProperty("layout")).toBe("horizontal");
+
+    const actionPad = await page.find("calcite-action-pad");
+
+    actionPad.setProperty("layout", "vertical");
+    await page.waitForChanges();
+
+    expect(await group.getProperty("layout")).toBe("vertical");
+  });
 });

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -35,6 +35,7 @@ import { ExpandToggle, toggleChildActionText } from "../functional/ExpandToggle"
 import { Layout, Position, Scale } from "../interfaces";
 import { ActionPadMessages } from "./assets/action-pad/t9n";
 import { CSS, SLOTS } from "./resources";
+import { createObserver } from "../../utils/observers";
 
 /**
  * @slot - A slot for adding `calcite-action`s to the component.
@@ -125,6 +126,12 @@ export class ActionPad
 
   @Element() el: HTMLCalciteActionPadElement;
 
+  mutationObserver = createObserver("mutation", () => {
+    const actionGroups = Array.from(this.el.querySelectorAll("calcite-action-group"));
+
+    this.setGroupLayout(actionGroups);
+  });
+
   expandToggleEl: HTMLCalciteActionElement;
 
   @State() effectiveLocale = "";
@@ -207,6 +214,20 @@ export class ActionPad
     this.expandToggleEl = el;
   };
 
+  setGroupLayout = (groups: HTMLCalciteActionGroupElement[]): void => {
+    groups.forEach((group) => (group.layout = this.layout));
+  };
+
+  handleDefaultSlotChange = (event: Event): void => {
+    const groups = (event.target as HTMLSlotElement)
+      .assignedElements({
+        flatten: true
+      })
+      .filter((el) => el?.matches("calcite-action-group")) as HTMLCalciteActionGroupElement[];
+
+    this.setGroupLayout(groups);
+  };
+
   // --------------------------------------------------------------------------
   //
   //  Component Methods
@@ -245,7 +266,7 @@ export class ActionPad
     return (
       <Host onCalciteActionMenuOpen={this.actionMenuOpenHandler}>
         <div class={CSS.container}>
-          <slot />
+          <slot onSlotchange={this.handleDefaultSlotChange} />
           {this.renderBottomActionGroup()}
         </div>
       </Host>

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -78,6 +78,11 @@ export class ActionPad
    */
   @Prop({ reflect: true }) layout: Layout = "vertical";
 
+  @Watch("layout")
+  layoutHandler(): void {
+    this.updateGroups();
+  }
+
   /**
    * Arranges the component depending on the element's `dir` property.
    */
@@ -212,6 +217,12 @@ export class ActionPad
 
   setExpandToggleRef = (el: HTMLCalciteActionElement): void => {
     this.expandToggleEl = el;
+  };
+
+  updateGroups = (): void => {
+    const actionGroups = Array.from(this.el.querySelectorAll("calcite-action-group"));
+
+    this.setGroupLayout(actionGroups);
   };
 
   setGroupLayout = (groups: HTMLCalciteActionGroupElement[]): void => {

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -131,11 +131,9 @@ export class ActionPad
 
   @Element() el: HTMLCalciteActionPadElement;
 
-  mutationObserver = createObserver("mutation", () => {
-    const actionGroups = Array.from(this.el.querySelectorAll("calcite-action-group"));
-
-    this.setGroupLayout(actionGroups);
-  });
+  mutationObserver = createObserver("mutation", () =>
+    this.setGroupLayout(Array.from(this.el.querySelectorAll("calcite-action-group")))
+  );
 
   expandToggleEl: HTMLCalciteActionElement;
 
@@ -219,15 +217,13 @@ export class ActionPad
     this.expandToggleEl = el;
   };
 
-  updateGroups = (): void => {
-    const actionGroups = Array.from(this.el.querySelectorAll("calcite-action-group"));
+  updateGroups(): void {
+    this.setGroupLayout(Array.from(this.el.querySelectorAll("calcite-action-group")));
+  }
 
-    this.setGroupLayout(actionGroups);
-  };
-
-  setGroupLayout = (groups: HTMLCalciteActionGroupElement[]): void => {
+  setGroupLayout(groups: HTMLCalciteActionGroupElement[]): void {
     groups.forEach((group) => (group.layout = this.layout));
-  };
+  }
 
   handleDefaultSlotChange = (event: Event): void => {
     const groups = (event.target as HTMLSlotElement)

--- a/src/components/action-pad/action-pad.tsx
+++ b/src/components/action-pad/action-pad.tsx
@@ -16,7 +16,7 @@ import {
   connectConditionalSlotComponent,
   disconnectConditionalSlotComponent
 } from "../../utils/conditionalSlot";
-import { getSlotted } from "../../utils/dom";
+import { getSlotted, slotChangeGetAssignedElements } from "../../utils/dom";
 import {
   componentLoaded,
   LoadableComponent,
@@ -226,11 +226,9 @@ export class ActionPad
   }
 
   handleDefaultSlotChange = (event: Event): void => {
-    const groups = (event.target as HTMLSlotElement)
-      .assignedElements({
-        flatten: true
-      })
-      .filter((el) => el?.matches("calcite-action-group")) as HTMLCalciteActionGroupElement[];
+    const groups = slotChangeGetAssignedElements(event).filter((el) =>
+      el?.matches("calcite-action-group")
+    ) as HTMLCalciteActionGroupElement[];
 
     this.setGroupLayout(groups);
   };

--- a/src/components/shell/shell.stories.ts
+++ b/src/components/shell/shell.stories.ts
@@ -377,7 +377,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
     ></div>
     <calcite-shell-panel slot="panel-end" position="end" detached>
       <calcite-action-bar slot="action-bar">
-        <calcite-action-group layout="vertical">
+        <calcite-action-group>
           <calcite-action text="Idea" label="Add Item" icon="lightbulb" appearance="solid" scale="m"></calcite-action>
           <calcite-action
             text="Information"
@@ -387,7 +387,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
             scale="m"
           ></calcite-action>
         </calcite-action-group>
-        <calcite-action-group layout="vertical">
+        <calcite-action-group>
           <calcite-action
             text="Question"
             label="View Layers"

--- a/src/demos/action.html
+++ b/src/demos/action.html
@@ -531,11 +531,11 @@
         <div class="child-action-bar" style="flex: 1">
           <div>grouping</div>
           <calcite-action-bar layout="horizontal">
-            <calcite-action-group layout="horizontal">
+            <calcite-action-group>
               <calcite-action text="Add" icon="plus"> </calcite-action>
               <calcite-action text="Save" icon="save"> </calcite-action>
             </calcite-action-group>
-            <calcite-action-group layout="horizontal">
+            <calcite-action-group>
               <calcite-action text="Layers" icon="layers"> </calcite-action>
             </calcite-action-group>
           </calcite-action-bar>
@@ -553,12 +553,12 @@
         <div class="child-action-bar" style="flex: 1">
           <div>tall container</div>
           <calcite-action-bar layout="horizontal">
-            <calcite-action-group layout="horizontal">
+            <calcite-action-group>
               <calcite-action text="Add" icon="plus"> </calcite-action>
               <calcite-action text="Save" icon="save"> </calcite-action>
               <calcite-action text="Layers" icon="layers"> </calcite-action>
             </calcite-action-group>
-            <calcite-action-group layout="horizontal">
+            <calcite-action-group>
               <calcite-action text="Add" icon="plus"> </calcite-action>
               <calcite-action text="Save" active icon="save"> </calcite-action>
               <calcite-action text="Layers" icon="layers"> </calcite-action>
@@ -580,12 +580,12 @@
         <div class="child-action-bar" style="flex: 1">
           <div>Full width</div>
           <calcite-action-bar layout="horizontal" style="width: 100%">
-            <calcite-action-group layout="horizontal">
+            <calcite-action-group>
               <calcite-action text="Add" icon="plus"> </calcite-action>
               <calcite-action text="Save" icon="save"> </calcite-action>
               <calcite-action text="Layers" icon="layers"> </calcite-action>
             </calcite-action-group>
-            <calcite-action-group layout="horizontal">
+            <calcite-action-group>
               <calcite-action text="Add" icon="plus"> </calcite-action>
               <calcite-action text="Save" active icon="save"> </calcite-action>
               <calcite-action text="Layers" icon="layers"> </calcite-action>


### PR DESCRIPTION
**Related Issue:** #6390

## Summary

Deprecates the layout property on the `action-group` element. The parent component of the child `action-group` elements will set the `layout` property.