### PR TITLE
feat(input-time-picker): allow toggling time picker by clicking the input or entering the down/escape key

### DIFF
--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EPage, newE2EPage, E2EElement } from "@stencil/core/testing";
 import { localizeTimeString } from "../../utils/time";
 import {
   accessible,
@@ -11,6 +11,8 @@ import {
   reflects,
   renders
 } from "../../tests/commonTests";
+import { skipAnimations } from "../../tests/utils";
+import { html } from "../../../support/formatting";
 
 describe("calcite-input-time-picker", () => {
   it("renders", async () => renders("calcite-input-time-picker", { display: "inline-block" }));
@@ -60,7 +62,7 @@ describe("calcite-input-time-picker", () => {
 
     expect(await input.getProperty("value")).toBe("");
 
-    await component.callMethod("setFocus");
+    await component.click();
     await page.waitForChanges();
 
     expect(await page.evaluate(() => document.activeElement.id)).toBe("canReadOnly");
@@ -74,31 +76,6 @@ describe("calcite-input-time-picker", () => {
     await page.waitForChanges();
 
     expect(await input.getProperty("value")).toBe("");
-  });
-
-  it("opens the time picker on input keyboard focus", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker></calcite-input-time-picker>`
-    });
-    const popover = await page.find("calcite-input-time-picker >>> calcite-popover");
-
-    await page.keyboard.press("Tab");
-    await page.waitForChanges();
-
-    expect(await popover.getProperty("open")).toBe(true);
-  });
-
-  it("opens the time picker on input click", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker></calcite-input-time-picker>`
-    });
-    const input = await page.find("calcite-input-time-picker >>> calcite-input");
-    const popover = await page.find("calcite-input-time-picker >>> calcite-popover");
-
-    await input.click();
-    await page.waitForChanges();
-
-    expect(await popover.getProperty("open")).toBe(true);
   });
 
   it("programmatically changing the value reflects in the input for 24-hour (french lang)", async () => {
@@ -394,5 +371,65 @@ describe("calcite-input-time-picker", () => {
 
     expect(await inputTimePicker.getProperty("value")).toBe("11:00:00");
     expect(await input.getProperty("value")).toBe("11:00 AM");
+  });
+
+  describe("toggling time picker", () => {
+    let page: E2EPage;
+    let inputTimePicker: E2EElement;
+
+    beforeEach(async () => {
+      page = await newE2EPage();
+      await page.setContent(html` <calcite-input-time-picker></calcite-input-time-picker>`);
+      await skipAnimations(page);
+      await page.waitForChanges();
+      inputTimePicker = await page.find("calcite-input-time-picker");
+    });
+
+    it("does not open the time picker on input keyboard focus", async () => {
+      const popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      await page.keyboard.press("Tab");
+      await page.waitForChanges();
+
+      expect(await popover.getProperty("open")).not.toBe(true);
+    });
+
+    it("toggles the time picker when clicked", async () => {
+      let popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      expect(await popover.isVisible()).toBe(false);
+
+      await inputTimePicker.click();
+      await page.waitForChanges();
+      popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      expect(await popover.isVisible()).toBe(true);
+
+      await inputTimePicker.click();
+      await page.waitForChanges();
+      popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      expect(await popover.isVisible()).toBe(false);
+    });
+
+    it("toggles the time picker when using arrow down/escape key", async () => {
+      let popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      expect(await popover.isVisible()).toBe(false);
+
+      await inputTimePicker.callMethod("setFocus");
+      await page.waitForChanges();
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+      popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      expect(await popover.isVisible()).toBe(true);
+
+      await page.keyboard.press("Escape");
+      await page.waitForChanges();
+      popover = await page.find("calcite-input-time-picker >>> calcite-popover");
+
+      expect(await popover.isVisible()).toBe(false);
+    });
   });
 });

--- a/src/components/input-time-picker/input-time-picker.scss
+++ b/src/components/input-time-picker/input-time-picker.scss
@@ -5,3 +5,28 @@
 
 @include disabled();
 @include hidden-form-input();
+
+:host([scale="s"]) {
+  --calcite-toggle-spacing: theme("spacing.2");
+}
+
+:host([scale="m"]) {
+  --calcite-toggle-spacing: theme("spacing.3");
+}
+
+:host([scale="l"]) {
+  --calcite-toggle-spacing: theme("spacing.4");
+}
+
+.input-wrapper {
+  @apply relative;
+}
+
+.toggle-icon {
+  @apply absolute flex
+  w-4 cursor-pointer
+  items-center;
+  inset-inline-end: 0;
+  inset-block: 0;
+  padding-inline: var(--calcite-toggle-spacing);
+}

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -40,6 +40,8 @@ import {
 import { formatTimeString, isValidTime, localizeTimeString } from "../../utils/time";
 import { Scale } from "../interfaces";
 import { TimePickerMessages } from "../time-picker/assets/time-picker/t9n";
+import { CSS } from "./resources";
+import { toAriaBoolean } from "../../utils/dom";
 
 @Component({
   tag: "calcite-input-time-picker",
@@ -113,9 +115,6 @@ export class InputTimePicker
     }
   }
 
-  /**
-   * Use this property to override individual strings used by the component.
-   */
   @Prop() messagesOverrides: Partial<TimePickerMessages>;
 
   /** Specifies the name of the component on form submission. */
@@ -189,6 +188,8 @@ export class InputTimePicker
   private referenceElementId = `input-time-picker-${guid()}`;
 
   popoverEl: HTMLCalcitePopoverElement;
+
+  private dialogId = `time-picker-dialog--${guid()}`;
 
   //--------------------------------------------------------------------------
   //
@@ -287,6 +288,10 @@ export class InputTimePicker
     this.setInputValue(localizedValue);
   };
 
+  inputFocus = (): void => {
+    this.open = false;
+  };
+
   @Listen("click")
   clickHandler(event: MouseEvent): void {
     if (this.disabled || event.composedPath().includes(this.calciteTimePickerEl)) {
@@ -328,7 +333,6 @@ export class InputTimePicker
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);
-
     this.el.focus();
   }
 
@@ -359,9 +363,10 @@ export class InputTimePicker
       if (submitForm(this)) {
         event.preventDefault();
       }
-    }
-
-    if (key === "Escape" && this.open) {
+    } else if (key === "ArrowDown") {
+      this.open = true;
+      event.preventDefault();
+    } else if (key === "Escape" && this.open) {
       this.open = false;
       event.preventDefault();
     }
@@ -449,6 +454,14 @@ export class InputTimePicker
     }
   };
 
+  private onInputWrapperClick = () => {
+    this.open = !this.open;
+  };
+
+  deactivate = (): void => {
+    this.open = false;
+  };
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -492,39 +505,50 @@ export class InputTimePicker
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const popoverId = `${this.referenceElementId}-popover`;
+    const { dialogId } = this;
     return (
-      <Host onKeyDown={this.keyDownHandler}>
+      <Host onBlur={this.deactivate} onKeyDown={this.keyDownHandler}>
         <div
-          aria-controls={popoverId}
+          aria-controls={dialogId}
           aria-haspopup="dialog"
           aria-label={this.name}
-          aria-owns={popoverId}
+          aria-owns={dialogId}
           id={this.referenceElementId}
           role="combobox"
         >
-          <calcite-input
-            disabled={this.disabled}
-            icon="clock"
-            label={getLabelText(this)}
-            onCalciteInputInput={this.calciteInputInputHandler}
-            onCalciteInternalInputBlur={this.calciteInternalInputBlurHandler}
-            onCalciteInternalInputFocus={this.calciteInternalInputFocusHandler}
-            readOnly={this.readOnly}
-            scale={this.scale}
-            step={this.step}
-            // eslint-disable-next-line react/jsx-sort-props
-            ref={this.setCalciteInputEl}
-          />
+          <div class="input-wrapper" onClick={this.onInputWrapperClick}>
+            <calcite-input
+              aria-autocomplete="none"
+              aria-controls={this.dialogId}
+              aria-expanded={toAriaBoolean(this.open)}
+              aria-haspopup="dialog"
+              disabled={this.disabled}
+              icon="clock"
+              label={getLabelText(this)}
+              onCalciteInputInput={this.calciteInputInputHandler}
+              onCalciteInternalInputBlur={this.calciteInternalInputBlurHandler}
+              onCalciteInternalInputFocus={this.calciteInternalInputFocusHandler}
+              onFocus={this.inputFocus}
+              readOnly={this.readOnly}
+              role="combobox"
+              scale={this.scale}
+              step={this.step}
+              // eslint-disable-next-line react/jsx-sort-props
+              ref={this.setCalciteInputEl}
+            />
+            {this.renderToggleIcon(this.open)}
+          </div>
         </div>
         <calcite-popover
+          aria-live="polite"
           focusTrapDisabled={true}
-          id={popoverId}
+          id={dialogId}
           label="Time Picker"
           open={this.open}
           overlayPositioning={this.overlayPositioning}
           placement={this.placement}
           referenceElement={this.referenceElementId}
+          role="dialog"
           triggerDisabled={true}
           // eslint-disable-next-line react/jsx-sort-props
           ref={this.setCalcitePopoverEl}
@@ -543,6 +567,14 @@ export class InputTimePicker
         </calcite-popover>
         <HiddenFormInputSlot component={this} />
       </Host>
+    );
+  }
+
+  renderToggleIcon(open: boolean): VNode {
+    return (
+      <span class={CSS.toggleIcon}>
+        <calcite-icon icon={open ? "chevron-up" : "chevron-down"} scale="s" />
+      </span>
     );
   }
 }

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -115,6 +115,9 @@ export class InputTimePicker
     }
   }
 
+  /**
+   * Use this property to override individual strings used by the component.
+   */
   @Prop() messagesOverrides: Partial<TimePickerMessages>;
 
   /** Specifies the name of the component on form submission. */
@@ -170,15 +173,19 @@ export class InputTimePicker
   //
   //--------------------------------------------------------------------------
 
-  labelEl: HTMLCalciteLabelElement;
+  defaultValue: InputTimePicker["value"];
 
   formEl: HTMLFormElement;
 
-  defaultValue: InputTimePicker["value"];
+  labelEl: HTMLCalciteLabelElement;
+
+  popoverEl: HTMLCalcitePopoverElement;
 
   private calciteInputEl: HTMLCalciteInputElement;
 
   private calciteTimePickerEl: HTMLCalciteTimePickerElement;
+
+  private dialogId = `time-picker-dialog--${guid()}`;
 
   /** whether the value of the input was changed as a result of user typing or not */
   private internalValueChange = false;
@@ -186,10 +193,6 @@ export class InputTimePicker
   private previousValidValue: string = null;
 
   private referenceElementId = `input-time-picker-${guid()}`;
-
-  popoverEl: HTMLCalcitePopoverElement;
-
-  private dialogId = `time-picker-dialog--${guid()}`;
 
   //--------------------------------------------------------------------------
   //

--- a/src/components/input-time-picker/resources.ts
+++ b/src/components/input-time-picker/resources.ts
@@ -1,0 +1,3 @@
+export const CSS = {
+  toggleIcon: "toggle-icon"
+};


### PR DESCRIPTION
**Related Issue**: #6830

### Summary
This enhances the `input-time-picker` to allow it to be toggled via mouse and keyboard vs initial focus.

This also updates input to allow overriding `role` to accommodate other a11y structures.
