### PR TITLE
fix(tile-group): make horizontal layout always go horizontal

### DIFF
--- a/packages/components/src/components/tile-group/tile-group.scss
+++ b/packages/components/src/components/tile-group/tile-group.scss
@@ -12,6 +12,7 @@
 .container {
   display: grid;
   grid-auto-rows: minmax(auto, 1fr);
+  grid-auto-flow: column;
 }
 :host([scale="s"]) {
   .container {


### PR DESCRIPTION
**Related Issue:** #12606 

## Summary
Previously the `horizontal` layout actually laid out the tiles vertically if the tile content was narrower than the minimum grid column width for the tile group scale. This ensures that the gird cells always layout horizontally first and then wrap to create rows if needed.

This **does not** affect the `vertical` layout tile groups

This makes significant differences in the screenshot tests since the default and horizontal layout stories actually layout horizontally now.