### PR TITLE
fix(tooltip): emits `close` and `beforeClose` events when container is set to `display:none`

### DIFF
--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -25,11 +25,7 @@ import {
   reposition
 } from "../../utils/floating-ui";
 import { guid } from "../../utils/guid";
-import {
-  connectOpenCloseComponent,
-  disconnectOpenCloseComponent,
-  OpenCloseComponent
-} from "../../utils/openCloseComponent";
+import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { ARIA_DESCRIBED_BY, CSS } from "./resources";
 
 import TooltipManager from "./TooltipManager";
@@ -92,6 +88,7 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
 
   @Watch("open")
   openHandler(value: boolean): void {
+    onToggleOpenCloseComponent(this);
     if (value) {
       this.reposition(true);
     }
@@ -165,8 +162,14 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    connectOpenCloseComponent(this);
     this.setUpReferenceElement(this.hasLoaded);
+  }
+
+  async componentWillLoad(): Promise<void> {
+    // when modal initially renders, if active was set we need to open as watcher doesn't fire
+    if (this.open) {
+      onToggleOpenCloseComponent(this);
+    }
   }
 
   componentDidLoad(): void {
@@ -180,7 +183,6 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
   disconnectedCallback(): void {
     this.removeReferences();
     disconnectFloatingUI(this, this.effectiveReferenceElement, this.el);
-    disconnectOpenCloseComponent(this);
   }
 
   //--------------------------------------------------------------------------
@@ -264,7 +266,6 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
 
   private setTransitionEl = (el): void => {
     this.transitionEl = el;
-    connectOpenCloseComponent(this);
   };
 
   setUpReferenceElement = (warn = true): void => {

--- a/packages/calcite-components/src/demos/tooltip.html
+++ b/packages/calcite-components/src/demos/tooltip.html
@@ -45,16 +45,46 @@
       <div class="parent">
         <div class="child right-aligned-text">auto</div>
 
-        <div class="child">
-          <calcite-button appearance="outline" id="tooltip-auto-ref">auto</calcite-button>
+        <div>
+          <div class="container">
+            <div class="template">
+              <calcite-link id="tooltip-button">Hover for Tooltip</calcite-link>
+              <calcite-tooltip label="Example label" reference-element="tooltip-button" id="actualTestCase">
+                <span>Tooltip content lorem ipsum</span>
+              </calcite-tooltip>
+            </div>
+          </div>
         </div>
 
         <div class="child">
-          <calcite-button appearance="outline" id="tooltip-auto-start-ref">auto-start</calcite-button>
-        </div>
-        <div class="child">
           <calcite-button appearance="outline" id="tooltip-auto-end-ref">auto-end</calcite-button>
         </div>
+        <style>
+          .container {
+            border: 1px solid red;
+            height: 33vh;
+            min-height: 1.5em;
+          }
+
+          .container:hover .template {
+            display: initial;
+          }
+
+          .template {
+            display: none;
+          }
+        </style>
+        <script>
+          const tooltip = document.getElementById("actualTestCase");
+
+          tooltip.addEventListener("calciteTooltipBeforeClose", () => {
+            console.log("calciteTooltipBeforeClose");
+          });
+
+          tooltip.addEventListener("calciteTooltipClose", () => {
+            console.log("calciteTooltipClose");
+          });
+        </script>
       </div>
 
       <!-- top, top-start, top-end -->
@@ -190,7 +220,7 @@
 
       <!-- containers to hold the tooltip -->
       <div>
-        <calcite-tooltip placement="auto" reference-element="tooltip-auto-ref">
+        <calcite-tooltip placement="auto" reference-element="tooltip-auto-ref" id="testing">
           <p>placement: auto</p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
           magna aliqua.

--- a/packages/calcite-components/src/utils/openCloseComponent.ts
+++ b/packages/calcite-components/src/utils/openCloseComponent.ts
@@ -77,18 +77,16 @@ export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpe
   readTask((): void => {
     if (component.transitionEl) {
       const allTransitionPropsArray = getComputedStyle(component.transitionEl).transition.split(" ");
+      const visibility = getComputedStyle(component.transitionEl).visibility;
+      const display = getComputedStyle(component.transitionEl).display;
+      console.log("visibility", visibility);
+      console.log("display", display);
+
       const openTransitionPropIndex = allTransitionPropsArray.findIndex(
         (item) => item === component.openTransitionProp
       );
-      const transitionDuration = allTransitionPropsArray[openTransitionPropIndex + 1];
-      if (transitionDuration === "0s") {
-        (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
-          ? component.onBeforeOpen()
-          : component.onBeforeClose();
-        (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
-          ? component.onOpen()
-          : component.onClose();
-      } else {
+      const transitionDuration = Number(allTransitionPropsArray[openTransitionPropIndex + 1].replace(/^\D+/g, ""));
+      if (transitionDuration > 0) {
         component.transitionEl.addEventListener(
           "transitionstart",
           () => {
@@ -107,6 +105,13 @@ export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpe
           },
           { once: true }
         );
+      } else {
+        (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
+          ? component.onBeforeOpen()
+          : component.onBeforeClose();
+        (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
+          ? component.onOpen()
+          : component.onClose();
       }
     }
   });


### PR DESCRIPTION
**Related Issue:** #6279

## Summary
The `transitionend` event is fired when a transition has been completed. In the case where a transition is removed before completion, such as if the transition property is removed or `display` is set to `none`, then the event will not be generated.

This PR implements a more recent implementation of the `openCloseComponent interface` with the `onToggleOpenCloseComponent` function import, modified to emit in all cases where there is no transition happening.

An alternate solution is to call getComputedStyle():
`if (transitionDuration === "0s" || window.getComputedStyle(component.el).visibility === "hidden")`


For context, here is what the difference why it works with `visibility: hidden`, but not `display: none`:

`visibility: hidden`: the element is not visible but still takes up space in the layout. The element is rendered with transparent content, and it can still undergo opacity transitions. 
See it working here: https://codepen.io/elijbet/pen/wvQdyxw?editors=1111

`display: none`: the element is not rendered at all, and it does not take up any space in the layout. This means that the element cannot undergo any transitions, including opacity transitions. Since the element is not present in the layout, transition events related to `opacity`, such as `transitionend`, will not be fired.


