### PR TITLE
fix(list-item): always emit calciteListItemSelect on activation

### DIFF
--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -123,6 +123,22 @@ describe("calcite-list-item", () => {
     expect(eventSpy).toHaveReceivedEventTimes(1);
   });
 
+  it("emits calciteListItemSelect on click when selectionMode is none", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-list-item selection-mode="none" label="hello" description="world"></calcite-list-item>`
+    });
+
+    await page.waitForChanges();
+
+    const contentContainer = await page.find(`calcite-list-item >>> .${CSS.contentContainer}`);
+
+    const eventSpy = await page.spyOnEvent("calciteListItemSelect");
+
+    await contentContainer.click();
+
+    expect(eventSpy).toHaveReceivedEventTimes(1);
+  });
+
   it("does not emit calciteListItemSelect on click when selection-mode is none", async () => {
     const page = await newE2EPage({
       html: `<calcite-list-item selection-mode="none" label="hello" description="world"></calcite-list-item>`

--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -139,22 +139,6 @@ describe("calcite-list-item", () => {
     expect(eventSpy).toHaveReceivedEventTimes(1);
   });
 
-  it("does not emit calciteListItemSelect on click when selection-mode is none", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-list-item selection-mode="none" label="hello" description="world"></calcite-list-item>`
-    });
-
-    await page.waitForChanges();
-
-    const contentContainer = await page.find(`calcite-list-item >>> .${CSS.contentContainer}`);
-
-    const eventSpy = await page.spyOnEvent("calciteListItemSelect");
-
-    await contentContainer.click();
-
-    expect(eventSpy).toHaveReceivedEventTimes(0);
-  });
-
   it("honors defaultPrevented on click", async () => {
     const page = await newE2EPage({
       html: `<calcite-list-item selection-mode="single" label="hello" description="world">

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -610,7 +610,7 @@ export class ListItem
   toggleSelected = (): void => {
     const { selectionMode, selected } = this;
 
-    if (this.disabled || selectionMode === "none" || !selectionMode) {
+    if (this.disabled) {
       return;
     }
 
@@ -630,13 +630,12 @@ export class ListItem
 
     const { key } = event;
     const composedPath = event.composedPath();
-    const { containerEl, contentEl, actionsStartEl, actionsEndEl, open, openable, selectionMode } =
-      this;
+    const { containerEl, contentEl, actionsStartEl, actionsEndEl, open, openable } = this;
 
     const cells = [actionsStartEl, contentEl, actionsEndEl].filter(Boolean);
     const currentIndex = cells.findIndex((cell) => composedPath.includes(cell));
 
-    if (key === "Enter" && selectionMode && selectionMode !== "none") {
+    if (key === "Enter") {
       event.preventDefault();
       this.toggleSelected();
     } else if (key === "ArrowRight") {


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-components/issues/7059

## Summary

- Always emit calciteListItemSelect on activation