### PR TITLE
fix(tooltip): Open hovered tooltip while pointer is moving

### DIFF
--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -89,6 +89,12 @@ export default class TooltipManager {
 
     const tooltip = this.queryTooltip(composedPath);
 
+    if (this.isCloseOnClickTooltip(tooltip)) {
+      return;
+    } else {
+      this.clickedTooltip = null;
+    }
+
     if (tooltip) {
       this.toggleHoveredTooltip(tooltip, true);
     } else if (activeTooltipEl) {
@@ -138,6 +144,7 @@ export default class TooltipManager {
 
   private clearHoverTimeout(): void {
     window.clearTimeout(this.hoverTimeout);
+    this.hoverTimeout = null;
   }
 
   private closeExistingTooltip(): void {
@@ -168,6 +175,9 @@ export default class TooltipManager {
 
   private toggleHoveredTooltip = (tooltip: HTMLCalciteTooltipElement, value: boolean): void => {
     this.hoverTimeout = window.setTimeout(() => {
+      if (this.isCloseOnClickTooltip(tooltip) || this.hoverTimeout === null) {
+        return;
+      }
       this.closeExistingTooltip();
       this.toggleTooltip(tooltip, value);
     }, TOOLTIP_DELAY_MS);
@@ -176,11 +186,16 @@ export default class TooltipManager {
   private queryFocusedTooltip(event: FocusEvent, value: boolean): void {
     const tooltip = this.queryTooltip(event.composedPath());
 
-    if (!tooltip || tooltip === this.clickedTooltip) {
-      this.clickedTooltip = null;
+    if (this.isCloseOnClickTooltip(tooltip)) {
       return;
     }
 
     this.toggleFocusedTooltip(tooltip, value);
+  }
+
+  private isCloseOnClickTooltip(tooltip: HTMLCalciteTooltipElement): boolean {
+    const { clickedTooltip } = this;
+
+    return tooltip?.closeOnClick && clickedTooltip && tooltip === clickedTooltip;
   }
 }

--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -14,9 +14,9 @@ export default class TooltipManager {
 
   private hoverTimeout: number = null;
 
-  private clickedTooltip: HTMLCalciteTooltipElement;
+  private clickedTooltip: HTMLCalciteTooltipElement = null;
 
-  private activeTooltipEl: HTMLCalciteTooltipElement;
+  private activeTooltipEl: HTMLCalciteTooltipElement = null;
 
   private registeredElementCount = 0;
 
@@ -64,9 +64,9 @@ export default class TooltipManager {
     if (event.key === "Escape" && !event.defaultPrevented) {
       const { activeTooltipEl } = this;
 
-      if (activeTooltipEl && activeTooltipEl.open) {
+      if (activeTooltipEl?.open) {
         this.clearHoverTimeout();
-        this.toggleTooltip(activeTooltipEl, false);
+        this.closeExistingTooltip();
 
         const referenceElement = getEffectiveReferenceElement(activeTooltipEl);
 
@@ -77,10 +77,12 @@ export default class TooltipManager {
     }
   };
 
-  private queryHoveredTooltip = (composedPath: EventTarget[]): void => {
+  private pointerMoveHandler = (event: PointerEvent): void => {
+    const composedPath = event.composedPath();
     const { activeTooltipEl } = this;
+    const hoveringActiveTooltip = activeTooltipEl?.open && composedPath.includes(activeTooltipEl);
 
-    if (activeTooltipEl && composedPath.includes(activeTooltipEl)) {
+    if (hoveringActiveTooltip) {
       this.clearHoverTimeout();
       return;
     }
@@ -90,16 +92,9 @@ export default class TooltipManager {
     if (tooltip) {
       this.toggleHoveredTooltip(tooltip, true);
     } else if (activeTooltipEl) {
+      this.clearHoverTimeout();
       this.toggleHoveredTooltip(activeTooltipEl, false);
     }
-  };
-
-  private pointerMoveHandler = (event: PointerEvent): void => {
-    const composedPath = event.composedPath();
-
-    this.clearHoverTimeout();
-
-    this.hoverTimeout = window.setTimeout(() => this.queryHoveredTooltip(composedPath), TOOLTIP_DELAY_MS || 0);
   };
 
   private pointerDownHandler = (event: PointerEvent): void => {
@@ -148,7 +143,7 @@ export default class TooltipManager {
   private closeExistingTooltip(): void {
     const { activeTooltipEl } = this;
 
-    if (activeTooltipEl) {
+    if (activeTooltipEl?.open) {
       this.toggleTooltip(activeTooltipEl, false);
     }
   }
@@ -172,11 +167,10 @@ export default class TooltipManager {
   }
 
   private toggleHoveredTooltip = (tooltip: HTMLCalciteTooltipElement, value: boolean): void => {
-    if (value) {
+    this.hoverTimeout = window.setTimeout(() => {
       this.closeExistingTooltip();
-    }
-
-    this.toggleTooltip(tooltip, value);
+      this.toggleTooltip(tooltip, value);
+    }, TOOLTIP_DELAY_MS);
   };
 
   private queryFocusedTooltip(event: FocusEvent, value: boolean): void {

--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -91,9 +91,9 @@ export default class TooltipManager {
 
     if (this.isCloseOnClickTooltip(tooltip)) {
       return;
-    } else {
-      this.clickedTooltip = null;
     }
+
+    this.clickedTooltip = null;
 
     if (tooltip) {
       this.toggleHoveredTooltip(tooltip, true);
@@ -175,7 +175,7 @@ export default class TooltipManager {
 
   private toggleHoveredTooltip = (tooltip: HTMLCalciteTooltipElement, value: boolean): void => {
     this.hoverTimeout = window.setTimeout(() => {
-      if (this.isCloseOnClickTooltip(tooltip) || this.hoverTimeout === null) {
+      if (this.hoverTimeout === null) {
         return;
       }
       this.closeExistingTooltip();
@@ -186,7 +186,7 @@ export default class TooltipManager {
   private queryFocusedTooltip(event: FocusEvent, value: boolean): void {
     const tooltip = this.queryTooltip(event.composedPath());
 
-    if (this.isCloseOnClickTooltip(tooltip)) {
+    if (!tooltip || this.isCloseOnClickTooltip(tooltip)) {
       return;
     }
 
@@ -194,8 +194,6 @@ export default class TooltipManager {
   }
 
   private isCloseOnClickTooltip(tooltip: HTMLCalciteTooltipElement): boolean {
-    const { clickedTooltip } = this;
-
-    return tooltip?.closeOnClick && clickedTooltip && tooltip === clickedTooltip;
+    return tooltip?.closeOnClick && tooltip === this.clickedTooltip;
   }
 }

--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -89,7 +89,7 @@ export default class TooltipManager {
 
     const tooltip = this.queryTooltip(composedPath);
 
-    if (this.isCloseOnClickTooltip(tooltip)) {
+    if (this.isClosableClickedTooltip(tooltip)) {
       return;
     }
 
@@ -186,14 +186,14 @@ export default class TooltipManager {
   private queryFocusedTooltip(event: FocusEvent, value: boolean): void {
     const tooltip = this.queryTooltip(event.composedPath());
 
-    if (!tooltip || this.isCloseOnClickTooltip(tooltip)) {
+    if (!tooltip || this.isClosableClickedTooltip(tooltip)) {
       return;
     }
 
     this.toggleFocusedTooltip(tooltip, value);
   }
 
-  private isCloseOnClickTooltip(tooltip: HTMLCalciteTooltipElement): boolean {
+  private isClosableClickedTooltip(tooltip: HTMLCalciteTooltipElement): boolean {
     return tooltip?.closeOnClick && tooltip === this.clickedTooltip;
   }
 }

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -122,10 +122,10 @@ describe("calcite-tooltip", () => {
 
     const element = await page.find("calcite-tooltip");
 
-    await page.$eval("calcite-tooltip", (elm: any) => {
+    await page.$eval("calcite-tooltip", (el: any) => {
       const referenceElement = document.createElement("div");
       document.body.appendChild(referenceElement);
-      elm.referenceElement = referenceElement;
+      el.referenceElement = referenceElement;
     });
 
     await page.waitForChanges();
@@ -481,8 +481,8 @@ describe("calcite-tooltip", () => {
 
     expect(await hoverTip.getProperty("open")).toBe(false);
 
-    await page.$eval("#hoverRef", (elm: HTMLElement) => {
-      elm.dispatchEvent(new Event("pointermove"));
+    await page.$eval("#hoverRef", (el: HTMLElement) => {
+      el.dispatchEvent(new Event("pointermove"));
     });
 
     await page.waitForTimeout(TOOLTIP_DELAY_MS);
@@ -538,8 +538,8 @@ describe("calcite-tooltip", () => {
 
     expect(await hoverTip.getProperty("open")).toBe(false);
 
-    await page.$eval("#hoverRef", (elm: HTMLElement) => {
-      elm.dispatchEvent(new Event("pointermove"));
+    await page.$eval("#hoverRef", (el: HTMLElement) => {
+      el.dispatchEvent(new Event("pointermove"));
     });
 
     await page.waitForTimeout(TOOLTIP_DELAY_MS);
@@ -757,8 +757,8 @@ describe("calcite-tooltip", () => {
 
     const hoverPromises: Promise<void>[] = pointerMoves.map(async ({ delay }) => {
       await page.waitForTimeout(delay);
-      await page.$eval("#ref", (elm: HTMLElement) => {
-        elm.dispatchEvent(new Event("pointermove"));
+      await page.$eval("#ref", (el: HTMLElement) => {
+        el.dispatchEvent(new Event("pointermove"));
       });
     });
 


### PR DESCRIPTION
**Related Issue:** #6278 #6615 #6785

## Summary

- Only clears the hovering timeout for toggling a tooltip when:
  - An active tooltip is being hovered.
  - An active tooltip exists and a tooltip reference element is not being hovered.
- This means a newly hovered tooltip can be opened without having to stop moving the mouse.
- Had to make some adjustments for clicked tooltips when `closeOnClick` is true.
- Cleanup some code 
- Adds test 