### PR TITLE
refactor!: drop legacy VS Code IntelliSense file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "css.customData": ["../packages/calcite-components/dist/docs/vscode.css-custom-data.json"],
   "css.validate": false,
   "less.validate": false,
   "scss.validate": false,
@@ -8,9 +9,6 @@
   "editor.quickSuggestions": {
     "strings": true
   },
-  "html.customData": [
-    "./packages/calcite-components/dist/extras/vscode-data.json",
-    "./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"
-  ],
+  "html.customData": ["../packages/calcite-components/dist/docs/vscode.html-custom-data.json"],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/examples/components/preact/.vscode/settings.json
+++ b/examples/components/preact/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "html.customData": ["./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"]
+  "css.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.css-custom-data.json"],
+  "html.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.html-custom-data.json"]
 }

--- a/examples/components/rollup/.vscode/settings.json
+++ b/examples/components/rollup/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "html.customData": ["./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"]
+  "css.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.css-custom-data.json"],
+  "html.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.html-custom-data.json"]
 }

--- a/examples/components/vite/.vscode/settings.json
+++ b/examples/components/vite/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "html.customData": ["./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"]
+  "css.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.css-custom-data.json"],
+  "html.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.html-custom-data.json"]
 }

--- a/examples/components/vue/.vscode/settings.json
+++ b/examples/components/vue/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "html.customData": ["./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"]
+  "css.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.css-custom-data.json"],
+  "html.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.html-custom-data.json"]
 }

--- a/examples/components/web-dev-server/.vscode/settings.json
+++ b/examples/components/web-dev-server/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "html.customData": ["./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"]
+  "css.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.css-custom-data.json"],
+  "html.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.html-custom-data.json"]
 }

--- a/examples/components/webpack/.vscode/settings.json
+++ b/examples/components/webpack/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "html.customData": ["./node_modules/@esri/calcite-components/dist/extras/vscode-data.json"]
+  "css.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.css-custom-data.json"],
+  "html.customData": ["./node_modules/@esri/calcite-components/dist/docs/vscode.html-custom-data.json"]
 }

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "npm run util:prep-build-reqs && vite build",
-    "postbuild": "npm run util:generate-t9n-docs-json && npm run util:generate-supported-browsers-json && npm run util:copy-legacy-vscode-data",
+    "postbuild": "npm run util:generate-t9n-docs-json && npm run util:generate-supported-browsers-json",
     "build-storybook": "npm run util:prep-build-reqs && NODE_OPTIONS=--openssl-legacy-provider storybook build --output-dir ./docs --quiet",
     "build:dev": "vite build --mode development",
     "build:watch": "npm run util:prep-build-reqs && vite --mode production",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -63,7 +63,6 @@
     "util:clean-js-files": "rimraf --glob -- *.js {src,.storybook,support}/**/*.js",
     "util:ensure-playwright-workaround": "npx playwright install",
     "util:clean-tested-build": "npm ci && npm test && npm run build",
-    "util:copy-legacy-vscode-data": "cpy \"./dist/docs/vscode.html-custom-data.json\" \"./dist/extras/\" --rename=vscode-data.json --flat",
     "util:copy-assets": "npm run util:copy-icons",
     "util:copy-icons": "cpy \"../calcite-ui-icons/js/*.json\" \"src/components/icon/assets/\" --flat",
     "util:generate-t9n-docs-json": "tsx support/generateT9nDocsJSON.ts",


### PR DESCRIPTION
**Related Issue:** #13082

## Summary

✨🧹✨


BREAKING CHANGE: Developers using the legacy VS Code custom data files should use `vscode.html-custom-data.json` as suggested in https://developers.arcgis.com/calcite-design-system/resources/frameworks/#visual-studio-intellisense
