### PR TITLE
chore: fix sorting logic for t9nmanifest entries

### DIFF
--- a/packages/calcite-components/support/generateT9nTypes.ts
+++ b/packages/calcite-components/support/generateT9nTypes.ts
@@ -64,8 +64,9 @@ import { InputData, jsonInputForTargetLanguage, quicktype } from "quicktype-core
   const manifestFileContents = paths
     .sort((pathA, pathB) => {
       // ensure paths are sorted per component-name as `globby` does not guarantee order (see https://github.com/sindresorhus/globby/issues/131)
-      const componentAName = pathA.split(manifestFilePathSeparator)[2];
-      const componentBName = pathB.split(manifestFilePathSeparator)[2];
+      const componentAName = pathA.split(manifestFilePathSeparator).at(-2);
+      const componentBName = pathB.split(manifestFilePathSeparator).at(-2);
+
       return componentAName.localeCompare(componentBName);
     })
     .join("\n");

--- a/t9nmanifest.txt
+++ b/t9nmanifest.txt
@@ -2,8 +2,8 @@ packages\calcite-components\src\components\action\assets\action\t9n
 packages\calcite-components\src\components\action-bar\assets\action-bar\t9n
 packages\calcite-components\src\components\action-group\assets\action-group\t9n
 packages\calcite-components\src\components\action-pad\assets\action-pad\t9n
-packages\calcite-components\src\components\block\assets\block\t9n
 packages\calcite-components\src\components\alert\assets\alert\t9n
+packages\calcite-components\src\components\block\assets\block\t9n
 packages\calcite-components\src\components\block-section\assets\block-section\t9n
 packages\calcite-components\src\components\button\assets\button\t9n
 packages\calcite-components\src\components\card\assets\card\t9n
@@ -26,9 +26,9 @@ packages\calcite-components\src\components\menu\assets\menu\t9n
 packages\calcite-components\src\components\menu-item\assets\menu-item\t9n
 packages\calcite-components\src\components\modal\assets\modal\t9n
 packages\calcite-components\src\components\notice\assets\notice\t9n
+packages\calcite-components\src\components\pagination\assets\pagination\t9n
 packages\calcite-components\src\components\panel\assets\panel\t9n
 packages\calcite-components\src\components\pick-list-item\assets\pick-list-item\t9n
-packages\calcite-components\src\components\pagination\assets\pagination\t9n
 packages\calcite-components\src\components\popover\assets\popover\t9n
 packages\calcite-components\src\components\rating\assets\rating\t9n
 packages\calcite-components\src\components\scrim\assets\scrim\t9n


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes `t9nmanifest.txt` entry sorting by changing where it looks for the component name in the t9n dir. This broke when the paths were updated to the new monorepo structure.