### PR TITLE
chore: ensure t9nmanifest file is sorted consistently

### DIFF
--- a/support/generateT9nTypes.ts
+++ b/support/generateT9nTypes.ts
@@ -11,7 +11,7 @@ import { InputData, jsonInputForTargetLanguage, quicktype } from "quicktype-core
   const rootBundlePattern = `src/components/**/t9n/${rootBundleFile}`;
 
   const rootBundles = await globby([rootBundlePattern]);
-  const translationBuildPathSeparator = "\\";
+  const manifestFilePathSeparator = "\\";
 
   console.log("starting generation of t9n string typings...", rootBundlePattern);
 
@@ -53,7 +53,7 @@ import { InputData, jsonInputForTargetLanguage, quicktype } from "quicktype-core
         })
       );
       const t9nPath = `${bundle.split("/t9n")[0]}/t9n`;
-      return t9nPath.replace(/\//g, translationBuildPathSeparator);
+      return t9nPath.replace(/\//g, manifestFilePathSeparator);
     })
   );
 
@@ -62,8 +62,8 @@ import { InputData, jsonInputForTargetLanguage, quicktype } from "quicktype-core
   const manifestFileContents = paths
     .sort((pathA, pathB) => {
       // ensure paths are sorted per component-name `globby` does not guarantee order (see https://github.com/sindresorhus/globby/issues/131)
-      const componentAName = pathA.split(translationBuildPathSeparator)[2];
-      const componentBName = pathB.split(translationBuildPathSeparator)[2];
+      const componentAName = pathA.split(manifestFilePathSeparator)[2];
+      const componentBName = pathB.split(manifestFilePathSeparator)[2];
       return componentAName.localeCompare(componentBName);
     })
     .join("\n");

--- a/support/generateT9nTypes.ts
+++ b/support/generateT9nTypes.ts
@@ -61,7 +61,7 @@ import { InputData, jsonInputForTargetLanguage, quicktype } from "quicktype-core
 
   const manifestFileContents = paths
     .sort((pathA, pathB) => {
-      // ensure paths are sorted per component-name `globby` does not guarantee order (see https://github.com/sindresorhus/globby/issues/131)
+      // ensure paths are sorted per component-name as `globby` does not guarantee order (see https://github.com/sindresorhus/globby/issues/131)
       const componentAName = pathA.split(manifestFilePathSeparator)[2];
       const componentBName = pathB.split(manifestFilePathSeparator)[2];
       return componentAName.localeCompare(componentBName);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This addresses an issue where manual sorting of `t9nmanifest.txt` entries would not match the automated sorting.