### PR TITLE
ci(eslint): disable eslint rules that are failing

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -50,6 +50,9 @@ module.exports = {
     "@stencil-community/prefer-vdom-listener": "warn",
     "@stencil-community/required-jsdoc": "off",
     "@stencil-community/strict-boolean-conditions": "off",
+    "@stencil-community/reserved-member-names": "off",
+    "@stencil-community/ban-exported-const-enums": "off",
+    "@typescript-eslint/no-duplicate-enum-values": "off",
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/explicit-module-boundary-types": [
       "error",


### PR DESCRIPTION
**Related Issue:** #8371

## Summary

Disables a few ESLint rules that we have errors for in Calcite Components. Franco asked me to disable them for now and create an issue for him to see if any can be resolved and re-enabled.

- `@typescript-eslint/no-duplicate-enum-values` - once [here](https://github.com/Esri/calcite-design-system/blob/81fab56c6e8a76623c3f0adcb3f9cde761f46b98/packages/calcite-components/src/components/resources.ts#L3-L6)
- `@stencil-community/reserved-member-names` - lots of places related to the `hidden` prop

- `@stencil-community/ban-exported-const-enums` a few places in `resource.ts` files e.g. [here](https://github.com/Esri/calcite-design-system/blob/81fab56c6e8a76623c3f0adcb3f9cde761f46b98/packages/calcite-components/src/components/resources.ts#L3-L6) and [here](https://github.com/Esri/calcite-design-system/blob/81fab56c6e8a76623c3f0adcb3f9cde761f46b98/packages/calcite-components/src/components/value-list/resources.ts#L5-L7)


You can reproduce the errors with:

```sh
npm --workspace=@esri/calcite-components run lint:ts
```