### PR TITLE
test(input-date-picker): add accessible test for input-date-picker

### DIFF
--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -7,7 +7,8 @@ import {
   floatingUIOwner,
   renders,
   hidden,
-  t9n
+  t9n,
+  accessible
 } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
@@ -16,6 +17,14 @@ import { getFocusedElementProp, skipAnimations } from "../../tests/utils";
 const animationDurationInMs = 200;
 
 describe("calcite-input-date-picker", () => {
+  it("is accessible", () =>
+    accessible(html`
+      <calcite-label>
+        Input Date Picker
+        <calcite-input-date-picker></calcite-input-date-picker>
+      </calcite-label>
+    `));
+
   it("renders", async () => renders("calcite-input-date-picker", { display: "inline-block" }));
 
   it("honors hidden attribute", async () => hidden("calcite-input-date-picker"));

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -63,7 +63,6 @@ import { Position } from "../interfaces";
 import { InputMessages } from "./assets/input/t9n";
 import { InputPlacement, NumberNudgeDirection, SetValueOrigin } from "./interfaces";
 import { CSS, INPUT_TYPE_ICONS, SLOTS } from "./resources";
-import { unwatchGlobalAttributes, watchGlobalAttributes } from "../../utils/globalAttributes";
 
 /**
  * @slot action - A slot for positioning a `calcite-button` next to the component.
@@ -450,8 +449,6 @@ export class Input
     updateMessages(this, this.effectiveLocale);
   }
 
-  @State() globalAttributes = {};
-
   @State() localizedValue: string;
 
   @State() slottedActionElDisabledInternally = false;
@@ -472,7 +469,6 @@ export class Input
     }
     connectLabel(this);
     connectForm(this);
-    watchGlobalAttributes(this, ["role"]);
 
     this.setPreviousEmittedValue(this.value);
     this.setPreviousValue(this.value);
@@ -496,7 +492,6 @@ export class Input
     disconnectForm(this);
     disconnectLocalized(this);
     disconnectMessages(this);
-    unwatchGlobalAttributes(this);
 
     this.mutationObserver?.disconnect();
     this.el.removeEventListener("calciteInternalHiddenInputChange", this.hiddenInputChangeHandler);
@@ -1173,7 +1168,6 @@ export class Input
               value={this.value}
               // eslint-disable-next-line react/jsx-sort-props
               ref={this.setChildElRef}
-              {...this.globalAttributes}
             />,
             this.isTextarea ? (
               <div class={CSS.resizeIconWrapper}>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Wires up `accessible` test helper for input-date-picker suite. 

**Note**: this rolls back overriding `role` on `calcite-input`'s internal input (see https://github.com/Esri/calcite-components/pull/6805/). This ended up causing invalid markup as some roles require matching aria roles, which refs cannot be resolved between shadow/light DOM:

```
 ● calcite-input-date-picker › is accessible

    expect(received).toHaveNoViolations(expected)

    Expected the HTML found at $('calcite-input-date-picker,calcite-input,input[aria-label=""]') to have no violations:

    <input aria-label="" class="" inputmode="text" placeholder="MM/DD/YYYY" type="text" role="combobox">

    Received:

    "Required ARIA attributes must be provided (aria-required-attr)"

    Fix any of the following:
      Required ARIA attributes not present: aria-expanded, aria-controls
```

@geospatialem helped test and verified that both JAWS & NVDA provide relevant options regardless of this change. VoiceOver is the only one that will lack context when interpreting the component:

#### passing `role="combobox"` through to the internal input

<img width="675" alt="Screenshot 2023-04-24 at 11 59 24 AM" src="https://user-images.githubusercontent.com/197440/234107372-93d70d4e-b094-4933-af6d-d1f518fe43e5.png">

#### not passing `role="combobox"` through to the internal input
<img width="640" alt="Screenshot 2023-04-24 at 11 57 43 AM" src="https://user-images.githubusercontent.com/197440/234107358-9ee7c082-6997-49bf-a524-a1a24efcca06.png">

cc @Elijbet 