### PR TITLE
docs(action-pad): fix replacement suggestion in deprecation message

### DIFF
--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -22,7 +22,7 @@ declare global {
 }
 
 /**
- * @deprecated Use the `calcite-action-pad` component instead.
+ * @deprecated Use the `calcite-action-bar` component instead.
  * @slot - A slot for adding `calcite-action`s to the component.
  * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Updates the deprecation message to match the [doc site](https://developers.arcgis.com/calcite-design-system/components/action-pad/).