### PR TITLE
fix(chip): Ensure Chip displays without Chip Group label in Custom Element

### DIFF
--- a/src/components/chip-group/chip-group.e2e.ts
+++ b/src/components/chip-group/chip-group.e2e.ts
@@ -461,7 +461,7 @@ describe("calcite-chip-group", () => {
 
   it("correctly assigns aria-labelledby to child Chip elements", async () => {
     const page = await newE2EPage();
-    const label = "test-label";
+    const label = "test-group-label";
     await page.setContent(
       html`<calcite-chip-group label=${label} selection-mode="multiple">
         <calcite-chip label="test-label"></calcite-chip>

--- a/src/components/chip-group/chip-group.e2e.ts
+++ b/src/components/chip-group/chip-group.e2e.ts
@@ -458,6 +458,26 @@ describe("calcite-chip-group", () => {
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
     await assertSelectedItems(page, { expectedItemIds: [chip4.id, chip5.id] });
   });
+
+  it("correctly assigns aria-labelledby to child Chip elements", async () => {
+    const page = await newE2EPage();
+    const label = "test-label";
+    await page.setContent(
+      html`<calcite-chip-group label=${label} selection-mode="multiple">
+        <calcite-chip label="test-label"></calcite-chip>
+        <calcite-chip label="test-label"></calcite-chip>
+        <calcite-chip label="test-label"></calcite-chip>
+        <calcite-chip id="chip-4" label="test-label"></calcite-chip>
+        <calcite-chip id="chip-5" selected label="test-label"></calcite-chip>
+      </calcite-chip-group>`
+    );
+    const chip4 = await page.find("#chip-4");
+    const chip5 = await page.find("#chip-5");
+    await page.waitForChanges();
+
+    expect(await chip4.getAttribute("aria-labelledby")).toEqual(label);
+    expect(await chip5.getAttribute("aria-labelledby")).toEqual(label);
+  });
 });
 
 // Borrowed from Dropdown until a generic utility is set up.

--- a/src/components/chip-group/chip-group.tsx
+++ b/src/components/chip-group/chip-group.tsx
@@ -193,6 +193,7 @@ export class ChipGroup implements InteractiveComponent {
       el.interactive = true;
       el.scale = this.scale;
       el.selectionMode = this.selectionMode;
+      el.setAttribute("aria-labelledby", this.label);
     });
 
     this.setSelectedItems(false);

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -166,8 +166,6 @@ export class Chip
 
   private closeButtonEl: HTMLButtonElement;
 
-  private parentGroupEl: HTMLCalciteChipGroupElement;
-
   private mutationObserver = createObserver("mutation", () => this.updateHasText());
 
   // --------------------------------------------------------------------------
@@ -198,7 +196,6 @@ export class Chip
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    this.parentGroupEl = this.el.parentElement as HTMLCalciteChipGroupElement;
     connectConditionalSlotComponent(this);
     connectLocalized(this);
     connectMessages(this);
@@ -384,7 +381,6 @@ export class Chip
           aria-checked={this.interactive ? toAriaBoolean(this.selected) : undefined}
           aria-disabled={disableInteraction ? toAriaBoolean(this.disabled) : undefined}
           aria-label={this.label}
-          aria-labelledby={this.parentGroupEl.label}
           class={{
             [CSS.container]: true,
             [CSS.textSlotted]: this.hasText,

--- a/src/demos/chip.html
+++ b/src/demos/chip.html
@@ -120,6 +120,7 @@
     <demo-dom-swapper>
       <h1 style="margin: 0 auto; text-align: center">Chip</h1>
 
+      it go here
       <!-- Header -->
       <div class="parent">
         <div class="child"></div>
@@ -1014,6 +1015,20 @@
           </calcite-tooltip>
         </div>
       </div>
+      <div class="parent">
+        <div class="child right-aligned-text">Rendered programmatically</div>
+        <div class="child">
+          <div id="shadowEl"></div>
+        </div>
+      </div>
     </demo-dom-swapper>
   </body>
+  <script>
+    const chipHTML = `<calcite-chip appearance="outline" kind="neutral" icon="layers" value="layers">Layers</calcite-chip>`;
+
+    const shadowEl = document.getElementById("shadowEl");
+    const shadow = shadowEl.attachShadow({ mode: "open" });
+
+    shadow.innerHTML = chipHTML;
+  </script>
 </html>


### PR DESCRIPTION
**Related Issue:** #6856 

## Summary
Shifts responsibility of setting `aria-labelledby` to a parent Chip Group, to prevent the component from failing from lack of parent label.

I wonder if our `renders()` test helper could add a check for rendering component within a Custom Element.