### PR TITLE
fix: ensure mouse events are blocked only when components are disabled

### DIFF
--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -982,6 +982,16 @@ export async function disabled(
   await page.mouse.click(shadowFocusableCenterX, shadowFocusableCenterY);
   await expectToBeFocused("body");
 
+  assertOnMouseAndPointerEvents(eventSpies, (spy) => {
+    if (spy.eventName === "click") {
+      // some components emit more than one click event (e.g., from calling `click()`),
+      // so we check if at least one event is received
+      expect(spy.length).toBeGreaterThanOrEqual(2);
+    } else {
+      expect(spy).toHaveReceivedEventTimes(eventsExpectedToBubble.includes(spy.eventName) ? 2 : 1);
+    }
+  });
+
   // this needs to run in the browser context to ensure disabling and events fire immediately after being set
   await page.$eval(
     tag,

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -8,6 +8,7 @@ import { JSX } from "../components";
 import { hiddenFormInputSlotName } from "../utils/form";
 import { MessageBundle } from "../utils/t9n";
 import { GlobalTestProps, skipAnimations } from "./utils";
+import { InteractiveHTMLElement } from "../utils/interactive";
 
 expect.extend(toHaveNoViolations);
 
@@ -981,11 +982,17 @@ export async function disabled(
   await page.mouse.click(shadowFocusableCenterX, shadowFocusableCenterY);
   await expectToBeFocused("body");
 
+  // this needs to run in the browser context to ensure clicks happen right after re-enabling the component
+  await page.$eval(tag, (component: InteractiveHTMLElement) => {
+    component.disabled = false;
+    component.click();
+  });
+
   assertOnMouseAndPointerEvents(eventSpies, (spy) => {
     if (spy.eventName === "click") {
       // some components emit more than one click event (e.g., from calling `click()`),
       // so we check if at least one event is received
-      expect(spy.length).toBeGreaterThanOrEqual(2);
+      expect(spy.length).toBeGreaterThanOrEqual(3);
     } else {
       expect(spy).toHaveReceivedEventTimes(eventsExpectedToBubble.includes(spy.eventName) ? 2 : 1);
     }


### PR DESCRIPTION
**Related Issue:** #7022

## Summary

This updates `interactive.ts` to prevent blocking of mouse/pointer events unnecessarily. This is needed if mouse/pointer events happen right after toggling `disabled` on an interactive component.