### PR TITLE
ci(chromatic): zip storybook build

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,6 +48,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          zip: true
           exitOnceUploaded: true
           autoAcceptChanges: master
         env:


### PR DESCRIPTION
## Summary

Zips the storybook build files before uploading them to Chromatic. I ran into an error in one of my branches and needed to add the flag. We are getting a different error on master that may be related.

error: https://github.com/Esri/calcite-components/actions/runs/5103380478/jobs/9173575301#step:6:61