### PR TITLE
ci(actions): fix monday workflow trigger for `NotifyWorkflow` event

### DIFF
--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -79,10 +79,10 @@ jobs:
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateState.js')
             await action({github, context})
 
-      - name: "Handle Ready For Dev Automation"
-        if: github.event.inputs.event_type == 'ReadyForDev'
+      - name: "Handle Notify Workflow Event"
+        if: github.event.inputs.event_type == 'NotifyWorkflow'
         uses: actions/github-script@v7
         with:
           script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/handleReadyForDev.js')
+            const action = require('${{ github.workspace }}/.github/scripts/monday/handleNotifyWorkflow.js')
             await action({github, context})


### PR DESCRIPTION
**Related Issue:** #13022

## Summary
Fixes the `NotifyWorkflow` event step to run for the correct event and call the renamed file.

PR #13096 missed these changes.
