### PR TITLE
docs: provide context to slot and css var deprecations

### DIFF
--- a/src/components/flow-item/flow-item.tsx
+++ b/src/components/flow-item/flow-item.tsx
@@ -40,7 +40,7 @@ import { CSS, ICONS, SLOTS } from "./resources";
  * @slot header-content - A slot for adding custom content to the component's header.
  * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
- * @slot footer-actions - [Deprecated] A slot for adding `calcite-button`s to the component's footer.
+ * @slot footer-actions - [Deprecated] Use the `"footer"` slot instead. A slot for adding `calcite-button`s to the component's footer.
  * @slot footer - A slot for adding custom content to the component's footer.
  */
 @Component({

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -42,7 +42,7 @@ import { PanelMessages } from "./assets/panel/t9n";
  * @slot header-content - A slot for adding custom content to the header.
  * @slot header-menu-actions - A slot for adding an overflow menu with actions inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
- * @slot footer-actions - [Deprecated] A slot for adding buttons to the footer.
+ * @slot footer-actions - [Deprecated] Use the `"footer"` slot instead. A slot for adding `calcite-button`s to the component's footer.
  * @slot footer - A slot for adding custom content to the footer.
  */
 @Component({

--- a/src/components/shell-panel/shell-panel.scss
+++ b/src/components/shell-panel/shell-panel.scss
@@ -9,7 +9,7 @@
  * @prop --calcite-shell-panel-height: When `layout` is `horizontal`, or `layout` is `vertical` and `displayMode` is `float`, specifies the height of the component.
  * @prop --calcite-shell-panel-max-height: When `layout` is `horizontal`, or `layout` is `vertical` and `displayMode` is `float`, specifies the maximum height of the component.
  * @prop --calcite-shell-panel-min-height: When `layout` is `horizontal`, or `layout` is `vertical` and `displayMode` is `float`, specifies the minimum height of the component.
- * @prop [Deprecated] --calcite-shell-panel-detached-max-height: When `displayMode` is `float`, specifies the maximum height of the component.
+ * @prop --calcite-shell-panel-detached-max-height: [Deprecated] Use the `heightScale` property instead. When `displayMode` is `float`, specifies the maximum height of the component.
  * @prop --calcite-shell-panel-z-index: Specifies the z-index value for the component.
  *
  */

--- a/src/components/shell/shell.tsx
+++ b/src/components/shell/shell.tsx
@@ -15,7 +15,7 @@ import { CSS, SLOTS } from "./resources";
  * @slot panel-end - A slot for adding the ending `calcite-shell-panel`.
  * @slot panel-top - A slot for adding the top `calcite-shell-center-row`.
  * @slot panel-bottom - A slot for adding the bottom `calcite-shell-center-row`.
- * @slot center-row - [Deprecated] use `"panel-bottom"` instead. A slot for adding the bottom `calcite-shell-center-row`.
+ * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-shell-center-row`.
  * @slot modals - A slot for adding `calcite-modal` components. When placed in this slot, the modal position will be constrained to the extent of the shell.
  * @slot alerts - A slot for adding `calcite-alert` components. When placed in this slot, the alert position will be constrained to the extent of the shell.
  */


### PR DESCRIPTION
**Related Issue:** #7101 

## Summary
Adds context to the deprecations of the following slots:
1. Flow item's `"footer-actions"` slot -> use `"footer"`
2. Panel's `"footer-actions"` slot -> use `"footer"`
3. Shell `"center-row"` slot -> provide context to slot name

And the deprecated CSS vars:
1. Reformat Shell Panel to display in the docs and `--calcite-shell-panel-detached-max-height` -> use `heightScale` property.