### PR TITLE
ci: set design complete label conditionals

### DIFF
--- a/.github/workflows/design-complete.yml
+++ b/.github/workflows/design-complete.yml
@@ -40,17 +40,25 @@ jobs:
 
               /* Modify labels */
 
-              // Remove "Design" label
-              await github.rest.issues.removeLabel({
-                ...issueProps,
-                name: "design"
-              });
+              // Try to remove "Design" label
+              try {
+                await github.rest.issues.removeLabel({
+                  ...issueProps,
+                  name: "design"
+                });
+              } catch(err) {
+                console.log(err);
+              }
 
-              // Remove "1 - assigned" label
-              await github.rest.issues.removeLabel({
-                ...issueProps,
-                name: "1 - assigned"
-              });
+              // Try to remove "1 - assigned" label
+              try {
+                await github.rest.issues.removeLabel({
+                  ...issueProps,
+                  name: "1 - assigned"
+                });
+              } catch(err) {
+                console.log(err);
+              }
 
               // Add labels
               await github.rest.issues.addLabels({

--- a/.github/workflows/design-complete.yml
+++ b/.github/workflows/design-complete.yml
@@ -40,14 +40,18 @@ jobs:
 
               /* Modify labels */
 
-              // Try to remove "Design" label
+              /* Tries to remove labels */
+              /* If the label is not associated with the issue,
+                 the error is logged and the script will continue. */
+
+              // Tries to remove "Design" label
               try {
                 await github.rest.issues.removeLabel({
                   ...issueProps,
                   name: "design"
                 });
               } catch(err) {
-                console.log(err);
+                console.log("The 'design' label is not associated with the issue", err);
               }
 
               // Try to remove "1 - assigned" label
@@ -57,7 +61,7 @@ jobs:
                   name: "1 - assigned"
                 });
               } catch(err) {
-                console.log(err);
+                console.log("The '1 - assigned' label is not associated with the issue", err);
               }
 
               // Add labels


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates the design complete workflow for conditions, in the event labels are not present.

In this case, will continue to run if the `design` and/or `1 - assigned` label(s) are not included in the issue. 🤖 