### PR TITLE
feat(styles): Add additional animation classes

### DIFF
--- a/src/assets/styles/_animation.scss
+++ b/src/assets/styles/_animation.scss
@@ -29,6 +29,28 @@
   }
 }
 
+@keyframes in-right {
+  0% {
+    opacity: 0;
+    transform: translate3D(-5px, 0, 0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3D(0, 0, 0);
+  }
+}
+
+@keyframes in-left {
+  0% {
+    opacity: 0;
+    transform: translate3D(5px, 0, 0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3D(0, 0, 0);
+  }
+}
+
 @keyframes in-scale {
   0% {
     opacity: 0;
@@ -66,6 +88,14 @@
 
 .calcite-animate__in-up {
   animation-name: in-up;
+}
+
+.calcite-animate__in-right {
+  animation-name: in-right;
+}
+
+.calcite-animate__in-left {
+  animation-name: in-left;
 }
 
 .calcite-animate__in-scale {

--- a/src/demos/animation/animation.html
+++ b/src/demos/animation/animation.html
@@ -35,19 +35,20 @@
             const triggerAnimation = (animationName) => {
               const noticeEl = document.querySelector(`#${animationName}`);
               const noticePreEl = document.querySelector(`#${animationName} pre`);
-              if (!noticeEl.hasAttribute("active")) {
-                noticeEl.setAttribute("active", "");
+              if (!noticeEl.hasAttribute("open")) {
+                noticeEl.setAttribute("open", "");
               }
               noticeEl.classList.add(`calcite-animate__${animationName}`);
               noticePreEl.innerHTML = noticeEl.classList;
             };
+            const resetAnimations = () => {
+              document.querySelectorAll("calcite-notice").forEach((node) => {
+                node.open = false;
+                node.classList.remove(`calcite-animate__${node.id}`);
+              });
+            };
           </script>
-          <calcite-button
-            kind="danger"
-            onclick="document.querySelectorAll('calcite-notice').forEach(node => node.active = false)"
-          >
-            Reset
-          </calcite-button>
+          <calcite-button kind="danger" onclick="resetAnimations()"> Reset </calcite-button>
           <br />
           <br />
           <article>
@@ -77,6 +78,30 @@
           <article>
             <calcite-button onclick="triggerAnimation('in-down')">in-down</calcite-button>
             <calcite-notice width="half" id="in-down" class="calcite-animate">
+              <div slot="title">Hello world</div>
+              <div slot="message">
+                Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the
+                blind texts.
+                <pre></pre>
+              </div>
+            </calcite-notice>
+          </article>
+          <br />
+          <article>
+            <calcite-button onclick="triggerAnimation('in-left')">in-left</calcite-button>
+            <calcite-notice width="half" id="in-left" class="calcite-animate">
+              <div slot="title">Hello world</div>
+              <div slot="message">
+                Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the
+                blind texts.
+                <pre></pre>
+              </div>
+            </calcite-notice>
+          </article>
+          <br />
+          <article>
+            <calcite-button onclick="triggerAnimation('in-right')">in-right</calcite-button>
+            <calcite-notice width="half" id="in-right" class="calcite-animate">
               <div slot="title">Hello world</div>
               <div slot="message">
                 Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the

--- a/src/tests/globalStyles.e2e.ts
+++ b/src/tests/globalStyles.e2e.ts
@@ -13,6 +13,8 @@ describe("global styles", () => {
       "calcite-animate__in",
       "calcite-animate__in-down",
       "calcite-animate__in-up",
+      "calcite-animate__in-left",
+      "calcite-animate__in-right",
       "calcite-animate__in-scale"
     ];
 


### PR DESCRIPTION
## Summary
Adding additional "left" and "right" animation classes, to support https://github.com/Esri/calcite-components/pull/6919 and other future needs.

- Adds `calcite-animate__in-left` and `calcite-animate__in-right` classes.
- Updates demo page with new classes, and updates demo page "Reset" button functionality.
- Q - I am imagining for now components will set the correct animation where needed based on `rtl`. Not sure if there's a better way to make these rtl / ltr supportive with the classes themselves.