### PR TITLE
docs(shell-panel): update resizable property to indicate only 'dock' and 'overlay' are resizable

### DIFF
--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -118,7 +118,7 @@ export class ShellPanel extends LitElement {
    */
   @property({ reflect: true }) position: Extract<"start" | "end", Position> = "start";
 
-  /** When `true` and `displayMode` is not `float-content` or `float`, the component's content area is resizable. */
+  /** When `true` and `displayMode` is not `float-all`, `float-content`, or `float`, the component's content area is resizable. */
   @property({ reflect: true }) resizable = false;
 
   /** Specifies the height of the component. */

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -118,7 +118,7 @@ export class ShellPanel extends LitElement {
    */
   @property({ reflect: true }) position: Extract<"start" | "end", Position> = "start";
 
-  /** When `true` and `displayMode` is not `float-all`, `float-content`, or `float`, the component's content area is resizable. */
+  /** When `true` and `displayMode` is `"dock"` or `"overlay"`, the component's content area is resizable. */
   @property({ reflect: true }) resizable = false;
 
   /** Specifies the height of the component. */


### PR DESCRIPTION
**Related Issue:** #10072 

## Summary
Update shell-panel's resizable property to indicate only 'dock' and 'overlay' are resizable.