### PR TITLE
test: split up form-associated test helper to run a test per use case

### DIFF
--- a/src/components/checkbox/checkbox.e2e.ts
+++ b/src/components/checkbox/checkbox.e2e.ts
@@ -23,7 +23,9 @@ describe("calcite-checkbox", () => {
   it("is labelable", async () =>
     labelable("calcite-checkbox", { propertyToToggle: "checked", shadowFocusTargetSelector: ".toggle" }));
 
-  it("is form-associated", async () => formAssociated("calcite-checkbox", { testValue: true, inputType: "checkbox" }));
+  describe("is form-associated", () => {
+    formAssociated("calcite-checkbox", { testValue: true, inputType: "checkbox" });
+  });
 
   it("can be disabled", () => disabled("calcite-checkbox"));
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -1169,7 +1169,7 @@ describe("calcite-combobox", () => {
     expect(await combobox.getProperty("open")).toBe(true);
   });
 
-  it("is form-associated", () =>
+  describe("is form-associated", () => {
     formAssociated(
       html`<calcite-combobox selection-mode="single">
         <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
@@ -1177,7 +1177,8 @@ describe("calcite-combobox", () => {
         <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
       </calcite-combobox>`,
       { testValue: "two", submitsOnEnter: true }
-    ));
+    );
+  });
 
   it("owns a floating-ui", () =>
     floatingUIOwner(

--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -392,13 +392,16 @@ describe("calcite-input-date-picker", () => {
   });
 
   describe("is form-associated", () => {
-    it("supports single value", () =>
-      formAssociated("calcite-input-date-picker", { testValue: "1985-03-23", submitsOnEnter: true }));
-    it("supports range", () =>
+    describe("supports single value", () => {
+      formAssociated("calcite-input-date-picker", { testValue: "1985-03-23", submitsOnEnter: true });
+    });
+
+    describe("supports range", () => {
       formAssociated(`<calcite-input-date-picker range name="calcite-input-date-picker"></calcite-input-date-picker>`, {
         testValue: ["1985-03-23", "1985-10-30"],
         submitsOnEnter: true
-      }));
+      });
+    });
   });
 
   it("updates internally when min attribute is updated after initialization", async () => {

--- a/src/components/input-number/input-number.e2e.ts
+++ b/src/components/input-number/input-number.e2e.ts
@@ -1510,12 +1510,13 @@ describe("calcite-input-number", () => {
     expect(await input.getProperty("disabled")).toBe(true);
   });
 
-  it("is form-associated", () =>
+  describe("is form-associated", () => {
     formAssociated("calcite-input-number", {
       testValue: 5,
       submitsOnEnter: true,
       inputType: "number"
-    }));
+    });
+  });
 
   it("supports translation", () => t9n("calcite-input-number"));
 });

--- a/src/components/input-text/input-text.e2e.ts
+++ b/src/components/input-text/input-text.e2e.ts
@@ -419,7 +419,9 @@ describe("calcite-input-text", () => {
     expect(await input.getProperty("disabled")).toBe(true);
   });
 
-  it("is form-associated", () => formAssociated("calcite-input-text", { testValue: "test", submitsOnEnter: true }));
+  describe("is form-associated", () => {
+    formAssociated("calcite-input-text", { testValue: "test", submitsOnEnter: true });
+  });
 
   it("supports translation", () => t9n("calcite-input-text"));
 });

--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -346,8 +346,9 @@ describe("calcite-input-time-picker", () => {
     expect(await inputTimePicker.getProperty("value")).toBeUndefined();
   });
 
-  it("is form-associated", () =>
-    formAssociated("calcite-input-time-picker", { testValue: "03:23", submitsOnEnter: true }));
+  describe("is form-associated", () => {
+    formAssociated("calcite-input-time-picker", { testValue: "03:23", submitsOnEnter: true });
+  });
 
   it("toggles seconds display when step is < 60", async () => {
     const page = await newE2EPage({

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -1733,7 +1733,7 @@ describe("calcite-input", () => {
     expect(await input.getProperty("disabled")).toBe(true);
   });
 
-  it("is form-associated", async () => {
+  describe("is form-associated", () => {
     const supportedSubmissionTypes = [
       {
         type: "color",
@@ -1786,7 +1786,7 @@ describe("calcite-input", () => {
     ];
 
     for (const { type, value } of supportedSubmissionTypes) {
-      await formAssociated(`<calcite-input type="${type}"></calcite-input>`, {
+      formAssociated(`<calcite-input type="${type}"></calcite-input>`, {
         testValue: value,
         submitsOnEnter: true,
         inputType: type

--- a/src/components/radio-button/radio-button.e2e.ts
+++ b/src/components/radio-button/radio-button.e2e.ts
@@ -438,5 +438,7 @@ describe("calcite-radio-button", () => {
     expect(await inputs[1].getProperty("checked")).toBe(true);
   });
 
-  it("is form-associated", () => formAssociated("calcite-radio-button", { testValue: true, inputType: "radio" }));
+  describe("is form-associated", () => {
+    formAssociated("calcite-radio-button", { testValue: true, inputType: "radio" });
+  });
 });

--- a/src/components/rating/rating.e2e.ts
+++ b/src/components/rating/rating.e2e.ts
@@ -39,7 +39,9 @@ describe("calcite-rating", () => {
         shadowFocusTargetSelector: "input[value='3']"
       }));
 
-    it("is form-associated", () => formAssociated("calcite-rating", { testValue: 3 }));
+    describe("is form-associated", () => {
+      formAssociated("calcite-rating", { testValue: 3 });
+    });
   });
 
   describe("rendering", () => {

--- a/src/components/segmented-control/segmented-control.e2e.ts
+++ b/src/components/segmented-control/segmented-control.e2e.ts
@@ -329,7 +329,7 @@ describe("calcite-segmented-control", () => {
   describe("is form-associated", () => {
     const formAssociatedOptions = { testValue: "2" };
 
-    it("unselected value", () =>
+    describe("unselected value", () => {
       formAssociated(
         html`
           <calcite-segmented-control>
@@ -339,9 +339,10 @@ describe("calcite-segmented-control", () => {
           </calcite-segmented-control>
         `,
         formAssociatedOptions
-      ));
+      );
+    });
 
-    it("selected-value", () =>
+    describe("selected-value", () => {
       formAssociated(
         html`
           <calcite-segmented-control>
@@ -351,6 +352,7 @@ describe("calcite-segmented-control", () => {
           </calcite-segmented-control>
         `,
         formAssociatedOptions
-      ));
+      );
+    });
   });
 });

--- a/src/components/select/select.e2e.ts
+++ b/src/components/select/select.e2e.ts
@@ -339,7 +339,7 @@ describe("calcite-select", () => {
     expect(selectedOptionId).toBe("2");
   });
 
-  it("is form-associated", () =>
+  describe("is form-associated", () => {
     formAssociated(
       html`
         <calcite-select>
@@ -349,5 +349,6 @@ describe("calcite-select", () => {
         </calcite-select>
       `,
       { testValue: "dos" }
-    ));
+    );
+  });
 });

--- a/src/components/slider/slider.e2e.ts
+++ b/src/components/slider/slider.e2e.ts
@@ -757,9 +757,15 @@ describe("calcite-slider", () => {
     });
   });
 
-  it("is form-associated", () => formAssociated("calcite-slider", { testValue: 5 }));
+  describe("is form-associated", () => {
+    describe("single value", () => {
+      formAssociated("calcite-slider", { testValue: 5 });
+    });
 
-  it("is form-associated with range", () => formAssociated("calcite-slider", { testValue: [5, 10] }));
+    describe("range", () => {
+      formAssociated("calcite-slider", { testValue: [5, 10] });
+    });
+  });
 
   describe("number locale support", () => {
     let page: E2EPage;

--- a/src/components/switch/switch.e2e.ts
+++ b/src/components/switch/switch.e2e.ts
@@ -20,7 +20,9 @@ describe("calcite-switch", () => {
 
   it("is labelable", async () => labelable("calcite-switch", { propertyToToggle: "checked" }));
 
-  it("is form-associated", async () => formAssociated("calcite-switch", { testValue: true, inputType: "checkbox" }));
+  describe("is form-associated", () => {
+    formAssociated("calcite-switch", { testValue: true, inputType: "checkbox" });
+  });
 
   it("can be disabled", () => disabled("calcite-switch"));
 

--- a/src/components/text-area/text-area.e2e.ts
+++ b/src/components/text-area/text-area.e2e.ts
@@ -60,12 +60,13 @@ describe("calcite-text-area", () => {
 
   it("is focusable", () => focusable("calcite-text-area"));
 
-  it("is form associated", () =>
+  describe("is form associated", () => {
     formAssociated("calcite-text-area", {
       testValue: "zion national park",
       expectedSubmitValue: "zion national park",
       submitsOnEnter: false
-    }));
+    });
+  });
 
   it("should emit calciteTextAreaInput event when user type in the textarea and emit calciteTextAreaChange when users tabs out", async () => {
     const page = await newE2EPage();

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -505,14 +505,18 @@ interface FormAssociatedOptions {
 /**
  * Helper for testing form-associated components; specifically form submitting and resetting.
  *
+ * Note that this helper should be used within a describe block.
+ *
+ * describe("form-associated), () => {
+ *   formAssociated("calcite-component", { testValue: 1337 });
+ * });
+ *
  * @param {string} componentTagOrHtml - the component tag or HTML markup to test against
  * @param {FormAssociatedOptions} options - form associated options
  */
-export async function formAssociated(componentTagOrHtml: TagOrHTML, options: FormAssociatedOptions): Promise<void> {
-  describe("form-associated", () => {
-    it("supports association via ancestry", () => testAncestorFormAssociated());
-    it("supports association via form ID", () => testIdFormAssociated());
-  });
+export function formAssociated(componentTagOrHtml: TagOrHTML, options: FormAssociatedOptions): void {
+  it("supports association via ancestry", () => testAncestorFormAssociated());
+  it("supports association via form ID", () => testIdFormAssociated());
 
   async function testAncestorFormAssociated(): Promise<void> {
     const componentTag = getTag(componentTagOrHtml);

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -509,8 +509,10 @@ interface FormAssociatedOptions {
  * @param {FormAssociatedOptions} options - form associated options
  */
 export async function formAssociated(componentTagOrHtml: TagOrHTML, options: FormAssociatedOptions): Promise<void> {
-  await testAncestorFormAssociated();
-  await testIdFormAssociated();
+  describe("form-associated", () => {
+    it("supports association via ancestry", () => testAncestorFormAssociated());
+    it("supports association via form ID", () => testIdFormAssociated());
+  });
 
   async function testAncestorFormAssociated(): Promise<void> {
     const componentTag = getTag(componentTagOrHtml);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This should help mitigate timeouts caused by additional test coverage added to the `formAssociated` test helper.

This also changes the way we have to use the helpers in E2E tests. I've updated the helper doc to reflect this as well.