### PR TITLE
ci: hardcode release version due to reverting feat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43876,7 +43876,7 @@
     },
     "packages/calcite-components": {
       "name": "@esri/calcite-components",
-      "version": "1.5.0-next.5",
+      "version": "1.4.3-next.7",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@floating-ui/dom": "1.4.1",
@@ -43902,10 +43902,10 @@
     },
     "packages/calcite-components-react": {
       "name": "@esri/calcite-components-react",
-      "version": "1.5.0-next.5",
+      "version": "1.4.3-next.7",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-components": "^1.5.0-next.5"
+        "@esri/calcite-components": "1.4.3-next.7"
       },
       "peerDependencies": {
         "react": ">=16.7",
@@ -45740,7 +45740,7 @@
     "@esri/calcite-components-react": {
       "version": "file:packages/calcite-components-react",
       "requires": {
-        "@esri/calcite-components": "^1.5.0-next.5"
+        "@esri/calcite-components": "1.4.3-next.7"
       }
     },
     "@esri/calcite-design-tokens": {

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@esri/calcite-components-react",
   "sideEffects": false,
-  "version": "1.5.0-next.5",
+  "version": "1.4.3-next.7",
   "description": "A set of React components that wrap calcite components",
   "license": "SEE LICENSE.md",
   "scripts": {
@@ -17,7 +17,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@esri/calcite-components": "^1.5.0-next.5"
+    "@esri/calcite-components": "1.4.3-next.7"
   },
   "peerDependencies": {
     "react": ">=16.7",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "1.5.0-next.5",
+  "version": "1.4.3-next.7",
   "description": "Web Components for Esri's Calcite Design System.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,10 +7,12 @@
   "packages": {
     "packages/calcite-components": {
       "component": "@esri/calcite-components",
-      "extra-files": ["readme.md"]
+      "extra-files": ["readme.md"],
+      "release-as": "1.4.3"
     },
     "packages/calcite-components-react": {
-      "component": "@esri/calcite-components-react"
+      "component": "@esri/calcite-components-react",
+      "release-as": "1.4.3"
     }
   },
   "plugins": [


### PR DESCRIPTION
**Related Issue:** #7222

## Summary
Pinning the `release-please` Github Action version in the PR above fixed the error, so their release must have broken something for us. `release-please` is trying to release `v1.5.0` instead of `v1.4.3` because we installed a feat and subsequently reverted it, but our current version is still `1.5.0-next.5`. 

[The logs](https://github.com/Esri/calcite-components/actions/runs/5383995298/jobs/9771404018#step:2:102) say it's skipping the conventional commit versioning strategy and forcing `1.5.0`. I'm hoping I can force `1.4.3` instead, as described in their [manifest doc](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile). If this doesn't work I may need to change the package.json versions back to `1.4.3-next.7`.