### PR TITLE
ci: double build cc when publishing to workaround stencil types bug

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -34,7 +34,7 @@
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\" >/dev/null",
     "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
     "posttest": "npm run test:prerender",
-    "prepublishOnly": "npm run build && npm run util:test-types",
+    "prepublishOnly": "./support/stencilDoubleBuildTypesWorkaround.sh",
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",
     "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\" \"ts-node --esm ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
     "test": "stencil test --no-docs --no-build --spec --e2e",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -34,6 +34,7 @@
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\" >/dev/null",
     "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
     "posttest": "npm run test:prerender",
+    "prepublishOnly": "npm run build && npm run util:test-types",
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",
     "start": "concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\" \"ts-node --esm ./support/cleanOnProcessExit.ts --path ./src/demos/**/*.js \"",
     "test": "stencil test --no-docs --no-build --spec --e2e",

--- a/packages/calcite-components/support/stencilDoubleBuildTypesWorkaround.sh
+++ b/packages/calcite-components/support/stencilDoubleBuildTypesWorkaround.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+# This script builds the stencil components and ensures
+# the types are generated correctly as a workaround for
+# https://github.com/ionic-team/stencil/issues/3239
+#
+# It runs in the prepublishOnly NPM script hook
+# to prevent releasing with type bugs, and because
+# it needs to execute after versioning so that the
+# preamble in the dist source code is correct.
+#
+# Refs:
+# https://github.com/lerna/lerna/blob/main/libs/commands/publish/README.md#lifecycle-scripts
+# https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts
+# https://github.com/Esri/calcite-components/pull/4303
+npm run build
+npm run util:test-types


### PR DESCRIPTION
**Related Issue:** #

## Summary

Add a `prepublishOnly` npm script hook to calcite-components, which builds and makes sure the types aren't broken. In addition to the Stencil bug, Calcite Components also needs to be built after versioning so that the preamble is correct. It has been [a version behind in `next` releases](https://unpkg.com/browse/@esri/calcite-components@1.5.0-next.5/dist/calcite/calcite.esm.js). 

ref: https://github.com/lerna/lerna/tree/main/libs/commands/publish#lifecycle-scripts