### PR TITLE
ci: modify ready for dev label name

### DIFF
--- a/.github/workflows/ready-for-dev.yml
+++ b/.github/workflows/ready-for-dev.yml
@@ -1,4 +1,4 @@
-# When the "ready-for-dev" label is added to an issue:
+# When the "ready for dev" label is added to an issue:
 # 1. Modifies the labels,
 # 2. Updates the assignees and milestone, and
 # 3. Generates a notification to the Calcite project manager(s)
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ready-for-dev:
-    if: github.event.label.name == 'ready-for-dev'
+    if: github.event.label.name == 'ready for dev'
     permissions:
       issues: write
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
             const { managers } = process.env;
             const { label } = context.payload;
 
-            if (label && label.name === "ready-for-dev") {
+            if (label && label.name === "ready for dev") {
 
               // Add a "@" character to notify the user
               const calcite_managers = managers.split(",").map(v => " @" + v.trim());


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates the ready for dev workflow in removing the dashes `-` in the `ready for dev` label for readability. 

Once merged in will update the label to reflect the spaces ` `. 
