### PR TITLE
refactor(icon): remove unused IconNameOrString type

### DIFF
--- a/packages/calcite-components/src/components/icon/interfaces.ts
+++ b/packages/calcite-components/src/components/icon/interfaces.ts
@@ -13,4 +13,3 @@ type CamelCaseIcons = ExtractBaseIcon<keyof typeof icons>;
 type KebabCaseIcons = KebabCase<CamelCaseIcons>;
 
 export type IconName = KebabCaseIcons | CamelCaseIcons;
-export type IconNameOrString = IconName | string;


### PR DESCRIPTION
**Related Issue:** #12357 [](https://github.com/Esri/calcite-design-system/issues/12357)

Removed `IconNameOrString` from the icon interface, as icon no longer supports string fallback.