### PR TITLE
fix(input, input-number): allows numeric characters.

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -899,7 +899,7 @@ describe("calcite-input-number", () => {
     expect(Number(await element.getProperty("value"))).toBe(195);
   });
 
-  it("disallows typing characters with shift modifier key down", async () => {
+  it("disallows typing non-numeric characters with shift modifier key down", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input-number></calcite-input-number>`);
     const calciteInput = await page.find("calcite-input-number");
@@ -915,8 +915,7 @@ describe("calcite-input-number", () => {
     }
   });
 
-  // refer to issue here https://github.com/Esri/calcite-components/issues/6854
-  it("allows typing numbers with shift modifier key down", async () => {
+  it("allows typing numeric characters with shift modifier key down (#6854)", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input type="number"></calcite-input>`);
     const calciteInput = await page.find("calcite-input");

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -13,7 +13,7 @@ import {
   t9n
 } from "../../tests/commonTests";
 import { getElementXY, selectText } from "../../tests/utils";
-import { letterKeys } from "../../utils/key";
+import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 
 describe("calcite-input-number", () => {
@@ -912,6 +912,26 @@ describe("calcite-input-number", () => {
       await page.keyboard.up("Shift");
       expect(await calciteInput.getProperty("value")).toBeFalsy();
       expect(await input.getProperty("value")).toBeFalsy();
+    }
+  });
+
+  // refer to issue here https://github.com/Esri/calcite-components/issues/6854
+  it("allows typing numbers with shift modifier key down", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input type="number"></calcite-input>`);
+    const calciteInput = await page.find("calcite-input");
+    const input = await page.find("calcite-input >>> input");
+    await calciteInput.callMethod("setFocus");
+    const numberKeysExcludingZero = numberKeys.slice(1);
+
+    let result = "";
+    for (let i = 0; i < numberKeysExcludingZero.length; i++) {
+      await page.keyboard.down("Shift");
+      await page.keyboard.press(numberKeysExcludingZero[i] as KeyInput);
+      result += numberKeysExcludingZero[i];
+      await page.keyboard.up("Shift");
+      expect(await calciteInput.getProperty("value")).toBe(result);
+      expect(await input.getProperty("value")).toBe(result);
     }
   });
 

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -13,7 +13,7 @@ import {
   t9n
 } from "../../tests/commonTests";
 import { getElementXY, selectText } from "../../tests/utils";
-import { letterKeys, numberKeys } from "../../utils/key";
+import { letterKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 
 describe("calcite-input-number", () => {

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -899,20 +899,12 @@ describe("calcite-input-number", () => {
     expect(Number(await element.getProperty("value"))).toBe(195);
   });
 
-  it("disallows typing number with shift modifier key down", async () => {
+  it("disallows typing characters with shift modifier key down", async () => {
     const page = await newE2EPage();
     await page.setContent(html`<calcite-input-number></calcite-input-number>`);
     const calciteInput = await page.find("calcite-input-number");
     const input = await page.find("calcite-input-number >>> input");
     await calciteInput.callMethod("setFocus");
-
-    for (let i = 0; i < numberKeys.length; i++) {
-      await page.keyboard.down("Shift");
-      await page.keyboard.press(numberKeys[i] as KeyInput);
-      await page.keyboard.up("Shift");
-      expect(await calciteInput.getProperty("value")).toBeFalsy();
-      expect(await input.getProperty("value")).toBeFalsy();
-    }
     const nonELetterKeys = letterKeys.filter((key) => key !== "e");
     for (let i = 0; i < nonELetterKeys.length; i++) {
       await page.keyboard.down("Shift");

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -668,15 +668,10 @@ export class InputNumber
       return;
     }
     const isShiftTabEvent = event.shiftKey && event.key === "Tab";
-    if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
+    if (supportedKeys.includes(event.key) || isShiftTabEvent) {
       if (event.key === "Enter") {
         this.emitChangeIfUserModified();
       }
-      return;
-    }
-
-    // identifies French AZERTY keyboard input
-    if (numberKeys.includes(event.key) && event.shiftKey) {
       return;
     }
 

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -675,6 +675,11 @@ export class InputNumber
       return;
     }
 
+    // identifies French AZERTY keyboard input
+    if (numberKeys.includes(event.key) && event.shiftKey) {
+      return;
+    }
+
     numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -11,7 +11,7 @@ import {
   t9n
 } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { letterKeys, numberKeys } from "../../utils/key";
+import { letterKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 import { getElementXY, selectText } from "../../tests/utils";
 import { KeyInput } from "puppeteer";

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -1055,7 +1055,7 @@ describe("calcite-input", () => {
       expect(Number(await element.getProperty("value"))).toBe(195);
     });
 
-    it("disallows typing any letter  with shift modifier key down", async () => {
+    it("disallows typing any characters with shift modifier key down", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-input type="number"></calcite-input>`);
       const calciteInput = await page.find("calcite-input");

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -1055,20 +1055,12 @@ describe("calcite-input", () => {
       expect(Number(await element.getProperty("value"))).toBe(195);
     });
 
-    it("disallows typing any letter or number with shift modifier key down", async () => {
+    it("disallows typing any letter  with shift modifier key down", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-input type="number"></calcite-input>`);
       const calciteInput = await page.find("calcite-input");
       const input = await page.find("calcite-input >>> input");
       await calciteInput.callMethod("setFocus");
-
-      for (let i = 0; i < numberKeys.length; i++) {
-        await page.keyboard.down("Shift");
-        await page.keyboard.press(numberKeys[i] as KeyInput);
-        await page.keyboard.up("Shift");
-        expect(await calciteInput.getProperty("value")).toBeFalsy();
-        expect(await input.getProperty("value")).toBeFalsy();
-      }
       const nonELetterKeys = letterKeys.filter((key) => key !== "e");
       for (let i = 0; i < nonELetterKeys.length; i++) {
         await page.keyboard.down("Shift");

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -1055,7 +1055,7 @@ describe("calcite-input", () => {
       expect(Number(await element.getProperty("value"))).toBe(195);
     });
 
-    it("disallows typing any characters with shift modifier key down", async () => {
+    it("disallows typing any non-numeric characters with shift modifier key down", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-input type="number"></calcite-input>`);
       const calciteInput = await page.find("calcite-input");
@@ -1071,8 +1071,7 @@ describe("calcite-input", () => {
       }
     });
 
-    // refer to issue here https://github.com/Esri/calcite-components/issues/6854
-    it("allows typing numbers with shift modifier key down", async () => {
+    it("allows typing numeric characters with shift modifier key down (#6854)", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-input type="number"></calcite-input>`);
       const calciteInput = await page.find("calcite-input");

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -11,7 +11,7 @@ import {
   t9n
 } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { letterKeys } from "../../utils/key";
+import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 import { getElementXY, selectText } from "../../tests/utils";
 import { KeyInput } from "puppeteer";
@@ -1068,6 +1068,26 @@ describe("calcite-input", () => {
         await page.keyboard.up("Shift");
         expect(await calciteInput.getProperty("value")).toBeFalsy();
         expect(await input.getProperty("value")).toBeFalsy();
+      }
+    });
+
+    // refer to issue here https://github.com/Esri/calcite-components/issues/6854
+    it("allows typing numbers with shift modifier key down", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input type="number"></calcite-input>`);
+      const calciteInput = await page.find("calcite-input");
+      const input = await page.find("calcite-input >>> input");
+      await calciteInput.callMethod("setFocus");
+      const numberKeysExcludingZero = numberKeys.slice(1);
+
+      let result = "";
+      for (let i = 0; i < numberKeysExcludingZero.length; i++) {
+        await page.keyboard.down("Shift");
+        await page.keyboard.press(numberKeysExcludingZero[i] as KeyInput);
+        result += numberKeysExcludingZero[i];
+        await page.keyboard.up("Shift");
+        expect(await calciteInput.getProperty("value")).toBe(result);
+        expect(await input.getProperty("value")).toBe(result);
       }
     });
 

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -790,6 +790,12 @@ export class Input
       }
       return;
     }
+
+    // identifies French AZERTY keyboard input
+    if (numberKeys.includes(event.key) && event.shiftKey) {
+      return;
+    }
+
     numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -784,15 +784,10 @@ export class Input
       return;
     }
     const isShiftTabEvent = event.shiftKey && event.key === "Tab";
-    if (supportedKeys.includes(event.key) && (!event.shiftKey || isShiftTabEvent)) {
+    if (supportedKeys.includes(event.key) || isShiftTabEvent) {
       if (event.key === "Enter") {
         this.emitChangeIfUserModified();
       }
-      return;
-    }
-
-    // identifies French AZERTY keyboard input
-    if (numberKeys.includes(event.key) && event.shiftKey) {
       return;
     }
 

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -790,7 +790,6 @@ export class Input
       }
       return;
     }
-
     numberStringFormatter.numberFormatOptions = {
       locale: this.effectiveLocale,
       numberingSystem: this.numberingSystem,


### PR DESCRIPTION
**Related Issue:** #6854 

## Summary

This PR will support French AZERTY keyboard layout in `calcite-input` & `calcite-input-number`