### PR TITLE
fix(panel): Remove min-block-size from footer

### DIFF
--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -108,7 +108,6 @@
   justify-evenly;
 
   flex: 0 0 auto;
-  min-block-size: theme("spacing.12");
   padding: theme("spacing.2");
 }
 


### PR DESCRIPTION
**Related Issue:** #6733

## Summary

The footer now has no minimum size defined.