### PR TITLE
feat(avatar): add label prop for alternative text & aria-label

### DIFF
--- a/src/components/avatar/avatar.stories.ts
+++ b/src/components/avatar/avatar.stories.ts
@@ -17,6 +17,7 @@ export const simple = (): string => html`
   <calcite-avatar
     scale="${select("scale", ["s", "m", "l"], "m")}"
     full-name="${text("full-name", "John Doe")}"
+    label="${text("label", "John Doe")}"
     username="${text("username", "jdoe")}"
     user-id="${text("user-id", "9a7c50e6b3ce4b859f7b31e302437164")}"
     thumbnail="${text("thumbnail", placeholderImage({ width: 120, height: 120 }))}"

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -39,6 +39,9 @@ export class Avatar {
   /** Specifies the unique id of the user. */
   @Prop({ reflect: true }) userId: string;
 
+  /** Specifies alternate text for thumbnail and accessible label for initials.*/
+  @Prop() label: string;
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -67,7 +70,7 @@ export class Avatar {
     if (this.thumbnail && !this.thumbnailFailedToLoad) {
       return (
         <img
-          alt=""
+          alt={this.label || ""}
           class="thumbnail"
           onError={() => (this.thumbnailFailedToLoad = true)}
           src={this.thumbnail}
@@ -77,7 +80,12 @@ export class Avatar {
     const initials = this.generateInitials();
     const backgroundColor = this.generateFillColor();
     return (
-      <span class="background" style={{ backgroundColor }}>
+      <span
+        aria-label={this.label || this.fullName}
+        class="background"
+        role="img"
+        style={{ backgroundColor }}
+      >
         {initials ? (
           <span aria-hidden="true" class="initials">
             {initials}

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -39,7 +39,7 @@ export class Avatar {
   /** Specifies the unique id of the user. */
   @Prop({ reflect: true }) userId: string;
 
-  /** Specifies alternate text for thumbnail and accessible label for initials.*/
+  /** When `thumbnail` is defined, specifies alternate text for the image. Otherwise specifies accessible label for the component.*/
   @Prop() label: string;
 
   //--------------------------------------------------------------------------

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -80,12 +80,7 @@ export class Avatar {
     const initials = this.generateInitials();
     const backgroundColor = this.generateFillColor();
     return (
-      <span
-        aria-label={this.label || this.fullName}
-        class="background"
-        role="img"
-        style={{ backgroundColor }}
-      >
+      <span aria-label={this.label || this.fullName} class="background" style={{ backgroundColor }}>
         {initials ? (
           <span aria-hidden="true" class="initials">
             {initials}

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -30,7 +30,7 @@ export class Avatar {
   /** Specifies the `src` to an image (remember to add a token if the user is private). */
   @Prop({ reflect: true }) thumbnail: string;
 
-  /** Specifies the full name of the user. */
+  /** Specifies the full name of the user. When `label` and `thumbnail` are not defined, specifies the accessible name for the component. */
   @Prop({ reflect: true }) fullName: string;
 
   /** Specifies the username of the user. */
@@ -39,7 +39,7 @@ export class Avatar {
   /** Specifies the unique id of the user. */
   @Prop({ reflect: true }) userId: string;
 
-  /** When `thumbnail` is defined, specifies alternate text for the image. Otherwise specifies accessible label for the component.*/
+  /** Specifies alternative text when `thumbnail` is defined, otherwise specifies an accessible label.*/
   @Prop() label: string;
 
   //--------------------------------------------------------------------------
@@ -80,7 +80,12 @@ export class Avatar {
     const initials = this.generateInitials();
     const backgroundColor = this.generateFillColor();
     return (
-      <span aria-label={this.label || this.fullName} class="background" style={{ backgroundColor }}>
+      <span
+        aria-label={this.label || this.fullName}
+        class="background"
+        role="figure"
+        style={{ backgroundColor }}
+      >
         {initials ? (
           <span aria-hidden="true" class="initials">
             {initials}

--- a/src/demos/avatar.html
+++ b/src/demos/avatar.html
@@ -49,18 +49,18 @@
 
       <!-- Image -->
       <div class="parent">
-        <div class="child right-aligned-text">Image</div>
+        <div class="child right-aligned-text">Image With Label</div>
 
         <div class="child">
-          <calcite-avatar thumbnail="http://placekitten.com/105/105" scale="s"> </calcite-avatar>
+          <calcite-avatar thumbnail="http://placekitten.com/105/105" scale="s" label="kitten"> </calcite-avatar>
         </div>
 
         <div class="child">
-          <calcite-avatar thumbnail="http://placekitten.com/40/40" scale="m"></calcite-avatar>
+          <calcite-avatar thumbnail="http://placekitten.com/40/40" scale="m" label="kitten"></calcite-avatar>
         </div>
 
         <div class="child">
-          <calcite-avatar thumbnail="http://placekitten.com/120/120" scale="l"></calcite-avatar>
+          <calcite-avatar thumbnail="http://placekitten.com/120/120" scale="l" label="kitten"></calcite-avatar>
         </div>
       </div>
 


### PR DESCRIPTION
**Related Issue:** #5564 

## Summary

This PR will add a `label` property in `calcite-avatar` which is used to provide context for Assistive Technology users. 