### PR TITLE
fix(input,input-number): allow typing decimal separator in firefox for arabic locale

### DIFF
--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -402,7 +402,11 @@ export class NumberStringFormat {
     ].reverse();
 
     const index = new Map(this._digits.map((d, i) => [d, i]));
-    const parts = new Intl.NumberFormat(this._numberFormatOptions.locale).formatToParts(-12345678.9);
+
+    // numberingSystem is required to return consistent decimal separator across browsers
+    const parts = new Intl.NumberFormat(this._numberFormatOptions.locale, {
+      numberingSystem: this._numberFormatOptions.numberingSystem
+    } as Intl.NumberFormatOptions).formatToParts(-12345678.9);
 
     this._actualGroup = parts.find((d) => d.type === "group").value;
     // change whitespace group characters that don't render correctly

--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -403,7 +403,7 @@ export class NumberStringFormat {
 
     const index = new Map(this._digits.map((d, i) => [d, i]));
 
-    // numberingSystem is required to return consistent decimal separator across browsers
+    // numberingSystem is parsed to return consistent decimal separator across browsers.
     const parts = new Intl.NumberFormat(this._numberFormatOptions.locale, {
       numberingSystem: this._numberFormatOptions.numberingSystem
     } as Intl.NumberFormatOptions).formatToParts(-12345678.9);


### PR DESCRIPTION
**Related Issue:** #7130 

## Summary

This PR will allow users to type `latn` decimal separator for `arabic` lang in  Firefox & safari for `calcite-input` and `calcite-input-number`.