### PR TITLE
chore: drop nomodule script usage

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,6 @@
 <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
 <link rel="stylesheet" href="./build/calcite.css" />
 <script type="module" src="./build/calcite.esm.js"></script>
-<script nomodule src="./build/calcite.js"></script>
 
 <!-- docs fixes for displaying components -->
 <style>

--- a/src/demos/_assets/head.ts
+++ b/src/demos/_assets/head.ts
@@ -8,7 +8,6 @@
   interface Script {
     src: string;
     type?: "module";
-    noModule?: boolean;
   }
 
   const SCRIPTS: Script[] = [

--- a/src/demos/input-time-picker.html
+++ b/src/demos/input-time-picker.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
     <link rel="stylesheet" href="../build/calcite.css" />
     <script type="module" src="../build/calcite.esm.js"></script>
-    <script nomodule src="../build/calcite.js"></script>
     <script src="./_assets/head.js"></script>
     <style>
       .demo-header {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

`nomodule` fallback scripts are no longer needed as we don't support ES5 anymore.