### PR TITLE
fix(color-picker): fix pasting hex with leading # character

### DIFF
--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -154,6 +154,7 @@ export class ColorPickerHexInput implements LoadableComponent {
     const willClearValue = allowEmpty && !inputValue;
     const isLonghand = isLonghandHex(hex);
 
+    // ensure modified pasted hex values are committed since we prevent default to remove the # char.
     this.onHexInputChange();
 
     if (willClearValue || (isValidHex(hex) && isLonghand)) {

--- a/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -154,6 +154,8 @@ export class ColorPickerHexInput implements LoadableComponent {
     const willClearValue = allowEmpty && !inputValue;
     const isLonghand = isLonghandHex(hex);
 
+    this.onHexInputChange();
+
     if (willClearValue || (isValidHex(hex) && isLonghand)) {
       return;
     }
@@ -279,6 +281,7 @@ export class ColorPickerHexInput implements LoadableComponent {
     if (isValidHex(hex)) {
       event.preventDefault();
       this.hexInputNode.value = hex.slice(1);
+      this.hexInputNode.internalSyncChildElValue();
     }
   };
 


### PR DESCRIPTION
**Related Issue:** #4072 

## Summary

This ensures pasted values with `#` are committed on blur since the event is canceled to intercept and modify the text value.  

**Note**: there is no corresponding E2E test due to the puppeteer limitations outlined [here](https://github.com/Esri/calcite-components/pull/5189#issue-1344620750). 