### PR TITLE
refactor(floating-ui): apply composed getOffsetParent consistently

### DIFF
--- a/packages/calcite-components/src/utils/browser.ts
+++ b/packages/calcite-components/src/utils/browser.ts
@@ -4,7 +4,7 @@ interface NavigatorUAData {
   platform: string;
 }
 
-export function getUserAgentData(): NavigatorUAData | undefined {
+function getUserAgentData(): NavigatorUAData | undefined {
   return (navigator as any).userAgentData;
 }
 

--- a/packages/calcite-components/src/utils/config.ts
+++ b/packages/calcite-components/src/utils/config.ts
@@ -7,14 +7,6 @@
 const configOverrides = globalThis["calciteComponentsConfig"];
 
 const config = {
-  /**
-   * We apply a custom fix to improve positioning for non-Chromium browsers.
-   * The fix comes at a performance cost, so provides users a way to opt-out if necessary.
-   *
-   * @internal
-   */
-  floatingUINonChromiumPositioningFix: true,
-
   ...configOverrides
 };
 

--- a/packages/calcite-components/src/utils/floating-ui.spec.ts
+++ b/packages/calcite-components/src/utils/floating-ui.spec.ts
@@ -16,22 +16,6 @@ const {
   repositionDebounceTimeout
 } = floatingUI;
 
-import * as floatingUIDOM from "@floating-ui/dom";
-
-(floatingUIDOM as any).computePosition = async (_: HTMLElement, floatingEl: HTMLElement) => {
-  floatingEl.style.transform = "some value";
-  floatingEl.style.top = "0";
-  floatingEl.style.left = "0";
-
-  return {
-    x: 0,
-    y: 0,
-    placement: "bottom",
-    strategy: "absolute",
-    middlewareData: {}
-  };
-};
-
 it("should set calcite placement to FloatingUI placement", () => {
   const el = document.createElement("div");
 

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -16,42 +16,16 @@ import {
 } from "@floating-ui/dom";
 import { Build } from "@stencil/core";
 import { debounce, DebouncedFunc } from "lodash-es";
-import { config } from "./config";
 import { getElementDir } from "./dom";
 import { Layout } from "../components/interfaces";
-import { getUserAgentData, getUserAgentString } from "./browser";
+import { offsetParent } from "composed-offset-position";
 
-const floatingUIBrowserCheck = patchFloatingUiForNonChromiumBrowsers();
-
-function isChrome109OrAbove(): boolean {
-  const uaData = getUserAgentData();
-
-  if (uaData?.brands) {
-    return !!uaData.brands.find(
-      ({ brand, version }) => (brand === "Google Chrome" || brand === "Chromium") && Number(version) >= 109
-    );
-  }
-
-  return !!navigator.userAgent.split(" ").find((ua) => {
-    const [browser, version] = ua.split("/");
-
-    return browser === "Chrome" && parseInt(version) >= 109;
-  });
-}
-
-async function patchFloatingUiForNonChromiumBrowsers(): Promise<void> {
-  if (
-    Build.isBrowser &&
-    config.floatingUINonChromiumPositioningFix &&
-    // ⚠️ browser-sniffing is not a best practice and should be avoided ⚠️
-    (/firefox|safari/i.test(getUserAgentString()) || isChrome109OrAbove())
-  ) {
-    const { offsetParent } = await import("composed-offset-position");
-
+(function setUpFloatingUiForShadowDomPositioning(): void {
+  if (Build.isBrowser) {
     const originalGetOffsetParent = platform.getOffsetParent;
     platform.getOffsetParent = (element: Element) => originalGetOffsetParent(element, offsetParent);
   }
-}
+})();
 
 /**
  * Positions the floating element relative to the reference element.
@@ -122,8 +96,6 @@ export const positionFloatingUI =
     if (!referenceEl || !floatingEl) {
       return null;
     }
-
-    await floatingUIBrowserCheck;
 
     const {
       x,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

We no longer need to check for Chromium 109+ before applying `getOffsetParent` ponyfill since our supported Chrome versions are now 113 & 114.

**Note**: this also removes internal config flag to bypass the custom logic to handle positioning across shadow DOM (no longer an issue as the ponyfill does not impact performance).