### PR TITLE
ci(release-please): pin action version and allow manually running action

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -1,5 +1,6 @@
 name: Deploy Latest
 on:
+  workflow_dispatch:
   push:
     branches: [master]
 permissions:
@@ -9,7 +10,7 @@ jobs:
   release-please:
     runs-on: ubuntu-20.04
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v3.7.9
         id: release
         with:
           command: manifest
@@ -22,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.ADMIN_TOKEN }}
-          ref: release-please
+          ref: master
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
**Related Issue:** #

## Summary
The release-please action randomly started failing 3 days ago with this [unhelpful error](https://github.com/Esri/calcite-components/actions/runs/5360304923/jobs/9725004712#step:2:234). It looks like they [released 3 days ago](https://github.com/google-github-actions/release-please-action/releases/tag/v3.7.10), so I'm pinning the version to the one before that and hoping it will fix it. 

I also added the [`workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) trigger so we can run the action manually.