### PR TITLE
ci(actions): make `Stalled` milestone clearable

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -389,6 +389,7 @@ module.exports = function Monday(issue) {
       {
         column: columnIds.stalled,
         value: "Stalled",
+        clearable: true,
       },
     ],
   ]);


### PR DESCRIPTION
**Related Issue:** #13229

## Summary
Makes the `Stalled` milestone clearable in Monday through the `clearable` property.
