### PR TITLE
docs: add color-picker-swatch name

### DIFF
--- a/src/components/color-picker-swatch/readme.md
+++ b/src/components/color-picker-swatch/readme.md
@@ -1,4 +1,4 @@
-# my-component
+# calcite-color-picker-swatch
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Observed by Esri staff where the component name was listed as "my component"

Adds context to our internal `color-picker-switch` component page.