### PR TITLE
test(tooltip): unskip tests

### DIFF
--- a/packages/calcite-components/src/components/tooltip/tooltip.browser.e2e.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.browser.e2e.tsx
@@ -1,0 +1,140 @@
+import { h } from "@arcgis/lumina";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { it, expect, beforeAll, afterAll, describe, vi } from "vitest";
+import { mockConsole } from "../../tests/utils/logging";
+import { TOOLTIP_CLOSE_DELAY_MS, TOOLTIP_OPEN_DELAY_MS } from "./resources";
+import { Tooltip } from "./tooltip";
+
+describe("calcite-tooltip", () => {
+  describe("pointer movement toggling", () => {
+    async function dispatchPointerEvent(selector: string): Promise<void> {
+      const eventOptions = { bubbles: true, cancelable: true };
+      const target: EventTarget = document.querySelector(selector)!;
+      target.dispatchEvent(new PointerEvent("pointermove", eventOptions));
+    }
+
+    interface PointerMoveOptions {
+      delay: number;
+      selector: string;
+      property: string;
+      value: boolean;
+    }
+
+    mockConsole();
+
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+
+    afterAll(() => {
+      vi.useRealTimers();
+    });
+
+    it("should open hovered tooltip while pointer is moving", async () => {
+      const { el: tooltip } = await mount<Tooltip>(
+        <div>
+          <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
+          <button id="ref">Button</button>
+        </div>,
+      );
+
+      expect(tooltip.open).toBe(false);
+
+      const pointerMoves: PointerMoveOptions[] = [
+        {
+          delay: 0,
+          property: "open",
+          value: false,
+          selector: "#ref",
+        },
+        {
+          delay: TOOLTIP_OPEN_DELAY_MS * 0.25,
+          property: "open",
+          value: false,
+          selector: "#ref",
+        },
+        {
+          delay: TOOLTIP_OPEN_DELAY_MS * 0.25,
+          property: "open",
+          value: false,
+          selector: "#ref",
+        },
+        {
+          delay: TOOLTIP_OPEN_DELAY_MS,
+          property: "open",
+          value: true,
+          selector: "#ref",
+        },
+        {
+          delay: TOOLTIP_OPEN_DELAY_MS + TOOLTIP_OPEN_DELAY_MS * 0.5,
+          property: "open",
+          value: true,
+          selector: "#ref",
+        },
+      ];
+
+      for (const pointerMove of pointerMoves) {
+        const { delay, selector } = pointerMove;
+        vi.advanceTimersByTime(delay);
+        await dispatchPointerEvent(selector);
+        expect(await tooltip[pointerMove.property]).toBe(pointerMove.value);
+      }
+    });
+
+    it("should close non hovered tooltip while pointer is moving", async () => {
+      const { el: tooltip } = await mount<Tooltip>(
+        <div>
+          <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
+          <p>
+            <button id="ref">Button</button>
+          </p>
+          <p>
+            <button id="ref2">No tooltip button</button>
+          </p>
+        </div>,
+      );
+
+      expect(tooltip.open).toBe(false);
+
+      const pointerMoves: PointerMoveOptions[] = [
+        {
+          delay: 0,
+          property: "open",
+          value: false,
+          selector: "#ref",
+        },
+        {
+          delay: TOOLTIP_CLOSE_DELAY_MS,
+          property: "open",
+          value: true,
+          selector: "#ref",
+        },
+        {
+          delay: TOOLTIP_CLOSE_DELAY_MS * 0.25,
+          property: "open",
+          value: true,
+          selector: "#ref2",
+        },
+        {
+          delay: TOOLTIP_CLOSE_DELAY_MS * 0.5,
+          property: "open",
+          value: true,
+          selector: "#ref2",
+        },
+        {
+          delay: TOOLTIP_CLOSE_DELAY_MS * 0.5,
+          property: "open",
+          value: false,
+          selector: "#ref2",
+        },
+      ];
+
+      for (const pointerMove of pointerMoves) {
+        const { delay, selector } = pointerMove;
+        vi.advanceTimersByTime(delay);
+        await dispatchPointerEvent(selector);
+        expect(await tooltip[pointerMove.property]).toBe(pointerMove.value);
+      }
+    });
+  });
+});

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -9,13 +9,6 @@ import { mockConsole } from "../../tests/utils/logging";
 import { TOOLTIP_OPEN_DELAY_MS, TOOLTIP_CLOSE_DELAY_MS, CSS, TOOLTIP_QUICK_OPEN_DELAY_MS } from "./resources";
 import type { Tooltip } from "./tooltip";
 
-interface PointerMoveOptions {
-  delay: number;
-  selector: string;
-  property: string;
-  value: boolean;
-}
-
 const eventOptions = { bubbles: true, cancelable: true };
 
 describe("calcite-tooltip", () => {
@@ -1036,113 +1029,6 @@ describe("calcite-tooltip", () => {
       expect(beforeCloseEvent).toHaveReceivedEventTimes(1);
       expect(closeEvent).toHaveReceivedEventTimes(1);
     });
-  });
-
-  it.skip("should open hovered tooltip while pointer is moving", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
-      <button id="ref">Button</button>
-    `);
-
-    const tooltip = await page.find("calcite-tooltip");
-    expect(await tooltip.getProperty("open")).toBe(false);
-
-    const pointerMoves: PointerMoveOptions[] = [
-      {
-        delay: 0,
-        property: "open",
-        value: false,
-        selector: "#ref",
-      },
-      {
-        delay: TOOLTIP_OPEN_DELAY_MS * 0.25,
-        property: "open",
-        value: false,
-        selector: "#ref",
-      },
-      {
-        delay: TOOLTIP_OPEN_DELAY_MS * 0.5,
-        property: "open",
-        value: false,
-        selector: "#ref",
-      },
-      {
-        delay: TOOLTIP_OPEN_DELAY_MS,
-        property: "open",
-        value: true,
-        selector: "#ref",
-      },
-      {
-        delay: TOOLTIP_OPEN_DELAY_MS + TOOLTIP_OPEN_DELAY_MS * 0.5,
-        property: "open",
-        value: true,
-        selector: "#ref",
-      },
-    ];
-
-    for (let i = 0; i < pointerMoves.length; i++) {
-      const { delay, selector } = pointerMoves[i];
-      await page.waitForTimeout(delay);
-      await dispatchPointerEvent(page, selector);
-      expect(await tooltip.getProperty(pointerMoves[i].property)).toBe(pointerMoves[i].value);
-    }
-  });
-
-  it.skip("should close non hovered tooltip while pointer is moving", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-tooltip reference-element="ref">Content</calcite-tooltip>
-      <p>
-        <button id="ref">Button</button>
-      </p>
-      <p>
-        <button id="ref2">No tooltip button</button>
-      </p>
-    `);
-
-    const tooltip = await page.find("calcite-tooltip");
-    expect(await tooltip.getProperty("open")).toBe(false);
-
-    const pointerMoves: PointerMoveOptions[] = [
-      {
-        delay: 0,
-        property: "open",
-        value: false,
-        selector: "#ref",
-      },
-      {
-        delay: TOOLTIP_CLOSE_DELAY_MS,
-        property: "open",
-        value: true,
-        selector: "#ref",
-      },
-      {
-        delay: TOOLTIP_CLOSE_DELAY_MS * 0.25,
-        property: "open",
-        value: true,
-        selector: "#ref2",
-      },
-      {
-        delay: TOOLTIP_CLOSE_DELAY_MS * 0.5,
-        property: "open",
-        value: true,
-        selector: "#ref2",
-      },
-      {
-        delay: TOOLTIP_CLOSE_DELAY_MS * 0.5,
-        property: "open",
-        value: false,
-        selector: "#ref2",
-      },
-    ];
-
-    for (let i = 0; i < pointerMoves.length; i++) {
-      const { delay, selector } = pointerMoves[i];
-      await page.waitForTimeout(delay);
-      await dispatchPointerEvent(page, selector);
-      expect(await tooltip.getProperty(pointerMoves[i].property)).toBe(pointerMoves[i].value);
-    }
   });
 
   describe("within shadowRoot", () => {


### PR DESCRIPTION
**Related Issue:** #10627 

## Summary

Restores skipped tests that relied on precise timing by moving them over to browser-mode tests, which removes delays from async puppeteer APIs, and using fake timers.