### PR TITLE
fix(block): Corrects alignment of slotted icon

### DIFF
--- a/src/components/block/block.scss
+++ b/src/components/block/block.scss
@@ -93,9 +93,9 @@ calcite-handle {
 }
 
 .icon {
+  display: flex;
   margin-inline-start: theme("spacing.3");
   margin-inline-end: 0px;
-  margin-block: theme("spacing.3");
 }
 
 .status-icon.valid {

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -192,21 +192,22 @@ export const contentCanTakeFullHeight_TestOnly = (): string =>
 
 export const alignmentHeading_TestOnly = (): string => html`<calcite-block heading="Heading"></calcite-block>`;
 
+export const alignmentDescription_TestOnly = (): string =>
+  html`<calcite-block description="description"></calcite-block>`;
+
 export const alignmentHeadingAndDescription_TestOnly = (): string =>
   html`<calcite-block heading="Heading" description="description"></calcite-block>`;
 
-export const alignmentDescription_TestOnly = (): string => html`<calcite-block heading="Heading"></calcite-block>`;
-
 export const alignmentIconHeading_TestOnly = (): string =>
   html`<calcite-block heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
+
+export const alignmentIconDescription_TestOnly = (): string =>
+  html`<calcite-block description="description"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
 
 export const alignmentIconHeadingAndDescription_TestOnly = (): string =>
   html`<calcite-block heading="Heading" description="description"
     ><calcite-icon scale="s" slot="icon" icon="layer"
   /></calcite-block>`;
-
-export const alignmentIconDescription_TestOnly = (): string =>
-  html`<calcite-block heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
 
 export const contentSpacing_TestOnly = (): string =>
   html`

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -190,6 +190,24 @@ export const contentCanTakeFullHeight_TestOnly = (): string =>
     <div style="background: red; height: 100%;">should take full width of the content area</div>
   </calcite-block>`;
 
+export const alignmentHeading_TestOnly = (): string => html`<calcite-block open heading="Heading"></calcite-block>`;
+
+export const alignmentHeadingAndDescription_TestOnly = (): string =>
+  html`<calcite-block open heading="Heading" description="description"></calcite-block>`;
+
+export const alignmentDescription_TestOnly = (): string => html`<calcite-block open heading="Heading"></calcite-block>`;
+
+export const alignmentIconHeading_TestOnly = (): string =>
+  html`<calcite-block open heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
+
+export const alignmentIconHeadingAndDescription_TestOnly = (): string =>
+  html`<calcite-block open heading="Heading" description="description"
+    ><calcite-icon scale="s" slot="icon" icon="layer"
+  /></calcite-block>`;
+
+export const alignmentIconDescription_TestOnly = (): string =>
+  html`<calcite-block open heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
+
 export const contentSpacing_TestOnly = (): string =>
   html`
     <calcite-block heading="Block heading" open>

--- a/src/components/block/block.stories.ts
+++ b/src/components/block/block.stories.ts
@@ -190,23 +190,23 @@ export const contentCanTakeFullHeight_TestOnly = (): string =>
     <div style="background: red; height: 100%;">should take full width of the content area</div>
   </calcite-block>`;
 
-export const alignmentHeading_TestOnly = (): string => html`<calcite-block open heading="Heading"></calcite-block>`;
+export const alignmentHeading_TestOnly = (): string => html`<calcite-block heading="Heading"></calcite-block>`;
 
 export const alignmentHeadingAndDescription_TestOnly = (): string =>
-  html`<calcite-block open heading="Heading" description="description"></calcite-block>`;
+  html`<calcite-block heading="Heading" description="description"></calcite-block>`;
 
-export const alignmentDescription_TestOnly = (): string => html`<calcite-block open heading="Heading"></calcite-block>`;
+export const alignmentDescription_TestOnly = (): string => html`<calcite-block heading="Heading"></calcite-block>`;
 
 export const alignmentIconHeading_TestOnly = (): string =>
-  html`<calcite-block open heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
+  html`<calcite-block heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
 
 export const alignmentIconHeadingAndDescription_TestOnly = (): string =>
-  html`<calcite-block open heading="Heading" description="description"
+  html`<calcite-block heading="Heading" description="description"
     ><calcite-icon scale="s" slot="icon" icon="layer"
   /></calcite-block>`;
 
 export const alignmentIconDescription_TestOnly = (): string =>
-  html`<calcite-block open heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
+  html`<calcite-block heading="Heading"><calcite-icon scale="s" slot="icon" icon="layer" /></calcite-block>`;
 
 export const contentSpacing_TestOnly = (): string =>
   html`

--- a/src/demos/block.html
+++ b/src/demos/block.html
@@ -43,7 +43,7 @@
         <div class="child right-aligned-text">default (non-collapsible + no block-section)</div>
 
         <div class="child">
-          <calcite-block heading="Fruit" summary="It's nature's candy"> </calcite-block>
+          <calcite-block heading="Fruit" description="It's nature's candy"> </calcite-block>
         </div>
       </div>
 
@@ -52,7 +52,7 @@
         <div class="child right-aligned-text">default collapsible + no controls</div>
 
         <div class="child">
-          <calcite-block heading="Heading" summary="summary" collapsible open>
+          <calcite-block heading="Heading" description="summary" collapsible open>
             <calcite-block-section text="input block-section" open>
               <calcite-input
                 icon="form-field"
@@ -70,7 +70,7 @@
         <div class="child right-aligned-text">switch collapsible + no controls</div>
 
         <div class="child">
-          <calcite-block heading="Heading" summary="summary" collapsible>
+          <calcite-block heading="Heading" description="summary" collapsible>
             <calcite-block-section text="input block-section w/ switch" toggle-display="switch">
               <calcite-input
                 icon="form-field"
@@ -90,7 +90,7 @@
         <div class="child right-aligned-text">switch collapsible + no controls + loading</div>
 
         <div class="child">
-          <calcite-block heading="Heading" summary="summary" loading collapsible>
+          <calcite-block heading="Heading" description="summary" loading collapsible>
             <calcite-block-section text="input block-section w/ switch" toggle-display="switch">
               <calcite-input
                 icon="form-field"
@@ -106,13 +106,38 @@
       </div>
 
       <hr />
+      <!-- various icon  -->
+      <div class="parent">
+        <div class="child right-aligned-text">various icon and heading / description alignment</div>
+        <div class="child">
+          <calcite-block heading="The block heading" description="The block summary" collapsible>
+            <calcite-icon slot="icon" scale="s" icon="layer"></calcite-icon>
+          </calcite-block>
+          <calcite-block heading="The block heading" collapsible>
+            <calcite-icon slot="icon" scale="s" icon="layer"></calcite-icon>
+          </calcite-block>
+          <calcite-block description="The block summary" collapsible>
+            <calcite-icon slot="icon" scale="s" icon="layer"></calcite-icon>
+          </calcite-block>
+          <calcite-block heading="The block heading" description="The block summary">
+            <calcite-icon slot="icon" scale="s" icon="layer"></calcite-icon>
+          </calcite-block>
+          <calcite-block heading="The block heading">
+            <calcite-icon slot="icon" scale="s" icon="layer"></calcite-icon>
+          </calcite-block>
+          <calcite-block description="The block summary">
+            <calcite-icon slot="icon" scale="s" icon="layer"></calcite-icon>
+          </calcite-block>
+        </div>
+      </div>
+      <hr />
 
       <!-- collapsible + controls + icons -->
       <div class="parent">
         <div class="child right-aligned-text">collapsible + controls + icons</div>
 
         <div class="child">
-          <calcite-block heading="The block heading" summary="The block summary" collapsible>
+          <calcite-block heading="The block heading" description="The block summary" collapsible>
             <calcite-block-section text="input block-section w/ switch" toggle-display="switch">
               <calcite-input
                 icon="form-field"
@@ -166,13 +191,13 @@
       <div class="parent">
         <div class="child right-aligned-text">block status</div>
         <div class="child">
-          <calcite-block heading="Valid status" summary="summary" collapsible status="valid">
+          <calcite-block heading="Valid status" description="summary" collapsible status="valid">
             <calcite-input icon="form-field" placeholder="This is valid input field"></calcite-input>
           </calcite-block>
 
-          <calcite-block heading="Invalid status" summary="summary" status="invalid"> </calcite-block>
+          <calcite-block heading="Invalid status" description="summary" status="invalid"> </calcite-block>
 
-          <calcite-block heading="Idle status" summary="summary" status="idle"> </calcite-block>
+          <calcite-block heading="Idle status" description="summary" status="idle"> </calcite-block>
         </div>
       </div>
 
@@ -180,7 +205,7 @@
       <div class="parent">
         <div class="child right-aligned-text">block-section status</div>
         <div class="child">
-          <calcite-block heading="The block heading" summary="The block summary" collapsible>
+          <calcite-block heading="The block heading" description="The block summary" collapsible>
             <calcite-block-section text="valid input" toggle-display="switch" status="valid">
               <calcite-input icon="form-field" placeholder="This is a valid input field"></calcite-input>
             </calcite-block-section>
@@ -203,7 +228,7 @@
         <div class="child right-aligned-text">with drag handle</div>
 
         <div class="child">
-          <calcite-block heading="Who dis?" summary="seriously! who dis?" drag-handle></calcite-block>
+          <calcite-block heading="Who dis?" description="seriously! who dis?" drag-handle></calcite-block>
         </div>
       </div>
     </demo-dom-swapper>


### PR DESCRIPTION
**Related Issue:** #6627 

## Summary
Adjust slotted icon container css to better align the icon container. Small misalignments due to icon may still occur but this should be better than before. Adds a handful of test-only stories to capture more Block states, and fixes some instance of an outdated prop used in demo pages.

cc @ashetland @SkyeSeitz - I think this was already correct in Figma, but FYI as this will likely require Chromatic approval.
cc @asangma @mitc7862 - FYI

Before:
<img width="800" alt="Screen Shot 2023-04-28 at 10 29 41 AM" src="https://user-images.githubusercontent.com/4733155/235215454-66f2c11e-5e5b-44cb-b3ca-194137e6d58b.png">


After:
<img width="800" alt="Screen Shot 2023-04-28 at 10 29 32 AM" src="https://user-images.githubusercontent.com/4733155/235215463-d2ff17f1-c309-4cef-ac12-ddaab1f4f33c.png">
