### PR TITLE
fix(flow-item): Close back button tooltip on click

### DIFF
--- a/src/components/flow-item/flow-item.e2e.ts
+++ b/src/components/flow-item/flow-item.e2e.ts
@@ -92,6 +92,11 @@ describe("calcite-flow-item", () => {
 
     expect(backButtonNew).not.toBeNull();
 
+    const backButtonTooltip = await page.find(`calcite-flow-item >>> calcite-tooltip`);
+
+    expect(backButtonTooltip).not.toBeNull();
+    expect(await backButtonTooltip.getProperty("closeOnClick")).toBe(true);
+
     expect(await backButtonNew.isVisible()).toBe(true);
 
     const calciteFlowItemBack = await page.spyOnEvent("calciteFlowItemBack", "window");

--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -336,6 +336,7 @@ export class FlowItem
         </calcite-panel>
         {backButtonEl ? (
           <calcite-tooltip
+            closeOnClick={true}
             label={label}
             overlayPositioning="fixed"
             placement="top"


### PR DESCRIPTION
**Related Issue:** None

## Summary

If you have already clicked the back button close the tooltip.