### PR TITLE
feat: make getAssetPath available in output targets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// ⚠️do not modify this file ⚠️
-// this file was added as a work around to force the build to export `getAssetPath`,
+// ⚠️ do not modify this file ⚠️
+// this file was added as a workaround to force the build to export `getAssetPath`,
 // which enables developers to check if the asset path has been set or not
 export { getAssetPath } from "@stencil/core";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+// ⚠️do not modify this file ⚠️
+// this file was added as a work around to force the build to export `getAssetPath`,
+// which enables developers to check if the asset path has been set or not
+export { getAssetPath } from "@stencil/core";


### PR DESCRIPTION
**Related Issue:** #6696 

## Summary

Adds workaround to force Stencil build to export `getAssetPath` for developers to check if the asset path has been set.