### PR TITLE
ci: add design complete automation

### DIFF
--- a/.github/workflows/design-complete.yml
+++ b/.github/workflows/design-complete.yml
@@ -1,0 +1,85 @@
+# When the "design-complete" label is added to an issue:
+# 1. Modifies the labels,
+# 2. Updates the assignees and milestone, and
+# 3. Generates a notification to the Calcite project manager(s)
+#
+# The secret is formatted like so: person1, person2, person3
+#
+# Note the script automatically adds the "@" character in to notify the project manager(s)
+name: "Design complete"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify-designer-new-component:
+    if: github.event.label.name == 'design-complete'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        env:
+          managers: ${{secrets.CALCITE_MANAGERS}}
+        with:
+          github-token: ${{ secrets.ADMIN_TOKEN }}
+          script: |
+            const { managers } = process.env;
+            const { label } = context.payload;
+
+            if (label && label.name === "design-complete") {
+
+              // Add a "@" character to notify the user
+              const calcite_managers = managers.split(",").map(v => " @" + v.trim());
+
+              const { data: issue } = await github.rest.issues.get({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+
+              /* Modify labels */
+
+              // Remove "Design" label
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: "design"
+              });
+
+              // Remove "1 - assigned" label
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: "1 - assigned"
+              });
+
+              // Add "0 - new" label
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['0 - new', 'needs milestone']
+              })
+
+              /* Update issue */
+              
+              // Remove assignees and milestone
+              await github.rest.issues.update({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                assignees: [],
+                milestone: null
+              });
+
+              // Add a comment to notify the project managers
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `cc ${calcite_managers}`,
+              });
+
+            }

--- a/.github/workflows/design-complete.yml
+++ b/.github/workflows/design-complete.yml
@@ -55,7 +55,7 @@ jobs:
                 name: "1 - assigned"
               });
 
-              // Add "0 - new" label
+              // Add labels
               await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
@@ -65,7 +65,7 @@ jobs:
 
               /* Update issue */
               
-              // Remove assignees and milestone
+              // Clear assignees and milestone
               await github.rest.issues.update({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
@@ -74,7 +74,7 @@ jobs:
                 milestone: null
               });
 
-              // Add a comment to notify the project managers
+              // Add a comment to notify the project manager(s)
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Adds automation for our design complete process, where when the `design-complete` label is added the following occurs:
- Remove the `design` and `1 - assigned` labels
    - Achieved through two separate `removeLabel` API calls, as there is not an API call to remove more than one without removing all labels.
- Add the `0 - new` and `needs milestone` labels
- Clear the assignee(s) and milestone
- CC @brittneytewks and I in the issue's body
    - Achieved via the `CALCITE_MANAGERS` secret (current value: `geospatialem, brittneytewks`)

Leverages the `ADMIN_TOKEN` secret 🔒  for admin access to update the labels with the proper permissions.