### PR TITLE
build(deps): bump calcite-ui-icons to 3.22.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@babel/preset-react": "7.18.6",
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.1.0",
-        "@esri/calcite-ui-icons": "3.22.2",
+        "@esri/calcite-ui-icons": "3.22.4",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -2421,9 +2421,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.2.tgz",
-      "integrity": "sha512-kqcEVKr5ZWg+LecINTLZV9K8hO0IIYI9XpIx3PXMxhDYhkmpxjArTcfdAuOScb/B2mR85Jz5Qox+vwS++xlyfw==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.4.tgz",
+      "integrity": "sha512-iUO+AKUDKDIncJfpnpC1w6+30II9dnzwE71cbhqu0ocO8/bZdbiJI54aZlFwuGptUemuhLQJNRuuqgbOymqTyw==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -35400,9 +35400,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.2.tgz",
-      "integrity": "sha512-kqcEVKr5ZWg+LecINTLZV9K8hO0IIYI9XpIx3PXMxhDYhkmpxjArTcfdAuOScb/B2mR85Jz5Qox+vwS++xlyfw==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.4.tgz",
+      "integrity": "sha512-iUO+AKUDKDIncJfpnpC1w6+30II9dnzwE71cbhqu0ocO8/bZdbiJI54aZlFwuGptUemuhLQJNRuuqgbOymqTyw==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-react": "7.18.6",
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.1.0",
-    "@esri/calcite-ui-icons": "3.22.2",
+    "@esri/calcite-ui-icons": "3.22.4",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/6925

## Summary
Adds in the latest Calcite UI icons to support an ArcGIS Online workflow in the upcoming R02 release.