### PR TITLE
fix(list): update selectedItems property on all item selection changes

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -131,10 +131,8 @@ export class ListItem
   @Prop({ reflect: true, mutable: true }) selected = false;
 
   @Watch("selected")
-  handleSelectedChange(value: boolean): void {
-    if (value) {
-      this.calciteInternalListItemSelect.emit();
-    }
+  handleSelectedChange(): void {
+    this.calciteInternalListItemSelect.emit();
   }
 
   /**

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -328,5 +328,17 @@ describe("calcite-list", () => {
     await calciteListChangeEvent2;
     expect(await listItemOne.getProperty("selected")).toBe(false);
     expect(await list.getProperty("selectedItems")).toHaveLength(0);
+
+    listItemOne.setProperty("selected", true);
+    await page.waitForChanges();
+    await page.waitForTimeout(listDebounceTimeout);
+    expect(await listItemOne.getProperty("selected")).toBe(true);
+    expect(await list.getProperty("selectedItems")).toHaveLength(1);
+
+    listItemOne.setProperty("selected", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(listDebounceTimeout);
+    expect(await listItemOne.getProperty("selected")).toBe(false);
+    expect(await list.getProperty("selectedItems")).toHaveLength(0);
   });
 });

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -185,11 +185,13 @@ export class List implements InteractiveComponent, LoadableComponent {
     const target = event.target as HTMLCalciteListItemElement;
     const { listItems, selectionMode } = this;
 
-    listItems.forEach((listItem) => {
-      if (selectionMode === "single" || selectionMode === "single-persist") {
-        listItem.selected = listItem === target;
-      }
-    });
+    if (target.selected) {
+      listItems.forEach((listItem) => {
+        if (selectionMode === "single" || selectionMode === "single-persist") {
+          listItem.selected = listItem === target;
+        }
+      });
+    }
 
     this.updateSelectedItems();
   }

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -185,12 +185,8 @@ export class List implements InteractiveComponent, LoadableComponent {
     const target = event.target as HTMLCalciteListItemElement;
     const { listItems, selectionMode } = this;
 
-    if (target.selected) {
-      listItems.forEach((listItem) => {
-        if (selectionMode === "single" || selectionMode === "single-persist") {
-          listItem.selected = listItem === target;
-        }
-      });
+    if (target.selected && (selectionMode === "single" || selectionMode === "single-persist")) {
+      listItems.forEach((listItem) => (listItem.selected = listItem === target));
     }
 
     this.updateSelectedItems();


### PR DESCRIPTION
**Related Issue:** #7202

## Summary

- Updates `selectedItems` when an item's selection is toggled.
- Fixes current logic which depends on value being `true`.
- Adds test coverage
