### PR TITLE
fix(color-picker): fix initial setting of alpha object color values

### DIFF
--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -252,6 +252,20 @@ describe("calcite-color-picker", () => {
     expect(inputSpy.length).toBe(previousInputEventLength);
   });
 
+  it("allows setting color object on initialization", async () => {
+    const page = await newProgrammaticE2EPage();
+    await page.evaluate((rgbaValue) => {
+      const picker = document.createElement("calcite-color-picker");
+      picker.alphaChannel = true;
+      picker.value = rgbaValue;
+      document.body.append(picker);
+    }, supportedAlphaFormatToSampleValue.rgba);
+    await page.waitForChanges();
+
+    const picker = await page.find("calcite-color-picker");
+    expect(await picker.getProperty("value")).toEqual(supportedAlphaFormatToSampleValue.rgba);
+  });
+
   it("increments channel's value by 1 when clearing input and pressing ArrowUp. Same should apply to other channel inputs", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-color-picker></calcite-color-picker>");

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -426,7 +426,11 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
     const parsedMode = parseMode(value);
     const valueIsCompatible =
       willSetNoColor || (format === "auto" && parsedMode) || format === parsedMode;
-    const initialColor = willSetNoColor ? null : valueIsCompatible ? Color(value) : color;
+    const initialColor = willSetNoColor
+      ? null
+      : valueIsCompatible
+        ? this.colorFromValue(value, isClearable, parsedMode)
+        : color;
 
     if (!valueIsCompatible) {
       this.showIncompatibleColorWarning(value, format);
@@ -585,14 +589,7 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
       return;
     }
 
-    const color =
-      isClearable && !value
-        ? null
-        : Color(
-            value != null && typeof value === "object" && alphaCompatible(this.mode)
-              ? normalizeColor(value as RGBA | HSVA | HSLA)
-              : value,
-          );
+    const color = this.colorFromValue(value, isClearable, this.mode);
     const colorChanged = !colorEqual(color, this.color);
 
     if (modeChanged || colorChanged) {
@@ -603,6 +600,22 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
         "internal",
       );
     }
+  }
+
+  private colorFromValue(
+    value: ColorValue | null,
+    clearable = false,
+    mode: SupportedMode,
+  ): ColorInstance | null {
+    if (clearable && !value) {
+      return null;
+    }
+
+    return Color(
+      value != null && typeof value === "object" && alphaCompatible(mode)
+        ? normalizeColor(value as RGBA | HSVA | HSLA)
+        : value,
+    );
   }
 
   private handleTabActivate(event: Event): void {


### PR DESCRIPTION
**Related Issue:** #12871

## Summary

This improves the initial color-handling logic by taking component state/context into account.
