### PR TITLE
fix(dropdown): trigger should break words when overflowing container.

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -33,6 +33,7 @@
 }
 .calcite-trigger-container {
   @apply relative flex flex-auto;
+  @include word-break;
 }
 
 @media (forced-colors: active) {

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -490,3 +490,18 @@ export const mediumIconForLargeDropdownItem_TestOnly = (): string => html`
     </calcite-dropdown-group>
   </calcite-dropdown>
 `;
+
+export const triggerWordBreak_TestOnly = (): string => html`<div style="width:300px;">
+<calcite-dropdown scale="m">
+  <calcite-button slot="trigger" alignment="icon-end-space-between" appearance="transparent" icon-end="chevronDown"
+    scale="m" type="button" width="full">BirdObservationCommentBirdObservationComment</calcite-button>
+  <calcite-dropdown-group role="group" selection-mode="single">
+    <calcite-dropdown-item>BirdObservationComment</calcite-dropdown-item>
+    <calcite-dropdown-item>BirdObservationComment-BirdObservationComment</calcite-dropdown-item>
+    <calcite-dropdown-item>BirdObservationCommentBirdObservationComment</calcite-dropdown-item>
+  </calcite-dropdown-group>
+  <calcite-dropdown-item>BirdObservationComment BirdObservationComment</calcite-dropdown-item>
+  <calcite-dropdown-item>Bird_Observation_Comment_Bird_Observation_Comment</calcite-dropdown-item>
+  </calcite-dropdown-group>
+</calcite-dropdown>
+</div>`;


### PR DESCRIPTION

**Related Issue:** #5903

## Summary

Applies css word break to the container of the trigger slotted element. If it overflows its bounds, words will be broken.
