### PR TITLE
fix(tab-nav): justify centered `tab-titles` evenly to extend across the width of `tab-nav`

### DIFF
--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -17,7 +17,7 @@
 .tab-nav {
   @apply flex
     w-full
-    justify-evenly
+    justify-start
     overflow-auto;
 }
 
@@ -39,6 +39,10 @@
     h-0.5
     transition-all
     ease-out;
+}
+
+:host([layout="center"]) {
+  @apply justify-evenly;
 }
 
 :host([position="bottom"]) .tab-nav-active-indicator {

--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -41,7 +41,7 @@
     ease-out;
 }
 
-:host([layout="center"]) {
+:host([layout="center"]) .tab-nav {
   @apply justify-evenly;
 }
 

--- a/src/components/tab-nav/tab-nav.scss
+++ b/src/components/tab-nav/tab-nav.scss
@@ -17,7 +17,7 @@
 .tab-nav {
   @apply flex
     w-full
-    justify-start
+    justify-evenly
     overflow-auto;
 }
 

--- a/src/components/tab-title/tab-title.scss
+++ b/src/components/tab-title/tab-title.scss
@@ -4,8 +4,11 @@
   margin-inline-end: theme("margin.5");
 }
 
-:host([layout="center"]) {
+:host([layout="center"][scale="s"]),
+:host([layout="center"][scale="m"]),
+:host([layout="center"][scale="l"]) {
   @apply my-0 text-center;
+  margin-inline-end: theme("margin.0");
   flex-basis: theme("spacing.48");
   .content {
     @apply m-auto;

--- a/src/components/tab-title/tab-title.scss
+++ b/src/components/tab-title/tab-title.scss
@@ -5,7 +5,7 @@
 }
 
 :host([layout="center"]) {
-  @apply my-0 mx-5 text-center;
+  @apply my-0 text-center;
   flex-basis: theme("spacing.48");
   .content {
     @apply m-auto;

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -220,7 +220,6 @@ export const centeredBorderedClosable_TestOnly = (): string => html`
   <calcite-tabs layout="center" bordered>
     <calcite-tab-nav slot="title-group">
       <calcite-tab-title closable>Tab 1 Title</calcite-tab-title>
-      <calcite-tab-title icon-start="arrow-left" closable>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title icon-end="arrow-right" closable>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" closable selected
         >Tab 4 Title</calcite-tab-title
@@ -230,6 +229,21 @@ export const centeredBorderedClosable_TestOnly = (): string => html`
     <calcite-tab><p>Tab 2 Content</p></calcite-tab>
     <calcite-tab><p>Tab 3 Content</p></calcite-tab>
     <calcite-tab><p>Tab 4 Content</p></calcite-tab>
+  </calcite-tabs>
+`;
+
+export const centeredTabsAreEvenlyJustifiedAcrossNavWidth_TestOnly = (): string => html`
+  <calcite-tabs layout="center">
+    <calcite-tab-nav slot="title-group">
+      <calcite-tab-title closable>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-end="arrow-right" closable>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" closable selected
+        >Tab 3 Title</calcite-tab-title
+      >
+    </calcite-tab-nav>
+    <calcite-tab><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 3 Content</p></calcite-tab>
   </calcite-tabs>
 `;
 

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -220,6 +220,7 @@ export const centeredBorderedClosable_TestOnly = (): string => html`
   <calcite-tabs layout="center" bordered>
     <calcite-tab-nav slot="title-group">
       <calcite-tab-title closable>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="arrow-left" closable>Tab 2 Title</calcite-tab-title>
       <calcite-tab-title icon-end="arrow-right" closable>Tab 3 Title</calcite-tab-title>
       <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" closable selected
         >Tab 4 Title</calcite-tab-title

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -248,6 +248,21 @@ export const centeredTabsAreEvenlyJustifiedAcrossNavWidth_TestOnly = (): string 
   </calcite-tabs>
 `;
 
+export const inlineTabsJustifyAgainstTheStartOfTheNavWidth_TestOnly = (): string => html`
+  <calcite-tabs layout="inline">
+    <calcite-tab-nav slot="title-group">
+      <calcite-tab-title closable>Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title icon-end="arrow-right" closable>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" closable selected
+        >Tab 3 Title</calcite-tab-title
+      >
+    </calcite-tab-nav>
+    <calcite-tab><p>Tab 1 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 2 Content</p></calcite-tab>
+    <calcite-tab><p>Tab 3 Content</p></calcite-tab>
+  </calcite-tabs>
+`;
+
 export const TabChildrenWithPercentageHeights = (): string => html`
   <calcite-tabs style="height: 250px;">
     <calcite-tab-nav slot="title-group">


### PR DESCRIPTION
**Related Issue:** #7025 

## Summary

Follow-up to fix to #7026.

Centered `tabs` should spread the `tab-titles` evenly to extend across the entire width of `tab-nav`, as opposed to `inline tab-titles` that only justify against the start of `tab-nav` width.

Added coverage for both `centeredTabsAreEvenlyJustifiedAcrossNavWidth` and `inlineTabsJustifyAgainstTheStartOfTheNavWidth`. 