### PR TITLE
fix(tooltip, popover): Support transparent backgrounds

### DIFF
--- a/src/assets/styles/_floating-ui.scss
+++ b/src/assets/styles/_floating-ui.scss
@@ -112,7 +112,6 @@ $pointer_offset: -$pointer_size * 0.5;
 
   .arrow::before {
     content: "";
-    @apply shadow-1;
     background: var(--calcite-ui-foreground-1);
   }
 

--- a/src/assets/styles/_floating-ui.scss
+++ b/src/assets/styles/_floating-ui.scss
@@ -98,7 +98,7 @@ $floating-ui-transform-right: translateX(-5px);
   @include calciteHydratedHidden();
 }
 
-$pointer_size: 8px;
+$pointer_size: 12px;
 $pointer_offset: -$pointer_size * 0.5;
 
 @mixin floatingUIArrow {
@@ -113,7 +113,6 @@ $pointer_offset: -$pointer_size * 0.5;
   .arrow::before {
     content: "";
     @apply shadow-1;
-    transform: rotate(45deg);
     background: var(--calcite-ui-foreground-1);
   }
 
@@ -121,8 +120,16 @@ $pointer_offset: -$pointer_size * 0.5;
     inset-block-end: $pointer_offset;
   }
 
+  :host([data-placement^="top"]) .arrow::before {
+    clip-path: polygon(50% 100%, 0 50%, 100% 50%);
+  }
+
   :host([data-placement^="bottom"]) .arrow {
     inset-block-start: $pointer_offset;
+  }
+
+  :host([data-placement^="bottom"]) .arrow::before {
+    clip-path: polygon(50% 0, 0 50%, 100% 50%);
   }
 
   :host([data-placement^="right"]) .arrow,
@@ -135,7 +142,15 @@ $pointer_offset: -$pointer_size * 0.5;
     inset-inline-end: $pointer_offset;
   }
 
+  :host([data-placement^="left"]) .arrow::before {
+    clip-path: polygon(100% 50%, 50% 0, 50% 100%);
+  }
+
   :host([data-placement^="right"]) .arrow {
     inset-inline-start: $pointer_offset;
+  }
+
+  :host([data-placement^="right"]) .arrow::before {
+    clip-path: polygon(0 50%, 50% 0, 50% 100%);
   }
 }

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -81,8 +81,7 @@
 }
 
 .container {
-  @apply bg-foreground-1
-    text-color-1
+  @apply text-color-1
     relative
     flex
     h-full

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -59,7 +59,6 @@
 
 .header {
   @apply border-b-color-3
-    bg-foreground-1
     flex
     flex-auto
     items-stretch

--- a/src/components/popover/popover.stories.ts
+++ b/src/components/popover/popover.stories.ts
@@ -202,3 +202,25 @@ export const largeScaleLayout_TestOnly = (): string => html`
     </calcite-popover>
   </div>
 `;
+
+export const transparentBG_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-ui-foreground-1: rgba(0, 0, 0, 0.5);
+      --calcite-ui-text-1: orange;
+    }
+  </style>
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-popover
+      heading="these 🥨s are making me thirsty"
+      reference-element="reference-element"
+      placement="auto"
+      open
+      closable
+      scale="l"
+    >
+      ${contentHTML}
+    </calcite-popover>
+  </div>
+`;

--- a/src/components/popover/popover.stories.ts
+++ b/src/components/popover/popover.stories.ts
@@ -205,7 +205,7 @@ export const largeScaleLayout_TestOnly = (): string => html`
 
 export const transparentBG_TestOnly = (): string => html`
   <style>
-    :root {
+    calcite-popover {
       --calcite-ui-foreground-1: rgba(0, 0, 0, 0.5);
       --calcite-ui-text-1: orange;
     }

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -533,6 +533,7 @@ export class Popover
     return closable ? (
       <div class={CSS.closeButtonContainer} key={CSS.closeButtonContainer}>
         <calcite-action
+          appearance="transparent"
           class={CSS.closeButton}
           onClick={this.hide}
           scale={this.scale}

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -14,8 +14,7 @@
 @include floatingUIArrow();
 
 .container {
-  @apply bg-foreground-1
-    text-color-1
+  @apply text-color-1
     text-n2-wrap
     relative
     overflow-hidden

--- a/src/components/tooltip/tooltip.stories.ts
+++ b/src/components/tooltip/tooltip.stories.ts
@@ -72,3 +72,16 @@ export const rightAligned_TestOnly = (): string => html`<div style="text-align: 
     <span>Tooltip content lorem ipsum</span>
   </calcite-tooltip>
 </div>`;
+
+export const transparentBG_TestOnly = (): string => html`
+  <style>
+    :root {
+      --calcite-ui-foreground-1: rgba(0, 0, 0, 0.5);
+      --calcite-ui-text-1: orange;
+    }
+  </style>
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-tooltip reference-element="reference-element" placement="auto" open> ${contentHTML} </calcite-tooltip>
+  </div>
+`;

--- a/src/components/tooltip/tooltip.stories.ts
+++ b/src/components/tooltip/tooltip.stories.ts
@@ -75,7 +75,7 @@ export const rightAligned_TestOnly = (): string => html`<div style="text-align: 
 
 export const transparentBG_TestOnly = (): string => html`
   <style>
-    :root {
+    calcite-tooltip {
       --calcite-ui-foreground-1: rgba(0, 0, 0, 0.5);
       --calcite-ui-text-1: orange;
     }


### PR DESCRIPTION
**Related Issue:** #6798

## Summary

- Uses css `clip-path` instead of `transform: rotate` to create the caret arrow tail.
- Removes CSS where we are setting the BG on two separate elements.
- Screener tests