### PR TITLE
ci(actions): fix component label action

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -13,11 +13,12 @@ body:
   - type: dropdown
     id: component
     validations:
-      required: false
+      required: true
     attributes:
       label: Which Component
       description: Which component(s) are related to this issue? (Select all that apply).
       multiple: true
+      default: 0
       options:
         - N/A
         - Unknown / Not Sure

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,11 +13,12 @@ body:
   - type: dropdown
     id: component
     validations:
-      required: false
+      required: true
     attributes:
       label: Which Component
       description: Which component(s) are related to this issue? (Select all that apply).
       multiple: true
+      default: 0
       options:
         - N/A
         - Unknown / Not Sure

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -10,11 +10,12 @@ body:
   - type: dropdown
     id: component
     validations:
-      required: false
+      required: true
     attributes:
       label: Which Component
       description: Which component(s) are related to this issue? (Select all that apply).
       multiple: true
+      default: 0
       options:
         - N/A
         - Unknown / Not Sure
@@ -125,12 +126,6 @@ body:
     attributes:
       label: Description
       description: What needs to be added or fixed?
-    validations:
-      required: true
-  - type: textarea
-    id: component
-    attributes:
-      label: Which Component
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -13,11 +13,12 @@ body:
   - type: dropdown
     id: component
     validations:
-      required: false
+      required: true
     attributes:
       label: Which Component
       description: Which component(s) are related to this issue? (Select all that apply).
       multiple: true
+      default: 0
       options:
         - N/A
         - Unknown / Not Sure

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -7,6 +7,120 @@ body:
       value: |
         - Please [check for existing issues](https://github.com/Esri/calcite-design-system/issues) to avoid duplicates. If someone has already opened an issue for what you are experiencing, please add a 👍 reaction to the existing issue instead of creating a new one.
         - For support, please check the [community forum](https://developers.arcgis.com/calcite-design-system/community/).
+  - type: dropdown
+    id: component
+    validations:
+      required: true
+    attributes:
+      label: Which Component
+      description: Which component(s) are related to this issue? (Select all that apply).
+      multiple: true
+      default: 0
+      options:
+        - N/A
+        - Unknown / Not Sure
+        - Accordion
+        - Accordion Item
+        - Action
+        - Action Bar
+        - Action Group
+        - Action Pad
+        - Alert
+        - Autocomplete
+        - Autocomplete Item
+        - Autocomplete Item Group
+        - Avatar
+        - Block
+        - Block Group
+        - Block Section
+        - Button
+        - Card
+        - Card Group
+        - Carousel
+        - Carousel Item
+        - Checkbox
+        - Chip
+        - Chip Group
+        - Color Picker
+        - Combobox
+        - Combobox Item
+        - Combobox Item Group
+        - Date Picker
+        - Dialog
+        - Dropdown
+        - Dropdown Group
+        - Dropdown Item
+        - Fab
+        - Filter
+        - Flow
+        - Flow Item
+        - Icon
+        - Inline Editable
+        - Input
+        - Input Date Picker
+        - Input Message
+        - Input Number
+        - Input Text
+        - Input Time Picker
+        - Input Time Zone
+        - Label
+        - Link
+        - List
+        - List Item
+        - List Item Group
+        - Loader
+        - Menu
+        - Menu Item
+        - Meter
+        - Modal
+        - Navigation
+        - Navigation Logo
+        - Navigation User
+        - Notice
+        - Option
+        - Option Group
+        - Pagination
+        - Panel
+        - Popover
+        - Progress
+        - Radio Button
+        - Radio Button Group
+        - Rating
+        - Scrim
+        - Segmented Control
+        - Segmented Control Item
+        - Select
+        - Sheet
+        - Shell
+        - Shell Center Row
+        - Shell Panel
+        - Slider
+        - Split Button
+        - Stepper
+        - Stepper Item
+        - Swatch
+        - Swatch Group
+        - Switch
+        - Tab
+        - Tab Nav
+        - Tab Title
+        - Table
+        - Table Cell
+        - Table Header
+        - Table Row
+        - Tabs
+        - Text Area
+        - Tile
+        - Tile Group
+        - Tile Select
+        - Tile Select Group
+        - Time Picker
+        - Tip
+        - Tip Group
+        - Tip Manager
+        - Tooltip
+        - Tree
+        - Tree Item
   - type: textarea
     id: description
     attributes:
@@ -19,12 +133,6 @@ body:
     attributes:
       label: Proposed Advantages
       description: Why should the code change?
-    validations:
-      required: true
-  - type: textarea
-    id: component
-    attributes:
-      label: Which Component
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -8,6 +8,120 @@ body:
         - Please [check for existing issues](https://github.com/Esri/calcite-design-system/issues) to avoid duplicates. If someone has already opened an issue for what you are experiencing, please add a 👍 reaction to the existing issue instead of creating a new one.
         - For support, please check the [community forum](https://developers.arcgis.com/calcite-design-system/community/).
   - type: dropdown
+    id: component
+    validations:
+      required: true
+    attributes:
+      label: Which Component
+      description: Which component(s) are related to this issue? (Select all that apply).
+      multiple: true
+      default: 0
+      options:
+        - N/A
+        - Unknown / Not Sure
+        - Accordion
+        - Accordion Item
+        - Action
+        - Action Bar
+        - Action Group
+        - Action Pad
+        - Alert
+        - Autocomplete
+        - Autocomplete Item
+        - Autocomplete Item Group
+        - Avatar
+        - Block
+        - Block Group
+        - Block Section
+        - Button
+        - Card
+        - Card Group
+        - Carousel
+        - Carousel Item
+        - Checkbox
+        - Chip
+        - Chip Group
+        - Color Picker
+        - Combobox
+        - Combobox Item
+        - Combobox Item Group
+        - Date Picker
+        - Dialog
+        - Dropdown
+        - Dropdown Group
+        - Dropdown Item
+        - Fab
+        - Filter
+        - Flow
+        - Flow Item
+        - Icon
+        - Inline Editable
+        - Input
+        - Input Date Picker
+        - Input Message
+        - Input Number
+        - Input Text
+        - Input Time Picker
+        - Input Time Zone
+        - Label
+        - Link
+        - List
+        - List Item
+        - List Item Group
+        - Loader
+        - Menu
+        - Menu Item
+        - Meter
+        - Modal
+        - Navigation
+        - Navigation Logo
+        - Navigation User
+        - Notice
+        - Option
+        - Option Group
+        - Pagination
+        - Panel
+        - Popover
+        - Progress
+        - Radio Button
+        - Radio Button Group
+        - Rating
+        - Scrim
+        - Segmented Control
+        - Segmented Control Item
+        - Select
+        - Sheet
+        - Shell
+        - Shell Center Row
+        - Shell Panel
+        - Slider
+        - Split Button
+        - Stepper
+        - Stepper Item
+        - Swatch
+        - Swatch Group
+        - Switch
+        - Tab
+        - Tab Nav
+        - Tab Title
+        - Table
+        - Table Cell
+        - Table Header
+        - Table Row
+        - Tabs
+        - Text Area
+        - Tile
+        - Tile Group
+        - Tile Select
+        - Tile Select Group
+        - Time Picker
+        - Tip
+        - Tip Group
+        - Tip Manager
+        - Tooltip
+        - Tree
+        - Tree Item
+  - type: dropdown
     id: priority-impact
     validations:
       required: true
@@ -25,12 +139,6 @@ body:
       label: Test type
       description: What type of test is being requested?
       placeholder: "e.g., new test, unstable test, Chromatic, etc."
-    validations:
-      required: true
-  - type: input
-    id: component
-    attributes:
-      label: Which Component(s)
     validations:
       required: true
   - type: textarea

--- a/.github/scripts/addComponentLabel.js
+++ b/.github/scripts/addComponentLabel.js
@@ -21,7 +21,7 @@ module.exports = async ({ github, context }) => {
   if (whichComponentRegexMatch) {
     const componentsString = (whichComponentRegexMatch[1] || "").trim();
 
-    if (componentsString !== "N/A") {
+    if (componentsString !== "N/A" && componentsString !== "Unknown / Not Sure") {
       const componentsList = componentsString
         .split(", ")
         .map((component) => `c-${component}`.replace(" ", "-").toLowerCase());

--- a/.github/scripts/updateIssueTemplateComponents.js
+++ b/.github/scripts/updateIssueTemplateComponents.js
@@ -39,7 +39,7 @@ async function main() {
   const allFiles = fs.readdirSync(templateDir);
 
   // Only update these template types
-  const targetPattern = /bug|accessibility|documentation|enhancement/i;
+  const targetPattern = /bug|accessibility|documentation|enhancement|refactor|test/i;
   const files = allFiles.filter((f) => targetPattern.test(f));
   if (files.length === 0) {
     console.log("No templates for bug, accessibility, documentation, or enhancement found in", templateDir);


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
The component label action did not cover the case of no user response and resulted in a weird "component" labels like `c-_no-response_`

In this PR:
- Make the "Which Component" field in the issue templates `required` but set's a default value of "N/A" so it doesn't add any friction for folks. 
- Adds "Which Component" dropdown to templates that it was previously missing from (missed on initial pass)
- Add those new templates to the `updateIssueTemplateComponents` script so that they update when components change.