### PR TITLE
refactor(color-picker): tidy up

### DIFF
--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -25,13 +25,13 @@ import {
   alphaCompatible,
   alphaToOpacity,
   colorEqual,
+  colorFromValue,
   CSSColorMode,
   Format,
   getColorFieldDimensions,
   getSliderWidth,
   hexify,
   normalizeAlpha,
-  normalizeColor,
   normalizeHex,
   opacityToAlpha,
   parseMode,
@@ -51,7 +51,7 @@ import {
   STATIC_DIMENSIONS,
   ICONS,
 } from "./resources";
-import { Channels, ColorMode, ColorValue, HSLA, HSVA, InternalColor, RGBA } from "./interfaces";
+import { Channels, ColorMode, ColorValue, InternalColor } from "./interfaces";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { styles } from "./color-picker.scss";
 
@@ -426,11 +426,7 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
     const parsedMode = parseMode(value);
     const valueIsCompatible =
       willSetNoColor || (format === "auto" && parsedMode) || format === parsedMode;
-    const initialColor = willSetNoColor
-      ? null
-      : valueIsCompatible
-        ? this.colorFromValue(value, isClearable, parsedMode)
-        : color;
+    const initialColor = valueIsCompatible ? colorFromValue(value, isClearable, parsedMode) : color;
 
     if (!valueIsCompatible) {
       this.showIncompatibleColorWarning(value, format);
@@ -589,7 +585,7 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
       return;
     }
 
-    const color = this.colorFromValue(value, isClearable, this.mode);
+    const color = colorFromValue(value, isClearable, this.mode);
     const colorChanged = !colorEqual(color, this.color);
 
     if (modeChanged || colorChanged) {
@@ -600,22 +596,6 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
         "internal",
       );
     }
-  }
-
-  private colorFromValue(
-    value: ColorValue | null,
-    clearable = false,
-    mode: SupportedMode,
-  ): ColorInstance | null {
-    if (clearable && !value) {
-      return null;
-    }
-
-    return Color(
-      value != null && typeof value === "object" && alphaCompatible(mode)
-        ? normalizeColor(value as RGBA | HSVA | HSLA)
-        : value,
-    );
   }
 
   private handleTabActivate(event: Event): void {

--- a/packages/calcite-components/src/components/color-picker/utils.spec.ts
+++ b/packages/calcite-components/src/components/color-picker/utils.spec.ts
@@ -16,7 +16,6 @@ describe("utils", () => {
   describe("colorFromValue()", () => {
     it("returns null with clearable value + clearable=true", () => {
       expect(colorFromValue(null, true, "hex")).toBeNull();
-      expect(colorFromValue(undefined, true, "hex")).toBeNull();
       expect(colorFromValue("", true, "hex")).toBeNull();
     });
 
@@ -43,7 +42,6 @@ describe("utils", () => {
 
     it("returns default Color for clearable value + clearable=false", () => {
       expect(colorFromValue(null, false, "hex")).not.toBeNull();
-      expect(colorFromValue(undefined, false, "hex")).not.toBeNull();
     });
   });
 

--- a/packages/calcite-components/src/components/color-picker/utils.spec.ts
+++ b/packages/calcite-components/src/components/color-picker/utils.spec.ts
@@ -2,6 +2,7 @@ import Color from "color";
 import { describe, expect, it } from "vitest";
 import {
   colorEqual,
+  colorFromValue,
   hexToRGB,
   isLonghandHex,
   isShorthandHex,
@@ -12,6 +13,40 @@ import {
 } from "./utils";
 
 describe("utils", () => {
+  describe("colorFromValue()", () => {
+    it("returns null with clearable value + clearable=true", () => {
+      expect(colorFromValue(null, true, "hex")).toBeNull();
+      expect(colorFromValue(undefined, true, "hex")).toBeNull();
+      expect(colorFromValue("", true, "hex")).toBeNull();
+    });
+
+    it("returns Color instance for valid modes + clearable=false", () => {
+      expect(colorFromValue("#ff0000", false, "hex").hex().toLowerCase()).toBe("#ff0000");
+      expect(colorFromValue("#ff0000ff", false, "hexa").hexa().toLowerCase()).toBe("#ff0000ff");
+      expect(colorFromValue("rgb(255, 0, 0)", false, "rgb-css").rgb().array()).toEqual([255, 0, 0]);
+      expect(colorFromValue("rgba(255, 0, 0, 0.5)", false, "rgba-css").rgb().array()).toEqual([255, 0, 0, 0.5]);
+      expect(colorFromValue("hsl(0, 100%, 50%)", false, "hsl-css").hsl().array()[0]).toBeCloseTo(0);
+      expect(colorFromValue("hsla(0, 100%, 50%, 0.5)", false, "hsla-css").hsl().array()[3]).toBeCloseTo(0.5);
+      expect(colorFromValue({ r: 10, g: 20, b: 30 }, false, "rgb").rgb().array()).toEqual([10, 20, 30]);
+      expect(colorFromValue({ r: 10, g: 20, b: 30, a: 0.5 }, false, "rgba").rgb().array()).toEqual([10, 20, 30, 0.5]);
+      expect(colorFromValue({ h: 120, s: 100, l: 50, a: 0.5 }, false, "hsla").hsl().array()[3]).toBeCloseTo(0.5);
+      expect(colorFromValue({ h: 120, s: 100, v: 50, a: 0.5 }, false, "hsva").hsv().array()[3]).toBeCloseTo(0.5);
+      expect(colorFromValue({ h: 120, s: 100, v: 50 }, false, "hsv").hsv().array()[0]).toBeCloseTo(120);
+      expect(colorFromValue({ h: 120, s: 100, l: 50 }, false, "hsl").hsl().array()[0]).toBeCloseTo(120);
+    });
+
+    it("throws with alpha property but non-alpha-compatible mode", () => {
+      expect(() => colorFromValue({ r: 10, g: 20, b: 30, a: 0.5 }, false, "rgb")).toThrow();
+      expect(() => colorFromValue({ r: 10, g: 20, b: 30, a: 0.5 }, false, "hsl")).toThrow();
+      expect(() => colorFromValue({ r: 10, g: 20, b: 30, a: 0.5 }, false, "hsv")).toThrow();
+    });
+
+    it("returns default Color for clearable value + clearable=false", () => {
+      expect(colorFromValue(null, false, "hex")).not.toBeNull();
+      expect(colorFromValue(undefined, false, "hex")).not.toBeNull();
+    });
+  });
+
   it("can parse supported color modes", () => {
     expect(parseMode("#abc")).toBe("hex");
     expect(parseMode("#aabbcc")).toBe("hex");

--- a/packages/calcite-components/src/components/color-picker/utils.spec.ts
+++ b/packages/calcite-components/src/components/color-picker/utils.spec.ts
@@ -21,18 +21,18 @@ describe("utils", () => {
     });
 
     it("returns Color instance for valid modes + clearable=false", () => {
-      expect(colorFromValue("#ff0000", false, "hex").hex().toLowerCase()).toBe("#ff0000");
-      expect(colorFromValue("#ff0000ff", false, "hexa").hexa().toLowerCase()).toBe("#ff0000ff");
-      expect(colorFromValue("rgb(255, 0, 0)", false, "rgb-css").rgb().array()).toEqual([255, 0, 0]);
-      expect(colorFromValue("rgba(255, 0, 0, 0.5)", false, "rgba-css").rgb().array()).toEqual([255, 0, 0, 0.5]);
-      expect(colorFromValue("hsl(0, 100%, 50%)", false, "hsl-css").hsl().array()[0]).toBeCloseTo(0);
-      expect(colorFromValue("hsla(0, 100%, 50%, 0.5)", false, "hsla-css").hsl().array()[3]).toBeCloseTo(0.5);
-      expect(colorFromValue({ r: 10, g: 20, b: 30 }, false, "rgb").rgb().array()).toEqual([10, 20, 30]);
-      expect(colorFromValue({ r: 10, g: 20, b: 30, a: 0.5 }, false, "rgba").rgb().array()).toEqual([10, 20, 30, 0.5]);
-      expect(colorFromValue({ h: 120, s: 100, l: 50, a: 0.5 }, false, "hsla").hsl().array()[3]).toBeCloseTo(0.5);
-      expect(colorFromValue({ h: 120, s: 100, v: 50, a: 0.5 }, false, "hsva").hsv().array()[3]).toBeCloseTo(0.5);
-      expect(colorFromValue({ h: 120, s: 100, v: 50 }, false, "hsv").hsv().array()[0]).toBeCloseTo(120);
-      expect(colorFromValue({ h: 120, s: 100, l: 50 }, false, "hsl").hsl().array()[0]).toBeCloseTo(120);
+      expect(colorFromValue("#ff0000", false, "hex")!.hex().toLowerCase()).toBe("#ff0000");
+      expect(colorFromValue("#ff0000ff", false, "hexa")!.hexa().toLowerCase()).toBe("#ff0000ff");
+      expect(colorFromValue("rgb(255, 0, 0)", false, "rgb-css")!.rgb().array()).toEqual([255, 0, 0]);
+      expect(colorFromValue("rgba(255, 0, 0, 0.5)", false, "rgba-css")!.rgb().array()).toEqual([255, 0, 0, 0.5]);
+      expect(colorFromValue("hsl(0, 100%, 50%)", false, "hsl-css")!.hsl().array()[0]).toBeCloseTo(0);
+      expect(colorFromValue("hsla(0, 100%, 50%, 0.5)", false, "hsla-css")!.hsl().array()[3]).toBeCloseTo(0.5);
+      expect(colorFromValue({ r: 10, g: 20, b: 30 }, false, "rgb")!.rgb().array()).toEqual([10, 20, 30]);
+      expect(colorFromValue({ r: 10, g: 20, b: 30, a: 0.5 }, false, "rgba")!.rgb().array()).toEqual([10, 20, 30, 0.5]);
+      expect(colorFromValue({ h: 120, s: 100, l: 50, a: 0.5 }, false, "hsla")!.hsl().array()[3]).toBeCloseTo(0.5);
+      expect(colorFromValue({ h: 120, s: 100, v: 50, a: 0.5 }, false, "hsva")!.hsv().array()[3]).toBeCloseTo(0.5);
+      expect(colorFromValue({ h: 120, s: 100, v: 50 }, false, "hsv")!.hsv().array()[0]).toBeCloseTo(120);
+      expect(colorFromValue({ h: 120, s: 100, l: 50 }, false, "hsl")!.hsl().array()[0]).toBeCloseTo(120);
     });
 
     it("throws with alpha property but non-alpha-compatible mode", () => {

--- a/packages/calcite-components/src/components/color-picker/utils.ts
+++ b/packages/calcite-components/src/components/color-picker/utils.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { ColorInstance as Color } from "color";
+import Color, { type ColorInstance } from "color";
 import { Dimensions, Scale } from "../interfaces";
 import { ColorValue, HSLA, HSVA, RGB, RGBA } from "./interfaces";
 import { STATIC_DIMENSIONS } from "./resources";
@@ -9,6 +9,18 @@ const shorthandHex = /^#[0-9A-F]{3}$/i;
 const longhandHex = /^#[0-9A-F]{6}$/i;
 const shorthandHexWithAlpha = /^#[0-9A-F]{4}$/i;
 const longhandHexWithAlpha = /^#[0-9A-F]{8}$/i;
+
+export function colorFromValue(value: ColorValue | null, clearable = false, mode: SupportedMode): ColorInstance | null {
+  if (clearable && !value) {
+    return null;
+  }
+
+  return Color(
+    value != null && typeof value === "object" && alphaCompatible(mode)
+      ? normalizeColor(value as RGBA | HSVA | HSLA)
+      : value,
+  );
+}
 
 export const alphaToOpacity = (alpha: number): number => Number((alpha * 100).toFixed());
 
@@ -65,7 +77,7 @@ export function normalizeHex(hex: string, hasAlpha = false, convertFromHexToHexa
   return hex;
 }
 
-export function hexify(color: Color, hasAlpha = false): string {
+export function hexify(color: ColorInstance, hasAlpha = false): string {
   return hasAlpha ? color.hexa() : color.hex();
 }
 
@@ -84,14 +96,14 @@ function numToHex(num: number): string {
   return num.toString(16).padStart(2, "0");
 }
 
-export function normalizeAlpha<T extends RGBA | HSVA | HSLA>(colorObject: ReturnType<Color["object"]>): T {
+export function normalizeAlpha<T extends RGBA | HSVA | HSLA>(colorObject: ReturnType<ColorInstance["object"]>): T {
   const normalized = { ...colorObject, a: colorObject.alpha ?? 1 /* Color() will omit alpha if 1 */ };
   delete normalized.alpha;
 
   return normalized as T;
 }
 
-export function normalizeColor(alphaColorObject: RGBA | HSVA | HSLA): ReturnType<Color["object"]> {
+export function normalizeColor(alphaColorObject: RGBA | HSVA | HSLA): ReturnType<ColorInstance["object"]> {
   const normalized = { ...alphaColorObject, alpha: alphaColorObject.a ?? 1 };
   delete normalized.a;
 
@@ -208,7 +220,7 @@ function hasChannels(colorObject: Exclude<ColorValue, string> | null, ...channel
   return channels.every((channel) => channel && colorObject && `${channel}` in colorObject);
 }
 
-export function colorEqual(value1: Color | null, value2: Color | null): boolean {
+export function colorEqual(value1: ColorInstance | null, value2: ColorInstance | null): boolean {
   return value1?.rgb().array().toString() === value2?.rgb().array().toString();
 }
 


### PR DESCRIPTION
**monday.com sync:** #12164414723

**Related Issue:** N/A

## Summary

* Extracts `colorFromValue` util
* Cleans up `Color` and associated types
* Simplifies color-picker's `load` logic