### PR TITLE
ci: fix a couple release ci issues

### DIFF
--- a/.github/workflows/remove-next-changelog-entries.yml
+++ b/.github/workflows/remove-next-changelog-entries.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 16
       - name: Remove Next Changelog Entries
         run: |
+          git pull
           npm install
           npm run util:remove-next-changelog-entries
       - name: Push Changes

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "prepare": "husky install",
     "preversion": "npm run util:is-in-sync-with-origin && npm run util:is-working-tree-clean",
     "test": "turbo run test",
-    "util:is-in-sync-with-origin": "[ \"$(git rev-parse --abbrev-ref HEAD)\" = \"main\" ] && [ \"$(git rev-parse main)\" = \"$(git rev-parse origin/main)\" ]",
+    "util:is-in-sync-with-origin": "[ \"$(git rev-parse --abbrev-ref HEAD)\" = \"master\" ] && [ \"$(git rev-parse master)\" = \"$(git rev-parse origin/master)\" ]",
     "util:is-next-deployable": "ts-node --esm support/isNextDeployable.ts",
     "util:is-working-tree-clean": "[ -z \"$(git status --porcelain=v1)\" ]",
-    "util:push-tags": "git push origin main --follow-tags",
+    "util:push-tags": "git push origin master --follow-tags",
     "util:remove-next-changelog-entries": "ts-node --esm support/removeNextChangelogEntries.ts",
     "util:sync-linked-package-versions": "ts-node --esm support/syncLinkedPackageVersions.ts"
   },


### PR DESCRIPTION
**Related Issue:** #6988

## Summary

Fixes a couple release CI issues:

1. We were going to rename `master` to `main` but not sure what happened to that so I changed the branch names back before installing the monorepo PR. However I missed a few in `package.json`. I think it is still going to happen but I want to wait for Franco to get back before pulling the trigger. cc @alisonailea 
2. Looks like the Action gets out of sync in a real dev environment rather than my isolated testing. I need to pull before pushing the changelog cleaning. Error: https://github.com/Esri/calcite-components/actions/runs/5191460111/jobs/9359307809#step:5:35