### PR TITLE
fix(modal): fix focusing out of modal when elements inside modal are clicked

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -57,7 +57,6 @@
 
 .content {
   margin-inline: var(--calcite-button-content-margin-internal);
-  pointer-events: none;
 }
 
 .icon-start-empty {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -57,6 +57,7 @@
 
 .content {
   margin-inline: var(--calcite-button-content-margin-internal);
+  pointer-events: none;
 }
 
 .icon-start-empty {

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -372,6 +372,8 @@ export class Modal
 
   contentId: string;
 
+  focusTrapContentEl: HTMLElement;
+
   @State() cssWidth: string | number;
 
   @State() cssHeight: string | number;
@@ -479,6 +481,7 @@ export class Modal
 
   private setTransitionEl = (el: HTMLDivElement): void => {
     this.transitionEl = el;
+    this.focusTrapContentEl = el;
   };
 
   onBeforeOpen(): void {

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -14,6 +14,8 @@ export interface FocusTrapComponent {
 
   /**
    * The focus trap content element.
+   *
+   * When set, this element prevents clicked child elements from deactivating the focus trap.
    */
   focusTrapContentEl?: HTMLElement;
 

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -67,14 +67,7 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
 
   const focusTrapOptions: FocusTrapOptions = {
     clickOutsideDeactivates: (event) => {
-      const target = event.target as FocusableElement;
-      const deactivateFocusTrap = !event.composedPath().includes(component.focusTrapContentEl ?? el);
-
-      if (!deactivateFocusTrap && target !== el) {
-        focusElement(target);
-      }
-
-      return deactivateFocusTrap;
+      return !event.composedPath().includes(component.focusTrapContentEl ?? el);
     },
     escapeDeactivates: false,
     fallbackFocus: focusTrapNode,

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -13,6 +13,11 @@ export interface FocusTrapComponent {
   el: HTMLElement;
 
   /**
+   * The focus trap content element.
+   */
+  focusTrapContentEl?: HTMLElement;
+
+  /**
    * When `true`, prevents focus trapping.
    */
   focusTrapDisabled: boolean;
@@ -59,11 +64,20 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
   }
 
   const focusTrapOptions: FocusTrapOptions = {
-    clickOutsideDeactivates: true,
+    clickOutsideDeactivates: (event) => {
+      const target = event.target as FocusableElement;
+      const deactivateFocusTrap = !event.composedPath().includes(component.focusTrapContentEl ?? el);
+
+      if (!deactivateFocusTrap && target !== el) {
+        focusElement(target);
+      }
+
+      return deactivateFocusTrap;
+    },
     escapeDeactivates: false,
     fallbackFocus: focusTrapNode,
-    setReturnFocus: (el) => {
-      focusElement(el as FocusableElement);
+    setReturnFocus: (target) => {
+      focusElement(target as FocusableElement);
       return false;
     },
     ...options?.focusTrapOptions,


### PR DESCRIPTION
**Related Issue:** #6579

## Summary

- Adds optional private property `focusTrapContentEl` to the `FocusTrapComponent` which prevents clicked child elements from deactivating the focus trap.
  - If this property isn't defined on the `FocusTrapComponent` the host element will be used.
- Anytime an element is clicked, it runs to check if the element is within the `focusTrapContentEl` and will prevent focus trap from being disabled if true.
- Adds CSS pointer-events none to content within button for preventing pointer event on it.