### PR TITLE
feat: support focus traps outside of components

### DIFF
--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -130,6 +130,13 @@ export class InputDatePicker
   }
 
   /**
+   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   *
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   */
+  @Prop() focusTrapStack: FocusTrap[];
+
+  /**
    * The ID of the form that will be associated with the component.
    *
    * When not set, the component will be associated with its ancestor form element, if any.

--- a/src/components/input-date-picker/input-date-picker.tsx
+++ b/src/components/input-date-picker/input-date-picker.tsx
@@ -130,9 +130,14 @@ export class InputDatePicker
   }
 
   /**
-   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   * The global focus trap stack. This makes it possible to define and share the same global focus trap stack.
    *
-   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions) `trapStack`
+   * @example
+   * const myFocusTrapStack = [];
+   * document.querySelectorAll("calcite-input-date-picker").forEach((inputDatePicker) => {
+   *  inputDatePicker.focusTrapStack = myFocusTrapStack;
+   * });
    */
   @Prop() focusTrapStack: FocusTrap[];
 

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -137,9 +137,14 @@ export class InputTimePicker
   }
 
   /**
-   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   * The global focus trap stack. This makes it possible to define and share the same global focus trap stack.
    *
-   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions) `trapStack`
+   * @example
+   * const myFocusTrapStack = [];
+   * document.querySelectorAll("calcite-input-time-picker").forEach((inputTimePicker) => {
+   *  inputTimePicker.focusTrapStack = myFocusTrapStack;
+   * });
    */
   @Prop() focusTrapStack: FocusTrap[];
 

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -137,6 +137,13 @@ export class InputTimePicker
   }
 
   /**
+   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   *
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   */
+  @Prop() focusTrapStack: FocusTrap[];
+
+  /**
    * The ID of the form that will be associated with the component.
    *
    * When not set, the component will be associated with its ancestor form element, if any.

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -114,6 +114,13 @@ export class Modal
     focusTrapDisabled ? deactivateFocusTrap(this) : activateFocusTrap(this);
   }
 
+  /**
+   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   *
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   */
+  @Prop() focusTrapStack: FocusTrap[];
+
   /** When `true`, disables the closing of the component when clicked outside. */
   @Prop({ reflect: true }) outsideCloseDisabled = false;
 

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -115,9 +115,14 @@ export class Modal
   }
 
   /**
-   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   * The global focus trap stack. This makes it possible to define and share the same global focus trap stack.
    *
-   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions) `trapStack`
+   * @example
+   * const myFocusTrapStack = [];
+   * document.querySelectorAll("calcite-modal").forEach((modal) => {
+   *  modal.focusTrapStack = myFocusTrapStack;
+   * });
    */
   @Prop() focusTrapStack: FocusTrap[];
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -120,6 +120,13 @@ export class Popover
   }
 
   /**
+   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   *
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   */
+  @Prop() focusTrapStack: FocusTrap[];
+
+  /**
    * When `true`, removes the caret pointer.
    */
   @Prop({ reflect: true }) pointerDisabled = false;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -120,9 +120,14 @@ export class Popover
   }
 
   /**
-   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   * The global focus trap stack. This makes it possible to define and share the same global focus trap stack.
    *
-   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions) `trapStack`
+   * @example
+   * const myFocusTrapStack = [];
+   * document.querySelectorAll("calcite-popover").forEach((popover) => {
+   *  popover.focusTrapStack = myFocusTrapStack;
+   * });
    */
   @Prop() focusTrapStack: FocusTrap[];
 

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -23,6 +23,13 @@ export interface FocusTrapComponent {
   focusTrap: FocusTrap;
 
   /**
+   * The global focus trap stack. This makes it possible to share the same focus trap stack.
+   *
+   * @see [FocusTrap Options](https://github.com/focus-trap/focus-trap#createoptions)
+   */
+  focusTrapStack: FocusTrap[];
+
+  /**
    * Method to update the element(s) that are used within the FocusTrap component.
    *
    * This should be implemented for components that allow user content and/or have conditionally-rendered focusable elements within the trap.
@@ -51,7 +58,7 @@ interface ConnectFocusTrapOptions {
  * @param options
  */
 export function connectFocusTrap(component: FocusTrapComponent, options?: ConnectFocusTrapOptions): void {
-  const { el } = component;
+  const { el, focusTrapStack } = component;
   const focusTrapNode = options?.focusTrapEl || el;
 
   if (!focusTrapNode) {
@@ -71,7 +78,7 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
     // the following options are not overrideable
     document: el.ownerDocument,
     tabbableOptions,
-    trapStack
+    trapStack: focusTrapStack ? [...focusTrapStack, ...trapStack] : trapStack
   };
 
   component.focusTrap = createFocusTrap(focusTrapNode, focusTrapOptions);

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -78,7 +78,7 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
     // the following options are not overrideable
     document: el.ownerDocument,
     tabbableOptions,
-    trapStack: focusTrapStack ? [...focusTrapStack, ...trapStack] : trapStack
+    trapStack: focusTrapStack ?? trapStack
   };
 
   component.focusTrap = createFocusTrap(focusTrapNode, focusTrapOptions);

--- a/src/utils/focusTrapComponent.ts
+++ b/src/utils/focusTrapComponent.ts
@@ -1,7 +1,7 @@
 import { createFocusTrap, FocusTrap as _FocusTrap, Options as FocusTrapOptions } from "focus-trap";
 import { FocusableElement, focusElement, tabbableOptions } from "./dom";
 
-const trapStack: _FocusTrap[] = [];
+const calciteTrapStack: _FocusTrap[] = [];
 
 /**
  * Defines interface for components with a focus trap. Focusable content is required for components implementing focus trapping with this interface.
@@ -78,7 +78,7 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
     // the following options are not overrideable
     document: el.ownerDocument,
     tabbableOptions,
-    trapStack: focusTrapStack ?? trapStack
+    trapStack: focusTrapStack ?? calciteTrapStack
   };
 
   component.focusTrap = createFocusTrap(focusTrapNode, focusTrapOptions);


### PR DESCRIPTION
**Related Issue:** #6659

## Summary

- Adds `focusTrapStack` property to all components supporting focusTraps.
- This makes it possible to share the same focus trap stack outside of calcite-components.
- A user would create their own `trapStack` array and pass it to all the components they need to use that have the `focusTrapStack` property.
- In the future, maybe we can expose another way to set it just one time and not per component.
