### PR TITLE
fix: fix inheritance of default focus-color value

### DIFF
--- a/calcite-preset.ts
+++ b/calcite-preset.ts
@@ -255,14 +255,14 @@ export default {
           "outline-color": "transparent"
         },
         ".focus-normal": {
-          outline: "2px solid var(--calcite-ui-focus-color)"
+          outline: "2px solid var(--calcite-ui-focus-color, var(--calcite-ui-brand))"
         },
         ".focus-outset": {
-          outline: "2px solid var(--calcite-ui-focus-color)",
+          outline: "2px solid var(--calcite-ui-focus-color, var(--calcite-ui-brand))",
           "outline-offset": invert("2px", "--calcite-ui-focus-offset-invert")
         },
         ".focus-inset": {
-          outline: "2px solid var(--calcite-ui-focus-color)",
+          outline: "2px solid var(--calcite-ui-focus-color, var(--calcite-ui-brand))",
           "outline-offset": invert("-2px", "--calcite-ui-focus-offset-invert")
         },
         ".focus-outset-danger": {

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -45,7 +45,6 @@
   --calcite-border-radius: 4px;
   --calcite-border-radius-base: 0;
   --calcite-panel-width-multiplier: 1;
-  --calcite-ui-focus-color: var(--calcite-ui-brand);
   --calcite-ui-focus-offset-invert: 0; // should be 0 or 1
   --calcite-ui-icon-color: currentColor;
   --calcite-ui-opacity-disabled: 0.5;


### PR DESCRIPTION
**Related Issue:** #6857 

## Summary

This fixes an issue where `--calcite-ui-focus-color`'s default was resolved at `:root` and would not allow it to inherit `--calcite-ui-brand` further down the DOM tree.
