### PR TITLE
fix(input-time-picker): allow en-us and other supported lowercase locale codes

### DIFF
--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -29,6 +29,10 @@ describe("calcite-input-time-picker", () => {
     renders("calcite-input-time-picker", { display: "inline-block" });
   });
 
+  describe("renders with en-us lowercase locale code", () => {
+    renders(`<calcite-input-time-picker lang="en-us"></calcite-input-time-picker>`, { display: "inline-block" });
+  });
+
   describe("honors hidden attribute", () => {
     hidden("calcite-input-time-picker");
   });

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -501,27 +501,18 @@ export class InputTimePicker
   };
 
   private async loadDateTimeLocaleData(): Promise<void> {
-    const { effectiveLocale } = this;
-    let dayjsLocale = effectiveLocale.toLowerCase();
+    const normalizedLocale = this.getNormalizedLocale();
 
-    if (dayjsLocale === "en" || dayjsLocale === "en-us") {
+    if (normalizedLocale === "en" || normalizedLocale === "en-us") {
       return;
     }
 
-    if (dayjsLocale === "pt-PT") {
-      dayjsLocale = "pt";
-    }
-
-    if (dayjsLocale === "no") {
-      dayjsLocale = "nb";
-    }
-
     const { default: localeConfig } = await supportedDayJsLocaleToLocaleConfigImport.get(
-      dayjsLocale
+      normalizedLocale
     )();
 
     dayjs.locale(localeConfig, null, true);
-    dayjs.updateLocale(dayjsLocale, this.getExtendedLocaleConfig(dayjsLocale));
+    dayjs.updateLocale(normalizedLocale, this.getExtendedLocaleConfig(normalizedLocale));
   }
 
   private getExtendedLocaleConfig(
@@ -597,6 +588,22 @@ export class InputTimePicker
         meridiem: (hour) => (hour > 12 ? "下午" : "上午")
       };
     }
+  }
+
+  private getNormalizedLocale(): string {
+    const { effectiveLocale } = this;
+    let normalizedLocale = effectiveLocale ? effectiveLocale.toLowerCase() : "en";
+
+    if (normalizedLocale === "en-us") {
+      normalizedLocale = "en";
+    }
+    if (normalizedLocale === "pt-pt") {
+      normalizedLocale = "pt";
+    }
+    if (normalizedLocale === "no") {
+      normalizedLocale = "nb";
+    }
+    return normalizedLocale;
   }
 
   onLabelClick(): void {
@@ -704,19 +711,7 @@ export class InputTimePicker
   connectedCallback() {
     connectLocalized(this);
 
-    let { effectiveLocale } = this;
-    const normalizedLocale = effectiveLocale.toLowerCase();
-
-    if (normalizedLocale === "en-us") {
-      effectiveLocale = "en";
-    }
-    if (normalizedLocale === "pt-pt") {
-      effectiveLocale = "pt";
-    }
-    if (normalizedLocale === "no") {
-      effectiveLocale = "nb";
-    }
-    this.effectiveLocale = effectiveLocale;
+    this.effectiveLocale = this.getNormalizedLocale();
 
     if (isValidTime(this.value)) {
       this.setValueDirectly(this.value);

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -502,18 +502,17 @@ export class InputTimePicker
 
   private async loadDateTimeLocaleData(): Promise<void> {
     const { effectiveLocale } = this;
+    let dayjsLocale = effectiveLocale.toLowerCase();
 
-    if (effectiveLocale === "en" || effectiveLocale === "en-US") {
+    if (dayjsLocale === "en" || dayjsLocale === "en-us") {
       return;
     }
 
-    let dayjsLocale = effectiveLocale.toLowerCase();
-
-    if (effectiveLocale === "pt-PT") {
+    if (dayjsLocale === "pt-PT") {
       dayjsLocale = "pt";
     }
 
-    if (effectiveLocale === "no") {
+    if (dayjsLocale === "no") {
       dayjsLocale = "nb";
     }
 
@@ -706,13 +705,15 @@ export class InputTimePicker
     connectLocalized(this);
 
     let { effectiveLocale } = this;
-    if (effectiveLocale === "en-US") {
+    const normalizedLocale = effectiveLocale.toLowerCase();
+
+    if (normalizedLocale === "en-us") {
       effectiveLocale = "en";
     }
-    if (effectiveLocale === "pt-PT") {
+    if (normalizedLocale === "pt-pt") {
       effectiveLocale = "pt";
     }
-    if (effectiveLocale === "no") {
+    if (normalizedLocale === "no") {
       effectiveLocale = "nb";
     }
     this.effectiveLocale = effectiveLocale;


### PR DESCRIPTION
**Related Issue:** #7036 

## Summary

This fixes an issue where passing in `en-us` instead of `en-US` (or inheriting the lang from the HTML tag) was blocking rendering and throwing a console error.