### PR TITLE
docs(navigation, menu-item): reallocate slots for jsdoc generation

### DIFF
--- a/src/components/menu-item/menu-item.tsx
+++ b/src/components/menu-item/menu-item.tsx
@@ -36,16 +36,15 @@ import { LocalizedComponent, connectLocalized, disconnectLocalized } from "../..
 
 type Layout = "horizontal" | "vertical";
 
+/**
+ * @slot submenu-item - A slot for adding `calcite-menu-item`s in a submenu.
+ */
 @Component({
   tag: "calcite-menu-item",
   styleUrl: "menu-item.scss",
   shadow: true,
   assetsDirs: ["assets"]
 })
-
-/**
- * @slot submenu-item - A slot for adding `calcite-menu-item`s in submenu.
- */
 export class CalciteMenuItem implements LoadableComponent, T9nComponent, LocalizedComponent {
   //--------------------------------------------------------------------------
   //

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -20,12 +20,6 @@ import {
   setUpLoadableComponent
 } from "../../utils/loadable";
 
-@Component({
-  tag: "calcite-navigation",
-  styleUrl: "navigation.scss",
-  shadow: true
-})
-
 /**
  * @slot logo - A slot for adding a `calcite-logo` component to the primary navigation level.
  * @slot user - A slot for adding a `calcite-user` component to the primary navigation level.
@@ -37,6 +31,11 @@ import {
  * @slot navigation-secondary - A slot for adding a `calcite-navigation` component in the secondary navigation level. Components rendered here will not display `calcite-navigation-logo` or `calcite-navigation-user` components.
  * @slot navigation-tertiary - A slot for adding a `calcite-navigation` component in the tertiary navigation level.  Components rendered here will not display `calcite-navigation-logo` or `calcite-navigation-user` components.
  */
+@Component({
+  tag: "calcite-navigation",
+  styleUrl: "navigation.scss",
+  shadow: true
+})
 export class CalciteNavigation implements LoadableComponent {
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #7006 

## Summary
Reallocates the slots outside of the `@component` decorator for JSDoc.