### PR TITLE
chore(linting): ban use of `:host-context` until all browsers support it

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -13,6 +13,13 @@
       }
     ],
     "property-case": "lower",
+    "selector-disallowed-list": [
+      ["/:host-context/"],
+      {
+        "message": ":host-context is not supported in all browsers, so it should be avoided",
+        "severity": "error"
+      }
+    ],
     "selector-max-specificity": [
       "0,5,5",
       {

--- a/src/components/stepper/stepper.scss
+++ b/src/components/stepper/stepper.scss
@@ -17,7 +17,6 @@
   display: grid;
   // grid-templates-columns are dynamically generated
   // grid-templates-rows are dynamically generated
-  grid-template-areas:
-    "items"
+  grid-template-areas: "items"
     "content";
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

https://caniuse.com/mdn-css_selectors_host-context

Stems from https://github.com/Esri/calcite-components/pull/6959.