### PR TITLE
fix(tree-item): ensure tree-item properly reflect ancestor-mode selection on initialization

### DIFF
--- a/src/components/tree-item/tree-item.e2e.ts
+++ b/src/components/tree-item/tree-item.e2e.ts
@@ -166,35 +166,71 @@ describe("calcite-tree-item", () => {
   });
 
   describe("when a tree-item has ancestors selection-mode and is selected", () => {
-    it("should update its ancestor tree-items' indeterminate properties", async () => {
-      const tree = `<calcite-tree selection-mode="ancestors">
-        <calcite-tree-item expanded data-id="ancestor">
-          <span> Fruits </span>
-          <calcite-tree slot="children">
-            <calcite-tree-item>
-              <calcite-link href="#go" tabindex="-1"> Bananas </calcite-link>
-            </calcite-tree-item>
-            <calcite-tree-item expanded data-id="ancestor">
-              <span> Pears </span>
-              <calcite-tree slot="children">
-                <calcite-tree-item selected>
-                  <calcite-link href="#go" tabindex="-1"> Anjou </calcite-link>
-                </calcite-tree-item>
-                <calcite-tree-item>
-                  <calcite-link href="#go" tabindex="-1"> Bartlett </calcite-link>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-          </calcite-tree>
-        </calcite-tree-item>
-      </calcite-tree>
+    it("should update its ancestor tree-items' indeterminate properties (ancestors are indeterminate)", async () => {
+      const tree = html`
+        <calcite-tree selection-mode="ancestors">
+          <calcite-tree-item expanded data-id="ancestor">
+            <span>Fruits</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item>
+                <calcite-link href="#go" tabindex="-1">Bananas</calcite-link>
+              </calcite-tree-item>
+              <calcite-tree-item expanded data-id="ancestor">
+                <span>Pears</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item selected>
+                    <calcite-link href="#go" tabindex="-1">Anjou</calcite-link>
+                  </calcite-tree-item>
+                  <calcite-tree-item>
+                    <calcite-link href="#go" tabindex="-1">Bartlett</calcite-link>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
       `;
-      const page = await newE2EPage({ html: tree });
+      const page = await newE2EPage();
+      await page.setContent(tree);
       const ancestors = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
 
-      for (let i = 0; i < ancestors.length; i++) {
-        const node = ancestors[i];
+      for (const node of ancestors) {
         expect(await node.getProperty("indeterminate")).toBe(true);
+        expect(await node.getProperty("selected")).toBe(false);
+      }
+    });
+
+    it("should update its ancestor tree-items' indeterminate properties (ancestors are selected)", async () => {
+      const tree = html`
+        <calcite-tree selection-mode="ancestors">
+          <calcite-tree-item expanded data-id="ancestor">
+            <span>Fruits</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item>
+                <calcite-link href="#go" tabindex="-1">Bananas</calcite-link>
+              </calcite-tree-item>
+              <calcite-tree-item expanded data-id="ancestor">
+                <span>Pears</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item selected>
+                    <calcite-link href="#go" tabindex="-1">Anjou</calcite-link>
+                  </calcite-tree-item>
+                  <calcite-tree-item selected>
+                    <calcite-link href="#go" tabindex="-1">Bartlett</calcite-link>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+      `;
+      const page = await newE2EPage();
+      await page.setContent(tree);
+      const ancestors = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
+
+      for (const node of ancestors) {
+        expect(await node.getProperty("indeterminate")).toBe(false);
+        expect(await node.getProperty("selected")).toBe(true);
       }
     });
   });

--- a/src/components/tree-item/tree-item.e2e.ts
+++ b/src/components/tree-item/tree-item.e2e.ts
@@ -45,7 +45,10 @@ describe("calcite-tree-item", () => {
         propertyName: "hasChildren",
         defaultValue: false
       },
-      { propertyName: "indeterminate", defaultValue: undefined }
+      {
+        propertyName: "indeterminate",
+        defaultValue: false
+      }
     ]));
 
   it("has slots", () => slots("calcite-tree-item", SLOTS));
@@ -192,6 +195,7 @@ describe("calcite-tree-item", () => {
       `;
       const page = await newE2EPage();
       await page.setContent(tree);
+      await page.waitForChanges();
       const ancestors = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
 
       for (const node of ancestors) {
@@ -226,12 +230,14 @@ describe("calcite-tree-item", () => {
       `;
       const page = await newE2EPage();
       await page.setContent(tree);
-      const ancestors = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
+      await page.waitForChanges();
+      const [indeterminateAncestor, selectedAncestor] = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
 
-      for (const node of ancestors) {
-        expect(await node.getProperty("indeterminate")).toBe(false);
-        expect(await node.getProperty("selected")).toBe(true);
-      }
+      expect(await indeterminateAncestor.getProperty("indeterminate")).toBe(true);
+      expect(await indeterminateAncestor.getProperty("selected")).toBe(false);
+
+      expect(await selectedAncestor.getProperty("indeterminate")).toBe(false);
+      expect(await selectedAncestor.getProperty("selected")).toBe(true);
     });
   });
 

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -496,18 +496,33 @@ export class TreeItem
     items.forEach((item) => (item.parentExpanded = expanded));
   };
 
-  private updateAncestorTree = (): void => {
-    if (this.selected && this.selectionMode === "ancestors") {
-      const ancestors: HTMLCalciteTreeItemElement[] = [];
-      let parent = this.parentTreeItem;
-      while (parent) {
-        ancestors.push(parent);
-        parent = parent.parentElement?.closest("calcite-tree-item");
-      }
-      ancestors.forEach((item) => (item.indeterminate = true));
+  /**
+   * This is meant to be called in `componentDidLoad` in order to take advantage of the hierarchical component lifecycle
+   * and help check for item selection as items are initialized
+   *
+   * @private
+   */
+  private updateAncestorTree(): void {
+    if (this.selectionMode !== "ancestors") {
       return;
     }
-  };
+
+    if (this.selected) {
+      const parentItem = this.parentTreeItem;
+      const parentTree = this.el.parentElement;
+      const siblings = Array.from(parentTree?.children);
+      const selectedSiblings = siblings.filter(
+        (child: HTMLCalciteTreeItemElement) => child.selected
+      );
+
+      if (siblings.length === selectedSiblings.length) {
+        parentItem.selected = true;
+        parentItem.indeterminate = false;
+      } else if (selectedSiblings.length > 0) {
+        parentItem.indeterminate = true;
+      }
+    }
+  }
 
   private actionsEndSlotChangeHandler = (event: Event): void => {
     this.hasEndActions = slotChangeHasAssignedElement(event);

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -111,7 +111,7 @@ export class TreeItem
    *
    * @internal
    */
-  @Prop({ reflect: true }) indeterminate: boolean;
+  @Prop({ reflect: true }) indeterminate = false;
 
   /**
    * @internal
@@ -521,6 +521,9 @@ export class TreeItem
       } else if (selectedSiblings.length > 0) {
         parentItem.indeterminate = true;
       }
+    } else if (this.indeterminate) {
+      const parentItem = this.parentTreeItem;
+      parentItem.indeterminate = true;
     }
   }
 

--- a/src/components/tree-item/tree-item.tsx
+++ b/src/components/tree-item/tree-item.tsx
@@ -503,12 +503,13 @@ export class TreeItem
    * @private
    */
   private updateAncestorTree(): void {
-    if (this.selectionMode !== "ancestors") {
+    const parentItem = this.parentTreeItem;
+
+    if (this.selectionMode !== "ancestors" || !parentItem) {
       return;
     }
 
     if (this.selected) {
-      const parentItem = this.parentTreeItem;
       const parentTree = this.el.parentElement;
       const siblings = Array.from(parentTree?.children);
       const selectedSiblings = siblings.filter(


### PR DESCRIPTION
**Related Issue:** #5867 

## Summary

This updates the initial tree-item initialization logic to consider each tier of selected items in the tree hierarchy.