### PR TITLE
docs(inline-editable): remove default scaling info from `scale` property

### DIFF
--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -91,7 +91,7 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /** Specifies the size of the component. Defaults to the scale of the wrapped `calcite-input` or the scale of the closest wrapping component with a set scale. */
+  /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** #10466

## Summary
With the change in behavior via #12241, removes the documention for how Inline Editable's `scale` could be based on the `scale` of a slotted input.
