### PR TITLE
ci(actions): ignore issues in stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues"
+name: "Close stale PRs"
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -9,11 +9,7 @@ jobs:
       - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
           stale-pr-message: "This PR has been automatically marked as stale because it has not had recent activity. Please close your PR if it is no longer relevant. Thank you for your contributions."
-          close-issue-message: "This issue has been automatically closed due to inactivity."
-          exempt-issue-labels: "0 - new,1 - assigned,2 - in development,epic"
-          days-before-issue-stale: 30
-          days-before-issue-close: 7
+          days-before-issue-stale: -1
           days-before-pr-stale: 7
           days-before-pr-close: -1


### PR DESCRIPTION
**Related Issue:** #13253

## Summary
Ignores issues from being labeled or closed as `stale` by using the `-1` day value for `days-before-issue-stale`.
