### PR TITLE
feat(flow-item): Focus the first tabbable element within setFocus method

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -11,7 +11,7 @@ import {
   VNode,
   Watch
 } from "@stencil/core";
-import { getElementDir } from "../../utils/dom";
+import { focusFirstTabbable, getElementDir } from "../../utils/dom";
 import {
   connectInteractive,
   disconnectInteractive,
@@ -214,15 +214,7 @@ export class FlowItem
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);
-
-    const { backButtonEl, containerEl } = this;
-
-    if (backButtonEl) {
-      backButtonEl.setFocus();
-      return;
-    }
-
-    containerEl?.setFocus();
+    focusFirstTabbable(this.el);
   }
 
   /**

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -214,6 +214,13 @@ export class FlowItem
   @Method()
   async setFocus(): Promise<void> {
     await componentLoaded(this);
+
+    const { backButtonEl } = this;
+
+    if (backButtonEl) {
+      return backButtonEl.setFocus();
+    }
+
     focusFirstTabbable(this.el);
   }
 


### PR DESCRIPTION
**Related Issue:** #6400 #5369

## Summary

- Updates flow-item setFocus method to use tabbable to find first focusable element and focus it.
- The benefit here is that it will focus elements within the flow-item if the back button isn't present.