### PR TITLE
chore(storybook): use quiet flag to reduce noise from storybook build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postbuild": "npm run util:patch && git restore src/components/*/readme.md",
     "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
     "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
-    "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs",
+    "build-storybook": "npm run util:build-docs && build-storybook --output-dir ./docs --quiet",
     "deps:update": "updtr --exclude chalk cheerio typescript @types/jest jest jest-cli ts-jest puppeteer @whitespace/storybook-addon-html && npm audit fix",
     "docs": "concurrently --kill-others --raw \"npm run build-storybook\" \"ts-node --esm ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",
     "docs:preview": "concurrently --raw \"npm:util:build-docs && start-storybook\" \"ts-node --esm ./support/cleanOnProcessExit.ts --path ./__docs-temp__\"",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Using `--quiet` to reduce noise in storybook build logs. Note that this isn't an issue in the CLI, which clears status messages as the build progresses.