### PR TITLE
fix(input-date-picker): update input-date-picker to properly handle Buddhist calendar changes

### DIFF
--- a/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -10,7 +10,14 @@ import {
   VNode,
   Watch
 } from "@stencil/core";
-import { dateFromRange, getOrder, nextMonth, prevMonth } from "../../utils/date";
+import {
+  dateFromRange,
+  parseCalendarYear,
+  getOrder,
+  nextMonth,
+  prevMonth,
+  formatCalendarYear
+} from "../../utils/date";
 
 import { closestElementCrossShadowBoundary } from "../../utils/dom";
 import { isActivationKey } from "../../utils/key";
@@ -19,7 +26,7 @@ import { DatePickerMessages } from "../date-picker/assets/date-picker/t9n";
 import { DateLocaleData } from "../date-picker/utils";
 import { Heading, HeadingLevel } from "../functional/Heading";
 import { Scale } from "../interfaces";
-import { BUDDHIST_CALENDAR_YEAR_OFFSET, CSS, ICON } from "./resources";
+import { CSS, ICON } from "./resources";
 
 @Component({
   tag: "calcite-date-picker-month-header",
@@ -239,20 +246,13 @@ export class DatePickerMonthHeader {
   };
 
   private formatCalendarYear(year: number): string {
-    const { localeData } = this;
-    const buddhistCalendar = localeData["default-calendar"] === "buddhist";
-    const yearOffset = buddhistCalendar ? BUDDHIST_CALENDAR_YEAR_OFFSET : 0;
-
-    return numberStringFormatter.localize(`${year + yearOffset}`);
+    return numberStringFormatter.localize(`${formatCalendarYear(year, this.localeData)}`);
   }
 
   private parseCalendarYear(year: string): string {
-    const { localeData } = this;
-    const buddhistCalendar = localeData["default-calendar"] === "buddhist";
-    const yearOffset = buddhistCalendar ? BUDDHIST_CALENDAR_YEAR_OFFSET : 0;
-
-    const parsedYear = Number(numberStringFormatter.delocalize(year)) - yearOffset;
-    return numberStringFormatter.localize(`${parsedYear}`);
+    return numberStringFormatter.localize(
+      `${parseCalendarYear(Number(numberStringFormatter.delocalize(year)), this.localeData)}`
+    );
   }
 
   private onYearChange = (event: Event): void => {

--- a/src/components/date-picker-month-header/resources.ts
+++ b/src/components/date-picker-month-header/resources.ts
@@ -1,5 +1,3 @@
-export const BUDDHIST_CALENDAR_YEAR_OFFSET = 543;
-
 export const CSS = {
   header: "header",
   month: "month",

--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -374,6 +374,30 @@ describe("calcite-input-date-picker", () => {
         newLangTranslations.placeholder.replace("DD", day).replace("MM", month).replace("YYYY", year)
       );
     });
+
+    it("parses/formats buddhist calendar locales when date is selected", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-input-date-picker lang="th" value="2023-05-31"></calcite-input-date-picker>`);
+      const inputDatePicker = await page.find("calcite-input-date-picker");
+      const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
+
+      await inputDatePicker.click();
+      await calciteInputDatePickerOpenEvent;
+
+      await page.evaluate(async () =>
+        // select first day of month
+        document
+          .querySelector<HTMLCalciteInputDatePickerElement>("calcite-input-date-picker")
+          .shadowRoot.querySelector<HTMLCalciteDatePickerElement>("calcite-date-picker")
+          .shadowRoot.querySelector<HTMLCalciteDatePickerMonthElement>("calcite-date-picker-month")
+          .shadowRoot.querySelector<HTMLCalciteDatePickerDayElement>("calcite-date-picker-day[current-month]")
+          .click()
+      );
+      await page.waitForChanges();
+      await inputDatePicker.callMethod("blur");
+
+      expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
+    });
   });
 
   it("allows clicking a date in the calendar popup", async () => {

--- a/src/utils/date.spec.ts
+++ b/src/utils/date.spec.ts
@@ -3,9 +3,11 @@ import {
   dateFromISO,
   dateFromRange,
   dateToISO,
+  formatCalendarYear,
   getOrder,
   inRange,
   nextMonth,
+  parseCalendarYear,
   parseDateString,
   prevMonth,
   sameDate
@@ -232,5 +234,19 @@ describe("getOrder", () => {
     expect(getOrder("MM/DD/YYYY")).toEqual(["m", "d", "y"]);
     expect(getOrder("YYYY/MM/DD")).toEqual(["y", "m", "d"]);
     expect(getOrder("YYYY. MM. DD.")).toEqual(["y", "m", "d"]);
+  });
+});
+
+describe("formatCalendarYear", () => {
+  it("formats calendar years for display", () => {
+    expect(formatCalendarYear(2023, { "default-calendar": "gregorian" } as DateLocaleData)).toBe(2023);
+    expect(formatCalendarYear(2023, { "default-calendar": "buddhist" } as DateLocaleData)).toBe(2566);
+  });
+});
+
+describe("parseCalendarYear", () => {
+  it("parses display calendar years", () => {
+    expect(parseCalendarYear(2023, { "default-calendar": "gregorian" } as DateLocaleData)).toBe(2023);
+    expect(parseCalendarYear(2566, { "default-calendar": "buddhist" } as DateLocaleData)).toBe(2023);
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -86,7 +86,11 @@ export function dateFromLocalizedString(value: string, localeData: DateLocaleDat
     return null;
   }
   const { separator } = localeData;
-  const { day, month, year } = parseDateString(value, localeData);
+  const parts = parseDateString(value, localeData);
+
+  const { day, month } = parts;
+  const year = parseCalendarYear(parts.year, localeData);
+
   const date = new Date(year, month, day);
   date.setFullYear(year);
 
@@ -100,6 +104,25 @@ export function dateFromLocalizedString(value: string, localeData: DateLocaleDat
     return date;
   }
   return null;
+}
+
+export function parseCalendarYear(year: number, localeData: DateLocaleData): number {
+  return processCalendarYear(year, localeData, "read");
+}
+
+export function formatCalendarYear(year: number, localeData: DateLocaleData): number {
+  return processCalendarYear(year, localeData, "write");
+}
+
+function processCalendarYear(year: number, localeData: DateLocaleData, mode: "read" | "write"): number {
+  if (localeData["default-calendar"] !== "buddhist") {
+    return year;
+  }
+
+  const BUDDHIST_CALENDAR_YEAR_OFFSET = 543;
+  const yearOffset = BUDDHIST_CALENDAR_YEAR_OFFSET * (mode === "read" ? -1 : 1);
+
+  return year + yearOffset;
 }
 
 /**


### PR DESCRIPTION
**Related Issue:** #6636

## Summary

This updates `input-date-picker` to follow `date-picker`'s logic and map between the internal and displayed date values for Buddhist calendars.