### PR TITLE
build: ignore node_modules and build outputs when watching for changes during stencil tests

### DIFF
--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -127,6 +127,7 @@ export const create: () => Config = () => ({
     })
   ],
   testing: {
+    watchPathIgnorePatterns: ["<rootDir>/../../node_modules", "<rootDir>/dist", "<rootDir>/www", "<rootDir>/hydrate"],
     moduleNameMapper: {
       "^/assets/(.*)$": "<rootDir>/src/tests/iconPathDataStub.ts",
       "^lodash-es$": "lodash"


### PR DESCRIPTION
## Summary

Currently our `npm run test:watch` script watches files in `node_modules`, `dist`, and other build outputs, which doesn't make sense unless you're monkey patching stuff. I've been getting an error due to watching too many files since we transitioned to a monorepo:

```log
[ ERROR ]  runJest: Error: EMFILE: too many open files, watch
          '/app/packages/calcite-components'

npm ERR! Lifecycle script `test` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: @esri/calcite-components@1.5.0-next.4
npm ERR!   at location: /app/packages/calcite-components
```

Ignoring `node_modules` and the build outputs resolved the issue for me (ref: https://github.com/jestjs/jest/issues/8088#issuecomment-473101715).

If anyone still experiences this error, installing watchman is another option (ref: https://github.com/jestjs/jest/issues/3436#issuecomment-299894570). 

[Jest uses watchman by default](https://jestjs.io/docs/configuration#watchman-boolean) if it is installed.