### PR TITLE
fix(option): replace line breaks within text content

### DIFF
--- a/packages/calcite-components/src/components/option/option.e2e.ts
+++ b/packages/calcite-components/src/components/option/option.e2e.ts
@@ -106,14 +106,23 @@ describe("calcite-option", () => {
         <calcite-option><br />breaks<br /></calcite-option>
         <calcite-option>&nbsp;non-breaking-space&nbsp;</calcite-option>
 
+        <!-- the following options disable prettier to preserve newlines -->
+
         <!-- prettier-ignore -->
-        <!-- need to preserve newlines -->
-        <calcite-option> newlines </calcite-option>
+        <calcite-option> 
+          newlines
+        </calcite-option>
+
+        <!-- prettier-ignore -->
+        <calcite-option>multi
+        line
+        breaks
+        </calcite-option>
       `);
       const options = await findAll(page, "calcite-option");
       const labels = await Promise.all(options.map((option) => option.getProperty("label")));
 
-      expect(labels).toEqual(["spaces", "breaks", "\u00A0non-breaking-space\u00A0", "newlines"]);
+      expect(labels).toEqual(["spaces", "breaks", "\u00A0non-breaking-space\u00A0", "newlines", "multi line breaks"]);
     });
 
     it("preserves all whitespace when provided via label", async () => {
@@ -127,6 +136,12 @@ describe("calcite-option", () => {
 newlines (label)
 "
         ></calcite-option>
+        <calcite-option
+          label="multi
+line
+breaks (label)
+"
+        ></calcite-option>
       `);
       const options = await findAll(page, "calcite-option");
       const labels = await Promise.all(options.map((option) => option.getProperty("label")));
@@ -136,6 +151,7 @@ newlines (label)
         "<br>breaks (label)<br>",
         "\u00A0non-breaking-space (label)\u00A0",
         "\nnewlines (label)\n",
+        "multi\nline\nbreaks (label)\n",
       ]);
     });
   });

--- a/packages/calcite-components/src/components/option/option.tsx
+++ b/packages/calcite-components/src/components/option/option.tsx
@@ -12,6 +12,7 @@ declare global {
 }
 
 const whitespaceCharsToTrim = [" ", "\n", "\t", "\r"];
+const whitespaceToReplaceRegexp = /[^\S\u00A0]+/g;
 
 export class Option extends LitElement {
   // #region Static Members
@@ -115,7 +116,10 @@ export class Option extends LitElement {
 
   private ensureTextContentDependentProps(): void {
     const { el, internallySetLabel, internallySetValue, label, value } = this;
-    const trimmedContent = trim(el.textContent, whitespaceCharsToTrim);
+    const trimmedContent = trim(el.textContent, whitespaceCharsToTrim).replaceAll(
+      whitespaceToReplaceRegexp,
+      " ",
+    );
     const trimmedLabel = label;
 
     if (!trimmedLabel || trimmedLabel === internallySetLabel) {


### PR DESCRIPTION
**Related Issue:** #12146 

## Summary

Covers an additional missing case from the repro, which was not handled in https://github.com/Esri/calcite-design-system/pull/13076.