### PR TITLE
docs(chip, chip-group): provide context to parent scale inheritance

### DIFF
--- a/src/components/chip-group/chip-group.tsx
+++ b/src/components/chip-group/chip-group.tsx
@@ -38,13 +38,13 @@ export class ChipGroup implements InteractiveComponent {
   //
   //--------------------------------------------------------------------------
 
-  /** When true, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   /** Accessible name for the component. */
   @Prop() label!: string;
 
-  /** Specifies the size of the component. */
+  /** Specifies the size of the component. Child `calcite-chip`s inherit the component's value and display consistent spacing. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /** Specifies the selection mode of the component. */

--- a/src/components/chip-group/chip-group.tsx
+++ b/src/components/chip-group/chip-group.tsx
@@ -44,7 +44,7 @@ export class ChipGroup implements InteractiveComponent {
   /** Accessible name for the component. */
   @Prop() label!: string;
 
-  /** Specifies the size of the component. Child `calcite-chip`s inherit the component's value and display consistent spacing. */
+  /** Specifies the size of the component. Child `calcite-chip`s inherit the component's value. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /** Specifies the selection mode of the component. */

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -73,7 +73,7 @@ export class Chip
   //  Public Properties
   //
   //--------------------------------------------------------------------------
-  /** When true, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
   /** Specifies the appearance style of the component. */
@@ -92,7 +92,7 @@ export class Chip
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
 
-  /** Specifies the size of the component. */
+  /** Specifies the size of the component. When contained in a parent `calcite-chip-group` inherits the parent's `scale` value and displays consistent spacing. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /** Accessible name for the component. */
@@ -113,7 +113,7 @@ export class Chip
   @Prop() selectionMode: Extract<"multiple" | "single" | "single-persist" | "none", SelectionMode> =
     "none";
 
-  /** When true, the component is selected.  */
+  /** When `true`, the component is selected.  */
   @Prop({ reflect: true, mutable: true }) selected = false;
 
   /**

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -92,7 +92,7 @@ export class Chip
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
 
-  /** Specifies the size of the component. When contained in a parent `calcite-chip-group` inherits the parent's `scale` value and displays consistent spacing. */
+  /** Specifies the size of the component. When contained in a parent `calcite-chip-group` inherits the parent's `scale` value. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /** Accessible name for the component. */


### PR DESCRIPTION
**Related Issue:** #6945

## Summary
- Provides additional context to the `scale` inheritance of `chip-group` in relation to `chip`.
- Adds backticks to "`true`" values in `chip` and `chip-group`