### PR TITLE
test: split up `renders` test helper to run a test per use case

### DIFF
--- a/src/components/accordion-item/accordion-item.e2e.ts
+++ b/src/components/accordion-item/accordion-item.e2e.ts
@@ -2,7 +2,10 @@ import { accessible, renders, slots, hidden } from "../../tests/commonTests";
 import { SLOTS } from "./resources";
 
 describe("calcite-accordion-item", () => {
-  it("renders", async () => renders("calcite-accordion-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-accordion-item", { display: "flex" });
+  });
+
   it("honors hidden attribute", async () => hidden("calcite-accordion-item"));
   it("is accessible", async () => accessible(`<calcite-accordion-item heading="My Heading"></calcite-accordion-item>`));
   it("has slots", () => slots("calcite-accordion-item", SLOTS));

--- a/src/components/accordion/accordion.e2e.ts
+++ b/src/components/accordion/accordion.e2e.ts
@@ -13,7 +13,10 @@ describe("calcite-accordion", () => {
     <calcite-accordion-item heading="Accordion Title 1" id="2" expanded>Accordion Item Content </calcite-accordion-item>
     <calcite-accordion-item heading="Accordion Title 3" id="3">Accordion Item Content </calcite-accordion-item>
   `;
-  it("renders", async () => renders("calcite-accordion", { display: "block" }));
+
+  describe("renders", () => {
+    renders("calcite-accordion", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-accordion"));
 

--- a/src/components/action-bar/action-bar.e2e.ts
+++ b/src/components/action-bar/action-bar.e2e.ts
@@ -5,7 +5,9 @@ import { CSS, SLOTS } from "./resources";
 import { overflowActionsDebounceInMs } from "./utils";
 
 describe("calcite-action-bar", () => {
-  it("renders", async () => renders("calcite-action-bar", { display: "inline-flex" }));
+  describe("renders", () => {
+    renders("calcite-action-bar", { display: "inline-flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-action-bar"));
 

--- a/src/components/action-group/action-group.e2e.ts
+++ b/src/components/action-group/action-group.e2e.ts
@@ -16,7 +16,9 @@ describe("calcite-action-group", () => {
       }
     ]));
 
-  it("renders", async () => renders("calcite-action-group", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-action-group", { display: "flex" });
+  });
 
   it("focusable", async () => focusable(actionGroupHTML, { shadowFocusTargetSelector: "calcite-action" }));
 

--- a/src/components/action-menu/action-menu.e2e.ts
+++ b/src/components/action-menu/action-menu.e2e.ts
@@ -5,7 +5,9 @@ import { TOOLTIP_DELAY_MS } from "../tooltip/resources";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-action-menu", () => {
-  it("renders", async () => renders("calcite-action-menu", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-action-menu", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-action-menu"));
 

--- a/src/components/action-pad/action-pad.e2e.ts
+++ b/src/components/action-pad/action-pad.e2e.ts
@@ -4,7 +4,9 @@ import { CSS, SLOTS } from "./resources";
 import { html } from "../../../support/formatting";
 
 describe("calcite-action-pad", () => {
-  it("renders", async () => renders("calcite-action-pad", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-action-pad", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-action-pad"));
 

--- a/src/components/action/action.e2e.ts
+++ b/src/components/action/action.e2e.ts
@@ -39,7 +39,9 @@ describe("calcite-action", () => {
       }
     ]));
 
-  it("renders", async () => renders("calcite-action", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-action", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-action"));
 

--- a/src/components/alert/alert.e2e.ts
+++ b/src/components/alert/alert.e2e.ts
@@ -11,7 +11,9 @@ describe("calcite-alert", () => {
     <a slot="link" href="">Action</a>
   `;
 
-  it("renders", async () => renders("calcite-alert", { visible: false, display: "block" }));
+  describe("renders", () => {
+    renders("calcite-alert", { visible: false, display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden(`<calcite-alert open></calcite-alert>`));
 

--- a/src/components/avatar/avatar.e2e.ts
+++ b/src/components/avatar/avatar.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-avatar", () => {
-  it("renders", async () => renders("calcite-avatar", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-avatar", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-avatar"));
 

--- a/src/components/block-section/block-section.e2e.ts
+++ b/src/components/block-section/block-section.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, defaults, hidden, reflects, renders, t9n } from "../../test
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 
 describe("calcite-block-section", () => {
-  it("renders", async () => renders("calcite-block-section", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-block-section", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-block-section"));
 

--- a/src/components/block/block.e2e.ts
+++ b/src/components/block/block.e2e.ts
@@ -4,7 +4,9 @@ import { accessible, defaults, disabled, hidden, renders, slots, t9n } from "../
 import { html } from "../../../support/formatting";
 
 describe("calcite-block", () => {
-  it("renders", async () => renders("calcite-block", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-block", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-block"));
 

--- a/src/components/card/card.e2e.ts
+++ b/src/components/card/card.e2e.ts
@@ -8,7 +8,9 @@ const placeholder = placeholderImage({
 });
 
 describe("calcite-card", () => {
-  it("renders", async () => renders("calcite-card", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-card", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-card"));
 

--- a/src/components/chip-group/chip-group.e2e.ts
+++ b/src/components/chip-group/chip-group.e2e.ts
@@ -5,10 +5,11 @@ import { GlobalTestProps } from "../../tests/utils";
 import { CSS as CHIP_CSS } from "../chip/resources";
 
 describe("calcite-chip-group", () => {
-  it("renders", async () =>
+  describe("renders", () => {
     renders("<calcite-chip-group><calcite-chip></calcite-chip></calcite-chip-group>", {
       display: "flex"
-    }));
+    });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-chip-group"));
 

--- a/src/components/chip/chip.e2e.ts
+++ b/src/components/chip/chip.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, disabled, focusable, hidden, renders, slots, t9n } from "..
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-chip", () => {
-  it("renders", async () => renders("<calcite-chip>doritos</calcite-chip>", { display: "inline-flex" }));
+  describe("renders", () => {
+    renders("<calcite-chip>doritos</calcite-chip>", { display: "inline-flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-chip"));
 

--- a/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
@@ -5,7 +5,9 @@ import { isValidHex, normalizeHex } from "../color-picker/utils";
 import { CSS } from "./resources";
 
 describe("calcite-color-picker-hex-input", () => {
-  it("renders", () => renders("calcite-color-picker-hex-input", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-color-picker-hex-input", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-color-picker-hex-input"));
 

--- a/src/components/color-picker-swatch/color-picker-swatch.e2e.ts
+++ b/src/components/color-picker-swatch/color-picker-swatch.e2e.ts
@@ -3,7 +3,9 @@ import { CSS } from "./resources";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-color-picker-swatch", () => {
-  it("renders", () => renders("calcite-color-picker-swatch", { display: "inline-flex" }));
+  describe("renders", () => {
+    renders("calcite-color-picker-swatch", { display: "inline-flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-color-picker-swatch"));
 

--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -50,7 +50,9 @@ describe("calcite-color-picker", () => {
       }
     ]));
 
-  it("renders", async () => renders("calcite-color-picker", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-color-picker", { display: "inline-block" });
+  });
 
   it("has defaults", async () =>
     defaults("calcite-color-picker", [

--- a/src/components/combobox-item/combobox-item.e2e.ts
+++ b/src/components/combobox-item/combobox-item.e2e.ts
@@ -1,7 +1,9 @@
 import { disabled, hidden, renders, slots } from "../../tests/commonTests";
 
 describe("calcite-combobox-item", () => {
-  it("renders", async () => renders("calcite-combobox-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-combobox-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-combobox-item"));
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -15,7 +15,10 @@ import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-combobox", () => {
-  it("renders", async () => renders("calcite-combobox", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-combobox", { display: "block" });
+  });
+
   it("defaults", async () =>
     defaults("calcite-combobox", [
       {

--- a/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
+++ b/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
@@ -3,7 +3,9 @@ import { html } from "../../../support/formatting";
 import { renders } from "../../tests/commonTests";
 
 describe("calcite-date-picker-month-header", () => {
-  it("renders", async () => renders("calcite-date-picker-month-header", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-date-picker-month-header", { display: "block" });
+  });
 
   const localeDataFixture = {
     "default-calendar": "gregorian",

--- a/src/components/date-picker/date-picker.e2e.ts
+++ b/src/components/date-picker/date-picker.e2e.ts
@@ -5,7 +5,9 @@ import { skipAnimations } from "../../tests/utils";
 import { formatTimePart } from "../../utils/time";
 
 describe("calcite-date-picker", () => {
-  it("renders", async () => renders("calcite-date-picker", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-date-picker", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-date-picker"));
 

--- a/src/components/dropdown-group/dropdown-group.e2e.ts
+++ b/src/components/dropdown-group/dropdown-group.e2e.ts
@@ -1,7 +1,9 @@
 import { renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-dropdown-group", () => {
-  it("renders", () => renders("calcite-dropdown-group", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-dropdown-group", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-dropdown-group"));
 });

--- a/src/components/dropdown-item/dropdown-item.e2e.ts
+++ b/src/components/dropdown-item/dropdown-item.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { focusable, renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-dropdown-item", () => {
-  it("renders", () => renders("calcite-dropdown-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-dropdown-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-dropdown-item"));
 

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -20,7 +20,9 @@ describe("calcite-dropdown", () => {
       focusTargetSelector: '[slot="trigger"]'
     }));
 
-  it("renders", () => renders(simpleDropdownHTML, { display: "inline-flex" }));
+  describe("renders", () => {
+    renders(simpleDropdownHTML, { display: "inline-flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-dropdown"));
 

--- a/src/components/fab/fab.e2e.ts
+++ b/src/components/fab/fab.e2e.ts
@@ -4,7 +4,9 @@ import { CSS } from "./resources";
 import { defaults } from "../../tests/commonTests";
 
 describe("calcite-fab", () => {
-  it("renders", async () => renders("calcite-fab", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-fab", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-fab"));
 

--- a/src/components/filter/filter.e2e.ts
+++ b/src/components/filter/filter.e2e.ts
@@ -4,7 +4,9 @@ import { DEBOUNCE_TIMEOUT } from "./resources";
 import { CSS as INPUT_CSS } from "../input/resources";
 
 describe("calcite-filter", () => {
-  it("renders", async () => renders("calcite-filter", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-filter", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-filter"));
 

--- a/src/components/flow-item/flow-item.e2e.ts
+++ b/src/components/flow-item/flow-item.e2e.ts
@@ -4,7 +4,9 @@ import { CSS, SLOTS } from "./resources";
 import { html } from "../../../support/formatting";
 
 describe("calcite-flow-item", () => {
-  it("renders", async () => renders("calcite-flow-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-flow-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-flow-item"));
 

--- a/src/components/flow/flow.e2e.ts
+++ b/src/components/flow/flow.e2e.ts
@@ -6,7 +6,9 @@ import { CSS as ITEM_CSS } from "../flow-item/resources";
 import { CSS } from "./resources";
 
 describe("calcite-flow", () => {
-  it("renders", async () => renders("calcite-flow", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-flow", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-flow"));
 

--- a/src/components/graph/graph.e2e.ts
+++ b/src/components/graph/graph.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-graph", () => {
-  it("renders", async () => renders(`<calcite-graph></calcite-graph>`, { display: "block" }));
+  describe("renders", () => {
+    renders(`<calcite-graph></calcite-graph>`, { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-graph"));
 

--- a/src/components/handle/handle.e2e.ts
+++ b/src/components/handle/handle.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, hidden, renders, t9n } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-handle", () => {
-  it("renders", async () => renders("calcite-handle", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-handle", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-handle"));
 

--- a/src/components/icon/icon.e2e.ts
+++ b/src/components/icon/icon.e2e.ts
@@ -18,9 +18,7 @@ describe("calcite-icon", () => {
       { propertyName: "scale", value: "m" }
     ]));
 
-  describe("accessible", () => {
-    accessible(`<calcite-icon icon="a-z" text-label="sort options"></calcite-icon>`);
-  });
+  it("is accessible", async () => accessible(`<calcite-icon icon="a-z" text-label="sort options"></calcite-icon>`));
 
   it("flips icon when enabled and in RTL", async () => {
     const page = await newE2EPage();

--- a/src/components/icon/icon.e2e.ts
+++ b/src/components/icon/icon.e2e.ts
@@ -18,7 +18,9 @@ describe("calcite-icon", () => {
       { propertyName: "scale", value: "m" }
     ]));
 
-  it("is accessible", async () => accessible(`<calcite-icon icon="a-z" text-label="sort options"></calcite-icon>`));
+  describe("accessible", () => {
+    accessible(`<calcite-icon icon="a-z" text-label="sort options"></calcite-icon>`);
+  });
 
   it("flips icon when enabled and in RTL", async () => {
     const page = await newE2EPage();
@@ -36,7 +38,9 @@ describe("calcite-icon", () => {
   });
 
   describe("rendering", () => {
-    it("basic", async () => renders("calcite-icon", { display: "inline-flex" }));
+    describe("renders", () => {
+      renders("calcite-icon", { display: "inline-flex" });
+    });
 
     it("uses path data to render icon", async () => {
       const page = await newE2EPage();

--- a/src/components/inline-editable/inline-editable.e2e.ts
+++ b/src/components/inline-editable/inline-editable.e2e.ts
@@ -5,7 +5,7 @@ import { CSS } from "./resources";
 import { html } from "../../../support/formatting";
 
 describe("calcite-inline-editable", () => {
-  it("renders", () =>
+  describe("renders", () => {
     renders(
       html`
         <calcite-inline-editable>
@@ -13,7 +13,8 @@ describe("calcite-inline-editable", () => {
         </calcite-inline-editable>
       `,
       { display: "block" }
-    ));
+    );
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-inline-editable"));
 

--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -25,7 +25,9 @@ describe("calcite-input-date-picker", () => {
       </calcite-label>
     `));
 
-  it("renders", async () => renders("calcite-input-date-picker", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-input-date-picker", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-input-date-picker"));
 

--- a/src/components/input-message/input-message.e2e.ts
+++ b/src/components/input-message/input-message.e2e.ts
@@ -3,9 +3,9 @@ import { accessible, hidden, renders } from "../../tests/commonTests";
 import { StatusIconDefaults } from "./interfaces";
 
 describe("calcite-input-message", () => {
-  it("renders", async () => {
-    await renders(`<calcite-input-message hidden></calcite-input-message>`, { display: "none", visible: false });
-    await renders(`<calcite-input-message></calcite-input-message>`, { display: "flex", visible: true });
+  describe("renders", () => {
+    renders(`<calcite-input-message hidden></calcite-input-message>`, { display: "none", visible: false });
+    renders(`<calcite-input-message></calcite-input-message>`, { display: "flex", visible: true });
   });
 
   it("honors hidden attribute", async () => hidden(`<calcite-input-message>Text</calcite-input-message>`));

--- a/src/components/input-number/input-number.e2e.ts
+++ b/src/components/input-number/input-number.e2e.ts
@@ -31,7 +31,9 @@ describe("calcite-input-number", () => {
 
   it("is labelable", async () => labelable("calcite-input-number"));
 
-  it("renders", () => renders("calcite-input-number", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-input-number", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-input-number"));
 

--- a/src/components/input-text/input-text.e2e.ts
+++ b/src/components/input-text/input-text.e2e.ts
@@ -16,7 +16,9 @@ import { selectText } from "../../tests/utils";
 describe("calcite-input-text", () => {
   it("is labelable", async () => labelable("calcite-input-text"));
 
-  it("renders", () => renders("calcite-input-text", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-input-text", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-input-text"));
 

--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -17,7 +17,9 @@ import { skipAnimations } from "../../tests/utils";
 import { html } from "../../../support/formatting";
 
 describe("calcite-input-time-picker", () => {
-  it("renders", async () => renders("calcite-input-time-picker", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-input-time-picker", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-input-time-picker"));
 

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -31,7 +31,9 @@ describe("calcite-input", () => {
 
   it("is labelable", async () => labelable("calcite-input"));
 
-  it("renders", () => renders("calcite-input", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-input", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-input"));
 

--- a/src/components/label/label.e2e.ts
+++ b/src/components/label/label.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-label", () => {
-  it("renders", () => renders("calcite-label", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-label", { display: "flex" });
+  });
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();

--- a/src/components/link/link.e2e.ts
+++ b/src/components/link/link.e2e.ts
@@ -2,7 +2,9 @@ import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-link", () => {
-  it("renders", async () => renders("<calcite-link href='/'>link</calcite-link>", { display: "inline" }));
+  describe("renders", () => {
+    renders("<calcite-link href='/'>link</calcite-link>", { display: "inline" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-link"));
 

--- a/src/components/list-item-group/list-item-group.e2e.ts
+++ b/src/components/list-item-group/list-item-group.e2e.ts
@@ -2,7 +2,9 @@ import { hidden, renders, disabled } from "../../tests/commonTests";
 import { defaults } from "../../tests/commonTests";
 
 describe("calcite-list-item-group", () => {
-  it("renders", async () => renders("calcite-list-item-group", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-list-item-group", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-list-item-group"));
 

--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -3,7 +3,9 @@ import { defaults, disabled, focusable, hidden, renders, slots } from "../../tes
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-list-item", () => {
-  it("renders", async () => renders("calcite-list-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-list-item", { display: "flex" });
+  });
 
   it("is focusable", () =>
     focusable("<calcite-list-item active></calcite-list-item>", {

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -58,7 +58,9 @@ describe("calcite-list", () => {
       }
     ]));
 
-  it("renders", async () => renders("calcite-list", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-list", { display: "block" });
+  });
 
   it("is focusable", () =>
     focusable(

--- a/src/components/loader/loader.e2e.ts
+++ b/src/components/loader/loader.e2e.ts
@@ -2,9 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-loader", () => {
-  it("renders", async () => {
-    await renders(`<calcite-loader></calcite-loader>`, { display: "flex", visible: true });
-    await renders(`<calcite-loader inline></calcite-loader>`, { display: "flex", visible: true });
+  describe("renders", () => {
+    renders(`<calcite-loader></calcite-loader>`, { display: "flex", visible: true });
+    renders(`<calcite-loader inline></calcite-loader>`, { display: "flex", visible: true });
   });
 
   it("honors hidden attribute", async () => hidden("calcite-loader"));

--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -5,7 +5,9 @@ import { CSS, SLOTS, DURATIONS } from "./resources";
 import { isElementFocused, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils";
 
 describe("calcite-modal properties", () => {
-  it("renders", () => renders("calcite-modal", { display: "flex", visible: false }));
+  describe("renders", () => {
+    renders("calcite-modal", { display: "flex", visible: false });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-modal"));
 

--- a/src/components/notice/notice.e2e.ts
+++ b/src/components/notice/notice.e2e.ts
@@ -9,7 +9,10 @@ describe("calcite-notice", () => {
   <div slot="message">Message Text</div>
   <calcite-link slot="link" href="">Action</calcite-link>
 `;
-  it("renders", async () => renders(`<calcite-notice open>${noticeContent}</calcite-notice>`, { display: "flex" }));
+
+  describe("renders", () => {
+    renders(`<calcite-notice open>${noticeContent}</calcite-notice>`, { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-notice"));
 

--- a/src/components/option-group/option-group.e2e.ts
+++ b/src/components/option-group/option-group.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-option-group", () => {
-  it("renders", async () => renders("calcite-option-group", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-option-group", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-option-group"));
 

--- a/src/components/option/option.e2e.ts
+++ b/src/components/option/option.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-option", () => {
-  it("renders", async () => renders("calcite-option", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-option", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-option"));
 

--- a/src/components/pagination/pagination.e2e.ts
+++ b/src/components/pagination/pagination.e2e.ts
@@ -4,7 +4,9 @@ import { accessible, focusable, hidden, renders, t9n } from "../../tests/commonT
 import { CSS } from "./resources";
 
 describe("calcite-pagination", () => {
-  it("renders", async () => renders("calcite-pagination", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-pagination", { display: "flex" });
+  });
 
   it("focuses previous button when not on the first page", async () =>
     focusable('<calcite-pagination page-size="1" start-item="2" total-items="10"></calcite-pagination>', {

--- a/src/components/panel/panel.e2e.ts
+++ b/src/components/panel/panel.e2e.ts
@@ -13,7 +13,9 @@ const panelTemplate = (scrollable = false) => html`<div style="height: 200px; di
 </div>`;
 
 describe("calcite-panel", () => {
-  it("renders", async () => renders("calcite-panel", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-panel", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-panel"));
 

--- a/src/components/pick-list-group/pick-list-group.e2e.ts
+++ b/src/components/pick-list-group/pick-list-group.e2e.ts
@@ -4,7 +4,9 @@ import { accessible, defaults, renders, slots, hidden } from "../../tests/common
 import { html } from "../../../support/formatting";
 
 describe("calcite-pick-list-group", () => {
-  it("renders", async () => renders("calcite-pick-list-group", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-pick-list-group", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-pick-list-group"));
 

--- a/src/components/pick-list-item/pick-list-item.e2e.ts
+++ b/src/components/pick-list-item/pick-list-item.e2e.ts
@@ -4,7 +4,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 
 describe("calcite-pick-list-item", () => {
-  it("renders", async () => renders("calcite-pick-list-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-pick-list-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-list-item"));
 

--- a/src/components/pick-list/pick-list.e2e.ts
+++ b/src/components/pick-list/pick-list.e2e.ts
@@ -22,7 +22,9 @@ describe("calcite-pick-list", () => {
       }
     ]));
 
-  it("renders", async () => renders("calcite-pick-list", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-pick-list", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-pick-list"));
 

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -5,12 +5,11 @@ import { accessible, defaults, hidden, renders, floatingUIOwner, focusable, t9n 
 import { CSS } from "./resources";
 
 describe("calcite-popover", () => {
-  it("renders", async () => {
-    await renders("calcite-popover", { visible: false, display: "block" });
-    await renders(
-      `<calcite-popover label="test" open reference-element="ref"></calcite-popover><div id="ref">😄</div>`,
-      { display: "block" }
-    );
+  describe("renders", () => {
+    renders("calcite-popover", { visible: false, display: "block" });
+    renders(`<calcite-popover label="test" open reference-element="ref"></calcite-popover><div id="ref">😄</div>`, {
+      display: "block"
+    });
   });
 
   it("supports translations", () => t9n("calcite-popover"));

--- a/src/components/progress/progress.e2e.ts
+++ b/src/components/progress/progress.e2e.ts
@@ -1,7 +1,9 @@
 import { accessible, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-progress", () => {
-  it("renders", () => renders("calcite-progress", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-progress", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-progress"));
 

--- a/src/components/radio-button-group/radio-button-group.e2e.ts
+++ b/src/components/radio-button-group/radio-button-group.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, defaults, hidden, reflects, renders } from "../../tests/com
 import { html } from "../../../support/formatting";
 
 describe("calcite-radio-button-group", () => {
-  it("renders", async () => renders("calcite-radio-button-group", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-radio-button-group", { display: "flex" });
+  });
 
   it("is accessible", async () =>
     accessible(

--- a/src/components/radio-button/radio-button.e2e.ts
+++ b/src/components/radio-button/radio-button.e2e.ts
@@ -12,7 +12,9 @@ import {
 } from "../../tests/commonTests";
 
 describe("calcite-radio-button", () => {
-  it("renders", async () => renders("calcite-radio-button", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-radio-button", { display: "block" });
+  });
 
   it("is accessible", async () =>
     accessible(

--- a/src/components/rating/rating.e2e.ts
+++ b/src/components/rating/rating.e2e.ts
@@ -12,7 +12,9 @@ import {
 
 describe("calcite-rating", () => {
   describe("common tests", () => {
-    it("renders", async () => renders("<calcite-rating></calcite-rating>", { display: "flex" }));
+    describe("renders", () => {
+      renders("<calcite-rating></calcite-rating>", { display: "flex" });
+    });
 
     it("honors hidden attribute", async () => hidden("calcite-rating"));
 

--- a/src/components/scrim/scrim.e2e.ts
+++ b/src/components/scrim/scrim.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTe
 import { CSS } from "./resources";
 
 describe("calcite-scrim", () => {
-  it("renders", async () => renders("<calcite-scrim></calcite-scrim>", { display: "flex" }));
+  describe("renders", () => {
+    renders("<calcite-scrim></calcite-scrim>", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-scrim"));
 

--- a/src/components/segmented-control-item/segmented-control-item.e2e.ts
+++ b/src/components/segmented-control-item/segmented-control-item.e2e.ts
@@ -2,7 +2,9 @@ import { newE2EPage } from "@stencil/core/testing";
 import { renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-segmented-control-item", () => {
-  it("renders", () => renders("calcite-segmented-control-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-segmented-control-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-segmented-control-item"));
 

--- a/src/components/segmented-control/segmented-control.e2e.ts
+++ b/src/components/segmented-control/segmented-control.e2e.ts
@@ -3,7 +3,9 @@ import { html } from "../../../support/formatting";
 import { disabled, focusable, formAssociated, hidden, labelable, renders } from "../../tests/commonTests";
 
 describe("calcite-segmented-control", () => {
-  it("renders", () => renders("calcite-segmented-control", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-segmented-control", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-segmented-control"));
 

--- a/src/components/select/select.e2e.ts
+++ b/src/components/select/select.e2e.ts
@@ -21,7 +21,9 @@ describe("calcite-select", () => {
     </calcite-select>
   `;
 
-  it("renders", async () => renders(simpleTestMarkup, { display: "flex" }));
+  describe("renders", () => {
+    renders(simpleTestMarkup, { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-select"));
 

--- a/src/components/shell-center-row/shell-center-row.e2e.ts
+++ b/src/components/shell-center-row/shell-center-row.e2e.ts
@@ -4,7 +4,9 @@ import { accessible, defaults, hidden, renders, slots } from "../../tests/common
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-shell-center-row", () => {
-  it("renders", async () => renders("calcite-shell-center-row", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-shell-center-row", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-shell-center-row"));
 

--- a/src/components/shell-panel/shell-panel.e2e.ts
+++ b/src/components/shell-panel/shell-panel.e2e.ts
@@ -5,7 +5,9 @@ import { getElementXY } from "../../tests/utils";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-shell-panel", () => {
-  it("renders", async () => renders("calcite-shell-panel", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-shell-panel", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-shell-panel"));
 

--- a/src/components/shell/shell.e2e.ts
+++ b/src/components/shell/shell.e2e.ts
@@ -4,7 +4,9 @@ import { CSS, SLOTS } from "./resources";
 import { html } from "../../../support/formatting";
 
 describe("calcite-shell", () => {
-  it("renders", async () => renders("calcite-shell", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-shell", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-shell"));
 

--- a/src/components/slider/slider.e2e.ts
+++ b/src/components/slider/slider.e2e.ts
@@ -7,7 +7,9 @@ import { CSS } from "./resources";
 describe("calcite-slider", () => {
   const sliderWidthFor1To1PixelValueTrack = "114px";
 
-  it("renders", async () => renders("calcite-slider", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-slider", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-slider"));
 

--- a/src/components/sortable-list/sortable-list.e2e.ts
+++ b/src/components/sortable-list/sortable-list.e2e.ts
@@ -4,7 +4,9 @@ import { dragAndDrop } from "../../tests/utils";
 import { html } from "../../../support/formatting";
 
 describe("calcite-sortable-list", () => {
-  it("renders", async () => renders("calcite-sortable-list", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-sortable-list", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-sortable-list"));
 

--- a/src/components/split-button/split-button.e2e.ts
+++ b/src/components/split-button/split-button.e2e.ts
@@ -18,7 +18,9 @@ describe("calcite-split-button", () => {
     <calcite-dropdown-item id="item-2" active>Item2</calcite-dropdown-item>
   </calcite-dropdown-group>`;
 
-  it("renders", () => renders("calcite-split-button", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-split-button", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-split-button"));
 

--- a/src/components/stepper-item/stepper-item.e2e.ts
+++ b/src/components/stepper-item/stepper-item.e2e.ts
@@ -1,7 +1,9 @@
 import { disabled, renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-stepper-item", () => {
-  it("renders", () => renders("calcite-stepper-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-stepper-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-stepper-item"));
 

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -5,7 +5,7 @@ import { NumberStringFormatOptions } from "../../utils/locale";
 
 // todo test the automatic setting of first item to selected
 describe("calcite-stepper", () => {
-  it("renders", () =>
+  describe("renders", () => {
     renders(
       html`<calcite-stepper>
         <calcite-stepper-item heading="Step 1" id="step-1">
@@ -22,7 +22,8 @@ describe("calcite-stepper", () => {
         </calcite-stepper-item>
       </calcite-stepper>`,
       { display: "grid" }
-    ));
+    );
+  });
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();

--- a/src/components/tab-nav/tab-nav.e2e.ts
+++ b/src/components/tab-nav/tab-nav.e2e.ts
@@ -5,7 +5,9 @@ import { html } from "../../../support/formatting";
 describe("calcite-tab-nav", () => {
   const tabNavHtml = "<calcite-tab-nav></calcite-tab-nav>";
 
-  it("renders", async () => await renders(tabNavHtml, { display: "flex" }));
+  describe("renders", () => {
+    renders(tabNavHtml, { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tab-nav"));
 

--- a/src/components/tab-title/tab-title.e2e.ts
+++ b/src/components/tab-title/tab-title.e2e.ts
@@ -7,7 +7,9 @@ describe("calcite-tab-title", () => {
   const iconStartHtml = `calcite-tab-title >>> .${CSS.titleIcon}.${CSS.iconStart}`;
   const iconEndHtml = `calcite-tab-title >>> .${CSS.titleIcon}.${CSS.iconEnd}`;
 
-  it("renders", async () => renders(tabTitleHtml, { display: "block" }));
+  describe("renders", () => {
+    renders(tabTitleHtml, { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tab-title"));
 

--- a/src/components/tab/tab.e2e.ts
+++ b/src/components/tab/tab.e2e.ts
@@ -4,9 +4,9 @@ import { defaults, renders, hidden } from "../../tests/commonTests";
 describe("calcite-tab", () => {
   const tabHtml = "<calcite-tab>A tab</calcite-tab>";
 
-  it("renders", async () => {
-    await renders("calcite-tab", { display: "none", visible: false });
-    await renders("<calcite-tab selected></calcite-tab>", { display: "block", visible: true });
+  describe("renders", () => {
+    renders("calcite-tab", { display: "none", visible: false });
+    renders("<calcite-tab selected></calcite-tab>", { display: "block", visible: true });
   });
 
   it("honors hidden attribute", async () => hidden("calcite-tab"));

--- a/src/components/tabs/tabs.e2e.ts
+++ b/src/components/tabs/tabs.e2e.ts
@@ -17,7 +17,9 @@ describe("calcite-tabs", () => {
   `;
   const tabsSnippet = `<calcite-tabs>${tabsContent}</calcite-tabs>`;
 
-  it("renders", async () => renders(tabsSnippet, { display: "flex" }));
+  describe("renders", () => {
+    renders(tabsSnippet, { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tabs"));
 

--- a/src/components/text-area/text-area.e2e.ts
+++ b/src/components/text-area/text-area.e2e.ts
@@ -14,7 +14,9 @@ import {
 import { CSS } from "./resources";
 
 describe("calcite-text-area", () => {
-  it("renders", async () => renders("calcite-text-area", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-text-area", { display: "inline-block" });
+  });
 
   it("defaults", async () =>
     defaults("calcite-text-area", [

--- a/src/components/tile-select-group/tile-select-group.e2e.ts
+++ b/src/components/tile-select-group/tile-select-group.e2e.ts
@@ -2,7 +2,9 @@ import { accessible, defaults, disabled, reflects, renders, hidden } from "../..
 import { html } from "../../../support/formatting";
 
 describe("calcite-tile-select-group", () => {
-  it("renders", async () => renders("calcite-tile-select-group", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-tile-select-group", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tile-select-group"));
 

--- a/src/components/tile-select/tile-select.e2e.ts
+++ b/src/components/tile-select/tile-select.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, defaults, disabled, focusable, hidden, reflects, renders } 
 import { html } from "../../../support/formatting";
 
 describe("calcite-tile-select", () => {
-  it("renders", async () => renders("calcite-tile-select", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-tile-select", { display: "block" });
+  });
 
   it("is accessible", async () => accessible(`<calcite-tile-select heading="label"></calcite-tile-select>`));
 

--- a/src/components/tile/tile.e2e.ts
+++ b/src/components/tile/tile.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, defaults, disabled, reflects, renders, slots, hidden } from
 import { SLOTS } from "./resources";
 
 describe("calcite-tile", () => {
-  it("renders", async () => renders("calcite-tile", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-tile", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tile"));
 

--- a/src/components/time-picker/time-picker.e2e.ts
+++ b/src/components/time-picker/time-picker.e2e.ts
@@ -35,7 +35,9 @@ const letterKeys = [
 export type NumericString = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
 
 describe("calcite-time-picker", () => {
-  it("renders", async () => renders("calcite-time-picker", { display: "inline-block" }));
+  describe("renders", () => {
+    renders("calcite-time-picker", { display: "inline-block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-time-picker"));
 

--- a/src/components/tip-group/tip-group.e2e.ts
+++ b/src/components/tip-group/tip-group.e2e.ts
@@ -1,7 +1,9 @@
 import { accessible, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tip-group", () => {
-  it("renders", async () => renders("calcite-tip-group", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-tip-group", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tip-group"));
 

--- a/src/components/tip-manager/tip-manager.e2e.ts
+++ b/src/components/tip-manager/tip-manager.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTe
 import { CSS, TEXT } from "./resources";
 
 describe("calcite-tip-manager", () => {
-  it("renders", async () => renders("calcite-tip-manager", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-tip-manager", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tip-manager"));
 

--- a/src/components/tip/tip.e2e.ts
+++ b/src/components/tip/tip.e2e.ts
@@ -3,7 +3,9 @@ import { accessible, hidden, renders, defaults, slots, t9n } from "../../tests/c
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-tip", () => {
-  it("renders", async () => renders("calcite-tip", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-tip", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tip"));
 

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -31,9 +31,9 @@ describe("calcite-tooltip", () => {
     expect(await page.evaluate(() => (window as CanceledEscapeKeyPressTestWindow).escapeKeyCanceled)).toBe(expected);
   }
 
-  it("renders", async () => {
-    await renders(`calcite-tooltip`, { visible: false, display: "block" });
-    await renders(`<calcite-tooltip open reference-element="ref"></calcite-tooltip><div id="ref">😄</div>`, {
+  describe("renders", () => {
+    renders(`calcite-tooltip`, { visible: false, display: "block" });
+    renders(`<calcite-tooltip open reference-element="ref"></calcite-tooltip><div id="ref">😄</div>`, {
       display: "block"
     });
   });

--- a/src/components/tree-item/tree-item.e2e.ts
+++ b/src/components/tree-item/tree-item.e2e.ts
@@ -4,7 +4,9 @@ import { html } from "../../../support/formatting";
 import { SLOTS } from "./resources";
 
 describe("calcite-tree-item", () => {
-  it("renders", async () => renders("calcite-tree-item", { visible: false, display: "block" }));
+  describe("renders", () => {
+    renders("calcite-tree-item", { visible: false, display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden(`<calcite-tree-item expanded></calcite-tree-item>`));
 

--- a/src/components/tree/tree.e2e.ts
+++ b/src/components/tree/tree.e2e.ts
@@ -5,7 +5,9 @@ import { CSS } from "../tree-item/resources";
 import SpyInstance = jest.SpyInstance;
 
 describe("calcite-tree", () => {
-  it("renders", () => renders("calcite-tree", { display: "block" }));
+  describe("renders", () => {
+    renders("calcite-tree", { display: "block" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-tree"));
 

--- a/src/components/value-list-item/value-list-item.e2e.ts
+++ b/src/components/value-list-item/value-list-item.e2e.ts
@@ -4,7 +4,9 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 
 describe("calcite-value-list-item", () => {
-  it("renders", async () => renders("calcite-value-list-item", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-value-list-item", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-value-list-item"));
 

--- a/src/components/value-list/value-list.e2e.ts
+++ b/src/components/value-list/value-list.e2e.ts
@@ -14,7 +14,9 @@ import {
 import { CSS, ICON_TYPES } from "./resources";
 
 describe("calcite-value-list", () => {
-  it("renders", () => renders("calcite-value-list", { display: "flex" }));
+  describe("renders", () => {
+    renders("calcite-value-list", { display: "flex" });
+  });
 
   it("honors hidden attribute", async () => hidden("calcite-value-list"));
 

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-export -- util functions are now imported to be used as `it` blocks within `descirbe` instead of assertions within `it` blocks */
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing";
 import axe from "axe-core";
 import { toHaveNoViolations } from "jest-axe";
@@ -69,7 +70,11 @@ export async function accessible(componentTagOrHTML: TagOrHTML, page?: E2EPage):
 }
 
 /**
- * Helper for asserting that a component renders and is hydrated
+ * Note that this helper should be used within a describe block.
+ *
+ * describe("renders), () => {
+ *   renders(`<calcite-tree></calcite-tree>`);
+ * });
  *
  * @param {string} componentTagOrHTML - the component tag or HTML markup to test against
  * @param {object} options - additional options to assert
@@ -85,12 +90,14 @@ export async function renders(
     display: string;
   }
 ): Promise<void> {
-  const page = await simplePageSetup(componentTagOrHTML);
-  const element = await page.find(getTag(componentTagOrHTML));
+  it("renders", async () => {
+    const page = await simplePageSetup(componentTagOrHTML);
+    const element = await page.find(getTag(componentTagOrHTML));
 
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
-  expect(await element.isVisible()).toBe(options?.visible ?? true);
-  expect((await element.getComputedStyle()).display).toBe(options?.display ?? "inline");
+    expect(element).toHaveAttribute(HYDRATED_ATTR);
+    expect(await element.isVisible()).toBe(options?.visible ?? true);
+    expect((await element.getComputedStyle()).display).toBe(options?.display ?? "inline");
+  });
 }
 
 /**

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-export -- util functions are now imported to be used as `it` blocks within `descirbe` instead of assertions within `it` blocks */
+/* eslint-disable jest/no-export -- util functions are now imported to be used as `it` blocks within `describe` instead of assertions within `it` blocks */
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing";
 import axe from "axe-core";
 import { toHaveNoViolations } from "jest-axe";
@@ -90,7 +90,7 @@ export async function renders(
     display: string;
   }
 ): Promise<void> {
-  it(`renders ${componentTagOrHTML}`, async () => {
+  it(`renders`, async () => {
     const page = await simplePageSetup(componentTagOrHTML);
     const element = await page.find(getTag(componentTagOrHTML));
 

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -72,7 +72,7 @@ export async function accessible(componentTagOrHTML: TagOrHTML, page?: E2EPage):
 /**
  * Note that this helper should be used within a describe block.
  *
- * describe("renders), () => {
+ * describe("renders", () => {
  *   renders(`<calcite-tree></calcite-tree>`);
  * });
  *
@@ -90,7 +90,7 @@ export async function renders(
     display: string;
   }
 ): Promise<void> {
-  it("renders", async () => {
+  it(`renders ${componentTagOrHTML}`, async () => {
     const page = await simplePageSetup(componentTagOrHTML);
     const element = await page.find(getTag(componentTagOrHTML));
 


### PR DESCRIPTION
**Related Issue:** #N/A

## Summary
This should help mitigate timeouts caused by additional test coverage added to the `renders` test helper.
The updated helper doc reflects how to use the helpers in E2E tests.