### PR TITLE
fix(popover): change event listener to 'pointerup'

### DIFF
--- a/src/components/popover/PopoverManager.ts
+++ b/src/components/popover/PopoverManager.ts
@@ -91,12 +91,12 @@ export default class PopoverManager {
   };
 
   private addListeners(): void {
-    document.addEventListener("pointerdown", this.clickHandler, { capture: true });
+    document.addEventListener("pointerup", this.clickHandler, { capture: true });
     document.addEventListener("keydown", this.keyHandler, { capture: true });
   }
 
   private removeListeners(): void {
-    document.removeEventListener("pointerdown", this.clickHandler, { capture: true });
+    document.removeEventListener("pointerup", this.clickHandler, { capture: true });
     document.removeEventListener("keydown", this.keyHandler, { capture: true });
   }
 }

--- a/src/components/popover/PopoverManager.ts
+++ b/src/components/popover/PopoverManager.ts
@@ -91,6 +91,7 @@ export default class PopoverManager {
   };
 
   private addListeners(): void {
+    // using pointerup to allow elements to become focused before shifting focus to the popover
     document.addEventListener("pointerup", this.clickHandler, { capture: true });
     document.addEventListener("keydown", this.keyHandler, { capture: true });
   }


### PR DESCRIPTION
**Related Issue:** #6455

## Summary

- Changes `PopoverManager` event listener to be 'pointerup' instead of `pointerdown` to allow elements to become focused first. (seems like safari was the only browser with an issue)
  - `focus-trap` listens for `pointerdown` to get the element to return focus to.
- If these elements become focused first then their focus is returned correctly. 
