### PR TITLE
fix(input-time-picker): only load valid dayjs locale files and fallback to base lang when region code is unsupported

### DIFF
--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -37,6 +37,14 @@ describe("calcite-input-time-picker", () => {
     renders(`<calcite-input-time-picker lang="nl-nl"></calcite-input-time-picker>`, { display: "inline-block" });
   });
 
+  describe("renders with pt-PT locale", () => {
+    renders(`<calcite-input-time-picker lang="pt-PT"></calcite-input-time-picker>`, { display: "inline-block" });
+  });
+
+  describe("renders with no locale", () => {
+    renders(`<calcite-input-time-picker lang="no"></calcite-input-time-picker>`, { display: "inline-block" });
+  });
+
   describe("honors hidden attribute", () => {
     hidden("calcite-input-time-picker");
   });

--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -647,7 +647,7 @@ describe("calcite-input-time-picker", () => {
     it("localizes initial display value in arab numbering system", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-input-time-picker step="1" lang="ar" numbering-system  ="arab" value="14:02:30"></calcite-input-time-picker>`
+        `<calcite-input-time-picker step="1" lang="ar" numbering-system="arab" value="14:02:30"></calcite-input-time-picker>`
       );
 
       const inputTimePicker = await page.find("calcite-input-time-picker");

--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -33,6 +33,10 @@ describe("calcite-input-time-picker", () => {
     renders(`<calcite-input-time-picker lang="en-us"></calcite-input-time-picker>`, { display: "inline-block" });
   });
 
+  describe("renders with base lang when region code is unsupported", () => {
+    renders(`<calcite-input-time-picker lang="nl-nl"></calcite-input-time-picker>`, { display: "inline-block" });
+  });
+
   describe("honors hidden attribute", () => {
     hidden("calcite-input-time-picker");
   });
@@ -643,7 +647,7 @@ describe("calcite-input-time-picker", () => {
     it("localizes initial display value in arab numbering system", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-input-time-picker step="1" lang="ar" numbering-system="arab" value="14:02:30"></calcite-input-time-picker>`
+        `<calcite-input-time-picker step="1" lang="ar" numbering-system  ="arab" value="14:02:30"></calcite-input-time-picker>`
       );
 
       const inputTimePicker = await page.find("calcite-input-time-picker");

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -556,7 +556,15 @@ export class InputTimePicker
   };
 
   private async loadDateTimeLocaleData(): Promise<void> {
-    const supportedLocale = getSupportedLocale(this.effectiveLocale).toLowerCase();
+    let supportedLocale = getSupportedLocale(this.effectiveLocale).toLowerCase();
+
+    if (supportedLocale === "no") {
+      supportedLocale = "nb";
+    }
+
+    if (supportedLocale === "pt-pt") {
+      supportedLocale = "pt";
+    }
 
     if (supportedDayJsLocaleToLocaleConfigImport.has(supportedLocale)) {
       const { default: localeConfig } = await supportedDayJsLocaleToLocaleConfigImport.get(

--- a/src/components/input-time-picker/input-time-picker.tsx
+++ b/src/components/input-time-picker/input-time-picker.tsx
@@ -566,14 +566,12 @@ export class InputTimePicker
       supportedLocale = "pt";
     }
 
-    if (supportedDayJsLocaleToLocaleConfigImport.has(supportedLocale)) {
-      const { default: localeConfig } = await supportedDayJsLocaleToLocaleConfigImport.get(
-        supportedLocale
-      )();
+    const { default: localeConfig } = await supportedDayJsLocaleToLocaleConfigImport.get(
+      supportedLocale
+    )();
 
-      dayjs.locale(localeConfig, null, true);
-      dayjs.updateLocale(supportedLocale, this.getExtendedLocaleConfig(supportedLocale));
-    }
+    dayjs.locale(localeConfig, null, true);
+    dayjs.updateLocale(supportedLocale, this.getExtendedLocaleConfig(supportedLocale));
   }
 
   private getExtendedLocaleConfig(


### PR DESCRIPTION
**Related Issue:** #7040

## Summary

This fixes an issue where setting `lang` to a locale code with an unsupported region (e.g. `nl-nl`) failed to fall back to the base language and didn't render the component.