### PR TITLE
fix(hydrate): fix errors caused by message bundle fetch attempts during prerendering

### DIFF
--- a/src/utils/t9n.ts
+++ b/src/utils/t9n.ts
@@ -1,4 +1,4 @@
-import { getAssetPath } from "@stencil/core";
+import { Build, getAssetPath } from "@stencil/core";
 import { getSupportedLocale, LocalizedComponent } from "./locale";
 
 export type MessageBundle = Record<string, string>;
@@ -37,7 +37,6 @@ function mergeMessages(component: T9nComponent): void {
 
 /**
  * This utility sets up the messages used by the component. It should be awaited in the `componentWillLoad` lifecycle hook.
- *
  * @param component
  */
 export async function setUpMessages(component: T9nComponent): Promise<void> {
@@ -46,6 +45,10 @@ export async function setUpMessages(component: T9nComponent): Promise<void> {
 }
 
 async function fetchMessages(component: T9nComponent, lang: string): Promise<MessageBundle> {
+  if (!Build.isBrowser) {
+    return {};
+  }
+
   const { el } = component;
   const tag = el.tagName.toLowerCase();
   const componentName = tag.replace("calcite-", "");
@@ -60,7 +63,6 @@ async function fetchMessages(component: T9nComponent, lang: string): Promise<Mes
  *
  * 1. called from `LocalizedComponent`'s `onLocaleChange` method or
  * 2. called from a watcher configured to watch `LocalizedComponent`'s `effectiveLocale` prop
- *
  * @param component
  * @param lang
  */
@@ -75,7 +77,6 @@ export async function updateMessages(component: T9nComponent, lang: string): Pro
  * It needs to be called in `connectedCallback`
  *
  * **Note**: this must be called after `LocalizedComponent`'s `connectLocalized` method.
- *
  * @param component
  */
 export function connectMessages(component: T9nComponent): void {
@@ -86,7 +87,6 @@ export function connectMessages(component: T9nComponent): void {
  * This utility tears down internals for messages support.
  *
  * It needs to be called in `disconnectedCallback`
- *
  * @param component
  */
 export function disconnectMessages(component: T9nComponent): void {
@@ -127,7 +127,6 @@ export interface T9nComponent extends LocalizedComponent {
    * This private method ensures messages are kept in sync.
    *
    * This method should be empty and configured to watch for changes on  `messageOverrides` property.
-   *
    * @Watch("messageOverrides")
    * onMessagesChange(): void {
    *  \/* wired up by t9n util *\/


### PR DESCRIPTION
**Related Issue:** #7001

## Summary

This skips message bundle loading when prerendering.