### PR TITLE
test(list): skip unstable test

### DIFF
--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -100,7 +100,7 @@ describe("calcite-list", () => {
       { focusTarget: "child" }
     ));
 
-  it("navigating items after filtering", async () => {
+  it.skip("navigating items after filtering", async () => {
     const page = await newE2EPage({
       html: html`
         <calcite-list filter-enabled>

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -4,14 +4,14 @@ import { html } from "../../../support/formatting";
 import { newE2EPage } from "@stencil/core/testing";
 import { debounceTimeout } from "./resources";
 import { CSS } from "../list-item/resources";
-import { DEBOUNCE_TIMEOUT } from "../filter/resources";
+import { DEBOUNCE_TIMEOUT as FILTER_DEBOUNCE_TIMEOUT } from "../filter/resources";
 
 const placeholder = placeholderImage({
   width: 140,
   height: 100
 });
 
-const listDebounceTimeout = debounceTimeout + DEBOUNCE_TIMEOUT;
+const listDebounceTimeout = debounceTimeout + FILTER_DEBOUNCE_TIMEOUT;
 
 describe("calcite-list", () => {
   it("defaults", async () =>
@@ -182,13 +182,14 @@ describe("calcite-list", () => {
         </calcite-list>
       `
     });
-
-    const list = await page.find("calcite-list");
-    await page.waitForTimeout(listDebounceTimeout);
     await page.waitForChanges();
 
-    expect(await list.getProperty("filteredData")).toHaveLength(3);
+    const list = await page.find("calcite-list");
+    await list.callMethod("setFocus");
+    await page.waitForTimeout(listDebounceTimeout);
+
     expect(await list.getProperty("filteredItems")).toHaveLength(3);
+    expect(await list.getProperty("filteredData")).toHaveLength(3);
 
     const visibleItems = await page.findAll("calcite-list-item:not([hidden])");
 

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -151,7 +151,7 @@ describe("calcite-list", () => {
     expect(await list.getProperty("filterText")).toBe("twoblah");
   });
 
-  it("filters initially", async () => {
+  it.skip("filters initially", async () => {
     const page = await newE2EPage({
       html: html`
         <calcite-list filter-enabled filter-text="match">
@@ -182,14 +182,13 @@ describe("calcite-list", () => {
         </calcite-list>
       `
     });
-    await page.waitForChanges();
 
     const list = await page.find("calcite-list");
-    await list.callMethod("setFocus");
     await page.waitForTimeout(listDebounceTimeout);
+    await page.waitForChanges();
 
-    expect(await list.getProperty("filteredItems")).toHaveLength(3);
     expect(await list.getProperty("filteredData")).toHaveLength(3);
+    expect(await list.getProperty("filteredItems")).toHaveLength(3);
 
     const visibleItems = await page.findAll("calcite-list-item:not([hidden])");
 

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -4,13 +4,14 @@ import { html } from "../../../support/formatting";
 import { newE2EPage } from "@stencil/core/testing";
 import { debounceTimeout } from "./resources";
 import { CSS } from "../list-item/resources";
+import { DEBOUNCE_TIMEOUT } from "../filter/resources";
 
 const placeholder = placeholderImage({
   width: 140,
   height: 100
 });
 
-const listDebounceTimeout = debounceTimeout + 1;
+const listDebounceTimeout = debounceTimeout + DEBOUNCE_TIMEOUT;
 
 describe("calcite-list", () => {
   it("defaults", async () =>


### PR DESCRIPTION
Skips unstable list test.

The filter component needs to be refactored to be able to access its data after changing the filterText since its debounced.