### PR TITLE
test: set up floatingUIOwner helper to run a test per use case

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1451,16 +1451,19 @@ describe("calcite-combobox", () => {
     );
   });
 
-  it("owns a floating-ui", () =>
+  describe("owns a floating-ui", () => {
     floatingUIOwner(
-      html` <calcite-combobox>
-        <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two" selected></calcite-combobox-item>
-        <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
-      </calcite-combobox>`,
+      html`
+        <calcite-combobox>
+          <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
+          <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two" selected></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+        </calcite-combobox>
+      `,
       "open",
       { shadowSelector: ".floating-ui-container" }
-    ));
+    );
+  });
 
   it("should emit component status for transition-chained events: 'calciteComoboxBeforeOpen', 'calciteComboboxOpen', 'calciteComboboxBeforeClose', 'calciteComboboxClose'", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -1070,21 +1070,24 @@ describe("calcite-dropdown", () => {
     expect(dropdownContentHeight.height).toBe("72px");
   });
 
-  it("owns a floating-ui", () =>
+  describe("owns a floating-ui", () => {
     floatingUIOwner(
-      html` <calcite-dropdown>
-        <calcite-button slot="trigger">Open</calcite-button>
-        <calcite-dropdown-group selection-mode="single">
-          <calcite-dropdown-item id="item-1" selected>1</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>`,
+      html`
+        <calcite-dropdown>
+          <calcite-button slot="trigger">Open</calcite-button>
+          <calcite-dropdown-group selection-mode="single">
+            <calcite-dropdown-item id="item-1" selected>1</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+            <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+      `,
       "open",
       {
         shadowSelector: ".calcite-dropdown-wrapper"
       }
-    ));
+    );
+  });
 
   it("should emit component status for transition-chained events: 'calciteDropdownBeforeOpen', 'calciteDropdownOpen', 'calciteDropdownBeforeClose', 'calciteDropdownClose'", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -456,12 +456,13 @@ describe("calcite-input-date-picker", () => {
     expect(minDateAsTime).toEqual(new Date(minDateString).getTime());
   });
 
-  it("owns a floating-ui", () =>
+  describe("owns a floating-ui", () => {
     floatingUIOwner(
       `<calcite-input-date-picker value="2022-11-27" min="2022-11-15" max="2024-11-15"></calcite-input-date-picker>`,
       "open",
       { shadowSelector: ".menu-container" }
-    ));
+    );
+  });
 
   it("when set to readOnly, element still focusable but won't display the controls or allow for changing the value", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/popover/popover.e2e.ts
+++ b/packages/calcite-components/src/components/popover/popover.e2e.ts
@@ -609,11 +609,12 @@ describe("calcite-popover", () => {
     expect(await popover.getProperty("open")).toBe(false);
   });
 
-  it("owns a floating-ui", () =>
+  describe("owns a floating-ui", () => {
     floatingUIOwner(
       `<calcite-popover placement="auto" reference-element="ref">content</calcite-popover><div id="ref">referenceElement</div>`,
       "open"
-    ));
+    );
+  });
 
   it("should autoClose shadow popovers when clicked outside", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -514,11 +514,12 @@ describe("calcite-tooltip", () => {
     expect(await hoverTip.getProperty("open")).toBe(false);
   });
 
-  it("owns a floating-ui", () =>
+  describe("owns a floating-ui", () => {
     floatingUIOwner(
       `<calcite-tooltip reference-element="ref">content</calcite-tooltip><div id="ref">referenceElement</div>`,
       "open"
-    ));
+    );
+  });
 
   it("should only open the last hovered tooltip", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/tests/commonTests.ts
+++ b/packages/calcite-components/src/tests/commonTests.ts
@@ -611,10 +611,7 @@ interface FormAssociatedOptions {
  *
  * Note that this helper should be used within a describe block.
  *
- * @example
- * describe("form-associated), () => {
- *    formAssociated("calcite-component", { testValue: 1337 });
- * });
+
  *
  * @param {string} componentTagOrHtml - the component tag or HTML markup to test against
  * @param {FormAssociatedOptions} options - form associated options
@@ -1096,12 +1093,23 @@ export async function disabled(
  * This helper will test if a floating-ui-owning component has configured the floating-ui correctly.
  * At the moment, this only tests if the scroll event listeners are only active when the floating-ui is displayed.
  *
- * @param componentTagOrHTML - the component tag or HTML markup to test against
- * @param togglePropName - the component property that toggles the floating-ui
- * @param options - the floating-ui owner test configuration
+ * Note that this helper should be used within a describe block.
+ *
+ * @example
+ * describe("owns a floating-ui", () => {
+ *  floatingUIOwner(
+ *    `<calcite-input-date-picker></calcite-input-date-picker>`,
+ *      "open",
+ *      { shadowSelector: ".menu-container" }
+ *  )
+ * });
+ *
+ * @param componentTagOrHTML - The component tag or HTML markup to test against.
+ * @param togglePropName - The component property that toggles the floating-ui.
+ * @param options - The floating-ui owner test configuration.
  * @param options.shadowSelector
  */
-export async function floatingUIOwner(
+export function floatingUIOwner(
   componentTagOrHTML: TagOrHTML,
   togglePropName: string,
   options?: {
@@ -1110,69 +1118,71 @@ export async function floatingUIOwner(
      */
     shadowSelector?: string;
   }
-): Promise<void> {
-  const page = await simplePageSetup(componentTagOrHTML);
+): void {
+  it("owns a floating-ui", async () => {
+    const page = await simplePageSetup(componentTagOrHTML);
 
-  const scrollablePageSizeInPx = 2400;
-  await page.addStyleTag({
-    content: `body {
+    const scrollablePageSizeInPx = 2400;
+    await page.addStyleTag({
+      content: `body {
       height: ${scrollablePageSizeInPx}px;
       width: ${scrollablePageSizeInPx}px;
     }`
+    });
+    await page.waitForChanges();
+
+    const tag = getTag(componentTagOrHTML);
+    const component = await page.find(tag);
+
+    async function getTransform(): Promise<string> {
+      // need to get the style attribute from the browser context since the E2E element returns null
+      return page.$eval(
+        tag,
+        (component: HTMLElement, shadowSelector: string): string => {
+          const floatingUIEl = shadowSelector
+            ? component.shadowRoot.querySelector<HTMLElement>(shadowSelector)
+            : component;
+
+          return floatingUIEl.getAttribute("style");
+        },
+        options?.shadowSelector
+      );
+    }
+
+    async function scrollTo(x: number, y: number): Promise<void> {
+      await page.evaluate((x: number, y: number) => document.firstElementChild.scrollTo(x, y), x, y);
+    }
+
+    component.setProperty(togglePropName, false);
+    await page.waitForChanges();
+
+    const initialClosedTransform = await getTransform();
+
+    await scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
+    await page.waitForChanges();
+
+    expect(await getTransform()).toBe(initialClosedTransform);
+
+    await scrollTo(0, 0);
+    await page.waitForChanges();
+
+    expect(await getTransform()).toBe(initialClosedTransform);
+
+    component.setProperty(togglePropName, true);
+    await page.waitForChanges();
+
+    const initialOpenTransform = await getTransform();
+
+    await scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
+    await page.waitForChanges();
+
+    expect(await getTransform()).not.toBe(initialOpenTransform);
+
+    await scrollTo(0, 0);
+    await page.waitForChanges();
+
+    expect(await getTransform()).toBe(initialOpenTransform);
   });
-  await page.waitForChanges();
-
-  const tag = getTag(componentTagOrHTML);
-  const component = await page.find(tag);
-
-  async function getTransform(): Promise<string> {
-    // need to get the style attribute from the browser context since the E2E element returns null
-    return page.$eval(
-      tag,
-      (component: HTMLElement, shadowSelector: string): string => {
-        const floatingUIEl = shadowSelector
-          ? component.shadowRoot.querySelector<HTMLElement>(shadowSelector)
-          : component;
-
-        return floatingUIEl.getAttribute("style");
-      },
-      options?.shadowSelector
-    );
-  }
-
-  async function scrollTo(x: number, y: number): Promise<void> {
-    await page.evaluate((x: number, y: number) => document.firstElementChild.scrollTo(x, y), x, y);
-  }
-
-  component.setProperty(togglePropName, false);
-  await page.waitForChanges();
-
-  const initialClosedTransform = await getTransform();
-
-  await scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
-  await page.waitForChanges();
-
-  expect(await getTransform()).toBe(initialClosedTransform);
-
-  await scrollTo(0, 0);
-  await page.waitForChanges();
-
-  expect(await getTransform()).toBe(initialClosedTransform);
-
-  component.setProperty(togglePropName, true);
-  await page.waitForChanges();
-
-  const initialOpenTransform = await getTransform();
-
-  await scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
-  await page.waitForChanges();
-
-  expect(await getTransform()).not.toBe(initialOpenTransform);
-
-  await scrollTo(0, 0);
-  await page.waitForChanges();
-
-  expect(await getTransform()).toBe(initialOpenTransform);
 }
 
 /**


### PR DESCRIPTION
**Related Issue:** #N/A

## Summary
Refactor `floatingUIOwner` test helper to help mitigate timeouts.

Splitting up our common test helpers into individual tests helps mitigate timeouts that occurred when a helper's coverage ended up taking longer than the default test timeout.

The updated doc reflects how to use the helpers in E2E tests.