### PR TITLE
fix(input-date-picker): Fix showing the placeholder when resetting the value

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -805,4 +805,24 @@ describe("calcite-input-date-picker", () => {
       expect(await getFocusedElementProp(page, "id")).toBe("next-sibling");
     });
   });
+
+  it("should reset input value", async () => {
+    const page = await newE2EPage();
+    const expectedValue = "2022-10-01";
+    const expectedInputValue = "10/1/2022";
+
+    await page.setContent(html` <calcite-input-date-picker value="${expectedValue}"></calcite-input-date-picker>`);
+
+    const inputDatePickerEl = await page.find("calcite-input-date-picker");
+    const input = await page.find("calcite-input-date-picker >>> calcite-input");
+
+    expect(await inputDatePickerEl.getProperty("value")).toEqual(expectedValue);
+    expect(await input.getProperty("value")).toEqual(expectedInputValue);
+
+    inputDatePickerEl.setProperty("value", "");
+    await page.waitForChanges();
+
+    expect(await inputDatePickerEl.getProperty("value")).toEqual("");
+    expect(await input.getProperty("value")).toEqual("");
+  });
 });

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -158,23 +158,15 @@ export class InputDatePicker
   @Watch("value")
   valueWatcher(newValue: string | string[]): void {
     if (!this.userChangedValue) {
-      const valueIsArray = Array.isArray(newValue);
       let newValueAsDate: Date | Date[];
 
-      if (valueIsArray) {
+      if (Array.isArray(newValue)) {
         newValueAsDate = getValueAsDateRange(newValue);
       } else if (newValue) {
         newValueAsDate = dateFromISO(newValue);
       } else {
         newValueAsDate = undefined;
       }
-
-      const { focusedInput } = this;
-
-      this.setInputValue(
-        valueIsArray ? newValue[focusedInput === "end" ? 1 : 0] : newValue,
-        focusedInput
-      );
 
       if (!this.valueAsDateChangedExternally && newValueAsDate !== this.valueAsDate) {
         this.valueAsDate = newValueAsDate;
@@ -1006,8 +998,8 @@ export class InputDatePicker
     const localizedEndDate =
       endDate && this.formatNumerals(endDate.toLocaleDateString(this.effectiveLocale));
 
-    localizedDate && this.setInputValue(localizedDate, "start");
-    this.range && localizedEndDate && this.setInputValue(localizedEndDate, "end");
+    this.setInputValue(localizedDate ?? "", "start");
+    this.setInputValue((this.range && localizedEndDate) ?? "", "end");
   }
 
   private setInputValue = (newValue: string, input: "start" | "end" = "start"): void => {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -158,8 +158,10 @@ export class InputDatePicker
   @Watch("value")
   valueWatcher(newValue: string | string[]): void {
     if (!this.userChangedValue) {
-      let newValueAsDate;
-      if (Array.isArray(newValue)) {
+      const valueIsArray = Array.isArray(newValue);
+      let newValueAsDate: Date | Date[];
+
+      if (valueIsArray) {
         newValueAsDate = getValueAsDateRange(newValue);
       } else if (newValue) {
         newValueAsDate = dateFromISO(newValue);
@@ -167,12 +169,20 @@ export class InputDatePicker
         newValueAsDate = undefined;
       }
 
+      const { focusedInput } = this;
+
+      this.setInputValue(
+        valueIsArray ? newValue[focusedInput === "end" ? 1 : 0] : newValue,
+        focusedInput
+      );
+
       if (!this.valueAsDateChangedExternally && newValueAsDate !== this.valueAsDate) {
         this.valueAsDate = newValueAsDate;
       }
 
       this.localizeInputValues();
     }
+
     this.userChangedValue = false;
   }
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -174,7 +174,6 @@ export class InputDatePicker
 
       this.localizeInputValues();
     }
-
     this.userChangedValue = false;
   }
 


### PR DESCRIPTION
**Related Issue:** #6378

## Summary

- Updates internal input's value when the value on the input-date-picker is changed.
- Adds a test