### PR TITLE
docs(list-item): add context to selected prop with parent list's selectionMode prop

### DIFF
--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -121,7 +121,7 @@ export class ListItem
   @Prop() setPosition: number = null;
 
   /**
-   * When `true`, the component is selected.
+   * When `true` and the parent `calcite-list`'s `selectionMode` is `"single"` or `"multiple"`, the component is selected.
    */
   @Prop({ reflect: true, mutable: true }) selected = false;
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Received anonymous feedback this morning where `list-item`s `selected` attr is not always reflected, when the parent `list` has a `selection-mode` of `"none"`.

Updates the `selected` attribute to reflect changes when the parent `list` has a `selection-mode`  

Also, audited `selected` and `checked` attributes across components, which have already been handled or do not apply to this case  
    - cc: @macandcheese for inclusion in `chip`/`chip-group` in the near future.