### PR TITLE
test(alert): Restore skipped test

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -29,11 +29,11 @@ describe("calcite-alert", () => {
     hidden("<calcite-alert open></calcite-alert>");
   });
 
-  describe.skip("accessible", () => {
+  describe("accessible", () => {
     accessible(html` <calcite-alert open label="test"> ${alertContent} </calcite-alert> `);
   });
 
-  describe.skip("accessible with auto-close", () => {
+  describe("accessible with auto-close", () => {
     accessible(html`
       <calcite-alert open auto-close auto-close-duration="slow" label="test"> ${alertContent} </calcite-alert>
     `);


### PR DESCRIPTION
**Related Issue:** #7748 

## Summary
This test no longer produces failures (at least locally). cc @driskull 