### PR TITLE
docs(tabs): indicate --calcite-tab-background-color can be used regardless of bordered property value

### DIFF
--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-background-color: When `calcite-tabs` is `bordered`, specifies the component's background color.
+ * @prop --calcite-tab-background-color: Specifies the component's background color.
  * @prop --calcite-tab-border-color: When `calcite-tabs` is `bordered`, specifies the component's border color.
  * @prop --calcite-tab-text-color: Specifies the component's `iconStart, `iconEnd`, and text color.
  */

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-background-color: When `bordered`, specifies the component's background color.
+ * @prop --calcite-tab-background-color: Specifies the component's background color.
  * @prop --calcite-tab-border-color: Specifies the component's border color.
  */
 


### PR DESCRIPTION
**Related Issue:** #12970 

## Summary
Update the docs to indicate `--calcite-tab-background-color` can be used regardless of `bordered` property value  since [PR #12850](https://github.com/Esri/calcite-design-system/pull/12850) made improvements to how the `--calcite-tab-background-color` works on `tabs` without the `bordered` property. 
