### PR TITLE
fix(chip): Uses correct aria role in a selection-mode:none Chip Group

### DIFF
--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -380,11 +380,17 @@ export class Chip
         ? "checkbox"
         : this.selectionMode !== "none" && this.interactive
         ? "radio"
+        : this.interactive
+        ? "button"
         : undefined;
     return (
       <Host>
         <div
-          aria-checked={this.interactive ? toAriaBoolean(this.selected) : undefined}
+          aria-checked={
+            this.selectionMode !== "none" && this.interactive
+              ? toAriaBoolean(this.selected)
+              : undefined
+          }
           aria-disabled={disableInteraction ? toAriaBoolean(this.disabled) : undefined}
           aria-label={this.label}
           class={{

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -375,6 +375,12 @@ export class Chip
 
   render(): VNode {
     const disableInteraction = this.disabled || (!this.disabled && !this.interactive);
+    const role =
+      this.selectionMode === "multiple" && this.interactive
+        ? "checkbox"
+        : this.selectionMode !== "none" && this.interactive
+        ? "radio"
+        : undefined;
     return (
       <Host>
         <div
@@ -397,13 +403,7 @@ export class Chip
                 (!!this.selectionMode && this.selectionMode !== "multiple" && !this.selected))
           }}
           onClick={this.handleEmittingEvent}
-          role={
-            this.selectionMode === "multiple" && this.interactive
-              ? "checkbox"
-              : this.interactive
-              ? "radio"
-              : undefined
-          }
+          role={role}
           tabIndex={disableInteraction ? -1 : 0}
           // eslint-disable-next-line react/jsx-sort-props
           ref={(el) => (this.containerEl = el)}


### PR DESCRIPTION
## Summary
Handles the case where a parent Chip Group of `selection-mode="none"` caused the Chip to incorrectly have role of "radio" set. 

cc @geospatialem 