### PR TITLE
feat(semantic-tokens): update border color token values

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
@@ -360,14 +360,6 @@
       },
       "border": {
         "1": {
-          "value": "{core.color.neutral.blk-050}",
-          "type": "color",
-          "attributes": {
-            "category": "color",
-            "group": "border"
-          }
-        },
-        "2": {
           "value": "{core.color.neutral.blk-040}",
           "type": "color",
           "attributes": {
@@ -375,8 +367,16 @@
             "group": "border"
           }
         },
-        "3": {
+        "2": {
           "value": "{core.color.neutral.blk-030}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "border"
+          }
+        },
+        "3": {
+          "value": "{core.color.neutral.blk-020}",
           "type": "color",
           "attributes": {
             "category": "color",

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -1110,9 +1110,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-border-white: #ffffff;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-input: #949494;
-  --calcite-color-border-3: #dedede;
-  --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-1: #c9c9c9;
+  --calcite-color-border-3: #ebebeb;
+  --calcite-color-border-2: #dedede;
+  --calcite-color-border-1: #d4d4d4;
   --calcite-color-text-link: #00619b;
   --calcite-color-text-inverse: #ffffff;
   --calcite-color-text-highlight: #004874;
@@ -1158,9 +1158,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-border-white: #ffffff;
     --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
     --calcite-color-border-input: #949494;
-    --calcite-color-border-3: #dedede;
-    --calcite-color-border-2: #d4d4d4;
-    --calcite-color-border-1: #c9c9c9;
+    --calcite-color-border-3: #ebebeb;
+    --calcite-color-border-2: #dedede;
+    --calcite-color-border-1: #d4d4d4;
     --calcite-color-text-link: #00619b;
     --calcite-color-text-inverse: #ffffff;
     --calcite-color-text-highlight: #004874;
@@ -1255,9 +1255,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-border-white: #ffffff;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-input: #949494;
-  --calcite-color-border-3: #dedede;
-  --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-1: #c9c9c9;
+  --calcite-color-border-3: #ebebeb;
+  --calcite-color-border-2: #dedede;
+  --calcite-color-border-1: #d4d4d4;
   --calcite-color-text-link: #00619b;
   --calcite-color-text-inverse: #ffffff;
   --calcite-color-text-highlight: #004874;
@@ -1394,9 +1394,9 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-text-highlight: #004874;
   --calcite-color-text-inverse: #ffffff;
   --calcite-color-text-link: #00619b;
-  --calcite-color-border-1: #c9c9c9;
-  --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-3: #dedede;
+  --calcite-color-border-1: #d4d4d4;
+  --calcite-color-border-2: #dedede;
+  --calcite-color-border-3: #ebebeb;
   --calcite-color-border-input: #949494;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-white: #ffffff;
@@ -18739,7 +18739,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
     },
     {
       "key": "{semantic.color.border.1}",
-      "value": "{\\"light\\":\\"#c9c9c9\\",\\"dark\\":\\"#545454\\"}",
+      "value": "{\\"light\\":\\"#d4d4d4\\",\\"dark\\":\\"#545454\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18766,7 +18766,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
     },
     {
       "key": "{semantic.color.border.2}",
-      "value": "{\\"light\\":\\"#d4d4d4\\",\\"dark\\":\\"#4a4a4a\\"}",
+      "value": "{\\"light\\":\\"#dedede\\",\\"dark\\":\\"#4a4a4a\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18793,7 +18793,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
     },
     {
       "key": "{semantic.color.border.3}",
-      "value": "{\\"light\\":\\"#dedede\\",\\"dark\\":\\"#404040\\"}",
+      "value": "{\\"light\\":\\"#ebebeb\\",\\"dark\\":\\"#404040\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -30149,9 +30149,9 @@ export const calciteColorText3 = { light: "#6b6b6b", dark: "#9e9e9e" };
 export const calciteColorTextHighlight = { light: "#004874", dark: "#d6efff" };
 export const calciteColorTextInverse = { light: "#ffffff", dark: "#141414" };
 export const calciteColorTextLink = { light: "#00619b", dark: "#00a0ff" };
-export const calciteColorBorder1 = { light: "#c9c9c9", dark: "#545454" };
-export const calciteColorBorder2 = { light: "#d4d4d4", dark: "#4a4a4a" };
-export const calciteColorBorder3 = { light: "#dedede", dark: "#404040" };
+export const calciteColorBorder1 = { light: "#d4d4d4", dark: "#545454" };
+export const calciteColorBorder2 = { light: "#dedede", dark: "#4a4a4a" };
+export const calciteColorBorder3 = { light: "#ebebeb", dark: "#404040" };
 export const calciteColorBorderInput = { light: "#949494", dark: "#757575" };
 export const calciteColorBorderGhost = {
   light: "rgba(0, 0, 0, 0.3)",
@@ -32249,9 +32249,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-border-white: #ffffff;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-input: #949494;
-  --calcite-color-border-3: #dedede;
-  --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-1: #c9c9c9;
+  --calcite-color-border-3: #ebebeb;
+  --calcite-color-border-2: #dedede;
+  --calcite-color-border-1: #d4d4d4;
   --calcite-color-text-link: #00619b;
   --calcite-color-text-inverse: #ffffff;
   --calcite-color-text-highlight: #004874;
@@ -32386,9 +32386,9 @@ $calcite-color-text-3: #6b6b6b;
 $calcite-color-text-highlight: #004874;
 $calcite-color-text-inverse: #ffffff;
 $calcite-color-text-link: #00619b;
-$calcite-color-border-1: #c9c9c9;
-$calcite-color-border-2: #d4d4d4;
-$calcite-color-border-3: #dedede;
+$calcite-color-border-1: #d4d4d4;
+$calcite-color-border-2: #dedede;
+$calcite-color-border-3: #ebebeb;
 $calcite-color-border-input: #949494;
 $calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
 $calcite-color-border-white: #ffffff;


### PR DESCRIPTION
**Related Issue:** #10755

## Summary

Light mode color token updates
- `semantic.color.border.1` now references `core.neutral.blk.040`
- `semantic.color.border.2` now references `core.neutral.blk.030`
- `semantic.color.border.3` now references `core.neutral.blk.020`