### PR TITLE
fix(alert): Sets autoCloseDuration to "medium" by default

### DIFF
--- a/packages/calcite-components/conventions/README.md
+++ b/packages/calcite-components/conventions/README.md
@@ -153,6 +153,22 @@ It is recommended to reflect properties that fit the following criteria:
 
 Doing so will give developers more flexibility when querying the DOM. This is important in framework environments where we can't safely assume components will have their attributes set vs properties.
 
+### Property defaults
+
+Properties should have static default values. There should be no conditional logic when defining the default value of a property.
+
+#### Incorrect example
+
+```ts
+@Prop({ reflect: true }) autoCloseDuration: AlertDuration = this.autoClose ? "medium" : null;
+```
+
+#### Correct example
+
+```ts
+@Prop({ reflect: true }) autoCloseDuration: AlertDuration = "medium";
+```
+
 ### `ref` usage
 
 Due to a [bug in Stencil](https://github.com/ionic-team/stencil/issues/4074), `ref` should be set as the last property in JSX to ensure the node's attributes/properties are up to date.

--- a/packages/calcite-components/conventions/README.md
+++ b/packages/calcite-components/conventions/README.md
@@ -153,22 +153,6 @@ It is recommended to reflect properties that fit the following criteria:
 
 Doing so will give developers more flexibility when querying the DOM. This is important in framework environments where we can't safely assume components will have their attributes set vs properties.
 
-### Property defaults
-
-Properties should have static default values. There should be no conditional logic when defining the default value of a property.
-
-#### Incorrect example
-
-```ts
-@Prop({ reflect: true }) autoCloseDuration: AlertDuration = this.autoClose ? "medium" : null;
-```
-
-#### Correct example
-
-```ts
-@Prop({ reflect: true }) autoCloseDuration: AlertDuration = "medium";
-```
-
 ### `ref` usage
 
 Due to a [bug in Stencil](https://github.com/ionic-team/stencil/issues/4074), `ref` should be set as the last property in JSX to ensure the node's attributes/properties are up to date.

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -1,8 +1,17 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { accessible, hidden, HYDRATED_ATTR, renders, t9n } from "../../tests/commonTests";
+import { accessible, defaults, hidden, HYDRATED_ATTR, renders, t9n } from "../../tests/commonTests";
 import { getElementXY } from "../../tests/utils";
 import { CSS, DURATIONS } from "./resources";
+
+describe("defaults", () => {
+  defaults("calcite-alert", [
+    {
+      propertyName: "autoCloseDuration",
+      defaultValue: "medium"
+    }
+  ]);
+});
 
 describe("calcite-alert", () => {
   const alertContent = `

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -100,7 +100,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   @Prop({ reflect: true }) autoClose = false;
 
   /** Specifies the duration before the component automatically closes (only use with `autoClose`). */
-  @Prop({ reflect: true }) autoCloseDuration: AlertDuration = this.autoClose ? "medium" : null;
+  @Prop({ reflect: true }) autoCloseDuration: AlertDuration = "medium";
 
   /** Specifies the kind of the component (will apply to top border and icon). */
   @Prop({ reflect: true }) kind: Extract<


### PR DESCRIPTION
**Related Issue:** #6363

## Summary

fix(alert): Sets autoCloseDuration to "medium" by default. #6363

@jcfranco ~~can we have linting to prevent having any conditional defaults? If not, we should maybe update conventions to say not to do this~~ Lets discuss how we can properly document and test this pattern.