### PR TITLE
fix(menu-item): Ensure icon displays when `href` is populated

### DIFF
--- a/src/components/menu-item/menu-item.scss
+++ b/src/components/menu-item/menu-item.scss
@@ -167,7 +167,7 @@ calcite-action {
   transition: all var(--calcite-internal-animation-timing-medium) ease-in-out;
 }
 
-content:focus .hover-href-icon,
-content:hover .hover-href-icon {
+.content:focus .hover-href-icon,
+.content:hover .hover-href-icon {
   @apply opacity-100 -end-1;
 }

--- a/src/components/menu-item/menu-item.tsx
+++ b/src/components/menu-item/menu-item.tsx
@@ -480,7 +480,7 @@ export class CalciteMenuItem implements LoadableComponent, T9nComponent, Localiz
               ref={(el) => (this.anchorEl = el)}
             >
               {this.renderItemContent(dir)}
-              {this.href && this.topLevelMenuLayout === "vertical" ? (
+              {this.href && (this.topLevelMenuLayout === "vertical" || !this.isTopLevelItem) ? (
                 <calcite-icon
                   class={CSS.hoverHrefIcon}
                   icon={dir === "rtl" ? "arrow-left" : "arrow-right"}


### PR DESCRIPTION
**Related Issue:** #7027 

## Summary
Fixes a css typo and adds a condition to ensure the "href icon" shows as expected.

Before:
<img width="200" alt="Screen Shot 2023-05-24 at 10 27 05 PM" src="https://github.com/Esri/calcite-components/assets/4733155/1b5f97f1-1ca6-4752-9a58-f6103a9a3712">
<img width="200" alt="Screen Shot 2023-05-24 at 10 26 37 PM" src="https://github.com/Esri/calcite-components/assets/4733155/b6372763-73f4-4075-b970-fa9b80494589">
<img width="200" alt="Screen Shot 2023-05-24 at 10 30 32 PM" src="https://github.com/Esri/calcite-components/assets/4733155/4b3c4ef7-dd2b-4880-a795-dfa7ec5abeda">

After:
<img width="200" alt="Screen Shot 2023-05-24 at 10 26 23 PM" src="https://github.com/Esri/calcite-components/assets/4733155/8780c7a0-8feb-4d1b-af01-045610795a7d">
<img width="200" alt="Screen Shot 2023-05-24 at 10 26 31 PM" src="https://github.com/Esri/calcite-components/assets/4733155/6b68adb8-f07b-4da8-8488-a657b0490e51">
<img width="200" alt="Screen Shot 2023-05-24 at 10 30 19 PM" src="https://github.com/Esri/calcite-components/assets/4733155/c16941df-eed4-4e9e-a542-ed761c87c773">
