### PR TITLE
feat(panel, flow-item): Add CSS custom property to define footer padding and deprecate "footer-actions" slot.

### DIFF
--- a/src/components/flow-item/flow-item.scss
+++ b/src/components/flow-item/flow-item.scss
@@ -1,3 +1,11 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-flow-item-footer-padding: Specifies the padding of the component's footer.
+ */
+
 :host {
   @extend %component-host;
   @apply relative flex w-full flex-auto overflow-hidden;
@@ -10,4 +18,8 @@
   border-0
   border-solid;
   border-inline-end-width: theme("borderWidth.DEFAULT");
+}
+
+calcite-panel {
+  --calcite-panel-footer-padding: var(--calcite-flow-item-footer-padding);
 }

--- a/src/components/flow-item/flow-item.scss
+++ b/src/components/flow-item/flow-item.scss
@@ -9,6 +9,7 @@
 :host {
   @extend %component-host;
   @apply relative flex w-full flex-auto overflow-hidden;
+  --calcite-flow-item-footer-padding: theme("spacing.2");
 }
 
 @include disabled();

--- a/src/components/flow-item/flow-item.stories.ts
+++ b/src/components/flow-item/flow-item.stories.ts
@@ -223,3 +223,11 @@ export const withActionBar_TestOnly = (): string => html`<div style="width: 300p
     <p>Slotted content!</p>
   </calcite-flow-item>
 </div>`;
+
+export const footerPadding_TestOnly = (): string => html`<div style="width: 300px;">
+  <calcite-flow-item height-scale="s" style="--calcite-flow-item-footer-padding: 20px;">
+    <div slot="header-content">Header!</div>
+    <p>Slotted content!</p>
+    <div slot="footer">Footer!</div>
+  </calcite-flow-item>
+</div>`;

--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -40,7 +40,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
  * @slot header-content - A slot for adding custom content to the component's header.
  * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
- * @slot footer-actions - A slot for adding `calcite-button`s to the component's footer.
+ * @slot footer-actions - [Deprecated] A slot for adding `calcite-button`s to the component's footer.
  * @slot footer - A slot for adding custom content to the component's footer.
  */
 @Component({

--- a/src/components/flow/readme.md
+++ b/src/components/flow/readme.md
@@ -21,17 +21,17 @@ Renders a basic flow with a couple `calcite-panel`s.
 </calcite-flow>
 ```
 
-### Menu-actions-and-footer-actions
+### Menu-actions-and-footer
 
-Renders a flow with menu-actions and footer-actions in the form of buttons.
+Renders a flow with menu-actions and footer in the form of buttons.
 
 ```html
 <calcite-flow>
   <calcite-panel heading="What are the most popular commute alternatives?">
     <button slot="header-menu-actions">Reset</button>
     <button slot="header-menu-actions">Rename</button>
-    <button slot="footer-actions">Save</button>
-    <button slot="footer-actions">Cancel</button>
+    <button slot="footer">Save</button>
+    <button slot="footer">Cancel</button>
   </calcite-panel>
 </calcite-flow>
 ```

--- a/src/components/flow/usage/Menu-actions-and-footer-actions.md
+++ b/src/components/flow/usage/Menu-actions-and-footer-actions.md
@@ -1,12 +1,12 @@
-Renders a flow with menu-actions and footer-actions in the form of buttons.
+Renders a flow with menu-actions and footer in the form of buttons.
 
 ```html
 <calcite-flow>
   <calcite-panel heading="What are the most popular commute alternatives?">
     <button slot="header-menu-actions">Reset</button>
     <button slot="header-menu-actions">Rename</button>
-    <button slot="footer-actions">Save</button>
-    <button slot="footer-actions">Cancel</button>
+    <button slot="footer">Save</button>
+    <button slot="footer">Cancel</button>
   </calcite-panel>
 </calcite-flow>
 ```

--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -1,8 +1,17 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-panel-footer-padding: Specifies the padding of the component's footer.
+ */
+
 :host {
   @extend %component-host;
   @apply relative flex w-full h-full flex-auto overflow-hidden;
 
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
+  --calcite-panel-footer-padding: theme("spacing.2");
 }
 
 @include disabled();
@@ -109,7 +118,7 @@
 
   flex: 0 0 auto;
   min-block-size: theme("spacing.12");
-  padding: theme("spacing.2");
+  padding: var(--calcite-panel-footer-padding);
 }
 
 .fab-container {

--- a/src/components/panel/panel.stories.ts
+++ b/src/components/panel/panel.stories.ts
@@ -191,3 +191,11 @@ export const withActionBar_TestOnly = (): string => html`<div style="width: 300p
     <p>Slotted content!</p>
   </calcite-panel>
 </div>`;
+
+export const footerPadding_TestOnly = (): string => html`<div style="width: 300px;">
+  <calcite-panel height-scale="s" style="--calcite-panel-footer-padding: 20px;">
+    <div slot="header-content">Header!</div>
+    <p>Slotted content!</p>
+    <div slot="footer">Footer!</div>
+  </calcite-panel>
+</div>`;

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -42,7 +42,7 @@ import { PanelMessages } from "./assets/panel/t9n";
  * @slot header-content - A slot for adding custom content to the header.
  * @slot header-menu-actions - A slot for adding an overflow menu with actions inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
- * @slot footer-actions - A slot for adding buttons to the footer.
+ * @slot footer-actions - [Deprecated] A slot for adding buttons to the footer.
  * @slot footer - A slot for adding custom content to the footer.
  */
 @Component({

--- a/src/components/shell/shell.stories.ts
+++ b/src/components/shell/shell.stories.ts
@@ -282,8 +282,8 @@ const advancedTrailingPanelHTMl = html(`
           </calcite-block-section>
         </calcite-block-content>
       </calcite-block>
-      <calcite-button slot="footer-actions" width="half" appearance="outline">Cancel</calcite-button>
-      <calcite-button slot="footer-actions" width="half">Save</calcite-button>
+      <calcite-button slot="footer" width="half" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="footer" width="half">Save</calcite-button>
     </calcite-flow-item>
     <calcite-flow-item heading="Deeper flow item">
       <calcite-block collapsible open heading="End Content" summary="Select goodness">
@@ -316,8 +316,8 @@ const advancedTrailingPanelHTMl = html(`
           </calcite-block-section>
         </calcite-block-content>
       </calcite-block>
-      <calcite-button slot="footer-actions" width="half" appearance="outline">Cancel</calcite-button>
-      <calcite-button slot="footer-actions" width="half">Save</calcite-button>
+      <calcite-button slot="footer" width="half" appearance="outline">Cancel</calcite-button>
+      <calcite-button slot="footer" width="half">Save</calcite-button>
     </calcite-flow-item>
   </calcite-flow>
 `);
@@ -465,7 +465,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
             </calcite-block-content>
           </calcite-block>
           <calcite-button
-            slot="footer-actions"
+            slot="footer"
             width="half"
             appearance="outline"
             alignment="center"
@@ -475,7 +475,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
             Cancel
           </calcite-button>
           <calcite-button
-            slot="footer-actions"
+            slot="footer"
             width="half"
             alignment="center"
             appearance="solid"
@@ -525,7 +525,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
             </calcite-block-content>
           </calcite-block>
           <calcite-button
-            slot="footer-actions"
+            slot="footer"
             width="half"
             appearance="outline"
             alignment="center"
@@ -535,7 +535,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
             Cancel
           </calcite-button>
           <calcite-button
-            slot="footer-actions"
+            slot="footer"
             width="half"
             alignment="center"
             appearance="solid"

--- a/src/demos/flow.html
+++ b/src/demos/flow.html
@@ -45,22 +45,23 @@
             </calcite-flow-item>
             <calcite-flow-item heading="tell me that you love me more">
               <!-- image -->
+              <div slot="footer">test</div>
             </calcite-flow-item>
           </calcite-flow>
         </div>
       </div>
 
-      <!-- menu-actions & footer-actions -->
+      <!-- menu-actions & footer -->
       <div class="parent">
-        <div class="child right-aligned-text">menu-actions & footer-actions</div>
+        <div class="child right-aligned-text">menu-actions & footer</div>
 
         <div class="child">
           <calcite-flow>
             <calcite-flow-item heading="What are the most popular commute alternatives?">
               <button slot="header-menu-actions">Reset</button>
               <button slot="header-menu-actions">Rename</button>
-              <button slot="footer-actions">Save</button>
-              <button slot="footer-actions">Cancel</button>
+              <button slot="footer">Save</button>
+              <button slot="footer">Cancel</button>
             </calcite-flow-item>
           </calcite-flow>
         </div>
@@ -78,8 +79,8 @@
             >
               <button slot="menu-actions">Reset</button>
               <button slot="menu-actions">Rename</button>
-              <button slot="footer-actions" class="btn">Save</button>
-              <button slot="footer-actions" class="btn btn-secondary">Cancel</button>
+              <button slot="footer" class="btn">Save</button>
+              <button slot="footer" class="btn btn-secondary">Cancel</button>
               <p><img src="https://placeimg.com/300/200/nature" alt="placeholder" /></p>
               <p><img src="https://placeimg.com/300/200/nature" alt="placeholder" /></p>
             </calcite-flow-item>
@@ -111,8 +112,8 @@
           <p><img src="https://placeimg.com/300/200/nature" alt="nature" /></p>
           <p><img src="https://placeimg.com/300/200/nature" alt="nature" /></p>
           <calcite-action label="pencil icon" slot="menu-actions" icon="pencil"></calcite-action>
-          <button slot="footer-actions">Save</button>
-          <button slot="footer-actions">Cancel</button>
+          <button slot="footer">Save</button>
+          <button slot="footer">Cancel</button>
         `;
               flowNode.appendChild(newNode);
               setTimeout(function () {

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -814,8 +814,8 @@
                   <calcite-tooltip label="tooltip" reference-element="label-fab" pointer-disabled>
                     Add label class
                   </calcite-tooltip>
-                  <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                  <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                  <calcite-button slot="footer" appearance="outline" width="half">Cancel</calcite-button>
+                  <calcite-button slot="footer" width="half">Done</calcite-button>
                 </calcite-flow-item>
               </calcite-flow>
               <!-- </div> -->

--- a/src/demos/shell/demo-app-advanced-2-shell-header.html
+++ b/src/demos/shell/demo-app-advanced-2-shell-header.html
@@ -231,8 +231,8 @@
                   <calcite-tooltip label="tooltip" reference-element="label-fab" pointer-disabled>
                     Add label class
                   </calcite-tooltip>
-                  <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                  <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                  <calcite-button slot="footer" appearance="outline" width="half">Cancel</calcite-button>
+                  <calcite-button slot="footer" width="half">Done</calcite-button>
                 </calcite-panel>
               </something>
             </calcite-shell-panel>

--- a/src/demos/shell/demo-app-advanced-center-row-async.html
+++ b/src/demos/shell/demo-app-advanced-center-row-async.html
@@ -139,8 +139,8 @@
               </calcite-action-bar>
               <calcite-panel heading="Single panel" description="I'm in the contextual-panel" width-scale="m">
                 Default slot of panel
-                <calcite-button width="half" slot="footer-actions" appearance="outline">Cancel</calcite-button>
-                <calcite-button width="half" slot="footer-actions">Done</calcite-button>
+                <calcite-button width="half" slot="footer" appearance="outline">Cancel</calcite-button>
+                <calcite-button width="half" slot="footer">Done</calcite-button>
               </calcite-panel>
             </calcite-shell-panel>
             <div class="gnav" slot="header">

--- a/src/demos/shell/demo-app-advanced-center-row.html
+++ b/src/demos/shell/demo-app-advanced-center-row.html
@@ -118,8 +118,8 @@
               </calcite-action-bar>
               <calcite-panel heading="Single panel" summary="I'm in the contextual-panel" width-scale="m">
                 Default slot of panel
-                <calcite-button width="half" slot="footer-actions" appearance="outline">Cancel</calcite-button>
-                <calcite-button width="half" slot="footer-actions">Done</calcite-button>
+                <calcite-button width="half" slot="footer" appearance="outline">Cancel</calcite-button>
+                <calcite-button width="half" slot="footer">Done</calcite-button>
               </calcite-panel>
             </calcite-shell-panel>
             <div class="gnav" slot="header">

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -227,8 +227,8 @@
                       </calcite-block-section>
                     </calcite-block-content>
                   </calcite-block>
-                  <calcite-button width="halft" appearance="outline" slot="footer-actions">Cancel</calcite-button>
-                  <calcite-button width="halft" slot="footer-actions">Save</calcite-button>
+                  <calcite-button width="halft" appearance="outline" slot="footer">Cancel</calcite-button>
+                  <calcite-button width="halft" slot="footer">Save</calcite-button>
                 </calcite-flow-item>
                 <calcite-flow-item heading="Deeper flow item" height-scale="l" width-scale="m">
                   <calcite-value-list id="one" multiple filter-enabled>
@@ -347,8 +347,8 @@
                       </calcite-block-section>
                     </calcite-block-content>
                   </calcite-block>
-                  <calcite-button slot="footer-actions" width="half">Save</calcite-button>
-                  <calcite-button slot="footer-actions" width="half" appearance="outline">Cancel</calcite-button>
+                  <calcite-button slot="footer" width="half">Save</calcite-button>
+                  <calcite-button slot="footer" width="half" appearance="outline">Cancel</calcite-button>
                 </calcite-flow-item>
               </calcite-flow>
             </calcite-shell-panel>
@@ -433,8 +433,8 @@
                 value="4"
               ></calcite-pick-list-item>
             </calcite-pick-list>
-            <calcite-button slot="footer-actions" width="half">Yeah!</calcite-button>
-            <calcite-button slot="footer-actions" width="half" appearance="outline">Naw.</calcite-button>
+            <calcite-button slot="footer" width="half">Yeah!</calcite-button>
+            <calcite-button slot="footer" width="half" appearance="outline">Naw.</calcite-button>
           </calcite-panel>
         </calcite-popover>
         <script>

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -101,10 +101,8 @@
                     </div>
                   </calcite-block-content>
                 </calcite-block>
-                <calcite-button width="half" scale="s" slot="footer-actions" appearance="outline"
-                  >Cancel</calcite-button
-                >
-                <calcite-button width="half" scale="s" slot="footer-actions">OK</calcite-button>
+                <calcite-button width="half" scale="s" slot="footer" appearance="outline">Cancel</calcite-button>
+                <calcite-button width="half" scale="s" slot="footer">OK</calcite-button>
               </calcite-panel>
             </calcite-shell-panel>
 
@@ -190,10 +188,8 @@
                       </calcite-block-section>
                     </calcite-block-content>
                   </calcite-block>
-                  <calcite-button width="half" scale="s" appearance="outline" slot="footer-actions"
-                    >Save</calcite-button
-                  >
-                  <calcite-button width="half" scale="s" slot="footer-actions">Cancel</calcite-button>
+                  <calcite-button width="half" scale="s" appearance="outline" slot="footer">Save</calcite-button>
+                  <calcite-button width="half" scale="s" slot="footer">Cancel</calcite-button>
                 </calcite-flow-item>
                 <calcite-flow-item
                   heading="A capability"
@@ -327,10 +323,8 @@
                       </calcite-block-section>
                     </calcite-block-content>
                   </calcite-block>
-                  <calcite-button slot="footer-actions" scale="s" width="half">Save</calcite-button>
-                  <calcite-button slot="footer-actions" scale="s" width="half" appearance="outline"
-                    >Cancel</calcite-button
-                  >
+                  <calcite-button slot="footer" scale="s" width="half">Save</calcite-button>
+                  <calcite-button slot="footer" scale="s" width="half" appearance="outline">Cancel</calcite-button>
                   <calcite-fab slot="fab" label="Add Item" text="Add"></calcite-fab>
                 </calcite-flow-item>
               </calcite-flow>

--- a/src/demos/shell/demo-app-rtl.html
+++ b/src/demos/shell/demo-app-rtl.html
@@ -157,8 +157,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-flow-item>
                   <calcite-flow-item heading="Deeper flow item">
                     <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
@@ -191,8 +191,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-flow-item>
                 </calcite-flow>
               </calcite-shell-panel>
@@ -296,8 +296,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-panel>
                   <calcite-panel heading="Deeper flow item">
                     <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
@@ -330,8 +330,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-panel>
                 </calcite-flow>
               </calcite-shell-panel>

--- a/src/demos/shell/demo-app.html
+++ b/src/demos/shell/demo-app.html
@@ -157,8 +157,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-flow-item>
                   <calcite-flow-item heading="Deeper flow item">
                     <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
@@ -191,8 +191,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-flow-item>
                 </calcite-flow>
               </calcite-shell-panel>
@@ -345,8 +345,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-panel>
                   <calcite-panel heading="Deeper flow item">
                     <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
@@ -379,8 +379,8 @@
                         </calcite-block-section>
                       </calcite-block-content>
                     </calcite-block>
-                    <button slot="footer-actions">Save</button>
-                    <button slot="footer-actions">Cancel</button>
+                    <button slot="footer">Save</button>
+                    <button slot="footer">Cancel</button>
                   </calcite-panel>
                 </calcite-flow>
               </calcite-shell-panel>

--- a/src/demos/shell/nesting-testing-flow.html
+++ b/src/demos/shell/nesting-testing-flow.html
@@ -258,8 +258,8 @@
                       <calcite-tooltip label="tooltip" reference-element="label-fab" pointer-disabled>
                         Add label class
                       </calcite-tooltip>
-                      <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                      <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                      <calcite-button slot="footer" appearance="outline" width="half">Cancel</calcite-button>
+                      <calcite-button slot="footer" width="half">Done</calcite-button>
                     </calcite-flow-item>
                   </some-custom-element>
                 </calcite-flow>

--- a/src/demos/shell/nesting-testing.html
+++ b/src/demos/shell/nesting-testing.html
@@ -211,8 +211,8 @@
                   <calcite-tooltip label="tooltip" reference-element="label-fab" pointer-disabled>
                     Add label class
                   </calcite-tooltip>
-                  <calcite-button slot="footer-actions" appearance="outline" width="half">Cancel</calcite-button>
-                  <calcite-button slot="footer-actions" width="half">Done</calcite-button>
+                  <calcite-button slot="footer" appearance="outline" width="half">Cancel</calcite-button>
+                  <calcite-button slot="footer" width="half">Done</calcite-button>
                 </calcite-panel>
               </some-custom-element>
             </calcite-shell-panel>


### PR DESCRIPTION
**Related Issue:** #6892

## Summary

- Panel
  - Adds `--calcite-panel-footer-padding` to specify the padding of the component's footer.
  - Deprecates the `footer-actions` slot, use the `footer` slot instead.
- FlowItem 
  - Adds `--calcite-flow-item-footer-padding` to specify the padding of the component's footer.
  - Deprecates the `footer-actions` slot, use the `footer` slot instead.