### PR TITLE
build(deps): update calcite-ui-icons from 3.21.2 to 3.21.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.1.0",
-        "@esri/calcite-ui-icons": "3.21.2",
+        "@esri/calcite-ui-icons": "3.21.9",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -2420,9 +2420,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.21.2.tgz",
-      "integrity": "sha512-iEEgF6xresx9S8DD6TkYUMHyxKQuHQvvZumbeg/cPbH7TCknXfQbtxvE7hnBcnv6StBUDmThc/5jdqARi0dgeg==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.21.9.tgz",
+      "integrity": "sha512-z3Rc+Z7ToS3LTNPNLPCy0lH+xgrdE6Oim/87U8JDyDTcl9Yl90u9FQ5KKjZALKul1d180dCA3gFY/J9ycoBYVg==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -35382,9 +35382,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.21.2.tgz",
-      "integrity": "sha512-iEEgF6xresx9S8DD6TkYUMHyxKQuHQvvZumbeg/cPbH7TCknXfQbtxvE7hnBcnv6StBUDmThc/5jdqARi0dgeg==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.21.9.tgz",
+      "integrity": "sha512-z3Rc+Z7ToS3LTNPNLPCy0lH+xgrdE6Oim/87U8JDyDTcl9Yl90u9FQ5KKjZALKul1d180dCA3gFY/J9ycoBYVg==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.1.0",
-    "@esri/calcite-ui-icons": "3.21.2",
+    "@esri/calcite-ui-icons": "3.21.9",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION

## Summary

I noticed the UI Icon versions were again not being published, so I have made the npm versions up to date with the github releases. I then checked and Calcite Components was pretty far behind so updating y'all to the latest so all the new icons are available to teams through CC. 