### PR TITLE
ci(actions): add back adjusted status side-effect logic

### DIFF
--- a/.github/scripts/monday/updateAssignee.js
+++ b/.github/scripts/monday/updateAssignee.js
@@ -1,13 +1,39 @@
 // @ts-check
 const Monday = require("../support/monday");
+const { notInLifecycle } = require("../support/utils");
+const {
+  labels: {
+    issueWorkflow: { new: newLabel, assigned: assignedLabel },
+  },
+} = require("../support/resources");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
-  const { issue } =
+  const { issue, action } =
     /** @type {import('@octokit/webhooks-types').IssuesAssignedEvent | import('@octokit/webhooks-types').IssuesUnassignedEvent } */ (
       context.payload
     );
   const monday = Monday(issue);
+  const { labels, assignees: currentAssignees } = issue;
+  const skippedLabels = [newLabel, assignedLabel];
+
+  if (
+    action === "unassigned" &&
+    currentAssignees.length === 0 &&
+    notInLifecycle({ labels, skip: skippedLabels }) &&
+    !monday.inMilestoneStatus()
+  ) {
+    monday.addLabel(newLabel);
+    console.info("Set status to unassigned.");
+  } else if (
+    action === "assigned" &&
+    notInLifecycle({ labels, skip: skippedLabels }) &&
+    !monday.inMilestoneStatus()
+  ) {
+    monday.addLabel(assignedLabel);
+    console.info("Set status to assigned.");
+  }
+
   monday.handleAssignees();
   await monday.commit();
 };


### PR DESCRIPTION
**Related Issue:** #13159

## Summary
After an over-correction in #13164, adds back the Status side-effect logic for the `updateAssignee` script with the `needsTriage` and `needsMilestone` labels no longer skipped.
