### PR TITLE
ci(actions): fix skip label removal logic

### DIFF
--- a/.github/scripts/monday/removeLabel.js
+++ b/.github/scripts/monday/removeLabel.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired, notInLifecycle } = require("../support/utils");
+const { assertRequired, notInLifecycle, includesLabel } = require("../support/utils");
 const {
   labels: {
     planning: { spike, spikeComplete },
@@ -16,14 +16,18 @@ module.exports = async ({ context }) => {
   const { labels: issueLabels, assignee } = issue;
   const [labelName] = assertRequired([label?.name]);
 
-  if (labelName === spike && issueLabels) {
-    const isSpikeComplete = issueLabels.some((label) => label.name === spikeComplete);
-    assertRequired([isSpikeComplete], "Issue is marked as a spike complete. Skipping label removal.");
+  if (labelName === spike && issueLabels && includesLabel(issueLabels, spikeComplete)) {
+    console.log("Issue is marked as a spike complete. Skipping label removal.");
+    process.exit(0);
   }
 
-  if ([designTokens, tokensPackage].includes(labelName) && issueLabels) {
-    const areTokensStillPresent = issueLabels.some((label) => label.name === designTokens);
-    assertRequired([areTokensStillPresent], "Issue is still marked as a design token issue. Skipping label removal.");
+  const tokensLabels = [designTokens, tokensPackage];
+  if (tokensLabels.includes(labelName) && issueLabels) {
+    const remainingLabel = tokensLabels.find((label) => label !== labelName);
+    if (issueLabels.some((label) => label.name === remainingLabel)) {
+      console.error("Issue is still marked as a design token issue. Skipping label removal.");
+      process.exit(0);
+    }
   }
 
   const monday = Monday(issue);

--- a/.github/scripts/monday/removeLabel.js
+++ b/.github/scripts/monday/removeLabel.js
@@ -16,18 +16,16 @@ module.exports = async ({ context }) => {
   const { labels: issueLabels, assignee } = issue;
   const [labelName] = assertRequired([label?.name]);
 
-  if (labelName === spike && issueLabels && includesLabel(issueLabels, spikeComplete)) {
+  if (labelName === spike && includesLabel(issueLabels, spikeComplete)) {
     console.log("Issue is marked as a spike complete. Skipping label removal.");
     process.exit(0);
   }
 
   const tokensLabels = [designTokens, tokensPackage];
-  if (tokensLabels.includes(labelName) && issueLabels) {
-    const remainingLabel = tokensLabels.find((label) => label !== labelName);
-    if (issueLabels.some((label) => label.name === remainingLabel)) {
-      console.error("Issue is still marked as a design token issue. Skipping label removal.");
-      process.exit(0);
-    }
+  const remainingTokenLabel = tokensLabels.includes(labelName) && tokensLabels.find((l) => l !== labelName);
+  if (remainingTokenLabel && includesLabel(issueLabels, remainingTokenLabel)) {
+    console.error("Issue is still marked as a design token issue. Skipping label removal.");
+    process.exit(0);
   }
 
   const monday = Monday(issue);


### PR DESCRIPTION
**Related Issue:** #12960

## Summary
Fixes two issues with label skipping logic:
1. The `assertRequired` function only checks if a value is `undefined`/`null`, but was being called with `boolean` values, so the labels were never skipped. These calls are replaced with `if` checks.
2. The Design Tokens logic only matched the case when `calcite-design-tokens` was removed and `design-tokens` was still present. It now checks if the design token label other than the one removed is still present.
