### PR TITLE
build(deps): bump calcite-icons to v3.22.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.1.0",
-        "@esri/calcite-ui-icons": "3.22.1",
+        "@esri/calcite-ui-icons": "3.22.2",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -2421,9 +2421,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.1.tgz",
-      "integrity": "sha512-Mj/30GOz1nzetSPxXrmWCXNE0JuSU7Pgiy37/QPHK2J2X4kDEGH78wIKGb1WEiViYfZGaD+ubQqEONuuhDnd6g==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.2.tgz",
+      "integrity": "sha512-kqcEVKr5ZWg+LecINTLZV9K8hO0IIYI9XpIx3PXMxhDYhkmpxjArTcfdAuOScb/B2mR85Jz5Qox+vwS++xlyfw==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -35400,9 +35400,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.1.tgz",
-      "integrity": "sha512-Mj/30GOz1nzetSPxXrmWCXNE0JuSU7Pgiy37/QPHK2J2X4kDEGH78wIKGb1WEiViYfZGaD+ubQqEONuuhDnd6g==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.2.tgz",
+      "integrity": "sha512-kqcEVKr5ZWg+LecINTLZV9K8hO0IIYI9XpIx3PXMxhDYhkmpxjArTcfdAuOScb/B2mR85Jz5Qox+vwS++xlyfw==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.1.0",
-    "@esri/calcite-ui-icons": "3.22.1",
+    "@esri/calcite-ui-icons": "3.22.2",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
## Summary

Updates calcite-ui-icons to the latest published version.