### PR TITLE
ci(actions): require absence of `3 - installed` in `Unassigned` milestone logic

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -783,7 +783,7 @@ module.exports = function Monday(issue) {
       setColumnValue(columnIds.date, milestoneDate);
       clearLabel(milestone.stalled);
 
-      const { new: newLabel, assigned, needsTriage, needsMilestone, readyForDev } = issueWorkflow;
+      const { new: newLabel, assigned, needsTriage, needsMilestone, readyForDev, installed } = issueWorkflow;
       if (
         assignee &&
         notInLifecycle({
@@ -793,7 +793,7 @@ module.exports = function Monday(issue) {
       ) {
         addLabel(assigned);
       }
-      if (!assignee && !includesLabel(labels, readyForDev)) {
+      if (!assignee && !includesLabel(labels, installed) && !includesLabel(labels, readyForDev)) {
         addLabel(newLabel);
       }
     } else {


### PR DESCRIPTION
**Related Issue:** #13113

## Summary
Requires the `3 - installed` label to be absent when a milestone is set in order for the `Unassigned` status to be set in Monday.
