### PR TITLE
build(deps): bump calcite-ui-icons to 3.22.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.1.0",
         "@esri/calcite-design-tokens": "1.0.0",
-        "@esri/calcite-ui-icons": "3.22.4",
+        "@esri/calcite-ui-icons": "3.22.6",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -2430,9 +2430,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.4.tgz",
-      "integrity": "sha512-iUO+AKUDKDIncJfpnpC1w6+30II9dnzwE71cbhqu0ocO8/bZdbiJI54aZlFwuGptUemuhLQJNRuuqgbOymqTyw==",
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.6.tgz",
+      "integrity": "sha512-54O1fmXecY9fBGOjllL14eHWM57sBhJoUuNtMutLi6gMRXhhiBeIDhaUJwSXam76iBWb21FMJrtzh85c6nQ4LA==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -35609,9 +35609,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.4.tgz",
-      "integrity": "sha512-iUO+AKUDKDIncJfpnpC1w6+30II9dnzwE71cbhqu0ocO8/bZdbiJI54aZlFwuGptUemuhLQJNRuuqgbOymqTyw==",
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.6.tgz",
+      "integrity": "sha512-54O1fmXecY9fBGOjllL14eHWM57sBhJoUuNtMutLi6gMRXhhiBeIDhaUJwSXam76iBWb21FMJrtzh85c6nQ4LA==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.1.0",
     "@esri/calcite-design-tokens": "1.0.0",
-    "@esri/calcite-ui-icons": "3.22.4",
+    "@esri/calcite-ui-icons": "3.22.6",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Adds in the latest Calcite UI icons, `3.22.6` for this week's `1.4.0` release.
