### PR TITLE
chore: ensure icon bounding box consistency

### DIFF
--- a/packages/calcite-ui-icons/icons/carousel-frames-16.svg
+++ b/packages/calcite-ui-icons/icons/carousel-frames-16.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M3 13v1H1V2h2v1H2v10zm9-12v14H4V1zm-1 1H5v12h6zm-1 1H6v1h4zm3-1v1h1v10h-1v1h2V2z"/><path d="M0 0h16v16H0z" style="fill:none"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M3 13v1H1V2h2v1H2v10zm9-12v14H4V1zm-1 1H5v12h6zm-1 1H6v1h4zm3-1v1h1v10h-1v1h2V2z"/><path d="M0 0h16v16H0z" fill="none"/></svg>

--- a/packages/calcite-ui-icons/icons/carousel-frames-24.svg
+++ b/packages/calcite-ui-icons/icons/carousel-frames-24.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 1v23h14V1zm13 22H6V2h12zM15 5H9V4h6zm8-2v19h-3v-1h2V4h-2V3zM4 22H1V3h3v1H2v17h2z"/><path d="M0 0h24v24H0z" style="fill:none"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 1v23h14V1zm13 22H6V2h12zM15 5H9V4h6zm8-2v19h-3v-1h2V4h-2V3zM4 22H1V3h3v1H2v17h2z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/packages/calcite-ui-icons/icons/carousel-frames-32.svg
+++ b/packages/calcite-ui-icons/icons/carousel-frames-32.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M7 2v28h17V2zm16 27H8V3h15zM20 6h-9V5h9zM6 27v1H2V4h4v1H3v22zM29 4v24h-4v-1h3V5h-3V4z"/><path d="M0 0h32v32H0z" style="fill:none"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M7 2v28h17V2zm16 27H8V3h15zM20 6h-9V5h9zM6 27v1H2V4h4v1H3v22zM29 4v24h-4v-1h3V5h-3V4z"/><path d="M0 0h32v32H0z" fill="none"/></svg>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Changes remaining use `style="fill:none"` with `fill="none"` (follows https://github.com/Esri/calcite-design-system/pull/13153/files).

```diff
packages/calcite-ui-icons/icons/carousel-frames-16.svg
- <path d="M0 0h16v16H0z" style="fill:none"/>
+ <path d="M0 0h16v16H0z" fill="none"/>

packages/calcite-ui-icons/icons/carousel-frames-24.svg
- <path d="M0 0h24v24H0z" style="fill:none"/>
+ <path d="M0 0h24v24H0z" fill="none"/>

packages/calcite-ui-icons/icons/carousel-frames-32.svg
- <path d="M0 0h32v32H0z" style="fill:none"/>
+ <path d="M0 0h32v32H0z" fill="none"/>

```