### PR TITLE
build(deps): Bump focus-trap from 7.4.1 to 7.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "color": "4.2.3",
         "composed-offset-position": "0.0.4",
         "dayjs": "1.11.7",
-        "focus-trap": "7.4.1",
+        "focus-trap": "7.4.2",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
@@ -17201,9 +17201,9 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.1.tgz",
-      "integrity": "sha512-rnXP5ERIjlo1gEZp7hQb4ekYqUxRuSDQeyWvxhahH3/GkWtd8h8g1C8Eu/KGpuvbUWNVeogK0kuzzrM4u2Z9jA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.2.tgz",
+      "integrity": "sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==",
       "dependencies": {
         "tabbable": "^6.1.2"
       }
@@ -33208,11 +33208,14 @@
       }
     },
     "node_modules/webpack/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -47021,9 +47024,9 @@
       }
     },
     "focus-trap": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.1.tgz",
-      "integrity": "sha512-rnXP5ERIjlo1gEZp7hQb4ekYqUxRuSDQeyWvxhahH3/GkWtd8h8g1C8Eu/KGpuvbUWNVeogK0kuzzrM4u2Z9jA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.2.tgz",
+      "integrity": "sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==",
       "requires": {
         "tabbable": "^6.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "color": "4.2.3",
     "composed-offset-position": "0.0.4",
     "dayjs": "1.11.7",
-    "focus-trap": "7.4.1",
+    "focus-trap": "7.4.2",
     "form-request-submit-polyfill": "2.0.0",
     "lodash-es": "4.17.21",
     "sortablejs": "1.15.0"


### PR DESCRIPTION
**Related Issue:** #6579

## Summary

Bump focus-trap from 7.4.1 to 7.4.2