### PR TITLE
refactor(shell-panel, shell-center-row): Set layout property on slotted action-bar components.

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -90,6 +90,8 @@ export class ActionBar
 
   /**
    *  The layout direction of the actions.
+   *
+   * @deprecated It is no longer necessary to set this property.
    */
   @Prop({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "vertical";
 

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -90,8 +90,6 @@ export class ActionBar
 
   /**
    *  The layout direction of the actions.
-   *
-   * @deprecated It is no longer necessary to set this property.
    */
   @Prop({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "vertical";
 

--- a/src/components/shell-center-row/shell-center-row.tsx
+++ b/src/components/shell-center-row/shell-center-row.tsx
@@ -78,6 +78,10 @@ export class ShellCenterRow implements ConditionalSlotComponent {
 
     const actionBar = getSlotted<HTMLCalciteActionBarElement>(el, SLOTS.actionBar);
 
+    if (actionBar) {
+      actionBar.layout = "horizontal";
+    }
+
     const actionBarNode = actionBar ? (
       <div class={CSS.actionBarContainer} key="action-bar">
         <slot name={SLOTS.actionBar} />

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -211,7 +211,9 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
       />
     ) : null;
 
-    const actionBarNode = <slot key="action-bar" name={SLOTS.actionBar} />;
+    const actionBarNode = (
+      <slot key="action-bar" name={SLOTS.actionBar} onSlotchange={this.handleActionBarSlotChange} />
+    );
 
     const mainNodes = [actionBarNode, contentNode, separatorNode];
 
@@ -405,5 +407,15 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
 
   disconnectSeparator = (): void => {
     this.separatorEl?.removeEventListener("pointerdown", this.separatorPointerDown);
+  };
+
+  handleActionBarSlotChange = (event: Event): void => {
+    const actionBars = (event.target as HTMLSlotElement)
+      .assignedElements({
+        flatten: true
+      })
+      .filter((el) => el?.matches("calcite-action-bar")) as HTMLCalciteActionBarElement[];
+
+    actionBars.forEach((actionBar) => (actionBar.layout = "vertical"));
   };
 }

--- a/src/components/shell-panel/shell-panel.tsx
+++ b/src/components/shell-panel/shell-panel.tsx
@@ -4,7 +4,12 @@ import {
   connectConditionalSlotComponent,
   disconnectConditionalSlotComponent
 } from "../../utils/conditionalSlot";
-import { getElementDir, getSlotted, isPrimaryPointerButton } from "../../utils/dom";
+import {
+  getElementDir,
+  getSlotted,
+  isPrimaryPointerButton,
+  slotChangeGetAssignedElements
+} from "../../utils/dom";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
 import { clamp } from "../../utils/math";
 import {
@@ -410,12 +415,10 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
   };
 
   handleActionBarSlotChange = (event: Event): void => {
-    const actionBars = (event.target as HTMLSlotElement)
-      .assignedElements({
-        flatten: true
-      })
-      .filter((el) => el?.matches("calcite-action-bar")) as HTMLCalciteActionBarElement[];
-
-    actionBars.forEach((actionBar) => (actionBar.layout = "vertical"));
+    (
+      slotChangeGetAssignedElements(event).filter((el) =>
+        el?.matches("calcite-action-bar")
+      ) as HTMLCalciteActionBarElement[]
+    ).forEach((actionBar) => (actionBar.layout = "vertical"));
   };
 }


### PR DESCRIPTION
**Related Issue:** #6739

## Summary

`shell-panel`, and `shell-center-row` components will set the `layout` property for slotted `action-bar` components.




