### PR TITLE
feat: add json for de-AT locale with locale-specific data

### DIFF
--- a/src/components/date-picker/assets/date-picker/nls/de-AT.json
+++ b/src/components/date-picker/assets/date-picker/nls/de-AT.json
@@ -1,0 +1,32 @@
+{
+  "default-calendar": "gregorian",
+  "separator": ".",
+  "unitOrder": "DD.MM.YYYY",
+  "weekStart": 1,
+  "placeholder": "DD.MM.YYYY",
+  "days": {
+    "abbreviated": ["So.", "Mo.", "Di.", "Mi.", "Do.", "Fr.", "Sa."],
+    "narrow": ["S", "M", "D", "M", "D", "F", "S"],
+    "short": ["So.", "Mo.", "Di.", "Mi.", "Do.", "Fr.", "Sa."],
+    "wide": ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
+  },
+  "numerals": "0123456789",
+  "months": {
+    "abbreviated": ["Jän", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
+    "narrow": ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"],
+    "wide": [
+      "Jänner",
+      "Februar",
+      "März",
+      "April",
+      "Mai",
+      "Juni",
+      "Juli",
+      "August",
+      "September",
+      "Oktober",
+      "November",
+      "Dezember"
+    ]
+  }
+}

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -55,6 +55,7 @@ export const locales = [
   "cs",
   "da",
   "de",
+  "de-AT",
   "de-CH",
   "el",
   defaultLocale,


### PR DESCRIPTION
**Related Issue:** #6737 

## Summary
The change in this PR is to add support for the German - Austria (de-AT) locale in the date-picker component. It was requested by an international distributor. The change entails adding a new json file for the de-AT locale with locale-specific data.
