### PR TITLE
ci: adds support and community to issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Esri Support
+    url: https://support.esri.com/en/contact-tech-support
+    about: Report bugs in released versions of Calcite Design System, and request enhancements.
+  - name: Esri Community
+    url: https://community.esri.com/t5/calcite-design-system/ct-p/calcite-design-system
+    about: Ask questions, share ideas, and collaborate with others on Calcite Design System.


### PR DESCRIPTION
**Related Issue:** #6629 

## Summary
Adds two links to our [issue template chooser](https://github.com/Esri/calcite-components/issues/new/choose) using `contact_links` for:
- Esri Support
- Esri Community

Learn more on [template chooser and `contact_links`](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).

Experience will be similar to [JS's next feedback repo](https://github.com/Esri/feedback-js-api-next/issues/new/choose):

![screenshot of JS next feedback repo new issue templates](https://user-images.githubusercontent.com/5023024/234710483-355f792c-8894-4612-a58b-6273c112e45c.png)
