### PR TITLE
fix(tooltip): close tooltip when pointer is moving

### DIFF
--- a/src/components/tooltip/TooltipManager.ts
+++ b/src/components/tooltip/TooltipManager.ts
@@ -14,9 +14,11 @@ export default class TooltipManager {
 
   private hoverTimeout: number = null;
 
+  private hoveredTooltip: HTMLCalciteTooltipElement = null;
+
   private clickedTooltip: HTMLCalciteTooltipElement = null;
 
-  private activeTooltipEl: HTMLCalciteTooltipElement = null;
+  private activeTooltip: HTMLCalciteTooltipElement = null;
 
   private registeredElementCount = 0;
 
@@ -62,13 +64,13 @@ export default class TooltipManager {
 
   private keyDownHandler = (event: KeyboardEvent): void => {
     if (event.key === "Escape" && !event.defaultPrevented) {
-      const { activeTooltipEl } = this;
+      const { activeTooltip } = this;
 
-      if (activeTooltipEl?.open) {
+      if (activeTooltip?.open) {
         this.clearHoverTimeout();
         this.closeExistingTooltip();
 
-        const referenceElement = getEffectiveReferenceElement(activeTooltipEl);
+        const referenceElement = getEffectiveReferenceElement(activeTooltip);
 
         if (referenceElement instanceof Element && referenceElement.contains(event.target as HTMLElement)) {
           event.preventDefault();
@@ -79,8 +81,8 @@ export default class TooltipManager {
 
   private pointerMoveHandler = (event: PointerEvent): void => {
     const composedPath = event.composedPath();
-    const { activeTooltipEl } = this;
-    const hoveringActiveTooltip = activeTooltipEl?.open && composedPath.includes(activeTooltipEl);
+    const { activeTooltip } = this;
+    const hoveringActiveTooltip = activeTooltip?.open && composedPath.includes(activeTooltip);
 
     if (hoveringActiveTooltip) {
       this.clearHoverTimeout();
@@ -88,6 +90,7 @@ export default class TooltipManager {
     }
 
     const tooltip = this.queryTooltip(composedPath);
+    this.hoveredTooltip = tooltip;
 
     if (this.isClosableClickedTooltip(tooltip)) {
       return;
@@ -97,9 +100,8 @@ export default class TooltipManager {
 
     if (tooltip) {
       this.toggleHoveredTooltip(tooltip, true);
-    } else if (activeTooltipEl) {
-      this.clearHoverTimeout();
-      this.toggleHoveredTooltip(activeTooltipEl, false);
+    } else if (activeTooltip) {
+      this.toggleHoveredTooltip(activeTooltip, false);
     }
   };
 
@@ -148,10 +150,10 @@ export default class TooltipManager {
   }
 
   private closeExistingTooltip(): void {
-    const { activeTooltipEl } = this;
+    const { activeTooltip } = this;
 
-    if (activeTooltipEl?.open) {
-      this.toggleTooltip(activeTooltipEl, false);
+    if (activeTooltip?.open) {
+      this.toggleTooltip(activeTooltip, false);
     }
   }
 
@@ -169,7 +171,7 @@ export default class TooltipManager {
     tooltip.open = value;
 
     if (value) {
-      this.activeTooltipEl = tooltip;
+      this.activeTooltip = tooltip;
     }
   }
 
@@ -178,7 +180,13 @@ export default class TooltipManager {
       if (this.hoverTimeout === null) {
         return;
       }
+
       this.closeExistingTooltip();
+
+      if (tooltip !== this.hoveredTooltip) {
+        return;
+      }
+
       this.toggleTooltip(tooltip, value);
     }, TOOLTIP_DELAY_MS);
   };


### PR DESCRIPTION
**Related Issue:** #6785

## Summary

- Closes tooltip when pointer is not moving on the tooltip or its reference element.
- Adds test