### PR TITLE
ci(actions): run script on every `unlabeled` event so assigned logic always fires

### DIFF
--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -38,16 +38,7 @@ jobs:
             await action({context})
 
       - name: "Remove Label from Task"
-        if: |
-          github.event.action == 'unlabeled' && (
-            github.event.label.name == 'blocked' ||
-            github.event.label.name == 'design' ||
-            github.event.label.name == 'design-tokens' ||
-            github.event.label.name == 'calcite-design-tokens' ||
-            github.event.label.name == 'a11y' ||
-            github.event.label.name == 'figma changes' ||
-            github.event.label.name == 'spike'
-          )
+        if: github.event.action == 'unlabeled'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
**Related Issue:** #13049

## Summary
#13057 added logic for syncing the `Assigned` state to Monday when labels are removed, but the `removeLabel.js` script only ran on specific label events. This PR moves the list of clearable labels into the script itself, ensuring the assigned logic is executed on any label removal.

This also avoids the case when a lifecycle label is removed and `assignedLabel` is synced, it would be cleared by the following `clearLabel` call.
