### PR TITLE
feat(action-bar): Improve border display in horizontal layout

### DIFF
--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -50,6 +50,10 @@
   }
 }
 
+:host([layout="horizontal"][expand-disabled]) ::slotted(calcite-action-group:last-of-type) {
+  @apply border-r-0;
+}
+
 ::slotted(calcite-action-group:last-child) {
   @apply border-b-0 border-r-0;
 }

--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -36,28 +36,23 @@
 }
 
 ::slotted(calcite-action-group) {
-  @apply border-color-3
-    border-0
-    border-b
-    border-solid;
+  border-block-end: 1px solid var(--calcite-ui-border-3);
 }
 
-:host([layout="horizontal"]) {
-  ::slotted(calcite-action-group) {
-    @apply border-0
-      border-r
-      border-solid;
-  }
+:host([layout="horizontal"]) ::slotted(calcite-action-group) {
+  border-block-end: 0;
+  border-inline-end: 1px solid var(--calcite-ui-border-3);
 }
 
 :host([layout="horizontal"][expand-disabled]) ::slotted(calcite-action-group:last-of-type) {
-  @apply border-r-0;
+  border-inline-end: 0;
 }
 
 ::slotted(calcite-action-group:last-child) {
-  @apply border-b-0 border-r-0;
+  border-block-end: 0;
+  border-inline-end: 0;
 }
 
 .action-group--bottom {
-  @apply flex-grow justify-end pb-0 pr-0;
+  @apply flex-grow justify-end;
 }

--- a/src/demos/panel.html
+++ b/src/demos/panel.html
@@ -73,7 +73,34 @@
           </div>
         </div>
       </div>
-
+      <!-- with action bar -->
+      <div class="parent">
+        <div class="child right-aligned-text">Slotted Action Bar action end</div>
+        <div class="child">
+          <div style="height: 200px; display: flex">
+            <calcite-panel height-scale="s">
+              <calcite-action-bar slot="action-bar" expand-disabled>
+                <calcite-action-group>
+                  <calcite-action text="Add" icon="plus"> </calcite-action>
+                  <calcite-action text="Save" icon="save"> </calcite-action>
+                  <calcite-action text="Layers" icon="layers"> </calcite-action>
+                </calcite-action-group>
+                <calcite-action-group slot="bottom-actions">
+                  <calcite-action text="Add" icon="plus"> </calcite-action>
+                  <calcite-action text="Save" icon="save"> </calcite-action>
+                  <calcite-action text="Layers" icon="layers"> </calcite-action>
+                </calcite-action-group>
+              </calcite-action-bar>
+              <div slot="header-content">Header!</div>
+              <p>Slotted content!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p slot="footer">Slotted content!</p>
+            </calcite-panel>
+          </div>
+        </div>
+      </div>
       <!-- disabled -->
       <div class="parent">
         <div class="child right-aligned-text">disabled</div>

--- a/src/demos/panel.html
+++ b/src/demos/panel.html
@@ -78,12 +78,15 @@
         <div class="child right-aligned-text">Slotted Action Bar action end</div>
         <div class="child">
           <div style="height: 200px; display: flex">
-            <calcite-panel height-scale="s">
+            <calcite-panel height-scale="s" heading="Action bar example">
               <calcite-action-bar slot="action-bar" expand-disabled>
                 <calcite-action-group>
                   <calcite-action text="Add" icon="plus"> </calcite-action>
                   <calcite-action text="Save" icon="save"> </calcite-action>
                   <calcite-action text="Layers" icon="layers"> </calcite-action>
+                </calcite-action-group>
+                <calcite-action-group>
+                  <calcite-action text="Add" icon="plus"> </calcite-action>
                 </calcite-action-group>
                 <calcite-action-group slot="bottom-actions">
                   <calcite-action text="Add" icon="plus"> </calcite-action>
@@ -91,8 +94,6 @@
                   <calcite-action text="Layers" icon="layers"> </calcite-action>
                 </calcite-action-group>
               </calcite-action-bar>
-              <div slot="header-content">Header!</div>
-              <p>Slotted content!</p>
               <p style="height: 400px">Hello world!</p>
               <p style="height: 400px">Hello world!</p>
               <p style="height: 400px">Hello world!</p>


### PR DESCRIPTION
**Related Issue:** #6758 

## Summary
Adds a css case to prevent the border at the edge of horizontal action bar bottom-actions.

Before:

<img width="731" alt="Screen Shot 2023-04-28 at 3 05 45 PM" src="https://user-images.githubusercontent.com/4733155/235262082-480d0c1b-8486-4e6e-9ab8-634f96aeb1ff.png">


After:

<img width="731" alt="Screen Shot 2023-04-28 at 3 05 38 PM" src="https://user-images.githubusercontent.com/4733155/235262095-03bd9de1-e2e8-4e2a-b1b2-9091305deaae.png">

