### PR TITLE
fix(navigation-logo, navigation-user): Prevent inheriting line-height

### DIFF
--- a/src/components/navigation-logo/navigation-logo.scss
+++ b/src/components/navigation-logo/navigation-logo.scss
@@ -1,47 +1,45 @@
 :host {
   @apply inline-flex outline-none;
-  & a {
-    @apply flex 
+}
+
+.anchor {
+  @apply flex 
     m-0 
     items-center 
     justify-center 
     cursor-pointer 
     transition-default 
     focus-base 
-    no-underline;
-    border-block-end: 2px solid transparent;
-  }
-  & img {
-    @apply flex h-7 m-0;
-  }
+    no-underline
+    text-0h;
+  border-block-end: 2px solid transparent;
 }
 
-a:hover,
-a:focus {
+.anchor:hover,
+.anchor:focus {
   @apply bg-foreground-2;
 }
-
-a:focus {
+.anchor:focus {
   @apply focus-inset;
 }
 
-a:active {
+.anchor:active {
   @apply bg-foreground-3;
 }
 
-img {
-  padding-inline: 1rem;
+.image {
+  @apply flex h-7 m-0 px-4;
 }
 
-img ~ .container {
+.image ~ .container {
   @apply ps-0;
 }
 
-:host(:active) a {
+:host(:active) .anchor {
   @apply text-color-1;
 }
 
-:host([active]) a {
+:host([active]) .anchor {
   @apply text-color-1;
   border-color: var(--calcite-ui-brand);
   --calcite-ui-icon-color: var(--calcite-ui-brand);
@@ -51,8 +49,9 @@ img ~ .container {
   @apply flex 
   flex-col 
   truncate 
-  text-start;
-  padding-inline: 1rem;
+  text-start 
+  px-4 
+  mt-0.5;
 }
 
 .heading {
@@ -61,7 +60,6 @@ img ~ .container {
   truncate
   text-color-1
   font-medium;
-  margin-block-start: 2px;
 }
 
 .description {

--- a/src/components/navigation-logo/navigation-logo.stories.ts
+++ b/src/components/navigation-logo/navigation-logo.stories.ts
@@ -46,3 +46,15 @@ export const All_TestOnly = (): string => html`<calcite-navigation-logo
   description="City of AcmeCo"
   thumbnail="${placeholderImage({ width: 50, height: 50 })}"
 />`;
+
+export const slottedInNav_TestOnly = (): string =>
+  html`
+    <calcite-navigation style="--calcite-ui-brand: #bf390f">
+      <calcite-navigation-logo
+        heading="ArcGIS Online"
+        description="City of AcmeCo"
+        thumbnail="${placeholderImage({ width: 50, height: 50 })}"
+        slot="logo"
+      />
+    </calcite-navigation>
+  `;

--- a/src/components/navigation-logo/navigation-logo.tsx
+++ b/src/components/navigation-logo/navigation-logo.tsx
@@ -39,7 +39,6 @@ export class CalciteNavigationLogo implements LoadableComponent {
 
   /**
    * Defines the relationship between the `href` value and the current document.
-   *
    * @mdn [rel](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel)
    */
   @Prop({ reflect: true }) rel: string;
@@ -49,7 +48,6 @@ export class CalciteNavigationLogo implements LoadableComponent {
 
   /**
    * Specifies where to open the linked document defined in the `href` property.
-   *
    * @mdn [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target)
    */
   @Prop({ reflect: true }) target: string;
@@ -99,8 +97,8 @@ export class CalciteNavigationLogo implements LoadableComponent {
     const { heading, description, thumbnail } = this;
     return (
       <Host>
-        <a href={this.href} rel={this.rel} target={this.target}>
-          {thumbnail && <img alt={this.label || ""} src={thumbnail} />}
+        <a class={CSS.anchor} href={this.href} rel={this.rel} target={this.target}>
+          {thumbnail && <img alt={this.label || ""} class={CSS.image} src={thumbnail} />}
           {(heading || description) && (
             <div class={CSS.container}>
               {heading && (

--- a/src/components/navigation-logo/resources.ts
+++ b/src/components/navigation-logo/resources.ts
@@ -1,5 +1,7 @@
 export const CSS = {
   container: "container",
   heading: "heading",
-  description: "description"
+  description: "description",
+  anchor: "anchor",
+  image: "image"
 };

--- a/src/components/navigation-user/navigation-user.scss
+++ b/src/components/navigation-user/navigation-user.scss
@@ -1,6 +1,6 @@
 :host {
   @apply inline-flex outline-none;
-  & button {
+  & .button {
     background-color: transparent;
     border: none;
     @apply flex 
@@ -10,47 +10,44 @@
       cursor-pointer 
       transition-default 
       focus-base
-      font-sans;
+      font-sans
+      text-0h;
     border-block-end: 2px solid transparent;
   }
 }
 
-:host(:hover) button,
-:host(:focus) button {
+:host(:hover) .button,
+:host(:focus) .button {
   @apply bg-foreground-2;
 }
 
-:host(:focus) button {
+:host(:focus) .button {
   @apply focus-inset;
 }
 
-:host(:active) button {
-  @apply bg-foreground-3;
+:host(:active) .button {
+  @apply bg-foreground-3 text-color-1;
 }
 
 calcite-avatar {
-  padding-inline: 1rem;
+  @apply px-4;
 }
 
 calcite-avatar ~ .text-container {
   @apply ps-0;
 }
 
-:host(:active) button {
-  @apply text-color-1;
-}
-
-:host([active]) button {
-  @apply text-color-1;
-  border-color: var(--calcite-ui-brand);
+:host([active]) .button {
+  @apply text-color-1 border-color-brand;
   --calcite-ui-icon-color: var(--calcite-ui-brand);
 }
 
 .text-container {
   @apply flex 
   flex-col 
-  text-start;
-  padding-inline: 1rem;
+  text-start
+  px-4
+  mt-0.5;
 }
 
 .full-name {
@@ -58,7 +55,6 @@ calcite-avatar ~ .text-container {
   ms-0 
   text-color-1
   font-medium;
-  margin-block-start: 2px;
 }
 
 .username {

--- a/src/components/navigation-user/navigation-user.stories.ts
+++ b/src/components/navigation-user/navigation-user.stories.ts
@@ -43,3 +43,15 @@ export const All_TestOnly = (): string => html`<calcite-navigation-user
   username="eabbey_123"
   thumbnail="${placeholderImage({ width: 50, height: 50 })}"
 />`;
+
+export const slottedInNav_TestOnly = (): string =>
+  html`
+    <calcite-navigation style="--calcite-ui-brand: #bf390f">
+      <calcite-navigation-user
+        full-name="Edward Abbey"
+        username="eabbey_123"
+        thumbnail="${placeholderImage({ width: 50, height: 50 })}"
+        slot="user"
+      />
+    </calcite-navigation>
+  `;

--- a/src/components/navigation-user/navigation-user.tsx
+++ b/src/components/navigation-user/navigation-user.tsx
@@ -86,7 +86,7 @@ export class CalciteNavigationUser implements LoadableComponent {
   render(): VNode {
     return (
       <Host>
-        <button aria-label={this.label}>
+        <button aria-label={this.label} class={CSS.button}>
           <calcite-avatar
             full-name={this.fullName}
             label={this.label}

--- a/src/components/navigation-user/resources.ts
+++ b/src/components/navigation-user/resources.ts
@@ -1,5 +1,6 @@
 export const CSS = {
   textContainer: "text-container",
   fullName: "full-name",
-  username: "username"
+  username: "username",
+  button: "button"
 };

--- a/src/components/navigation/navigation.stories.ts
+++ b/src/components/navigation/navigation.stories.ts
@@ -79,6 +79,21 @@ export const primaryAndSecondarySlots_TestOnly = (): string =>
     </calcite-navigation>
   `;
 
+export const primaryWithAllLogoAndUserSlots_TestOnly = (): string =>
+  html`
+      <calcite-navigation style="--calcite-ui-brand: #bf390f">
+        <calcite-navigation-logo heading="Walt's Chips" description="Eastern Potato Chip Company" slot="logo">
+        </calcite-navigation-logo>
+        <calcite-menu slot="content-start">
+          <calcite-menu-item text="Potatoes"></calcite-menu-item>
+          <calcite-menu-item active text="Chips"></calcite-menu-item>
+          <calcite-menu-item text="Employees"></calcite-menu-item>
+          <calcite-menu-item text="Suppliers"></calcite-menu-item>
+        </calcite-menu>
+        <calcite-navigation-user slot="user" full-name="Walt McChipson" username="m_chipson></calcite-navigation-user>
+      </calcite-navigation>
+    `;
+
 export const allSlots_TestOnly = (): string =>
   html`
     <calcite-navigation style="--calcite-ui-brand: #bf390f">


### PR DESCRIPTION
**Related Issue:** #7010 

## Summary
This more explicitly sets the line height within our components, adds class name where we were targeting elements previously, and does a bit of clean up of related css.

Before (with css from JSAPI `4.27` - this wasn't an issue with `4.26` or prior):

<img width="1728" alt="Screen Shot 2023-05-23 at 7 06 56 PM" src="https://github.com/Esri/calcite-components/assets/4733155/bac00cc1-8565-4bda-abf4-9a7196120885">


After:
<img width="1728" alt="Screen Shot 2023-05-23 at 7 06 08 PM" src="https://github.com/Esri/calcite-components/assets/4733155/b4a787ad-e996-4b90-a800-44989969b7e6">
