### PR TITLE
feat(table-cell): remove border styling from selected cell

### DIFF
--- a/packages/calcite-components/src/components/table-cell/table-cell.scss
+++ b/packages/calcite-components/src/components/table-cell/table-cell.scss
@@ -118,7 +118,7 @@ td.last-cell {
 }
 
 .selection-cell.selected-cell {
-  box-shadow: inset 0.25rem 0 0 0 var(--calcite-table-row-accent-color-selected, var(--calcite-color-brand));
+  box-shadow: inset 0 0 0 0 var(--calcite-table-row-accent-color-selected, var(--calcite-color-brand));
   color: var(--calcite-table-selection-cell-icon-color-selected, var(--calcite-color-brand));
 }
 


### PR DESCRIPTION
**Related Issue:** [#10770](https://github.com/Esri/calcite-design-system/issues/10770) 

## Summary
Clean up selection styling by removing border color from selected table cells for 4.0. 