### PR TITLE
fix(value-list, sortable-list): Emit calciteListOrderChange correctly

### DIFF
--- a/src/components/sortable-list/sortable-list.tsx
+++ b/src/components/sortable-list/sortable-list.tsx
@@ -186,7 +186,7 @@ export class SortableList implements InteractiveComponent, SortableComponent {
         onSortingEnd(this);
         this.beginObserving();
       },
-      onUpdate: () => {
+      onSort: () => {
         this.items = Array.from(this.el.children);
         this.calciteListOrderChange.emit();
       }

--- a/src/components/value-list/value-list.tsx
+++ b/src/components/value-list/value-list.tsx
@@ -347,7 +347,7 @@ export class ValueList<
         onSortingEnd(this);
         initializeObserver.call(this);
       },
-      onUpdate: () => {
+      onSort: () => {
         this.items = Array.from(this.el.querySelectorAll<ItemElement>("calcite-value-list-item"));
         const values = this.items.map((item) => item.value);
         this.calciteListOrderChange.emit(values);


### PR DESCRIPTION
**Related Issue:** TBD

## Summary

- Changes sortable listener from onUpdate to onSort.
  - onSort happens onUpdate as well as when list items are moved from other lists so we should always use onSort.
  - onUpdate only happens when things are moved within the list.