### PR TITLE
chore: apply svgo overrides properly

### DIFF
--- a/packages/calcite-ui-icons/bin/optimize.js
+++ b/packages/calcite-ui-icons/bin/optimize.js
@@ -7,18 +7,26 @@ const options = {
   plugins: [
     {
       name: "preset-default",
-      overrides: {
-        cleanupIDs: { remove: false },
-        removeUselessStrokeAndFill: false,
-        convertShapeToPath: { convertArcs: true },
-        convertPathData: { noSpaceAfterFlags: false },
-        mergePaths: false,
-        removeAttrs: { attrs: ["class", "(stroke)"] },
-      },
+      params: {
+        overrides: {
+          convertPathData: { noSpaceAfterFlags: false },
+          convertShapeToPath: { convertArcs: true },
+          mergePaths: false,
+          removeUselessStrokeAndFill: false,
+        },
+      }
     },
+    {
+      name: "cleanupIds",
+      params: { remove: false },
+    },
+    {
+      name: "removeAttrs",
+      params: { attrs: ["class", "(stroke)"] },
+    },
+    "removeDimensions",
     "removeStyleElement",
     "removeTitle",
-    "removeDimensions",
   ],
   multipass: true,
 };
@@ -46,7 +54,7 @@ export default (function (files, remove = false) {
   if (!files) {
     return Promise.resolve(true);
   }
-  options.plugins.find(({ name }) => name === "preset-default").overrides.cleanupIDs.remove = remove;
+  options.plugins.find(({ name }) => name === "cleanupIds").remove = remove;
   return globby(files).then((iconPaths) => {
     const format = "  \x1b[32m {bar} {percentage}% | {value}/{total} \x1b[0m";
     const bar = new progress.SingleBar({ format }, progress.Presets.shades_classic);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

When SVGO was upgraded to v3 in https://github.com/Esri/calcite-design-system/pull/12415/files#diff-e3f40f8a385daea688f42e92395e25b7cc98377068140f294feaa72b7715cdd8R8-R17, the `preset-default` overrides were not applied correctly. The overrides need to be defined at the `params` level per the [v2 ➡️ v3 migration notes](https://svgo.dev/docs/migrations/migration-from-v2-to-v3/).