### PR TITLE
fix(combobox): restore toggling of single-select combobox items

### DIFF
--- a/src/components/combobox-item/combobox-item.tsx
+++ b/src/components/combobox-item/combobox-item.tsx
@@ -128,9 +128,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   // --------------------------------------------------------------------------
 
   toggleSelected(): Promise<void> {
-    const isSingleSelect = getElementProp(this.el, "selection-mode", "multiple") === "single";
-
-    if (this.disabled || (isSingleSelect && this.selected)) {
+    if (this.disabled) {
       return;
     }
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -366,28 +366,32 @@ describe("calcite-combobox", () => {
 
   describe("item selection", () => {
     describe("toggling items", () => {
-      it("single-selection mode does not allow toggling selection once the selected item is clicked", async () => {
+      it("single-selection mode allows toggling selection once the selected item is clicked", async () => {
         const page = await newE2EPage();
         await page.setContent(
           html`
-            <calcite-combobox>
+            <calcite-combobox selection-mode="single">
               <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
               <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
             </calcite-combobox>
           `
         );
-        const cbox = await page.find("calcite-combobox");
-        const openEvent = page.waitForEvent("calciteComboboxOpen");
-        await cbox.click();
-        await openEvent;
+        const combobox = await page.find("calcite-combobox");
+        const firstOpenEvent = page.waitForEvent("calciteComboboxOpen");
+        await combobox.click();
+        await firstOpenEvent;
 
-        const item1 = await cbox.find("calcite-combobox-item[value=one]");
-
-        await item1.click();
-        expect(await page.find("calcite-combobox >>> calcite-chip")).toBeDefined();
+        const item1 = await combobox.find("calcite-combobox-item[value=one]");
 
         await item1.click();
-        expect(await page.find("calcite-combobox >>> calcite-chip")).toBeDefined();
+        expect(await combobox.getProperty("value")).toBe("one");
+
+        const secondOpenEvent = page.waitForEvent("calciteComboboxOpen");
+        await combobox.click();
+        await secondOpenEvent;
+
+        await item1.click();
+        expect(await combobox.getProperty("value")).toBe("");
       });
 
       it("multiple-selection mode allows toggling selection once the selected item is clicked", async () => {


### PR DESCRIPTION
**Related Issue:** #4738, #3074

## Summary

This reverts the fix for #4738 to prevent breaking existing user workflows that rely on clicking an item to deselect.
