### PR TITLE
build(deps): bump calcite-ui-icons to 3.22.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@esri/calcite-base": "^1.2.0",
         "@esri/calcite-colors": "6.1.0",
         "@esri/calcite-design-tokens": "1.0.0",
-        "@esri/calcite-ui-icons": "3.22.7",
+        "@esri/calcite-ui-icons": "3.22.8",
         "@esri/eslint-plugin-calcite-components": "0.2.2",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -2430,9 +2430,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.22.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.7.tgz",
-      "integrity": "sha512-3hQs93VLWYeu5ySB2OhOcxofKFoqWeF2b6aeXJdB9Z77T/IC7fsHsBxVoh9W/5UrdtxM8KoGpQbpOxC+VNP5NQ==",
+      "version": "3.22.8",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.8.tgz",
+      "integrity": "sha512-JH7Dy+wkxxI9fkDBym0FwjEsLgsp7cA8k+BV4Ftla4ynnJvqCTdvahgsMuNsDHSxGBlYz5++/ryzukUMSUp71A==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -35657,9 +35657,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.22.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.7.tgz",
-      "integrity": "sha512-3hQs93VLWYeu5ySB2OhOcxofKFoqWeF2b6aeXJdB9Z77T/IC7fsHsBxVoh9W/5UrdtxM8KoGpQbpOxC+VNP5NQ==",
+      "version": "3.22.8",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.22.8.tgz",
+      "integrity": "sha512-JH7Dy+wkxxI9fkDBym0FwjEsLgsp7cA8k+BV4Ftla4ynnJvqCTdvahgsMuNsDHSxGBlYz5++/ryzukUMSUp71A==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@esri/calcite-base": "^1.2.0",
     "@esri/calcite-colors": "6.1.0",
     "@esri/calcite-design-tokens": "1.0.0",
-    "@esri/calcite-ui-icons": "3.22.7",
+    "@esri/calcite-ui-icons": "3.22.8",
     "@esri/eslint-plugin-calcite-components": "0.2.2",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Calcite UI icons have had many releases the past week, and SceneViewer is looking for the latest update, released yesterday, in our upcoming patch release.