### PR TITLE
ci(lint): add blank line before first jsdoc tag

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,6 +71,7 @@
     "jest/no-export": "warn",
     "jsdoc/check-tag-names": "off",
     "jsdoc/require-jsdoc": "off",
+    "jsdoc/tag-lines": ["error", "any", { "startLines": 1 }],
     "lines-between-class-members": ["error", "always"],
     "no-eval": "error",
     "no-implied-eval": "error",


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/pull/7007#issuecomment-1560276591

## Summary

Add a blank line before the first jsdoc tag, after the description.