### PR TITLE
test(focusable): fail when testing on focus-trap-enabled components

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.e2e.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.e2e.ts
@@ -706,7 +706,7 @@ describe("calcite-dialog", () => {
 
   describe("focusable", () => {
     const createDialogHTML = (contentHTML?: string, attrs?: string) =>
-      `<calcite-dialog heading="Title" open ${attrs}>${contentHTML}</calcite-dialog>`;
+      `<calcite-dialog heading="Title" open ${attrs} focus-trap-disabled>${contentHTML}</calcite-dialog>`;
 
     const focusableContentTargetClass = "test";
     const shadowFocusTargetSelector = `.${CSS.panel}`;

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -90,7 +90,7 @@ describe("calcite-input-date-picker", () => {
   });
 
   describe("should focus the input when setFocus is called", () => {
-    focusable(`calcite-input-date-picker`, {
+    focusable(`<calcite-input-date-picker focus-trap-disabled></calcite-input-date-picker>`, {
       shadowFocusTargetSelector: "calcite-input-text",
     });
   });

--- a/packages/calcite-components/src/components/popover/popover.e2e.ts
+++ b/packages/calcite-components/src/components/popover/popover.e2e.ts
@@ -758,7 +758,7 @@ describe("calcite-popover", () => {
 
   describe("setFocus", () => {
     const createPopoverHTML = (contentHTML?: string, attrs?: string) =>
-      `<calcite-popover open ${attrs} reference-element="ref">${contentHTML}</calcite-popover><button id="ref">Button</button>`;
+      `<calcite-popover open ${attrs} reference-element="ref" focus-trap-disabled>${contentHTML}</calcite-popover><button id="ref">Button</button>`;
 
     const contentButtonClass = "my-button";
     const contentHTML = "Hello World!";

--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -140,7 +140,7 @@ describe("calcite-sheet", () => {
 
   describe("setFocus", () => {
     const createSheetHTML = (contentHTML?: string, attrs?: string) =>
-      `<calcite-sheet open ${attrs}>${contentHTML}</calcite-sheet>`;
+      `<calcite-sheet open ${attrs} focus-trap-disabled>${contentHTML}</calcite-sheet>`;
 
     const focusableContentTargetClass = "test";
 

--- a/packages/calcite-components/src/tests/commonTests/focusable.ts
+++ b/packages/calcite-components/src/tests/commonTests/focusable.ts
@@ -81,10 +81,21 @@ export function focusable(componentTestSetup: ComponentTestSetup, options?: Focu
     });
     await page.waitForChanges();
 
+    let receivedFocusOptions = await page.evaluate(() => {
+      const testWindow = window as TestWindow;
+      return testWindow.receivedFocusOptions;
+    });
+
+    if (receivedFocusOptions?.length > 0) {
+      throw new Error(
+        `unexpected focus calls before setFocus() was called, if testing a focus-trapping component, please disable for proper testing.`,
+      );
+    }
+
     await element.callMethod("setFocus", fakeFocusOptions);
     await page.waitForChanges();
 
-    const receivedFocusOptions = await page.evaluate(() => {
+    receivedFocusOptions = await page.evaluate(() => {
       const testWindow = window as TestWindow;
       return testWindow.receivedFocusOptions;
     });


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

Improves test stability by updating `focusable` to handle unexpected `focus()` calls triggered by focus trapping.  

The `focusable` helper [blurs the active element](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/tests/commonTests/focusable.ts#L60-L70) before tracking `focus()` calls, which conflicts with `focus-trap`’s logic that [keeps focus within the trap](https://github.com/focus-trap/focus-trap/blob/master/index.js#L657).  

Props to @DintaMel for catching this. 🎉  