### PR TITLE
ci(release-please): change PR title and ensure git tag consistency

### DIFF
--- a/packages/calcite-components/CHANGELOG.md
+++ b/packages/calcite-components/CHANGELOG.md
@@ -9,13 +9,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **navigation:** label is no longer a required property ([#7084](https://github.com/Esri/calcite-components/issues/7084)) ([ba2bd4d](https://github.com/Esri/calcite-components/commit/ba2bd4db32b3bfbc5403a75156d4fde6859114e3)), closes [#7013](https://github.com/Esri/calcite-components/issues/7013)
 
-## [v1.4.3-next.1](https://github.com/Esri/calcite-components/compare/v1.4.3-next.0...v1.4.3-next.1) (2023-06-02)
+## [1.4.3-next.1](https://github.com/Esri/calcite-components/compare/v1.4.3-next.0...v1.4.3-next.1) (2023-06-02)
 
 ### Bug Fixes
 
 - **menu-item:** Ensure correct order of rendered icons ([#7098](https://github.com/Esri/calcite-components/issues/7098)) ([fd344e9](https://github.com/Esri/calcite-components/commit/fd344e91fb02b5dcb3e7ef6565fc679935c078c2)), closes [#7097](https://github.com/Esri/calcite-components/issues/7097)
 
-## [v1.4.3-next.0](https://github.com/Esri/calcite-components/compare/@esri/calcite-components@1.4.2...v1.4.3-next.0) (2023-05-31)
+## [1.4.3-next.0](https://github.com/Esri/calcite-components/compare/@esri/calcite-components@1.4.2...v1.4.3-next.0) (2023-05-31)
 
 ### Bug Fixes
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "tag-separator": "@",
+  "group-pull-request-title-pattern": "chore: release latest",
+  "include-v-in-tag": false,
   "packages": {
     "packages/calcite-components": {
       "component": "@esri/calcite-components",


### PR DESCRIPTION
**Related Issue:** #6988

## Summary

This PR changes the `release-please` PR title to `chore: release latest`. The default is `chore: release master`. 

It also makes sure a `v` isn't added before the version in git tags. Their schema doc says it doesn't by default, 
but I'm not convinced (see links below) so I want to hardcode the config value. The `v` being in the tag wouldn't break anything in our CI, but Lerna doesn't add a `v` and we should make sure our tag format is consistent for our consumer's CI.

https://github.com/googleapis/release-please/blob/bdd9b0158ce79d958da01ebf54cb6b07925bc125/schemas/config.json#L77-L79

https://github.com/googleapis/release-please/blob/bdd9b0158ce79d958da01ebf54cb6b07925bc125/src/strategies/base.ts#L139