### PR TITLE
fix(tile): center text content for short headings

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -132,6 +132,9 @@ calcite-link {
   .icon {
     align-self: center;
   }
+  .text-content-container {
+    justify-content: center;
+  }
   .text-content {
     text-align: center;
   }


### PR DESCRIPTION
**Related Issue:** #12606 

## Summary
Partially fix part of the problem in #12606. Tiles with `alignment="center"` should always center the text-content. Currently tiles with short headings and missing or short descriptions will be left justified and not center in the container.

This behavior is seen in the tile demos "heading centered". This PR fixes that issue without harming display of other elements.