### PR TITLE
fix(semantic-tokens): provide sufficient warning color contrast across components

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
@@ -165,21 +165,21 @@
         },
         "warning": {
           "default": {
-            "value": "{core.color.dark.yellow.d-yy-420}",
+            "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "hover": {
-            "value": "{core.color.vibrant.yellow.v-yy-140}",
+            "value": "{core.color.vibrant.orange-yellow.v-oy-120}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "press": {
-            "value": "{core.color.vibrant.yellow.v-yy-160}",
+            "value": "{core.color.vibrant.orange-yellow.v-oy-140}",
             "type": "color",
             "category": "color"
           }

--- a/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
@@ -167,21 +167,21 @@
         },
         "warning": {
           "default": {
-            "value": "{core.color.high-saturation.yellow.h-yy-060}",
+            "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "hover": {
-            "value": "{core.color.high-saturation.yellow.h-yy-070}",
+            "value": "{core.color.vibrant.orange-yellow.v-oy-180}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "press": {
-            "value": "{core.color.high-saturation.yellow.h-yy-080}",
+            "value": "{core.color.high-saturation.orange-yellow.h-oy-080}",
             "type": "color",
             "attributes": {
               "category": "color"

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -920,9 +920,9 @@ exports[`generated tokens > CSS > dark should match 1`] = `
   --calcite-color-status-success: #36da43;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success-press: #00b81b;
-  --calcite-color-status-warning: #ffc900;
-  --calcite-color-status-warning-hover: #ffee33;
-  --calcite-color-status-warning-press: #f5d000;
+  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-hover: #ffb54d;
+  --calcite-color-status-warning-press: #ff9500;
   --calcite-color-status-danger: #fe583e;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger-press: #d90012;
@@ -1091,9 +1091,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #bfa200;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -1135,9 +1135,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-status-danger-press: #7c1d13;
     --calcite-color-status-danger-hover: #a82b1e;
     --calcite-color-status-danger: #d83020;
-    --calcite-color-status-warning-press: #bfa200;
-    --calcite-color-status-warning-hover: #d9bc00;
-    --calcite-color-status-warning: #edd317;
+    --calcite-color-status-warning-press: #9a5b10;
+    --calcite-color-status-warning-hover: #d17300;
+    --calcite-color-status-warning: #f89927;
     --calcite-color-status-success-press: #1a6324;
     --calcite-color-status-success-hover: #288835;
     --calcite-color-status-success: #35ac46;
@@ -1181,9 +1181,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-status-danger-press: #d90012;
     --calcite-color-status-danger-hover: #ff0015;
     --calcite-color-status-danger: #fe583e;
-    --calcite-color-status-warning-press: #f5d000;
-    --calcite-color-status-warning-hover: #ffee33;
-    --calcite-color-status-warning: #ffc900;
+    --calcite-color-status-warning-press: #ff9500;
+    --calcite-color-status-warning-hover: #ffb54d;
+    --calcite-color-status-warning: #f89927;
     --calcite-color-status-success-press: #00b81b;
     --calcite-color-status-success-hover: #3bed52;
     --calcite-color-status-success: #36da43;
@@ -1224,9 +1224,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #bfa200;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -1268,9 +1268,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
-  --calcite-color-status-warning-press: #f5d000;
-  --calcite-color-status-warning-hover: #ffee33;
-  --calcite-color-status-warning: #ffc900;
+  --calcite-color-status-warning-press: #ff9500;
+  --calcite-color-status-warning-hover: #ffb54d;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #00b81b;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success: #36da43;
@@ -1323,9 +1323,9 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-status-success: #35ac46;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success-press: #1a6324;
-  --calcite-color-status-warning: #edd317;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning-press: #bfa200;
+  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning-press: #9a5b10;
   --calcite-color-status-danger: #d83020;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger-press: #7c1d13;
@@ -29958,14 +29958,14 @@ export const calciteColorStatusSuccessPress = {
   light: "#1a6324",
   dark: "#00b81b",
 };
-export const calciteColorStatusWarning = { light: "#edd317", dark: "#ffc900" };
+export const calciteColorStatusWarning = "#f89927";
 export const calciteColorStatusWarningHover = {
-  light: "#d9bc00",
-  dark: "#ffee33",
+  light: "#d17300",
+  dark: "#ffb54d",
 };
 export const calciteColorStatusWarningPress = {
-  light: "#bfa200",
-  dark: "#f5d000",
+  light: "#9a5b10",
+  dark: "#ff9500",
 };
 export const calciteColorStatusDanger = { light: "#d83020", dark: "#fe583e" };
 export const calciteColorStatusDangerHover = {
@@ -30428,7 +30428,7 @@ export const calciteColorStatusInfoPress: { light: string; dark: string };
 export const calciteColorStatusSuccess: { light: string; dark: string };
 export const calciteColorStatusSuccessHover: { light: string; dark: string };
 export const calciteColorStatusSuccessPress: { light: string; dark: string };
-export const calciteColorStatusWarning: { light: string; dark: string };
+export const calciteColorStatusWarning: string;
 export const calciteColorStatusWarningHover: { light: string; dark: string };
 export const calciteColorStatusWarningPress: { light: string; dark: string };
 export const calciteColorStatusDanger: { light: string; dark: string };
@@ -68637,9 +68637,9 @@ $calcite-color-status-info-press: #009af2;
 $calcite-color-status-success: #36da43;
 $calcite-color-status-success-hover: #3bed52;
 $calcite-color-status-success-press: #00b81b;
-$calcite-color-status-warning: #ffc900;
-$calcite-color-status-warning-hover: #ffee33;
-$calcite-color-status-warning-press: #f5d000;
+$calcite-color-status-warning: #f89927;
+$calcite-color-status-warning-hover: #ffb54d;
+$calcite-color-status-warning-press: #ff9500;
 $calcite-color-status-danger: #fe583e;
 $calcite-color-status-danger-hover: #ff0015;
 $calcite-color-status-danger-press: #d90012;
@@ -68805,9 +68805,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #bfa200;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -68849,9 +68849,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
-  --calcite-color-status-warning-press: #f5d000;
-  --calcite-color-status-warning-hover: #ffee33;
-  --calcite-color-status-warning: #ffc900;
+  --calcite-color-status-warning-press: #ff9500;
+  --calcite-color-status-warning-hover: #ffb54d;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #00b81b;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success: #36da43;
@@ -68902,9 +68902,9 @@ $calcite-color-status-info-press: #00304d;
 $calcite-color-status-success: #35ac46;
 $calcite-color-status-success-hover: #288835;
 $calcite-color-status-success-press: #1a6324;
-$calcite-color-status-warning: #edd317;
-$calcite-color-status-warning-hover: #d9bc00;
-$calcite-color-status-warning-press: #bfa200;
+$calcite-color-status-warning: #f89927;
+$calcite-color-status-warning-hover: #d17300;
+$calcite-color-status-warning-press: #9a5b10;
 $calcite-color-status-danger: #d83020;
 $calcite-color-status-danger-hover: #a82b1e;
 $calcite-color-status-danger-press: #7c1d13;

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -18211,7 +18211,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.success.press}"
     },
     {
-      "value": "{\\"light\\":\\"#edd317\\",\\"dark\\":\\"#ffc900\\"}",
+      "value": "#f89927",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18239,7 +18239,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.warning.default}"
     },
     {
-      "value": "{\\"light\\":\\"#d9bc00\\",\\"dark\\":\\"#ffee33\\"}",
+      "value": "{\"light\":\"#d17300\",\"dark\":\"#ffb54d\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18267,7 +18267,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.warning.hover}"
     },
     {
-      "value": "{\\"light\\":\\"#bfa200\\",\\"dark\\":\\"#f5d000\\"}",
+      "value": "{\"light\":\"#9a5b10\",\"dark\":\"#ff9500\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -53663,10 +53663,7 @@ export default {
         },
         warning: {
           default: {
-            value: {
-              light: "#edd317",
-              dark: "#ffc900",
-            },
+            value: "#f89927",
             type: "color",
             attributes: {
               category: "color",
@@ -53702,8 +53699,8 @@ export default {
           },
           hover: {
             value: {
-              light: "#d9bc00",
-              dark: "#ffee33",
+              light: "#d17300",
+              dark: "#ffb54d",
             },
             type: "color",
             attributes: {
@@ -53740,8 +53737,8 @@ export default {
           },
           press: {
             value: {
-              light: "#bfa200",
-              dark: "#f5d000",
+              light: "#9a5b10",
+              dark: "#ff9500",
             },
             type: "color",
             attributes: {

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -53690,7 +53690,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.yellow.h-yy-060}",
+              value: "{core.color.high-saturation.orange-yellow.h-oy-060}",
               type: "color",
               attributes: {
                 category: "color",
@@ -53728,7 +53728,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.yellow.h-yy-070}",
+              value: "{core.color.vibrant.orange-yellow.v-oy-180}",
               type: "color",
               attributes: {
                 category: "color",
@@ -53766,7 +53766,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.yellow.h-yy-080}",
+              value: "{core.color.high-saturation.orange-yellow.h-oy-080}",
               type: "color",
               attributes: {
                 category: "color",

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -920,9 +920,9 @@ exports[`generated tokens > CSS > dark should match 1`] = `
   --calcite-color-status-success: #36da43;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success-press: #00b81b;
-  --calcite-color-status-warning: #f89927;
-  --calcite-color-status-warning-hover: #ffb54d;
-  --calcite-color-status-warning-press: #ff9500;
+  --calcite-color-status-warning: #ffc900;
+  --calcite-color-status-warning-hover: #ffee33;
+  --calcite-color-status-warning-press: #f5d000;
   --calcite-color-status-danger: #fe583e;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger-press: #d90012;
@@ -1091,9 +1091,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #9a5b10;
-  --calcite-color-status-warning-hover: #d17300;
-  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-press: #bfa200;
+  --calcite-color-status-warning-hover: #d9bc00;
+  --calcite-color-status-warning: #edd317;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -1135,9 +1135,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-status-danger-press: #7c1d13;
     --calcite-color-status-danger-hover: #a82b1e;
     --calcite-color-status-danger: #d83020;
-    --calcite-color-status-warning-press: #9a5b10;
-    --calcite-color-status-warning-hover: #d17300;
-    --calcite-color-status-warning: #f89927;
+    --calcite-color-status-warning-press: #bfa200;
+    --calcite-color-status-warning-hover: #d9bc00;
+    --calcite-color-status-warning: #edd317;
     --calcite-color-status-success-press: #1a6324;
     --calcite-color-status-success-hover: #288835;
     --calcite-color-status-success: #35ac46;
@@ -1181,9 +1181,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-status-danger-press: #d90012;
     --calcite-color-status-danger-hover: #ff0015;
     --calcite-color-status-danger: #fe583e;
-    --calcite-color-status-warning-press: #ff9500;
-    --calcite-color-status-warning-hover: #ffb54d;
-    --calcite-color-status-warning: #f89927;
+    --calcite-color-status-warning-press: #f5d000;
+    --calcite-color-status-warning-hover: #ffee33;
+    --calcite-color-status-warning: #ffc900;
     --calcite-color-status-success-press: #00b81b;
     --calcite-color-status-success-hover: #3bed52;
     --calcite-color-status-success: #36da43;
@@ -1224,9 +1224,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #9a5b10;
-  --calcite-color-status-warning-hover: #d17300;
-  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-press: #bfa200;
+  --calcite-color-status-warning-hover: #d9bc00;
+  --calcite-color-status-warning: #edd317;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -1268,9 +1268,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
-  --calcite-color-status-warning-press: #ff9500;
-  --calcite-color-status-warning-hover: #ffb54d;
-  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-press: #f5d000;
+  --calcite-color-status-warning-hover: #ffee33;
+  --calcite-color-status-warning: #ffc900;
   --calcite-color-status-success-press: #00b81b;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success: #36da43;
@@ -1323,9 +1323,9 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-status-success: #35ac46;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success-press: #1a6324;
-  --calcite-color-status-warning: #f89927;
-  --calcite-color-status-warning-hover: #d17300;
-  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-hover: #d9bc00;
+  --calcite-color-status-warning-press: #bfa200;
   --calcite-color-status-danger: #d83020;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger-press: #7c1d13;
@@ -18211,7 +18211,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.success.press}"
     },
     {
-      "value": "#f89927",
+      "value": "{\\"light\\":\\"#edd317\\",\\"dark\\":\\"#ffc900\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18239,7 +18239,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.warning.default}"
     },
     {
-      "value": "{\"light\":\"#d17300\",\"dark\":\"#ffb54d\"}",
+      "value": "{\\"light\\":\\"#d9bc00\\",\\"dark\\":\\"#ffee33\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18267,7 +18267,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.warning.hover}"
     },
     {
-      "value": "{\"light\":\"#9a5b10\",\"dark\":\"#ff9500\"}",
+      "value": "{\\"light\\":\\"#bfa200\\",\\"dark\\":\\"#f5d000\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -29958,14 +29958,14 @@ export const calciteColorStatusSuccessPress = {
   light: "#1a6324",
   dark: "#00b81b",
 };
-export const calciteColorStatusWarning = "#f89927";
+export const calciteColorStatusWarning = { light: "#edd317", dark: "#ffc900" };
 export const calciteColorStatusWarningHover = {
-  light: "#d17300",
-  dark: "#ffb54d",
+  light: "#d9bc00",
+  dark: "#ffee33",
 };
 export const calciteColorStatusWarningPress = {
-  light: "#9a5b10",
-  dark: "#ff9500",
+  light: "#bfa200",
+  dark: "#f5d000",
 };
 export const calciteColorStatusDanger = { light: "#d83020", dark: "#fe583e" };
 export const calciteColorStatusDangerHover = {
@@ -30428,7 +30428,7 @@ export const calciteColorStatusInfoPress: { light: string; dark: string };
 export const calciteColorStatusSuccess: { light: string; dark: string };
 export const calciteColorStatusSuccessHover: { light: string; dark: string };
 export const calciteColorStatusSuccessPress: { light: string; dark: string };
-export const calciteColorStatusWarning: string;
+export const calciteColorStatusWarning: { light: string; dark: string };
 export const calciteColorStatusWarningHover: { light: string; dark: string };
 export const calciteColorStatusWarningPress: { light: string; dark: string };
 export const calciteColorStatusDanger: { light: string; dark: string };
@@ -53663,7 +53663,10 @@ export default {
         },
         warning: {
           default: {
-            value: "#f89927",
+            value: {
+              light: "#edd317",
+              dark: "#ffc900",
+            },
             type: "color",
             attributes: {
               category: "color",
@@ -53687,7 +53690,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.orange-yellow.h-oy-060}",
+              value: "{core.color.high-saturation.yellow.h-yy-060}",
               type: "color",
               attributes: {
                 category: "color",
@@ -53699,8 +53702,8 @@ export default {
           },
           hover: {
             value: {
-              light: "#d17300",
-              dark: "#ffb54d",
+              light: "#d9bc00",
+              dark: "#ffee33",
             },
             type: "color",
             attributes: {
@@ -53725,7 +53728,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.vibrant.orange-yellow.v-oy-180}",
+              value: "{core.color.high-saturation.yellow.h-yy-070}",
               type: "color",
               attributes: {
                 category: "color",
@@ -53737,8 +53740,8 @@ export default {
           },
           press: {
             value: {
-              light: "#9a5b10",
-              dark: "#ff9500",
+              light: "#bfa200",
+              dark: "#f5d000",
             },
             type: "color",
             attributes: {
@@ -53763,7 +53766,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.orange-yellow.h-oy-080}",
+              value: "{core.color.high-saturation.yellow.h-yy-080}",
               type: "color",
               attributes: {
                 category: "color",
@@ -68634,9 +68637,9 @@ $calcite-color-status-info-press: #009af2;
 $calcite-color-status-success: #36da43;
 $calcite-color-status-success-hover: #3bed52;
 $calcite-color-status-success-press: #00b81b;
-$calcite-color-status-warning: #f89927;
-$calcite-color-status-warning-hover: #ffb54d;
-$calcite-color-status-warning-press: #ff9500;
+$calcite-color-status-warning: #ffc900;
+$calcite-color-status-warning-hover: #ffee33;
+$calcite-color-status-warning-press: #f5d000;
 $calcite-color-status-danger: #fe583e;
 $calcite-color-status-danger-hover: #ff0015;
 $calcite-color-status-danger-press: #d90012;
@@ -68802,9 +68805,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #9a5b10;
-  --calcite-color-status-warning-hover: #d17300;
-  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-press: #bfa200;
+  --calcite-color-status-warning-hover: #d9bc00;
+  --calcite-color-status-warning: #edd317;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -68846,9 +68849,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
-  --calcite-color-status-warning-press: #ff9500;
-  --calcite-color-status-warning-hover: #ffb54d;
-  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-press: #f5d000;
+  --calcite-color-status-warning-hover: #ffee33;
+  --calcite-color-status-warning: #ffc900;
   --calcite-color-status-success-press: #00b81b;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success: #36da43;
@@ -68899,9 +68902,9 @@ $calcite-color-status-info-press: #00304d;
 $calcite-color-status-success: #35ac46;
 $calcite-color-status-success-hover: #288835;
 $calcite-color-status-success-press: #1a6324;
-$calcite-color-status-warning: #f89927;
-$calcite-color-status-warning-hover: #d17300;
-$calcite-color-status-warning-press: #9a5b10;
+$calcite-color-status-warning: #edd317;
+$calcite-color-status-warning-hover: #d9bc00;
+$calcite-color-status-warning-press: #bfa200;
 $calcite-color-status-danger: #d83020;
 $calcite-color-status-danger-hover: #a82b1e;
 $calcite-color-status-danger-press: #7c1d13;


### PR DESCRIPTION
**Related Issue:** [#7798](https://github.com/Esri/calcite-design-system/issues/7798)

## Summary
Update the following semantic tokens to resolve contrast issues:

LIGHT MODE
status/warning/default → `color/high-saturation/orange-yellow/h-oy-060`
status/warning/hover → `color/vibrant/orange-yellow/v-oy-180`
status/warning/press → `color/high-saturation/orange-yellow/h-oy-080`

DARK MODE
status/warning/default → `color/high-saturation/orange-yellow/h-oy-060`
status/warning/hover → `color/vibrant/orange-yellow/v-oy-120`
status/warning/press → `color/vibrant/orange-yellow/v-oy-140`